### PR TITLE
refactor(posts): the reply gate is asked in one place, not two [2m]

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -383,10 +383,9 @@ defmodule Vutuv.Posts do
   renders the parent card from an id in the URL — so without this a guessed id
   would confirm and quote the post of a pending or frozen page.
 
-  Public because the reply **page** must ask it too. That page cannot run the
-  whole of `check_reply_allowed/2` (a quiet block has to let the blocked member
-  reach the composer and be refused on submit, or the block leaks), so a named
-  predicate is what keeps the two gates from drifting apart.
+  Public because it is the first arm of `answerable_by?/2`, which the reply
+  **page** asks — and it is a fair question on its own, about the post rather
+  than about anybody wanting to answer it.
   """
   def answerable?(%Post{organization_id: nil}), do: true
 
@@ -401,6 +400,24 @@ defmodule Vutuv.Posts do
       nil -> false
       page -> Organizations.public_visible?(page)
     end
+  end
+
+  @doc """
+  Whether `user` may open a composer answering `post` — the compose page's half
+  of `check_reply_allowed/2` below, which is the same rule minus the block.
+
+  The block is deliberately left out: quiet blocking has to let the blocked
+  member reach the composer and be refused on submit, or the block leaks. That
+  one difference is the whole reason the page cannot simply call the gate, and
+  it is why the rule was written out a second time in
+  `VutuvWeb.PostLive.Reply.mount/3` — where nothing tied it to the gate, so a
+  fifth arm added here would have silently missed the page (issue #1797).
+
+  `restricted?/1` here rather than the gate's fresh re-read: the page is a cheap
+  "may I show you this at all", and the submit path re-asks anyway.
+  """
+  def answerable_by?(%Post{} = post, user) do
+    answerable?(post) and visible_to?(post, user) and not restricted?(post)
   end
 
   defp check_reply_allowed(%User{} = author, %Post{} = parent) do

--- a/lib/vutuv_web/live/post_live/reply.ex
+++ b/lib/vutuv_web/live/post_live/reply.ex
@@ -1,14 +1,16 @@
 defmodule VutuvWeb.PostLive.Reply do
   @moduledoc """
   Reply page — the parent post (read-only preview) above the same composer
-  as the feed. Only visible, **public**, `Vutuv.Posts.answerable?/1` parents can
-  be answered; everything else is sent away with the unknown-id flash, so
-  existence never leaks. A post published in a page's name is answerable like any
-  other (issue #1336) as long as the page itself is publicly visible, which is
-  what `answerable?/1` — shared with `create_reply/3`'s own gate — asks; the
-  heading then names whichever author `Vutuv.Posts.author/1` hands back rather
-  than reaching for a member author a page's post has not got. A block is
-  deliberately *not* part of the gate: quiet blocking has to let the blocked
+  as the feed. Which parents may be answered is `Vutuv.Posts.answerable_by?/2`,
+  the one predicate that also states the compose half of `create_reply/3`'s own
+  gate (issue #1797) — this page used to spell its three arms out here, where
+  nothing tied them to the gate. Everything it refuses is sent away with the
+  unknown-id flash, so existence never leaks. A post published in a page's name
+  is answerable like any other (issue #1336) as long as the page itself is
+  publicly visible, which is what `answerable?/1`, that predicate's first arm,
+  asks; the heading then names whichever author `Vutuv.Posts.author/1` hands
+  back rather than reaching for a member author a page's post has not got. A
+  block is deliberately *not* part of it: quiet blocking has to let the blocked
   member reach the composer and be refused on submit, or the block leaks.
 
   **Quoting a passage** (issue #1114): a reader who marks part of a post before
@@ -36,8 +38,9 @@ defmodule VutuvWeb.PostLive.Reply do
     user = socket.assigns.current_user
     parent = Posts.get_post(id)
 
-    if parent && Posts.answerable?(parent) && Posts.visible_to?(parent, user) &&
-         not Posts.restricted?(parent) do
+    # `Vutuv.Posts.answerable_by?/2` is the compose page's half of the submit
+    # gate, and lives beside it — see its doc for why the block is not in it.
+    if parent && Posts.answerable_by?(parent, user) do
       {:ok,
        socket
        |> assign(:page_title, gettext("Reply"))

--- a/test/vutuv/posts_test.exs
+++ b/test/vutuv/posts_test.exs
@@ -1893,6 +1893,42 @@ defmodule Vutuv.PostsTest do
       assert {:error, :not_visible} = Posts.create_reply(replier, parent, %{body: "y"})
     end
 
+    test "answerable_by?/2 refuses what the submit gate refuses, save a block (issue #1797)" do
+      # The point of the shared predicate: every arm the compose page can ask
+      # is an arm the submit gate asks too, so the two cannot answer
+      # differently. Drop an arm from `answerable_by?/2` and the matching pair
+      # below goes red on its own.
+      replier = user()
+      author = user()
+      follow!(replier, author)
+
+      restricted =
+        create_post!(author, %{body: "x", denials: [%{"wildcard" => "logged_out"}]})
+
+      refute Posts.answerable_by?(restricted, replier)
+      assert {:error, :restricted} = Posts.create_reply(replier, restricted, %{body: "y"})
+
+      hidden = create_post!(author, %{body: "x", denials: [%{"denied_user_id" => replier.id}]})
+
+      refute Posts.answerable_by?(hidden, replier)
+      assert {:error, :not_visible} = Posts.create_reply(replier, hidden, %{body: "y"})
+
+      # The fourth arm — a page's post while the page is not publicly visible —
+      # is `answerable?/1` on its own, covered against a guessed id in
+      # `VutuvWeb.OrganizationPostsWebTest`.
+
+      # And the one deliberate difference, which is why the page cannot simply
+      # call the gate: a block lets the blocked member reach the composer and
+      # refuses them on submit. Allowing it here is the assertion — a quiet
+      # block that closed the composer would announce itself.
+      blocker = user()
+      blocked_parent = create_post!(blocker, %{body: "x"})
+      {:ok, _} = Vutuv.Social.block_user(blocker, replier)
+
+      assert Posts.answerable_by?(blocked_parent, replier)
+      assert {:error, :restricted} = Posts.create_reply(replier, blocked_parent, %{body: "y"})
+    end
+
     test "rejects an empty reply like an empty post" do
       parent = create_post!(user(), %{body: "x"})
 


### PR DESCRIPTION
**Symptom:** Who may answer a post is decided twice — `Vutuv.Posts.check_reply_allowed/2` asks four things, `VutuvWeb.PostLive.Reply.mount/3` spells three of them out again, and nothing ties the two lists together. A fifth arm added to the gate would silently miss the page.

**Change:** One public predicate, `Posts.answerable_by?/2`, beside the gate that owns the rest. The page calls it. No behaviour change.

**Not included:** The block stays out of the predicate. A quiet block has to let the blocked member reach the composer and be refused on submit, or it announces itself — that one difference is why the page cannot simply call the gate.

**Verified:** A new test pins both directions, including that difference. Calibrated: drop any arm and only that test goes red, which is also what shows the reply page's own tests never covered this. `mix precommit` green.

I kept the name `answerable_by?` rather than a wider "carry" word, so `main` is not left with an abstraction whose second caller sits in an unmerged branch — overrule me if you disagree. #1754 builds on this and widens it there; merging this one first is what makes that diff read as a feature.

*An AI agent wrote this text in my name. I know that is problematic.*

Closes #1797.
