### PR TITLE
Member directory lists everyone, with a live name search

### DIFF
--- a/docs/architecture/agents-and-seo.md
+++ b/docs/architecture/agents-and-seo.md
@@ -224,14 +224,67 @@ because every report here describes the site as it was at the last crawl.
 
 ## Member directory (`/system/members`)
 
-The crawlable A-Z index of every member whose profile is open to search engines
-— the same set `/sitemap.xml` advertises (`Vutuv.Directory` owns that one
-definition).
+The browsable A-Z index of **every** listed member, and the crawl surface for
+search engines that follow links rather than reading `/sitemap.xml`.
 
 An overview of letter tiles with counts plus one page per last-name initial,
 paginated at 50 members per page (accents folded, DIN 5007; names without a
 letter share an "other" bucket), linked in the footer of every page, so
-link-following crawlers and humans reach every indexable profile.
+link-following crawlers and humans reach every profile.
+
+`Vutuv.Directory` holds two member sets apart, and the difference is the point.
+`listed_users/0` — confirmed, not moderation-hidden — is what the directory
+shows. `indexable_users/0` is that set minus the search-engine opt-out
+(`noindex?`), and it is what `/sitemap.xml` advertises. Until v7.407.0 the
+directory used the second for both, so a member who had opted out of search
+engines was missing from the one page whose job is to help somebody find them —
+while `/search`, the most-followed listing and every follower list had listed
+them all along. The directory was the outlier, not the rule.
+
+What the opt-out buys now is `rel="nofollow"` on that member's row
+(`UserHelpers.profile_rel/1`, applied in the shared `card_list` and `user_row`
+and in the two public member lists that build their own rows, `/:slug/connections`
+and `/:slug/tags/:id/endorsers`) plus their absence from the sitemap and the
+`X-Robots-Tag: noindex` their profile already answers with. `noindex?` rides in
+`User.listing_fields/0` so a listing row can decide its own `rel` without a
+second query — left out, the struct would carry the schema default `false` and
+the link would fail *open*.
+
+### The search box
+
+`VutuvWeb.DirectorySearchLive`, embedded into the overview with `live_render`
+so `DirectoryController` keeps owning the agent-format siblings. A **field**
+search rather than the free-text page at `/search`: a case-insensitive
+substring in first name, last name and username, OR-ed across whichever of the
+three checkboxes are ticked, with every word of a multi-word query having to
+match some ticked field ("anna mei" and "mei anna" both find Anna Meier).
+
+All three boxes start ticked and unticking the last one ticks all three again —
+one rule, `Directory.parse_search_fields/1`, applied on every path. Keeping the
+previous selection instead cannot be rendered: `@fields` would not change, so
+the diff would carry nothing for that checkbox and it would stay visibly
+unticked while the server searched as though it were on.
+
+A large result set is revealed in bites of `results_step/0` (25) up to
+`results_ceiling/0` (the site-wide page maximum), with the total stated first;
+past the ceiling the box asks for a narrower query rather than offering another
+press. A pager would be the wrong control here — the next keystroke invalidates
+whichever page you walked to.
+
+Being off-router it cannot `push_patch`, so the box is a real GET form at
+`/system/members`: keystrokes patch results over the socket, Enter lands on a
+shareable `?q=` URL whose dead render shows the same results, and "show more"
+is a `?show=` link until the socket connects. A `?q=` page is stamped
+`noindex` — search results are the hall of mirrors `/search` is noindexed for,
+and here they would additionally publish the names of members who asked to stay
+out of search results. The bare overview stays indexable.
+
+The minimum is three characters, and that number is not arbitrary: pg_trgm
+needs three to form a trigram, so a shorter needle plans a sequential scan of
+`users` whatever indexes exist. `20260828083124_add_users_name_trigram_indexes`
+adds the GIN trigram indexes on the three columns, and the total rides along on
+the rows as a window count rather than as a second `Repo.aggregate/2` — one walk
+of the match set instead of two, on a query a member re-runs at every keystroke.
 
 A letter page files each row under the name it is sorted by ("Özil, Mesut",
 `UserHelpers.filed_name/1`, switched on by the `filed_names` assign the
@@ -240,18 +293,15 @@ Nachname" under a heading of "M" leaves the reader scanning for the word the
 order is built on. The avatar's alt text and the agent docs keep the canonical
 name, so only the visible listing changes.
 
-Members with `noindex?` never appear here or in the sitemap, and their profile
-answers with the robots meta tag *and* an `X-Robots-Tag` header.
-
-The overview prints **one** figure, the count it lists, in a single line that
-also says who is missing from it ("… anyone who does not open their profile to
-search engines is not among them"). It briefly printed three — the listed
+The overview prints **one** figure, the count it lists. It briefly printed three — the listed
 count, the whole membership and the Fediverse head count — and that was one
 number too many for a page whose job is an A-Z index: those two belong to the
 top bar's people pill, which is on this page like on every other (Stefan,
 2026-08-13). The agent formats carry the listed figure as `total` and repeat
 the sentence in the doc description, for the Markdown and text renderings,
-which print no counts of their own.
+which print no counts of their own. Those siblings answer for the directory
+itself and never for a `?q=`: a doc that changed under a query would make the
+canonical URL name a different document every time.
 
 It lives under `/system/` — the one reserved word all future site pages share,
 so new pages stop burning root path words members could have as handles.

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -516,7 +516,11 @@ defmodule Vutuv.Accounts.User do
     # :profile_work_experience_id is loaded so a listing row's work line reflects
     # a member's pinned profile job title (issue #833) via work_information_map/2,
     # not just the automatic heuristic.
-    ~w(id first_name last_name honorific_prefix honorific_suffix username avatar avatar_fingerprint updated_at profile_work_experience_id)a
+    # :noindex? is loaded because a listing row links the profile
+    # `rel="nofollow"` for a member who opted out of search engines
+    # (VutuvWeb.UserHelpers.profile_rel/1). Left out, the struct would carry the
+    # schema default `false` and the link would silently fail open.
+    ~w(id first_name last_name honorific_prefix honorific_suffix username avatar avatar_fingerprint updated_at profile_work_experience_id noindex?)a
   end
 
   # :username is deliberately NOT here: the username is unique, rate-limited

--- a/lib/vutuv/directory.ex
+++ b/lib/vutuv/directory.ex
@@ -1,23 +1,35 @@
 defmodule Vutuv.Directory do
   @moduledoc """
-  The public member directory (`/system/members`): the one definition of the
-  **crawlable member set** — activated members who have not opted out of
-  search engines (`noindex?: false`) and are not moderation-hidden — grouped
-  alphabetically for browsing. `Vutuv.Sitemap` advertises the same set to
-  crawlers, so a member appears in the directory exactly when their profile
-  is in the sitemap.
+  The public member directory (`/system/members`): **every** member the site
+  lists publicly — activated, not moderation-hidden — grouped alphabetically
+  for browsing.
+
+  Two sets live here, and the difference is the whole point. `listed_users/0`
+  is what the directory shows: the same gate the most-followed listing, the
+  follower lists and the search page have always used, so the directory no
+  longer hides members those pages have listed all along.
+  `indexable_users/0` is the narrower **crawlable** set (`noindex?: false`)
+  that `Vutuv.Sitemap` advertises and that decides whether a directory row
+  links its profile `rel="nofollow"` — an opted-out member is listed for
+  people, and crawlers are told not to walk through to the profile.
 
   Members are filed by **last name** (first name only as a fallback), with
   accents folded into their base letter so Özil sorts under O (DIN 5007);
   names that start with no letter at all share the `"other"` bucket. The
   bucket expression lives in SQL so the letter pages paginate in the
   database (`Vutuv.Pages`), like every other browse page.
+
+  `search/3` is the other half of the page: the alphabet answers "who is filed
+  under M", a search box answers "where is Müller", which is what somebody
+  arriving with a name in mind actually types.
   """
 
   import Ecto.Query
   import Vutuv.Moderation.Query
+  import Vutuv.SearchText, only: [contains: 1, normalize_search: 1]
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Pages
   alias Vutuv.Repo
 
   @letters Enum.map(?a..?z, &<<&1>>)
@@ -29,6 +41,32 @@ defmodule Vutuv.Directory do
   # a directory page is browsed, not scanned once, so short pages with a
   # visible pager beat one endless scroll.
   @per_page 50
+
+  # What the search box looks in, in checkbox order. Also the allowlist the
+  # `fields` param is read through — never `String.to_atom/1` on a URL value.
+  @search_fields [:first_name, :last_name, :username]
+
+  # Three, like `Vutuv.Search.min_chars/0`, and for a reason that is not
+  # symmetry: pg_trgm needs three characters to form a trigram, so a shorter
+  # needle plans a sequential scan of `users` whatever indexes exist (measured
+  # 27.1 ms against 1.3 ms on a 100k-row copy). Two would make the very first
+  # query past the minimum the most expensive one on the page and the one most
+  # likely to match half the membership.
+  @min_query_chars 3
+
+  # A search reveals its results in bites rather than as one wall, and stops
+  # growing well before a page becomes unreadable: past the ceiling the answer
+  # is another letter in the box, not another press.
+  @results_step 25
+
+  # The rows a listing row actually renders, plus the headline
+  # `work_information_map/2` falls back to — `users` carries ~98 columns and a
+  # search fetches up to `results_ceiling/0` rows per keystroke, so selecting
+  # the whole struct would move ~1.5 KB per row where ~150 bytes will do. The
+  # same projection `Vutuv.Search` and the most-followed listing use for the
+  # same `card_list` template; `noindex?` rides in it, which is what lets
+  # `UserHelpers.profile_rel/1` decide the row's `rel` without a second query.
+  @listing_fields [:headline | User.listing_fields()]
 
   # ascii() is deliberate: BETWEEN 'a' AND 'z' would be collation-dependent
   # (an ICU locale sorts 'ä' inside that range), while the code-point check
@@ -101,18 +139,170 @@ defmodule Vutuv.Directory do
   def per_page, do: @per_page
 
   @doc """
-  The crawlable member set: activated, indexable (`noindex?: false`), not
-  moderation-hidden. The shared base of the directory pages and the
-  sitemap's member/post entries (`Vutuv.Sitemap`).
+  The listed member set: activated and not moderation-hidden — what the
+  directory shows. `account_confirmed_row/1` is the shared confirmed-member
+  gate every other listing query uses: it treats a legacy NULL flag as
+  confirmed, so the directory lists the same members as the most-followed
+  listing, the follower lists and search rather than hand-rolling a stricter
+  `u.email_confirmed?` test here.
+  """
+  def listed_users do
+    from(u in User, where: account_confirmed_row(u) and not account_hidden_row(u))
+  end
+
+  @doc """
+  The crawlable subset of `listed_users/0`: members who did not opt out of
+  search engines (`noindex?: false`). What `Vutuv.Sitemap` advertises, and
+  the line the directory's `rel="nofollow"` is drawn along — an opted-out
+  member is listed for people to browse, and crawlers are asked not to walk
+  through the row to the profile.
   """
   def indexable_users do
-    # account_confirmed_row/1 is the shared confirmed-member gate every other
-    # listing query uses: it treats a legacy NULL flag as confirmed, so the
-    # crawlable set matches the rest of the app rather than hand-rolling a
-    # stricter `u.email_confirmed?` test here.
-    from(u in User,
-      where: account_confirmed_row(u) and not u.noindex? and not account_hidden_row(u)
-    )
+    where(listed_users(), [u], not u.noindex?)
+  end
+
+  @doc "The fields the search box can look in, in checkbox order."
+  def search_fields, do: @search_fields
+
+  @doc "Shortest query the search box answers; below it, it says so instead."
+  def min_query_chars, do: @min_query_chars
+
+  @doc "How many more results one press of the search box's \"show more\" reveals."
+  def results_step, do: @results_step
+
+  @doc """
+  The most results one search will ever render before asking for a narrower
+  query — the site-wide page maximum, read from `Vutuv.Pages` rather than
+  copied, so an installation that lowers that knob lowers this too.
+  """
+  def results_ceiling, do: Pages.max_page_items()
+
+  @doc """
+  How many rows a search may render, from whatever the request asked for: an
+  integer or the `show` param's string, clamped to `results_ceiling/0`, with
+  anything else (absent, blank, zero, negative, not a number) falling back to
+  one bite.
+
+  One owner rather than a clamp in the query and a second one where the param
+  is read: the ceiling is what stops `?show=100000` from asking Postgres for
+  the whole membership, and a ceiling enforced in two places is a ceiling that
+  will eventually be enforced in one.
+  """
+  def results_limit(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {n, _rest} -> results_limit(n)
+      :error -> @results_step
+    end
+  end
+
+  def results_limit(value) when is_integer(value) and value > 0,
+    do: min(value, results_ceiling())
+
+  def results_limit(_value), do: @results_step
+
+  @doc """
+  The search fields a request asks for, read through the allowlist: the `fields`
+  param the checkboxes send, falling back to **all** of them.
+
+  That fallback is the whole "at least one box stays ticked" rule, and it holds
+  on every path because it is asked on every path. An unticked checkbox sends
+  nothing at all, so a form submitted with all three off arrives here
+  indistinguishable from one that named no preference — and answering either
+  with "look in no field" would be a search box that finds nobody however the
+  name is spelled.
+  """
+  def parse_search_fields(fields) do
+    # Strings from a form, atoms from a caller that already parsed once. Both
+    # are compared as strings so a caller never has to convert on the way in
+    # and back out again — `to_string/1` on an atom cannot fail, and anything
+    # that is neither is dropped by the allowlist below anyway.
+    wanted =
+      fields
+      |> List.wrap()
+      |> Enum.filter(&(is_binary(&1) or is_atom(&1)))
+      |> MapSet.new(&to_string/1)
+
+    case Enum.filter(@search_fields, &MapSet.member?(wanted, Atom.to_string(&1))) do
+      [] -> @search_fields
+      selected -> selected
+    end
+  end
+
+  @doc """
+  Members whose selected name fields contain `query`: a case-insensitive
+  substring in each field, OR-ed across the fields, so "mei" finds Meier and
+  Meierhoff and a search across all three finds somebody by whichever of their
+  names the searcher happens to remember. With both name fields selected the
+  **whole name** matches too ("anna mei"), because that is what a person with a
+  name in mind types and matching it per column would find nothing.
+
+  Returns `nil` below `min_query_chars/0` (the box says so rather than answering
+  with the whole membership), otherwise `%{users: users, total: total}` where
+  `total` counts **every** match while `users` holds at most `limit` of them,
+  filed by last name like every other page here. `limit` goes through
+  `results_limit/1`, so a short query against a large installation can neither
+  render a hundred thousand rows nor be talked into it by a crafted URL.
+
+  The total rides along on the rows as a window count rather than as a second
+  `Repo.aggregate/2`: both have to walk the whole match set, and one walk is
+  half the work of two on a query a member re-runs at every keystroke (measured
+  33 ms against 67 ms on a 100k-row copy).
+  """
+  def search(query, fields \\ @search_fields, limit \\ @results_step) do
+    with needle when is_binary(needle) <- normalize_search(query),
+         true <- String.length(needle) >= @min_query_chars do
+      listed_users()
+      |> where(^field_match(parse_search_fields(fields), needle))
+      |> filed_order()
+      |> limit(^results_limit(limit))
+      |> select([u], {struct(u, ^@listing_fields), fragment("count(*) OVER ()")})
+      |> Repo.all()
+      |> page_with_total()
+    else
+      _ -> nil
+    end
+  end
+
+  # A window count is per row, so an empty result set carries no count at all.
+  defp page_with_total([]), do: %{users: [], total: 0}
+
+  defp page_with_total([{_user, total} | _rest] = rows),
+    do: %{users: Enum.map(rows, &elem(&1, 0)), total: total}
+
+  # "Zabel, Anna" before "Zabel, Zoe", with the id (creation order, UUID v7) as
+  # the tiebreaker. One definition for the letter pages and the search, so a
+  # result can never be filed differently from the page it would be browsed on.
+  defp filed_order(query),
+    do: order_by(query, [u], asc: name_sort_key(u), asc: u.first_name, asc: u.id)
+
+  # Every word of the query has to match **some** selected column: "anna mei"
+  # finds Anna Meier because "anna" matches a first name and "mei" a last one.
+  # A one-word query is the same single OR it always was.
+  #
+  # The obvious alternative — matching the query against `first || ' ' || last`,
+  # which is what `SearchText.name_ilike/3` adds and what the admin browser and
+  # the composer's typeahead use — was measured and rejected here: a
+  # concatenation is an expression, no trigram index covers it, and one such arm
+  # in the OR turns the whole query back into a sequential scan (18.5 ms against
+  # 0.36 ms on today's ~6,000 rows). Splitting into words keeps every arm a bare
+  # column ILIKE, so the plan stays a BitmapAnd over BitmapOrs — and it matches
+  # "meier anna" too, which the concatenation never could.
+  defp field_match(fields, needle) do
+    needle
+    |> String.split(~r/\s+/, trim: true)
+    |> Enum.reduce(dynamic(true), fn word, acc ->
+      dynamic([u], ^acc and ^any_field_match(fields, contains(word)))
+    end)
+  end
+
+  # OR across the selected columns, built as a dynamic so the field list stays
+  # data rather than a query per combination. `fields` arrives already through
+  # `parse_search_fields/1`, so "no field" can never reach the query as
+  # `where: false`.
+  defp any_field_match(fields, pattern) do
+    Enum.reduce(fields, dynamic(false), fn field, acc ->
+      dynamic([u], ^acc or ilike(field(u, ^field), ^pattern))
+    end)
   end
 
   @doc """
@@ -121,7 +311,7 @@ defmodule Vutuv.Directory do
   """
   def letter_entries do
     counts =
-      indexable_users()
+      listed_users()
       |> group_by([u], letter_bucket(u))
       |> select([u], {letter_bucket(u), count(u.id)})
       |> Repo.all()
@@ -142,13 +332,13 @@ defmodule Vutuv.Directory do
   `per_page/0` members per page.
   """
   def members_page(letter, params) do
-    base = where(indexable_users(), [u], letter_bucket(u) == ^bucket_key(letter))
+    base = where(listed_users(), [u], letter_bucket(u) == ^bucket_key(letter))
     total = Repo.aggregate(base, :count)
 
     users =
       base
-      |> order_by([u], asc: name_sort_key(u), asc: u.first_name, asc: u.id)
-      |> Vutuv.Pages.paginate(params, total, @per_page)
+      |> filed_order()
+      |> Pages.paginate(params, total, @per_page)
       |> Repo.all()
 
     %{users: users, total: total}

--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -1830,9 +1830,16 @@ defmodule Vutuv.Organizations do
   end
 
   @doc """
-  The number of members whose linked work experience is at `organization` and who are
-  publicly listable (`Vutuv.Directory.indexable_users` semantics: confirmed, not
-  search-opted-out, not moderation-hidden). The count the People section shows.
+  The number of members whose linked work experience is at `organization` and who
+  are publicly listable here: confirmed, not moderation-hidden, and **not opted
+  out of search engines**. The count the People section shows.
+
+  That last condition used to cite `Vutuv.Directory.indexable_users` as its
+  authority, and no longer can: since v7.407.0 the member directory lists an
+  opted-out member and marks the row `rel="nofollow"` instead of hiding them.
+  Whether an organization's People list should follow is a product question
+  nobody has answered, so the gate is spelled out here rather than borrowed —
+  if it does follow, `people_base/1` is the one place to change.
   """
   def organization_people_count(%Organization{id: id}) do
     people_base(id)
@@ -1848,10 +1855,11 @@ defmodule Vutuv.Organizations do
 
   Each entry is `%{user:, title:, current?:}` where `title` is the linked role's
   title **exactly as the member wrote it** (their most recent role at the
-  organization). Privacy is the member-directory gate (`indexable_users` semantics),
-  so a member who opted out of public listing or is moderation-hidden never
-  appears — the same set the agent-format people list carries. Returns
-  `%{entries:, more?:, next_offset:}`.
+  organization). Privacy is `people_base/1`'s own gate (spelled out under
+  `organization_people_count/1`, and no longer borrowed from the member
+  directory), so a member who opted out of search engines or is
+  moderation-hidden never appears — the same set the agent-format people list
+  carries. Returns `%{entries:, more?:, next_offset:}`.
   """
   def organization_people_page(%Organization{id: organization_id}, opts \\ []) do
     limit = Keyword.get(opts, :limit, @people_per_page)

--- a/lib/vutuv/sitemap.ex
+++ b/lib/vutuv/sitemap.ex
@@ -167,8 +167,13 @@ defmodule Vutuv.Sitemap do
     query |> limit(^@chunk_size) |> offset(^((chunk - 1) * @chunk_size))
   end
 
-  # The crawlable member set lives in Vutuv.Directory (the /members pages),
-  # so directory and sitemap can never drift apart.
+  # The crawlable member set lives in Vutuv.Directory, where it is derived in
+  # one `where` from the set that module lists (`listed_users/0` minus the
+  # search-engine opt-out), so the two cannot drift apart in the direction that
+  # would matter — a member the sitemap advertises is always one the directory
+  # shows. The reverse is deliberately false since v7.407.0: the directory
+  # lists an opted-out member for people to find and marks their row
+  # `rel="nofollow"`, while this set still leaves them out.
   defp indexable_users, do: Vutuv.Directory.indexable_users()
 
   # scope_visible(nil) already drops restricted posts, frozen posts and

--- a/lib/vutuv_web/agent_docs/list_docs.ex
+++ b/lib/vutuv_web/agent_docs/list_docs.ex
@@ -203,7 +203,7 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
   # page prints under its heading.
   defp directory_description(total) do
     gettext(
-      "%{listed} vutuv members are listed here, grouped by the first letter of their last name; anyone who does not open their profile to search engines is not among them.",
+      "%{listed} vutuv members are listed here, grouped by the first letter of their last name.",
       listed: UI.delimited_count(total)
     )
   end

--- a/lib/vutuv_web/controllers/directory_controller.ex
+++ b/lib/vutuv_web/controllers/directory_controller.ex
@@ -1,11 +1,18 @@
 defmodule VutuvWeb.DirectoryController do
   @moduledoc """
-  The public member directory: `/system/members` is the A-Z overview,
-  `/system/members/:letter` one letter's members (paginated, sorted by last name).
-  The crawl-friendly sibling of the sitemap for search engines that browse
-  links instead of `/sitemap.xml` — and a browsable index for humans. Only
-  the crawlable member set shows up (`Vutuv.Directory.indexable_users/0`);
-  members who opted out of search engines are never listed.
+  The public member directory: `/system/members` is the A-Z overview plus the
+  live search box (`VutuvWeb.DirectorySearchLive`, embedded with `live_render`
+  so this controller keeps owning the agent-format siblings),
+  `/system/members/:letter` one letter's members (paginated, sorted by last
+  name). A browsable index for humans, and the crawl-friendly sibling of the
+  sitemap for search engines that browse links instead of `/sitemap.xml`.
+
+  It lists **every** member the site lists anywhere (`Directory.listed_users/0`)
+  — the most-followed listing, the follower lists and `/search` never filtered
+  by the search-engine opt-out, and a directory that did was the odd one out,
+  missing the member somebody came here to look up. What the opt-out buys is the
+  `rel="nofollow"` on that member's row (`UserHelpers.profile_rel/1`) plus the
+  `X-Robots-Tag: noindex` their profile already answers with.
   """
 
   use VutuvWeb, :controller
@@ -13,14 +20,22 @@ defmodule VutuvWeb.DirectoryController do
   alias Vutuv.Directory
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.AgentDocs.ListDocs
+  alias VutuvWeb.ContentPolicy
   alias VutuvWeb.UserHelpers
 
   # Also served as Markdown / text / JSON / XML via VutuvWeb.AgentDocs.ListDocs.
   # Keep index.html/show.html and the doc builders in sync
   # (agent_docs_drift_test.exs).
-  def index(conn, _params) do
+  def index(conn, params) do
     entries = Directory.letter_entries()
     total = Directory.total(entries)
+    query = params["q"] || ""
+
+    # The search box's own state, handed to it as its mount session so a `?q=`
+    # URL renders its results server-side — the no-JS path, and what makes a
+    # search shareable and reloadable from an off-router LiveView that cannot
+    # `push_patch` its own URL.
+    search_session = %{"q" => query, "fields" => params["fields"], "show" => params["show"]}
 
     # Deliberately the listed count and nothing else. The whole membership and
     # the Fediverse head count sat beside it until 2026-08-13; both are the top
@@ -28,15 +43,28 @@ defmodule VutuvWeb.DirectoryController do
     # above the A-Z strip turned a directory into a statistics page.
     AgentDocs.respond(conn,
       html: fn conn ->
-        render(conn, "index.html",
+        conn
+        # A search result is not a page to index: `/search` is noindexed for
+        # being an endless hall of mirrors, and this one would additionally
+        # publish the names of members who asked to stay out of search results.
+        # The bare A-Z overview stays indexable, which is the whole point of it.
+        |> noindex_search(query)
+        |> render("index.html",
           page_title: gettext("Member directory"),
           entries: entries,
-          total: total
+          total: total,
+          search_session: search_session
         )
       end,
+      # The agent formats answer for the directory itself, never for a query:
+      # `?q=` is a person typing, and a doc that changed under it would make
+      # the canonical URL name a different document every time.
       doc: fn -> ListDocs.build_directory_index(entries, total) end
     )
   end
+
+  defp noindex_search(conn, ""), do: conn
+  defp noindex_search(conn, _query), do: ContentPolicy.put_robots_header(conn, true, false)
 
   def show(conn, %{"letter" => letter}) do
     if Directory.valid_letter?(letter) do

--- a/lib/vutuv_web/controllers/page_controller.ex
+++ b/lib/vutuv_web/controllers/page_controller.ex
@@ -379,8 +379,8 @@ defmodule VutuvWeb.PageController do
   - `/<username>/tags/<tag>/endorsers` — everyone who endorses this member for that tag
   - `/tags/<tag>` — a tag and its most endorsed members
   - `/listings/most_followed_users` — the most followed members
-  - `/system/members` — the member directory: everyone open to search engines,
-    filed by last-name initial at `/system/members/<a-z|other>`
+  - `/system/members` — the member directory: every member, filed by last-name
+    initial at `/system/members/<a-z|other>`, plus a name search on the index
   - `/system/markdown` — what members may write in a post: the Markdown
     reference, also raw at `/system/markdown.md` (`?lang=` for {{locales}})
   - `/system/mastodon` — how to reach this installation from a Mastodon-compatible

--- a/lib/vutuv_web/live/directory_search_live.ex
+++ b/lib/vutuv_web/live/directory_search_live.ex
@@ -1,0 +1,264 @@
+defmodule VutuvWeb.DirectorySearchLive do
+  @moduledoc """
+  The member directory's search box, embedded into `/system/members` via
+  `live_render` from `VutuvWeb.DirectoryController` (the profile / feed /
+  job-board pattern) so the controller keeps owning the agent-format siblings
+  `/system/members.md` and friends.
+
+  It is a **field** search, not the free-text page at `/search`: a plain
+  case-insensitive substring in first name, last name and username, OR-ed
+  across whichever of the three the member leaves ticked
+  (`Vutuv.Directory.search/3`). The rows are the directory's own
+  (`UserHTML.card_list` with `filed_names`), so a result reads exactly like the
+  letter page it would otherwise have been found on, `rel="nofollow"` on an
+  opted-out member's row included.
+
+  **At least one box is always ticked, and unticking the last one ticks all
+  three** — the fallback `Directory.parse_search_fields/1` applies, unchanged,
+  on every path. One rule rather than two, and the reason is a rendering fact
+  worth knowing: keeping the previous selection instead (the obvious "refuse
+  the click") leaves `@fields` unchanged, so the diff carries nothing for that
+  checkbox, morphdom never touches it, and the box stays visibly unticked while
+  the server searches as though it were on. A refusal the page cannot show is
+  not a refusal. Resetting to all three changes `@fields`, so all three boxes
+  tick themselves again in the same patch and the count moves with them.
+
+  **A large result set is revealed in bites, not paged.** The count is stated
+  first (that is the answer to "did I spell it right"), then
+  `Directory.results_step/0` rows, then a control for the next bite up to
+  `results_ceiling/0`, past which the box asks for another letter instead — a
+  pager under a search-as-you-type field is a trap, since the next keystroke
+  invalidates whichever page you walked to.
+
+  Because it is off-router it cannot `push_patch`, so the box is a real **GET
+  form** at `/system/members`: keystrokes patch the results over the socket
+  (`phx-change`, debounced), while Enter submits the form and lands on a
+  shareable `?q=` URL whose dead render shows the same results. That is also
+  the no-JS path, which is why "show more" renders as a `?show=` link until
+  the socket connects and why a follow pressed on a result row (a classic CSRF
+  POST back to the referrer) comes back to the search it was pressed in.
+
+  The `?q=` page is `noindex` (the controller stamps it): search results are
+  the hall of mirrors `/search` is noindexed for, and here they would be a
+  second one carrying members who asked to stay out of search engines.
+  """
+
+  use Phoenix.LiveView
+
+  use Phoenix.VerifiedRoutes,
+    endpoint: VutuvWeb.Endpoint,
+    router: VutuvWeb.Router,
+    statics: ~w(assets fonts images favicon.ico)
+
+  import VutuvWeb.UI, only: [checkbox_class: 0, delimited_count: 1, input_class: 0]
+
+  use Gettext, backend: VutuvWeb.Gettext
+
+  alias Vutuv.Directory
+  alias VutuvWeb.Live.InitAssigns
+  alias VutuvWeb.UserHelpers
+  alias VutuvWeb.UserHTML
+
+  # The work line every listing row shows, at the width the letter pages use.
+  # A plain function rather than an assign: it is a constant, and a constant in
+  # the socket is a change-tracked value that can never change.
+  @work_string_length 60
+  defp work_string_length, do: @work_string_length
+
+  @impl true
+  def mount(_params, session, socket) do
+    socket
+    |> InitAssigns.assign_embedded(session)
+    |> assign(:connected?, connected?(socket))
+    |> apply_search(session, Directory.results_limit(session["show"]))
+    |> then(&{:ok, &1})
+  end
+
+  @impl true
+  def handle_event("search", params, socket) do
+    # A changed query — or a changed field set — is a different search, so the
+    # revealed bite starts over rather than carrying the last one's depth.
+    {:noreply, apply_search(socket, params, Directory.results_step())}
+  end
+
+  def handle_event("show-more", _params, socket) do
+    %{q: q, fields: fields, limit: limit} = socket.assigns
+    params = %{"q" => q, "fields" => fields}
+
+    # Re-running the whole search rather than fetching only the next bite: it
+    # is one indexed query either way, the ceiling bounds how often it can
+    # happen, and appending would mean merging the two per-row maps and
+    # rebuilding both on a rejoin — three states to keep in step for work the
+    # database does in about a millisecond.
+    {:noreply, apply_search(socket, params, limit + Directory.results_step())}
+  end
+
+  # One place computes everything a query implies, so a `?q=` mount, a socket
+  # rejoin, a keystroke and a "show more" can never disagree about the answer.
+  # `params` is string-keyed either way: the controller hands the mount session
+  # the form's own keys, so the two entry points differ only in the limit.
+  defp apply_search(socket, params, limit) do
+    q = params["q"] || ""
+    fields = Directory.parse_search_fields(params["fields"])
+    limit = Directory.results_limit(limit)
+    results = Directory.search(q, fields, limit)
+    users = (results && results.users) || []
+
+    socket
+    |> assign(:q, q)
+    |> assign(:fields, fields)
+    |> assign(:limit, limit)
+    |> assign(:results, results)
+    # The two page-wide maps every row reads, one query each, so a result list
+    # never queries per row (`UserHTML.card_list`'s contract).
+    |> assign(:work_info_by_id, UserHelpers.work_information_map(users, work_string_length()))
+    |> assign(:following_by_id, UserHelpers.following_map(socket.assigns.current_user, users))
+  end
+
+  # Whether the list is cut short, and whether the cut can still be lifted.
+  # Two names for one comparison, so the "show more" control and the
+  # narrow-your-search hint read as the two sides they are instead of as a
+  # condition and its double negative.
+  defp truncated?(%{users: users, total: total}), do: length(users) < total
+
+  defp more?(results, limit),
+    do: truncated?(results) and limit < Directory.results_ceiling()
+
+  defp more_path(q, fields, limit) do
+    params = %{"q" => q, "fields" => fields, "show" => limit + Directory.results_step()}
+    ~p"/system/members?#{params}"
+  end
+
+  defp field_label(:first_name), do: gettext("First name")
+  defp field_label(:last_name), do: gettext("Last name")
+  defp field_label(:username), do: gettext("Username")
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id="directory-search" class="card-list">
+      <section class="card">
+        <h2>{gettext("Find a member")}</h2>
+
+        <%!-- A real GET form, not just a phx-change box: Enter (and a browser
+        with no JavaScript) submits it to this same URL, so a search is
+        shareable, reloadable and survives a follow's round trip. The debounce
+        sits on the text field alone, so ticking a box answers at once. --%>
+        <form id="directory-search-form" action={~p"/system/members"} method="get" phx-change="search">
+          <input
+            type="search"
+            name="q"
+            value={@q}
+            placeholder={gettext("Search members by name")}
+            aria-label={gettext("Search members by name")}
+            autocomplete="off"
+            phx-debounce="250"
+            class={input_class()}
+          />
+
+          <fieldset class="mt-3 flex flex-wrap items-center gap-x-5">
+            <legend class="sr-only">{gettext("Which names to search")}</legend>
+            <label
+              :for={field <- Directory.search_fields()}
+              class="inline-flex min-h-10 items-center gap-2 text-sm font-normal"
+            >
+              <input
+                type="checkbox"
+                name="fields[]"
+                value={field}
+                checked={field in @fields}
+                data-search-field={field}
+                class={checkbox_class()}
+              />
+              {field_label(field)}
+            </label>
+          </fieldset>
+
+          <%!-- The no-JS submit. With a socket it is redundant (every change
+          already answers), so it is hidden from sight and from the reading
+          order rather than rendered twice or left out of the markup. --%>
+          <noscript>
+            <button type="submit" class="button">{gettext("Search")}</button>
+          </noscript>
+        </form>
+
+        <p :if={is_nil(@results) and String.trim(@q) != ""} id="directory-search-hint" class="card__empty">
+          {gettext("Results appear once you have typed at least %{count} letters.",
+            count: Directory.min_query_chars()
+          )}
+        </p>
+      </section>
+
+      <section :if={@results} class="card" id="directory-search-results">
+        <%= if @results.total == 0 do %>
+          <p id="directory-search-empty" class="card__empty">
+            {gettext("No members found for \"%{query}\".", query: @q)}
+          </p>
+        <% else %>
+          <%!-- The count comes first: it is the answer to "did I spell it
+          right", and it is the whole reason a large result set does not need a
+          pager to be understood. --%>
+          <p id="directory-search-count">
+            <%= if truncated?(@results) do %>
+              {gettext("Showing %{shown} of %{total} members.",
+                shown: delimited_count(length(@results.users)),
+                total: delimited_count(@results.total)
+              )}
+            <% else %>
+              {ngettext("One member found.", "%{formatted} members found.", @results.total,
+                formatted: delimited_count(@results.total)
+              )}
+            <% end %>
+          </p>
+
+          <UserHTML.card_list
+            users={@results.users}
+            current_user={@current_user}
+            current_user_id={@current_user_id}
+            filed_names={true}
+            work_string_length={work_string_length()}
+            work_info_by_id={@work_info_by_id}
+            tags_by_id={nil}
+            following_by_id={@following_by_id}
+          />
+
+          <%!-- Reveal the next bite: a phx-click once the socket carries it, a
+          plain `?show=` link until then, so the control is never a button that
+          does nothing. One label for both, or a wording change has to be made
+          twice. --%>
+          <% more_label = gettext("Show %{count} more", count: Directory.results_step()) %>
+          <p :if={more?(@results, @limit)} class="text-center">
+            <button
+              :if={@connected?}
+              type="button"
+              id="directory-search-more"
+              phx-click="show-more"
+              class="button button--secondary"
+            >
+              {more_label}
+            </button>
+            <a
+              :if={!@connected?}
+              id="directory-search-more-link"
+              href={more_path(@q, @fields, @limit)}
+              class="button button--secondary"
+            >
+              {more_label}
+            </a>
+          </p>
+
+          <%!-- Cut short and no further to go: at the ceiling the answer is
+          another letter in the box, so say that rather than nothing. --%>
+          <p
+            :if={truncated?(@results) and not more?(@results, @limit)}
+            id="directory-search-narrow"
+            class="card__empty"
+          >
+            {gettext("That is as far as this list goes. Type more of the name to narrow it down.")}
+          </p>
+        <% end %>
+      </section>
+    </div>
+    """
+  end
+end

--- a/lib/vutuv_web/templates/connection/index.html.heex
+++ b/lib/vutuv_web/templates/connection/index.html.heex
@@ -20,10 +20,15 @@
         :for={%{user: u, follow_id: follow_id} <- @connections}
         class="flex items-center gap-3 py-3 first:pt-0 last:pb-0"
       >
-        <.link href={~p"/#{u}"} class="shrink-0"><.avatar user={u} size="sm" presence /></.link>
+        <%!-- rel="nofollow" for a member who asked search engines to leave their
+        profile alone. This list builds its own rows rather than using
+        `card_list`, so it does not inherit that rule and has to ask for it. --%>
+        <% rel = profile_rel(u) %>
+        <.link href={~p"/#{u}"} rel={rel} class="shrink-0"><.avatar user={u} size="sm" presence /></.link>
         <div class="min-w-0 flex-1">
           <.link
             href={~p"/#{u}"}
+            rel={rel}
             class="block truncate font-medium text-slate-800 hover:text-brand-700 dark:hover:text-brand-300 dark:text-slate-100"
           >
             {full_name(u)}

--- a/lib/vutuv_web/templates/directory/index.html.heex
+++ b/lib/vutuv_web/templates/directory/index.html.heex
@@ -3,6 +3,15 @@
   crumbs={[{gettext("Home"), ~p"/"}, gettext("Member directory")]}
 />
 
+<%!-- The search box, above the A-Z strip because it is what somebody with a
+name in mind reaches for; the alphabet below is for browsing. Embedded rather
+than routed so the controller keeps serving the agent-format siblings, and it
+takes `q` from the URL so a submitted search reloads and shares as itself. --%>
+{live_render(@conn, VutuvWeb.DirectorySearchLive,
+  id: "directory-search-lv",
+  session: Map.merge(VutuvWeb.ControllerHelpers.live_render_session(@conn), @search_session)
+)}
+
 <div class="card-list">
   <section class="card">
     <%!-- One line, and it says what the page is. The membership total and the
@@ -11,8 +20,7 @@
     three figures above an A-Z strip read as a statistics page rather than as a
     directory (Stefan, 2026-08-13). --%>
     <p>
-      {gettext(
-        "%{count} vutuv members whose profiles are open to search engines, filed alphabetically by last name.",
+      {gettext("%{count} vutuv members, filed alphabetically by last name.",
         count: delimited_count(@total)
       )}
     </p>

--- a/lib/vutuv_web/templates/user/card_list.html.heex
+++ b/lib/vutuv_web/templates/user/card_list.html.heex
@@ -19,8 +19,12 @@ shows the name the way its owner writes it. --%>
 <ul class={["button-list profiles", tags_by_id && "profiles--tags"]}>
   <%= for user <- @users do %>
     <li>
+      <%!-- rel="nofollow" for a member who asked search engines to leave their
+      profile alone: the directory lists them for people, and both links in
+      the row tell a crawler not to walk through (UserHelpers.profile_rel/1). --%>
+      <% rel = profile_rel(user) %>
       <div class="profile-image">
-        <%= link to: ~p"/#{user}" do %>
+        <%= link to: ~p"/#{user}", rel: rel do %>
           <%!-- src is passed for users with a picture so the row keeps the
                 small :thumb version; without one, <.avatar> renders the
                 initials tile instead of the light-grey default image (a
@@ -35,7 +39,7 @@ shows the name the way its owner writes it. --%>
         <% end %>
       </div>
       <% tag_summary = tags_by_id && Map.get(tags_by_id, user.id) %>
-      <p><strong><%= link (if filed_names?, do: filed_name(user), else: full_name(user)), to: ~p"/#{user}" %></strong>
+      <p><strong><%= link (if filed_names?, do: filed_name(user), else: full_name(user)), to: ~p"/#{user}", rel: rel %></strong>
       <%= Map.get_lazy(work_info_by_id, user.id, fn -> work_information_string(user, @work_string_length) end) %>
       <span :if={tag_summary} class="profile-tags">
         <.link :for={user_tag <- tag_summary.top} href={~p"/tags/#{user_tag.tag.slug}"}>

--- a/lib/vutuv_web/templates/user_tag/endorsers.html.heex
+++ b/lib/vutuv_web/templates/user_tag/endorsers.html.heex
@@ -32,10 +32,14 @@
           </tr>
         </thead>
         <tbody>
+          <%!-- rel="nofollow" for a member who asked search engines to leave
+          their profile alone. This table builds its own rows rather than using
+          `card_list`, so it does not inherit that rule and has to ask for it. --%>
           <tr :for={user <- @endorsers}>
+            <% rel = profile_rel(user) %>
             <td>
               <div class="flex items-center gap-2">
-                <.link href={~p"/#{user}"}>
+                <.link href={~p"/#{user}"} rel={rel}>
                   <.avatar
                     user={user}
                     src={user.avatar && Vutuv.Avatar.display_url(user, :thumb)}
@@ -44,14 +48,14 @@
                     presence
                   />
                 </.link>
-                <.link href={~p"/#{user}"}>{full_name(user)}</.link>
+                <.link href={~p"/#{user}"} rel={rel}>{full_name(user)}</.link>
                 <% work = Map.get(@work_info_by_id, user.id) %>
                 <span :if={work not in [nil, ""]} class="breakwrap text-slate-600 dark:text-slate-400">
                   · {work}
                 </span>
               </div>
             </td>
-            <td><.link href={~p"/#{user}"}>@{user.username}</.link></td>
+            <td><.link href={~p"/#{user}"} rel={rel}>@{user.username}</.link></td>
             <td>
               <% at = Map.get(@endorsed_at_by_id, user.id) %>
               <.local_time :if={at} at={at} />

--- a/lib/vutuv_web/views/user_helpers.ex
+++ b/lib/vutuv_web/views/user_helpers.ex
@@ -74,6 +74,27 @@ defmodule VutuvWeb.UserHelpers do
   end
 
   @doc """
+  The `rel` for a link that points at a member's profile from a public listing:
+  `"nofollow"` for a member who asked search engines to leave their profile out
+  (`noindex?`), `nil` for everyone else.
+
+  The profile itself already answers a crawler with `X-Robots-Tag: noindex`
+  (`VutuvWeb.ContentPolicy`), but only once the crawler has fetched it. The
+  `rel` says it a step earlier, at the link, so a listing that shows an
+  opted-out member to people — the member directory since it stopped hiding
+  them, and the most-followed / follower listings, which never did — does not
+  hand a crawler a path to walk.
+
+  One definition rather than the flag re-read per template: it is the same
+  question at every listing row, and the answer must not depend on which
+  template remembered to ask. `noindex?` rides in `User.listing_fields/0` for
+  exactly this reason — a row selected without it would default to `false` and
+  fail *open*.
+  """
+  def profile_rel(%User{noindex?: true}), do: "nofollow"
+  def profile_rel(%User{}), do: nil
+
+  @doc """
   The `{label, value}` options for the Basics form's employment-status select
   (issue #870): the two real statuses derived from the schema's single source
   (`User.employment_statuses/0` mapped through `User.employment_status_label/1`,

--- a/lib/vutuv_web/views/user_html.ex
+++ b/lib/vutuv_web/views/user_html.ex
@@ -70,11 +70,11 @@ defmodule VutuvWeb.UserHTML do
     ~H"""
     <li class="space-y-2">
       <div class="flex items-center gap-3">
-        <.link href={~p"/#{@user}"} class="shrink-0">
+        <.link href={~p"/#{@user}"} rel={profile_rel(@user)} class="shrink-0">
           <.avatar user={@user} size="sm" alt={"Avatar of #{full_name(@user)}"} />
         </.link>
         <div class="min-w-0 text-sm">
-          <.link href={~p"/#{@user}"} class="block truncate font-medium text-slate-800 hover:text-brand-700 dark:hover:text-brand-300 dark:text-slate-100">{highlight(full_name(@user), @highlight)}</.link>
+          <.link href={~p"/#{@user}"} rel={profile_rel(@user)} class="block truncate font-medium text-slate-800 hover:text-brand-700 dark:hover:text-brand-300 dark:text-slate-100">{highlight(full_name(@user), @highlight)}</.link>
           <%!-- Always render a line (non-breaking space when empty) so rows keep a
           uniform height and the side-by-side follower/following cards stay aligned.
           Pin text-sm + mb-0 so the legacy global `p` default (15px font, 15px bottom

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.393.1",
+      version: "7.407.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -162,7 +162,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:3153
+#: lib/vutuv_web/components/post_components.ex:3170
 #: lib/vutuv_web/components/ui.ex:4106
 #: lib/vutuv_web/live/admin/job_live.ex:489
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -211,7 +211,7 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:3118
+#: lib/vutuv_web/components/post_components.ex:3135
 #: lib/vutuv_web/components/ui.ex:4097
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -475,7 +475,7 @@ msgstr "Mehr"
 msgid "Name"
 msgstr "Name"
 
-#: lib/vutuv_web/components/post_components.ex:629
+#: lib/vutuv_web/components/post_components.ex:640
 #: lib/vutuv_web/live/notification_live/index.ex:699
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -643,6 +643,7 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/admin/activity_live.ex:193
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:219
+#: lib/vutuv_web/live/directory_search_live.ex:181
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:49
 #: lib/vutuv_web/live/search_live.ex:570
@@ -657,7 +658,7 @@ msgstr "Speichern"
 msgid "Search"
 msgstr "Suche"
 
-#: lib/vutuv_web/components/post_components.ex:1627
+#: lib/vutuv_web/components/post_components.ex:1643
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -795,6 +796,7 @@ msgstr "User wurde verifiziert."
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
+#: lib/vutuv_web/live/directory_search_live.ex:134
 #: lib/vutuv_web/live/notification_live/index.ex:1099
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
@@ -1783,7 +1785,7 @@ msgstr "Nachrichten"
 msgid "Network"
 msgstr "Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:436
+#: lib/vutuv_web/components/post_components.ex:447
 #: lib/vutuv_web/components/ui.ex:4216
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
@@ -2142,7 +2144,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:3150
+#: lib/vutuv_web/components/post_components.ex:3167
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2158,7 +2160,7 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:114
 #: lib/vutuv_web/live/post_live/feed.ex:206
-#: lib/vutuv_web/live/post_live/feed.ex:1591
+#: lib/vutuv_web/live/post_live/feed.ex:1598
 #: lib/vutuv_web/live/shell_live.ex:973
 #: lib/vutuv_web/live/shell_live.ex:1272
 #: lib/vutuv_web/templates/layout/app.html.heex:171
@@ -2186,8 +2188,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:3104
-#: lib/vutuv_web/components/post_components.ex:3106
+#: lib/vutuv_web/components/post_components.ex:3121
+#: lib/vutuv_web/components/post_components.ex:3123
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2203,7 +2205,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1802
+#: lib/vutuv_web/live/post_live/feed.ex:1810
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2255,13 +2257,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:3568
-#: lib/vutuv_web/components/post_components.ex:3572
+#: lib/vutuv_web/components/post_components.ex:3585
+#: lib/vutuv_web/components/post_components.ex:3589
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:3569
+#: lib/vutuv_web/components/post_components.ex:3586
 #: lib/vutuv_web/live/fediverse_account_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2269,7 +2271,7 @@ msgstr "Weniger anzeigen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:376
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1249
+#: lib/vutuv_web/components/post_components.ex:1265
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2279,7 +2281,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/post_live/composer.ex:1940
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
-#: lib/vutuv_web/templates/connection/index.html.heex:40
+#: lib/vutuv_web/templates/connection/index.html.heex:45
 #: lib/vutuv_web/views/settings_html.ex:342
 #, elixir-autogen, elixir-format
 msgid "Remove"
@@ -2297,7 +2299,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1703
+#: lib/vutuv_web/live/post_live/feed.ex:1710
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2353,27 +2355,27 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:3101
+#: lib/vutuv_web/components/post_components.ex:3118
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:4957
+#: lib/vutuv_web/components/post_components.ex:4987
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:4961
+#: lib/vutuv_web/components/post_components.ex:4991
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:4959
+#: lib/vutuv_web/components/post_components.ex:4989
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:4960
+#: lib/vutuv_web/components/post_components.ex:4990
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2414,8 +2416,8 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1842
-#: lib/vutuv_web/components/post_components.ex:5053
+#: lib/vutuv_web/components/post_components.ex:1858
+#: lib/vutuv_web/components/post_components.ex:5083
 #: lib/vutuv_web/components/ui.ex:3629
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
@@ -2433,8 +2435,8 @@ msgstr "Lesezeichen setzen"
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:1795
-#: lib/vutuv_web/components/post_components.ex:5289
+#: lib/vutuv_web/components/post_components.ex:1811
+#: lib/vutuv_web/components/post_components.ex:5319
 #: lib/vutuv_web/components/ui.ex:3615
 #: lib/vutuv_web/live/notification_live/index.ex:1089
 #: lib/vutuv_web/views/user_html.ex:467
@@ -2443,7 +2445,7 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:5299
+#: lib/vutuv_web/components/post_components.ex:5329
 #: lib/vutuv_web/live/notification_live/index.ex:1022
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
@@ -2465,40 +2467,40 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:5041
+#: lib/vutuv_web/components/post_components.ex:5071
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:1841
-#: lib/vutuv_web/components/post_components.ex:5052
+#: lib/vutuv_web/components/post_components.ex:1857
+#: lib/vutuv_web/components/post_components.ex:5082
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:1823
-#: lib/vutuv_web/components/post_components.ex:5038
+#: lib/vutuv_web/components/post_components.ex:1839
+#: lib/vutuv_web/components/post_components.ex:5068
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:2088
-#: lib/vutuv_web/components/post_components.ex:4163
+#: lib/vutuv_web/components/post_components.ex:2104
+#: lib/vutuv_web/components/post_components.ex:4193
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1822
-#: lib/vutuv_web/components/post_components.ex:5037
+#: lib/vutuv_web/components/post_components.ex:1838
+#: lib/vutuv_web/components/post_components.ex:5067
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:1794
-#: lib/vutuv_web/components/post_components.ex:5288
+#: lib/vutuv_web/components/post_components.ex:1810
+#: lib/vutuv_web/components/post_components.ex:5318
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:467
 #, elixir-autogen, elixir-format
@@ -2506,14 +2508,14 @@ msgid "Unlike"
 msgstr "Gefällt mir entfernen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:377
-#: lib/vutuv_web/components/post_components.ex:2407
+#: lib/vutuv_web/components/post_components.ex:2424
 #: lib/vutuv_web/components/ui.ex:2484
 #: lib/vutuv_web/components/ui.ex:2484
 #: lib/vutuv_web/components/ui.ex:2621
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:489
-#: lib/vutuv_web/live/post_live/feed.ex:1851
+#: lib/vutuv_web/live/post_live/feed.ex:1859
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2525,27 +2527,27 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:5343
+#: lib/vutuv_web/components/post_components.ex:5373
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
-#: lib/vutuv_web/components/post_components.ex:394
+#: lib/vutuv_web/components/post_components.ex:405
 #: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1808
-#: lib/vutuv_web/components/post_components.ex:5326
-#: lib/vutuv_web/components/post_components.ex:5327
+#: lib/vutuv_web/components/post_components.ex:1824
+#: lib/vutuv_web/components/post_components.ex:5356
+#: lib/vutuv_web/components/post_components.ex:5357
 #: lib/vutuv_web/live/notification_live/index.ex:1086
 #: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:3068
+#: lib/vutuv_web/components/post_components.ex:3085
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2566,7 +2568,7 @@ msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beitr
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/components/post_components.ex:2604
+#: lib/vutuv_web/components/post_components.ex:2621
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:57
@@ -2574,14 +2576,14 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:3042
+#: lib/vutuv_web/components/post_components.ex:3059
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:3033
-#: lib/vutuv_web/components/post_components.ex:3060
-#: lib/vutuv_web/components/post_components.ex:3063
+#: lib/vutuv_web/components/post_components.ex:3050
+#: lib/vutuv_web/components/post_components.ex:3077
+#: lib/vutuv_web/components/post_components.ex:3080
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2806,14 +2808,14 @@ msgstr "Ersten Beitrag schreiben"
 msgid "Manage"
 msgstr "Verwalten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1629
+#: lib/vutuv_web/live/post_live/feed.ex:1636
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr "Beitrag schreiben"
 
-#: lib/vutuv_web/views/user_helpers.ex:192
-#: lib/vutuv_web/views/user_helpers.ex:204
+#: lib/vutuv_web/views/user_helpers.ex:213
+#: lib/vutuv_web/views/user_helpers.ex:225
 #, elixir-autogen, elixir-format
 msgid "Added %{count} tag."
 msgid_plural "Added %{count} tags."
@@ -2827,8 +2829,8 @@ msgid_plural "%{formatted} connections"
 msgstr[0] "1 Vernetzung"
 msgstr[1] "%{formatted} Vernetzungen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1953
-#: lib/vutuv_web/templates/user/card_list.html.heex:46
+#: lib/vutuv_web/live/post_live/feed.ex:1961
+#: lib/vutuv_web/templates/user/card_list.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
 msgid_plural "+%{formatted} more tags"
@@ -2849,7 +2851,7 @@ msgstr "Vernetzungen"
 msgid "Markdown"
 msgstr "Markdown"
 
-#: lib/vutuv_web/templates/connection/index.html.heex:45
+#: lib/vutuv_web/templates/connection/index.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "No connections yet."
 msgstr "Noch keine Vernetzungen."
@@ -2882,7 +2884,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:4958
+#: lib/vutuv_web/components/post_components.ex:4988
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -3163,7 +3165,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:3009
+#: lib/vutuv_web/components/post_components.ex:3026
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3242,9 +3244,9 @@ msgstr "Abgelehnt"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
-#: lib/vutuv_web/components/post_components.ex:1259
-#: lib/vutuv_web/components/post_components.ex:2419
-#: lib/vutuv_web/components/post_components.ex:3173
+#: lib/vutuv_web/components/post_components.ex:1275
+#: lib/vutuv_web/components/post_components.ex:2436
+#: lib/vutuv_web/components/post_components.ex:3190
 #: lib/vutuv_web/live/organization_live/show.ex:562
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
@@ -4708,7 +4710,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1807
+#: lib/vutuv_web/live/post_live/feed.ex:1815
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -4789,8 +4791,8 @@ msgstr ""
 msgid "Similar names"
 msgstr "Ähnliche Namen"
 
-#: lib/vutuv_web/components/post_components.ex:391
-#: lib/vutuv_web/components/post_components.ex:410
+#: lib/vutuv_web/components/post_components.ex:402
+#: lib/vutuv_web/components/post_components.ex:421
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -5640,11 +5642,11 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:3239
-#: lib/vutuv_web/components/post_components.ex:3294
-#: lib/vutuv_web/components/post_components.ex:3705
+#: lib/vutuv_web/components/post_components.ex:3256
+#: lib/vutuv_web/components/post_components.ex:3311
+#: lib/vutuv_web/components/post_components.ex:3722
 #: lib/vutuv_web/live/notification_live/index.ex:743
-#: lib/vutuv_web/live/post_live/feed.ex:1994
+#: lib/vutuv_web/live/post_live/feed.ex:2002
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -6458,7 +6460,7 @@ msgid "Previous day"
 msgstr "Vorheriger Tag"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:393
+#: lib/vutuv_web/components/post_components.ex:404
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6557,7 +6559,7 @@ msgstr "Empfohlen am"
 msgid "Members who endorsed %{name} for %{tag}"
 msgstr "Mitglieder, die %{name} für %{tag} empfohlen haben"
 
-#: lib/vutuv_web/templates/user_tag/endorsers.html.heex:74
+#: lib/vutuv_web/templates/user_tag/endorsers.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "No endorsements yet."
 msgstr "Noch keine Empfehlungen."
@@ -6882,8 +6884,8 @@ msgstr ""
 "Schalten Sie einen Schalter aus, geht der passende Opt-out auf den Seiten "
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
-#: lib/vutuv_web/components/post_components.ex:2387
-#: lib/vutuv_web/components/post_components.ex:3170
+#: lib/vutuv_web/components/post_components.ex:2404
+#: lib/vutuv_web/components/post_components.ex:3187
 #: lib/vutuv_web/components/ui.ex:2809
 #: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/live/organization_live/following.ex:376
@@ -6905,12 +6907,12 @@ msgstr "Stummgeschaltet. Die Beiträge erscheinen nicht mehr in Ihrem Feed."
 msgid "New messages and new connections"
 msgstr "Neue Nachrichten und neue Vernetzungen"
 
-#: lib/vutuv_web/templates/connection/index.html.heex:38
+#: lib/vutuv_web/templates/connection/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
-#: lib/vutuv_web/components/post_components.ex:3170
+#: lib/vutuv_web/components/post_components.ex:3187
 #: lib/vutuv_web/components/ui.ex:2808
 #: lib/vutuv_web/live/fediverse_account_live.ex:379
 #: lib/vutuv_web/live/organization_live/following.ex:376
@@ -7645,7 +7647,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5199
+#: lib/vutuv_web/components/post_components.ex:5229
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8230,7 +8232,7 @@ msgid "Admins"
 msgstr "Administratoren"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:1962
+#: lib/vutuv_web/live/post_live/feed.ex:1970
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Alle Mitglieder"
@@ -8837,12 +8839,12 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr "Geben Sie zur Bestätigung Ihren Benutzernamen ein:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1979
+#: lib/vutuv_web/live/post_live/feed.ex:1987
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr "Andere Beiträge anzeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1975
+#: lib/vutuv_web/live/post_live/feed.ex:1983
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr "Vorgeschlagene Beiträge"
@@ -8902,7 +8904,7 @@ msgid "Invalid address (skipped)"
 msgstr "Ungültige Adresse (übersprungen)"
 
 #: lib/vutuv_web/agent_docs/list_docs.ex:191
-#: lib/vutuv_web/controllers/directory_controller.ex:32
+#: lib/vutuv_web/controllers/directory_controller.ex:53
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:5
@@ -8911,14 +8913,14 @@ msgstr "Ungültige Adresse (übersprungen)"
 msgid "Member directory"
 msgstr "Mitgliederverzeichnis"
 
-#: lib/vutuv_web/templates/directory/index.html.heex:24
+#: lib/vutuv_web/templates/directory/index.html.heex:32
 #: lib/vutuv_web/templates/directory/show.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Members by initial"
 msgstr "Mitglieder nach Anfangsbuchstaben"
 
 #: lib/vutuv_web/agent_docs/list_docs.ex:217
-#: lib/vutuv_web/controllers/directory_controller.ex:58
+#: lib/vutuv_web/controllers/directory_controller.ex:86
 #: lib/vutuv_web/templates/directory/show.html.heex:2
 #, elixir-autogen, elixir-format
 msgid "Members: %{letter}"
@@ -9218,7 +9220,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:4166
+#: lib/vutuv_web/components/post_components.ex:4196
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9356,12 +9358,12 @@ msgstr "%{job} wird oben in Ihrem Profil angezeigt."
 msgid "Choose automatically instead"
 msgstr "Stattdessen automatisch wählen"
 
-#: lib/vutuv_web/views/user_helpers.ex:469
+#: lib/vutuv_web/views/user_helpers.ex:490
 #, elixir-autogen, elixir-format
 msgid "Show at top of profile"
 msgstr "Oben im Profil anzeigen"
 
-#: lib/vutuv_web/views/user_helpers.ex:460
+#: lib/vutuv_web/views/user_helpers.ex:481
 #, elixir-autogen, elixir-format
 msgid "Shown at the top of your profile"
 msgstr "Wird oben in Ihrem Profil angezeigt"
@@ -9908,18 +9910,18 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
-#: lib/vutuv/accounts/user.ex:1173
+#: lib/vutuv/accounts/user.ex:1177
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
 msgstr "Auf Jobsuche"
 
-#: lib/vutuv_web/views/user_helpers.ex:86
+#: lib/vutuv_web/views/user_helpers.ex:107
 #, elixir-autogen, elixir-format
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
-#: lib/vutuv/accounts/user.ex:1170
+#: lib/vutuv/accounts/user.ex:1174
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10218,19 +10220,21 @@ msgstr ""
 "Ihr Geburtsdatum wird entfernt und Ihr Alter wird nicht mehr in Ihrem Profil"
 " angezeigt. Sie können es jederzeit wieder hinzufügen."
 
+#: lib/vutuv_web/live/directory_search_live.ex:132
 #: lib/vutuv_web/templates/page/index.html.heex:90
 #: lib/vutuv_web/views/account_event_text.ex:210
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
 
+#: lib/vutuv_web/live/directory_search_live.ex:133
 #: lib/vutuv_web/templates/page/index.html.heex:95
 #: lib/vutuv_web/views/account_event_text.ex:211
 #, elixir-autogen, elixir-format
 msgid "Last name"
 msgstr "Nachname"
 
-#: lib/vutuv_web/views/user_helpers.ex:109
+#: lib/vutuv_web/views/user_helpers.ex:130
 #, elixir-autogen, elixir-format
 msgid "Prefer not to say"
 msgstr "Keine Angabe"
@@ -11398,19 +11402,19 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
-#: lib/vutuv/accounts/user.ex:1211
+#: lib/vutuv/accounts/user.ex:1215
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
-#: lib/vutuv/accounts/user.ex:1216
+#: lib/vutuv/accounts/user.ex:1220
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
-#: lib/vutuv/accounts/user.ex:1214
+#: lib/vutuv/accounts/user.ex:1218
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:771
 #, elixir-autogen, elixir-format
@@ -12776,7 +12780,7 @@ msgstr "Hervorgehobene Tags passen zu Ihrem Profil."
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
 
-#: lib/vutuv/accounts/user.ex:1185
+#: lib/vutuv/accounts/user.ex:1189
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12895,7 +12899,7 @@ msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
 
-#: lib/vutuv/accounts/user.ex:1184
+#: lib/vutuv/accounts/user.ex:1188
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12977,7 +12981,7 @@ msgstr "Anzeige nicht gefunden."
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: lib/vutuv/accounts/user.ex:1186
+#: lib/vutuv/accounts/user.ex:1190
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
 #: lib/vutuv_web/agent_docs/markdown.ex:466
@@ -13704,7 +13708,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/components/post_components.ex:2563
+#: lib/vutuv_web/components/post_components.ex:2580
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:695
 #: lib/vutuv_web/controllers/settings_controller.ex:713
@@ -14006,7 +14010,7 @@ msgstr "Screenshot entfernt."
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
-#: lib/vutuv/accounts/user.ex:1229
+#: lib/vutuv/accounts/user.ex:1233
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -14017,19 +14021,19 @@ msgstr "Nur das Alter, ohne das Datum"
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
-#: lib/vutuv/accounts/user.ex:1232
+#: lib/vutuv/accounts/user.ex:1236
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
-#: lib/vutuv/accounts/user.ex:1235
+#: lib/vutuv/accounts/user.ex:1239
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
-#: lib/vutuv/accounts/user.ex:1226
+#: lib/vutuv/accounts/user.ex:1230
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14128,22 +14132,22 @@ msgstr "Mobil (privat)"
 msgid "Work mobile"
 msgstr "Mobil (Arbeit)"
 
-#: lib/vutuv_web/components/post_components.ex:433
+#: lib/vutuv_web/components/post_components.ex:444
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr "Noch keine Beiträge."
 
-#: lib/vutuv_web/components/post_components.ex:435
+#: lib/vutuv_web/components/post_components.ex:446
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr "Noch keine Antworten."
 
-#: lib/vutuv_web/components/post_components.ex:434
+#: lib/vutuv_web/components/post_components.ex:445
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr "Noch keine Reposts."
 
-#: lib/vutuv_web/components/post_components.ex:392
+#: lib/vutuv_web/components/post_components.ex:403
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr "Eigene Beiträge"
@@ -14158,14 +14162,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4516
 #: lib/vutuv_web/controllers/settings_controller.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:1837
+#: lib/vutuv_web/live/post_live/feed.ex:1845
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr "Tags, denen Sie folgen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1852
+#: lib/vutuv_web/live/post_live/feed.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr "#%{tag} entfolgen"
@@ -14323,34 +14327,34 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:4807
+#: lib/vutuv_web/components/post_components.ex:4837
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4764
+#: lib/vutuv_web/components/post_components.ex:4794
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:4808
+#: lib/vutuv_web/components/post_components.ex:4838
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:4810
+#: lib/vutuv_web/components/post_components.ex:4840
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:4806
+#: lib/vutuv_web/components/post_components.ex:4836
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4763
+#: lib/vutuv_web/components/post_components.ex:4793
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14361,12 +14365,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:4805
+#: lib/vutuv_web/components/post_components.ex:4835
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:4809
+#: lib/vutuv_web/components/post_components.ex:4839
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14386,7 +14390,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:4846
+#: lib/vutuv_web/components/post_components.ex:4876
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14394,27 +14398,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:4876
+#: lib/vutuv_web/components/post_components.ex:4906
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:4877
+#: lib/vutuv_web/components/post_components.ex:4907
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:4875
+#: lib/vutuv_web/components/post_components.ex:4905
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:4835
+#: lib/vutuv_web/components/post_components.ex:4865
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:4882
+#: lib/vutuv_web/components/post_components.ex:4912
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14444,7 +14448,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4649
+#: lib/vutuv_web/components/post_components.ex:4679
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14492,7 +14496,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:4640
+#: lib/vutuv_web/components/post_components.ex:4670
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -14886,14 +14890,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2836
+#: lib/vutuv_web/components/post_components.ex:2853
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2859
+#: lib/vutuv_web/components/post_components.ex:2876
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14920,7 +14924,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:5298
+#: lib/vutuv_web/components/post_components.ex:5328
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -16084,21 +16088,21 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:5244
+#: lib/vutuv_web/components/post_components.ex:5274
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:5248
+#: lib/vutuv_web/components/post_components.ex:5278
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:5252
+#: lib/vutuv_web/components/post_components.ex:5282
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16106,7 +16110,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1153
-#: lib/vutuv_web/components/post_components.ex:5203
+#: lib/vutuv_web/components/post_components.ex:5233
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16122,14 +16126,14 @@ msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem 
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
-#: lib/vutuv_web/components/post_components.ex:1371
-#: lib/vutuv_web/components/post_components.ex:2030
+#: lib/vutuv_web/components/post_components.ex:1387
+#: lib/vutuv_web/components/post_components.ex:2046
 #: lib/vutuv_web/live/fediverse_account_live.ex:294
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:1247
+#: lib/vutuv_web/components/post_components.ex:1263
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Diese Antwort aus Ihrem Beitrag entfernen?"
@@ -16158,7 +16162,7 @@ msgstr "Antwort aus einem anderen Netzwerk"
 msgid "Reply removed."
 msgstr "Antwort entfernt."
 
-#: lib/vutuv_web/components/post_components.ex:1256
+#: lib/vutuv_web/components/post_components.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
@@ -16168,7 +16172,7 @@ msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
 msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
-#: lib/vutuv_web/components/post_components.ex:1270
+#: lib/vutuv_web/components/post_components.ex:1286
 #: lib/vutuv_web/live/notification_live/index.ex:597
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -16200,9 +16204,9 @@ msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1337
-#: lib/vutuv_web/components/post_components.ex:1302
-#: lib/vutuv_web/components/post_components.ex:1502
-#: lib/vutuv_web/components/post_components.ex:2483
+#: lib/vutuv_web/components/post_components.ex:1318
+#: lib/vutuv_web/components/post_components.ex:1518
+#: lib/vutuv_web/components/post_components.ex:2500
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Original ansehen"
@@ -16869,22 +16873,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:3021
+#: lib/vutuv_web/components/post_components.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:3137
+#: lib/vutuv_web/components/post_components.ex:3154
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:3145
+#: lib/vutuv_web/components/post_components.ex:3162
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:3131
+#: lib/vutuv_web/components/post_components.ex:3148
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -17016,17 +17020,17 @@ msgstr "Nächstes Foto"
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:2616
+#: lib/vutuv_web/components/post_components.ex:2633
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:3834
+#: lib/vutuv_web/components/post_components.ex:3851
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:3982
+#: lib/vutuv_web/components/post_components.ex:3999
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -17039,7 +17043,7 @@ msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1298
 #: lib/vutuv_web/agent_docs/text.ex:785
-#: lib/vutuv_web/components/post_components.ex:4064
+#: lib/vutuv_web/components/post_components.ex:4081
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
@@ -17065,7 +17069,7 @@ msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qual
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2669
+#: lib/vutuv_web/components/post_components.ex:2686
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
@@ -17085,7 +17089,7 @@ msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen S
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/components/post_components.ex:2660
+#: lib/vutuv_web/components/post_components.ex:2677
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
@@ -17095,12 +17099,12 @@ msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht �
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/components/post_components.ex:2678
+#: lib/vutuv_web/components/post_components.ex:2695
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Diese Seite nimmt nicht am Fediverse teil."
 
-#: lib/vutuv_web/components/post_components.ex:2612
+#: lib/vutuv_web/components/post_components.ex:2629
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
@@ -17115,7 +17119,7 @@ msgstr "Wer diese Fotos weiterverwenden darf"
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:2673
+#: lib/vutuv_web/components/post_components.ex:2690
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
@@ -17125,7 +17129,7 @@ msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshal
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
 
-#: lib/vutuv_web/components/post_components.ex:2626
+#: lib/vutuv_web/components/post_components.ex:2643
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fediverse-Follower. Auf vutuv ist sie ebenfalls ein öffentlicher Beitrag."
@@ -17146,8 +17150,8 @@ msgstr "Fotos hinzufügen"
 msgid "Licence"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1638
-#: lib/vutuv_web/live/post_live/feed.ex:1639
+#: lib/vutuv_web/live/post_live/feed.ex:1645
+#: lib/vutuv_web/live/post_live/feed.ex:1646
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr "Fotos posten"
@@ -17212,13 +17216,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1171
-#: lib/vutuv_web/components/post_components.ex:5241
+#: lib/vutuv_web/components/post_components.ex:5271
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1169
-#: lib/vutuv_web/components/post_components.ex:5238
+#: lib/vutuv_web/components/post_components.ex:5268
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17228,7 +17232,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:5130
+#: lib/vutuv_web/components/post_components.ex:5160
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17577,7 +17581,7 @@ msgstr "Von hier aus wird %{follows} Konten in anderen Netzwerken gefolgt, davon
 msgid "Cached posts"
 msgstr "Zwischengespeicherte Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:2428
+#: lib/vutuv_web/components/post_components.ex:2445
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Nur für die Follower dieses Kontos"
@@ -17587,7 +17591,7 @@ msgstr "Nur für die Follower dieses Kontos"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:2482
+#: lib/vutuv_web/components/post_components.ex:2499
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -17607,12 +17611,12 @@ msgstr "Zwischengespeicherter Beitrag gemeldet, hier für alle entfernt"
 msgid "Content from other networks taken down by members"
 msgstr "Von Mitgliedern entfernte Inhalte aus anderen Netzwerken"
 
-#: lib/vutuv_web/components/post_components.ex:1630
+#: lib/vutuv_web/components/post_components.ex:1646
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Verbergen"
 
-#: lib/vutuv_web/components/post_components.ex:2447
+#: lib/vutuv_web/components/post_components.ex:2464
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Von der verfassenden Person als sensibel markiert"
@@ -17628,7 +17632,7 @@ msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwin
 msgid "Nobody has removed or reported anything yet."
 msgstr "Bisher hat niemand etwas entfernt oder gemeldet."
 
-#: lib/vutuv_web/components/post_components.ex:2414
+#: lib/vutuv_web/components/post_components.ex:2431
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr "Diesen Beitrag als unangemessen melden? Unsere Kopie wird sofort für alle auf diesem vutuv gelöscht."
@@ -17850,27 +17854,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(ein Bild)"
 msgstr[1] "(%{count} Bilder)"
 
-#: lib/vutuv_web/components/post_components.ex:2150
+#: lib/vutuv_web/components/post_components.ex:2167
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr "Bild wird geprüft"
 
-#: lib/vutuv_web/components/post_components.ex:2179
+#: lib/vutuv_web/components/post_components.ex:2196
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Wieder verdecken"
 
-#: lib/vutuv_web/components/post_components.ex:2174
+#: lib/vutuv_web/components/post_components.ex:2191
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Heikles Motiv. Bild anzeigen."
 
-#: lib/vutuv_web/components/post_components.ex:2519
+#: lib/vutuv_web/components/post_components.ex:2536
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:2525
+#: lib/vutuv_web/components/post_components.ex:2542
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
@@ -17880,7 +17884,7 @@ msgstr "Diesen Beitrag gibt es hier nicht mehr."
 msgid "Back to the feed"
 msgstr "Zurück zum Feed"
 
-#: lib/vutuv_web/components/post_components.ex:2664
+#: lib/vutuv_web/components/post_components.ex:2681
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18593,14 +18597,14 @@ msgstr "Seiten, von denen nie ein Screenshot entsteht, weil ein Browser ohne Anz
 msgid "Screenshot blocklist"
 msgstr "Screenshot-Blockliste"
 
-#: lib/vutuv_web/components/post_components.ex:425
+#: lib/vutuv_web/components/post_components.ex:436
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 "Noch nichts aus dem Fediverse. Folgen Sie Konten dort draußen, um diesen Tab "
 "zu füllen."
 
-#: lib/vutuv_web/components/post_components.ex:422
+#: lib/vutuv_web/components/post_components.ex:433
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
@@ -18643,7 +18647,7 @@ msgstr "Auf vutuv gibt es zu diesem Tag noch keine Beiträge."
 msgid "word in a post"
 msgstr "Wort in einem Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:2522
+#: lib/vutuv_web/components/post_components.ex:2539
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Diese Antwort gibt es hier nicht mehr."
@@ -18946,19 +18950,19 @@ msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:4336
+#: lib/vutuv_web/components/post_components.ex:4366
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4338
+#: lib/vutuv_web/components/post_components.ex:4368
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:4349
+#: lib/vutuv_web/components/post_components.ex:4379
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
@@ -19934,17 +19938,17 @@ msgstr ""
 "Kommt keine PIN an? Ist die E-Mail-Adresse {email} korrekt? Haben Sie einmal "
 "in Ihren Spam-Ordner geschaut?"
 
-#: lib/vutuv/accounts/user.ex:1332
+#: lib/vutuv/accounts/user.ex:1336
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/vutuv/accounts/user.ex:1330
+#: lib/vutuv/accounts/user.ex:1334
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Weiblich"
 
-#: lib/vutuv/accounts/user.ex:1331
+#: lib/vutuv/accounts/user.ex:1335
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
@@ -20632,7 +20636,7 @@ msgstr "Suchen Sie so oft Sie möchten und nehmen Sie dazu, was gehört. Abkürz
 msgid "Start over"
 msgstr "Von vorn beginnen"
 
-#: lib/vutuv_web/components/post_components.ex:2552
+#: lib/vutuv_web/components/post_components.ex:2569
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr "Ein Herz oder ein Repost geht zurück in das Netzwerk, aus dem dieser Beitrag stammt. Ihr Konto nimmt derzeit nicht am Fediverse teil. Einschalten können Sie das in den {settings}."
@@ -21140,21 +21144,6 @@ msgstr[0] ""
 msgstr[1] ""
 "%{members} vutuv-Mitglieder plus %{fediverse} Fediverse-Accounts, die folgen"
 
-#: lib/vutuv_web/templates/directory/index.html.heex:14
-#, elixir-autogen, elixir-format
-msgid "%{count} vutuv members whose profiles are open to search engines, filed alphabetically by last name."
-msgstr ""
-"%{count} vutuv Mitglieder, deren Profile für Suchmaschinen freigegeben sind, "
-"alphabetisch nach Nachnamen sortiert."
-
-#: lib/vutuv_web/agent_docs/list_docs.ex:205
-#, elixir-autogen, elixir-format
-msgid "%{listed} vutuv members are listed here, grouped by the first letter of their last name; anyone who does not open their profile to search engines is not among them."
-msgstr ""
-"Hier sind %{listed} vutuv Mitglieder aufgeführt, gruppiert nach dem "
-"Anfangsbuchstaben des Nachnamens; wer sein Profil nicht für Suchmaschinen "
-"freigibt, ist nicht dabei."
-
 #: lib/vutuv_web/live/section_reorder_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Add this under Messengers"
@@ -21483,7 +21472,7 @@ msgstr ""
 "Archiv neuere enthält."
 
 #: lib/vutuv_web/controllers/import_controller.ex:272
-#: lib/vutuv_web/views/user_helpers.ex:219
+#: lib/vutuv_web/views/user_helpers.ex:240
 #, elixir-autogen, elixir-format
 msgid "%{count} tag did not fit: your profile holds at most %{max}. Remove some and try again."
 msgid_plural "%{count} tags did not fit: your profile holds at most %{max}. Remove some and try again."
@@ -21504,7 +21493,7 @@ msgstr "Zuerst Tags entfernen"
 msgid "Select as many as fit"
 msgstr "So viele wie möglich auswählen"
 
-#: lib/vutuv_web/views/user_helpers.ex:209
+#: lib/vutuv_web/views/user_helpers.ex:230
 #, elixir-autogen, elixir-format
 msgid "Skipped %{count} tag that is a duplicate or invalid."
 msgid_plural "Skipped %{count} tags that are duplicates or invalid."
@@ -21548,27 +21537,27 @@ msgstr "Sprache des Beitrags"
 msgid "The language this post is written in"
 msgstr "Die Sprache, in der dieser Beitrag geschrieben ist"
 
-#: lib/vutuv_web/components/post_components.ex:4230
+#: lib/vutuv_web/components/post_components.ex:4260
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Original anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:4266
+#: lib/vutuv_web/components/post_components.ex:4296
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Übersetzen"
 
-#: lib/vutuv_web/components/post_components.ex:4275
+#: lib/vutuv_web/components/post_components.ex:4305
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Übersetzt"
 
-#: lib/vutuv_web/components/post_components.ex:4278
+#: lib/vutuv_web/components/post_components.ex:4308
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Übersetzt aus %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:4255
+#: lib/vutuv_web/components/post_components.ex:4285
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Wird übersetzt …"
@@ -21578,7 +21567,7 @@ msgstr "Wird übersetzt …"
 msgid "Feed language settings reset to the site defaults."
 msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
 
-#: lib/vutuv_web/components/post_components.ex:4245
+#: lib/vutuv_web/components/post_components.ex:4275
 #: lib/vutuv_web/components/ui.ex:4509
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -21707,20 +21696,20 @@ msgstr "Wir haben den Link in Ihrem Profil noch nicht gefunden. Bitte versuchen 
 msgid "Your username, or paste the address of your profile page."
 msgstr "Ihr Benutzername – oder fügen Sie die Adresse Ihrer Profilseite ein."
 
-#: lib/vutuv_web/components/post_components.ex:4030
+#: lib/vutuv_web/components/post_components.ex:4047
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] "Unsere KI prüft es gerade. Sobald die Prüfung durch ist, erscheint das Foto von selbst."
 msgstr[1] "Unsere KI prüft sie gerade, %{done} von %{total} sind durch. Sobald die letzte durch ist, erscheinen die Fotos von selbst."
 
-#: lib/vutuv_web/components/post_components.ex:4027
+#: lib/vutuv_web/components/post_components.ex:4044
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Ihr Beitrag ist veröffentlicht, das Foto noch nicht."
 
-#: lib/vutuv_web/components/post_components.ex:2201
-#: lib/vutuv_web/components/post_components.ex:3354
+#: lib/vutuv_web/components/post_components.ex:2218
+#: lib/vutuv_web/components/post_components.ex:3371
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -21737,7 +21726,7 @@ msgstr "Empfohlen: %{width} × %{height} Pixel (%{ratio})."
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Empfohlen: quadratisch, mindestens %{width} × %{height} Pixel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1894
+#: lib/vutuv_web/live/post_live/feed.ex:1902
 #: lib/vutuv_web/views/user_html.ex:338
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -22231,7 +22220,7 @@ msgstr "Land suchen"
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr "Diese Seite folgt bereits so vielen Konten, wie hier erlaubt sind (%{max})."
 
-#: lib/vutuv_web/components/post_components.ex:2402
+#: lib/vutuv_web/components/post_components.ex:2419
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr "%{handle} nicht mehr folgen? Die Beiträge verschwinden aus Ihrem Feed."
@@ -22357,12 +22346,12 @@ msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public po
 msgstr ""
 "Folgen Sie #%{tag} von Mastodon oder einer anderen Fediverse-App aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1876
+#: lib/vutuv_web/live/post_live/feed.ex:1884
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Andere Mitglieder begrüßen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1872
+#: lib/vutuv_web/live/post_live/feed.ex:1880
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr "Neu dabei"
@@ -22408,33 +22397,33 @@ msgstr "Der beste Weg: Folgen Sie %{name} hier. Neue Beiträge landen in Ihrem F
 msgid "With a vutuv account"
 msgstr "Mit einem vutuv-Konto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1886
+#: lib/vutuv_web/live/post_live/feed.ex:1894
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
 "Ein paar der neuesten Mitglieder. Ihnen zu folgen ist eine herzliche "
 "Begrüßung."
 
-#: lib/vutuv_web/components/post_components.ex:602
+#: lib/vutuv_web/components/post_components.ex:613
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post"
 msgid_plural "%{formatted} new posts"
 msgstr[0] "%{formatted} neuer Beitrag"
 msgstr[1] "%{formatted} neue Beiträge"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1314
+#: lib/vutuv_web/live/post_live/feed.ex:1312
 #, elixir-autogen, elixir-format
 msgid "%{source}: %{formatted} new post"
 msgid_plural "%{source}: %{formatted} new posts"
 msgstr[0] "%{source}: %{formatted} neuer Beitrag"
 msgstr[1] "%{source}: %{formatted} neue Beiträge"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1311
+#: lib/vutuv_web/live/post_live/feed.ex:1309
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post"
 msgstr "%{source}: neuer Beitrag"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1308
+#: lib/vutuv_web/live/post_live/feed.ex:1306
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post from %{who}"
 msgstr "%{source}: neuer Beitrag von %{who}"
@@ -22733,3 +22722,61 @@ msgstr "Ihr LinkedIn-Profil kann mitkommen."
 #, elixir-autogen, elixir-format
 msgid "Being checked"
 msgstr "Wird geprüft"
+
+#: lib/vutuv_web/templates/directory/index.html.heex:23
+#, elixir-autogen, elixir-format
+msgid "%{count} vutuv members, filed alphabetically by last name."
+msgstr "%{count} vutuv Mitglieder, alphabetisch nach Nachname sortiert."
+
+#: lib/vutuv_web/agent_docs/list_docs.ex:205
+#, elixir-autogen, elixir-format
+msgid "%{listed} vutuv members are listed here, grouped by the first letter of their last name."
+msgstr "Hier sind %{listed} vutuv Mitglieder aufgeführt, gruppiert nach dem Anfangsbuchstaben des Nachnamens."
+
+#: lib/vutuv_web/live/directory_search_live.ex:141
+#, elixir-autogen, elixir-format
+msgid "Find a member"
+msgstr "Mitglied finden"
+
+#: lib/vutuv_web/live/directory_search_live.ex:195
+#, elixir-autogen, elixir-format
+msgid "No members found for \"%{query}\"."
+msgstr "Kein Mitglied für „%{query}“ gefunden."
+
+#: lib/vutuv_web/live/directory_search_live.ex:208
+#, elixir-autogen, elixir-format
+msgid "One member found."
+msgid_plural "%{formatted} members found."
+msgstr[0] "Ein Mitglied gefunden."
+msgstr[1] "%{formatted} Mitglieder gefunden."
+
+#: lib/vutuv_web/live/directory_search_live.ex:186
+#, elixir-autogen, elixir-format
+msgid "Results appear once you have typed at least %{count} letters."
+msgstr "Ergebnisse erscheinen, sobald Sie mindestens %{count} Buchstaben eingegeben haben."
+
+#: lib/vutuv_web/live/directory_search_live.ex:152
+#: lib/vutuv_web/live/directory_search_live.ex:153
+#, elixir-autogen, elixir-format
+msgid "Search members by name"
+msgstr "Mitglieder nach Namen suchen"
+
+#: lib/vutuv_web/live/directory_search_live.ex:229
+#, elixir-autogen, elixir-format
+msgid "Show %{count} more"
+msgstr "%{count} weitere anzeigen"
+
+#: lib/vutuv_web/live/directory_search_live.ex:203
+#, elixir-autogen, elixir-format
+msgid "Showing %{shown} of %{total} members."
+msgstr "%{shown} von %{total} Mitgliedern werden angezeigt."
+
+#: lib/vutuv_web/live/directory_search_live.ex:257
+#, elixir-autogen, elixir-format
+msgid "That is as far as this list goes. Type more of the name to narrow it down."
+msgstr "Weiter geht diese Liste nicht. Tippen Sie mehr vom Namen, um sie einzugrenzen."
+
+#: lib/vutuv_web/live/directory_search_live.ex:160
+#, elixir-autogen, elixir-format
+msgid "Which names to search"
+msgstr "Welche Namen durchsucht werden"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -162,7 +162,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3153
+#: lib/vutuv_web/components/post_components.ex:3170
 #: lib/vutuv_web/components/ui.ex:4106
 #: lib/vutuv_web/live/admin/job_live.ex:489
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -211,7 +211,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3118
+#: lib/vutuv_web/components/post_components.ex:3135
 #: lib/vutuv_web/components/ui.ex:4097
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -475,7 +475,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:629
+#: lib/vutuv_web/components/post_components.ex:640
 #: lib/vutuv_web/live/notification_live/index.ex:699
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -643,6 +643,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:193
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:219
+#: lib/vutuv_web/live/directory_search_live.ex:181
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:49
 #: lib/vutuv_web/live/search_live.ex:570
@@ -657,7 +658,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1627
+#: lib/vutuv_web/components/post_components.ex:1643
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -793,6 +794,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
+#: lib/vutuv_web/live/directory_search_live.ex:134
 #: lib/vutuv_web/live/notification_live/index.ex:1099
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
@@ -1750,7 +1752,7 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:436
+#: lib/vutuv_web/components/post_components.ex:447
 #: lib/vutuv_web/components/ui.ex:4216
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
@@ -2101,7 +2103,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3150
+#: lib/vutuv_web/components/post_components.ex:3167
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2117,7 +2119,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:114
 #: lib/vutuv_web/live/post_live/feed.ex:206
-#: lib/vutuv_web/live/post_live/feed.ex:1591
+#: lib/vutuv_web/live/post_live/feed.ex:1598
 #: lib/vutuv_web/live/shell_live.ex:973
 #: lib/vutuv_web/live/shell_live.ex:1272
 #: lib/vutuv_web/templates/layout/app.html.heex:171
@@ -2145,8 +2147,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3104
-#: lib/vutuv_web/components/post_components.ex:3106
+#: lib/vutuv_web/components/post_components.ex:3121
+#: lib/vutuv_web/components/post_components.ex:3123
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2162,7 +2164,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1802
+#: lib/vutuv_web/live/post_live/feed.ex:1810
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2212,13 +2214,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3568
-#: lib/vutuv_web/components/post_components.ex:3572
+#: lib/vutuv_web/components/post_components.ex:3585
+#: lib/vutuv_web/components/post_components.ex:3589
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3569
+#: lib/vutuv_web/components/post_components.ex:3586
 #: lib/vutuv_web/live/fediverse_account_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2226,7 +2228,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:376
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1249
+#: lib/vutuv_web/components/post_components.ex:1265
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2236,7 +2238,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/composer.ex:1940
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
-#: lib/vutuv_web/templates/connection/index.html.heex:40
+#: lib/vutuv_web/templates/connection/index.html.heex:45
 #: lib/vutuv_web/views/settings_html.ex:342
 #, elixir-autogen, elixir-format
 msgid "Remove"
@@ -2252,7 +2254,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1703
+#: lib/vutuv_web/live/post_live/feed.ex:1710
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2308,27 +2310,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3101
+#: lib/vutuv_web/components/post_components.ex:3118
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4957
+#: lib/vutuv_web/components/post_components.ex:4987
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4961
+#: lib/vutuv_web/components/post_components.ex:4991
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4959
+#: lib/vutuv_web/components/post_components.ex:4989
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4960
+#: lib/vutuv_web/components/post_components.ex:4990
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2369,8 +2371,8 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1842
-#: lib/vutuv_web/components/post_components.ex:5053
+#: lib/vutuv_web/components/post_components.ex:1858
+#: lib/vutuv_web/components/post_components.ex:5083
 #: lib/vutuv_web/components/ui.ex:3629
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
@@ -2388,8 +2390,8 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1795
-#: lib/vutuv_web/components/post_components.ex:5289
+#: lib/vutuv_web/components/post_components.ex:1811
+#: lib/vutuv_web/components/post_components.ex:5319
 #: lib/vutuv_web/components/ui.ex:3615
 #: lib/vutuv_web/live/notification_live/index.ex:1089
 #: lib/vutuv_web/views/user_html.ex:467
@@ -2398,7 +2400,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:5299
+#: lib/vutuv_web/components/post_components.ex:5329
 #: lib/vutuv_web/live/notification_live/index.ex:1022
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
@@ -2420,40 +2422,40 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5041
+#: lib/vutuv_web/components/post_components.ex:5071
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1841
-#: lib/vutuv_web/components/post_components.ex:5052
+#: lib/vutuv_web/components/post_components.ex:1857
+#: lib/vutuv_web/components/post_components.ex:5082
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1823
-#: lib/vutuv_web/components/post_components.ex:5038
+#: lib/vutuv_web/components/post_components.ex:1839
+#: lib/vutuv_web/components/post_components.ex:5068
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2088
-#: lib/vutuv_web/components/post_components.ex:4163
+#: lib/vutuv_web/components/post_components.ex:2104
+#: lib/vutuv_web/components/post_components.ex:4193
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1822
-#: lib/vutuv_web/components/post_components.ex:5037
+#: lib/vutuv_web/components/post_components.ex:1838
+#: lib/vutuv_web/components/post_components.ex:5067
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1794
-#: lib/vutuv_web/components/post_components.ex:5288
+#: lib/vutuv_web/components/post_components.ex:1810
+#: lib/vutuv_web/components/post_components.ex:5318
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:467
 #, elixir-autogen, elixir-format
@@ -2461,14 +2463,14 @@ msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:377
-#: lib/vutuv_web/components/post_components.ex:2407
+#: lib/vutuv_web/components/post_components.ex:2424
 #: lib/vutuv_web/components/ui.ex:2484
 #: lib/vutuv_web/components/ui.ex:2484
 #: lib/vutuv_web/components/ui.ex:2621
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:489
-#: lib/vutuv_web/live/post_live/feed.ex:1851
+#: lib/vutuv_web/live/post_live/feed.ex:1859
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2480,27 +2482,27 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5343
+#: lib/vutuv_web/components/post_components.ex:5373
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:394
+#: lib/vutuv_web/components/post_components.ex:405
 #: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1808
-#: lib/vutuv_web/components/post_components.ex:5326
-#: lib/vutuv_web/components/post_components.ex:5327
+#: lib/vutuv_web/components/post_components.ex:1824
+#: lib/vutuv_web/components/post_components.ex:5356
+#: lib/vutuv_web/components/post_components.ex:5357
 #: lib/vutuv_web/live/notification_live/index.ex:1086
 #: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3068
+#: lib/vutuv_web/components/post_components.ex:3085
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2521,7 +2523,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2604
+#: lib/vutuv_web/components/post_components.ex:2621
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:57
@@ -2529,14 +2531,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3042
+#: lib/vutuv_web/components/post_components.ex:3059
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3033
-#: lib/vutuv_web/components/post_components.ex:3060
-#: lib/vutuv_web/components/post_components.ex:3063
+#: lib/vutuv_web/components/post_components.ex:3050
+#: lib/vutuv_web/components/post_components.ex:3077
+#: lib/vutuv_web/components/post_components.ex:3080
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2759,14 +2761,14 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1629
+#: lib/vutuv_web/live/post_live/feed.ex:1636
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:192
-#: lib/vutuv_web/views/user_helpers.ex:204
+#: lib/vutuv_web/views/user_helpers.ex:213
+#: lib/vutuv_web/views/user_helpers.ex:225
 #, elixir-autogen, elixir-format
 msgid "Added %{count} tag."
 msgid_plural "Added %{count} tags."
@@ -2780,8 +2782,8 @@ msgid_plural "%{formatted} connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1953
-#: lib/vutuv_web/templates/user/card_list.html.heex:46
+#: lib/vutuv_web/live/post_live/feed.ex:1961
+#: lib/vutuv_web/templates/user/card_list.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
 msgid_plural "+%{formatted} more tags"
@@ -2802,7 +2804,7 @@ msgstr ""
 msgid "Markdown"
 msgstr ""
 
-#: lib/vutuv_web/templates/connection/index.html.heex:45
+#: lib/vutuv_web/templates/connection/index.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "No connections yet."
 msgstr ""
@@ -2835,7 +2837,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4958
+#: lib/vutuv_web/components/post_components.ex:4988
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3098,7 +3100,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3009
+#: lib/vutuv_web/components/post_components.ex:3026
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3173,9 +3175,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1259
-#: lib/vutuv_web/components/post_components.ex:2419
-#: lib/vutuv_web/components/post_components.ex:3173
+#: lib/vutuv_web/components/post_components.ex:1275
+#: lib/vutuv_web/components/post_components.ex:2436
+#: lib/vutuv_web/components/post_components.ex:3190
 #: lib/vutuv_web/live/organization_live/show.ex:562
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
@@ -4541,7 +4543,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1807
+#: lib/vutuv_web/live/post_live/feed.ex:1815
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4618,8 +4620,8 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:391
-#: lib/vutuv_web/components/post_components.ex:410
+#: lib/vutuv_web/components/post_components.ex:402
+#: lib/vutuv_web/components/post_components.ex:421
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -5419,11 +5421,11 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3239
-#: lib/vutuv_web/components/post_components.ex:3294
-#: lib/vutuv_web/components/post_components.ex:3705
+#: lib/vutuv_web/components/post_components.ex:3256
+#: lib/vutuv_web/components/post_components.ex:3311
+#: lib/vutuv_web/components/post_components.ex:3722
 #: lib/vutuv_web/live/notification_live/index.ex:743
-#: lib/vutuv_web/live/post_live/feed.ex:1994
+#: lib/vutuv_web/live/post_live/feed.ex:2002
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -6214,7 +6216,7 @@ msgid "Previous day"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:393
+#: lib/vutuv_web/components/post_components.ex:404
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6307,7 +6309,7 @@ msgstr ""
 msgid "Members who endorsed %{name} for %{tag}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user_tag/endorsers.html.heex:74
+#: lib/vutuv_web/templates/user_tag/endorsers.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "No endorsements yet."
 msgstr ""
@@ -6607,8 +6609,8 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2387
-#: lib/vutuv_web/components/post_components.ex:3170
+#: lib/vutuv_web/components/post_components.ex:2404
+#: lib/vutuv_web/components/post_components.ex:3187
 #: lib/vutuv_web/components/ui.ex:2809
 #: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/live/organization_live/following.ex:376
@@ -6630,12 +6632,12 @@ msgstr ""
 msgid "New messages and new connections"
 msgstr ""
 
-#: lib/vutuv_web/templates/connection/index.html.heex:38
+#: lib/vutuv_web/templates/connection/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3170
+#: lib/vutuv_web/components/post_components.ex:3187
 #: lib/vutuv_web/components/ui.ex:2808
 #: lib/vutuv_web/live/fediverse_account_live.ex:379
 #: lib/vutuv_web/live/organization_live/following.ex:376
@@ -7345,7 +7347,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5199
+#: lib/vutuv_web/components/post_components.ex:5229
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7886,7 +7888,7 @@ msgid "Admins"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:1962
+#: lib/vutuv_web/live/post_live/feed.ex:1970
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -8443,12 +8445,12 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1979
+#: lib/vutuv_web/live/post_live/feed.ex:1987
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1975
+#: lib/vutuv_web/live/post_live/feed.ex:1983
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8501,7 +8503,7 @@ msgid "Invalid address (skipped)"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/list_docs.ex:191
-#: lib/vutuv_web/controllers/directory_controller.ex:32
+#: lib/vutuv_web/controllers/directory_controller.ex:53
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:5
@@ -8510,14 +8512,14 @@ msgstr ""
 msgid "Member directory"
 msgstr ""
 
-#: lib/vutuv_web/templates/directory/index.html.heex:24
+#: lib/vutuv_web/templates/directory/index.html.heex:32
 #: lib/vutuv_web/templates/directory/show.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Members by initial"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/list_docs.ex:217
-#: lib/vutuv_web/controllers/directory_controller.ex:58
+#: lib/vutuv_web/controllers/directory_controller.ex:86
 #: lib/vutuv_web/templates/directory/show.html.heex:2
 #, elixir-autogen, elixir-format
 msgid "Members: %{letter}"
@@ -8792,7 +8794,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4166
+#: lib/vutuv_web/components/post_components.ex:4196
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -8911,12 +8913,12 @@ msgstr ""
 msgid "Choose automatically instead"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:469
+#: lib/vutuv_web/views/user_helpers.ex:490
 #, elixir-autogen, elixir-format
 msgid "Show at top of profile"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:460
+#: lib/vutuv_web/views/user_helpers.ex:481
 #, elixir-autogen, elixir-format
 msgid "Shown at the top of your profile"
 msgstr ""
@@ -9455,18 +9457,18 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1173
+#: lib/vutuv/accounts/user.ex:1177
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:86
+#: lib/vutuv_web/views/user_helpers.ex:107
 #, elixir-autogen, elixir-format
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1170
+#: lib/vutuv/accounts/user.ex:1174
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9747,19 +9749,21 @@ msgstr ""
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
 
+#: lib/vutuv_web/live/directory_search_live.ex:132
 #: lib/vutuv_web/templates/page/index.html.heex:90
 #: lib/vutuv_web/views/account_event_text.ex:210
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
+#: lib/vutuv_web/live/directory_search_live.ex:133
 #: lib/vutuv_web/templates/page/index.html.heex:95
 #: lib/vutuv_web/views/account_event_text.ex:211
 #, elixir-autogen, elixir-format
 msgid "Last name"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:109
+#: lib/vutuv_web/views/user_helpers.ex:130
 #, elixir-autogen, elixir-format
 msgid "Prefer not to say"
 msgstr ""
@@ -10821,19 +10825,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1211
+#: lib/vutuv/accounts/user.ex:1215
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1216
+#: lib/vutuv/accounts/user.ex:1220
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1214
+#: lib/vutuv/accounts/user.ex:1218
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:771
 #, elixir-autogen, elixir-format
@@ -12131,7 +12135,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1185
+#: lib/vutuv/accounts/user.ex:1189
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12250,7 +12254,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1184
+#: lib/vutuv/accounts/user.ex:1188
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12332,7 +12336,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1186
+#: lib/vutuv/accounts/user.ex:1190
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
 #: lib/vutuv_web/agent_docs/markdown.ex:466
@@ -13053,7 +13057,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2563
+#: lib/vutuv_web/components/post_components.ex:2580
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:695
 #: lib/vutuv_web/controllers/settings_controller.ex:713
@@ -13347,7 +13351,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1229
+#: lib/vutuv/accounts/user.ex:1233
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13358,19 +13362,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1232
+#: lib/vutuv/accounts/user.ex:1236
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1235
+#: lib/vutuv/accounts/user.ex:1239
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1226
+#: lib/vutuv/accounts/user.ex:1230
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13467,22 +13471,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:433
+#: lib/vutuv_web/components/post_components.ex:444
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:435
+#: lib/vutuv_web/components/post_components.ex:446
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:434
+#: lib/vutuv_web/components/post_components.ex:445
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:392
+#: lib/vutuv_web/components/post_components.ex:403
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13494,14 +13498,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4516
 #: lib/vutuv_web/controllers/settings_controller.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:1837
+#: lib/vutuv_web/live/post_live/feed.ex:1845
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1852
+#: lib/vutuv_web/live/post_live/feed.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13657,34 +13661,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4807
+#: lib/vutuv_web/components/post_components.ex:4837
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4764
+#: lib/vutuv_web/components/post_components.ex:4794
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4808
+#: lib/vutuv_web/components/post_components.ex:4838
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4810
+#: lib/vutuv_web/components/post_components.ex:4840
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4806
+#: lib/vutuv_web/components/post_components.ex:4836
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4763
+#: lib/vutuv_web/components/post_components.ex:4793
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13695,12 +13699,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4805
+#: lib/vutuv_web/components/post_components.ex:4835
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4809
+#: lib/vutuv_web/components/post_components.ex:4839
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13720,7 +13724,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4846
+#: lib/vutuv_web/components/post_components.ex:4876
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13728,27 +13732,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4876
+#: lib/vutuv_web/components/post_components.ex:4906
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4877
+#: lib/vutuv_web/components/post_components.ex:4907
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4875
+#: lib/vutuv_web/components/post_components.ex:4905
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4835
+#: lib/vutuv_web/components/post_components.ex:4865
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4882
+#: lib/vutuv_web/components/post_components.ex:4912
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13778,7 +13782,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4649
+#: lib/vutuv_web/components/post_components.ex:4679
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13826,7 +13830,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4640
+#: lib/vutuv_web/components/post_components.ex:4670
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14198,14 +14202,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2836
+#: lib/vutuv_web/components/post_components.ex:2853
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2859
+#: lib/vutuv_web/components/post_components.ex:2876
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14232,7 +14236,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5298
+#: lib/vutuv_web/components/post_components.ex:5328
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -15380,21 +15384,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5244
+#: lib/vutuv_web/components/post_components.ex:5274
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5248
+#: lib/vutuv_web/components/post_components.ex:5278
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5252
+#: lib/vutuv_web/components/post_components.ex:5282
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15402,7 +15406,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1153
-#: lib/vutuv_web/components/post_components.ex:5203
+#: lib/vutuv_web/components/post_components.ex:5233
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15418,14 +15422,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1371
-#: lib/vutuv_web/components/post_components.ex:2030
+#: lib/vutuv_web/components/post_components.ex:1387
+#: lib/vutuv_web/components/post_components.ex:2046
 #: lib/vutuv_web/live/fediverse_account_live.ex:294
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1247
+#: lib/vutuv_web/components/post_components.ex:1263
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15454,7 +15458,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1256
+#: lib/vutuv_web/components/post_components.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15464,7 +15468,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1270
+#: lib/vutuv_web/components/post_components.ex:1286
 #: lib/vutuv_web/live/notification_live/index.ex:597
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15496,9 +15500,9 @@ msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1337
-#: lib/vutuv_web/components/post_components.ex:1302
-#: lib/vutuv_web/components/post_components.ex:1502
-#: lib/vutuv_web/components/post_components.ex:2483
+#: lib/vutuv_web/components/post_components.ex:1318
+#: lib/vutuv_web/components/post_components.ex:1518
+#: lib/vutuv_web/components/post_components.ex:2500
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -16161,22 +16165,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3021
+#: lib/vutuv_web/components/post_components.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3137
+#: lib/vutuv_web/components/post_components.ex:3154
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3145
+#: lib/vutuv_web/components/post_components.ex:3162
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3131
+#: lib/vutuv_web/components/post_components.ex:3148
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16302,17 +16306,17 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2616
+#: lib/vutuv_web/components/post_components.ex:2633
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3834
+#: lib/vutuv_web/components/post_components.ex:3851
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3982
+#: lib/vutuv_web/components/post_components.ex:3999
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16325,7 +16329,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1298
 #: lib/vutuv_web/agent_docs/text.ex:785
-#: lib/vutuv_web/components/post_components.ex:4064
+#: lib/vutuv_web/components/post_components.ex:4081
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
@@ -16351,7 +16355,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2669
+#: lib/vutuv_web/components/post_components.ex:2686
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16371,7 +16375,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2660
+#: lib/vutuv_web/components/post_components.ex:2677
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16381,12 +16385,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2678
+#: lib/vutuv_web/components/post_components.ex:2695
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2612
+#: lib/vutuv_web/components/post_components.ex:2629
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16401,7 +16405,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2673
+#: lib/vutuv_web/components/post_components.ex:2690
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16411,7 +16415,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2626
+#: lib/vutuv_web/components/post_components.ex:2643
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16432,8 +16436,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1638
-#: lib/vutuv_web/live/post_live/feed.ex:1639
+#: lib/vutuv_web/live/post_live/feed.ex:1645
+#: lib/vutuv_web/live/post_live/feed.ex:1646
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr ""
@@ -16498,13 +16502,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1171
-#: lib/vutuv_web/components/post_components.ex:5241
+#: lib/vutuv_web/components/post_components.ex:5271
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1169
-#: lib/vutuv_web/components/post_components.ex:5238
+#: lib/vutuv_web/components/post_components.ex:5268
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16514,7 +16518,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5130
+#: lib/vutuv_web/components/post_components.ex:5160
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -16854,7 +16858,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2428
+#: lib/vutuv_web/components/post_components.ex:2445
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16864,7 +16868,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2482
+#: lib/vutuv_web/components/post_components.ex:2499
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16884,12 +16888,12 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1630
+#: lib/vutuv_web/components/post_components.ex:1646
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2447
+#: lib/vutuv_web/components/post_components.ex:2464
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr ""
@@ -16905,7 +16909,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2414
+#: lib/vutuv_web/components/post_components.ex:2431
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17127,27 +17131,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2150
+#: lib/vutuv_web/components/post_components.ex:2167
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2179
+#: lib/vutuv_web/components/post_components.ex:2196
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2174
+#: lib/vutuv_web/components/post_components.ex:2191
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2519
+#: lib/vutuv_web/components/post_components.ex:2536
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2525
+#: lib/vutuv_web/components/post_components.ex:2542
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr ""
@@ -17157,7 +17161,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2664
+#: lib/vutuv_web/components/post_components.ex:2681
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17857,12 +17861,12 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:425
+#: lib/vutuv_web/components/post_components.ex:436
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:422
+#: lib/vutuv_web/components/post_components.ex:433
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
@@ -17904,7 +17908,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2522
+#: lib/vutuv_web/components/post_components.ex:2539
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -18207,19 +18211,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4336
+#: lib/vutuv_web/components/post_components.ex:4366
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4338
+#: lib/vutuv_web/components/post_components.ex:4368
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4349
+#: lib/vutuv_web/components/post_components.ex:4379
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -19177,17 +19181,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1332
+#: lib/vutuv/accounts/user.ex:1336
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1330
+#: lib/vutuv/accounts/user.ex:1334
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1331
+#: lib/vutuv/accounts/user.ex:1335
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19873,7 +19877,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2552
+#: lib/vutuv_web/components/post_components.ex:2569
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -20379,16 +20383,6 @@ msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/directory/index.html.heex:14
-#, elixir-autogen, elixir-format
-msgid "%{count} vutuv members whose profiles are open to search engines, filed alphabetically by last name."
-msgstr ""
-
-#: lib/vutuv_web/agent_docs/list_docs.ex:205
-#, elixir-autogen, elixir-format
-msgid "%{listed} vutuv members are listed here, grouped by the first letter of their last name; anyone who does not open their profile to search engines is not among them."
-msgstr ""
-
 #: lib/vutuv_web/live/section_reorder_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Add this under Messengers"
@@ -20706,7 +20700,7 @@ msgid "You can analyse the same or a newer LinkedIn archive again at any time. N
 msgstr ""
 
 #: lib/vutuv_web/controllers/import_controller.ex:272
-#: lib/vutuv_web/views/user_helpers.ex:219
+#: lib/vutuv_web/views/user_helpers.ex:240
 #, elixir-autogen, elixir-format
 msgid "%{count} tag did not fit: your profile holds at most %{max}. Remove some and try again."
 msgid_plural "%{count} tags did not fit: your profile holds at most %{max}. Remove some and try again."
@@ -20723,7 +20717,7 @@ msgstr ""
 msgid "Select as many as fit"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:209
+#: lib/vutuv_web/views/user_helpers.ex:230
 #, elixir-autogen, elixir-format
 msgid "Skipped %{count} tag that is a duplicate or invalid."
 msgid_plural "Skipped %{count} tags that are duplicates or invalid."
@@ -20765,27 +20759,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4230
+#: lib/vutuv_web/components/post_components.ex:4260
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4266
+#: lib/vutuv_web/components/post_components.ex:4296
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4275
+#: lib/vutuv_web/components/post_components.ex:4305
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4278
+#: lib/vutuv_web/components/post_components.ex:4308
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4255
+#: lib/vutuv_web/components/post_components.ex:4285
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20795,7 +20789,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4245
+#: lib/vutuv_web/components/post_components.ex:4275
 #: lib/vutuv_web/components/ui.ex:4509
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20924,20 +20918,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4030
+#: lib/vutuv_web/components/post_components.ex:4047
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4027
+#: lib/vutuv_web/components/post_components.ex:4044
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2201
-#: lib/vutuv_web/components/post_components.ex:3354
+#: lib/vutuv_web/components/post_components.ex:2218
+#: lib/vutuv_web/components/post_components.ex:3371
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20954,7 +20948,7 @@ msgstr ""
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1894
+#: lib/vutuv_web/live/post_live/feed.ex:1902
 #: lib/vutuv_web/views/user_html.ex:338
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -21448,7 +21442,7 @@ msgstr ""
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2402
+#: lib/vutuv_web/components/post_components.ex:2419
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
@@ -21573,12 +21567,12 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1876
+#: lib/vutuv_web/live/post_live/feed.ex:1884
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1872
+#: lib/vutuv_web/live/post_live/feed.ex:1880
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr ""
@@ -21624,31 +21618,31 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1886
+#: lib/vutuv_web/live/post_live/feed.ex:1894
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:602
+#: lib/vutuv_web/components/post_components.ex:613
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post"
 msgid_plural "%{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1314
+#: lib/vutuv_web/live/post_live/feed.ex:1312
 #, elixir-autogen, elixir-format
 msgid "%{source}: %{formatted} new post"
 msgid_plural "%{source}: %{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1311
+#: lib/vutuv_web/live/post_live/feed.ex:1309
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1308
+#: lib/vutuv_web/live/post_live/feed.ex:1306
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post from %{who}"
 msgstr ""
@@ -21923,4 +21917,62 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1029
 #, elixir-autogen, elixir-format
 msgid "Being checked"
+msgstr ""
+
+#: lib/vutuv_web/templates/directory/index.html.heex:23
+#, elixir-autogen, elixir-format
+msgid "%{count} vutuv members, filed alphabetically by last name."
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/list_docs.ex:205
+#, elixir-autogen, elixir-format
+msgid "%{listed} vutuv members are listed here, grouped by the first letter of their last name."
+msgstr ""
+
+#: lib/vutuv_web/live/directory_search_live.ex:141
+#, elixir-autogen, elixir-format
+msgid "Find a member"
+msgstr ""
+
+#: lib/vutuv_web/live/directory_search_live.ex:195
+#, elixir-autogen, elixir-format
+msgid "No members found for \"%{query}\"."
+msgstr ""
+
+#: lib/vutuv_web/live/directory_search_live.ex:208
+#, elixir-autogen, elixir-format
+msgid "One member found."
+msgid_plural "%{formatted} members found."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/directory_search_live.ex:186
+#, elixir-autogen, elixir-format
+msgid "Results appear once you have typed at least %{count} letters."
+msgstr ""
+
+#: lib/vutuv_web/live/directory_search_live.ex:152
+#: lib/vutuv_web/live/directory_search_live.ex:153
+#, elixir-autogen, elixir-format
+msgid "Search members by name"
+msgstr ""
+
+#: lib/vutuv_web/live/directory_search_live.ex:229
+#, elixir-autogen, elixir-format
+msgid "Show %{count} more"
+msgstr ""
+
+#: lib/vutuv_web/live/directory_search_live.ex:203
+#, elixir-autogen, elixir-format
+msgid "Showing %{shown} of %{total} members."
+msgstr ""
+
+#: lib/vutuv_web/live/directory_search_live.ex:257
+#, elixir-autogen, elixir-format
+msgid "That is as far as this list goes. Type more of the name to narrow it down."
+msgstr ""
+
+#: lib/vutuv_web/live/directory_search_live.ex:160
+#, elixir-autogen, elixir-format
+msgid "Which names to search"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -160,7 +160,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3153
+#: lib/vutuv_web/components/post_components.ex:3170
 #: lib/vutuv_web/components/ui.ex:4106
 #: lib/vutuv_web/live/admin/job_live.ex:489
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -209,7 +209,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3118
+#: lib/vutuv_web/components/post_components.ex:3135
 #: lib/vutuv_web/components/ui.ex:4097
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -473,7 +473,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:629
+#: lib/vutuv_web/components/post_components.ex:640
 #: lib/vutuv_web/live/notification_live/index.ex:699
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -641,6 +641,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:193
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:219
+#: lib/vutuv_web/live/directory_search_live.ex:181
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:49
 #: lib/vutuv_web/live/search_live.ex:570
@@ -655,7 +656,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1627
+#: lib/vutuv_web/components/post_components.ex:1643
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -791,6 +792,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
+#: lib/vutuv_web/live/directory_search_live.ex:134
 #: lib/vutuv_web/live/notification_live/index.ex:1099
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
@@ -1748,7 +1750,7 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:436
+#: lib/vutuv_web/components/post_components.ex:447
 #: lib/vutuv_web/components/ui.ex:4216
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
@@ -2099,7 +2101,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3150
+#: lib/vutuv_web/components/post_components.ex:3167
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2115,7 +2117,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:114
 #: lib/vutuv_web/live/post_live/feed.ex:206
-#: lib/vutuv_web/live/post_live/feed.ex:1591
+#: lib/vutuv_web/live/post_live/feed.ex:1598
 #: lib/vutuv_web/live/shell_live.ex:973
 #: lib/vutuv_web/live/shell_live.ex:1272
 #: lib/vutuv_web/templates/layout/app.html.heex:171
@@ -2143,8 +2145,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3104
-#: lib/vutuv_web/components/post_components.ex:3106
+#: lib/vutuv_web/components/post_components.ex:3121
+#: lib/vutuv_web/components/post_components.ex:3123
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2160,7 +2162,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1802
+#: lib/vutuv_web/live/post_live/feed.ex:1810
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2210,13 +2212,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3568
-#: lib/vutuv_web/components/post_components.ex:3572
+#: lib/vutuv_web/components/post_components.ex:3585
+#: lib/vutuv_web/components/post_components.ex:3589
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3569
+#: lib/vutuv_web/components/post_components.ex:3586
 #: lib/vutuv_web/live/fediverse_account_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2224,7 +2226,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:376
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1249
+#: lib/vutuv_web/components/post_components.ex:1265
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2234,7 +2236,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/composer.ex:1940
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
-#: lib/vutuv_web/templates/connection/index.html.heex:40
+#: lib/vutuv_web/templates/connection/index.html.heex:45
 #: lib/vutuv_web/views/settings_html.ex:342
 #, elixir-autogen, elixir-format
 msgid "Remove"
@@ -2250,7 +2252,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1703
+#: lib/vutuv_web/live/post_live/feed.ex:1710
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2306,27 +2308,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3101
+#: lib/vutuv_web/components/post_components.ex:3118
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4957
+#: lib/vutuv_web/components/post_components.ex:4987
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4961
+#: lib/vutuv_web/components/post_components.ex:4991
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4959
+#: lib/vutuv_web/components/post_components.ex:4989
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4960
+#: lib/vutuv_web/components/post_components.ex:4990
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2367,8 +2369,8 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1842
-#: lib/vutuv_web/components/post_components.ex:5053
+#: lib/vutuv_web/components/post_components.ex:1858
+#: lib/vutuv_web/components/post_components.ex:5083
 #: lib/vutuv_web/components/ui.ex:3629
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
@@ -2386,8 +2388,8 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1795
-#: lib/vutuv_web/components/post_components.ex:5289
+#: lib/vutuv_web/components/post_components.ex:1811
+#: lib/vutuv_web/components/post_components.ex:5319
 #: lib/vutuv_web/components/ui.ex:3615
 #: lib/vutuv_web/live/notification_live/index.ex:1089
 #: lib/vutuv_web/views/user_html.ex:467
@@ -2396,7 +2398,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:5299
+#: lib/vutuv_web/components/post_components.ex:5329
 #: lib/vutuv_web/live/notification_live/index.ex:1022
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
@@ -2418,40 +2420,40 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5041
+#: lib/vutuv_web/components/post_components.ex:5071
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1841
-#: lib/vutuv_web/components/post_components.ex:5052
+#: lib/vutuv_web/components/post_components.ex:1857
+#: lib/vutuv_web/components/post_components.ex:5082
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1823
-#: lib/vutuv_web/components/post_components.ex:5038
+#: lib/vutuv_web/components/post_components.ex:1839
+#: lib/vutuv_web/components/post_components.ex:5068
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2088
-#: lib/vutuv_web/components/post_components.ex:4163
+#: lib/vutuv_web/components/post_components.ex:2104
+#: lib/vutuv_web/components/post_components.ex:4193
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1822
-#: lib/vutuv_web/components/post_components.ex:5037
+#: lib/vutuv_web/components/post_components.ex:1838
+#: lib/vutuv_web/components/post_components.ex:5067
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1794
-#: lib/vutuv_web/components/post_components.ex:5288
+#: lib/vutuv_web/components/post_components.ex:1810
+#: lib/vutuv_web/components/post_components.ex:5318
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:467
 #, elixir-autogen, elixir-format
@@ -2459,14 +2461,14 @@ msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:377
-#: lib/vutuv_web/components/post_components.ex:2407
+#: lib/vutuv_web/components/post_components.ex:2424
 #: lib/vutuv_web/components/ui.ex:2484
 #: lib/vutuv_web/components/ui.ex:2484
 #: lib/vutuv_web/components/ui.ex:2621
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:489
-#: lib/vutuv_web/live/post_live/feed.ex:1851
+#: lib/vutuv_web/live/post_live/feed.ex:1859
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2478,27 +2480,27 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5343
+#: lib/vutuv_web/components/post_components.ex:5373
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:394
+#: lib/vutuv_web/components/post_components.ex:405
 #: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1808
-#: lib/vutuv_web/components/post_components.ex:5326
-#: lib/vutuv_web/components/post_components.ex:5327
+#: lib/vutuv_web/components/post_components.ex:1824
+#: lib/vutuv_web/components/post_components.ex:5356
+#: lib/vutuv_web/components/post_components.ex:5357
 #: lib/vutuv_web/live/notification_live/index.ex:1086
 #: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3068
+#: lib/vutuv_web/components/post_components.ex:3085
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2519,7 +2521,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2604
+#: lib/vutuv_web/components/post_components.ex:2621
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:57
@@ -2527,14 +2529,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3042
+#: lib/vutuv_web/components/post_components.ex:3059
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3033
-#: lib/vutuv_web/components/post_components.ex:3060
-#: lib/vutuv_web/components/post_components.ex:3063
+#: lib/vutuv_web/components/post_components.ex:3050
+#: lib/vutuv_web/components/post_components.ex:3077
+#: lib/vutuv_web/components/post_components.ex:3080
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2757,14 +2759,14 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1629
+#: lib/vutuv_web/live/post_live/feed.ex:1636
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:192
-#: lib/vutuv_web/views/user_helpers.ex:204
+#: lib/vutuv_web/views/user_helpers.ex:213
+#: lib/vutuv_web/views/user_helpers.ex:225
 #, elixir-autogen, elixir-format
 msgid "Added %{count} tag."
 msgid_plural "Added %{count} tags."
@@ -2778,8 +2780,8 @@ msgid_plural "%{formatted} connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1953
-#: lib/vutuv_web/templates/user/card_list.html.heex:46
+#: lib/vutuv_web/live/post_live/feed.ex:1961
+#: lib/vutuv_web/templates/user/card_list.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
 msgid_plural "+%{formatted} more tags"
@@ -2800,7 +2802,7 @@ msgstr ""
 msgid "Markdown"
 msgstr ""
 
-#: lib/vutuv_web/templates/connection/index.html.heex:45
+#: lib/vutuv_web/templates/connection/index.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "No connections yet."
 msgstr ""
@@ -2833,7 +2835,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4958
+#: lib/vutuv_web/components/post_components.ex:4988
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3096,7 +3098,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3009
+#: lib/vutuv_web/components/post_components.ex:3026
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3171,9 +3173,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1259
-#: lib/vutuv_web/components/post_components.ex:2419
-#: lib/vutuv_web/components/post_components.ex:3173
+#: lib/vutuv_web/components/post_components.ex:1275
+#: lib/vutuv_web/components/post_components.ex:2436
+#: lib/vutuv_web/components/post_components.ex:3190
 #: lib/vutuv_web/live/organization_live/show.ex:562
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
@@ -4539,7 +4541,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1807
+#: lib/vutuv_web/live/post_live/feed.ex:1815
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4616,8 +4618,8 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:391
-#: lib/vutuv_web/components/post_components.ex:410
+#: lib/vutuv_web/components/post_components.ex:402
+#: lib/vutuv_web/components/post_components.ex:421
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -5417,11 +5419,11 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3239
-#: lib/vutuv_web/components/post_components.ex:3294
-#: lib/vutuv_web/components/post_components.ex:3705
+#: lib/vutuv_web/components/post_components.ex:3256
+#: lib/vutuv_web/components/post_components.ex:3311
+#: lib/vutuv_web/components/post_components.ex:3722
 #: lib/vutuv_web/live/notification_live/index.ex:743
-#: lib/vutuv_web/live/post_live/feed.ex:1994
+#: lib/vutuv_web/live/post_live/feed.ex:2002
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -6212,7 +6214,7 @@ msgid "Previous day"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:393
+#: lib/vutuv_web/components/post_components.ex:404
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6305,7 +6307,7 @@ msgstr ""
 msgid "Members who endorsed %{name} for %{tag}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user_tag/endorsers.html.heex:74
+#: lib/vutuv_web/templates/user_tag/endorsers.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "No endorsements yet."
 msgstr ""
@@ -6605,8 +6607,8 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2387
-#: lib/vutuv_web/components/post_components.ex:3170
+#: lib/vutuv_web/components/post_components.ex:2404
+#: lib/vutuv_web/components/post_components.ex:3187
 #: lib/vutuv_web/components/ui.ex:2809
 #: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/live/organization_live/following.ex:376
@@ -6628,12 +6630,12 @@ msgstr ""
 msgid "New messages and new connections"
 msgstr ""
 
-#: lib/vutuv_web/templates/connection/index.html.heex:38
+#: lib/vutuv_web/templates/connection/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3170
+#: lib/vutuv_web/components/post_components.ex:3187
 #: lib/vutuv_web/components/ui.ex:2808
 #: lib/vutuv_web/live/fediverse_account_live.ex:379
 #: lib/vutuv_web/live/organization_live/following.ex:376
@@ -7343,7 +7345,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5199
+#: lib/vutuv_web/components/post_components.ex:5229
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7884,7 +7886,7 @@ msgid "Admins"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:1962
+#: lib/vutuv_web/live/post_live/feed.ex:1970
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -8441,12 +8443,12 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1979
+#: lib/vutuv_web/live/post_live/feed.ex:1987
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1975
+#: lib/vutuv_web/live/post_live/feed.ex:1983
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8499,7 +8501,7 @@ msgid "Invalid address (skipped)"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/list_docs.ex:191
-#: lib/vutuv_web/controllers/directory_controller.ex:32
+#: lib/vutuv_web/controllers/directory_controller.ex:53
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:5
@@ -8508,14 +8510,14 @@ msgstr ""
 msgid "Member directory"
 msgstr ""
 
-#: lib/vutuv_web/templates/directory/index.html.heex:24
+#: lib/vutuv_web/templates/directory/index.html.heex:32
 #: lib/vutuv_web/templates/directory/show.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Members by initial"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/list_docs.ex:217
-#: lib/vutuv_web/controllers/directory_controller.ex:58
+#: lib/vutuv_web/controllers/directory_controller.ex:86
 #: lib/vutuv_web/templates/directory/show.html.heex:2
 #, elixir-autogen, elixir-format
 msgid "Members: %{letter}"
@@ -8790,7 +8792,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4166
+#: lib/vutuv_web/components/post_components.ex:4196
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -8909,12 +8911,12 @@ msgstr ""
 msgid "Choose automatically instead"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:469
+#: lib/vutuv_web/views/user_helpers.ex:490
 #, elixir-autogen, elixir-format
 msgid "Show at top of profile"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:460
+#: lib/vutuv_web/views/user_helpers.ex:481
 #, elixir-autogen, elixir-format
 msgid "Shown at the top of your profile"
 msgstr ""
@@ -9453,18 +9455,18 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1173
+#: lib/vutuv/accounts/user.ex:1177
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:86
+#: lib/vutuv_web/views/user_helpers.ex:107
 #, elixir-autogen, elixir-format
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1170
+#: lib/vutuv/accounts/user.ex:1174
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9745,19 +9747,21 @@ msgstr ""
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
 
+#: lib/vutuv_web/live/directory_search_live.ex:132
 #: lib/vutuv_web/templates/page/index.html.heex:90
 #: lib/vutuv_web/views/account_event_text.ex:210
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
+#: lib/vutuv_web/live/directory_search_live.ex:133
 #: lib/vutuv_web/templates/page/index.html.heex:95
 #: lib/vutuv_web/views/account_event_text.ex:211
 #, elixir-autogen, elixir-format
 msgid "Last name"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:109
+#: lib/vutuv_web/views/user_helpers.ex:130
 #, elixir-autogen, elixir-format
 msgid "Prefer not to say"
 msgstr ""
@@ -10819,19 +10823,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1211
+#: lib/vutuv/accounts/user.ex:1215
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1216
+#: lib/vutuv/accounts/user.ex:1220
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1214
+#: lib/vutuv/accounts/user.ex:1218
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:771
 #, elixir-autogen, elixir-format
@@ -12129,7 +12133,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1185
+#: lib/vutuv/accounts/user.ex:1189
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12248,7 +12252,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1184
+#: lib/vutuv/accounts/user.ex:1188
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12330,7 +12334,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1186
+#: lib/vutuv/accounts/user.ex:1190
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
 #: lib/vutuv_web/agent_docs/markdown.ex:466
@@ -13051,7 +13055,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2563
+#: lib/vutuv_web/components/post_components.ex:2580
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:695
 #: lib/vutuv_web/controllers/settings_controller.ex:713
@@ -13345,7 +13349,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1229
+#: lib/vutuv/accounts/user.ex:1233
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13356,19 +13360,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1232
+#: lib/vutuv/accounts/user.ex:1236
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1235
+#: lib/vutuv/accounts/user.ex:1239
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1226
+#: lib/vutuv/accounts/user.ex:1230
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13465,22 +13469,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:433
+#: lib/vutuv_web/components/post_components.ex:444
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:435
+#: lib/vutuv_web/components/post_components.ex:446
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:434
+#: lib/vutuv_web/components/post_components.ex:445
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:392
+#: lib/vutuv_web/components/post_components.ex:403
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13492,14 +13496,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4516
 #: lib/vutuv_web/controllers/settings_controller.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:1837
+#: lib/vutuv_web/live/post_live/feed.ex:1845
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1852
+#: lib/vutuv_web/live/post_live/feed.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13655,34 +13659,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4807
+#: lib/vutuv_web/components/post_components.ex:4837
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4764
+#: lib/vutuv_web/components/post_components.ex:4794
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4808
+#: lib/vutuv_web/components/post_components.ex:4838
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4810
+#: lib/vutuv_web/components/post_components.ex:4840
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4806
+#: lib/vutuv_web/components/post_components.ex:4836
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4763
+#: lib/vutuv_web/components/post_components.ex:4793
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13693,12 +13697,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4805
+#: lib/vutuv_web/components/post_components.ex:4835
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4809
+#: lib/vutuv_web/components/post_components.ex:4839
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13718,7 +13722,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4846
+#: lib/vutuv_web/components/post_components.ex:4876
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13726,27 +13730,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4876
+#: lib/vutuv_web/components/post_components.ex:4906
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4877
+#: lib/vutuv_web/components/post_components.ex:4907
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4875
+#: lib/vutuv_web/components/post_components.ex:4905
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4835
+#: lib/vutuv_web/components/post_components.ex:4865
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4882
+#: lib/vutuv_web/components/post_components.ex:4912
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13776,7 +13780,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4649
+#: lib/vutuv_web/components/post_components.ex:4679
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13824,7 +13828,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4640
+#: lib/vutuv_web/components/post_components.ex:4670
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14196,14 +14200,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2836
+#: lib/vutuv_web/components/post_components.ex:2853
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2859
+#: lib/vutuv_web/components/post_components.ex:2876
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14230,7 +14234,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5298
+#: lib/vutuv_web/components/post_components.ex:5328
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -15378,21 +15382,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5244
+#: lib/vutuv_web/components/post_components.ex:5274
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5248
+#: lib/vutuv_web/components/post_components.ex:5278
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5252
+#: lib/vutuv_web/components/post_components.ex:5282
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15400,7 +15404,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1153
-#: lib/vutuv_web/components/post_components.ex:5203
+#: lib/vutuv_web/components/post_components.ex:5233
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15416,14 +15420,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1371
-#: lib/vutuv_web/components/post_components.ex:2030
+#: lib/vutuv_web/components/post_components.ex:1387
+#: lib/vutuv_web/components/post_components.ex:2046
 #: lib/vutuv_web/live/fediverse_account_live.ex:294
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1247
+#: lib/vutuv_web/components/post_components.ex:1263
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15452,7 +15456,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1256
+#: lib/vutuv_web/components/post_components.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15462,7 +15466,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1270
+#: lib/vutuv_web/components/post_components.ex:1286
 #: lib/vutuv_web/live/notification_live/index.ex:597
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15494,9 +15498,9 @@ msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1337
-#: lib/vutuv_web/components/post_components.ex:1302
-#: lib/vutuv_web/components/post_components.ex:1502
-#: lib/vutuv_web/components/post_components.ex:2483
+#: lib/vutuv_web/components/post_components.ex:1318
+#: lib/vutuv_web/components/post_components.ex:1518
+#: lib/vutuv_web/components/post_components.ex:2500
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -16159,22 +16163,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3021
+#: lib/vutuv_web/components/post_components.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3137
+#: lib/vutuv_web/components/post_components.ex:3154
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3145
+#: lib/vutuv_web/components/post_components.ex:3162
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3131
+#: lib/vutuv_web/components/post_components.ex:3148
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16300,17 +16304,17 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2616
+#: lib/vutuv_web/components/post_components.ex:2633
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3834
+#: lib/vutuv_web/components/post_components.ex:3851
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3982
+#: lib/vutuv_web/components/post_components.ex:3999
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16323,7 +16327,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1298
 #: lib/vutuv_web/agent_docs/text.ex:785
-#: lib/vutuv_web/components/post_components.ex:4064
+#: lib/vutuv_web/components/post_components.ex:4081
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
@@ -16349,7 +16353,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2669
+#: lib/vutuv_web/components/post_components.ex:2686
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16369,7 +16373,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2660
+#: lib/vutuv_web/components/post_components.ex:2677
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16379,12 +16383,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2678
+#: lib/vutuv_web/components/post_components.ex:2695
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2612
+#: lib/vutuv_web/components/post_components.ex:2629
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16399,7 +16403,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2673
+#: lib/vutuv_web/components/post_components.ex:2690
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16409,7 +16413,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2626
+#: lib/vutuv_web/components/post_components.ex:2643
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16430,8 +16434,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1638
-#: lib/vutuv_web/live/post_live/feed.ex:1639
+#: lib/vutuv_web/live/post_live/feed.ex:1645
+#: lib/vutuv_web/live/post_live/feed.ex:1646
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post photos"
 msgstr ""
@@ -16496,13 +16500,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1171
-#: lib/vutuv_web/components/post_components.ex:5241
+#: lib/vutuv_web/components/post_components.ex:5271
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1169
-#: lib/vutuv_web/components/post_components.ex:5238
+#: lib/vutuv_web/components/post_components.ex:5268
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16512,7 +16516,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5130
+#: lib/vutuv_web/components/post_components.ex:5160
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -16852,7 +16856,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2428
+#: lib/vutuv_web/components/post_components.ex:2445
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16862,7 +16866,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2482
+#: lib/vutuv_web/components/post_components.ex:2499
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16882,12 +16886,12 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1630
+#: lib/vutuv_web/components/post_components.ex:1646
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2447
+#: lib/vutuv_web/components/post_components.ex:2464
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marked as sensitive by its author"
 msgstr ""
@@ -16903,7 +16907,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2414
+#: lib/vutuv_web/components/post_components.ex:2431
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17125,27 +17129,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2150
+#: lib/vutuv_web/components/post_components.ex:2167
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2179
+#: lib/vutuv_web/components/post_components.ex:2196
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2174
+#: lib/vutuv_web/components/post_components.ex:2191
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2519
+#: lib/vutuv_web/components/post_components.ex:2536
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2525
+#: lib/vutuv_web/components/post_components.ex:2542
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is not here any more."
 msgstr ""
@@ -17155,7 +17159,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2664
+#: lib/vutuv_web/components/post_components.ex:2681
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17855,12 +17859,12 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:425
+#: lib/vutuv_web/components/post_components.ex:436
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:422
+#: lib/vutuv_web/components/post_components.ex:433
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
@@ -17902,7 +17906,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2522
+#: lib/vutuv_web/components/post_components.ex:2539
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -18205,19 +18209,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4336
+#: lib/vutuv_web/components/post_components.ex:4366
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4338
+#: lib/vutuv_web/components/post_components.ex:4368
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4349
+#: lib/vutuv_web/components/post_components.ex:4379
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -19175,17 +19179,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1332
+#: lib/vutuv/accounts/user.ex:1336
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1330
+#: lib/vutuv/accounts/user.ex:1334
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1331
+#: lib/vutuv/accounts/user.ex:1335
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19871,7 +19875,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2552
+#: lib/vutuv_web/components/post_components.ex:2569
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -20377,16 +20381,6 @@ msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/directory/index.html.heex:14
-#, elixir-autogen, elixir-format, fuzzy
-msgid "%{count} vutuv members whose profiles are open to search engines, filed alphabetically by last name."
-msgstr ""
-
-#: lib/vutuv_web/agent_docs/list_docs.ex:205
-#, elixir-autogen, elixir-format
-msgid "%{listed} vutuv members are listed here, grouped by the first letter of their last name; anyone who does not open their profile to search engines is not among them."
-msgstr ""
-
 #: lib/vutuv_web/live/section_reorder_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Add this under Messengers"
@@ -20704,7 +20698,7 @@ msgid "You can analyse the same or a newer LinkedIn archive again at any time. N
 msgstr ""
 
 #: lib/vutuv_web/controllers/import_controller.ex:272
-#: lib/vutuv_web/views/user_helpers.ex:219
+#: lib/vutuv_web/views/user_helpers.ex:240
 #, elixir-autogen, elixir-format
 msgid "%{count} tag did not fit: your profile holds at most %{max}. Remove some and try again."
 msgid_plural "%{count} tags did not fit: your profile holds at most %{max}. Remove some and try again."
@@ -20721,7 +20715,7 @@ msgstr ""
 msgid "Select as many as fit"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:209
+#: lib/vutuv_web/views/user_helpers.ex:230
 #, elixir-autogen, elixir-format
 msgid "Skipped %{count} tag that is a duplicate or invalid."
 msgid_plural "Skipped %{count} tags that are duplicates or invalid."
@@ -20763,27 +20757,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4230
+#: lib/vutuv_web/components/post_components.ex:4260
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4266
+#: lib/vutuv_web/components/post_components.ex:4296
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4275
+#: lib/vutuv_web/components/post_components.ex:4305
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4278
+#: lib/vutuv_web/components/post_components.ex:4308
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4255
+#: lib/vutuv_web/components/post_components.ex:4285
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20793,7 +20787,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4245
+#: lib/vutuv_web/components/post_components.ex:4275
 #: lib/vutuv_web/components/ui.ex:4509
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20922,20 +20916,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4030
+#: lib/vutuv_web/components/post_components.ex:4047
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4027
+#: lib/vutuv_web/components/post_components.ex:4044
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2201
-#: lib/vutuv_web/components/post_components.ex:3354
+#: lib/vutuv_web/components/post_components.ex:2218
+#: lib/vutuv_web/components/post_components.ex:3371
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20952,7 +20946,7 @@ msgstr ""
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1894
+#: lib/vutuv_web/live/post_live/feed.ex:1902
 #: lib/vutuv_web/views/user_html.ex:338
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -21446,7 +21440,7 @@ msgstr ""
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2402
+#: lib/vutuv_web/components/post_components.ex:2419
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
@@ -21571,12 +21565,12 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1876
+#: lib/vutuv_web/live/post_live/feed.ex:1884
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1872
+#: lib/vutuv_web/live/post_live/feed.ex:1880
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr ""
@@ -21622,31 +21616,31 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1886
+#: lib/vutuv_web/live/post_live/feed.ex:1894
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:602
+#: lib/vutuv_web/components/post_components.ex:613
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} new post"
 msgid_plural "%{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1314
+#: lib/vutuv_web/live/post_live/feed.ex:1312
 #, elixir-autogen, elixir-format
 msgid "%{source}: %{formatted} new post"
 msgid_plural "%{source}: %{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1311
+#: lib/vutuv_web/live/post_live/feed.ex:1309
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1308
+#: lib/vutuv_web/live/post_live/feed.ex:1306
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post from %{who}"
 msgstr ""
@@ -21921,4 +21915,62 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1029
 #, elixir-autogen, elixir-format
 msgid "Being checked"
+msgstr ""
+
+#: lib/vutuv_web/templates/directory/index.html.heex:23
+#, elixir-autogen, elixir-format
+msgid "%{count} vutuv members, filed alphabetically by last name."
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/list_docs.ex:205
+#, elixir-autogen, elixir-format, fuzzy
+msgid "%{listed} vutuv members are listed here, grouped by the first letter of their last name."
+msgstr ""
+
+#: lib/vutuv_web/live/directory_search_live.ex:141
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Find a member"
+msgstr ""
+
+#: lib/vutuv_web/live/directory_search_live.ex:195
+#, elixir-autogen, elixir-format, fuzzy
+msgid "No members found for \"%{query}\"."
+msgstr ""
+
+#: lib/vutuv_web/live/directory_search_live.ex:208
+#, elixir-autogen, elixir-format, fuzzy
+msgid "One member found."
+msgid_plural "%{formatted} members found."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/directory_search_live.ex:186
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Results appear once you have typed at least %{count} letters."
+msgstr ""
+
+#: lib/vutuv_web/live/directory_search_live.ex:152
+#: lib/vutuv_web/live/directory_search_live.ex:153
+#, elixir-autogen, elixir-format
+msgid "Search members by name"
+msgstr ""
+
+#: lib/vutuv_web/live/directory_search_live.ex:229
+#, elixir-autogen, elixir-format
+msgid "Show %{count} more"
+msgstr ""
+
+#: lib/vutuv_web/live/directory_search_live.ex:203
+#, elixir-autogen, elixir-format
+msgid "Showing %{shown} of %{total} members."
+msgstr ""
+
+#: lib/vutuv_web/live/directory_search_live.ex:257
+#, elixir-autogen, elixir-format
+msgid "That is as far as this list goes. Type more of the name to narrow it down."
+msgstr ""
+
+#: lib/vutuv_web/live/directory_search_live.ex:160
+#, elixir-autogen, elixir-format
+msgid "Which names to search"
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -162,7 +162,7 @@ msgstr "Contatto"
 msgid "Couldn't follow back to %{name}."
 msgstr "Non è stato possibile ricambiare il follow a %{name}."
 
-#: lib/vutuv_web/components/post_components.ex:3153
+#: lib/vutuv_web/components/post_components.ex:3170
 #: lib/vutuv_web/components/ui.ex:4106
 #: lib/vutuv_web/live/admin/job_live.ex:489
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -211,7 +211,7 @@ msgstr "Disattiva"
 msgid "Download"
 msgstr "Scarica"
 
-#: lib/vutuv_web/components/post_components.ex:3118
+#: lib/vutuv_web/components/post_components.ex:3135
 #: lib/vutuv_web/components/ui.ex:4097
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -477,7 +477,7 @@ msgstr "Altro"
 msgid "Name"
 msgstr "Nome"
 
-#: lib/vutuv_web/components/post_components.ex:629
+#: lib/vutuv_web/components/post_components.ex:640
 #: lib/vutuv_web/live/notification_live/index.ex:699
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -645,6 +645,7 @@ msgstr "Salva"
 #: lib/vutuv_web/live/admin/activity_live.ex:193
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:219
+#: lib/vutuv_web/live/directory_search_live.ex:181
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:49
 #: lib/vutuv_web/live/search_live.ex:570
@@ -659,7 +660,7 @@ msgstr "Salva"
 msgid "Search"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:1627
+#: lib/vutuv_web/components/post_components.ex:1643
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -795,6 +796,7 @@ msgstr "Utente verificato."
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
+#: lib/vutuv_web/live/directory_search_live.ex:134
 #: lib/vutuv_web/live/notification_live/index.ex:1099
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
@@ -1783,7 +1785,7 @@ msgstr "Messaggi"
 msgid "Network"
 msgstr "Rete"
 
-#: lib/vutuv_web/components/post_components.ex:436
+#: lib/vutuv_web/components/post_components.ex:447
 #: lib/vutuv_web/components/ui.ex:4216
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
@@ -2144,7 +2146,7 @@ msgstr "Annulla il caricamento"
 msgid "Delete post"
 msgstr "Elimina il post"
 
-#: lib/vutuv_web/components/post_components.ex:3150
+#: lib/vutuv_web/components/post_components.ex:3167
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2160,7 +2162,7 @@ msgstr "Modifica il post"
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:114
 #: lib/vutuv_web/live/post_live/feed.ex:206
-#: lib/vutuv_web/live/post_live/feed.ex:1591
+#: lib/vutuv_web/live/post_live/feed.ex:1598
 #: lib/vutuv_web/live/shell_live.ex:973
 #: lib/vutuv_web/live/shell_live.ex:1272
 #: lib/vutuv_web/templates/layout/app.html.heex:171
@@ -2188,8 +2190,8 @@ msgstr "Nascondi a una persona specifica…"
 msgid "Hide this post from…"
 msgstr "Nascondi questo post a…"
 
-#: lib/vutuv_web/components/post_components.ex:3104
-#: lib/vutuv_web/components/post_components.ex:3106
+#: lib/vutuv_web/components/post_components.ex:3121
+#: lib/vutuv_web/components/post_components.ex:3123
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Pubblico limitato"
@@ -2205,7 +2207,7 @@ msgstr "Visitatori non connessi"
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1802
+#: lib/vutuv_web/live/post_live/feed.ex:1810
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2257,13 +2259,13 @@ msgstr "Post eliminato."
 msgid "Posts"
 msgstr "Post"
 
-#: lib/vutuv_web/components/post_components.ex:3568
-#: lib/vutuv_web/components/post_components.ex:3572
+#: lib/vutuv_web/components/post_components.ex:3585
+#: lib/vutuv_web/components/post_components.ex:3589
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Leggi tutto"
 
-#: lib/vutuv_web/components/post_components.ex:3569
+#: lib/vutuv_web/components/post_components.ex:3586
 #: lib/vutuv_web/live/fediverse_account_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2271,7 +2273,7 @@ msgstr "Mostra meno"
 
 #: lib/vutuv_web/components/fediverse_components.ex:376
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1249
+#: lib/vutuv_web/components/post_components.ex:1265
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2281,7 +2283,7 @@ msgstr "Mostra meno"
 #: lib/vutuv_web/live/post_live/composer.ex:1940
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
-#: lib/vutuv_web/templates/connection/index.html.heex:40
+#: lib/vutuv_web/templates/connection/index.html.heex:45
 #: lib/vutuv_web/views/settings_html.ex:342
 #, elixir-autogen, elixir-format
 msgid "Remove"
@@ -2299,7 +2301,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Salvataggio…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1703
+#: lib/vutuv_web/live/post_live/feed.ex:1710
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2355,27 +2357,27 @@ msgstr "Che c'è di nuovo?"
 msgid "What's new? Markdown is supported."
 msgstr "Che c'è di nuovo? Markdown è supportato."
 
-#: lib/vutuv_web/components/post_components.ex:3101
+#: lib/vutuv_web/components/post_components.ex:3118
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "modificato"
 
-#: lib/vutuv_web/components/post_components.ex:4957
+#: lib/vutuv_web/components/post_components.ex:4987
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "tutti gli altri"
 
-#: lib/vutuv_web/components/post_components.ex:4961
+#: lib/vutuv_web/components/post_components.ex:4991
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "visitatori non connessi"
 
-#: lib/vutuv_web/components/post_components.ex:4959
+#: lib/vutuv_web/components/post_components.ex:4989
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "persone che non La seguono"
 
-#: lib/vutuv_web/components/post_components.ex:4960
+#: lib/vutuv_web/components/post_components.ex:4990
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "persone che non segue"
@@ -2416,8 +2418,8 @@ msgstr "Vedi tutti i %{count} post"
 msgid "All posts"
 msgstr "Tutti i post"
 
-#: lib/vutuv_web/components/post_components.ex:1842
-#: lib/vutuv_web/components/post_components.ex:5053
+#: lib/vutuv_web/components/post_components.ex:1858
+#: lib/vutuv_web/components/post_components.ex:5083
 #: lib/vutuv_web/components/ui.ex:3629
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
@@ -2435,8 +2437,8 @@ msgstr "Salva"
 msgid "Bookmarks"
 msgstr "Salvati"
 
-#: lib/vutuv_web/components/post_components.ex:1795
-#: lib/vutuv_web/components/post_components.ex:5289
+#: lib/vutuv_web/components/post_components.ex:1811
+#: lib/vutuv_web/components/post_components.ex:5319
 #: lib/vutuv_web/components/ui.ex:3615
 #: lib/vutuv_web/live/notification_live/index.ex:1089
 #: lib/vutuv_web/views/user_html.ex:467
@@ -2445,7 +2447,7 @@ msgid "Like"
 msgstr "Mi piace"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:5299
+#: lib/vutuv_web/components/post_components.ex:5329
 #: lib/vutuv_web/live/notification_live/index.ex:1022
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
@@ -2467,40 +2469,40 @@ msgstr "Qui non c'è ancora nulla. I post che salva compaiono qui."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Qui non c'è ancora nulla. I post a cui mette Mi piace compaiono qui."
 
-#: lib/vutuv_web/components/post_components.ex:5041
+#: lib/vutuv_web/components/post_components.ex:5071
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Solo i post pubblici possono essere ripubblicati."
 
-#: lib/vutuv_web/components/post_components.ex:1841
-#: lib/vutuv_web/components/post_components.ex:5052
+#: lib/vutuv_web/components/post_components.ex:1857
+#: lib/vutuv_web/components/post_components.ex:5082
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Rimuovi dai salvati"
 
-#: lib/vutuv_web/components/post_components.ex:1823
-#: lib/vutuv_web/components/post_components.ex:5038
+#: lib/vutuv_web/components/post_components.ex:1839
+#: lib/vutuv_web/components/post_components.ex:5068
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Ripubblica"
 
-#: lib/vutuv_web/components/post_components.ex:2088
-#: lib/vutuv_web/components/post_components.ex:4163
+#: lib/vutuv_web/components/post_components.ex:2104
+#: lib/vutuv_web/components/post_components.ex:4193
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Ripubblicato da %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1822
-#: lib/vutuv_web/components/post_components.ex:5037
+#: lib/vutuv_web/components/post_components.ex:1838
+#: lib/vutuv_web/components/post_components.ex:5067
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Annulla la ripubblicazione"
 
-#: lib/vutuv_web/components/post_components.ex:1794
-#: lib/vutuv_web/components/post_components.ex:5288
+#: lib/vutuv_web/components/post_components.ex:1810
+#: lib/vutuv_web/components/post_components.ex:5318
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:467
 #, elixir-autogen, elixir-format
@@ -2508,14 +2510,14 @@ msgid "Unlike"
 msgstr "Togli Mi piace"
 
 #: lib/vutuv_web/components/fediverse_components.ex:377
-#: lib/vutuv_web/components/post_components.ex:2407
+#: lib/vutuv_web/components/post_components.ex:2424
 #: lib/vutuv_web/components/ui.ex:2484
 #: lib/vutuv_web/components/ui.ex:2484
 #: lib/vutuv_web/components/ui.ex:2621
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:489
-#: lib/vutuv_web/live/post_live/feed.ex:1851
+#: lib/vutuv_web/live/post_live/feed.ex:1859
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2527,27 +2529,27 @@ msgstr "Non seguire più"
 msgid "Welcome to vutuv!"
 msgstr "Benvenuto su vutuv."
 
-#: lib/vutuv_web/components/post_components.ex:5343
+#: lib/vutuv_web/components/post_components.ex:5373
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Solo ai post pubblici si può rispondere."
 
-#: lib/vutuv_web/components/post_components.ex:394
+#: lib/vutuv_web/components/post_components.ex:405
 #: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Risposte"
 
-#: lib/vutuv_web/components/post_components.ex:1808
-#: lib/vutuv_web/components/post_components.ex:5326
-#: lib/vutuv_web/components/post_components.ex:5327
+#: lib/vutuv_web/components/post_components.ex:1824
+#: lib/vutuv_web/components/post_components.ex:5356
+#: lib/vutuv_web/components/post_components.ex:5357
 #: lib/vutuv_web/live/notification_live/index.ex:1086
 #: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Rispondi"
 
-#: lib/vutuv_web/components/post_components.ex:3068
+#: lib/vutuv_web/components/post_components.ex:3085
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Risposta a un post eliminato"
@@ -2573,7 +2575,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr "ha risposto al Suo post."
 
-#: lib/vutuv_web/components/post_components.ex:2604
+#: lib/vutuv_web/components/post_components.ex:2621
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:57
@@ -2581,14 +2583,14 @@ msgstr "ha risposto al Suo post."
 msgid "Reply to %{handle}"
 msgstr "Rispondi a %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:3042
+#: lib/vutuv_web/components/post_components.ex:3059
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Risposta a un post di %{handle} ora eliminato"
 
-#: lib/vutuv_web/components/post_components.ex:3033
-#: lib/vutuv_web/components/post_components.ex:3060
-#: lib/vutuv_web/components/post_components.ex:3063
+#: lib/vutuv_web/components/post_components.ex:3050
+#: lib/vutuv_web/components/post_components.ex:3077
+#: lib/vutuv_web/components/post_components.ex:3080
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "In risposta a %{handle}"
@@ -2813,14 +2815,14 @@ msgstr "Scriva il Suo primo post"
 msgid "Manage"
 msgstr "Gestisci"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1629
+#: lib/vutuv_web/live/post_live/feed.ex:1636
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr "Scrivi un post"
 
-#: lib/vutuv_web/views/user_helpers.ex:192
-#: lib/vutuv_web/views/user_helpers.ex:204
+#: lib/vutuv_web/views/user_helpers.ex:213
+#: lib/vutuv_web/views/user_helpers.ex:225
 #, elixir-autogen, elixir-format
 msgid "Added %{count} tag."
 msgid_plural "Added %{count} tags."
@@ -2834,8 +2836,8 @@ msgid_plural "%{formatted} connections"
 msgstr[0] "1 collegamento"
 msgstr[1] "%{formatted} collegamenti"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1953
-#: lib/vutuv_web/templates/user/card_list.html.heex:46
+#: lib/vutuv_web/live/post_live/feed.ex:1961
+#: lib/vutuv_web/templates/user/card_list.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
 msgid_plural "+%{formatted} more tags"
@@ -2856,7 +2858,7 @@ msgstr "Collegamenti"
 msgid "Markdown"
 msgstr "Markdown"
 
-#: lib/vutuv_web/templates/connection/index.html.heex:45
+#: lib/vutuv_web/templates/connection/index.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "No connections yet."
 msgstr "Ancora nessun collegamento."
@@ -2889,7 +2891,7 @@ msgid_plural "connections"
 msgstr[0] "collegamento"
 msgstr[1] "collegamenti"
 
-#: lib/vutuv_web/components/post_components.ex:4958
+#: lib/vutuv_web/components/post_components.ex:4988
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "persone che non sono Suoi collegamenti"
@@ -3173,7 +3175,7 @@ msgstr "Nudità, violenza o altri contenuti che non hanno posto su vutuv."
 msgid "Only visible to you"
 msgstr "Visibile solo a Lei"
 
-#: lib/vutuv_web/components/post_components.ex:3009
+#: lib/vutuv_web/components/post_components.ex:3026
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solo Lei può vedere questo post finché la segnalazione è in corso."
@@ -3251,9 +3253,9 @@ msgstr "Respinta"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Lo rimuova. La segnalazione si chiude, senza altre domande."
 
-#: lib/vutuv_web/components/post_components.ex:1259
-#: lib/vutuv_web/components/post_components.ex:2419
-#: lib/vutuv_web/components/post_components.ex:3173
+#: lib/vutuv_web/components/post_components.ex:1275
+#: lib/vutuv_web/components/post_components.ex:2436
+#: lib/vutuv_web/components/post_components.ex:3190
 #: lib/vutuv_web/live/organization_live/show.ex:562
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
@@ -4719,7 +4721,7 @@ msgstr "Non ha bloccato nessuno."
 msgid "You unblocked @%{slug}."
 msgstr "Ha sbloccato @%{slug}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1807
+#: lib/vutuv_web/live/post_live/feed.ex:1815
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Scopra persone da seguire"
@@ -4796,8 +4798,8 @@ msgstr "I risultati compaiono dopo almeno tre lettere."
 msgid "Similar names"
 msgstr "Nomi simili"
 
-#: lib/vutuv_web/components/post_components.ex:391
-#: lib/vutuv_web/components/post_components.ex:410
+#: lib/vutuv_web/components/post_components.ex:402
+#: lib/vutuv_web/components/post_components.ex:421
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -5637,11 +5639,11 @@ msgstr "Navigazione principale"
 msgid "Footer navigation"
 msgstr "Navigazione a piè di pagina"
 
-#: lib/vutuv_web/components/post_components.ex:3239
-#: lib/vutuv_web/components/post_components.ex:3294
-#: lib/vutuv_web/components/post_components.ex:3705
+#: lib/vutuv_web/components/post_components.ex:3256
+#: lib/vutuv_web/components/post_components.ex:3311
+#: lib/vutuv_web/components/post_components.ex:3722
 #: lib/vutuv_web/live/notification_live/index.ex:743
-#: lib/vutuv_web/live/post_live/feed.ex:1994
+#: lib/vutuv_web/live/post_live/feed.ex:2002
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -6448,7 +6450,7 @@ msgid "Previous day"
 msgstr "Giorno precedente"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:393
+#: lib/vutuv_web/components/post_components.ex:404
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6547,7 +6549,7 @@ msgstr "Confermato"
 msgid "Members who endorsed %{name} for %{tag}"
 msgstr "Membri che hanno confermato %{name} per %{tag}"
 
-#: lib/vutuv_web/templates/user_tag/endorsers.html.heex:74
+#: lib/vutuv_web/templates/user_tag/endorsers.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "No endorsements yet."
 msgstr "Ancora nessuna conferma."
@@ -6874,8 +6876,8 @@ msgstr ""
 "Se disattiva un'opzione, la relativa esclusione viaggia con le pagine e le "
 "risposte che La riguardano. Con entrambe disattivate, ad esempio:"
 
-#: lib/vutuv_web/components/post_components.ex:2387
-#: lib/vutuv_web/components/post_components.ex:3170
+#: lib/vutuv_web/components/post_components.ex:2404
+#: lib/vutuv_web/components/post_components.ex:3187
 #: lib/vutuv_web/components/ui.ex:2809
 #: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/live/organization_live/following.ex:376
@@ -6897,12 +6899,12 @@ msgstr "Silenziato. I suoi post non compaiono più nel Suo feed."
 msgid "New messages and new connections"
 msgstr "Nuovi messaggi e nuovi collegamenti"
 
-#: lib/vutuv_web/templates/connection/index.html.heex:38
+#: lib/vutuv_web/templates/connection/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Remove this connection? You will stop following them."
 msgstr "Rimuovere questo collegamento? Smetterà di seguire questa persona."
 
-#: lib/vutuv_web/components/post_components.ex:3170
+#: lib/vutuv_web/components/post_components.ex:3187
 #: lib/vutuv_web/components/ui.ex:2808
 #: lib/vutuv_web/live/fediverse_account_live.ex:379
 #: lib/vutuv_web/live/organization_live/following.ex:376
@@ -7636,7 +7638,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "vale per l'intero elenco, non solo per questa pagina"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5199
+#: lib/vutuv_web/components/post_components.ex:5229
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8219,7 +8221,7 @@ msgid "Admins"
 msgstr "Amministratori"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:1962
+#: lib/vutuv_web/live/post_live/feed.ex:1970
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Tutti i membri"
@@ -8819,12 +8821,12 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr "Digiti il Suo nome utente per confermare:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1979
+#: lib/vutuv_web/live/post_live/feed.ex:1987
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr "Mostra altri post"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1975
+#: lib/vutuv_web/live/post_live/feed.ex:1983
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr "Post consigliati"
@@ -8880,7 +8882,7 @@ msgid "Invalid address (skipped)"
 msgstr "Indirizzo non valido (saltato)"
 
 #: lib/vutuv_web/agent_docs/list_docs.ex:191
-#: lib/vutuv_web/controllers/directory_controller.ex:32
+#: lib/vutuv_web/controllers/directory_controller.ex:53
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:5
@@ -8889,14 +8891,14 @@ msgstr "Indirizzo non valido (saltato)"
 msgid "Member directory"
 msgstr "Elenco dei membri"
 
-#: lib/vutuv_web/templates/directory/index.html.heex:24
+#: lib/vutuv_web/templates/directory/index.html.heex:32
 #: lib/vutuv_web/templates/directory/show.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Members by initial"
 msgstr "Membri per iniziale"
 
 #: lib/vutuv_web/agent_docs/list_docs.ex:217
-#: lib/vutuv_web/controllers/directory_controller.ex:58
+#: lib/vutuv_web/controllers/directory_controller.ex:86
 #: lib/vutuv_web/templates/directory/show.html.heex:2
 #, elixir-autogen, elixir-format
 msgid "Members: %{letter}"
@@ -9192,7 +9194,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Download del CV"
 
-#: lib/vutuv_web/components/post_components.ex:4166
+#: lib/vutuv_web/components/post_components.ex:4196
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9326,12 +9328,12 @@ msgstr "%{job} compare in cima al Suo profilo."
 msgid "Choose automatically instead"
 msgstr "Scegli invece automaticamente"
 
-#: lib/vutuv_web/views/user_helpers.ex:469
+#: lib/vutuv_web/views/user_helpers.ex:490
 #, elixir-autogen, elixir-format
 msgid "Show at top of profile"
 msgstr "Mostra in cima al profilo"
 
-#: lib/vutuv_web/views/user_helpers.ex:460
+#: lib/vutuv_web/views/user_helpers.ex:481
 #, elixir-autogen, elixir-format
 msgid "Shown at the top of your profile"
 msgstr "Mostrata in cima al Suo profilo"
@@ -9879,18 +9881,18 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Situazione lavorativa"
 
-#: lib/vutuv/accounts/user.ex:1173
+#: lib/vutuv/accounts/user.ex:1177
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
 msgstr "In cerca di lavoro"
 
-#: lib/vutuv_web/views/user_helpers.ex:86
+#: lib/vutuv_web/views/user_helpers.ex:107
 #, elixir-autogen, elixir-format
 msgid "Not open to work"
 msgstr "Non in cerca di lavoro"
 
-#: lib/vutuv/accounts/user.ex:1170
+#: lib/vutuv/accounts/user.ex:1174
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10188,19 +10190,21 @@ msgstr ""
 "La Sua data di nascita verrà rimossa e la Sua età non sarà più mostrata sul "
 "profilo. Può reinserirla in qualsiasi momento."
 
+#: lib/vutuv_web/live/directory_search_live.ex:132
 #: lib/vutuv_web/templates/page/index.html.heex:90
 #: lib/vutuv_web/views/account_event_text.ex:210
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Nome"
 
+#: lib/vutuv_web/live/directory_search_live.ex:133
 #: lib/vutuv_web/templates/page/index.html.heex:95
 #: lib/vutuv_web/views/account_event_text.ex:211
 #, elixir-autogen, elixir-format
 msgid "Last name"
 msgstr "Cognome"
 
-#: lib/vutuv_web/views/user_helpers.ex:109
+#: lib/vutuv_web/views/user_helpers.ex:130
 #, elixir-autogen, elixir-format
 msgid "Prefer not to say"
 msgstr "Preferisco non dirlo"
@@ -11366,19 +11370,19 @@ msgstr ""
 "Sua disponibilità ma non può garantirla, perché chiunque può creare un "
 "account. Scelga \"Nessuno\" per conservare lo stato senza mostrarlo."
 
-#: lib/vutuv/accounts/user.ex:1211
+#: lib/vutuv/accounts/user.ex:1215
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Tutti, compresi i visitatori non connessi"
 
-#: lib/vutuv/accounts/user.ex:1216
+#: lib/vutuv/accounts/user.ex:1220
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Nessuno"
 
-#: lib/vutuv/accounts/user.ex:1214
+#: lib/vutuv/accounts/user.ex:1218
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:771
 #, elixir-autogen, elixir-format
@@ -12763,7 +12767,7 @@ msgstr "I tag evidenziati corrispondono al Suo profilo."
 msgid "How to apply"
 msgstr "Come candidarsi"
 
-#: lib/vutuv/accounts/user.ex:1185
+#: lib/vutuv/accounts/user.ex:1189
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12885,7 +12889,7 @@ msgstr ""
 "Offri i formati leggibili dalle macchine (.md/.txt/.json/.xml) agli agenti "
 "IA."
 
-#: lib/vutuv/accounts/user.ex:1184
+#: lib/vutuv/accounts/user.ex:1188
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12969,7 +12973,7 @@ msgstr "Annuncio non trovato."
 msgid "Publish"
 msgstr "Pubblica"
 
-#: lib/vutuv/accounts/user.ex:1186
+#: lib/vutuv/accounts/user.ex:1190
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
 #: lib/vutuv_web/agent_docs/markdown.ex:466
@@ -13738,7 +13742,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "Interrompere gli avvisi via e-mail per la Sua ricerca salvata \"%{label}\"?"
 
-#: lib/vutuv_web/components/post_components.ex:2563
+#: lib/vutuv_web/components/post_components.ex:2580
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:695
 #: lib/vutuv_web/controllers/settings_controller.ex:713
@@ -14069,7 +14073,7 @@ msgstr ""
 "Se è venuto male (ad esempio con un avviso sui cookie che copre la pagina), "
 "può rimuoverlo."
 
-#: lib/vutuv/accounts/user.ex:1229
+#: lib/vutuv/accounts/user.ex:1233
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -14083,19 +14087,19 @@ msgstr ""
 "la data esatta, \"Giorno e mese\" nasconde l'anno (e la Sua età) e \"Non "
 "mostrare\" lo conserva ma lo tiene fuori dal profilo."
 
-#: lib/vutuv/accounts/user.ex:1232
+#: lib/vutuv/accounts/user.ex:1236
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Giorno e mese, senza l'anno"
 
-#: lib/vutuv/accounts/user.ex:1235
+#: lib/vutuv/accounts/user.ex:1239
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Non mostrare il mio compleanno"
 
-#: lib/vutuv/accounts/user.ex:1226
+#: lib/vutuv/accounts/user.ex:1230
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14205,22 +14209,22 @@ msgstr "Cellulare privato"
 msgid "Work mobile"
 msgstr "Cellulare di lavoro"
 
-#: lib/vutuv_web/components/post_components.ex:433
+#: lib/vutuv_web/components/post_components.ex:444
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr "Ancora nessun post."
 
-#: lib/vutuv_web/components/post_components.ex:435
+#: lib/vutuv_web/components/post_components.ex:446
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr "Ancora nessuna risposta."
 
-#: lib/vutuv_web/components/post_components.ex:434
+#: lib/vutuv_web/components/post_components.ex:445
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr "Ancora nessuna ripubblicazione."
 
-#: lib/vutuv_web/components/post_components.ex:392
+#: lib/vutuv_web/components/post_components.ex:403
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr "Post propri"
@@ -14235,14 +14239,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4516
 #: lib/vutuv_web/controllers/settings_controller.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:1837
+#: lib/vutuv_web/live/post_live/feed.ex:1845
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr "Tag che segue"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1852
+#: lib/vutuv_web/live/post_live/feed.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr "Smetti di seguire #%{tag}"
@@ -14408,34 +14412,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr "ha aggiunto %{count} nuove voci al proprio CV:"
 
-#: lib/vutuv_web/components/post_components.ex:4807
+#: lib/vutuv_web/components/post_components.ex:4837
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Audiolibro"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4764
+#: lib/vutuv_web/components/post_components.ex:4794
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Recensione di un libro"
 
-#: lib/vutuv_web/components/post_components.ex:4808
+#: lib/vutuv_web/components/post_components.ex:4838
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Cinema"
 
-#: lib/vutuv_web/components/post_components.ex:4810
+#: lib/vutuv_web/components/post_components.ex:4840
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:4806
+#: lib/vutuv_web/components/post_components.ex:4836
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4763
+#: lib/vutuv_web/components/post_components.ex:4793
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Recensione di un film"
@@ -14446,12 +14450,12 @@ msgstr "Recensione di un film"
 msgid "Look up"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:4805
+#: lib/vutuv_web/components/post_components.ex:4835
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Libro cartaceo"
 
-#: lib/vutuv_web/components/post_components.ex:4809
+#: lib/vutuv_web/components/post_components.ex:4839
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14471,7 +14475,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Anno"
 
-#: lib/vutuv_web/components/post_components.ex:4846
+#: lib/vutuv_web/components/post_components.ex:4876
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14479,27 +14483,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} pagina"
 msgstr[1] "%{formatted} pagine"
 
-#: lib/vutuv_web/components/post_components.ex:4876
+#: lib/vutuv_web/components/post_components.ex:4906
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} h"
 
-#: lib/vutuv_web/components/post_components.ex:4877
+#: lib/vutuv_web/components/post_components.ex:4907
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} h %{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:4875
+#: lib/vutuv_web/components/post_components.ex:4905
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:4835
+#: lib/vutuv_web/components/post_components.ex:4865
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(edizione cartacea)"
 
-#: lib/vutuv_web/components/post_components.ex:4882
+#: lib/vutuv_web/components/post_components.ex:4912
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "circa %{duration}"
@@ -14531,7 +14535,7 @@ msgstr "Con certificazione:"
 msgid "With qualification: %{name}"
 msgstr "Con certificazione: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4649
+#: lib/vutuv_web/components/post_components.ex:4679
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Editore:"
@@ -14579,7 +14583,7 @@ msgstr "ora La seguono."
 msgid "endorsed you for %{tags}."
 msgstr "L'ha confermata per %{tags}."
 
-#: lib/vutuv_web/components/post_components.ex:4640
+#: lib/vutuv_web/components/post_components.ex:4670
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "di:"
@@ -14986,14 +14990,14 @@ msgstr "Cerchi un account da bloccare"
 msgid "See all frozen accounts"
 msgstr "Vedi tutti gli account bloccati"
 
-#: lib/vutuv_web/components/post_components.ex:2836
+#: lib/vutuv_web/components/post_components.ex:2853
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "Mostra %{formatted} post precedente"
 msgstr[1] "Mostra %{formatted} post precedenti"
 
-#: lib/vutuv_web/components/post_components.ex:2859
+#: lib/vutuv_web/components/post_components.ex:2876
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -15022,7 +15026,7 @@ msgstr ""
 "Digiti un nome, un @handle o un indirizzo e-mail per trovare un account da "
 "bloccare."
 
-#: lib/vutuv_web/components/post_components.ex:5298
+#: lib/vutuv_web/components/post_components.ex:5328
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Non può mettere Mi piace al Suo stesso post."
@@ -16291,21 +16295,21 @@ msgstr ""
 " vedere dove va a finire. Modificare o eliminare un post su vutuv è solo una"
 " richiesta rivolta a quei server, e non tutti la rispettano."
 
-#: lib/vutuv_web/components/post_components.ex:5244
+#: lib/vutuv_web/components/post_components.ex:5274
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} risposta"
 msgstr[1] "%{formatted} risposte"
 
-#: lib/vutuv_web/components/post_components.ex:5248
+#: lib/vutuv_web/components/post_components.ex:5278
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Mi piace"
 msgstr[1] "%{formatted} Mi piace"
 
-#: lib/vutuv_web/components/post_components.ex:5252
+#: lib/vutuv_web/components/post_components.ex:5282
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16313,7 +16317,7 @@ msgstr[0] "%{formatted} ripubblicazione"
 msgstr[1] "%{formatted} ripubblicazioni"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1153
-#: lib/vutuv_web/components/post_components.ex:5203
+#: lib/vutuv_web/components/post_components.ex:5233
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Già conteggiate nei numeri qui sopra."
@@ -16334,14 +16338,14 @@ msgstr ""
 msgid "Content warning"
 msgstr "Avviso sul contenuto"
 
-#: lib/vutuv_web/components/post_components.ex:1371
-#: lib/vutuv_web/components/post_components.ex:2030
+#: lib/vutuv_web/components/post_components.ex:1387
+#: lib/vutuv_web/components/post_components.ex:2046
 #: lib/vutuv_web/live/fediverse_account_live.ex:294
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Da un'altra rete"
 
-#: lib/vutuv_web/components/post_components.ex:1247
+#: lib/vutuv_web/components/post_components.ex:1263
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Rimuovere questa risposta dal Suo post?"
@@ -16370,7 +16374,7 @@ msgstr "Risposta da un'altra rete"
 msgid "Reply removed."
 msgstr "Risposta rimossa."
 
-#: lib/vutuv_web/components/post_components.ex:1256
+#: lib/vutuv_web/components/post_components.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -16381,7 +16385,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr "Segnalata come non appropriata"
 
-#: lib/vutuv_web/components/post_components.ex:1270
+#: lib/vutuv_web/components/post_components.ex:1286
 #: lib/vutuv_web/live/notification_live/index.ex:597
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -16413,9 +16417,9 @@ msgid "That reply is not yours to remove."
 msgstr "Questa risposta non spetta a Lei rimuoverla."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1337
-#: lib/vutuv_web/components/post_components.ex:1302
-#: lib/vutuv_web/components/post_components.ex:1502
-#: lib/vutuv_web/components/post_components.ex:2483
+#: lib/vutuv_web/components/post_components.ex:1318
+#: lib/vutuv_web/components/post_components.ex:1518
+#: lib/vutuv_web/components/post_components.ex:2500
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Vedi l'originale"
@@ -17110,22 +17114,22 @@ msgstr ""
 msgid "device or detail"
 msgstr "dispositivo o dettaglio"
 
-#: lib/vutuv_web/components/post_components.ex:3021
+#: lib/vutuv_web/components/post_components.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Post fissato"
 
-#: lib/vutuv_web/components/post_components.ex:3137
+#: lib/vutuv_web/components/post_components.ex:3154
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "Fissa sul profilo"
 
-#: lib/vutuv_web/components/post_components.ex:3145
+#: lib/vutuv_web/components/post_components.ex:3162
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Togli dal profilo"
 
-#: lib/vutuv_web/components/post_components.ex:3131
+#: lib/vutuv_web/components/post_components.ex:3148
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -17260,17 +17264,17 @@ msgstr "Foto successiva"
 msgid "No image description yet"
 msgstr "Ancora nessuna descrizione dell'immagine"
 
-#: lib/vutuv_web/components/post_components.ex:2616
+#: lib/vutuv_web/components/post_components.ex:2633
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Apri le impostazioni del Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:3834
+#: lib/vutuv_web/components/post_components.ex:3851
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} di %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:3982
+#: lib/vutuv_web/components/post_components.ex:3999
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "La foto è in fase di controllo"
@@ -17283,7 +17287,7 @@ msgstr "Opzioni della foto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1298
 #: lib/vutuv_web/agent_docs/text.ex:785
-#: lib/vutuv_web/components/post_components.ex:4064
+#: lib/vutuv_web/components/post_components.ex:4081
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Foto:"
@@ -17311,7 +17315,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr "Mostra le impostazioni della fotocamera"
 
-#: lib/vutuv_web/components/post_components.ex:2669
+#: lib/vutuv_web/components/post_components.ex:2686
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -17337,7 +17341,7 @@ msgstr ""
 "Questa foto porta con sé il luogo in cui è stata scattata. Chiunque scarichi"
 " il file esatto può leggerlo."
 
-#: lib/vutuv_web/components/post_components.ex:2660
+#: lib/vutuv_web/components/post_components.ex:2677
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -17352,12 +17356,12 @@ msgstr ""
 "inviare le Sue parole a quella rete, cosa che vutuv fa solo per i membri che"
 " hanno attivato la partecipazione al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:2678
+#: lib/vutuv_web/components/post_components.ex:2695
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Questo sito non partecipa al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:2612
+#: lib/vutuv_web/components/post_components.ex:2629
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Attivi la partecipazione al Fediverso per rispondere"
@@ -17373,7 +17377,7 @@ msgid "You have sent a lot of answers to other networks in the past hour. Please
 msgstr ""
 "Nell'ultima ora ha inviato molte risposte ad altre reti. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:2673
+#: lib/vutuv_web/components/post_components.ex:2690
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -17387,7 +17391,7 @@ msgstr ""
 "Al momento le Sue impostazioni del Fediverso non consentono di inviare una "
 "risposta."
 
-#: lib/vutuv_web/components/post_components.ex:2626
+#: lib/vutuv_web/components/post_components.ex:2643
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -17410,8 +17414,8 @@ msgstr "Aggiungi foto"
 msgid "Licence"
 msgstr "Licenza"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1638
-#: lib/vutuv_web/live/post_live/feed.ex:1639
+#: lib/vutuv_web/live/post_live/feed.ex:1645
+#: lib/vutuv_web/live/post_live/feed.ex:1646
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr "Pubblica foto"
@@ -17482,13 +17486,13 @@ msgstr[1] ""
 "il file esatto lo rivela."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1171
-#: lib/vutuv_web/components/post_components.ex:5241
+#: lib/vutuv_web/components/post_components.ex:5271
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "A %{handle} è piaciuto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1169
-#: lib/vutuv_web/components/post_components.ex:5238
+#: lib/vutuv_web/components/post_components.ex:5268
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} lo ha condiviso"
@@ -17498,7 +17502,7 @@ msgstr "%{handle} lo ha condiviso"
 msgid "Fediverse reactions"
 msgstr "Reazioni dal Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:5130
+#: lib/vutuv_web/components/post_components.ex:5160
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Da altre reti"
@@ -17884,7 +17888,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr "Post in cache"
 
-#: lib/vutuv_web/components/post_components.ex:2428
+#: lib/vutuv_web/components/post_components.ex:2445
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Solo per i follower di questo account"
@@ -17894,7 +17898,7 @@ msgstr "Solo per i follower di questo account"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Grazie. La nostra copia è stata eliminata subito."
 
-#: lib/vutuv_web/components/post_components.ex:2482
+#: lib/vutuv_web/components/post_components.ex:2499
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Vota sull'originale"
@@ -17920,12 +17924,12 @@ msgstr "Post in cache segnalato, rimosso per tutti qui"
 msgid "Content from other networks taken down by members"
 msgstr "Contenuti da altre reti rimossi dai membri"
 
-#: lib/vutuv_web/components/post_components.ex:1630
+#: lib/vutuv_web/components/post_components.ex:1646
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Nascondi"
 
-#: lib/vutuv_web/components/post_components.ex:2447
+#: lib/vutuv_web/components/post_components.ex:2464
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Contrassegnato come sensibile dal suo autore"
@@ -17941,7 +17945,7 @@ msgstr "Silenziato. Continua a seguirlo; i suoi post spariscono dal Suo feed."
 msgid "Nobody has removed or reported anything yet."
 msgstr "Nessuno ha ancora rimosso o segnalato nulla."
 
-#: lib/vutuv_web/components/post_components.ex:2414
+#: lib/vutuv_web/components/post_components.ex:2431
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -18203,27 +18207,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(un'immagine)"
 msgstr[1] "(%{count} immagini)"
 
-#: lib/vutuv_web/components/post_components.ex:2150
+#: lib/vutuv_web/components/post_components.ex:2167
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr "L'immagine è in fase di controllo"
 
-#: lib/vutuv_web/components/post_components.ex:2179
+#: lib/vutuv_web/components/post_components.ex:2196
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Coprila di nuovo"
 
-#: lib/vutuv_web/components/post_components.ex:2174
+#: lib/vutuv_web/components/post_components.ex:2191
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Contenuto sensibile. Mostra l'immagine."
 
-#: lib/vutuv_web/components/post_components.ex:2519
+#: lib/vutuv_web/components/post_components.ex:2536
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Sono molti Mi piace in un'ora. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:2525
+#: lib/vutuv_web/components/post_components.ex:2542
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Quel post non è più qui."
@@ -18233,7 +18237,7 @@ msgstr "Quel post non è più qui."
 msgid "Back to the feed"
 msgstr "Torna al feed"
 
-#: lib/vutuv_web/components/post_components.ex:2664
+#: lib/vutuv_web/components/post_components.ex:2681
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -19002,14 +19006,14 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr "Elenco dei bloccati per gli screenshot"
 
-#: lib/vutuv_web/components/post_components.ex:425
+#: lib/vutuv_web/components/post_components.ex:436
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 "Ancora nulla dal Fediverso. Segua account là fuori per riempire questa "
 "scheda."
 
-#: lib/vutuv_web/components/post_components.ex:422
+#: lib/vutuv_web/components/post_components.ex:433
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr "Ancora nulla da vutuv. Segua persone qui per riempire questa scheda."
@@ -19051,7 +19055,7 @@ msgstr "Nessun post su vutuv porta ancora questo tag."
 msgid "word in a post"
 msgstr "parola in un post"
 
-#: lib/vutuv_web/components/post_components.ex:2522
+#: lib/vutuv_web/components/post_components.ex:2539
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Quella risposta non è più qui."
@@ -19430,19 +19434,19 @@ msgstr ""
 msgid "Liked by"
 msgstr "Piace a"
 
-#: lib/vutuv_web/components/post_components.ex:4336
+#: lib/vutuv_web/components/post_components.ex:4366
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Piace a %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4338
+#: lib/vutuv_web/components/post_components.ex:4368
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Piace a %{name} e a %{formatted} altro"
 msgstr[1] "Piace a %{name} e ad altri %{formatted}"
 
-#: lib/vutuv_web/components/post_components.ex:4349
+#: lib/vutuv_web/components/post_components.ex:4379
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -20503,17 +20507,17 @@ msgstr ""
 "Il PIN non arriva? L'indirizzo e-mail {email} è corretto? Ha controllato la "
 "cartella dello spam?"
 
-#: lib/vutuv/accounts/user.ex:1332
+#: lib/vutuv/accounts/user.ex:1336
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Non binario"
 
-#: lib/vutuv/accounts/user.ex:1330
+#: lib/vutuv/accounts/user.ex:1334
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Femminile"
 
-#: lib/vutuv/accounts/user.ex:1331
+#: lib/vutuv/accounts/user.ex:1335
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Maschile"
@@ -21273,7 +21277,7 @@ msgstr ""
 msgid "Start over"
 msgstr "Ricomincia"
 
-#: lib/vutuv_web/components/post_components.ex:2552
+#: lib/vutuv_web/components/post_components.ex:2569
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -21838,21 +21842,6 @@ msgstr[1] ""
 "%{members} membri vutuv più %{fediverse} account del Fediverso che li "
 "seguono"
 
-#: lib/vutuv_web/templates/directory/index.html.heex:14
-#, elixir-autogen, elixir-format
-msgid "%{count} vutuv members whose profiles are open to search engines, filed alphabetically by last name."
-msgstr ""
-"%{count} membri vutuv i cui profili sono aperti ai motori di ricerca, "
-"ordinati alfabeticamente per cognome."
-
-#: lib/vutuv_web/agent_docs/list_docs.ex:205
-#, elixir-autogen, elixir-format
-msgid "%{listed} vutuv members are listed here, grouped by the first letter of their last name; anyone who does not open their profile to search engines is not among them."
-msgstr ""
-"Qui sono elencati %{listed} membri vutuv, raggruppati per la prima lettera "
-"del cognome; chi non apre il proprio profilo ai motori di ricerca non è fra "
-"loro."
-
 #: lib/vutuv_web/live/section_reorder_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Add this under Messengers"
@@ -22200,7 +22189,7 @@ msgstr ""
 "che hanno su vutuv, anche quando il Suo archivio ne contiene di più recenti."
 
 #: lib/vutuv_web/controllers/import_controller.ex:272
-#: lib/vutuv_web/views/user_helpers.ex:219
+#: lib/vutuv_web/views/user_helpers.ex:240
 #, elixir-autogen, elixir-format
 msgid "%{count} tag did not fit: your profile holds at most %{max}. Remove some and try again."
 msgid_plural "%{count} tags did not fit: your profile holds at most %{max}. Remove some and try again."
@@ -22221,7 +22210,7 @@ msgstr "Prima rimuova dei tag"
 msgid "Select as many as fit"
 msgstr "Ne selezioni quanti ce ne stanno"
 
-#: lib/vutuv_web/views/user_helpers.ex:209
+#: lib/vutuv_web/views/user_helpers.ex:230
 #, elixir-autogen, elixir-format
 msgid "Skipped %{count} tag that is a duplicate or invalid."
 msgid_plural "Skipped %{count} tags that are duplicates or invalid."
@@ -22264,27 +22253,27 @@ msgstr "Lingua del post"
 msgid "The language this post is written in"
 msgstr "La lingua in cui è scritto questo post"
 
-#: lib/vutuv_web/components/post_components.ex:4230
+#: lib/vutuv_web/components/post_components.ex:4260
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Mostra l'originale"
 
-#: lib/vutuv_web/components/post_components.ex:4266
+#: lib/vutuv_web/components/post_components.ex:4296
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Traduci"
 
-#: lib/vutuv_web/components/post_components.ex:4275
+#: lib/vutuv_web/components/post_components.ex:4305
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Tradotto"
 
-#: lib/vutuv_web/components/post_components.ex:4278
+#: lib/vutuv_web/components/post_components.ex:4308
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Tradotto da %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:4255
+#: lib/vutuv_web/components/post_components.ex:4285
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Traduzione in corso…"
@@ -22295,7 +22284,7 @@ msgid "Feed language settings reset to the site defaults."
 msgstr ""
 "Impostazioni delle lingue del feed riportate ai valori predefiniti del sito."
 
-#: lib/vutuv_web/components/post_components.ex:4245
+#: lib/vutuv_web/components/post_components.ex:4275
 #: lib/vutuv_web/components/ui.ex:4509
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -22438,7 +22427,7 @@ msgid "Your username, or paste the address of your profile page."
 msgstr ""
 "Il Suo nome utente, oppure incolli l'indirizzo della Sua pagina di profilo."
 
-#: lib/vutuv_web/components/post_components.ex:4030
+#: lib/vutuv_web/components/post_components.ex:4047
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
@@ -22449,13 +22438,13 @@ msgstr[1] ""
 "La nostra IA le sta ancora controllando, %{done} su %{total} fatte. Appena "
 "avrà finito con l'ultima, le foto compariranno da sé."
 
-#: lib/vutuv_web/components/post_components.ex:4027
+#: lib/vutuv_web/components/post_components.ex:4044
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Il Suo post è pubblicato, la foto non c'è ancora."
 
-#: lib/vutuv_web/components/post_components.ex:2201
-#: lib/vutuv_web/components/post_components.ex:3354
+#: lib/vutuv_web/components/post_components.ex:2218
+#: lib/vutuv_web/components/post_components.ex:3371
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -22474,7 +22463,7 @@ msgstr "Consigliato: %{width} × %{height} pixel (%{ratio})."
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Consigliato: quadrata, almeno %{width} × %{height} pixel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1894
+#: lib/vutuv_web/live/post_live/feed.ex:1902
 #: lib/vutuv_web/views/user_html.ex:338
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -23026,7 +23015,7 @@ msgstr ""
 "Questa pagina sta seguendo il numero massimo di account che consentiamo "
 "(%{max})."
 
-#: lib/vutuv_web/components/post_components.ex:2402
+#: lib/vutuv_web/components/post_components.ex:2419
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr "Smettere di seguire %{handle}? I suoi post spariscono dal Suo feed."
@@ -23169,12 +23158,12 @@ msgstr ""
 "Segua #%{tag} da Mastodon o da qualsiasi altra app del Fediverso e i suoi "
 "post pubblici arriveranno nella Sua cronologia. Non serve un account vutuv."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1876
+#: lib/vutuv_web/live/post_live/feed.ex:1884
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Saluti gli altri membri"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1872
+#: lib/vutuv_web/live/post_live/feed.ex:1880
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr "Nuovi qui"
@@ -23224,31 +23213,31 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr "Con un account vutuv"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1886
+#: lib/vutuv_web/live/post_live/feed.ex:1894
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr "Alcuni fra i membri più recenti. Seguirli è un bel benvenuto."
 
-#: lib/vutuv_web/components/post_components.ex:602
+#: lib/vutuv_web/components/post_components.ex:613
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post"
 msgid_plural "%{formatted} new posts"
 msgstr[0] "%{formatted} nuovo post"
 msgstr[1] "%{formatted} nuovi post"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1314
+#: lib/vutuv_web/live/post_live/feed.ex:1312
 #, elixir-autogen, elixir-format
 msgid "%{source}: %{formatted} new post"
 msgid_plural "%{source}: %{formatted} new posts"
 msgstr[0] "%{source}: %{formatted} nuovo post"
 msgstr[1] "%{source}: %{formatted} nuovi post"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1311
+#: lib/vutuv_web/live/post_live/feed.ex:1309
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post"
 msgstr "%{source}: nuovo post"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1308
+#: lib/vutuv_web/live/post_live/feed.ex:1306
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post from %{who}"
 msgstr "%{source}: nuovo post di %{who}"
@@ -23537,3 +23526,61 @@ msgstr "Il suo profilo LinkedIn può venire con lei."
 #, elixir-autogen, elixir-format
 msgid "Being checked"
 msgstr "In verifica"
+
+#: lib/vutuv_web/templates/directory/index.html.heex:23
+#, elixir-autogen, elixir-format
+msgid "%{count} vutuv members, filed alphabetically by last name."
+msgstr "%{count} membri vutuv, in ordine alfabetico per cognome."
+
+#: lib/vutuv_web/agent_docs/list_docs.ex:205
+#, elixir-autogen, elixir-format
+msgid "%{listed} vutuv members are listed here, grouped by the first letter of their last name."
+msgstr "Qui sono elencati %{listed} membri vutuv, raggruppati per la prima lettera del cognome."
+
+#: lib/vutuv_web/live/directory_search_live.ex:141
+#, elixir-autogen, elixir-format
+msgid "Find a member"
+msgstr "Trova un membro"
+
+#: lib/vutuv_web/live/directory_search_live.ex:195
+#, elixir-autogen, elixir-format
+msgid "No members found for \"%{query}\"."
+msgstr "Nessun membro trovato per “%{query}”."
+
+#: lib/vutuv_web/live/directory_search_live.ex:208
+#, elixir-autogen, elixir-format
+msgid "One member found."
+msgid_plural "%{formatted} members found."
+msgstr[0] "Un membro trovato."
+msgstr[1] "%{formatted} membri trovati."
+
+#: lib/vutuv_web/live/directory_search_live.ex:186
+#, elixir-autogen, elixir-format
+msgid "Results appear once you have typed at least %{count} letters."
+msgstr "I risultati compaiono dopo almeno %{count} lettere."
+
+#: lib/vutuv_web/live/directory_search_live.ex:152
+#: lib/vutuv_web/live/directory_search_live.ex:153
+#, elixir-autogen, elixir-format
+msgid "Search members by name"
+msgstr "Cerca membri per nome"
+
+#: lib/vutuv_web/live/directory_search_live.ex:229
+#, elixir-autogen, elixir-format
+msgid "Show %{count} more"
+msgstr "Mostra altri %{count}"
+
+#: lib/vutuv_web/live/directory_search_live.ex:203
+#, elixir-autogen, elixir-format
+msgid "Showing %{shown} of %{total} members."
+msgstr "Vengono mostrati %{shown} di %{total} membri."
+
+#: lib/vutuv_web/live/directory_search_live.ex:257
+#, elixir-autogen, elixir-format
+msgid "That is as far as this list goes. Type more of the name to narrow it down."
+msgstr "Questo elenco non va oltre. Digiti altre lettere del nome per restringerlo."
+
+#: lib/vutuv_web/live/directory_search_live.ex:160
+#, elixir-autogen, elixir-format
+msgid "Which names to search"
+msgstr "Quali nomi cercare"

--- a/priv/repo/migrations/20260828083124_add_users_name_trigram_indexes.exs
+++ b/priv/repo/migrations/20260828083124_add_users_name_trigram_indexes.exs
@@ -1,0 +1,59 @@
+defmodule Vutuv.Repo.Migrations.AddUsersNameTrigramIndexes do
+  use Ecto.Migration
+
+  # The member directory's search box (`Vutuv.Directory.search/3`) matches a
+  # typed name with `ILIKE '%needle%'` against `users.first_name`,
+  # `users.last_name` and `users.username`. A leading wildcard can use no btree
+  # index — `users_username_index` is a plain unique btree, and the two name
+  # columns had no index at all — so every debounced keystroke was a sequential
+  # scan of `users`. Measured on a 101,558-row copy of production: 26.3 ms per
+  # scan, against 1.3 ms once these exist (a BitmapOr over three bitmap index
+  # scans). At today's ~6,000 rows the difference is a few milliseconds; the
+  # point is that the cost grows with the membership on a page whose whole job
+  # is to be typed into.
+  #
+  # This repo already learned the lesson once, for the same query shape:
+  # `20260613195046_add_trigram_index_to_search_terms` records "~280ms full
+  # scan → ~2ms bitmap index scan" for the people search on `search_terms`.
+  # That table carries first/last/combined names but not usernames, and its
+  # matcher ANDs the name fields rather than ORing a caller-chosen subset, so
+  # the directory box cannot borrow it.
+  #
+  # pg_trgm needs three characters to form a trigram, which is why
+  # `Directory.min_query_chars/0` is 3: a two-letter needle would plan a
+  # sequential scan however many indexes stand here (measured 27.1 ms against
+  # 1.3 ms on the same indexed table).
+  #
+  # Built CONCURRENTLY, so this migration may run neither in a transaction nor
+  # behind the migrator's advisory lock. Additive and N-1 compatible: it only
+  # speeds up queries, so the release still serving traffic keeps working.
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+
+    for column <- ~w(first_name last_name username) do
+      create_if_not_exists(
+        index(:users, ["#{column} gin_trgm_ops"],
+          using: :gin,
+          name: "users_#{column}_trgm_index",
+          concurrently: true
+        )
+      )
+    end
+  end
+
+  def down do
+    for column <- ~w(first_name last_name username) do
+      drop_if_exists(
+        index(:users, ["#{column} gin_trgm_ops"],
+          name: "users_#{column}_trgm_index",
+          concurrently: true
+        )
+      )
+    end
+
+    # pg_trgm stays installed: the search_terms and tags trigram indexes need it.
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -15,6 +15,7 @@ defmodule VutuvWeb.ConnCase do
       import Ecto.Query
       import Vutuv.Factory
       import Vutuv.MailboxHelpers
+      import VutuvWeb.HTMLHelpers
 
       use Phoenix.VerifiedRoutes,
         endpoint: VutuvWeb.Endpoint,

--- a/test/support/html_helpers.ex
+++ b/test/support/html_helpers.ex
@@ -1,0 +1,28 @@
+defmodule VutuvWeb.HTMLHelpers do
+  @moduledoc """
+  Assertions that read a rendered page rather than match a string in it.
+
+  Imported into every `VutuvWeb.ConnCase` test. It is a module of its own rather
+  than more lines in that case template's `quote` block, which is already at the
+  length Credo will refuse.
+  """
+
+  @doc """
+  Every `<a href="/<slug>">` in `html` that carries `rel="nofollow"` — the marker
+  a public listing puts on a member who asked search engines to leave their
+  profile alone (`VutuvWeb.UserHelpers.profile_rel/1`).
+
+  Read out of the parsed document, so the attribute order a template happens to
+  emit is not part of the promise.
+
+  The `Enum.to_list/1` is load-bearing: a LazyHTML node set is never `== []`, so
+  an empty one satisfies a `!= []` assertion with nothing in it and the test
+  passes whether or not the `rel` is there.
+  """
+  def nofollow_links(html, slug) do
+    html
+    |> LazyHTML.from_document()
+    |> LazyHTML.query(~s(a[href="/#{slug}"][rel~="nofollow"]))
+    |> Enum.to_list()
+  end
+end

--- a/test/vutuv/directory_test.exs
+++ b/test/vutuv/directory_test.exs
@@ -1,10 +1,16 @@
 defmodule Vutuv.DirectoryTest do
   @moduledoc """
-  The member directory (`Vutuv.Directory`): the crawlable member set grouped
+  The member directory (`Vutuv.Directory`): the listed member set grouped
   alphabetically. The grouping key is the last name (first name as fallback),
   accents folded so Ö sorts under O (DIN 5007), everything that doesn't start
-  with a letter in the shared "other" bucket. Members who opted out of search
-  engines (`noindex?`), are unconfirmed, or are moderation-hidden never appear.
+  with a letter in the shared "other" bucket. Unconfirmed and moderation-hidden
+  members never appear.
+
+  The two sets this module holds apart are `listed_users/0`, what the directory
+  shows, and `indexable_users/0`, the narrower crawlable set the sitemap
+  advertises. A member who opted out of search engines is in the first and not
+  the second — before v7.407.0 the directory used the second for both, which hid
+  them from a page whose whole job is to help somebody find them.
   """
 
   use Vutuv.DataCase, async: true
@@ -50,9 +56,8 @@ defmodule Vutuv.DirectoryTest do
     assert counts_by_letter()["other"] == 2
   end
 
-  test "opted-out, unconfirmed and moderation-hidden members are excluded" do
+  test "unconfirmed and moderation-hidden members are excluded" do
     insert_activated_user(last_name: "Visible")
-    insert_activated_user(last_name: "Vanished", noindex?: true)
     insert(:user, last_name: "Vague")
     insert_activated_user(last_name: "Verboten", frozen_at: ~N[2026-01-01 00:00:00])
     insert_activated_user(last_name: "Vergangen", deactivated_at: ~N[2026-01-01 00:00:00])
@@ -66,6 +71,21 @@ defmodule Vutuv.DirectoryTest do
 
     %{users: users} = Directory.members_page("v", %{})
     assert Enum.map(users, & &1.last_name) == ["Visible"]
+  end
+
+  test "a member who opted out of search engines is listed but not crawlable" do
+    insert_activated_user(last_name: "Nachbar")
+    insert_activated_user(last_name: "Nachbarin", noindex?: true)
+
+    # The directory lists both; only the sitemap's set drops the opted-out one.
+    assert counts_by_letter()["n"] == 2
+
+    assert %{users: users, total: 2} = Directory.members_page("n", %{})
+    assert Enum.map(users, & &1.last_name) == ["Nachbar", "Nachbarin"]
+
+    assert Directory.indexable_users()
+           |> Vutuv.Repo.all()
+           |> Enum.map(& &1.last_name) == ["Nachbar"]
   end
 
   test "unreachable (every-email-bounced) members are excluded, like the withheld profile" do
@@ -120,6 +140,82 @@ defmodule Vutuv.DirectoryTest do
 
     entries = Directory.letter_entries()
     assert Directory.total(entries) == 2
+  end
+
+  describe "search/3" do
+    setup do
+      insert_activated_user(first_name: "Anna", last_name: "Meier", username: "annadirsearch")
+      insert_activated_user(first_name: "Meier", last_name: "Bosch", username: "boschdirsearch")
+      insert_activated_user(first_name: "Carla", last_name: "Bosch", username: "meierdirsearch")
+      :ok
+    end
+
+    defp found(query, fields \\ Directory.search_fields()) do
+      case Directory.search(query, fields) do
+        nil -> nil
+        %{users: users} -> Enum.map(users, & &1.username) |> Enum.sort()
+      end
+    end
+
+    test "ORs across the selected fields rather than ANDing them" do
+      # One member per field carries "meier". All three come back together;
+      # an AND would return none of them.
+      assert found("meier") == ~w(annadirsearch boschdirsearch meierdirsearch)
+    end
+
+    test "each field can be searched on its own" do
+      assert found("meier", [:last_name]) == ~w(annadirsearch)
+      assert found("meier", [:first_name]) == ~w(boschdirsearch)
+      assert found("meier", [:username]) == ~w(meierdirsearch)
+    end
+
+    test "an empty field list looks everywhere rather than nowhere" do
+      # The last checkbox turned off arrives here as no field at all, and a
+      # search that can find nobody would be the worst reading of it.
+      assert found("meier", []) == ~w(annadirsearch boschdirsearch meierdirsearch)
+    end
+
+    test "every word of a multi-word query has to match some selected field" do
+      # "anna mei" is the most natural thing to type into a box that says it
+      # searches names, and no single-column match can answer it: "anna" is a
+      # first name and "mei" a last one. Order does not matter, which a
+      # first-then-last concatenation could never manage.
+      assert found("anna mei") == ~w(annadirsearch)
+      assert found("mei anna") == ~w(annadirsearch)
+
+      # Both words still have to land inside the ticked fields.
+      assert found("anna mei", [:last_name]) == []
+      assert found("anna bosch") == []
+    end
+
+    test "answers nil below the minimum instead of the whole membership" do
+      assert Directory.search("me") == nil
+      assert Directory.search(" ") == nil
+      assert Directory.search(nil) == nil
+      assert Directory.search("mei") != nil
+    end
+
+    test "a typed LIKE wildcard matches itself" do
+      # Unescaped, `%%%` would match every member and `_eier` every Meier.
+      assert found("%%%") == []
+      assert found("_eier") == []
+    end
+
+    test "total counts every match, users only the bite that is rendered" do
+      assert %{users: [_one], total: 3} = Directory.search("meier", Directory.search_fields(), 1)
+    end
+
+    test "parse_search_fields reads the param through an allowlist" do
+      assert Directory.parse_search_fields(["last_name"]) == [:last_name]
+      assert Directory.parse_search_fields(["username", "first_name"]) == [:first_name, :username]
+
+      # Anything not on the list is dropped, and a request left with nothing
+      # falls back to all three rather than to none.
+      assert Directory.parse_search_fields(["email", "password"]) == Directory.search_fields()
+      assert Directory.parse_search_fields([]) == Directory.search_fields()
+      assert Directory.parse_search_fields(nil) == Directory.search_fields()
+      assert Directory.parse_search_fields([%{}, 5]) == Directory.search_fields()
+    end
   end
 
   defp counts_by_letter do

--- a/test/vutuv_web/controllers/directory_controller_test.exs
+++ b/test/vutuv_web/controllers/directory_controller_test.exs
@@ -1,9 +1,15 @@
 defmodule VutuvWeb.DirectoryControllerTest do
   @moduledoc """
-  The public member directory (`/system/members` + `/system/members/:letter`): the
-  crawl-friendly, human-browsable index of every member who wants to be
-  found by search engines. Members who opted out (`noindex?`), are
-  unconfirmed or moderation-hidden must never show up here.
+  The public member directory (`/system/members` + `/system/members/:letter`):
+  the human-browsable index of **every** listed member, and the crawl-friendly
+  sibling of the sitemap.
+
+  The two sets it holds apart are what these tests are mostly about. A member
+  who opted out of search engines (`noindex?`) is listed like anybody else —
+  a directory that hid them was the odd one out beside the most-followed
+  listing, the follower lists and `/search`, none of which ever did — and what
+  the opt-out buys is `rel="nofollow"` on their row plus their absence from
+  the sitemap. Unconfirmed and moderation-hidden accounts are still nowhere.
   """
 
   use VutuvWeb.ConnCase, async: true
@@ -28,21 +34,21 @@ defmodule VutuvWeb.DirectoryControllerTest do
       refute html =~ ~p"/system/members/x"
     end
 
-    test "counts only crawlable members", %{conn: conn} do
-      # Otto Opt-Out is the only O-by-last-name besides Özil; his noindex?
-      # must keep the O count at 1 (Özil folds into o).
+    test "counts every listed member, opted out of search engines or not", %{conn: conn} do
+      # Otto Opt-Out and Özil both file under O. Before v7.407.0 his noindex?
+      # kept the count at 1 and left him off his own letter page.
       html = get(conn, ~p"/system/members") |> html_response(200)
 
-      assert html =~ ~s(data-letter="o" data-count="1")
+      assert html =~ ~s(data-letter="o" data-count="2")
       assert html =~ ~s(data-letter="a" data-count="1")
       assert html =~ ~s(data-letter="x" data-count="0")
     end
 
     test "opens with the listed count and nothing else", %{conn: conn, adler: adler} do
-      # Two of the three confirmed members allow search engines. The page used
-      # to name the whole membership and the Fediverse head count below that;
-      # both are the top bar's business, and three figures above an A-Z strip
-      # read as a statistics page (Stefan, 2026-08-13).
+      # All three confirmed members. The page used to name the whole membership
+      # and the Fediverse head count below that; both are the top bar's
+      # business, and three figures above an A-Z strip read as a statistics
+      # page (Stefan, 2026-08-13).
       Repo.insert!(%Vutuv.Fediverse.Follower{
         user_id: adler.id,
         actor_uri: "https://remote.example/users/frida",
@@ -51,7 +57,8 @@ defmodule VutuvWeb.DirectoryControllerTest do
 
       html = get(conn, ~p"/system/members") |> html_response(200)
 
-      assert html =~ "2 vutuv members whose profiles are open to search engines"
+      assert html =~ "3 vutuv members, filed alphabetically by last name."
+      refute html =~ "open to search engines"
       refute html =~ "members in total"
       refute html =~ "from the Fediverse"
     end
@@ -66,7 +73,7 @@ defmodule VutuvWeb.DirectoryControllerTest do
         |> get(~p"/system/members")
         |> html_response(200)
 
-      assert html =~ "2 vutuv Mitglieder, deren Profile für Suchmaschinen freigegeben sind"
+      assert html =~ "3 vutuv Mitglieder, alphabetisch nach Nachname sortiert."
       refute html =~ "Insgesamt gibt es"
     end
 
@@ -109,10 +116,30 @@ defmodule VutuvWeb.DirectoryControllerTest do
       assert html =~ "Özil, Mesut"
     end
 
-    test "never lists an opted-out member", %{conn: conn} do
+    test "lists an opted-out member, and tells crawlers not to follow the link", %{
+      conn: conn,
+      opted_out: opted_out,
+      ozil: ozil
+    } do
       html = get(conn, ~p"/system/members/o") |> html_response(200)
 
-      refute html =~ "Otto Opt-Out"
+      assert html =~ "Opt-Out, Otto"
+
+      # The row is there for people; the two links in it carry rel="nofollow"
+      # so a crawler does not walk through to a profile whose owner asked to
+      # stay out of search results. A member who allowed indexing gets none.
+      assert [_avatar, _name] = nofollow_links(html, opted_out.username)
+      assert nofollow_links(html, ozil.username) == []
+    end
+
+    test "keeps an opted-out member out of the sitemap", %{opted_out: opted_out, ozil: ozil} do
+      # The other half of the pair: listed for people, never advertised to a
+      # crawler. If this ever goes green with `listed_users/0` behind the
+      # sitemap, the opt-out has quietly stopped meaning anything.
+      paths = Vutuv.Sitemap.user_entries(1) |> Enum.map(&elem(&1, 0))
+
+      assert ("/" <> ozil.username) in paths
+      refute ("/" <> opted_out.username) in paths
     end
 
     test "serves the other bucket for names that start with no letter", %{conn: conn} do

--- a/test/vutuv_web/live/directory_search_live_test.exs
+++ b/test/vutuv_web/live/directory_search_live_test.exs
@@ -1,0 +1,275 @@
+defmodule VutuvWeb.DirectorySearchLiveTest do
+  @moduledoc """
+  The member directory's search box (`VutuvWeb.DirectorySearchLive`), embedded
+  into `/system/members` by the controller, so it is mounted here with
+  `live_isolated/3` the way the other `live_render` children are.
+
+  Three things it has to get right, each of which has a way of failing
+  silently. The field checkboxes narrow the search and at least one always
+  stays ticked (an unticked box sends nothing, so "all three off" and "no
+  preference" arrive identically and only one of them may mean "find
+  nobody"). A large result set is revealed in bites and stops at a ceiling
+  rather than rendering the whole membership. And the box works with no
+  socket at all: `?q=` renders its results server-side and the "show more"
+  control is a real link until the socket arrives to carry a `phx-click`.
+  """
+
+  use VutuvWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Directory
+
+  setup do
+    meier = insert_activated_user(first_name: "Anna", last_name: "Meier")
+    mayer = insert_activated_user(first_name: "Bruno", last_name: "Mayer")
+
+    quenstedt =
+      insert_activated_user(
+        first_name: "Clara",
+        last_name: "Quenstedt",
+        username: "quenstedtsearch"
+      )
+
+    opted_out =
+      insert_activated_user(first_name: "Otto", last_name: "Meierhoff", noindex?: true)
+
+    %{meier: meier, mayer: mayer, quenstedt: quenstedt, opted_out: opted_out}
+  end
+
+  defp mount_box(conn, session \\ %{}) do
+    live_isolated(conn, VutuvWeb.DirectorySearchLive, session: session)
+  end
+
+  defp search(view, params) do
+    render_change(view, "search", params)
+  end
+
+  describe "searching" do
+    test "finds a member by last name as you type", %{conn: conn} do
+      {:ok, view, _html} = mount_box(conn)
+
+      html = search(view, %{"q" => "meier", "fields" => ~w(first_name last_name username)})
+
+      assert html =~ "Meier, Anna"
+      # A substring, not a prefix: "meier" inside "Meierhoff" is a hit.
+      assert html =~ "Meierhoff, Otto"
+      refute html =~ "Mayer, Bruno"
+    end
+
+    test "finds a member by first name and by username", %{conn: conn} do
+      {:ok, view, _html} = mount_box(conn)
+
+      assert search(view, %{"q" => "clara", "fields" => ~w(first_name last_name username)}) =~
+               "Quenstedt, Clara"
+
+      assert search(view, %{"q" => "quenstedtsea", "fields" => ~w(first_name last_name username)}) =~
+               "Quenstedt, Clara"
+    end
+
+    test "says nothing found rather than showing an empty list", %{conn: conn} do
+      {:ok, view, _html} = mount_box(conn)
+
+      search(view, %{"q" => "nobodyhere", "fields" => ~w(first_name last_name username)})
+
+      assert has_element?(view, "#directory-search-empty")
+      refute has_element?(view, "#directory-search-count")
+    end
+
+    test "asks for more letters below the minimum instead of answering", %{conn: conn} do
+      {:ok, view, _html} = mount_box(conn)
+
+      search(view, %{"q" => "m", "fields" => ~w(first_name last_name username)})
+
+      assert has_element?(view, "#directory-search-hint")
+      refute has_element?(view, "#directory-search-results")
+    end
+  end
+
+  describe "the field checkboxes" do
+    test "all three start ticked", %{conn: conn} do
+      {:ok, view, _html} = mount_box(conn)
+
+      for field <- Directory.search_fields() do
+        assert has_element?(view, ~s([data-search-field="#{field}"][checked]))
+      end
+    end
+
+    test "unticking a field narrows what is searched", %{conn: conn} do
+      {:ok, view, _html} = mount_box(conn)
+
+      # "Otto" is a first name here and nobody's surname, so a last-name-only
+      # search must come up empty where the full search finds him.
+      assert search(view, %{"q" => "otto", "fields" => ~w(first_name last_name username)}) =~
+               "Meierhoff, Otto"
+
+      refute search(view, %{"q" => "otto", "fields" => ~w(last_name)}) =~ "Meierhoff, Otto"
+    end
+
+    test "unticking the last field ticks all three again", %{conn: conn} do
+      {:ok, view, _html} = mount_box(conn)
+
+      # Down to one field, then off: the form sends no `fields` key at all,
+      # which is the same thing a no-preference request sends, and both mean
+      # "look everywhere" rather than "look nowhere".
+      #
+      # Keeping the previous selection instead is the version that cannot be
+      # rendered: `@fields` would not change, so the diff would carry nothing
+      # for that checkbox and it would stay visibly unticked while the server
+      # searched as though it were on. Found in a browser, not by a test —
+      # which is why this one asserts the boxes and not only the results.
+      search(view, %{"q" => "otto", "fields" => ~w(first_name)})
+      refute has_element?(view, ~s([data-search-field="last_name"][checked]))
+
+      html = search(view, %{"q" => "otto"})
+
+      assert html =~ "Meierhoff, Otto"
+
+      for field <- Directory.search_fields() do
+        assert has_element?(view, ~s([data-search-field="#{field}"][checked]))
+      end
+    end
+  end
+
+  # One more than a bite, so the first press of "show more" is also the last and
+  # both sides of the control are exercised. Zero-padded surnames keep the
+  # filing order deterministic, so "the 26th" names one particular row.
+  defp insert_a_bite_and_one do
+    for i <- 1..(Directory.results_step() + 1) do
+      n = String.pad_leading(Integer.to_string(i), 2, "0")
+      insert_activated_user(first_name: "Rita", last_name: "Rasmussen#{n}")
+    end
+
+    Directory.results_step()
+  end
+
+  describe "a large result set" do
+    setup do
+      %{step: insert_a_bite_and_one()}
+    end
+
+    test "shows one bite with the full count, then reveals the next", %{conn: conn, step: step} do
+      {:ok, view, _html} = mount_box(conn)
+
+      html = search(view, %{"q" => "rasmussen", "fields" => ~w(last_name)})
+
+      assert html =~ "Showing #{step} of #{step + 1} members."
+      assert html =~ "Rasmussen01"
+      refute html =~ "Rasmussen26"
+      assert has_element?(view, "#directory-search-more")
+
+      more = render_click(view, "show-more")
+
+      assert more =~ "Rasmussen26"
+      assert more =~ "#{step + 1} members found."
+      refute has_element?(view, "#directory-search-more")
+    end
+  end
+
+  describe "the row ceiling" do
+    # Asserted on `results_limit/1` rather than on a result set, because the
+    # only honest way to see the clamp through `search/3` is to insert more
+    # members than the ceiling. A `length(users) <= ceiling` assertion over a
+    # handful of fixtures passes with the clamp removed, which is no test at
+    # all.
+    test "a crafted ?show= cannot ask for more than the ceiling" do
+      assert Directory.results_limit("100000") == Directory.results_ceiling()
+      assert Directory.results_limit(100_000) == Directory.results_ceiling()
+    end
+
+    test "an honest request under the ceiling is passed through" do
+      assert Directory.results_limit(Directory.results_step() * 2) ==
+               Directory.results_step() * 2
+    end
+
+    test "anything that is not a positive number falls back to one bite" do
+      for value <- [nil, "", "0", "-5", -5, 0, "abc", %{}] do
+        assert Directory.results_limit(value) == Directory.results_step()
+      end
+    end
+  end
+
+  describe "without a socket" do
+    test "a ?q= URL renders its results server-side", %{conn: conn} do
+      html = conn |> get(~p"/system/members?q=meier") |> html_response(200)
+
+      assert html =~ "Meier, Anna"
+      assert html =~ "Meierhoff, Otto"
+      refute html =~ "Mayer, Bruno"
+    end
+
+    test "the ?fields= param narrows the same way the checkboxes do", %{conn: conn} do
+      html =
+        conn
+        |> get(~p"/system/members?#{[q: "otto", fields: ["last_name"]]}")
+        |> html_response(200)
+
+      refute html =~ "Meierhoff, Otto"
+      assert html =~ "directory-search-empty"
+    end
+
+    test "show more is a real link, not a button that does nothing", %{conn: conn} do
+      insert_a_bite_and_one()
+
+      html = conn |> get(~p"/system/members?q=rasmussen") |> html_response(200)
+
+      refute html =~ "directory-search-more\""
+      assert html =~ "directory-search-more-link"
+      assert html =~ "show=#{2 * Directory.results_step()}"
+    end
+
+    test "an opted-out member is listed, with rel=nofollow on the row", %{
+      conn: conn,
+      opted_out: opted_out,
+      meier: meier
+    } do
+      html = conn |> get(~p"/system/members?q=meier") |> html_response(200)
+
+      assert [_avatar, _name] = nofollow_links(html, opted_out.username)
+      assert nofollow_links(html, meier.username) == []
+    end
+  end
+
+  describe "the German render" do
+    # vutuv is a German site, and `gettext.extract --merge` fuzzy-filled every
+    # one of these msgids from an unrelated string — two of them with a
+    # `%{query}` placeholder rewritten to `%{id}`, which renders as literal
+    # text. So each new sentence is asserted by name rather than trusted.
+    defp in_german(conn, path) do
+      conn
+      |> put_req_header("accept-language", "de-DE,de;q=0.9")
+      |> get(path)
+      |> html_response(200)
+    end
+
+    test "labels the box, its checkboxes and the result count", %{conn: conn} do
+      html = in_german(conn, ~p"/system/members?q=meier")
+
+      assert html =~ "Mitglied finden"
+      assert html =~ "Mitglieder nach Namen suchen"
+      assert html =~ "Vorname"
+      assert html =~ "Nachname"
+      assert html =~ "Benutzername"
+      assert html =~ "2 Mitglieder gefunden."
+    end
+
+    test "names the query it found nothing for, and the letters it still wants", %{conn: conn} do
+      assert in_german(conn, ~p"/system/members?q=nobodyhere") =~
+               "Kein Mitglied für „nobodyhere“ gefunden."
+
+      # The minimum is interpolated, not written into the translation: the
+      # merge filled this one in with a hard-coded "drei".
+      assert in_german(conn, ~p"/system/members?q=m") =~
+               "mindestens #{Directory.min_query_chars()} Buchstaben"
+    end
+  end
+
+  describe "indexability" do
+    test "the bare directory stays indexable but a search result does not", %{conn: conn} do
+      assert get_resp_header(get(conn, ~p"/system/members"), "x-robots-tag") == []
+
+      assert get_resp_header(get(build_conn(), ~p"/system/members?q=meier"), "x-robots-tag") ==
+               ["noindex"]
+    end
+  end
+end


### PR DESCRIPTION
**Symptom:** `/system/members` hid every member who had opted out of search
engines — the one page whose job is helping somebody find a member, while
`/search`, `/listings/most_followed_users` and every follower list had listed
them all along.

**Changed:** the directory now lists all members (`Vutuv.Directory.listed_users/0`).
The sitemap keeps the narrower `indexable_users/0`, and an opted-out member's row
is linked `rel="nofollow"` (`UserHelpers.profile_rel/1`, also applied to the
connections and tag-endorser lists). New `VutuvWeb.DirectorySearchLive` on the
index: substring search over first name / last name / username with three
checkboxes (unticking the last one ticks all three), results in bites of 25 up to
250, `?q=` shareable and `noindex`, and it works with no JavaScript. One
migration adds the GIN trigram indexes those columns lacked.

**Your call:** an organization's People list still hides opted-out members
(`Organizations.people_base/1`). Should it follow?

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_014pYuPWF3UNcVrpxdvFBzYk
