### PR TITLE
Member directory prints no figures

### DIFF
--- a/docs/architecture/agents-and-seo.md
+++ b/docs/architecture/agents-and-seo.md
@@ -293,13 +293,22 @@ Nachname" under a heading of "M" leaves the reader scanning for the word the
 order is built on. The avatar's alt text and the agent docs keep the canonical
 name, so only the visible listing changes.
 
-The overview prints **one** figure, the count it lists. It briefly printed three — the listed
-count, the whole membership and the Fediverse head count — and that was one
-number too many for a page whose job is an A-Z index: those two belong to the
-top bar's people pill, which is on this page like on every other (Stefan,
-2026-08-13). The agent formats carry the listed figure as `total` and repeat
-the sentence in the doc description, for the Markdown and text renderings,
-which print no counts of their own. Those siblings answer for the directory
+The overview prints **no figure at all** — not the total, and not a count under
+any letter tile. It went in two steps, both Stefan's: it briefly printed three
+(the listed count, the whole membership and the Fediverse head count), lost the
+last two on 2026-08-13 because they belong to the top bar's people pill which is
+on this page like every other, and lost the listed count and the per-letter
+counts on 2026-08-28. A page whose job is an A-Z index reads as a statistics
+page the moment it opens with numbers. A tile still says what a browsing reader
+needs by being a link or a muted square; the figure survives as `data-count`,
+which is invisible and what the tests read.
+
+The counts stay in the **agent formats** — `total` plus a per-letter `count`,
+and the `.md`/`.txt` renderings print `a (226)` per line — because a machine
+reader has no A-Z strip in front of them and a count is what they came for.
+That asymmetry is the point of having two renderings, not drift between them,
+so the drift test asserts the numberless sentence appears everywhere *and* that
+the structured counts are present. Those siblings answer for the directory
 itself and never for a `?q=`: a doc that changed under a query would make the
 canonical URL name a different document every time.
 

--- a/lib/vutuv_web/agent_docs/list_docs.ex
+++ b/lib/vutuv_web/agent_docs/list_docs.ex
@@ -19,7 +19,6 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.AgentDocs.JobPostingDoc
   alias VutuvWeb.AgentDocs.PostDoc
-  alias VutuvWeb.UI
   alias VutuvWeb.UserHelpers
 
   alias Vutuv.Tags.Tag
@@ -180,16 +179,19 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
   with its member count and letter-page URL. Zero-count letters ride along
   so the doc mirrors the HTML page's full A-Z strip.
 
-  `total` is what the directory lists — the one figure the page itself states.
-  It carried the whole membership and the Fediverse head count beside it until
-  2026-08-13; those belong to the top bar's people pill, and a page whose job
-  is an A-Z index should not open with three numbers.
+  `total` is what the directory lists, and since 2026-08-28 it is **structured
+  data for machine readers only**: the HTML page states no figure at all, having
+  shed the whole membership and the Fediverse head count in 2026-08-13 and its
+  own listed count on the later date (Stefan, both times — a page whose job is
+  an A-Z index reads as a statistics page the moment it opens with numbers).
+  They stay here because a reader of the JSON has no A-Z strip in front of them,
+  and a count is exactly the sort of thing they came for.
   """
   def build_directory_index(entries, total) do
     AgentDocs.doc_meta("directory", "/system/members")
     |> Map.merge(%{
       title: gettext("Member directory"),
-      description: directory_description(total),
+      description: directory_description(),
       total: total,
       letters:
         Enum.map(entries, fn %{letter: letter, count: count} ->
@@ -198,14 +200,12 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
     })
   end
 
-  # The Markdown and text renderings carry no counts of their own, so the
-  # listed figure has to live in the description — the same sentence the HTML
-  # page prints under its heading.
-  defp directory_description(total) do
-    gettext(
-      "%{listed} vutuv members are listed here, grouped by the first letter of their last name.",
-      listed: UI.delimited_count(total)
-    )
+  # The one sentence the HTML page prints under its heading, in the words a
+  # machine reader needs (no A-Z strip to look at, so the grouping is spelled
+  # out). It carried the listed figure until 2026-08-28; the number lives in the
+  # `total` field now, where it is data rather than prose.
+  defp directory_description do
+    gettext("Every vutuv member, grouped by the first letter of their last name.")
   end
 
   @doc """

--- a/lib/vutuv_web/controllers/directory_controller.ex
+++ b/lib/vutuv_web/controllers/directory_controller.ex
@@ -37,10 +37,11 @@ defmodule VutuvWeb.DirectoryController do
     # `push_patch` its own URL.
     search_session = %{"q" => query, "fields" => params["fields"], "show" => params["show"]}
 
-    # Deliberately the listed count and nothing else. The whole membership and
-    # the Fediverse head count sat beside it until 2026-08-13; both are the top
-    # bar's business (`#people-total` is on this page too), and three figures
-    # above the A-Z strip turned a directory into a statistics page.
+    # The page states no figure at all: the whole membership and the Fediverse
+    # head count left in 2026-08-13 (they are the top bar's business, and
+    # `#people-total` is on this page too) and the listed count on 2026-08-28.
+    # `total` is still computed, for the agent formats — a machine reader has no
+    # A-Z strip to look at, so there a count is data worth carrying.
     AgentDocs.respond(conn,
       html: fn conn ->
         conn
@@ -52,7 +53,6 @@ defmodule VutuvWeb.DirectoryController do
         |> render("index.html",
           page_title: gettext("Member directory"),
           entries: entries,
-          total: total,
           search_session: search_session
         )
       end,

--- a/lib/vutuv_web/templates/directory/index.html.heex
+++ b/lib/vutuv_web/templates/directory/index.html.heex
@@ -14,21 +14,21 @@ takes `q` from the URL so a submitted search reloads and shares as itself. --%>
 
 <div class="card-list">
   <section class="card">
-    <%!-- One line, and it says what the page is. The membership total and the
-    Fediverse head count used to follow it in two more paragraphs; they are the
-    top bar's business (`#people-total`, on this page like every other), and
-    three figures above an A-Z strip read as a statistics page rather than as a
-    directory (Stefan, 2026-08-13). --%>
-    <p>
-      {gettext("%{count} vutuv members, filed alphabetically by last name.",
-        count: delimited_count(@total)
-      )}
-    </p>
+    <%!-- One line, and it says what the page is and how it is filed — which the
+    rows need, since they read "Özil, Mesut". It carries **no figure**: this page
+    lost the membership total and the Fediverse head count in 2026-08-13 for
+    reading as a statistics page, and the listed count went the same way on
+    2026-08-28 (Stefan). The counts still ride the agent formats, where a machine
+    reader has no A-Z strip to look at. --%>
+    <p>{gettext("All vutuv members, filed alphabetically by last name.")}</p>
 
     <%!-- The A-Z strip: letters with members link to their page, empty ones
-    render as muted tiles so the strip always shows the whole alphabet. Plain
-    <a>/<span> tags keep the attribute order stable for the tests. --%>
+    render as muted tiles so the strip always shows the whole alphabet. The
+    count stays in `data-count` — invisible, and what the tests read — because
+    the tile says everything a browsing reader needs by being a link or not.
+    Plain <a>/<span> tags keep the attribute order stable for those tests. --%>
     <nav
+      id="directory-letters"
       aria-label={gettext("Members by initial")}
       class="mt-6 grid grid-cols-5 gap-2 sm:grid-cols-9"
     >
@@ -38,25 +38,17 @@ takes `q` from the URL so a submitted search reloads and shares as itself. --%>
             href={~p"/system/members/#{entry.letter}"}
             data-letter={entry.letter}
             data-count={entry.count}
-            class="flex flex-col items-center rounded-lg px-2 py-3 ring-1 ring-slate-200 hover:bg-brand-50 dark:ring-slate-800 dark:hover:bg-brand-900/40"
+            class="flex items-center justify-center rounded-lg px-2 py-3 text-lg font-semibold text-brand-700 ring-1 ring-slate-200 hover:bg-brand-50 dark:text-brand-100 dark:ring-slate-800 dark:hover:bg-brand-900/40"
           >
-            <span class="text-lg font-semibold text-brand-700 dark:text-brand-100">
-              {display_letter(entry.letter)}
-            </span>
-            <span class="text-xs text-slate-600 dark:text-slate-400">
-              {compact_count(entry.count)}
-            </span>
+            {display_letter(entry.letter)}
           </a>
         <% else %>
           <span
             data-letter={entry.letter}
             data-count="0"
-            class="flex flex-col items-center rounded-lg px-2 py-3 opacity-40 ring-1 ring-slate-200 dark:ring-slate-800"
+            class="flex items-center justify-center rounded-lg px-2 py-3 text-lg font-semibold text-slate-600 opacity-40 ring-1 ring-slate-200 dark:text-slate-400 dark:ring-slate-800"
           >
-            <span class="text-lg font-semibold text-slate-600 dark:text-slate-400">
-              {display_letter(entry.letter)}
-            </span>
-            <span class="text-xs text-slate-600 dark:text-slate-400">0</span>
+            {display_letter(entry.letter)}
           </span>
         <% end %>
       <% end %>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.407.0",
+      version: "7.414.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1105,7 +1105,7 @@ msgstr "User mit den meisten Followern"
 msgid "The 1,000 Users with the most Followers"
 msgstr "Die 1.000 User mit den meisten Followern"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:171
+#: lib/vutuv_web/agent_docs/list_docs.ex:170
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:12
 #, elixir-autogen
 msgid "We haven't yet figured out the best way to help everyone discover other interesting vutuv users. So for now, this page simply lists the 1,000 users with the most followers."
@@ -3980,7 +3980,7 @@ msgstr "%{count} Beiträge von %{name}"
 msgid "%{count} total"
 msgstr "%{count} insgesamt"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:48
+#: lib/vutuv_web/agent_docs/list_docs.ex:47
 #, elixir-autogen, elixir-format
 msgid "Followers of %{name}"
 msgstr "Follower von %{name}"
@@ -4026,12 +4026,12 @@ msgstr "Mitglied seit"
 msgid "Most endorsed members"
 msgstr "Am häufigsten empfohlene Mitglieder"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:169
+#: lib/vutuv_web/agent_docs/list_docs.ex:168
 #, elixir-autogen, elixir-format
 msgid "Most followed members"
 msgstr "Mitglieder mit den meisten Followern"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:49
+#: lib/vutuv_web/agent_docs/list_docs.ex:48
 #, elixir-autogen, elixir-format
 msgid "People %{name} follows"
 msgstr "Wem %{name} folgt"
@@ -4084,7 +4084,7 @@ msgstr "bis %{date}"
 msgid "This page in %{language}: %{url}"
 msgstr "Diese Seite auf %{language}: %{url}"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:50
+#: lib/vutuv_web/agent_docs/list_docs.ex:49
 #, elixir-autogen, elixir-format
 msgid "Connections of %{name}"
 msgstr "Vernetzungen von %{name}"
@@ -6553,7 +6553,7 @@ msgstr ""
 msgid "Endorsed"
 msgstr "Empfohlen am"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:142
+#: lib/vutuv_web/agent_docs/list_docs.ex:141
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Members who endorsed %{name} for %{tag}"
@@ -8903,8 +8903,8 @@ msgstr "Ungültig"
 msgid "Invalid address (skipped)"
 msgstr "Ungültige Adresse (übersprungen)"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:191
-#: lib/vutuv_web/controllers/directory_controller.ex:53
+#: lib/vutuv_web/agent_docs/list_docs.ex:193
+#: lib/vutuv_web/controllers/directory_controller.ex:54
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:5
@@ -8913,7 +8913,7 @@ msgstr "Ungültige Adresse (übersprungen)"
 msgid "Member directory"
 msgstr "Mitgliederverzeichnis"
 
-#: lib/vutuv_web/templates/directory/index.html.heex:32
+#: lib/vutuv_web/templates/directory/index.html.heex:31
 #: lib/vutuv_web/templates/directory/show.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Members by initial"
@@ -22723,16 +22723,6 @@ msgstr "Ihr LinkedIn-Profil kann mitkommen."
 msgid "Being checked"
 msgstr "Wird geprüft"
 
-#: lib/vutuv_web/templates/directory/index.html.heex:23
-#, elixir-autogen, elixir-format
-msgid "%{count} vutuv members, filed alphabetically by last name."
-msgstr "%{count} vutuv Mitglieder, alphabetisch nach Nachname sortiert."
-
-#: lib/vutuv_web/agent_docs/list_docs.ex:205
-#, elixir-autogen, elixir-format
-msgid "%{listed} vutuv members are listed here, grouped by the first letter of their last name."
-msgstr "Hier sind %{listed} vutuv Mitglieder aufgeführt, gruppiert nach dem Anfangsbuchstaben des Nachnamens."
-
 #: lib/vutuv_web/live/directory_search_live.ex:141
 #, elixir-autogen, elixir-format
 msgid "Find a member"
@@ -22780,3 +22770,14 @@ msgstr "Weiter geht diese Liste nicht. Tippen Sie mehr vom Namen, um sie einzugr
 #, elixir-autogen, elixir-format
 msgid "Which names to search"
 msgstr "Welche Namen durchsucht werden"
+
+#: lib/vutuv_web/templates/directory/index.html.heex:23
+#, elixir-autogen, elixir-format
+msgid "All vutuv members, filed alphabetically by last name."
+msgstr "Alle vutuv Mitglieder, alphabetisch nach Nachname sortiert."
+
+#: lib/vutuv_web/agent_docs/list_docs.ex:208
+#, elixir-autogen, elixir-format
+msgid "Every vutuv member, grouped by the first letter of their last name."
+
+msgstr "Alle vutuv Mitglieder, gruppiert nach dem Anfangsbuchstaben des Nachnamens."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "The 1,000 Users with the most Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:171
+#: lib/vutuv_web/agent_docs/list_docs.ex:170
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:12
 #, elixir-autogen
 msgid "We haven't yet figured out the best way to help everyone discover other interesting vutuv users. So for now, this page simply lists the 1,000 users with the most followers."
@@ -3856,7 +3856,7 @@ msgstr ""
 msgid "%{count} total"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:48
+#: lib/vutuv_web/agent_docs/list_docs.ex:47
 #, elixir-autogen, elixir-format
 msgid "Followers of %{name}"
 msgstr ""
@@ -3902,12 +3902,12 @@ msgstr ""
 msgid "Most endorsed members"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:169
+#: lib/vutuv_web/agent_docs/list_docs.ex:168
 #, elixir-autogen, elixir-format
 msgid "Most followed members"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:49
+#: lib/vutuv_web/agent_docs/list_docs.ex:48
 #, elixir-autogen, elixir-format
 msgid "People %{name} follows"
 msgstr ""
@@ -3960,7 +3960,7 @@ msgstr ""
 msgid "This page in %{language}: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:50
+#: lib/vutuv_web/agent_docs/list_docs.ex:49
 #, elixir-autogen, elixir-format
 msgid "Connections of %{name}"
 msgstr ""
@@ -6303,7 +6303,7 @@ msgstr ""
 msgid "Endorsed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:142
+#: lib/vutuv_web/agent_docs/list_docs.ex:141
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Members who endorsed %{name} for %{tag}"
@@ -8502,8 +8502,8 @@ msgstr ""
 msgid "Invalid address (skipped)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:191
-#: lib/vutuv_web/controllers/directory_controller.ex:53
+#: lib/vutuv_web/agent_docs/list_docs.ex:193
+#: lib/vutuv_web/controllers/directory_controller.ex:54
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:5
@@ -8512,7 +8512,7 @@ msgstr ""
 msgid "Member directory"
 msgstr ""
 
-#: lib/vutuv_web/templates/directory/index.html.heex:32
+#: lib/vutuv_web/templates/directory/index.html.heex:31
 #: lib/vutuv_web/templates/directory/show.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Members by initial"
@@ -21919,16 +21919,6 @@ msgstr ""
 msgid "Being checked"
 msgstr ""
 
-#: lib/vutuv_web/templates/directory/index.html.heex:23
-#, elixir-autogen, elixir-format
-msgid "%{count} vutuv members, filed alphabetically by last name."
-msgstr ""
-
-#: lib/vutuv_web/agent_docs/list_docs.ex:205
-#, elixir-autogen, elixir-format
-msgid "%{listed} vutuv members are listed here, grouped by the first letter of their last name."
-msgstr ""
-
 #: lib/vutuv_web/live/directory_search_live.ex:141
 #, elixir-autogen, elixir-format
 msgid "Find a member"
@@ -21975,4 +21965,14 @@ msgstr ""
 #: lib/vutuv_web/live/directory_search_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Which names to search"
+msgstr ""
+
+#: lib/vutuv_web/templates/directory/index.html.heex:23
+#, elixir-autogen, elixir-format
+msgid "All vutuv members, filed alphabetically by last name."
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/list_docs.ex:208
+#, elixir-autogen, elixir-format
+msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1084,7 +1084,7 @@ msgstr ""
 msgid "The 1,000 Users with the most Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:171
+#: lib/vutuv_web/agent_docs/list_docs.ex:170
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:12
 #, elixir-autogen
 msgid "We haven't yet figured out the best way to help everyone discover other interesting vutuv users. So for now, this page simply lists the 1,000 users with the most followers."
@@ -3854,7 +3854,7 @@ msgstr ""
 msgid "%{count} total"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:48
+#: lib/vutuv_web/agent_docs/list_docs.ex:47
 #, elixir-autogen, elixir-format
 msgid "Followers of %{name}"
 msgstr ""
@@ -3900,12 +3900,12 @@ msgstr ""
 msgid "Most endorsed members"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:169
+#: lib/vutuv_web/agent_docs/list_docs.ex:168
 #, elixir-autogen, elixir-format
 msgid "Most followed members"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:49
+#: lib/vutuv_web/agent_docs/list_docs.ex:48
 #, elixir-autogen, elixir-format
 msgid "People %{name} follows"
 msgstr ""
@@ -3958,7 +3958,7 @@ msgstr ""
 msgid "This page in %{language}: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:50
+#: lib/vutuv_web/agent_docs/list_docs.ex:49
 #, elixir-autogen, elixir-format
 msgid "Connections of %{name}"
 msgstr ""
@@ -6301,7 +6301,7 @@ msgstr ""
 msgid "Endorsed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:142
+#: lib/vutuv_web/agent_docs/list_docs.ex:141
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Members who endorsed %{name} for %{tag}"
@@ -8500,8 +8500,8 @@ msgstr ""
 msgid "Invalid address (skipped)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:191
-#: lib/vutuv_web/controllers/directory_controller.ex:53
+#: lib/vutuv_web/agent_docs/list_docs.ex:193
+#: lib/vutuv_web/controllers/directory_controller.ex:54
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:5
@@ -8510,7 +8510,7 @@ msgstr ""
 msgid "Member directory"
 msgstr ""
 
-#: lib/vutuv_web/templates/directory/index.html.heex:32
+#: lib/vutuv_web/templates/directory/index.html.heex:31
 #: lib/vutuv_web/templates/directory/show.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Members by initial"
@@ -21917,16 +21917,6 @@ msgstr ""
 msgid "Being checked"
 msgstr ""
 
-#: lib/vutuv_web/templates/directory/index.html.heex:23
-#, elixir-autogen, elixir-format
-msgid "%{count} vutuv members, filed alphabetically by last name."
-msgstr ""
-
-#: lib/vutuv_web/agent_docs/list_docs.ex:205
-#, elixir-autogen, elixir-format, fuzzy
-msgid "%{listed} vutuv members are listed here, grouped by the first letter of their last name."
-msgstr ""
-
 #: lib/vutuv_web/live/directory_search_live.ex:141
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Find a member"
@@ -21973,4 +21963,14 @@ msgstr ""
 #: lib/vutuv_web/live/directory_search_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Which names to search"
+msgstr ""
+
+#: lib/vutuv_web/templates/directory/index.html.heex:23
+#, elixir-autogen, elixir-format, fuzzy
+msgid "All vutuv members, filed alphabetically by last name."
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/list_docs.ex:208
+#, elixir-autogen, elixir-format
+msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -1106,7 +1106,7 @@ msgstr "Utenti più seguiti"
 msgid "The 1,000 Users with the most Followers"
 msgstr "I 1.000 utenti con più follower"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:171
+#: lib/vutuv_web/agent_docs/list_docs.ex:170
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:12
 #, elixir-autogen
 msgid "We haven't yet figured out the best way to help everyone discover other interesting vutuv users. So for now, this page simply lists the 1,000 users with the most followers."
@@ -3990,7 +3990,7 @@ msgstr "%{count} post di %{name}"
 msgid "%{count} total"
 msgstr "%{count} in totale"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:48
+#: lib/vutuv_web/agent_docs/list_docs.ex:47
 #, elixir-autogen, elixir-format
 msgid "Followers of %{name}"
 msgstr "Follower di %{name}"
@@ -4036,12 +4036,12 @@ msgstr "Membro da"
 msgid "Most endorsed members"
 msgstr "Membri più confermati"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:169
+#: lib/vutuv_web/agent_docs/list_docs.ex:168
 #, elixir-autogen, elixir-format
 msgid "Most followed members"
 msgstr "Membri più seguiti"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:49
+#: lib/vutuv_web/agent_docs/list_docs.ex:48
 #, elixir-autogen, elixir-format
 msgid "People %{name} follows"
 msgstr "Persone seguite da %{name}"
@@ -4094,7 +4094,7 @@ msgstr "fino al %{date}"
 msgid "This page in %{language}: %{url}"
 msgstr "Questa pagina in %{language}: %{url}"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:50
+#: lib/vutuv_web/agent_docs/list_docs.ex:49
 #, elixir-autogen, elixir-format
 msgid "Connections of %{name}"
 msgstr "Collegamenti di %{name}"
@@ -6543,7 +6543,7 @@ msgstr ""
 msgid "Endorsed"
 msgstr "Confermato"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:142
+#: lib/vutuv_web/agent_docs/list_docs.ex:141
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Members who endorsed %{name} for %{tag}"
@@ -8881,8 +8881,8 @@ msgstr "Non valido"
 msgid "Invalid address (skipped)"
 msgstr "Indirizzo non valido (saltato)"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:191
-#: lib/vutuv_web/controllers/directory_controller.ex:53
+#: lib/vutuv_web/agent_docs/list_docs.ex:193
+#: lib/vutuv_web/controllers/directory_controller.ex:54
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:5
@@ -8891,7 +8891,7 @@ msgstr "Indirizzo non valido (saltato)"
 msgid "Member directory"
 msgstr "Elenco dei membri"
 
-#: lib/vutuv_web/templates/directory/index.html.heex:32
+#: lib/vutuv_web/templates/directory/index.html.heex:31
 #: lib/vutuv_web/templates/directory/show.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Members by initial"
@@ -23527,16 +23527,6 @@ msgstr "Il suo profilo LinkedIn può venire con lei."
 msgid "Being checked"
 msgstr "In verifica"
 
-#: lib/vutuv_web/templates/directory/index.html.heex:23
-#, elixir-autogen, elixir-format
-msgid "%{count} vutuv members, filed alphabetically by last name."
-msgstr "%{count} membri vutuv, in ordine alfabetico per cognome."
-
-#: lib/vutuv_web/agent_docs/list_docs.ex:205
-#, elixir-autogen, elixir-format
-msgid "%{listed} vutuv members are listed here, grouped by the first letter of their last name."
-msgstr "Qui sono elencati %{listed} membri vutuv, raggruppati per la prima lettera del cognome."
-
 #: lib/vutuv_web/live/directory_search_live.ex:141
 #, elixir-autogen, elixir-format
 msgid "Find a member"
@@ -23584,3 +23574,14 @@ msgstr "Questo elenco non va oltre. Digiti altre lettere del nome per restringer
 #, elixir-autogen, elixir-format
 msgid "Which names to search"
 msgstr "Quali nomi cercare"
+
+#: lib/vutuv_web/templates/directory/index.html.heex:23
+#, elixir-autogen, elixir-format
+msgid "All vutuv members, filed alphabetically by last name."
+msgstr "Tutti i membri vutuv, in ordine alfabetico per cognome."
+
+#: lib/vutuv_web/agent_docs/list_docs.ex:208
+#, elixir-autogen, elixir-format
+msgid "Every vutuv member, grouped by the first letter of their last name."
+
+msgstr "Tutti i membri vutuv, raggruppati per la prima lettera del cognome."

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -1134,12 +1134,19 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     doc = Jason.decode!(rendered.json)
     assert doc["type"] == "directory"
 
-    # The one figure the page states, in every format. It named the whole
-    # membership and the Fediverse head count beside it until 2026-08-13; those
-    # moved out of this page entirely (the top bar's people pill carries them),
-    # so no format may reintroduce them here.
-    assert_fact_everywhere(rendered, "#{doc["total"]} vutuv member")
+    # The sentence the page states, in every format — and it carries no figure.
+    # The whole membership and the Fediverse head count left in 2026-08-13 (the
+    # top bar's people pill carries them) and the listed count on 2026-08-28, so
+    # no format may reintroduce either as prose.
+    assert_fact_everywhere(rendered, "vutuv member")
+    refute rendered.html =~ "#{doc["total"]} vutuv member"
     refute Map.has_key?(doc, "members_total")
+
+    # The count survives as **data**, for a reader with no A-Z strip in front of
+    # them: `total` plus a per-letter `count`. That asymmetry is the point of
+    # having two renderings, not drift between them.
+    assert doc["total"] > 0
+    assert Enum.any?(doc["letters"], &(&1["count"] > 0))
   end
 
   test "member directory letter page in every format", %{tag: tag} do

--- a/test/vutuv_web/controllers/directory_controller_test.exs
+++ b/test/vutuv_web/controllers/directory_controller_test.exs
@@ -36,7 +36,9 @@ defmodule VutuvWeb.DirectoryControllerTest do
 
     test "counts every listed member, opted out of search engines or not", %{conn: conn} do
       # Otto Opt-Out and Özil both file under O. Before v7.407.0 his noindex?
-      # kept the count at 1 and left him off his own letter page.
+      # kept the count at 1 and left him off his own letter page. The figure is
+      # `data-count` only — invisible since 2026-08-28, but still what decides
+      # whether a letter tile is a link.
       html = get(conn, ~p"/system/members") |> html_response(200)
 
       assert html =~ ~s(data-letter="o" data-count="2")
@@ -44,11 +46,11 @@ defmodule VutuvWeb.DirectoryControllerTest do
       assert html =~ ~s(data-letter="x" data-count="0")
     end
 
-    test "opens with the listed count and nothing else", %{conn: conn, adler: adler} do
-      # All three confirmed members. The page used to name the whole membership
-      # and the Fediverse head count below that; both are the top bar's
-      # business, and three figures above an A-Z strip read as a statistics
-      # page (Stefan, 2026-08-13).
+    test "prints no figure at all", %{conn: conn, adler: adler} do
+      # Three members, one of them with a Fediverse follower. The page named the
+      # whole membership and that head count until 2026-08-13, its own listed
+      # count until 2026-08-28, and now says none of them: an A-Z index reads as
+      # a statistics page the moment it opens with numbers (Stefan, both times).
       Repo.insert!(%Vutuv.Fediverse.Follower{
         user_id: adler.id,
         actor_uri: "https://remote.example/users/frida",
@@ -57,10 +59,23 @@ defmodule VutuvWeb.DirectoryControllerTest do
 
       html = get(conn, ~p"/system/members") |> html_response(200)
 
-      assert html =~ "3 vutuv members, filed alphabetically by last name."
+      assert html =~ "All vutuv members, filed alphabetically by last name."
+      refute html =~ "3 vutuv members"
       refute html =~ "open to search engines"
       refute html =~ "members in total"
       refute html =~ "from the Fediverse"
+
+      # Not a digit anywhere in the A-Z strip. Asserted on the rendered strip
+      # rather than on the sentence, because the tile counts were the other half
+      # of the change and a `refute html =~ "3 vutuv members"` would pass with
+      # every one of them still printed.
+      assert [strip] =
+               html
+               |> LazyHTML.from_document()
+               |> LazyHTML.query("#directory-letters")
+               |> Enum.to_list()
+
+      refute LazyHTML.text(strip) =~ ~r/\d/
     end
 
     test "says the same in German", %{conn: conn} do
@@ -73,7 +88,7 @@ defmodule VutuvWeb.DirectoryControllerTest do
         |> get(~p"/system/members")
         |> html_response(200)
 
-      assert html =~ "3 vutuv Mitglieder, alphabetisch nach Nachname sortiert."
+      assert html =~ "Alle vutuv Mitglieder, alphabetisch nach Nachname sortiert."
       refute html =~ "Insgesamt gibt es"
     end
 


### PR DESCRIPTION
`/system/members` stated two kinds of figure: the listed total above the
alphabet, and a count under every letter tile. Both are gone — an A-Z index
reads as a statistics page the moment it opens with numbers, the same reason the
membership total and the Fediverse head count left on 2026-08-13. A tile still
says what a browsing reader needs by being a link or a muted square.

The count survives where it is data rather than prose: `data-count` on each tile
(what the tests read) and the agent formats' `total` plus a per-letter `count` —
a reader of `/system/members.json` has no alphabet in front of them. The drift
test asserts both halves.

Search results keep their count ("Showing 25 of 352 members"): that is what
makes a large result set legible.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_014pYuPWF3UNcVrpxdvFBzYk
