### PR TITLE
test(core): share one mount-session helper across the off-router LiveViews [2m]

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.560.3",
+      version: "7.569.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -154,16 +154,18 @@ defmodule VutuvWeb.ConnCase do
   # it at 150 lines — it sat at exactly 150 before this pair moved out.
 
   @doc """
-  The mount session a browser hands `VutuvWeb.ShellLive`.
+  The mount session a browser hands the off-router `live_render` children —
+  `VutuvWeb.ShellLive`, `SectionReorderLive`, `ReferenceCheckLive`.
 
   A real, active session's raw token under `"session_token"` — the only
-  identity key the shell trusts (issue #1036), so a test drives it the way a
-  request does instead of curating a map (the curated map is the *production*
-  path, `VutuvWeb.LayoutHTML.shell_session/1`). `alert: false` keeps the
-  new-device security notice out of the test's mailbox.
+  identity key those LiveViews trust (issue #1036), so a test drives them the
+  way a request does instead of curating a map (the curated map is the
+  *production* path, `VutuvWeb.LayoutHTML.shell_session/1`). `alert: false`
+  keeps the new-device security notice out of the test's mailbox.
 
-  `extra` carries the non-identity keys the shell reads straight from the
-  session — `"path"`, `"locale"`, `"acting_as_organization_id"`.
+  `extra` carries the non-identity keys each child reads straight from the
+  session — `"path"`, `"acting_as_organization_id"`, `"section"`, `"slug"`,
+  `"job_reference_id"`.
   """
   def shell_session(user, extra \\ %{}) do
     {token, _session} =

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -15,6 +15,7 @@ defmodule VutuvWeb.ConnCase do
       import Ecto.Query
       import Vutuv.Factory
       import Vutuv.MailboxHelpers
+      import VutuvWeb.ConnCase
       import VutuvWeb.HTMLHelpers
 
       use Phoenix.VerifiedRoutes,
@@ -121,19 +122,6 @@ defmodule VutuvWeb.ConnCase do
         token
       end
 
-      # True when the <input type="checkbox" name=name> in `html` is rendered
-      # checked, regardless of attribute order. The assertion a form's default
-      # state needs: a box that submits "true" only because it is pre-ticked is
-      # a different product decision from one the member has to find and click.
-      defp checkbox_checked?(html, name) do
-        regex = ~r/<input(?=[^>]*\btype="checkbox")(?=[^>]*\bname="#{Regex.escape(name)}")[^>]*>/
-
-        case Regex.run(regex, html) do
-          [tag] -> tag =~ "checked"
-          _ -> false
-        end
-      end
-
       # ── /api/2.0 helpers (shared by every API test file) ──
 
       defp authed(conn, token) do
@@ -156,6 +144,48 @@ defmodule VutuvWeb.ConnCase do
         assert content_type =~ "application/problem+json"
         Jason.decode!(conn.resp_body)
       end
+    end
+  end
+
+  # ── Helpers imported into every case ──
+  #
+  # Plain functions rather than `defp`s in the quote above, because that quote
+  # is inlined into all ~330 ConnCase modules and credo's LongQuoteBlocks caps
+  # it at 150 lines — it sat at exactly 150 before this pair moved out.
+
+  @doc """
+  The mount session a browser hands `VutuvWeb.ShellLive`.
+
+  A real, active session's raw token under `"session_token"` — the only
+  identity key the shell trusts (issue #1036), so a test drives it the way a
+  request does instead of curating a map (the curated map is the *production*
+  path, `VutuvWeb.LayoutHTML.shell_session/1`). `alert: false` keeps the
+  new-device security notice out of the test's mailbox.
+
+  `extra` carries the non-identity keys the shell reads straight from the
+  session — `"path"`, `"locale"`, `"acting_as_organization_id"`.
+  """
+  def shell_session(user, extra \\ %{}) do
+    {token, _session} =
+      Vutuv.Sessions.start_session(user, Phoenix.ConnTest.build_conn(), alert: false)
+
+    Map.merge(%{"session_token" => token}, extra)
+  end
+
+  @doc """
+  True when the `<input type="checkbox" name=name>` in `html` is rendered
+  checked, regardless of attribute order.
+
+  The assertion a form's default state needs: a box that submits "true" only
+  because it is pre-ticked is a different product decision from one the member
+  has to find and click.
+  """
+  def checkbox_checked?(html, name) do
+    regex = ~r/<input(?=[^>]*\btype="checkbox")(?=[^>]*\bname="#{Regex.escape(name)}")[^>]*>/
+
+    case Regex.run(regex, html) do
+      [tag] -> tag =~ "checked"
+      _ -> false
     end
   end
 

--- a/test/vutuv_web/live/browser_tab_teaser_test.exs
+++ b/test/vutuv_web/live/browser_tab_teaser_test.exs
@@ -23,7 +23,6 @@ defmodule VutuvWeb.BrowserTabTeaserTest do
   alias Vutuv.Fediverse.Follow
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Posts
-  alias Vutuv.Sessions
   alias Vutuv.Social
 
   @app_js "assets/js/app.js"
@@ -51,10 +50,8 @@ defmodule VutuvWeb.BrowserTabTeaserTest do
   # TabBadge hook reports on connect: the server refuses to spend a lookup
   # until it hears that the member is looking somewhere else.
   defp tab(conn, user, hidden? \\ true) do
-    {token, _session} = Sessions.start_session(user, build_conn(), alert: false)
-
     {:ok, view, _html} =
-      live_isolated(conn, VutuvWeb.ShellLive, session: %{"session_token" => token})
+      live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
     render_hook(view, "tab:visibility", %{"hidden" => hidden?})
     view
@@ -267,10 +264,8 @@ defmodule VutuvWeb.BrowserTabTeaserTest do
 
       # No `tab:visibility` at all — the state a reconnected tab is in until it
       # reports again, and the reason the hook must report on `reconnected()`.
-      {token, _session} = Sessions.start_session(user, build_conn(), alert: false)
-
       {:ok, view, _html} =
-        live_isolated(conn, VutuvWeb.ShellLive, session: %{"session_token" => token})
+        live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
       {:ok, _post} = Posts.create_post(author, %{body: "nach dem Reconnect"})
 

--- a/test/vutuv_web/live/reference_check_live_test.exs
+++ b/test/vutuv_web/live/reference_check_live_test.exs
@@ -20,14 +20,11 @@ defmodule VutuvWeb.ReferenceCheckLiveTest do
   alias Vutuv.References.Check
   alias Vutuv.References.Checks
   alias Vutuv.Repo
-  alias Vutuv.Sessions
   alias VutuvWeb.JobReferenceHTML
 
   defp mount_panel(conn, user, reference) do
-    {token, _session} = Sessions.start_session(user, conn, alert: false)
-
     live_isolated(conn, VutuvWeb.ReferenceCheckLive,
-      session: %{"session_token" => token, "job_reference_id" => reference.id}
+      session: shell_session(user, %{"job_reference_id" => reference.id})
     )
   end
 

--- a/test/vutuv_web/live/section_reorder_live_test.exs
+++ b/test/vutuv_web/live/section_reorder_live_test.exs
@@ -18,17 +18,9 @@ defmodule VutuvWeb.SectionReorderLiveTest do
   alias Vutuv.Profiles.Url
   alias Vutuv.Sessions
 
-  # A real active session for the owner: the tool authenticates from the
-  # cookie's session_token the way the embedded child sees it at mount, not a
-  # page-supplied user_id.
-  defp session_for(conn, user, extra) do
-    {token, _session} = Sessions.start_session(user, conn, alert: false)
-    Map.merge(%{"session_token" => token}, extra)
-  end
-
   defp mount_tool(conn, user, section) do
     live_isolated(conn, VutuvWeb.SectionReorderLive,
-      session: session_for(conn, user, %{"section" => section, "slug" => user.username})
+      session: shell_session(user, %{"section" => section, "slug" => user.username})
     )
   end
 
@@ -210,7 +202,7 @@ defmodule VutuvWeb.SectionReorderLiveTest do
       a = insert(:url, user: user, position: 1)
       b = insert(:url, user: user, position: 2)
 
-      session = session_for(conn, user, %{"section" => "links", "slug" => user.username})
+      session = shell_session(user, %{"section" => "links", "slug" => user.username})
 
       Repo.update_all(from(u in Vutuv.Accounts.User, where: u.id == ^user.id),
         set: [suspended_until: NaiveDateTime.add(NaiveDateTime.utc_now(:second), 86_400)]

--- a/test/vutuv_web/live/shell_live_browser_notifications_test.exs
+++ b/test/vutuv_web/live/shell_live_browser_notifications_test.exs
@@ -23,16 +23,10 @@ defmodule VutuvWeb.ShellLiveBrowserNotificationsTest do
   @push_timeout 2_000
 
   alias Vutuv.Activity
-  alias Vutuv.Sessions
-
-  defp session_for(user, extra) do
-    {token, _session} = Sessions.start_session(user, build_conn(), alert: false)
-    Map.merge(%{"session_token" => token}, extra)
-  end
 
   defp mount_shell(conn, user, session_extra \\ %{}) do
     {:ok, view, _html} =
-      live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user, session_extra))
+      live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user, session_extra))
 
     view
   end

--- a/test/vutuv_web/live/shell_live_presence_test.exs
+++ b/test/vutuv_web/live/shell_live_presence_test.exs
@@ -13,22 +13,12 @@ defmodule VutuvWeb.ShellLivePresenceTest do
 
   import Phoenix.LiveViewTest
 
-  alias Vutuv.Sessions
   alias VutuvWeb.Presence
-
-  # The shell authenticates the live socket from the cookie's session_token
-  # (issue #1036) and reads "Show when I'm online" off the resolved user, not a
-  # curated key — so a test drives it with a real active session and sets the
-  # member's `show_online_status?` field to control tracking.
-  defp session_for(user, extra \\ %{}) do
-    {token, _session} = Sessions.start_session(user, build_conn(), alert: false)
-    Map.merge(%{"session_token" => token}, extra)
-  end
 
   test "tracks the member online and pushes them in the online set", %{conn: conn} do
     user = insert(:user)
 
-    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
     assert Presence.online?(Presence.online_ids(), user.id)
 
@@ -45,7 +35,7 @@ defmodule VutuvWeb.ShellLivePresenceTest do
     user = insert(:user, show_online_status?: false)
 
     {:ok, view, _html} =
-      live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+      live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
     refute Presence.online?(Presence.online_ids(), user.id)
     # No dot on their own avatar either.
@@ -62,7 +52,7 @@ defmodule VutuvWeb.ShellLivePresenceTest do
     agent = start_supervised!({Agent, fn -> :ok end})
     {:ok, _ref} = Presence.track_user(agent, blocked.id)
 
-    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(viewer))
+    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(viewer))
 
     assert Presence.online?(Presence.online_ids(), blocked.id)
 
@@ -73,7 +63,7 @@ defmodule VutuvWeb.ShellLivePresenceTest do
 
   test "a presence join re-pushes the viewer's online set live", %{conn: conn} do
     viewer = insert(:user)
-    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(viewer))
+    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(viewer))
     assert_push_event(view, "presence:set", %{online: _first})
 
     # Another member comes online; the shell re-pushes the (now larger) set.
@@ -108,7 +98,7 @@ defmodule VutuvWeb.ShellLivePresenceTest do
 
   test "a live opt-out untracks the member and drops their own dot", %{conn: conn} do
     user = insert(:user)
-    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
     assert Presence.online?(Presence.online_ids(), user.id)
 
     # The member flips "Show when I'm online" off (broadcast from another tab).
@@ -123,7 +113,7 @@ defmodule VutuvWeb.ShellLivePresenceTest do
     user = insert(:user, show_online_status?: false)
 
     {:ok, view, _html} =
-      live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+      live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
     refute Presence.online?(Presence.online_ids(), user.id)
 
@@ -141,7 +131,7 @@ defmodule VutuvWeb.ShellLivePresenceTest do
     agent = start_supervised!({Agent, fn -> :ok end})
     {:ok, _ref} = Presence.track_user(agent, other.id)
 
-    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(viewer))
+    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(viewer))
     assert_push_event(view, "presence:set", %{online: before_ids})
     assert to_string(other.id) in before_ids
 

--- a/test/vutuv_web/live/shell_live_test.exs
+++ b/test/vutuv_web/live/shell_live_test.exs
@@ -8,16 +8,6 @@ defmodule VutuvWeb.ShellLiveTest do
   @bell_badge ~s(a[title="Notifications"] span.bg-accent)
   @mail_badge ~s(a[title="Messages"] span.bg-accent)
 
-  # The shell authenticates the live socket from the cookie's session_token
-  # (issue #1036), so a test drives it with a real active session and reads the
-  # chrome back from the resolved user, not a curated map. `extra` still carries
-  # the non-identity keys the shell reads straight from the session (`path`,
-  # `locale`); any leftover curated identity key is simply ignored now.
-  defp session_for(user, extra \\ %{}) do
-    {token, _session} = Sessions.start_session(user, build_conn(), alert: false)
-    Map.merge(%{"session_token" => token}, extra)
-  end
-
   # The member whose name/handle the chrome assertions below expect. This module
   # is synchronous, so the fixed "stefan" handle is safe (no async file mints it
   # at the same time).
@@ -44,7 +34,7 @@ defmodule VutuvWeb.ShellLiveTest do
 
   test "renders the shell nav with the real unread notification count", %{conn: conn} do
     user = user_with_unread_notification()
-    {:ok, view, html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+    {:ok, view, html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
     assert html =~ "vutuv"
     assert has_element?(view, "#app-shell")
@@ -55,7 +45,7 @@ defmodule VutuvWeb.ShellLiveTest do
 
   test "renders the real unread conversation count", %{conn: conn} do
     user = with_unread_message(insert(:user))
-    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
     assert has_element?(view, @mail_badge, "1")
   end
@@ -66,7 +56,7 @@ defmodule VutuvWeb.ShellLiveTest do
     # On the messages page itself the badge deliberately starts at zero.
     {:ok, on_page, _} =
       live_isolated(conn, VutuvWeb.ShellLive,
-        session: session_for(user, %{"path" => "/messages"})
+        session: shell_session(user, %{"path" => "/messages"})
       )
 
     refute has_element?(on_page, @mail_badge)
@@ -75,7 +65,7 @@ defmodule VutuvWeb.ShellLiveTest do
     # so the real unread count must still show.
     {:ok, on_profile, _} =
       live_isolated(conn, VutuvWeb.ShellLive,
-        session: session_for(user, %{"path" => "/messagesanna"})
+        session: shell_session(user, %{"path" => "/messagesanna"})
       )
 
     assert has_element?(on_profile, @mail_badge, "1")
@@ -83,7 +73,7 @@ defmodule VutuvWeb.ShellLiveTest do
 
   test "the messages badge counts unread conversations, not message events", %{conn: conn} do
     user = with_unread_message(insert(:user))
-    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
     assert has_element?(view, @mail_badge, "1")
 
@@ -105,7 +95,7 @@ defmodule VutuvWeb.ShellLiveTest do
     {:ok, _} = Vutuv.Chat.send_message(other, conversation.id, "unread ping")
     with_unread_message(user)
 
-    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
     assert has_element?(view, @mail_badge, "2")
 
     # The member opens conversation one: MessageLive marks it read and
@@ -123,7 +113,7 @@ defmodule VutuvWeb.ShellLiveTest do
     conversation = insert_conversation_between(other, user)
     {:ok, _} = Vutuv.Chat.send_message(other, conversation.id, "unread ping")
 
-    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
     assert has_element?(view, @mail_badge, "1")
 
     Vutuv.Chat.mark_read(user, conversation.id)
@@ -136,7 +126,7 @@ defmodule VutuvWeb.ShellLiveTest do
     user = user_with_unread_notification()
     Vutuv.Activity.mark_notifications_read(user.id)
 
-    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
     refute has_element?(view, @bell_badge)
   end
@@ -146,7 +136,7 @@ defmodule VutuvWeb.ShellLiveTest do
       # On /feed the logo would only round-trip through "/" back to the feed,
       # so there it deep-links to the member's own profile instead.
       user = stefan()
-      session = session_for(user, %{"path" => "/feed"})
+      session = shell_session(user, %{"path" => "/feed"})
       {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session)
 
       assert has_element?(view, ~s(header a[data-brand][href="/stefan"]), "vutuv")
@@ -154,7 +144,7 @@ defmodule VutuvWeb.ShellLiveTest do
 
     test "stays the home link on every other page", %{conn: conn} do
       user = insert(:user)
-      session = session_for(user, %{"path" => "/search"})
+      session = shell_session(user, %{"path" => "/search"})
       {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session)
 
       assert has_element?(view, ~s(header a[data-brand][href="/"]), "vutuv")
@@ -186,7 +176,7 @@ defmodule VutuvWeb.ShellLiveTest do
 
   test "shows the user's avatar in the top bar when they have one", %{conn: conn} do
     user = stefan(avatar: "me.jpg")
-    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
     assert has_element?(view, ~s(summary[title="Stefan Wintermeyer"] img))
     refute has_element?(view, ~s(summary[title="Stefan Wintermeyer"]), "SW")
@@ -194,7 +184,7 @@ defmodule VutuvWeb.ShellLiveTest do
 
   test "falls back to initials when the user has no avatar", %{conn: conn} do
     user = stefan()
-    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
     assert has_element?(view, ~s(summary[title="Stefan Wintermeyer"]), "SW")
     refute has_element?(view, ~s(summary[title="Stefan Wintermeyer"] img))
@@ -210,7 +200,7 @@ defmodule VutuvWeb.ShellLiveTest do
         username: "anna-schmidt"
       )
 
-    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
     assert has_element?(view, ~s(summary[title="Dr. Anna Schmidt"]), "AS")
     refute has_element?(view, ~s(summary[title="Dr. Anna Schmidt"]), "DA")
@@ -218,7 +208,7 @@ defmodule VutuvWeb.ShellLiveTest do
 
   test "the avatar opens an account menu linking to every account area", %{conn: conn} do
     user = stefan()
-    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
     menu = "details[data-account-menu]"
     assert has_element?(view, menu)
@@ -292,7 +282,7 @@ defmodule VutuvWeb.ShellLiveTest do
       # obvious; a named "Profile" nav item makes the member's own profile a
       # first-class, discoverable destination.
       user = stefan()
-      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
       assert has_element?(view, ~s(nav a[data-nav-profile][href="/stefan"]), "Profile")
     end
@@ -301,7 +291,7 @@ defmodule VutuvWeb.ShellLiveTest do
       # Desktop is not the only surface: the bottom tab bar gets a Profile tab
       # too, so phone visitors can reach their profile without hunting for it.
       user = stefan()
-      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
       assert has_element?(view, ~s(nav a[data-mobile-profile][href="/stefan"]), "Profile")
       # Five tabs now (Feed, Search, Messages, Alerts, Profile), so the grid grows.
@@ -325,7 +315,9 @@ defmodule VutuvWeb.ShellLiveTest do
       user = insert(:user)
 
       {:ok, view, _html} =
-        live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user, %{"path" => "/feed"}))
+        live_isolated(conn, VutuvWeb.ShellLive,
+          session: shell_session(user, %{"path" => "/feed"})
+        )
 
       assert has_element?(view, ~s(nav a[href="/feed"][aria-current="page"]), "Feed")
       # No other nav item claims to be the current page.
@@ -340,7 +332,7 @@ defmodule VutuvWeb.ShellLiveTest do
 
       for path <- ["/stefan", "/stefan/tags"] do
         {:ok, view, _html} =
-          live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user, %{"path" => path}))
+          live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user, %{"path" => path}))
 
         assert has_element?(view, ~s(a[data-nav-profile][aria-current="page"]))
         assert has_element?(view, ~s(a[data-mobile-profile][aria-current="page"]))
@@ -353,7 +345,9 @@ defmodule VutuvWeb.ShellLiveTest do
       user = insert(:user)
 
       {:ok, view, _html} =
-        live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user, %{"path" => "/anna"}))
+        live_isolated(conn, VutuvWeb.ShellLive,
+          session: shell_session(user, %{"path" => "/anna"})
+        )
 
       refute has_element?(view, ~s(a[data-nav-profile][aria-current="page"]))
       refute has_element?(view, ~s(a[data-mobile-profile][aria-current="page"]))
@@ -364,7 +358,7 @@ defmodule VutuvWeb.ShellLiveTest do
 
       for path <- ["/jobs", "/jobs/some-posting-slug"] do
         {:ok, view, _html} =
-          live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user, %{"path" => path}))
+          live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user, %{"path" => path}))
 
         assert has_element?(view, ~s(nav a[href="/jobs"][aria-current="page"]), "Jobs")
       end
@@ -375,7 +369,7 @@ defmodule VutuvWeb.ShellLiveTest do
 
       {:ok, view, _html} =
         live_isolated(conn, VutuvWeb.ShellLive,
-          session: session_for(user, %{"path" => "/messages"})
+          session: shell_session(user, %{"path" => "/messages"})
         )
 
       assert has_element?(view, ~s(nav a[href="/messages"][aria-current="page"]))
@@ -387,14 +381,16 @@ defmodule VutuvWeb.ShellLiveTest do
 
       # /jobsy merely BEGINS with "/jobs"; it is not the jobs section.
       {:ok, view, _html} =
-        live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user, %{"path" => "/jobsy"}))
+        live_isolated(conn, VutuvWeb.ShellLive,
+          session: shell_session(user, %{"path" => "/jobsy"})
+        )
 
       refute has_element?(view, ~s(nav a[aria-current="page"]))
     end
 
     test "with no known path nothing is marked active", %{conn: conn} do
       user = insert(:user)
-      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
       refute has_element?(view, ~s(nav a[aria-current="page"]))
     end
@@ -433,7 +429,9 @@ defmodule VutuvWeb.ShellLiveTest do
       user = insert(:user)
 
       {:ok, view, _html} =
-        live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user, %{"path" => "/feed"}))
+        live_isolated(conn, VutuvWeb.ShellLive,
+          session: shell_session(user, %{"path" => "/feed"})
+        )
 
       assert has_element?(view, ~s(nav[data-nav-bar="tabs"] a[href="/feed"][data-scroll-top]))
       assert has_element?(view, ~s(a[data-scroll-top] svg[data-tab-icon="feed"]))
@@ -458,7 +456,9 @@ defmodule VutuvWeb.ShellLiveTest do
       user = insert(:user)
 
       {:ok, view, _html} =
-        live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user, %{"path" => "/feed"}))
+        live_isolated(conn, VutuvWeb.ShellLive,
+          session: shell_session(user, %{"path" => "/feed"})
+        )
 
       doc = view |> render() |> LazyHTML.from_fragment()
 
@@ -483,7 +483,7 @@ defmodule VutuvWeb.ShellLiveTest do
 
       {:ok, view, _html} =
         live_isolated(conn, VutuvWeb.ShellLive,
-          session: session_for(user, %{"path" => "/search"})
+          session: shell_session(user, %{"path" => "/search"})
         )
 
       refute has_element?(view, ~s(a[data-scroll-top]))
@@ -497,7 +497,9 @@ defmodule VutuvWeb.ShellLiveTest do
       user = insert(:user)
 
       {:ok, view, _html} =
-        live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user, %{"path" => "/feed"}))
+        live_isolated(conn, VutuvWeb.ShellLive,
+          session: shell_session(user, %{"path" => "/feed"})
+        )
 
       marked =
         view
@@ -556,7 +558,7 @@ defmodule VutuvWeb.ShellLiveTest do
         set: [suspended_until: NaiveDateTime.add(NaiveDateTime.utc_now(:second), 86_400)]
       )
 
-      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
       assert has_element?(view, "a", "Log in")
       refute has_element?(view, @bell_badge)
@@ -587,7 +589,7 @@ defmodule VutuvWeb.ShellLiveTest do
     conn: conn
   } do
     user = user_with_unread_notification()
-    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
     assert has_element?(view, @bell_badge, "1")
 
     # A second real unread event lands, then the push notification announces it.
@@ -609,7 +611,7 @@ defmodule VutuvWeb.ShellLiveTest do
     connect!(recipient, other)
 
     {:ok, view, _html} =
-      live_isolated(conn, VutuvWeb.ShellLive, session: session_for(recipient))
+      live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(recipient))
 
     # Seeded from the DB: a new follower plus the derived connection event.
     assert has_element?(view, @bell_badge)
@@ -628,7 +630,7 @@ defmodule VutuvWeb.ShellLiveTest do
     conn: conn
   } do
     user = with_unread_message(user_with_unread_notification())
-    session = session_for(user, %{"path" => "/notifications"})
+    session = shell_session(user, %{"path" => "/notifications"})
     {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session)
 
     refute has_element?(view, @bell_badge)
@@ -638,7 +640,7 @@ defmodule VutuvWeb.ShellLiveTest do
 
   test "marking notifications read clears the notification badge", %{conn: conn} do
     user = with_unread_message(user_with_unread_notification())
-    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
     send(view.pid, :notifications_read)
 
@@ -654,7 +656,7 @@ defmodule VutuvWeb.ShellLiveTest do
   describe "browser-tab title badge" do
     test "carries the tab-badge hook only for a logged-in member", %{conn: conn} do
       user = insert(:user)
-      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
       assert has_element?(view, "#tab-badge[phx-hook='TabBadge']")
 
       {:ok, anon, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: %{})
@@ -663,7 +665,7 @@ defmodule VutuvWeb.ShellLiveTest do
 
     test "pushes the unread total to the hook on connect", %{conn: conn} do
       user = with_unread_message(user_with_unread_notification())
-      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
       # one unread notification + one unread conversation
       assert_push_event(view, "tab:badge", %{unread: 2})
@@ -671,7 +673,7 @@ defmodule VutuvWeb.ShellLiveTest do
 
     test "re-pushes a raised total when a message arrives", %{conn: conn} do
       user = user_with_unread_notification()
-      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
       assert_push_event(view, "tab:badge", %{unread: 1})
 
       with_unread_message(user)
@@ -681,7 +683,7 @@ defmodule VutuvWeb.ShellLiveTest do
 
     test "re-pushes a lowered total when notifications are read", %{conn: conn} do
       user = with_unread_message(user_with_unread_notification())
-      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
       assert_push_event(view, "tab:badge", %{unread: 2})
 
       send(view.pid, :notifications_read)
@@ -691,7 +693,7 @@ defmodule VutuvWeb.ShellLiveTest do
 
     test "a new feed post from someone else nudges the tab title", %{conn: conn} do
       user = insert(:user)
-      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
       send(
         view.pid,
@@ -705,7 +707,7 @@ defmodule VutuvWeb.ShellLiveTest do
       # broadcast_to_followers/2 also delivers {:new_post} to the author, so the
       # shell must ignore a post it wrote itself.
       user = insert(:user)
-      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
       send(view.pid, {:new_post, %{post_id: Vutuv.UUIDv7.generate(), author_id: user.id}})
       refute_push_event(view, "tab:new_post", %{})
@@ -720,8 +722,6 @@ defmodule VutuvWeb.ShellLiveTest do
 
     # The admin pill is now gated on the resolved user's own admin flag (issue
     # #1036), not a curated session key, so the socket must resolve a real admin.
-    defp admin_session(user), do: session_for(user)
-
     defp admin, do: insert(:user, admin?: true)
 
     defp joined_today(count) do
@@ -735,7 +735,7 @@ defmodule VutuvWeb.ShellLiveTest do
       joined_today(2)
 
       {:ok, view, _html} =
-        live_isolated(conn, VutuvWeb.ShellLive, session: admin_session(admin()))
+        live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(admin()))
 
       assert has_element?(view, @pill, "2")
     end
@@ -744,7 +744,7 @@ defmodule VutuvWeb.ShellLiveTest do
       joined_today(2)
 
       {:ok, view, _html} =
-        live_isolated(conn, VutuvWeb.ShellLive, session: session_for(insert(:user)))
+        live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(insert(:user)))
 
       refute has_element?(view, @pill)
     end
@@ -754,7 +754,7 @@ defmodule VutuvWeb.ShellLiveTest do
       insert(:activated_user, inserted_at: day_start, updated_at: day_start)
 
       {:ok, view, _html} =
-        live_isolated(conn, VutuvWeb.ShellLive, session: admin_session(admin()))
+        live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(admin()))
 
       refute has_element?(view, @pill)
     end
@@ -771,7 +771,7 @@ defmodule VutuvWeb.ShellLiveTest do
       mounted = Vutuv.PeopleCounter.counts()
 
       {:ok, view, _html} =
-        live_isolated(conn, VutuvWeb.ShellLive, session: admin_session(admin()))
+        live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(admin()))
 
       refute has_element?(view, @pill)
 
@@ -792,7 +792,7 @@ defmodule VutuvWeb.ShellLiveTest do
 
     test "names the exact figure in the viewer's language", %{conn: conn} do
       joined_today(1)
-      session = admin_session(admin())
+      session = shell_session(admin())
 
       {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session)
       assert has_element?(view, ~s(#{@pill}[title="1 new member today"]))
@@ -809,7 +809,7 @@ defmodule VutuvWeb.ShellLiveTest do
       joined_today(1)
 
       {:ok, view, _html} =
-        live_isolated(conn, VutuvWeb.ShellLive, session: admin_session(admin()))
+        live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(admin()))
 
       assert has_element?(view, "#{@pill}.text-sm")
       refute has_element?(view, "#{@pill}.text-xs")
@@ -819,7 +819,7 @@ defmodule VutuvWeb.ShellLiveTest do
       joined_today(1)
 
       {:ok, view, _html} =
-        live_isolated(conn, VutuvWeb.ShellLive, session: admin_session(admin()))
+        live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(admin()))
 
       assert has_element?(view, @pill, "1")
 
@@ -849,7 +849,7 @@ defmodule VutuvWeb.ShellLiveTest do
 
     test "ticks the exact total up when the counter broadcasts a new value", %{conn: conn} do
       {:ok, view, _html} =
-        live_isolated(conn, VutuvWeb.ShellLive, session: session_for(insert(:user)))
+        live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(insert(:user)))
 
       broadcast_total(60_123)
 
@@ -966,7 +966,7 @@ defmodule VutuvWeb.ShellLiveTest do
 
     test "holds the word back until lg once a member's controls are in the bar", %{conn: conn} do
       {:ok, view, _html} =
-        live_isolated(conn, VutuvWeb.ShellLive, session: session_for(insert(:user)))
+        live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(insert(:user)))
 
       broadcast_total(60_123)
 

--- a/test/vutuv_web/organization_message_badge_test.exs
+++ b/test/vutuv_web/organization_message_badge_test.exs
@@ -11,6 +11,12 @@ defmodule VutuvWeb.OrganizationMessageBadgeTest do
   a badge that is right on load and then frozen looks *worse* than one that is
   always zero, because it invites you to trust it.
 
+  Every test mounts the shell with `live_isolated/3`: it is a nested
+  `live_render` inside the page layout, so a `live/2` on any route would hand
+  back the PAGE's LiveView and `send(view.pid, …)` would reach the wrong
+  process. It is also the honest unit — what is under test is the shell's own
+  count, not the feed's markup.
+
   `async: false` because the organization helpers flip the global
   `:verify_organization_domains` flag, and because the shell writes to the
   global `VutuvWeb.Presence` topic.
@@ -22,7 +28,6 @@ defmodule VutuvWeb.OrganizationMessageBadgeTest do
 
   alias Vutuv.Chat
   alias Vutuv.Organizations
-  alias Vutuv.Sessions
 
   # The same selector the member-side shell tests use.
   @mail_badge ~s(a[title="Messages"] span.bg-accent)
@@ -38,14 +43,8 @@ defmodule VutuvWeb.OrganizationMessageBadgeTest do
     :ok
   end
 
-  # The shell is a nested `live_render` inside the page layout, so a `live/2` on
-  # any route hands back the PAGE's LiveView, not this one - `send(view.pid, …)`
-  # would reach the wrong process. Mounting it isolated is also the honest unit:
-  # what is under test is the shell's own count, not the feed's markup.
-  defp session_for(user, extra \\ %{}) do
-    {token, _session} = Sessions.start_session(user, build_conn(), alert: false)
-    Map.merge(%{"session_token" => token, "path" => "/feed"}, extra)
-  end
+  # The page every mount below is drawn on, as the browser would report it.
+  @on_feed %{"path" => "/feed"}
 
   defp page_with_publisher do
     owner = insert_activated_user()
@@ -56,7 +55,7 @@ defmodule VutuvWeb.OrganizationMessageBadgeTest do
 
   # The session a publisher's browser carries while switched into the page.
   defp speaking_as(user, page),
-    do: session_for(user, %{"acting_as_organization_id" => page.id})
+    do: shell_session(user, Map.put(@on_feed, "acting_as_organization_id", page.id))
 
   test "the count is the page's inbox, not the publisher's own", %{conn: conn} do
     {page, owner} = page_with_publisher()
@@ -80,7 +79,7 @@ defmodule VutuvWeb.OrganizationMessageBadgeTest do
 
     # Themselves: their own two.
     {:ok, own_shell, _html} =
-      live_isolated(conn, VutuvWeb.ShellLive, session: session_for(owner))
+      live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(owner, @on_feed))
 
     assert has_element?(own_shell, @mail_badge, "2")
 
@@ -139,7 +138,9 @@ defmodule VutuvWeb.OrganizationMessageBadgeTest do
     {:ok, conversation} = Chat.find_or_create_conversation(other, me)
     {:ok, _} = Chat.send_message(other, conversation.id, "Hallo.")
 
-    {:ok, shell, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(me))
+    {:ok, shell, _html} =
+      live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(me, @on_feed))
+
     assert has_element?(shell, @mail_badge, "1")
   end
 


### PR DESCRIPTION
**Symptom:** the mount session for the off-router `live_render` children — the `"session_token"` key and the `alert: false` flag — was spelled out in seven test files. A change to `Vutuv.Sessions.start_session/3` meant seven edits.

**Change:** one `shell_session(user, extra \\ %{})` in `test/support/conn_case.ex`, called by all seven — `ShellLive`, `SectionReorderLive` and `ReferenceCheckLive` alike. Per-file defaults stay at the call site. `checkbox_checked?/2` moves out of the `using` quote with it: the quote sat at exactly credo's 150-line `LongQuoteBlocks` ceiling, so nothing could be added. Both are plain functions on `ConnCase` now, imported the way `Vutuv.DataCase` does with `errors_on/1`.

**Not included:** `ignore_comments: true` on that credo check would give the quote ~44 lines back, but it is repo-wide config.

**Verified:** test-only, no behaviour change. `mix precommit` gates green; the ten affected test files 259/259.

Closes #1779.
