### PR TITLE
refactor(mastodon-api): share the Web Push crypto instead of owning it [15m]

### DIFF
--- a/lib/vutuv/languages.ex
+++ b/lib/vutuv/languages.ex
@@ -107,6 +107,27 @@ defmodule Vutuv.Languages do
     |> Keyword.get(:locales, ["en"])
   end
 
+  @doc """
+  The language to tell somebody else this member reads, or `"en"` for a member
+  who never chose.
+
+  Deliberately **not** clamped to `site_locales/0`, which is the difference
+  between naming a locale and rendering in one. `Vutuv.Notifications.Emailer`
+  has to render, so it refuses a locale we hold no translations for; a Web Push
+  payload only *names* the language, and the reader on the other end may have
+  strings we do not — a third-party Mastodon client with a French translation
+  should be told "fr" rather than "en" (`Vutuv.MastodonApi.PushDispatcher`),
+  and our own service worker falls back to its own table on a locale it was
+  given no line for (`Vutuv.WebPush.Dispatcher`).
+
+  vutuv is installable by third parties, so the fallback is the same `"en"`
+  `VutuvWeb.Plug.Locale` falls back to, never a hardcoded `"de"` — a push and
+  the website must not disagree about what language they think this person
+  reads.
+  """
+  def user_locale(locale) when is_binary(locale) and locale != "", do: locale
+  def user_locale(_no_choice), do: "en"
+
   @doc "Whether `code` is one of the curated languages."
   def known?(code) when is_binary(code), do: MapSet.member?(@code_set, code)
   def known?(_code), do: false

--- a/lib/vutuv/mastodon_api/push_dispatcher.ex
+++ b/lib/vutuv/mastodon_api/push_dispatcher.ex
@@ -17,10 +17,9 @@ defmodule Vutuv.MastodonApi.PushDispatcher do
 
   import Ecto.Query, only: [from: 2]
 
-  require Logger
-
   alias Vutuv.Accounts.User
   alias Vutuv.ApiAuth.Token
+  alias Vutuv.Languages
   alias Vutuv.MastodonApi.Notifications
   alias Vutuv.MastodonApi.PushSubscription
   alias Vutuv.MastodonApi.WebPush
@@ -74,20 +73,10 @@ defmodule Vutuv.MastodonApi.PushDispatcher do
     )
     |> Repo.all()
     |> Enum.filter(fn {subscription, _locale} -> wants?(subscription, type) end)
-    |> Enum.map(fn {subscription, locale} -> {subscription, locale(locale)} end)
+    |> Enum.map(fn {subscription, locale} -> {subscription, Languages.user_locale(locale)} end)
   end
 
   defp wants?(%PushSubscription{alerts: alerts}, type), do: Map.get(alerts, type, true) == true
-
-  # The member's own language, not a hardcoded "de": vutuv is installable by
-  # third parties, and a client uses this to pick which of its own strings to
-  # show beside the notification. A member who never chose falls back to the
-  # same "en" `VutuvWeb.Plugs.Locale` falls back to, so the push and the website
-  # cannot disagree about what language they think this person reads.
-  @fallback_locale "en"
-
-  defp locale(value) when is_binary(value) and value != "", do: value
-  defp locale(_no_choice), do: @fallback_locale
 
   defp deliver(subscription, type, notification, locale) do
     # No content: the payload says what kind of thing happened and which
@@ -101,17 +90,11 @@ defmodule Vutuv.MastodonApi.PushDispatcher do
       body: nil
     }
 
+    # `push/2` owns what happens to the answer — a subscription the service
+    # reports as dead is deleted there, which is the same promise this module
+    # used to keep by hand and the installed app's dispatcher kept beside it.
     Task.Supervisor.start_child(Vutuv.TaskSupervisor, fn ->
-      case WebPush.send(subscription, payload) do
-        :ok ->
-          :ok
-
-        {:error, :gone} ->
-          Repo.delete(subscription)
-
-        {:error, reason} ->
-          Logger.warning("web push failed: #{inspect(reason)}")
-      end
+      WebPush.push(subscription, payload)
     end)
   end
 end

--- a/lib/vutuv/mastodon_api/push_subscription.ex
+++ b/lib/vutuv/mastodon_api/push_subscription.ex
@@ -7,8 +7,7 @@ defmodule Vutuv.MastodonApi.PushSubscription do
 
   use VutuvWeb, :model
 
-  alias Vutuv.MastodonApi.WebPush
-  alias Vutuv.Ssrf
+  alias Vutuv.WebPush.Validations
 
   @alert_kinds ~w(mention favourite reblog follow)
 
@@ -30,51 +29,13 @@ defmodule Vutuv.MastodonApi.PushSubscription do
     subscription
     |> cast(attrs, [:endpoint, :p256dh, :auth, :alerts])
     |> validate_required([:endpoint, :p256dh, :auth])
-    # The keys are base64url of a 65-byte point and a 16-byte secret; the length
-    # caps keep an oversized value out of a varchar(255) column, where Postgres
-    # would answer with a raised 22001 rather than a changeset error.
-    |> validate_length(:p256dh, max: 255)
-    |> validate_length(:auth, max: 255)
-    |> validate_change(:p256dh, &validate_key(&1, &2, 65))
-    |> validate_change(:auth, &validate_key(&1, &2, 16))
-    |> validate_change(:endpoint, &validate_endpoint/2)
+    # Shared with the installed app's own subscriptions, which store the same
+    # three values from the same browser API; see `Vutuv.WebPush.Validations`
+    # for why each check has to sit at this end.
+    |> Validations.validate_keys()
+    |> Validations.validate_endpoint()
     |> update_change(:alerts, &normalize_alerts/1)
     |> unique_constraint(:api_token_id)
-  end
-
-  # A subscription endpoint is a URL this installation will POST to, so it is
-  # the same shape of hazard as a webhook target: whoever writes it here picks
-  # where our server sends a request. https-only is not enough on its own —
-  # `https://10.0.0.5/` is a perfectly good https URL — so the literal check
-  # from `Vutuv.Ssrf` runs beside it, exactly as `Vutuv.Webhooks.Subscription`
-  # does. It is the cheap half of the pair and does no DNS, which is what makes
-  # it safe in a changeset; `Vutuv.MastodonApi.WebPush` re-checks with
-  # resolution at send time, because a public hostname can be re-pointed at an
-  # internal address after this row is written.
-  defp validate_endpoint(:endpoint, value) do
-    case URI.parse(value) do
-      %URI{scheme: "https", host: host} when is_binary(host) and host != "" ->
-        if Ssrf.internal_host?(host),
-          do: [endpoint: "must not point at a private, loopback or link-local address"],
-          else: []
-
-      _other ->
-        [endpoint: "must be an https URL"]
-    end
-  end
-
-  # The two keys are base64url of fixed-size binaries — a 65-byte P-256 point
-  # and a 16-byte secret — and they are checked here because nothing downstream
-  # can. `Vutuv.MastodonApi.WebPush` decodes them at delivery time, inside a
-  # fire-and-forget task, on **every** notification: an unusable key stored once
-  # is not one failed push, it is a task that dies again for as long as the row
-  # lives, and the member never learns why their phone is silent. The refusal
-  # belongs at the only point where somebody is still waiting for an answer.
-  defp validate_key(field, value, bytes) do
-    case WebPush.decode_key(value) do
-      {:ok, decoded} when byte_size(decoded) == bytes -> []
-      _undecodable_or_wrong_size -> [{field, "must be base64url of #{bytes} bytes"}]
-    end
   end
 
   defp normalize_alerts(alerts) when is_map(alerts) do

--- a/lib/vutuv/mastodon_api/web_push.ex
+++ b/lib/vutuv/mastodon_api/web_push.ex
@@ -1,294 +1,38 @@
 defmodule Vutuv.MastodonApi.WebPush do
   @moduledoc """
-  Web Push delivery: VAPID (RFC 8292) plus `aes128gcm` payload encryption
-  (RFC 8291 over RFC 8188).
+  The phone-client adapter's view of Web Push. Everything below is
+  `Vutuv.WebPush` — the crypto was never Mastodon-specific, and the installed
+  web app pushes through the same code with no access token in sight (issue
+  #1729).
 
-  **Deliberately no dependency.** The obvious hex package,
-  `web_push_encryption`, requires `httpoison ~> 1.0` — the HTTP client this
-  project bans (see CLAUDE.md) — and has not shipped since 2021, so taking it
-  would pin an ancient second HTTP stack beside `Req` to get a few hundred
-  lines of standard crypto. Everything below is in OTP's `:crypto`: ECDH on
-  `prime256v1`, HKDF built from `:crypto.mac/4`, and AES-128-GCM. Delivery goes
-  through `Req` like every other outbound call.
-
-  A push carries **no content**. The payload names the notification's kind and
-  its id and nothing else, so a push service — and anything reading the phone's
-  lock screen — learns that something happened, never what was said. The client
-  fetches the notification itself over the authenticated API.
-
-  **The key pair is this installation's own**, and nobody issues it: VAPID is a
-  self-signed identity, so a server that has none can simply make one. That is
-  what happens here when the operator configured nothing — the pair is derived
-  from `secret_key_base`, exactly as the login-PIN pepper is, so every node of
-  an installation computes the same one without a table, a migration or a
-  shared file, and two installations never share a key. Requiring an env var
-  first made push a feature nobody switched on: an operator who never read the
-  manual had clients answering "push is not configured" forever
-  (`WEB_PUSH_ENABLED=false` is the deliberate off switch for an intranet that
-  must not reach a push service; see `docs/ADMINS.md`).
-
-  `VAPID_PUBLIC_KEY`/`VAPID_PRIVATE_KEY` still win where they are set — both or
-  neither, since half a pair is a signature no push service will accept — which
-  is what an operator who rotates `secret_key_base` wants, and what carries a
-  key pair across a move to another installation.
+  What is *not* shared is the switch. A push to a phone client is the phone
+  client API, so `MASTODON_API_ENABLED=false` has to take it with it: a device
+  that subscribed while the adapter was on must stop being pushed to when the
+  operator switches the adapter off. A member's own installed app is unaffected
+  by that switch and gates on `Vutuv.WebPush.enabled?/0` alone.
   """
 
   alias Vutuv.MastodonApi
-  alias Vutuv.Ssrf
-  alias VutuvWeb.Endpoint
+  alias Vutuv.WebPush
 
-  @curve :prime256v1
-  @jwt_ttl_seconds 12 * 3600
-
-  # The order of P-256's base point. A derived scalar has to land inside it to
-  # be a private key at all; the odds of missing are about 2^-32, but "about"
-  # is not a thing to leave in a boot path.
-  @p256_order 0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551
-
-  @doc """
-  Whether this installation sends pushes at all. There is no "not configured"
-  state left (see the moduledoc), so this is the operator's switch — and the
-  adapter's own, because a push to a phone client is the phone client API:
-  switching that off with `MASTODON_API_ENABLED=false` must not leave devices
-  that subscribed beforehand still being pushed to.
-  """
-  def enabled?,
-    do: MastodonApi.enabled?() and Application.get_env(:vutuv, :web_push_enabled, true)
+  @doc "Whether the adapter may push: the operator's push switch AND its own."
+  def enabled?, do: MastodonApi.enabled?() and WebPush.enabled?()
 
   @doc "The VAPID public key a client needs to create a subscription."
-  def public_key, do: if(enabled?(), do: elem(keys(), 0))
+  def public_key, do: if(enabled?(), do: WebPush.public_key())
 
-  # RFC 8292 wants a way to reach whoever runs this server, and a push service
-  # is entitled to refuse a JWT without one — so the placeholder address this
-  # used to fall back to was worse than no default at all. `operator_email/0`
-  # is the adapter's own answer to "how do you reach whoever runs this", the
-  # one `security.txt` publishes.
-  defp subject, do: config(:vapid_subject) || "mailto:" <> MastodonApi.operator_email()
-
-  # Both halves or neither: an installation whose env carries a public key
-  # without its private one would advertise a key it cannot sign with, and
-  # every push would be refused by the push service with nothing in our log to
-  # say why.
-  defp keys do
-    case {config(:vapid_public_key), config(:vapid_private_key)} do
-      {public, private} when is_binary(public) and is_binary(private) -> {public, private}
-      _incomplete_or_absent -> derived_keys()
-    end
-  end
-
-  # 45µs, and its only input cannot change while a node runs, so a memo keyed
-  # on the secret would be correct — it just has to sit here rather than around
-  # `keys/0`, where it would freeze a pair an operator pins later. Not worth a
-  # `:persistent_term` write for 45µs on a path that runs once per push.
-  defp derived_keys(counter \\ 0) do
-    candidate =
-      :crypto.hash(:sha256, "vutuv/web_push/vapid/v1/#{counter}" <> secret_key_base())
-
-    case candidate do
-      <<scalar::unsigned-big-256>> when scalar > 0 and scalar < @p256_order ->
-        {public, private} = :crypto.generate_key(:ecdh, @curve, candidate)
-        {encode(public), encode(private)}
-
-      _outside_the_curve_order ->
-        derived_keys(counter + 1)
-    end
-  end
-
-  defp secret_key_base do
-    Application.fetch_env!(:vutuv, Endpoint)[:secret_key_base]
-  end
-
-  defp config(key) do
-    case Application.get_env(:vutuv, :web_push, [])[key] do
-      value when is_binary(value) and value != "" -> value
-      _absent -> nil
-    end
+  @doc "Sends one push; see `Vutuv.WebPush.send/2`."
+  def send(subscription, payload) do
+    if enabled?(), do: WebPush.send(subscription, payload), else: {:error, :disabled}
   end
 
   @doc """
-  Sends one push. Answers `:ok`, or `{:error, :gone}` when the subscription is
-  dead — the caller deletes it on that, which is how a push list stays clean
-  without a sweeper.
+  Sends one push and prunes a subscription the service reports as dead; see
+  `Vutuv.WebPush.push/2`. The gate is this module's own, so a device that
+  subscribed before `MASTODON_API_ENABLED=false` is left alone rather than
+  being deleted for an answer nobody asked for.
   """
-  def send(%{endpoint: endpoint, p256dh: p256dh, auth: auth}, payload) do
-    if enabled?() do
-      deliver(endpoint, p256dh, auth, Jason.encode!(payload))
-    else
-      {:error, :disabled}
-    end
-  end
-
-  defp deliver(endpoint, p256dh, auth, body) do
-    with :ok <- check_target(endpoint),
-         {:ok, ua_public} <- decode_key(p256dh),
-         {:ok, auth_secret} <- decode_key(auth) do
-      {encrypted, _} = encrypt(body, ua_public, auth_secret)
-
-      endpoint
-      |> Req.post(
-        body: encrypted,
-        headers: [
-          {"content-encoding", "aes128gcm"},
-          {"content-type", "application/octet-stream"},
-          {"ttl", "2419200"},
-          {"urgency", "normal"},
-          {"authorization", authorization(endpoint)}
-        ],
-        receive_timeout: 10_000,
-        retry: false,
-        # A push service has no business redirecting us, and following one would
-        # walk straight around the check above: the vetted host answers 302 and
-        # the next hop is wherever it likes. `Vutuv.Webhooks` refuses redirects
-        # for the same reason.
-        redirect: false
-      )
-      |> case do
-        {:ok, %{status: status}} when status in 200..299 -> :ok
-        {:ok, %{status: status}} when status in [404, 410] -> {:error, :gone}
-        {:ok, %{status: status}} -> {:error, {:status, status}}
-        {:error, reason} -> {:error, reason}
-      end
-    else
-      {:error, :blocked} ->
-        {:error, :blocked}
-
-      # A tagged tuple, never the bare `:error` this `with` would otherwise fall
-      # through with: the caller matches `{:error, reason}`, and a naked atom
-      # crashed its `case` rather than being logged. `PushSubscription` refuses
-      # such a key now, so this is the floor under rows written before it did.
-      _undecodable_key ->
-        {:error, :invalid_key}
-    end
-  end
-
-  # The resolving half of the SSRF pair. The changeset already refused an
-  # internal *literal*, but a hostname that was public when the subscription was
-  # written can be re-pointed at an internal address afterwards, and the whole
-  # point of a stored-then-fetched URL is that those are two different moments
-  # (`Vutuv.Webhooks` learned this as issue #775). Resolution failure is not
-  # treated as internal: there is nothing to reach, so the POST fails on its own.
-  defp check_target(endpoint) do
-    if Ssrf.resolves_to_internal?(URI.parse(endpoint).host),
-      do: {:error, :blocked},
-      else: :ok
-  end
-
-  @doc """
-  Decodes one of a subscription's base64url keys.
-
-  Padded input is accepted beside bare, and the standard alphabet beside
-  base64url: the keys are copied out of a browser's `PushManager` subscription
-  by hand-written client code, and the operator's own VAPID private key is
-  pasted in by a person. All of those spellings are in the wild, and the caller
-  checks the decoded size anyway.
-  """
-  def decode_key(value) when is_binary(value) do
-    trimmed = String.trim_trailing(value, "=")
-
-    case Base.url_decode64(trimmed, padding: false) do
-      {:ok, decoded} -> {:ok, decoded}
-      :error -> Base.decode64(trimmed, padding: false)
-    end
-  end
-
-  def decode_key(_value), do: :error
-
-  @doc """
-  RFC 8291 §3.4: one `aes128gcm` record, header and all. The whole point of the
-  ceremony is that the key is derived from a shared secret **plus** the
-  subscription's own `auth` secret, so a push service that relays the body
-  cannot read it.
-
-  `salt` and `keypair` exist so the ceremony can be checked against the test
-  vector in RFC 8291 §5, which fixes both (see `web_push_test.exs`). Left out,
-  they are fresh per message, which is what every real send does — a reused salt
-  with a reused key would leak the plaintext.
-  """
-  def encrypt(plaintext, ua_public, auth_secret, salt \\ nil, keypair \\ nil) do
-    salt = salt || :crypto.strong_rand_bytes(16)
-    {as_public, as_private} = keypair || :crypto.generate_key(:ecdh, @curve)
-    shared = :crypto.compute_key(:ecdh, ua_public, as_private, @curve)
-
-    key_info = "WebPush: info" <> <<0>> <> ua_public <> as_public
-    ikm = hkdf(auth_secret, shared, key_info, 32)
-    cek = hkdf(salt, ikm, "Content-Encoding: aes128gcm" <> <<0>>, 16)
-    nonce = hkdf(salt, ikm, "Content-Encoding: nonce" <> <<0>>, 12)
-
-    # The record delimiter is 0x02 for the last (here: only) record.
-    padded = plaintext <> <<2>>
-
-    {ciphertext, tag} =
-      :crypto.crypto_one_time_aead(:aes_128_gcm, cek, nonce, padded, <<>>, true)
-
-    header = salt <> <<4096::unsigned-big-32, byte_size(as_public)::unsigned-8>> <> as_public
-    {header <> ciphertext <> tag, salt}
-  end
-
-  # HKDF (RFC 5869) with the one-block expand every Web Push step needs.
-  defp hkdf(salt, ikm, info, length) do
-    prk = :crypto.mac(:hmac, :sha256, salt, ikm)
-    <<key::binary-size(^length), _rest::binary>> = :crypto.mac(:hmac, :sha256, prk, info <> <<1>>)
-    key
-  end
-
-  # RFC 8292: a JWT the push service checks against the public key we hand it,
-  # so only this installation can push to its own subscriptions.
-  defp authorization(endpoint) do
-    # One derivation, not two: both halves come out of the same tuple, and a
-    # member with three phones pays this per device per notification.
-    {public, private} = keys()
-    %URI{scheme: scheme, host: host} = URI.parse(endpoint)
-    audience = "#{scheme}://#{host}"
-
-    header = encode(Jason.encode!(%{typ: "JWT", alg: "ES256"}))
-
-    claims =
-      encode(
-        Jason.encode!(%{
-          aud: audience,
-          exp: System.system_time(:second) + @jwt_ttl_seconds,
-          sub: subject()
-        })
-      )
-
-    signing_input = header <> "." <> claims
-    signature = encode(sign(signing_input, private))
-
-    "vapid t=#{signing_input}.#{signature}, k=#{public}"
-  end
-
-  defp sign(message, private_key) do
-    {:ok, private} = decode_key(private_key)
-
-    :ecdsa
-    |> :crypto.sign(:sha256, message, [private, @curve])
-    |> der_to_raw()
-  end
-
-  # `:crypto.sign/4` answers DER; JWS wants the bare r‖s pair, each left-padded
-  # to the curve's 32 bytes.
-  defp der_to_raw(<<0x30, _len, 0x02, r_len, rest::binary>>) do
-    # Two matches, not one: `r_len` comes from the clause head and has to be
-    # pinned, while `s_len` is bound inside its own pattern and must not be.
-    <<r::binary-size(^r_len), tail::binary>> = rest
-    <<0x02, s_len, s::binary-size(s_len)>> = tail
-    pad(r) <> pad(s)
-  end
-
-  defp pad(<<0, rest::binary>>) when byte_size(rest) >= 32, do: pad(rest)
-  defp pad(value) when byte_size(value) == 32, do: value
-  defp pad(value), do: String.duplicate(<<0>>, 32 - byte_size(value)) <> value
-
-  defp encode(value), do: Base.url_encode64(value, padding: false)
-
-  @doc """
-  A fresh VAPID key pair as the two base64url strings an operator puts in the
-  environment. Nothing needs it — an installation derives its own pair — but it
-  is how an operator pins one that outlives a `secret_key_base` rotation. Run
-  it once with `mix run -e`, keep the private key secret.
-  """
-  def generate_keys do
-    {public, private} = :crypto.generate_key(:ecdh, @curve)
-    %{public_key: encode(public), private_key: encode(private)}
+  def push(subscription, payload) do
+    if enabled?(), do: WebPush.push(subscription, payload), else: :ok
   end
 end

--- a/lib/vutuv/web_push.ex
+++ b/lib/vutuv/web_push.ex
@@ -1,0 +1,371 @@
+defmodule Vutuv.WebPush do
+  @moduledoc """
+  Web Push delivery: VAPID (RFC 8292) plus `aes128gcm` payload encryption
+  (RFC 8291 over RFC 8188).
+
+  **Two callers, one implementation.** This started life inside the
+  Mastodon-compatible adapter, where a subscription hangs off an access token —
+  but the crypto was never Mastodon-specific, only the caller was, and the
+  installed web app has no token to hang anything off (issue #1729). So it
+  lives here, and `Vutuv.MastodonApi.WebPush` is the thin delegating module the
+  phone-client adapter keeps for its own switch.
+
+  **Deliberately no dependency.** The obvious hex package,
+  `web_push_encryption`, requires `httpoison ~> 1.0` — the HTTP client this
+  project bans (see CLAUDE.md) — and has not shipped since 2021, so taking it
+  would pin an ancient second HTTP stack beside `Req` to get a few hundred
+  lines of standard crypto. Everything below is in OTP's `:crypto`: ECDH on
+  `prime256v1`, HKDF built from `:crypto.mac/4`, and AES-128-GCM. Delivery goes
+  through `Req` like every other outbound call.
+
+  A push carries **no content**. The payload names the kind of thing that
+  happened and which one, and nothing else, so a push service — and anything
+  reading the phone's lock screen — learns that something happened, never what
+  was said. A phone client fetches the notification itself over the
+  authenticated API. That rule is why this module is worth sharing rather than
+  copying: it will matter more for the installed app than it does for a
+  third-party client, because there the result lands on a lock screen with our
+  own name on it.
+
+  **The key pair is this installation's own**, and nobody issues it: VAPID is a
+  self-signed identity, so a server that has none can simply make one. That is
+  what happens here when the operator configured nothing — the pair is derived
+  from `secret_key_base`, exactly as the login-PIN pepper is, so every node of
+  an installation computes the same one without a table, a migration or a
+  shared file, and two installations never share a key. Requiring an env var
+  first made push a feature nobody switched on: an operator who never read the
+  manual had clients answering "push is not configured" forever
+  (`WEB_PUSH_ENABLED=false` is the deliberate off switch for an intranet that
+  must not reach a push service; see `docs/ADMINS.md`).
+
+  `VAPID_PUBLIC_KEY`/`VAPID_PRIVATE_KEY` still win where they are set — both or
+  neither, since half a pair is a signature no push service will accept — which
+  is what an operator who rotates `secret_key_base` wants, and what carries a
+  key pair across a move to another installation.
+  """
+
+  # `push/2` calls this module's own `send/2`, which Elixir would otherwise read
+  # as `Kernel.send/2`. Nothing here sends a message to a process.
+  import Kernel, except: [send: 2]
+
+  require Logger
+
+  alias Vutuv.Repo
+  alias Vutuv.Ssrf
+  alias VutuvWeb.Endpoint
+
+  @curve :prime256v1
+  @jwt_ttl_seconds 12 * 3600
+
+  # The order of P-256's base point. A derived scalar has to land inside it to
+  # be a private key at all; the odds of missing are about 2^-32, but "about"
+  # is not a thing to leave in a boot path.
+  @p256_order 0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551
+
+  @doc """
+  Whether this installation sends pushes at all. There is no "not configured"
+  state left (see the moduledoc), so this is the operator's one switch, and it
+  is deliberately **not** the phone-client adapter's: the installed web app
+  pushes through this module without ever touching the Mastodon API, so
+  `MASTODON_API_ENABLED=false` must not silence a member's own phone.
+  `Vutuv.MastodonApi.WebPush` adds that gate for its own callers.
+  """
+  def enabled?, do: Application.get_env(:vutuv, :web_push_enabled, true)
+
+  @doc "The VAPID public key a client needs to create a subscription."
+  def public_key, do: if(enabled?(), do: elem(keys(), 0))
+
+  # RFC 8292 wants a way to reach whoever runs this server, and a push service
+  # is entitled to refuse a JWT without one — so the placeholder address this
+  # used to fall back to was worse than no default at all. `operator_email/0`
+  # is the adapter's own answer to "how do you reach whoever runs this", the
+  # one `security.txt` publishes.
+  defp subject, do: config(:vapid_subject) || "mailto:" <> operator_email()
+
+  defp operator_email do
+    {_name, email} = Application.fetch_env!(:vutuv, :operator_recipient)
+    email
+  end
+
+  # Both halves or neither: an installation whose env carries a public key
+  # without its private one would advertise a key it cannot sign with, and
+  # every push would be refused by the push service with nothing in our log to
+  # say why.
+  defp keys do
+    case {config(:vapid_public_key), config(:vapid_private_key)} do
+      {public, private} when is_binary(public) and is_binary(private) -> {public, private}
+      _incomplete_or_absent -> derived_keys()
+    end
+  end
+
+  # 45µs, and its only input cannot change while a node runs, so a memo keyed
+  # on the secret would be correct — it just has to sit here rather than around
+  # `keys/0`, where it would freeze a pair an operator pins later.
+  #
+  # Not worth a `:persistent_term` write while the only caller is a push that
+  # is already going out over the network. Watch this when `public_key/0`
+  # gains a caller on a **render** path rather than a send path — the installed
+  # app (issue #1729) needs it to draw its subscribe switch, which would make
+  # this once per page view per member instead of once per push. Memoise then,
+  # rather than re-reading this comment as though it still said "once per push".
+  defp derived_keys(counter \\ 0) do
+    candidate =
+      :crypto.hash(:sha256, "vutuv/web_push/vapid/v1/#{counter}" <> secret_key_base())
+
+    case candidate do
+      <<scalar::unsigned-big-256>> when scalar > 0 and scalar < @p256_order ->
+        {public, private} = :crypto.generate_key(:ecdh, @curve, candidate)
+        {encode(public), encode(private)}
+
+      _outside_the_curve_order ->
+        derived_keys(counter + 1)
+    end
+  end
+
+  defp secret_key_base do
+    Application.fetch_env!(:vutuv, Endpoint)[:secret_key_base]
+  end
+
+  defp config(key) do
+    case Application.get_env(:vutuv, :web_push, [])[key] do
+      value when is_binary(value) and value != "" -> value
+      _absent -> nil
+    end
+  end
+
+  @doc """
+  Sends one push and acts on the answer: a subscription the push service
+  reports as dead is deleted, anything else that failed is logged.
+
+  **The delete is the whole reason this exists rather than `send/2` alone.** A
+  push service reporting `404`/`410` is the only signal that a browser cleared
+  its site data or the app was uninstalled, and acting on it here is what keeps
+  both subscription lists clean without a sweeper. Left to the callers it was a
+  contract stated in a docstring and implemented twice by hand — and a third
+  caller would have had to remember it from prose.
+
+  Both subscription schemas are ordinary Ecto structs, so one `Repo.delete/1`
+  serves the phone-client rows and the installed app's alike.
+  """
+  def push(subscription, payload) do
+    case send(subscription, payload) do
+      :ok ->
+        :ok
+
+      # `allow_stale`, because two notifications a second apart are two tasks
+      # pushing to the same dead subscription: both are answered 410, and the
+      # second `Repo.delete/1` would find no row and raise
+      # `Ecto.StaleEntryError`. Deleting what is already deleted is exactly
+      # what this branch means.
+      {:error, :gone} ->
+        Repo.delete(subscription, allow_stale: true)
+        :ok
+
+      # A push nobody asked for is not a failure worth a line in the log: an
+      # installation with `WEB_PUSH_ENABLED=false` would otherwise write one
+      # per device per notification, for ever.
+      {:error, :disabled} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("web push failed: #{inspect(reason)}")
+        :ok
+    end
+  end
+
+  @doc """
+  Sends one push. Answers `:ok`, or `{:error, :gone}` when the subscription is
+  dead. Prefer `push/2`, which acts on that answer; this is the bare transport.
+  """
+  def send(%{endpoint: endpoint, p256dh: p256dh, auth: auth}, payload) do
+    if enabled?() do
+      deliver(endpoint, p256dh, auth, Jason.encode!(payload))
+    else
+      {:error, :disabled}
+    end
+  end
+
+  defp deliver(endpoint, p256dh, auth, body) do
+    with :ok <- check_target(endpoint),
+         {:ok, ua_public} <- decode_key(p256dh),
+         {:ok, auth_secret} <- decode_key(auth) do
+      {encrypted, _salt} = encrypt(body, ua_public, auth_secret)
+
+      case Req.post(endpoint, request_options(endpoint, encrypted)) do
+        {:ok, %{status: status}} when status in 200..299 -> :ok
+        {:ok, %{status: status}} when status in [404, 410] -> {:error, :gone}
+        {:ok, %{status: status}} -> {:error, {:status, status}}
+        {:error, reason} -> {:error, reason}
+      end
+    else
+      {:error, :blocked} ->
+        {:error, :blocked}
+
+      # A tagged tuple, never the bare `:error` this `with` would otherwise fall
+      # through with: the caller matches `{:error, reason}`, and a naked atom
+      # crashed its `case` rather than being logged. The two subscription
+      # changesets refuse such a key now, so this is the floor under rows
+      # written before they did.
+      _undecodable_key ->
+        {:error, :invalid_key}
+    end
+  end
+
+  # `:web_push_req_options` is the seam a test stubs the push service through
+  # (a `plug:`, the convention this app already uses for `Vutuv.Mastodon` and
+  # the fediverse fetches). Nothing sets it outside the test environment, so a
+  # real send is exactly the request written here.
+  defp request_options(endpoint, encrypted) do
+    Keyword.merge(
+      [
+        body: encrypted,
+        headers: [
+          {"content-encoding", "aes128gcm"},
+          {"content-type", "application/octet-stream"},
+          {"ttl", "2419200"},
+          {"urgency", "normal"},
+          {"authorization", authorization(endpoint)}
+        ],
+        receive_timeout: 10_000,
+        retry: false,
+        # A push service has no business redirecting us, and following one would
+        # walk straight around the check above: the vetted host answers 302 and
+        # the next hop is wherever it likes. `Vutuv.Webhooks` refuses redirects
+        # for the same reason.
+        redirect: false
+      ],
+      Application.get_env(:vutuv, :web_push_req_options, [])
+    )
+  end
+
+  # The resolving half of the SSRF pair. The changeset already refused an
+  # internal *literal*, but a hostname that was public when the subscription was
+  # written can be re-pointed at an internal address afterwards, and the whole
+  # point of a stored-then-fetched URL is that those are two different moments
+  # (`Vutuv.Webhooks` learned this as issue #775). Resolution failure is not
+  # treated as internal: there is nothing to reach, so the POST fails on its own.
+  defp check_target(endpoint) do
+    if Ssrf.resolves_to_internal?(URI.parse(endpoint).host),
+      do: {:error, :blocked},
+      else: :ok
+  end
+
+  @doc """
+  Decodes one of a subscription's base64url keys.
+
+  Padded input is accepted beside bare, and the standard alphabet beside
+  base64url: the keys are copied out of a browser's `PushManager` subscription
+  by hand-written client code, and the operator's own VAPID private key is
+  pasted in by a person. All of those spellings are in the wild, and the caller
+  checks the decoded size anyway.
+  """
+  def decode_key(value) when is_binary(value) do
+    trimmed = String.trim_trailing(value, "=")
+
+    case Base.url_decode64(trimmed, padding: false) do
+      {:ok, decoded} -> {:ok, decoded}
+      :error -> Base.decode64(trimmed, padding: false)
+    end
+  end
+
+  def decode_key(_value), do: :error
+
+  @doc """
+  RFC 8291 §3.4: one `aes128gcm` record, header and all. The whole point of the
+  ceremony is that the key is derived from a shared secret **plus** the
+  subscription's own `auth` secret, so a push service that relays the body
+  cannot read it.
+
+  `salt` and `keypair` exist so the ceremony can be checked against the test
+  vector in RFC 8291 §5, which fixes both (see `web_push_test.exs`). Left out,
+  they are fresh per message, which is what every real send does — a reused salt
+  with a reused key would leak the plaintext.
+  """
+  def encrypt(plaintext, ua_public, auth_secret, salt \\ nil, keypair \\ nil) do
+    salt = salt || :crypto.strong_rand_bytes(16)
+    {as_public, as_private} = keypair || :crypto.generate_key(:ecdh, @curve)
+    shared = :crypto.compute_key(:ecdh, ua_public, as_private, @curve)
+
+    key_info = "WebPush: info" <> <<0>> <> ua_public <> as_public
+    ikm = hkdf(auth_secret, shared, key_info, 32)
+    cek = hkdf(salt, ikm, "Content-Encoding: aes128gcm" <> <<0>>, 16)
+    nonce = hkdf(salt, ikm, "Content-Encoding: nonce" <> <<0>>, 12)
+
+    # The record delimiter is 0x02 for the last (here: only) record.
+    padded = plaintext <> <<2>>
+
+    {ciphertext, tag} =
+      :crypto.crypto_one_time_aead(:aes_128_gcm, cek, nonce, padded, <<>>, true)
+
+    header = salt <> <<4096::unsigned-big-32, byte_size(as_public)::unsigned-8>> <> as_public
+    {header <> ciphertext <> tag, salt}
+  end
+
+  # HKDF (RFC 5869) with the one-block expand every Web Push step needs.
+  defp hkdf(salt, ikm, info, length) do
+    prk = :crypto.mac(:hmac, :sha256, salt, ikm)
+    <<key::binary-size(^length), _rest::binary>> = :crypto.mac(:hmac, :sha256, prk, info <> <<1>>)
+    key
+  end
+
+  # RFC 8292: a JWT the push service checks against the public key we hand it,
+  # so only this installation can push to its own subscriptions.
+  defp authorization(endpoint) do
+    # One derivation, not two: both halves come out of the same tuple, and a
+    # member with three phones pays this per device per notification.
+    {public, private} = keys()
+    %URI{scheme: scheme, host: host} = URI.parse(endpoint)
+    audience = "#{scheme}://#{host}"
+
+    header = encode(Jason.encode!(%{typ: "JWT", alg: "ES256"}))
+
+    claims =
+      encode(
+        Jason.encode!(%{
+          aud: audience,
+          exp: System.system_time(:second) + @jwt_ttl_seconds,
+          sub: subject()
+        })
+      )
+
+    signing_input = header <> "." <> claims
+    signature = encode(sign(signing_input, private))
+
+    "vapid t=#{signing_input}.#{signature}, k=#{public}"
+  end
+
+  defp sign(message, private_key) do
+    {:ok, private} = decode_key(private_key)
+
+    :ecdsa
+    |> :crypto.sign(:sha256, message, [private, @curve])
+    |> der_to_raw()
+  end
+
+  # `:crypto.sign/4` answers DER; JWS wants the bare r‖s pair, each left-padded
+  # to the curve's 32 bytes.
+  defp der_to_raw(<<0x30, _len, 0x02, r_len, rest::binary>>) do
+    # Two matches, not one: `r_len` comes from the clause head and has to be
+    # pinned, while `s_len` is bound inside its own pattern and must not be.
+    <<r::binary-size(^r_len), tail::binary>> = rest
+    <<0x02, s_len, s::binary-size(s_len)>> = tail
+    pad(r) <> pad(s)
+  end
+
+  defp pad(<<0, rest::binary>>) when byte_size(rest) >= 32, do: pad(rest)
+  defp pad(value) when byte_size(value) == 32, do: value
+  defp pad(value), do: String.duplicate(<<0>>, 32 - byte_size(value)) <> value
+
+  defp encode(value), do: Base.url_encode64(value, padding: false)
+
+  @doc """
+  A fresh VAPID key pair as the two base64url strings an operator puts in the
+  environment. Nothing needs it — an installation derives its own pair — but it
+  is how an operator pins one that outlives a `secret_key_base` rotation. Run
+  it once with `mix run -e`, keep the private key secret.
+  """
+  def generate_keys do
+    {public, private} = :crypto.generate_key(:ecdh, @curve)
+    %{public_key: encode(public), private_key: encode(private)}
+  end
+end

--- a/lib/vutuv/web_push/validations.ex
+++ b/lib/vutuv/web_push/validations.ex
@@ -1,0 +1,80 @@
+defmodule Vutuv.WebPush.Validations do
+  @moduledoc """
+  The changeset rules a Web Push subscription obeys, wherever it came from.
+
+  Today one schema writes them, `Vutuv.MastodonApi.PushSubscription`, for a
+  phone client holding an access token. They live out here rather than in it
+  because the values are not the adapter's: they are the three a browser's
+  `PushManager` hands over, so any second subscriber — the installed app's own
+  worker is the one coming (issue #1729) — owes exactly the same checks, and a
+  check that lives inside one schema is a check the next one is one refactor
+  away from losing.
+  """
+
+  import Ecto.Changeset
+
+  alias Vutuv.Ssrf
+  alias Vutuv.WebPush
+
+  @doc """
+  The endpoint: an https URL that is not an internal address.
+
+  A subscription endpoint is a URL this installation will POST to, so it is
+  the same shape of hazard as a webhook target: whoever writes it here picks
+  where our server sends a request. https-only is not enough on its own —
+  `https://10.0.0.5/` is a perfectly good https URL — so the literal check
+  from `Vutuv.Ssrf` runs beside it, exactly as `Vutuv.Webhooks.Subscription`
+  does. It is the cheap half of the pair and does no DNS, which is what makes
+  it safe in a changeset; `Vutuv.WebPush` re-checks with resolution at send
+  time, because a public hostname can be re-pointed at an internal address
+  after this row is written.
+  """
+  def validate_endpoint(changeset) do
+    validate_change(changeset, :endpoint, &endpoint_errors/2)
+  end
+
+  defp endpoint_errors(:endpoint, value) do
+    case URI.parse(value) do
+      %URI{scheme: "https", host: host} when is_binary(host) and host != "" ->
+        internal_host_errors(host)
+
+      _other ->
+        [endpoint: "must be an https URL"]
+    end
+  end
+
+  defp internal_host_errors(host) do
+    if Ssrf.internal_host?(host),
+      do: [endpoint: "must not point at a private, loopback or link-local address"],
+      else: []
+  end
+
+  @doc """
+  The two keys: base64url of fixed-size binaries — a 65-byte P-256 point and a
+  16-byte secret.
+
+  They are checked here because nothing downstream can. `Vutuv.WebPush`
+  decodes them at delivery time, inside a fire-and-forget task, on **every**
+  notification: an unusable key stored once is not one failed push, it is a
+  task that dies again for as long as the row lives, and the member never
+  learns why their phone is silent. The refusal belongs at the only point
+  where somebody is still waiting for an answer.
+
+  The length caps keep an oversized value out of a varchar(255) column, where
+  Postgres would answer with a raised 22001 rather than a changeset error.
+  """
+  def validate_keys(changeset) do
+    changeset
+    |> validate_length(:p256dh, max: 255)
+    |> validate_length(:auth, max: 255)
+    |> validate_change(:p256dh, &validate_key(&1, &2, 65))
+    |> validate_change(:auth, &validate_key(&1, &2, 16))
+  end
+
+  defp validate_key(field, value, bytes) do
+    case WebPush.decode_key(value) do
+      {:ok, decoded} when byte_size(decoded) == bytes -> []
+      _undecodable_or_wrong_size -> [{field, "must be base64url of #{bytes} bytes"}]
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.525.1",
+      version: "7.534.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.507.2",
+      version: "7.531.8",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/web_push_test.exs
+++ b/test/vutuv/web_push_test.exs
@@ -1,4 +1,4 @@
-defmodule Vutuv.MastodonApi.WebPushTest do
+defmodule Vutuv.WebPushTest do
   @moduledoc """
   The Web Push payload encryption, against the test vector in **RFC 8291 §5**.
 
@@ -21,7 +21,7 @@ defmodule Vutuv.MastodonApi.WebPushTest do
   """
   use ExUnit.Case, async: false
 
-  alias Vutuv.MastodonApi.WebPush
+  alias Vutuv.WebPush
 
   # RFC 8291 §5, verbatim.
   @plaintext "When I grow up, I want to be a watermelon"
@@ -114,6 +114,28 @@ defmodule Vutuv.MastodonApi.WebPushTest do
 
       refute WebPush.enabled?()
       refute WebPush.public_key()
+    end
+
+    # The reason this module was lifted out of the Mastodon adapter (issue
+    # #1729): a member's own installed app pushes through here without ever
+    # touching the phone-client API, so switching that adapter off must not
+    # silence their phone. `Vutuv.MastodonApi.WebPush` keeps the narrower gate
+    # for its own callers, which `push_streaming_test.exs` pins.
+    test "is unaffected by the phone-client adapter's own switch" do
+      Application.put_env(:vutuv, :web_push_enabled, true)
+      original = Application.fetch_env(:vutuv, :mastodon_api_enabled)
+      Application.put_env(:vutuv, :mastodon_api_enabled, false)
+
+      on_exit(fn ->
+        case original do
+          {:ok, was} -> Application.put_env(:vutuv, :mastodon_api_enabled, was)
+          :error -> Application.delete_env(:vutuv, :mastodon_api_enabled)
+        end
+      end)
+
+      assert WebPush.enabled?()
+      assert is_binary(WebPush.public_key())
+      refute Vutuv.MastodonApi.WebPush.enabled?()
     end
 
     test "an installation with push off refuses to send rather than trying" do

--- a/test/vutuv_web/controllers/mastodon_api/push_streaming_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/push_streaming_test.exs
@@ -33,7 +33,7 @@ defmodule VutuvWeb.MastodonApi.PushStreamingTest do
 
   # Push on, with a pinned pair — what an operator who set the env vars has.
   defp pinned_keys do
-    keys = WebPush.generate_keys()
+    keys = Vutuv.WebPush.generate_keys()
     enable_push()
     with_vapid(vapid_public_key: keys.public_key, vapid_private_key: keys.private_key)
     keys
@@ -52,7 +52,7 @@ defmodule VutuvWeb.MastodonApi.PushStreamingTest do
 
   describe "VAPID keys" do
     test "generate_keys/0 produces a usable pair" do
-      %{public_key: public, private_key: private} = WebPush.generate_keys()
+      %{public_key: public, private_key: private} = Vutuv.WebPush.generate_keys()
 
       assert {:ok, decoded_public} = Base.url_decode64(public, padding: false)
       assert byte_size(decoded_public) == 65


### PR DESCRIPTION
First half of #1729, split out of #1752 at your request — **land this one first**.

**Where:** `Vutuv.WebPush`, `Vutuv.MastodonApi.WebPush`.

The VAPID and `aes128gcm` crypto lived inside the Mastodon adapter, where a subscription hangs off an API access token. An installed web app has no token, so it could reach none of it without dragging the adapter's `MASTODON_API_ENABLED` gate along — a gate that must not silence a member's own app.

- `Vutuv.WebPush` owns the keys and the delivery; `Vutuv.MastodonApi.WebPush` is a thin delegate that keeps its own gate.
- The changeset rules move to `Vutuv.WebPush.Validations`, so a second schema cannot quietly lose the SSRF check.
- `push/2` owns deleting a subscription the push service reports gone — the promise the dispatcher kept by hand.

Behaviour-preserving: no new table, route or config. #1752 is rebased onto this and carries the service worker, the new table and the settings switch.
