### PR TITLE
Strip custom-emoji shortcodes from remote fediverse text

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -274,6 +274,39 @@ every activity of a member it finds no key for, silently.
     installation), which the renderer below then links like any typed fediverse
     handle. The Mastodon profile feed normalizes its REST `mentions` to the same
     shape.
+  - **Custom-emoji shortcodes go out with the markup**
+    (`Vutuv.RemoteHtml.strip_shortcodes/1`, v7.449.1). Those networks let an
+    account put its **own server's** emoji in a post and send it as a shortcode
+    (`":tux:"`), with the picture it stands for in the object's `tag` array.
+    That picture is that server's, and vutuv shows no remote picture it has not
+    cached and put past the AI gate, so the token has nothing to render as and
+    read on the card as a literal `":tux:"`. It is taken out along with the gap
+    it leaves (the doubled space, the space in front of the comma that followed
+    it, a line that was nothing but emoji). A post that was nothing *but* one is
+    then a post with no text, and is kept only if it carries a picture, like any
+    other wordless post. **One grammar** for the whole app: `Handle.display_name/1`
+    reads it from here too, or the same server's `:blobcat:` would vanish from a
+    card's name and stay in its text.
+  - **Two plain-text paths call it themselves**, because they never reach
+    `to_text/3` and are easy to forget: a poll's option names (`oneOf`/`anyOf`,
+    whose `name` is text, not HTML — and `remote_post_text/1` re-derives
+    `content_text` on every upstream edit, so missing this wrote `• :tux: Linux`
+    back over a cleaned row) and a Mastodon status' content warning
+    (`Vutuv.Mastodon.post_text/1`, which the REST API sends as text). Together
+    with `to_text/3` those three are every path from a remote server's words
+    into a column here.
+  - **Cleaned on the way in, unlike a display name.** A name is re-derived from
+    its column on every render; this text *is* the column, and every reader of
+    it (the card, the agent formats, the Mastodon adapter, the teaser, the
+    translation prompt, the muted-word filter) would otherwise need the same
+    repair. Text carrying no shortcode comes back untouched rather than merely
+    unchanged — `translations.source_sha256` keys a cached translation to the
+    exact source string, so a cosmetic byte would re-run the whole stored corpus
+    past Ollama. Rows written earlier were cleaned once by
+    `Vutuv.Fediverse.strip_stored_shortcodes/0`, run from a migration: it covers
+    every column `remote_text/3` writes (both `content_text`s, all three
+    `summary`s), and it is the same function, not a second repair written in
+    SQL, so a backfilled row and a row written tomorrow cannot differ.
   - **Shown through `VutuvWeb.Markdown.render_remote/1`** — the same renderer
     the Mastodon profile feed uses, so remote text reads one way across the app.
     A post from those networks is largely links, and as raw strings they sat on

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -2431,6 +2431,66 @@ defmodule Vutuv.Fediverse do
   def remote_post_retention_days,
     do: Application.get_env(:vutuv, :fediverse_post_retention_days, @remote_post_retention_days)
 
+  # Every column `remote_text/3` writes, which is the same list
+  # `strip_stored_shortcodes/0` has to clean.
+  @remote_text_columns [
+    {RemotePost, [:content_text, :summary]},
+    {Note, [:content_text, :summary]},
+    {RemoteAccount, [:summary]}
+  ]
+
+  @doc """
+  Takes the custom-emoji shortcodes out of the remote text already stored, and
+  reports how many values it rewrote.
+
+  Run once, from the migration that introduced the strip.
+  `Vutuv.RemoteHtml.strip_shortcodes/1` does it on the way in from that release
+  on, but a cached post is written once and never re-read from its origin, so
+  everything stored before it would go on showing a literal `":tux:"` until it
+  aged out of its six-month retention. An account's bio would heal itself on
+  the 30-day recheck; it is in here anyway, because 30 days is a long time to
+  read `":tux:"` beside posts that no longer do.
+
+  The one repair, not a second one written in SQL: the migration calls this the
+  way the legacy tag and username cleanups call theirs, so a backfilled row and
+  a row written tomorrow cannot come out differently.
+
+  A cached **translation** of a rewritten value falls out on its own —
+  `translations.source_sha256` keys it to the exact source string, so it stops
+  matching and the post is translated again from the cleaned text.
+  """
+  def strip_stored_shortcodes do
+    for {schema, fields} <- @remote_text_columns, field <- fields, reduce: 0 do
+      total -> total + strip_stored_shortcodes(schema, field)
+    end
+  end
+
+  defp strip_stored_shortcodes(schema, field) do
+    # Every shortcode contains a colon, so this narrows the read to a cheap
+    # superset of the grammar rather than restating it — the grammar itself
+    # runs in Elixir below and decides. Reading the matches at once is bounded
+    # by what these tables are: a cache the six-month retention keeps small.
+    schema
+    |> where([r], like(field(r, ^field), "%:%"))
+    |> select([r], {r.id, field(r, ^field)})
+    |> Repo.all()
+    |> Enum.count(fn {id, text} -> strip_stored_value(schema, field, id, text) end)
+  end
+
+  defp strip_stored_value(schema, field, id, text) do
+    case RemoteHtml.strip_shortcodes(text) do
+      ^text ->
+        false
+
+      stripped ->
+        schema
+        |> where([r], r.id == ^id)
+        |> Repo.update_all(set: [{field, stripped}])
+
+        true
+    end
+  end
+
   @doc """
   Stores a post a followed account published (`Create(Note)` / `Create(Question)`).
 
@@ -3651,11 +3711,21 @@ defmodule Vutuv.Fediverse do
     options =
       for option <- List.wrap(object["oneOf"]) ++ List.wrap(object["anyOf"]),
           is_map(option),
-          name = SearchText.normalize_search(option["name"]),
+          # A `name` is plain text, so this is the one path into `content_text`
+          # that never reaches `RemoteHtml.to_text/3` and has to take the emoji
+          # strip itself — otherwise the next edit writes `• :tux: Linux` back
+          # over the cleaned row.
+          text = strip_option_shortcodes(option["name"]),
+          name = SearchText.normalize_search(text),
           do: name
 
     Enum.take(options, 20)
   end
+
+  defp strip_option_shortcodes(name) when is_binary(name),
+    do: RemoteHtml.strip_shortcodes(name)
+
+  defp strip_option_shortcodes(_name), do: nil
 
   # The author's own stamp, which is what orders the feed — clamped against the
   # future, so a server cannot pin itself to the top of somebody's feed forever

--- a/lib/vutuv/fediverse/handle.ex
+++ b/lib/vutuv/fediverse/handle.ex
@@ -22,17 +22,12 @@ defmodule Vutuv.Fediverse.Handle do
   host is shown instead, because the host is always true.
   """
 
+  alias Vutuv.RemoteHtml
   alias Vutuv.SearchText
 
   # Shaped like a name at all: one path segment, no whitespace, no separators,
   # and short enough not to be a wall of text in a chip.
   @username ~r/^[A-Za-z0-9_.-]{1,64}$/
-
-  # A custom-emoji shortcode as Mastodon spells one: `[a-zA-Z0-9_]{2,}` between
-  # colons, delimited by non-word characters. The delimiters are the whole
-  # point — they are what keeps a time ("10:30:45"), a scheme
-  # ("daniel:// stenberg://") and a doubled colon out of it.
-  @shortcode ~r/(?<=^|\W):[a-zA-Z0-9_]{2,}:(?=\W|$)/
 
   @doc """
   What a remote account is called on screen, from the display name its server
@@ -46,16 +41,17 @@ defmodule Vutuv.Fediverse.Handle do
   (`Vutuv.RemoteMedia`) — a name is not worth that pipeline. So the token has
   nothing to render as, and left in it reads as a literal `":coolified:"` on
   the card. Drop it; the Mastodon inline feed has made the same call since it
-  shipped, and this is the one implementation both use.
+  shipped. The grammar lives in `Vutuv.RemoteHtml.strip_shortcodes/1`, which a
+  remote post's *text* reads too — one owner, or the same server's `:blobcat:`
+  would vanish from the card's name and stay in its text.
 
-  Cleaned on the way **out**, not on the way in: the stored value stays what
-  the server said, so a row written before this can never be the odd one out
-  and a later decision to render the pictures still has the name to put them
-  back into.
+  A **name** is cleaned on the way **out**, unlike that text: it is re-derived
+  from its column on every render, so the stored value stays what the server
+  said and a row written before this can never be the odd one out.
   """
   def display_name(name) when is_binary(name) do
     name
-    |> String.replace(@shortcode, "")
+    |> RemoteHtml.strip_shortcodes()
     |> String.replace(~r/\s+/u, " ")
     |> SearchText.normalize_search()
   end

--- a/lib/vutuv/mastodon.ex
+++ b/lib/vutuv/mastodon.ex
@@ -169,7 +169,10 @@ defmodule Vutuv.Mastodon do
     spoiler = String.trim(to_string(status["spoiler_text"] || ""))
 
     cond do
-      spoiler != "" -> Post.truncate(spoiler)
+      # The REST API sends a content warning as plain text, so it is the one
+      # branch here that never reaches `RemoteHtml.to_text/3` — and a CW carries
+      # this server's custom emoji as readily as a body does.
+      spoiler != "" -> spoiler |> RemoteHtml.strip_shortcodes() |> Post.truncate()
       status["sensitive"] == true -> ""
       true -> RemoteHtml.to_text(to_string(status["content"] || ""), nil, mention_tags(status))
     end

--- a/lib/vutuv/remote_html.ex
+++ b/lib/vutuv/remote_html.ex
@@ -13,7 +13,9 @@ defmodule Vutuv.RemoteHtml do
     * `<br>` and `</p>` become the line breaks that carried the meaning,
     * every remaining tag is stripped (`HtmlSanitizeEx.strip_tags/1`), so there
       is no allowlist to get wrong and nothing to render `raw`,
-    * the base entities are decoded exactly **once**, and
+    * the base entities are decoded exactly **once**,
+    * the sending server's own **custom-emoji shortcodes** go out with it
+      (`strip_shortcodes/1`), and
     * the result is clamped, so one hostile delivery cannot park a novel.
 
   The script/style pass matters because `strip_tags/1` removes the *tags* and
@@ -55,6 +57,16 @@ defmodule Vutuv.RemoteHtml do
   # nothing real mentions more than a handful.
   @max_mention_tags 50
 
+  # A run of custom-emoji shortcodes as these networks spell them:
+  # `[a-zA-Z0-9_]{2,}` between colons, one or more in a row because two adjacent
+  # emoji are written `:blobcat::heart:` with no space between them.
+  #
+  # The delimiters are the whole point — they are what keeps a time ("10:30:45")
+  # and a scheme ("daniel:// stenberg://") out of it. A **colon** is not one of
+  # them, or `std::vector::size` would read as a `:vector:` emoji between two
+  # colons and come out `std::size`.
+  @shortcode ~r/(?<![\w:])(?::[a-zA-Z0-9_]{2,}:)+(?![\w:])/
+
   @doc """
   Reduces a remote server's HTML to clamped plain text, at most `max`
   characters (the shared social-feed clamp by default).
@@ -77,11 +89,54 @@ defmodule Vutuv.RemoteHtml do
     |> HtmlSanitizeEx.strip_tags()
     |> decode_entities()
     |> String.trim()
+    |> strip_shortcodes()
     |> expand_mentions(tags)
     |> clamp(max)
   end
 
   def to_text(_html, _max, _tags), do: ""
+
+  @doc """
+  `text` — already plain, not HTML — with its custom-emoji shortcodes taken out
+  and the gap each one leaves closed.
+
+  Those networks let an account put its **own server's** emoji in a post and
+  send it as a shortcode (`":tux:"`), with the picture it stands for in the
+  object's `tag` array. That picture is that server's, and vutuv shows no remote
+  picture it has not cached and put past the AI gate, so the token has nothing
+  to render as and reads on the card as a literal `":tux:"`.
+
+  `to_text/3` applies it to everything that arrives as HTML. It is public for
+  the two plain-text paths that never see any: a poll's option names
+  (`Vutuv.Fediverse`) and a Mastodon status' content warning (`Vutuv.Mastodon`),
+  which the REST API sends as text. Everything a remote server wrote and vutuv
+  stores goes through one of those three.
+
+  Cleaned on the way **in**, unlike a display name (`Handle.display_name/1`,
+  which calls this too) — the name is re-derived from its column on every
+  render, while this text *is* the column, and every reader of it would
+  otherwise need the same repair. Text carrying no shortcode comes back
+  untouched rather than merely unchanged: `translations.source_sha256` keys a
+  cached translation to the exact string, so a cosmetic byte would re-run the
+  whole stored corpus past Ollama.
+  """
+  def strip_shortcodes(text) when is_binary(text) do
+    # One whole-text `match?` before the line pass, and `match?` rather than a
+    # replace whose result is thrown away: nearly every post carries no
+    # shortcode at all, and for those this is the only work done (measured: 16
+    # reductions against 235 for splitting into lines and letting each line
+    # answer for itself, which grows with the post).
+    if Regex.match?(@shortcode, text) do
+      text
+      |> String.split("\n")
+      |> Enum.flat_map(&strip_line/1)
+      |> Enum.join("\n")
+      |> String.replace(~r/\n{3,}/, "\n\n")
+      |> String.trim()
+    else
+      text
+    end
+  end
 
   defp clamp(text, nil), do: Post.truncate(text)
   defp clamp(text, max), do: Post.truncate(text, max)
@@ -183,5 +238,30 @@ defmodule Vutuv.RemoteHtml do
       [^handle, u, h | _] -> u != "" and h != ""
       _ -> false
     end
+  end
+
+  # A line with no shortcode in it is left byte for byte alone, so the repair
+  # can only ever touch the lines it emptied out.
+  defp strip_line(line) do
+    case String.replace(line, @shortcode, "") do
+      ^line -> [line]
+      stripped -> close_gap(stripped)
+    end
+  end
+
+  # What the removed token leaves behind: a doubled space mid-sentence, a space
+  # in front of the comma that followed it, an indent at the start of the line
+  # it opened. A line that was **nothing but** emoji goes with them — the author
+  # gave it a line of its own, so an empty one in its place is not what they
+  # wrote either. (`strip_line/1` only calls this for a line that carried one,
+  # so an empty result here always means "emoji and nothing else".)
+  defp close_gap(stripped) do
+    repaired =
+      stripped
+      |> String.replace(~r/\s+/u, " ")
+      |> String.replace(~r/ +(?=[,.)\]])/u, "")
+      |> String.trim()
+
+    if repaired == "", do: [], else: [repaired]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.433.3",
+      version: "7.449.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260828112440_strip_custom_emoji_from_remote_text.exs
+++ b/priv/repo/migrations/20260828112440_strip_custom_emoji_from_remote_text.exs
@@ -1,0 +1,28 @@
+defmodule Vutuv.Repo.Migrations.StripCustomEmojiFromRemoteText do
+  use Ecto.Migration
+
+  alias Vutuv.Fediverse
+
+  # Takes the custom-emoji shortcodes out of the remote text already cached.
+  #
+  # `Vutuv.RemoteHtml.strip_shortcodes/1` drops them on the way in from this
+  # release on, but a cached post is written once and never re-read from its
+  # origin, so everything stored before this would go on showing a literal
+  # ":tux:" until it aged out of its six-month retention. The work lives in
+  # Vutuv.Fediverse.strip_stored_shortcodes/0, which covers every column
+  # remote_text/3 writes — calling it rather than transcribing the grammar into
+  # SQL is what keeps a backfilled row and a row written tomorrow identical.
+  #
+  # Data-only (no DDL), so it is N-1 compatible for the blue/green deploy: the
+  # previous release reads these columns as the plain text they already were,
+  # shorter text renders the same everywhere, and no column type changes, so no
+  # cached prepared plan is invalidated. A fresh or test database has nothing to
+  # clean, which makes it a no-op there.
+  def up do
+    IO.puts("stripped shortcodes from #{Fediverse.strip_stored_shortcodes()} stored value(s)")
+  end
+
+  # The shortcodes are gone from text a remote server sent us, and that text is
+  # a cache we never held another copy of.
+  def down, do: :ok
+end

--- a/test/vutuv/fediverse_handle_test.exs
+++ b/test/vutuv/fediverse_handle_test.exs
@@ -34,6 +34,7 @@ defmodule Vutuv.FediverseHandleTest do
       assert Handle.display_name("Alice (Live 10:30:45)") == "Alice (Live 10:30:45)"
       assert Handle.display_name("daniel:// stenberg://") == "daniel:// stenberg://"
       assert Handle.display_name("Spar|fin|dig :: Jan") == "Spar|fin|dig :: Jan"
+      assert Handle.display_name("Jan std::vector::size") == "Jan std::vector::size"
     end
   end
 

--- a/test/vutuv/fediverse_remote_posts_test.exs
+++ b/test/vutuv/fediverse_remote_posts_test.exs
@@ -121,6 +121,34 @@ defmodule Vutuv.FediverseRemotePostsTest do
       assert post.content_text == "Starker Track von @herrkaschke@social.cologne."
     end
 
+    test "a custom-emoji shortcode is not stored, and a post of nothing else is dropped" do
+      user = member()
+      acc = account()
+      follow(user, acc)
+
+      # The picture it stands for lives on that server, and we render no remote
+      # picture we have not cached and put past the AI gate — so the token has
+      # nothing to render as and read on the card as a literal ":tux:".
+      emoji =
+        create_activity(%{
+          object: %{"content" => "<p>Linux im Park :tux: :piraten:</p>"}
+        })
+
+      assert :ok = Fediverse.record_remote_post(emoji, @actor)
+      assert [post] = Repo.all(RemotePost)
+      assert post.content_text == "Linux im Park"
+
+      # A post that was nothing but one is a post with no text, and with no
+      # picture either it has nothing to show: dropped like any empty one.
+      only_emoji =
+        create_activity(%{
+          object: %{"id" => "https://social.example/posts/2", "content" => "<p>:blobcatcool:</p>"}
+        })
+
+      assert :skip = Fediverse.record_remote_post(only_emoji, @actor)
+      assert Repo.aggregate(RemotePost, :count) == 1
+    end
+
     test "a redelivery stores no second row, and is a skip" do
       user = member()
       acc = account()
@@ -252,6 +280,29 @@ defmodule Vutuv.FediverseRemotePostsTest do
       assert Repo.aggregate(RemotePost, :count) == 2
     end
 
+    test "a poll's options lose their shortcodes too, so an edit cannot write them back" do
+      user = member()
+      acc = account()
+      follow(user, acc)
+
+      # An option's `name` is plain text, so it is the one path into
+      # `content_text` that never reaches `RemoteHtml.to_text/3`.
+      poll = %{
+        "id" => "https://social.example/posts/poll",
+        "type" => "Question",
+        "content" => "<p>:tux: Welches System?</p>",
+        "oneOf" => [
+          %{"type" => "Note", "name" => ":tux: Linux"},
+          %{"type" => "Note", "name" => "BSD"}
+        ]
+      }
+
+      assert :ok = Fediverse.record_remote_post(create_activity(%{object: poll}), @actor)
+
+      post = Repo.get_by!(RemotePost, object_uri: "https://social.example/posts/poll")
+      assert post.content_text == "Welches System?\n\n• Linux\n• BSD"
+    end
+
     test "a poll keeps its options and is marked as one" do
       user = member()
       acc = account()
@@ -315,6 +366,44 @@ defmodule Vutuv.FediverseRemotePostsTest do
       assert post.summary == "Politics"
       assert post.sensitive
       assert RemotePost.warned?(post)
+    end
+  end
+
+  describe "strip_stored_shortcodes/0 (the backfill the migration runs)" do
+    test "cleans every column remote_text/3 writes, and leaves the rest alone" do
+      acc = account(name: "Droid Boy :coolified:")
+
+      # Written the way rows already in the database were: past the changeset,
+      # with the shortcodes still in them.
+      {1, _} =
+        Repo.update_all(RemoteAccount |> where([a], a.id == ^acc.id),
+          set: [summary: "Bastelt Buttons :blobcatcool: hier."]
+        )
+
+      follow(member(), acc)
+      assert :ok = Fediverse.record_remote_post(create_activity(), @actor)
+      post = Repo.get_by!(RemotePost, object_uri: "https://social.example/posts/1")
+
+      {1, _} =
+        Repo.update_all(RemotePost |> where([p], p.id == ^post.id),
+          set: [content_text: "Linux im Park :tux:", summary: ":cw_food: Essen"]
+        )
+
+      # Two values on the post, one on the account. The account's `name` is
+      # cleaned on the way out by `Handle.display_name/1`, so it is deliberately
+      # not counted and deliberately not rewritten.
+      assert Fediverse.strip_stored_shortcodes() == 3
+
+      post = Repo.reload!(post)
+      assert post.content_text == "Linux im Park"
+      assert post.summary == "Essen"
+
+      acc = Repo.reload!(acc)
+      assert acc.summary == "Bastelt Buttons hier."
+      assert acc.name == "Droid Boy :coolified:"
+
+      # Idempotent: a second pass has nothing left to do.
+      assert Fediverse.strip_stored_shortcodes() == 0
     end
   end
 

--- a/test/vutuv/mastodon_test.exs
+++ b/test/vutuv/mastodon_test.exs
@@ -218,6 +218,15 @@ defmodule Vutuv.MastodonTest do
       assert three.id == "3"
     end
 
+    test "a content warning loses its custom-emoji shortcodes like a body does" do
+      # The REST API sends a CW as plain text, so it is the one branch that
+      # never reaches `RemoteHtml.to_text/3` and used to keep the token.
+      serve([status(%{"id" => "1", "sensitive" => true, "spoiler_text" => ":cw_food: Essen"})])
+
+      assert {:ok, %Feed{posts: [one]}} = Mastodon.fetch_posts(@handle)
+      assert one.text == "Essen"
+    end
+
     test "skips media-only posts and unparseable timestamps" do
       serve([
         status(%{"id" => "1", "content" => ""}),

--- a/test/vutuv/remote_html_test.exs
+++ b/test/vutuv/remote_html_test.exs
@@ -165,4 +165,65 @@ defmodule Vutuv.RemoteHtmlTest do
       assert String.ends_with?(out, "…")
     end
   end
+
+  describe "a custom-emoji shortcode is taken out of the text" do
+    test "an inline one goes, and the gap it leaves closes" do
+      html = ~s(<p>Linux im Park mit den Piraten :tux: :piraten:</p>)
+
+      assert RemoteHtml.to_text(html) == "Linux im Park mit den Piraten"
+    end
+
+    test "one used as a bullet at the start of a line goes with its space" do
+      html =
+        "<p>:picklerick: Füg nicht die KI ein.</p><p>:cannabis: Wenn dir jemand schreibt.</p>"
+
+      assert RemoteHtml.to_text(html) ==
+               "Füg nicht die KI ein.\n\nWenn dir jemand schreibt."
+    end
+
+    test "a line that was nothing but one does not leave a blank line behind" do
+      html = "<p>Wir suchen jemanden.<br>:BoostOK:<br>Danke!</p>"
+
+      assert RemoteHtml.to_text(html) == "Wir suchen jemanden.\nDanke!"
+    end
+
+    test "the gap never turns into a stray space before punctuation" do
+      html = "<p>Hey Wesen des Fediversums :fediverse: , bis Sonntag.</p>"
+
+      assert RemoteHtml.to_text(html) == "Hey Wesen des Fediversums, bis Sonntag."
+    end
+
+    test "a post that was nothing but one reduces to nothing" do
+      assert RemoteHtml.to_text("<p>:blobcatcool:</p>") == ""
+    end
+
+    test "Unicode emoji are not shortcodes and stay exactly where they are" do
+      assert RemoteHtml.to_text("<p>Ever wanted to have fun? \u{1F911} Yes!</p>") ==
+               "Ever wanted to have fun? \u{1F911} Yes!"
+    end
+
+    test "two adjacent ones go together, the way those servers write them" do
+      assert RemoteHtml.to_text("<p>Cem :blobcat::verified: hier</p>") == "Cem hier"
+    end
+
+    test "a time, a URL and a scope operator are left alone" do
+      assert RemoteHtml.to_text("<p>Um 10:30:45 Uhr</p>") == "Um 10:30:45 Uhr"
+      assert RemoteHtml.to_text("<p>https://example.org/a</p>") == "https://example.org/a"
+      # A colon is not a delimiter, or this would read as a `:vector:` emoji
+      # between two colons and come out `std::size`.
+      assert RemoteHtml.to_text("<p>std::vector::size</p>") == "std::vector::size"
+    end
+
+    test "text carrying no shortcode comes out byte for byte as before" do
+      html = "<p>Zeile  eins</p><p>  Zeile zwei  </p>"
+
+      assert RemoteHtml.to_text(html) == "Zeile  eins\n\n  Zeile zwei"
+    end
+
+    test "the strip runs before the clamp, so the cap bounds real text" do
+      html = "<p>:tux: " <> String.duplicate("a", 40) <> "</p>"
+
+      assert RemoteHtml.to_text(html, 20) == String.duplicate("a", 19) <> "\u{2026}"
+    end
+  end
 end


### PR DESCRIPTION
Remote posts in the feed showed `:tux:` and `:piraten:` as literal text. Those servers send their own custom emoji as a shortcode, with the picture in the object's `tag` array — a picture we do not cache and never render, so the token had nothing to stand for. `Handle.display_name/1` has dropped it from a card's *name* since it shipped; the body never got the same treatment.

`Vutuv.RemoteHtml.strip_shortcodes/1` now owns the grammar and does it for both, closing the gap left behind (doubled space, the space before a following comma, a line that was only emoji). `to_text/3` covers everything arriving as HTML; two plain-text paths call it themselves — a poll's option names (re-derived on every upstream edit, so they would have overwritten cleaned rows) and a Mastodon content warning.

Cleaned on the way in, so every reader is consistent. Rows written earlier are fixed once by `Fediverse.strip_stored_shortcodes/0`, run from a migration and covering all five columns `remote_text/3` writes: 16 values in the prod copy.

Reverting the strip turns 9 of the new tests red.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_0191Nsi7s4DEZZL11Z7iGaxn
