### PR TITLE
Organization People list stops hiding search-engine opt-outs

### DIFF
--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -1831,15 +1831,17 @@ defmodule Vutuv.Organizations do
 
   @doc """
   The number of members whose linked work experience is at `organization` and who
-  are publicly listable here: confirmed, not moderation-hidden, and **not opted
-  out of search engines**. The count the People section shows.
+  are publicly listable: confirmed and not moderation-hidden, the same gate
+  `Vutuv.Directory.listed_users/0` holds. The count the People section shows.
 
-  That last condition used to cite `Vutuv.Directory.indexable_users` as its
-  authority, and no longer can: since v7.407.0 the member directory lists an
-  opted-out member and marks the row `rel="nofollow"` instead of hiding them.
-  Whether an organization's People list should follow is a product question
-  nobody has answered, so the gate is spelled out here rather than borrowed —
-  if it does follow, `people_base/1` is the one place to change.
+  It also excluded members who opted out of **search engines** until v7.433.0,
+  citing the member directory as its authority — which stopped being true in
+  v7.407.0, when the directory started listing them with a `rel="nofollow"` row
+  instead of hiding them. Left as it was, one switch in `/settings/privacy`
+  would mean "keep me out of Google" on the directory, search and every follower
+  list, and "hide me from humans" here: a member vanished from their own
+  employer's page, from colleagues and from themselves. The opt-out is about
+  search results, so it buys the `rel` on the row and nothing else.
   """
   def organization_people_count(%Organization{id: id}) do
     people_base(id)
@@ -1855,11 +1857,11 @@ defmodule Vutuv.Organizations do
 
   Each entry is `%{user:, title:, current?:}` where `title` is the linked role's
   title **exactly as the member wrote it** (their most recent role at the
-  organization). Privacy is `people_base/1`'s own gate (spelled out under
-  `organization_people_count/1`, and no longer borrowed from the member
-  directory), so a member who opted out of search engines or is
-  moderation-hidden never appears — the same set the agent-format people list
-  carries. Returns `%{entries:, more?:, next_offset:}`.
+  organization). Privacy is `people_base/1`'s gate (see
+  `organization_people_count/1`): an unconfirmed or moderation-hidden member
+  never appears, a member who opted out of search engines does — the same set
+  the agent-format people list carries. Returns
+  `%{entries:, more?:, next_offset:}`.
   """
   def organization_people_page(%Organization{id: organization_id}, opts \\ []) do
     limit = Keyword.get(opts, :limit, @people_per_page)
@@ -1905,7 +1907,7 @@ defmodule Vutuv.Organizations do
       on: u.id == w.user_id,
       where:
         w.organization_id == ^organization_id and account_confirmed_row(u) and
-          not u.noindex? and not account_hidden_row(u),
+          not account_hidden_row(u),
       group_by: u.id
     )
   end

--- a/lib/vutuv_web/live/organization_live/show.ex
+++ b/lib/vutuv_web/live/organization_live/show.ex
@@ -101,7 +101,9 @@ defmodule VutuvWeb.OrganizationLive.Show do
   # The organization page's "People" section (issue #931): members whose linked work
   # experience is at this organization, current members first. Loaded once at mount
   # (state-transition events keep their own paging); "Load more" appends the next
-  # page. The list honors the member-directory privacy gate in the context.
+  # page. Who may appear is `Organizations.people_base/1`'s gate: confirmed and
+  # not moderation-hidden, with the search-engine opt-out no longer among it
+  # (v7.433.0) — that one buys the row's `rel="nofollow"` instead.
   defp assign_people(socket, organization) do
     total = Organizations.organization_people_count(organization)
 
@@ -674,11 +676,18 @@ defmodule VutuvWeb.OrganizationLive.Show do
               <span class="text-sm text-slate-600 dark:text-slate-400">{compact_count(@people_total)}</span>
             </div>
             <ul id="organization-people" class="mt-4 space-y-3">
+              <%!-- rel="nofollow" for a member who asked search engines to leave
+              their profile alone. Since v7.433.0 the list shows them like anybody
+              else — the switch is about search results, not about colleagues —
+              and the `rel` is what it buys, the same as a directory row. This
+              list builds its own markup rather than using `card_list`, so it
+              does not inherit that rule and has to ask for it. --%>
               <li :for={person <- @people} class="flex items-center gap-3">
                 <.avatar user={person.user} size="sm" shape="circle" />
                 <div class="min-w-0">
                   <a
                     href={"/" <> person.user.username}
+                    rel={UserHelpers.profile_rel(person.user)}
                     class="font-semibold text-slate-900 hover:text-brand-700 dark:text-slate-100 dark:hover:text-brand-400"
                   >
                     {UserHelpers.full_name(person.user)}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.422.1",
+      version: "7.433.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/organizations_linking_test.exs
+++ b/test/vutuv/organizations_linking_test.exs
@@ -2,9 +2,12 @@ defmodule Vutuv.OrganizationsLinkingTest do
   @moduledoc """
   Linking a work experience to a verified organization page (issue #931): the
   editor's suggestion match, the canonical link path, the changeset guard that
-  only ever links to a **verified** organization, and the organization page's People
-  section (which member appears, in which order, under the directory privacy
-  gate).
+  only ever links to a **verified** organization, and the organization page's
+  People section (which member appears, and in which order).
+
+  That last gate is confirmed-and-not-moderation-hidden, and deliberately
+  **not** the search-engine opt-out: a switch about Google must not hide
+  somebody from their own employer's page (v7.433.0).
   """
   use Vutuv.DataCase, async: true
 
@@ -163,22 +166,49 @@ defmodule Vutuv.OrganizationsLinkingTest do
       refute second.current?
     end
 
-    test "respects the directory privacy gate", %{organization: organization} do
-      hidden = insert(:activated_user, noindex?: true)
+    test "lists a member who opted out of search engines", %{organization: organization} do
+      # The search-engine switch is about Google, not about colleagues. Until
+      # v7.433.0 it hid a member from their own employer's People list — from
+      # everyone, including other members and including themselves — while
+      # `/system/members`, `/search` and every follower list showed them. One
+      # switch cannot mean "keep me out of search results" on six pages and
+      # "hide me from humans" on the seventh; what it buys here is the same
+      # `rel="nofollow"` the directory row carries.
+      opted_out =
+        insert(:activated_user, first_name: "Nina", last_name: "Noindex", noindex?: true)
 
       insert(:work_experience,
-        user: hidden,
+        user: opted_out,
         organization_page: organization,
-        title: "Hidden",
+        title: "Quiet Engineer",
         end_year: nil
       )
 
+      assert Organizations.organization_people_count(organization) == 1
+
+      assert %{entries: [entry]} = Organizations.organization_people_page(organization)
+      assert entry.user.id == opted_out.id
+      assert entry.title == "Quiet Engineer"
+    end
+
+    test "still hides unconfirmed and moderation-hidden members", %{organization: organization} do
+      # The half of the old gate that stays: an account nobody has activated,
+      # and one moderation has withheld, belong on no public list at all.
       unconfirmed = insert(:user, email_confirmed?: false)
 
       insert(:work_experience,
         user: unconfirmed,
         organization_page: organization,
         title: "Unconfirmed",
+        end_year: nil
+      )
+
+      frozen = insert(:activated_user, frozen_at: ~N[2026-01-01 00:00:00])
+
+      insert(:work_experience,
+        user: frozen,
+        organization_page: organization,
+        title: "Frozen",
         end_year: nil
       )
 

--- a/test/vutuv_web/organization_people_test.exs
+++ b/test/vutuv_web/organization_people_test.exs
@@ -2,8 +2,11 @@ defmodule VutuvWeb.OrganizationPeopleTest do
   @moduledoc """
   The organization page's People section (issue #931): members whose linked work
   experience is at the organization appear, current members first, past members
-  tagged "Former", under the member-directory privacy gate. Load-more appends
-  the next page over the socket.
+  tagged "Former". Load-more appends the next page over the socket.
+
+  Who may appear is confirmed-and-not-moderation-hidden, and deliberately **not**
+  the search-engine opt-out (v7.433.0): a switch about Google must not hide
+  somebody from their own employer's page. It buys the row's `rel="nofollow"`.
   """
   use VutuvWeb.ConnCase, async: true
 
@@ -29,21 +32,53 @@ defmodule VutuvWeb.OrganizationPeopleTest do
     assert html =~ ~s(href="/cara")
   end
 
-  test "hides a member who opted out of public listing", %{conn: conn} do
+  test "lists a member who opted out of search engines, rel=nofollow", %{conn: conn} do
     organization = insert(:organization)
-    hidden = insert(:activated_user, first_name: "Hidden", last_name: "Person", noindex?: true)
+
+    opted_out =
+      insert(:activated_user,
+        first_name: "Nina",
+        last_name: "Noindex",
+        username: "nina",
+        noindex?: true
+      )
 
     insert(:work_experience,
-      user: hidden,
+      user: opted_out,
       organization_page: organization,
-      title: "Secret Role",
+      title: "Quiet Role",
       end_year: nil
     )
 
     html = conn |> get(path(organization)) |> html_response(200)
 
-    refute html =~ "Hidden Person"
-    refute html =~ "Secret Role"
+    # She is on her own employer's page like anybody else. Until v7.433.0 the
+    # search-engine switch hid her from it — from colleagues and from herself —
+    # while the directory, search and every follower list showed her.
+    assert html =~ "Nina Noindex"
+    assert html =~ "Quiet Role"
+
+    # What the switch buys instead: crawlers are told not to walk through.
+    assert [_link] = nofollow_links(html, "nina")
+  end
+
+  test "a member who allows indexing gets no nofollow", %{conn: conn} do
+    # The other side of the pair — without it the assertion above passes just as
+    # well with `rel="nofollow"` stamped on every row.
+    organization = insert(:organization)
+    open = insert(:activated_user, first_name: "Otto", last_name: "Open", username: "ottoopen")
+
+    insert(:work_experience,
+      user: open,
+      organization_page: organization,
+      title: "Loud Role",
+      end_year: nil
+    )
+
+    html = conn |> get(path(organization)) |> html_response(200)
+
+    assert html =~ "Otto Open"
+    assert nofollow_links(html, "ottoopen") == []
   end
 
   test "tags a past member as Former", %{conn: conn} do


### PR DESCRIPTION
Turning off *"Allow search engines to index your profile"* removed a member from
their own employer's People list — from everyone, including colleagues and
themselves — while `/system/members`, `/search` and every follower list showed
them throughout. One switch cannot mean "keep me out of Google" on six pages and
"hide me from humans" on the seventh.

`Organizations.people_base/1` now gates on confirmed and not moderation-hidden,
the set `Directory.listed_users/0` holds. The opt-out buys `rel="nofollow"` on
the row instead, as in the directory since v7.407.0 — which its docstring
already cited as its authority, untruthfully since that release.

The test that asserted the hiding now asserts the listing, plus a second for a
member who allows indexing and gets **no** `nofollow` — without the pair, the
nofollow claim passes with every row carrying it.

Affects nobody today: two work experiences in the production copy link an
organization at all, neither an opted-out member's.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_014pYuPWF3UNcVrpxdvFBzYk
