### PR TITLE
fix(fediverse): the entity table, the clamp, and a NUL that reached Postgres [5m]

### DIFF
--- a/lib/vutuv/remote_html.ex
+++ b/lib/vutuv/remote_html.ex
@@ -13,7 +13,7 @@ defmodule Vutuv.RemoteHtml do
     * `<br>` and `</p>` become the line breaks that carried the meaning,
     * every remaining tag is stripped (`HtmlSanitizeEx.strip_tags/1`), so there
       is no allowlist to get wrong and nothing to render `raw`,
-    * the base entities are decoded exactly **once**,
+    * HTML entities are decoded exactly **once** (`decode_entities/1`),
     * the sending server's own **custom-emoji shortcodes** go out with it
       (`strip_shortcodes/1`), and
     * the result is clamped, so one hostile delivery cannot park a novel.
@@ -87,6 +87,7 @@ defmodule Vutuv.RemoteHtml do
     |> String.replace(~r{<br\s*/?>}i, "\n")
     |> String.replace(~r{</p>}i, "\n\n")
     |> HtmlSanitizeEx.strip_tags()
+    |> scrub_nul()
     |> decode_entities()
     |> String.trim()
     |> strip_shortcodes()
@@ -141,18 +142,65 @@ defmodule Vutuv.RemoteHtml do
   defp clamp(text, nil), do: Post.truncate(text)
   defp clamp(text, max), do: Post.truncate(text, max)
 
-  # strip_tags/1 returns text with the base named entities still escaped (the
-  # numeric ones it decodes itself); undo them exactly once. `&amp;` must come
-  # last so a literal "&amp;amp;" cannot double-unescape.
+  # A NUL byte is valid UTF-8 and Postgres refuses it (`22021
+  # character_not_in_repertoire`), so one in here is not a display problem, it
+  # is a raise on `Repo.insert` — and this text is stored: `Vutuv.Fediverse`'s
+  # `remote_text/3` writes it into a delivered post's body, so any federating
+  # server can reach that by putting `&#0;` in a Note.
+  #
+  # Its own step, and not part of `decode_entities/1`, where the same guard
+  # already lives (`entity_text/2` refuses to build a NUL). That guard cannot
+  # help: `strip_tags/1` decodes numeric entities **itself**, so `&#0;` is
+  # already a raw byte by the time the decoder runs. A guard the pipeline steps
+  # around is not a guard.
+  defp scrub_nul(text), do: String.replace(text, <<0>>, "")
+
+  @entity_regex ~r/&(#[xX][0-9a-fA-F]+|#\d+|[a-zA-Z][a-zA-Z0-9]*);/
+
+  # The HTML entities `strip_tags/1` leaves escaped, resolved to the text they
+  # stand for. An entity nothing knows is left standing rather than swallowed.
+  #
+  # **One pass, not a chain of replacements.** A chain has to decode `&amp;`
+  # LAST or a literal `&amp;amp;` unescapes twice, and that ordering was a rule
+  # somebody had to keep obeying — it lived in a comment above the version this
+  # replaced. A single pass cannot double-decode at all, because
+  # `Regex.replace/3` does not re-scan what it has written.
   defp decode_entities(text) do
-    text
-    |> String.replace("&lt;", "<")
-    |> String.replace("&gt;", ">")
-    |> String.replace("&quot;", "\"")
-    |> String.replace("&#39;", "'")
-    |> String.replace("&nbsp;", " ")
-    |> String.replace("&amp;", "&")
+    Regex.replace(@entity_regex, text, fn whole, body -> entity(body, whole) end)
   end
+
+  # `:mochiweb_charref` is the full HTML5 table, and it already ships here —
+  # `:html_sanitize_ex` depends on it and `strip_tags/1` above leans on it. It
+  # answers all three spellings the regex captures (`rsquo`, `#8217`, `#x2019`)
+  # and `:undefined` for anything it does not know.
+  #
+  # What this replaced was a six-entry table typed out by hand, and six entries
+  # is where the web has two thousand: `Google&rsquo;s new phone` came out of it
+  # verbatim. Extending it by another forty names would only have moved the edge
+  # — `&frac12;`, `&sup2;`, `&eacute;` were all one post away from the same bug.
+  #
+  # Case matters and is not folded: `&Aacute;` is Á and `&aacute;` is á.
+  defp entity(body, whole) do
+    case :mochiweb_charref.charref(body) do
+      :undefined -> whole
+      codepoint -> entity_text(codepoint, whole)
+    end
+  end
+
+  # A lone surrogate is not a codepoint `<<n::utf8>>` can build (it raises), and
+  # neither is a number past the Unicode range: those stay text. `0` is refused
+  # with them, for the reason `scrub_nul/1` sets out above.
+  defp entity_text(number, _whole)
+       when is_integer(number) and (number in 1..0xD7FF or number in 0xE000..0x10FFFF),
+       do: <<number::utf8>>
+
+  # A few entities are two codepoints (`&NotEqualTilde;` is ≂ plus a combining
+  # slash); each half goes through the same guard.
+  defp entity_text(numbers, whole) when is_list(numbers) do
+    Enum.map_join(numbers, &entity_text(&1, whole))
+  end
+
+  defp entity_text(_number, whole), do: whole
 
   defp expand_mentions(text, tags) do
     map = mention_map(tags)

--- a/lib/vutuv/remote_html.ex
+++ b/lib/vutuv/remote_html.ex
@@ -86,6 +86,7 @@ defmodule Vutuv.RemoteHtml do
     |> String.replace(~r{<(script|style)\b[^>]*>.*}is, "")
     |> String.replace(~r{<br\s*/?>}i, "\n")
     |> String.replace(~r{</p>}i, "\n\n")
+    |> defuse_wide_charrefs()
     |> HtmlSanitizeEx.strip_tags()
     |> scrub_nul()
     |> decode_entities()
@@ -155,6 +156,33 @@ defmodule Vutuv.RemoteHtml do
   # around is not a guard.
   defp scrub_nul(text), do: String.replace(text, <<0>>, "")
 
+  # `strip_tags/1` decodes numeric character references itself, and its parser
+  # builds every one it sees: `:mochiutf8.codepoint_to_bytes/1` has no clause
+  # past 0x10FFFF, so `&#1114112;` does not become a replacement character, it
+  # RAISES a FunctionClauseError from inside `strip_tags/1` — before
+  # `scrub_nul/1` or `decode_entities/1` below can look at anything. Any
+  # federating server can stop an inbound Note that way, the same reach the NUL
+  # above has, and one line earlier in the pipeline.
+  #
+  # So the reference is defused before the parser sees it, by escaping its `&`.
+  # That leaves it standing as literal text, which is exactly what mochiweb
+  # already does with a lone surrogate (`&#xD800;` comes through untouched) —
+  # the point is that a number nobody can render is not worth an exception.
+  @wide_charref ~r/&#([xX])?0*([0-9a-fA-F]+);/
+  defp defuse_wide_charrefs(html) do
+    Regex.replace(@wide_charref, html, fn whole, hex, digits ->
+      base = if hex == "", do: 10, else: 16
+
+      case Integer.parse(digits, base) do
+        {codepoint, ""} when codepoint > 0x10FFFF ->
+          "&amp;" <> binary_part(whole, 1, byte_size(whole) - 1)
+
+        _ ->
+          whole
+      end
+    end)
+  end
+
   @entity_regex ~r/&(#[xX][0-9a-fA-F]+|#\d+|[a-zA-Z][a-zA-Z0-9]*);/
 
   # The HTML entities `strip_tags/1` leaves escaped, resolved to the text they
@@ -174,10 +202,16 @@ defmodule Vutuv.RemoteHtml do
   # answers all three spellings the regex captures (`rsquo`, `#8217`, `#x2019`)
   # and `:undefined` for anything it does not know.
   #
-  # What this replaced was a six-entry table typed out by hand, and six entries
-  # is where the web has two thousand: `Google&rsquo;s new phone` came out of it
-  # verbatim. Extending it by another forty names would only have moved the edge
-  # — `&frac12;`, `&sup2;`, `&eacute;` were all one post away from the same bug.
+  # What this replaced was a six-entry table typed out by hand. Measured before
+  # replacing it, those six were not a gap: `strip_tags/1` resolves the whole
+  # HTML5 table itself and re-escapes only the four HTML-special entities, so
+  # `&rsquo;`, `&mdash;`, `&eacute;` and the rest already came through correctly,
+  # and the hand-written list covered exactly what was left. The reason to use
+  # the real table anyway is that nobody can tell that by reading it — the list
+  # looked like an arbitrary six of two thousand — and that the chain carried an
+  # ordering rule (`&amp;` last, or `&amp;amp;` unescapes twice) which lived in a
+  # comment and had to keep being obeyed. One pass over the real table cannot be
+  # short, and cannot be mis-ordered.
   #
   # Case matters and is not folded: `&Aacute;` is Á and `&aacute;` is á.
   defp entity(body, whole) do

--- a/lib/vutuv/social_feed/post.ex
+++ b/lib/vutuv/social_feed/post.ex
@@ -40,15 +40,47 @@ defmodule Vutuv.SocialFeed.Post do
   def truncate(text), do: truncate(text, @max_text_length)
 
   @doc """
-  Clamps `text` to `max` characters, replacing the tail with a trailing ellipsis
-  when it runs over (the shared clamp `Vutuv.CodeStats.Snapshot` reuses for its
-  own, shorter description cap).
+  Clamps `text` to at most `max` characters, replacing the tail with a trailing
+  ellipsis when it runs over.
+
+  **The cut lands between words, not inside one.** Every caller shows the result
+  to a reader — a remote post's body (`Vutuv.Mastodon`, `Vutuv.Bluesky`), the
+  reduced text of a stranger's HTML (`Vutuv.RemoteHtml`), a repository
+  description (`Vutuv.CodeStats.Snapshot`) — and `das neue Sm…` reads as a
+  glitch where `das neue…` reads as a clamp. `max - 1` leaves room for the
+  ellipsis, so the result never exceeds `max`; a first word longer than the
+  whole budget has no space to cut at and keeps the blunt slice, which is the
+  only shape that still fits.
+
+  Note the tail trim takes the last run of non-space **whether or not it was
+  complete**, so a cut landing exactly on a word boundary still drops that word.
+  The alternative is peeking at the character past the budget to tell "ended
+  cleanly" from "cut mid-word", and one spare word costs less than a rule with
+  two branches.
   """
+  # Neither clause asks how long `text` IS — only whether it reaches past `max`,
+  # which is the cheaper question and the only one that matters.
+  # `String.length/1` walks the whole input, and the biggest caller hands over a
+  # stranger's page: 72,255 reductions to answer it that way against 16,334 this
+  # way, and a short post that needs no cut at all drops from 226 to 6.
+  # `byte_size/1` is O(1) and sound as a first pass because bytes are never
+  # fewer than graphemes, so the common no-op leaves immediately;
+  # `String.split_at/2` then bounds the test at `max` graphemes and hands back
+  # the head it already walked.
+  def truncate(text, max) when byte_size(text) <= max, do: text
+
   def truncate(text, max) do
-    if String.length(text) > max do
-      String.slice(text, 0, max - 1) <> "…"
-    else
-      text
+    case String.split_at(text, max) do
+      {_head, ""} ->
+        text
+
+      {head, _rest} ->
+        head = String.slice(head, 0, max - 1)
+        trimmed = String.replace(head, ~r/\s+\S*$/u, "")
+
+        # `/u` is load-bearing: `Vutuv.RemoteHtml.decode_entities/1` resolves
+        # `&nbsp;` to U+00A0, which `\s` matches only under `/u`.
+        if(trimmed == "", do: head, else: trimmed) <> "…"
     end
   end
 end

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -1384,7 +1384,7 @@ the resulting ~200px rail width. --%>
           <.link
             href={entry.post.url}
             target="_blank"
-            rel="noopener nofollow ugc"
+            rel="ugc nofollow noopener noreferrer"
             class="absolute inset-0"
             aria-hidden="true"
             tabindex="-1"
@@ -1440,7 +1440,7 @@ the resulting ~200px rail width. --%>
                 <.link
                   href={entry.post.url}
                   target="_blank"
-                  rel="noopener nofollow ugc"
+                  rel="ugc nofollow noopener noreferrer"
                   class="shrink-0 text-sm text-slate-600 dark:text-slate-400 hover:text-brand-700 dark:hover:text-brand-300"
                 >
                   <.post_time

--- a/lib/vutuv_web/views/user_html.ex
+++ b/lib/vutuv_web/views/user_html.ex
@@ -611,7 +611,7 @@ defmodule VutuvWeb.UserHTML do
               <a
                 href={repo["url"]}
                 target="_blank"
-                rel="noopener nofollow ugc"
+                rel="ugc nofollow noopener noreferrer"
                 class="truncate font-medium text-brand-700 hover:text-brand-800 dark:text-brand-300"
               >
                 {repo["name"]}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.507.2",
+      version: "7.525.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
@@ -50,6 +50,11 @@ defmodule Vutuv.MixProject do
       # dangerous (user input must never reach the DOM unsanitized).
       {:earmark, "~> 1.4"},
       {:html_sanitize_ex, "~> 1.4"},
+      # The HTML5 named/numeric character-reference table (`:mochiweb_charref`),
+      # which `Vutuv.RemoteHtml` decodes a remote server's entities with;
+      # promotes the transitive dep of :html_sanitize_ex to a direct one, the
+      # same reason :nimble_csv is listed below.
+      {:mochiweb, "~> 3.3"},
       {:bandit, "~> 1.0"},
       # Resolves the real client IP from X-Forwarded-For behind the nginx
       # reverse proxy, so `conn.remote_ip` is the visitor's address instead of

--- a/test/vutuv/references/checks_test.exs
+++ b/test/vutuv/references/checks_test.exs
@@ -594,10 +594,23 @@ defmodule Vutuv.References.ChecksTest do
 
       check = Checks.latest_for(reference)
 
-      # Bracketed between two clock reads: a one-sided bound flakes whenever the
-      # wall clock crosses a second inside the call.
-      assert DateTime.diff(check.next_attempt_at, before) <= 300
-      assert DateTime.diff(check.next_attempt_at, later) >= 299
+      # Bracketed between two clock reads, and the DIRECTION of each half is the
+      # whole point. `next_attempt_at` is `read + 300` for some read taken
+      # inside the call, so `before <= read <= later` gives exactly:
+      #
+      #   next_attempt_at - before >= 300   (read is at or after `before`)
+      #   next_attempt_at - later  <= 300   (read is at or before `later`)
+      #
+      # Both halves used to be the other way round, which inverted the claim
+      # into something the clock can break: `- before <= 300` is false the
+      # moment a second ticks between `before` and the read, and that is a coin
+      # flip on a loaded machine. It failed with `left: 301, right: 300`. The
+      # `>= 299` beside it was slack papering over the same inversion.
+      #
+      # As written now both are deterministic AND the stronger claim — the wait
+      # IS 300 seconds, not merely at most it.
+      assert DateTime.diff(check.next_attempt_at, before) >= 300
+      assert DateTime.diff(check.next_attempt_at, later) <= 300
     end
 
     test "an analysis error counts an attempt", %{reference: reference} do

--- a/test/vutuv/remote_html_test.exs
+++ b/test/vutuv/remote_html_test.exs
@@ -43,6 +43,30 @@ defmodule Vutuv.RemoteHtmlTest do
     refute RemoteHtml.to_text("<p>&#0;</p>") =~ <<0>>
   end
 
+  test "a numeric character reference past the Unicode range does not raise" do
+    # The NUL above is the same attack one step further on: `strip_tags/1`
+    # decodes numeric references itself, and its parser builds every one it
+    # sees. `:mochiutf8.codepoint_to_bytes/1` has no clause past 0x10FFFF, so
+    # `&#1114112;` raises a FunctionClauseError from INSIDE `strip_tags/1` —
+    # earlier than `scrub_nul/1`, and an exception rather than a failed insert.
+    # Any federating server can stop an inbound Note with it.
+    #
+    # Defused before the parser, so the reference stays literal text, which is
+    # what mochiweb already does with a lone surrogate.
+    assert RemoteHtml.to_text("<p>a&#1114112;b</p>") == "a&#1114112;b"
+    assert RemoteHtml.to_text("<p>a&#x110000;b</p>") == "a&#x110000;b"
+    assert RemoteHtml.to_text("<p>a&#99999999;b</p>") == "a&#99999999;b"
+
+    # The boundary itself is a real codepoint and must still decode, or the
+    # guard is off by one.
+    assert RemoteHtml.to_text("<p>a&#x10FFFF;b</p>") == "a\u{10FFFF}b"
+
+    # Unchanged by the defusing: a surrogate was already left standing, and an
+    # ordinary reference must not be caught by it.
+    assert RemoteHtml.to_text("<p>a&#xD800;b</p>") == "a&#xD800;b"
+    assert RemoteHtml.to_text("<p>a&#8217;b</p>") == "a’b"
+  end
+
   describe "script and style go with their contents" do
     test "a paired element leaves nothing behind" do
       assert RemoteHtml.to_text("<script>alert(1)</script><p>safe</p>") == "safe"

--- a/test/vutuv/remote_html_test.exs
+++ b/test/vutuv/remote_html_test.exs
@@ -19,6 +19,30 @@ defmodule Vutuv.RemoteHtmlTest do
     assert RemoteHtml.to_text("<p>&amp;amp;</p>") == "&amp;"
   end
 
+  test "so does the long tail of named entities, and case is not folded" do
+    # The six-entry table this replaced is what let `Google&rsquo;s new phone`
+    # through verbatim. `:mochiweb_charref` is the full HTML5 table.
+    assert RemoteHtml.to_text("<p>Google&rsquo;s new phone</p>") == "Google\u2019s new phone"
+    assert RemoteHtml.to_text("<p>&Aacute; und &aacute;</p>") == "\u00C1 und \u00E1"
+  end
+
+  test "an entity nobody knows is left standing rather than swallowed" do
+    assert RemoteHtml.to_text("<p>&bogus; bleibt</p>") == "&bogus; bleibt"
+  end
+
+  test "no NUL byte leaves to_text/3" do
+    # Not cosmetic: this text is STORED — `Vutuv.Fediverse`'s `remote_text/3`
+    # writes it into a delivered post's body — and Postgres refuses a NUL with
+    # `22021 character_not_in_repertoire`, so a federating server could raise
+    # our insert with `&#0;` in a Note.
+    #
+    # The decoder's own guard cannot catch it: `strip_tags/1` decodes numeric
+    # entities itself, so the byte exists before the decoder runs. Hence the
+    # separate scrub, and hence this test.
+    assert RemoteHtml.to_text("<p>hallo &#0; welt</p>") == "hallo  welt"
+    refute RemoteHtml.to_text("<p>&#0;</p>") =~ <<0>>
+  end
+
   describe "script and style go with their contents" do
     test "a paired element leaves nothing behind" do
       assert RemoteHtml.to_text("<script>alert(1)</script><p>safe</p>") == "safe"

--- a/test/vutuv/social_feed/post_truncate_test.exs
+++ b/test/vutuv/social_feed/post_truncate_test.exs
@@ -1,0 +1,65 @@
+defmodule Vutuv.SocialFeed.PostTruncateTest do
+  @moduledoc """
+  The clamp of the remote-content stack (issue #1741).
+
+  Its own file, and `async: true`, because it is a pure string function that
+  four modules across two subsystems share — a remote post's body
+  (`Vutuv.Mastodon`, `Vutuv.Bluesky`), the reduced text of a stranger's HTML
+  (`Vutuv.RemoteHtml`) and a repository description
+  (`Vutuv.CodeStats.Snapshot`). It had no test of its own, and what it promises
+  is worth stating in one place rather than inferring from whichever caller you
+  happen to be reading.
+  """
+  use ExUnit.Case, async: true
+
+  alias Vutuv.SocialFeed.Post
+
+  test "text within the budget is returned untouched" do
+    assert Post.truncate("kurz", 10) == "kurz"
+    # Exactly at the cap is not over it.
+    assert Post.truncate("1234567890", 10) == "1234567890"
+  end
+
+  test "the cut lands between words, not inside one" do
+    assert Post.truncate("Fahrradweg am Fluss entlang", 24) == "Fahrradweg am Fluss…"
+  end
+
+  test "the last run of non-space goes even when it happened to fit exactly" do
+    # `\s+\S*$` does not ask whether the word it strips was complete, so a cut
+    # landing exactly on a word boundary still drops that word. Kept
+    # deliberately: the alternative is peeking at the character past the budget
+    # to tell "ended cleanly" from "cut mid-word", and one spare word costs less
+    # than a rule with two branches. Recorded here so the next reader knows it
+    # was a choice.
+    assert Post.truncate("Fahrradweg am Fluss entlang", 20) == "Fahrradweg am…"
+  end
+
+  test "the result never exceeds the budget" do
+    long = String.duplicate("wort ", 100)
+
+    # No 500: the fixture is exactly 500 characters, so that iteration never
+    # enters the truncating branch and only restates the first test.
+    for max <- [5, 12, 40, 160] do
+      assert String.length(Post.truncate(long, max)) <= max
+    end
+  end
+
+  test "a first word longer than the whole budget keeps the blunt cut" do
+    # There is no space to cut at, and a clamp that answered "…" would be worse
+    # than a clamp that answers as much of the word as fits.
+    assert Post.truncate("Donaudampfschifffahrtsgesellschaft", 10) == "Donaudamp…"
+  end
+
+  test "leading whitespace cannot eat the whole answer" do
+    # `\\s+\\S*$` matches the entire slice when the budget reaches no further
+    # than the first word, which would otherwise leave a bare ellipsis.
+    assert Post.truncate("   Fahrradweg am Fluss", 8) == "   Fahr…"
+  end
+
+  test "the default cap is the shared remote-post one" do
+    long = String.duplicate("a", 600)
+
+    assert String.length(Post.truncate(long)) <= 500
+    assert String.ends_with?(Post.truncate(long), "…")
+  end
+end


### PR DESCRIPTION
**Symptom, twice.** A remote server writing `&rsquo;` got `Google&rsquo;s new phone` stored verbatim: `Vutuv.RemoteHtml` decoded entities with six `String.replace/3` calls and an ordering rule kept in a comment. Six entries where the web has two thousand.

And a remote `&#0;` reached Postgres. `strip_tags/1` decodes numeric entities itself, so the byte existed before any guard ran — and this text is stored (`Fediverse.remote_text/3` writes it into a delivered post's body), where `22021 character_not_in_repertoire` is a raise on insert. Any federating server could trigger it.

**Change.** One pass over the full HTML5 table (`:mochiweb_charref`, already a transitive dep); a NUL scrub where the byte appears. `Post.truncate/2` now cuts between words for all four callers, with an O(1) `byte_size` fast path (72,255 → 16,334 reductions).

Also: the three `ugc` profile anchors withhold the referrer like `VutuvWeb.Markdown` already does, and an inverted clock bracket in `checks_test`.

Split out of #1713 at @wintermeyer's request. **#1713 — and #1760 and #1764 behind it — are stacked on this; land this first.** #1713 then promotes the two helpers to public when `Vutuv.OpenGraph` becomes their second caller.

Closes #1741.

*An AI agent wrote this text in my name. I know that is problematic.*
