### PR TITLE
One dedup key for remote cards, and a guard that finds the next one

### DIFF
--- a/.claude/rules/liveview.md
+++ b/.claude/rules/liveview.md
@@ -86,6 +86,27 @@ pages — both render `PostComponents.post_actions/1` and share `PostLive.Action
   no `<.input>`; style raw inputs with `class={input_class()}`
   (`VutuvWeb.UI.input_class/0`) / `checkbox_class/0`, and nest with `<.inputs_for>`.
 
+- **A LiveComponent id derived from a record id obliges a test with two of that
+  record on one page — the obligation is the rule, not the reminder.** LiveView
+  raises `found duplicate ID` in `Phoenix.LiveView.Diff.render_pending_components/6`,
+  and that is the **static** render: the page 500s rather than degrading, so
+  "can this appear twice?" is a crash condition and not a cosmetic question.
+  The answer usually lives in a different file from the code that decides how
+  many times it renders, which is what makes it invisible. Two shapes exist here
+  and only one is safe by construction: the vutuv post bar keys on the **place**
+  (`"post-actions-#{entry_key}"`, so original + repost cannot collide), while the
+  remote card's bar keys on the **thing** (`RemoteActionsComponent.dom_id/1`)
+  because one bar's like has to update the other — which buys correct live state
+  at the price of an invariant every placement site must hold.
+  Prose does not hold it: `/feed` went down on 2026-08-28 (v7.422.1) because
+  `Posts.attach_remote_parents/3` deduped its batch reads and then re-expanded
+  the placement, in the same commit (#1708) whose sibling function wrote the
+  rule down in a comment. So (a) dedupe on `Vutuv.Fediverse.subject_key/1`, the
+  identity the id itself is built from, never on a field picked by hand, and
+  (b) add the pair to `test/vutuv_web/live/feed_duplicate_cards_test.exs`, which
+  builds the page a careless dedup chokes on and lets LiveView do the asserting
+  — that catches code paths nobody has written yet, which a rule cannot.
+
 ## Phoenix LiveView guidelines
 
 - **Never** use the deprecated `live_redirect` and `live_patch` functions, instead **always** use the `<.link navigate={href}>` and  `<.link patch={href}>` in templates, and `push_navigate` and `push_patch` functions LiveViews

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -5897,6 +5897,32 @@ defmodule Vutuv.Fediverse do
   def subject_kind(%RemotePost{}), do: :remote_post
   def subject_kind(%Note{}), do: :note
 
+  @doc """
+  What makes two cards **the same card**: `{kind, id}` for a thing from another
+  network.
+
+  This is the identity `VutuvWeb.PostLive.RemoteActionsComponent.dom_id/2` is
+  built from, and therefore the only key a page may dedupe its cards by. The two
+  have to be the same question, because the bar is a LiveComponent keyed by it:
+  a page that renders two cards for one subject emits one LiveView id twice,
+  which raises inside `render_pending_components/6` during the **static** render
+  — the page 500s rather than degrading.
+
+  That is not hypothetical. `/feed` went down on 2026-08-28 (v7.422.1) because
+  `Vutuv.Posts.attach_remote_parents/3` deduped its batch reads by
+  `remote_post.id` and then placed the cards from a list keyed by `post_id`, so
+  two member posts answering one cached post each drew the parent. The rule was
+  written in prose beside three sibling implementations and broken by the fourth
+  in the very commit that wrote it down. Prose beside an implementation is not
+  an invariant; one function every site keys on is.
+
+  So: whenever a page decides how many cards a subject gets — `dedupe_remote/1`,
+  `attach_thread_notes/3`, `attach_remote_parents/3`, and whatever comes next —
+  dedupe on this, not on a field picked by hand. A `grep` for it finds every
+  site that owes the rule.
+  """
+  def subject_key(subject), do: {subject_kind(subject), subject.id}
+
   defp subject_schema(%RemotePost{}), do: RemotePost
   defp subject_schema(%Note{}), do: Note
 

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2998,10 +2998,10 @@ defmodule Vutuv.Posts do
       for entry <- entries,
           post <- thread_posts(entry),
           %RemotePost{} = parent <- [remote_parent(post)],
-          parent.id not in taken,
+          Vutuv.Fediverse.subject_key(parent) not in taken,
           do: %{post_id: post.id, remote_post: parent}
 
-    case Enum.uniq_by(parents, & &1.remote_post.id) do
+    case Enum.uniq_by(parents, &Vutuv.Fediverse.subject_key(&1.remote_post)) do
       [] ->
         entries
 
@@ -3050,7 +3050,12 @@ defmodule Vutuv.Posts do
 
   # The cached posts that already have a card of their own on this page.
   defp standalone_remote_post_ids(remote),
-    do: for(entry <- remote, entry[:remote_post], do: entry.remote_post.id)
+    do:
+      for(
+        entry <- remote,
+        entry[:remote_post],
+        do: Vutuv.Fediverse.subject_key(entry.remote_post)
+      )
 
   # The replies from other networks (issues #1069/#1071) that belong inside the
   # threads on this page, read once for the whole page and hung on the entries
@@ -3098,20 +3103,27 @@ defmodule Vutuv.Posts do
     mine =
       entry
       |> thread_posts()
-      |> Map.new(fn post -> {post.id, Enum.reject(notes[post.id] || [], &(&1.id in seen))} end)
+      |> Map.new(fn post ->
+        {post.id, Enum.reject(notes[post.id] || [], &(Vutuv.Fediverse.subject_key(&1) in seen))}
+      end)
       |> Map.reject(fn {_post_id, notes} -> notes == [] end)
 
     if mine == %{} do
       {entry, seen}
     else
-      claimed = for {_post_id, notes} <- mine, note <- notes, into: seen, do: note.id
+      claimed =
+        for {_post_id, notes} <- mine,
+            note <- notes,
+            into: seen,
+            do: Vutuv.Fediverse.subject_key(note)
 
       {entry |> Map.put(:remote_replies, mine) |> Map.put(:note_marks, marks), claimed}
     end
   end
 
   # The notes that already have a row of their own on this page (issue #1275).
-  defp standalone_note_ids(remote), do: for(entry <- remote, entry[:note], do: entry.note.id)
+  defp standalone_note_ids(remote),
+    do: for(entry <- remote, entry[:note], do: Vutuv.Fediverse.subject_key(entry.note))
 
   # Every vutuv post an entry draws: the carrier and the thread nested under it.
   defp thread_posts(%{post: %Post{} = post} = entry), do: [post | entry[:ancestors] || []]
@@ -3161,7 +3173,7 @@ defmodule Vutuv.Posts do
     # direct entry — so a reader following an author out there saw their posts
     # relabelled "Reposted by <whoever boosted them>" the moment anybody did.
     |> Enum.sort_by(&(&1[:reposted_by] != nil or &1[:boosted_by] != nil))
-    |> Enum.uniq_by(& &1.remote_post.id)
+    |> Enum.uniq_by(&Vutuv.Fediverse.subject_key(&1.remote_post))
   end
 
   # What the reader has already done with each of the page's remote posts

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -1309,7 +1309,7 @@ defmodule VutuvWeb.PostComponents do
           <.live_component
             :if={@live? and @viewer}
             module={RemoteActionsComponent}
-            id={RemoteActionsComponent.dom_id(:note, @note.id)}
+            id={RemoteActionsComponent.dom_id(@note)}
             subject={@note}
             viewer={@viewer}
             marks={@marks}
@@ -2483,7 +2483,7 @@ defmodule VutuvWeb.PostComponents do
           <.live_component
             :if={@live? and @viewer}
             module={RemoteActionsComponent}
-            id={RemoteActionsComponent.dom_id(:remote_post, @remote_post.id)}
+            id={RemoteActionsComponent.dom_id(@remote_post)}
             subject={@remote_post}
             viewer={@viewer}
             marks={@marks}

--- a/lib/vutuv_web/live/post_live/remote_actions_component.ex
+++ b/lib/vutuv_web/live/post_live/remote_actions_component.ex
@@ -61,6 +61,20 @@ defmodule VutuvWeb.PostLive.RemoteActionsComponent do
   def dom_id(:note, id), do: "remote-actions-note-#{id}"
   def dom_id(:remote_post, id), do: "remote-actions-post-#{id}"
 
+  @doc """
+  The same id, from the subject itself — and the reason
+  `Vutuv.Fediverse.subject_key/1` exists.
+
+  A page must dedupe its cards by exactly what this id is built from, or it
+  renders one LiveView id twice and 500s in the static render (see that
+  function). Taking the subject rather than a hand-picked field is what keeps
+  the dedup key and the id key from drifting apart.
+  """
+  def dom_id(subject) do
+    {kind, id} = Vutuv.Fediverse.subject_key(subject)
+    dom_id(kind, id)
+  end
+
   # The origin's figures moved while this page was open. Its own clause, because
   # such an update carries nothing else — no subject, no viewer — and must not
   # go looking for them.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.433.0",
+      version: "7.433.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/feed_duplicate_cards_test.exs
+++ b/test/vutuv_web/live/feed_duplicate_cards_test.exs
@@ -1,0 +1,219 @@
+defmodule VutuvWeb.FeedDuplicateCardsTest do
+  @moduledoc """
+  The pathological feed: one page carrying **two of everything** that could
+  claim the same card.
+
+  This module exists because of a production outage. On 2026-08-28 `/feed`
+  started answering 500 for readers whose page held two member posts answering
+  the same cached fediverse post: each drew the parent card, the card's action
+  bar is a LiveComponent keyed by that post
+  (`RemoteActionsComponent.dom_id/1`), and a repeated LiveView id raises inside
+  `Phoenix.LiveView.Diff.render_pending_components/6` during the **static**
+  render. The page does not degrade, it dies. Nothing in the suite caught it
+  because every fixture had exactly one answer per remote post — the bug needed
+  a data shape that did not exist until a member produced it.
+
+  So the guard is data, not prose: build the page that a careless dedup would
+  choke on, and let LiveView's own duplicate-id check do the asserting. It fires
+  for any code path, including ones nobody has written yet, which is the point.
+  **When a new kind of card can reach the feed twice, add its pair here.**
+
+  The rule those paths owe is one card per subject per page, keyed by
+  `Vutuv.Fediverse.subject_key/1` — the same identity the DOM id is built from,
+  so the two cannot drift.
+
+  Not async: answering a note claims from `Vutuv.RateLimiter`, a shared ETS
+  table the SQL sandbox does not roll back.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Note
+  alias Vutuv.Fediverse.NoteRepost
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Posts
+  alias Vutuv.Social
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    :ok
+  end
+
+  defp reader(conn) do
+    {conn, user} = create_and_login_user(conn)
+    Social.follow(user, insert(:user, email_confirmed?: true).id)
+    {conn, user}
+  end
+
+  # A member who may answer things out there, followed by the reader so their
+  # posts reach the page at all.
+  defp answerer(reader) do
+    user = insert(:activated_user, fediverse_followers?: true)
+    {:ok, _actor} = Fediverse.ensure_actor(user)
+    Social.follow(reader, user.id)
+    Repo.reload!(user)
+  end
+
+  defp remote_account do
+    unique = System.unique_integer([:positive])
+
+    Repo.insert!(%RemoteAccount{
+      actor_uri: "https://social.example/users/them#{unique}",
+      host: "social.example",
+      handle: "them#{unique}",
+      name: "Thea Remote",
+      inbox_uri: "https://social.example/users/them#{unique}/inbox"
+    })
+  end
+
+  defp cached_post(body) do
+    now = DateTime.utc_now(:second)
+    unique = System.unique_integer([:positive])
+
+    Repo.insert!(%RemotePost{
+      remote_account_id: remote_account().id,
+      object_uri: "https://social.example/p/#{unique}",
+      origin_url: "https://social.example/@them/#{unique}",
+      content_text: body,
+      audience: "public",
+      kind: "note",
+      published_at: now,
+      received_at: now,
+      expires_at: DateTime.add(now, 86_400)
+    })
+    |> Repo.preload(:remote_account)
+  end
+
+  defp note_under(post, body) do
+    now = DateTime.utc_now(:second)
+    unique = System.unique_integer([:positive])
+
+    Repo.insert!(%Note{
+      post_id: post.id,
+      object_uri: "https://social.example/n/#{unique}",
+      actor_uri: "https://social.example/users/them",
+      origin_url: "https://social.example/@them/#{unique}",
+      handle: "them",
+      display_name: "Thea Remote",
+      content_text: body,
+      audience: "public",
+      inbox_uri: "https://social.example/users/them/inbox",
+      received_at: now,
+      checked_at: now,
+      expires_at: DateTime.add(now, 86_400)
+    })
+  end
+
+  # How many cards a cached post got. `data-remote-post` rides every one of
+  # them, so this counts the thing whose repeated LiveComponent id is fatal.
+  defp cards_for(html, %RemotePost{id: id}),
+    do: (html |> String.split(~s(data-remote-post="#{id}")) |> length()) - 1
+
+  test "two member posts answering one cached post", %{conn: conn} do
+    # The exact shape that took /feed down (v7.422.1).
+    {conn, user} = reader(conn)
+    remote = cached_post("was da draussen steht")
+
+    for body <- ["erste Antwort", "zweite Antwort"] do
+      {:ok, _post} = Posts.create_remote_post_reply(answerer(user), remote, %{body: body})
+    end
+
+    {:ok, view, _html} = live(conn, ~p"/feed")
+
+    html = render(view)
+    assert html =~ "erste Antwort"
+    assert html =~ "zweite Antwort"
+    # One card, not two — and not zero either: the answers still show what they
+    # answer, which is the whole point of the feature.
+    assert cards_for(html, remote) == 1
+  end
+
+  test "a note that is both reshared on its own and threaded under its post", %{conn: conn} do
+    # `standalone_note_ids/1` exists for this: the reshare gives the note a row
+    # of its own, and the thread under the post it answers would give it a
+    # second card.
+    {conn, user} = reader(conn)
+    {:ok, post} = Posts.create_post(user, %{body: "eine Frage in die Runde"})
+    note = note_under(post, "die weitergereichte Antwort")
+    Repo.insert!(%NoteRepost{user_id: user.id, note_id: note.id})
+
+    {:ok, view, _html} = live(conn, ~p"/feed")
+
+    assert render(view) =~ "die weitergereichte Antwort"
+  end
+
+  test "two member posts answering one note", %{conn: conn} do
+    # The note-side twin of the first case. `attach_thread_notes/3` carries a
+    # `seen` set across entries for it; this is the data that proves the set is
+    # doing something rather than being decoration.
+    {conn, user} = reader(conn)
+    {:ok, post} = Posts.create_post(user, %{body: "eine Frage in die Runde"})
+    note = note_under(post, "die Antwort von draussen")
+
+    for body <- ["mein Nachsatz", "und meiner auch"] do
+      {:ok, _reply} = Posts.create_remote_reply(answerer(user), note, %{body: body})
+    end
+
+    {:ok, view, _html} = live(conn, ~p"/feed")
+
+    html = render(view)
+    assert html =~ "mein Nachsatz"
+    assert html =~ "und meiner auch"
+  end
+
+  test "a cached post that is both a standalone row and a post's parent", %{conn: conn} do
+    # `standalone_remote_post_ids/1`'s case: the reader follows the account, so
+    # the cached post has a row of its own, and a member here answered it, which
+    # would draw it a second time above the answer.
+    {conn, user} = reader(conn)
+    remote = cached_post("was da draussen steht")
+
+    # A member the reader follows reshares it, which gives it a row of its own;
+    # another answers it, which would draw it again above the answer. Reshared
+    # rather than followed-directly because following an account out there is a
+    # signed request to a server that does not exist in a test, while the
+    # reshare produces the same standalone row.
+    {:ok, :reposted} = Fediverse.repost_remote_post(answerer(user), remote)
+
+    {:ok, _post} =
+      Posts.create_remote_post_reply(answerer(user), remote, %{body: "meine Antwort darauf"})
+
+    {:ok, view, _html} = live(conn, ~p"/feed")
+
+    html = render(view)
+    assert html =~ "meine Antwort darauf"
+    assert cards_for(html, remote) == 1
+  end
+
+  test "all four shapes on one page at once", %{conn: conn} do
+    # Each case above is one careless dedup; a real feed mixes them, and the
+    # sets they are checked against are shared. This is the page that finds an
+    # interaction between two of them.
+    {conn, user} = reader(conn)
+
+    remote = cached_post("was da draussen steht")
+
+    for body <- ["erste Antwort", "zweite Antwort"] do
+      {:ok, _post} = Posts.create_remote_post_reply(answerer(user), remote, %{body: body})
+    end
+
+    {:ok, post} = Posts.create_post(user, %{body: "eine Frage in die Runde"})
+    note = note_under(post, "die Antwort von draussen")
+    Repo.insert!(%NoteRepost{user_id: user.id, note_id: note.id})
+
+    for body <- ["mein Nachsatz", "und meiner auch"] do
+      {:ok, _reply} = Posts.create_remote_reply(answerer(user), note, %{body: body})
+    end
+
+    {:ok, view, _html} = live(conn, ~p"/feed")
+
+    html = render(view)
+    assert html =~ "erste Antwort"
+    assert html =~ "zweite Antwort"
+    assert html =~ "die Antwort von draussen"
+    assert html =~ "mein Nachsatz"
+  end
+end


### PR DESCRIPTION
Follow-up to the `/feed` outage in v7.422.1. The rule "one card per remote
subject per page" lived as prose beside three implementations and was broken by
the fourth — in the very commit (#1708) that wrote it down.

`Vutuv.Fediverse.subject_key/1` now returns the identity
`RemoteActionsComponent.dom_id/1` is built from. All four dedup sites key on it,
and both renderers call `dom_id(subject)` rather than interpolating a field by
hand, so a fifth site cannot invent its own key.

`feed_duplicate_cards_test.exs` builds a page with two of everything that could
claim one card. The assertion is LiveView's own duplicate-id check, not a count
I wrote, so it fires for code paths nobody has written yet. Calibrated: with the
old bug restored, two of five cases go red.

The rules entry is an obligation, not an admonition, and records both shapes:
the post bar keyed by *place* against the remote bar keyed by *thing*.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_014pYuPWF3UNcVrpxdvFBzYk
