### PR TITLE
Feed: one card per cached fediverse post per page

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -3006,16 +3006,31 @@ defmodule Vutuv.Posts do
         entries
 
       unique ->
-        decorated =
+        # **One card per cached post per page**, the rule `dedupe_remote/1`,
+        # `collapse_reposts/1` and `attach_thread_notes/3` already hold for the
+        # other kinds — and here it is not about repetition. The card's action
+        # bar is a LiveComponent keyed by the cached post
+        # (`RemoteActionsComponent.dom_id(:remote_post, id)`), so a second card
+        # emits a duplicate LiveView id, which raises inside
+        # `render_pending_components/6` during the **static** render: the page
+        # 500s rather than degrading. Two members answering the same post out
+        # there is ordinary behaviour, and the first such pair in the database
+        # took /feed down for every reader who had both answers on one page
+        # (2026-08-28).
+        #
+        # `unique` therefore decides where the card renders as well as which
+        # batch reads run, and the placement is built from the decorated list
+        # itself — the older version kept a second list to re-expand from, and
+        # a comment saying the repeats "must not pay for the batch reads, not
+        # the places they render" is exactly how the trap was rationalised.
+        # The answers that do not claim it keep their "Replying to …" line,
+        # which is what this feature replaced and still beats an error page.
+        by_post =
           unique
           |> attach_remote_images()
           |> attach_remote_follows(viewer)
           |> attach_remote_likes(viewer)
-          |> Map.new(&{&1.remote_post.id, &1})
-
-        # Back onto every post that answers one — `unique` dropped the repeats
-        # the batch reads must not pay for, not the places they render.
-        by_post = Map.new(parents, &{&1.post_id, decorated[&1.remote_post.id]})
+          |> Map.new(&{&1.post_id, &1})
 
         Enum.map(entries, &claim_remote_parents(&1, by_post))
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.414.1",
+      version: "7.422.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/feed_remote_thread_test.exs
+++ b/test/vutuv_web/live/feed_remote_thread_test.exs
@@ -205,6 +205,49 @@ defmodule VutuvWeb.FeedRemoteThreadTest do
                :binary.match(html, "meine Antwort darauf")
     end
 
+    test "two answers to the same post out there draw it once, not twice", %{conn: conn} do
+      # This 500ed /feed in production on 2026-08-28. The card's action bar is a
+      # LiveComponent keyed by the cached post
+      # (`RemoteActionsComponent.dom_id(:remote_post, id)`), so drawing the card
+      # above both answers emits one id twice, and LiveView raises
+      # `found duplicate ID` inside `render_pending_components/6` — during the
+      # **static** render, so the page does not degrade, it 500s. Two members
+      # answering the same post out there is ordinary behaviour and needs no
+      # unusual data at all: the first such pair in the database took the feed
+      # down for every reader who had both answers on one page.
+      {conn, user} = reader(conn)
+      remote = cached_post("was da draussen steht")
+
+      for body <- ["meine Antwort darauf", "und meine auch"] do
+        answerer = insert(:activated_user, fediverse_followers?: true)
+        {:ok, _actor} = Fediverse.ensure_actor(answerer)
+        Social.follow(user, answerer.id)
+
+        {:ok, _post} =
+          Posts.create_remote_post_reply(Repo.reload!(answerer), remote, %{body: body})
+      end
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      html = timeline(view)
+      assert html =~ "meine Antwort darauf"
+      assert html =~ "und meine auch"
+
+      # The cached post is drawn exactly once — for the first answer that
+      # claimed it. The second keeps the bare "Replying to …" line, which is
+      # what this feature replaced and is still far better than a 500.
+      assert html |> String.split("was da draussen steht") |> length() == 2
+
+      # One action bar for it, too — the bar is what carries the id that
+      # raised, and `subject_id` rides every one of its controls as
+      # `phx-value-id`. Counting the like control is the closest the DOM comes
+      # to counting the LiveComponents; the crash above is the real assertion,
+      # and it is what goes red when the fix is taken back out.
+      assert html
+             |> String.split(~s(phx-value-id="#{remote.id}"))
+             |> length() > 1
+    end
+
     test "a reader who does not federate may read it but not pass it on", %{conn: conn} do
       # These cards now reach members who have nothing to do with the
       # fediverse, since the thread they sit in is an ordinary vutuv thread. The


### PR DESCRIPTION
**Symptom:** `/feed` 500s for any reader whose page holds two member posts
answering the **same** cached fediverse post. 20 such 500s from 3 clients this
morning, ongoing. Predates every release today.

**Cause:** `Posts.attach_remote_parents/3` deduped its batch reads, then
re-expanded the placement over every answering post, so both drew the parent
card. That card's action bar is a LiveComponent keyed by the cached post, so the
second is a duplicate LiveView id — raised in `render_pending_components/6`
during the *static* render, which kills the page instead of degrading it.

**Fix:** build `by_post` from the deduped list itself, leaving no second list to
re-expand from. Answers that don't claim the card keep their "Replying to …"
line. `attach_thread_notes/3` looks identical and is not (it threads a `seen`
MapSet); checked, left alone.

The test reproduces the production data and is calibrated: without the fix it
fails with the same error and stack frame. Diagnosis by a parallel session
reading the production logs.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_014pYuPWF3UNcVrpxdvFBzYk
