### PR TITLE
Announce a released fediverse picture so the card stops waiting

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -1687,6 +1687,41 @@ renders as a neutral waiting tile with the same hourglass a member's own held
 post wears, because a photo post with its picture silently absent is not a quiet
 card, it is a broken one.
 
+**The verdict is announced, and it has to be** (issue #1801). Every other image
+kind reports itself through `Vutuv.Activity.broadcast(scan.owner_user_id, …)`,
+and these two are the ownerless ones, so for a while nothing was sent at all:
+`ImageSubjects.apply_approved/1` flipped a column and stopped, and a card
+already on screen kept its waiting tile until the reader pressed reload. That is
+the *ordinary* path, not an edge: `record_remote_post/2` records the picture and
+nudges the open feeds in the same breath, a second before the download finishes,
+so the first draw of a boosted photo post is the wordless tile — and it was also
+the last. Measured on production, a picture was approved 88 seconds before the
+screenshot that reported the bug.
+
+So both verdicts broadcast `{:remote_images_settled, %{remote_post_id: id}}` on
+`Fediverse.remote_images_topic/0` — **one** topic, the arrangement
+`counts_topic/0` makes and for the same reason: a verdict is rare, and each
+listener keeps only the cards it is showing. The alternative, a topic per
+waiting picture, would make every listening page walk its own entries at mount
+and again on each append, which is a great deal of bookkeeping for an event this
+quiet. A verdict that lost its race announces nothing, having changed no row.
+
+Listening is `VutuvWeb.Live.RemoteImages`, an `on_mount` hook, because the
+waiting tile prints its promise from **one shared component on six pages** (the
+feed, the post's own page, the account page, the URL lookup, a tag timeline and
+an organization's feed) and a guarantee made in one place must not depend on six
+hosts each remembering a subscription. It has two modes, since the pictures are
+held in two shapes: `:assigns` owns a page whose pictures are one `@images`
+assign end to end (no handler at all), and the default mode only subscribes, for
+a timeline whose cards are in a stream and whose redraw only it can write.
+
+**A remote account's avatar is deliberately left out**, though it is the other
+ownerless kind and just as silent: an unreleased avatar renders as the account's
+initials, a whole placeholder rather than a promise, so nobody is left waiting on
+it. `Fediverse.refresh_remote_account/1` does flip an approved avatar back to
+`pending` on an actor `Update`, so an open page can lose a face until the next
+load; if that is worth fixing, this is the topic it joins.
+
 Deletion is the part that is easy to get wrong: rows cascade, **files do not**.
 Every single-post delete therefore goes through one chokepoint
 (`delete_cached_post/1`) and every bulk sweep through `wipe_media/1` /

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -134,6 +134,9 @@ defmodule Vutuv.Fediverse do
   # well-known collection URI whose spelling the audience readers depend on.
   @followers_suffix "/followers"
 
+  # One topic for every picture leaving the AI gate; see `remote_images_topic/0`.
+  @remote_images_topic "fediverse:remote_images"
+
   @doc "The installation-wide switch (FEDIVERSE_ENABLED; off = no endpoints, no deliveries)."
   def enabled?, do: Application.get_env(:vutuv, :fediverse_enabled, true)
 
@@ -3190,6 +3193,75 @@ defmodule Vutuv.Fediverse do
     |> Repo.all()
     |> Enum.group_by(& &1.remote_post_id)
   end
+
+  @doc """
+  Every picture recorded for one cached post, in the author's order.
+
+  The singular of `list_remote_images/1`, and the same deliberate lack of a
+  filter: a row here is not a permission (see above). It exists because six
+  surfaces draw these pictures and each of them re-reads one post's set when a
+  verdict lands, which was `Map.get(list_remote_images([id]), id, [])` written
+  out four times.
+  """
+  def remote_images(remote_post_id) when is_binary(remote_post_id),
+    do: [remote_post_id] |> list_remote_images() |> Map.get(remote_post_id, [])
+
+  @doc """
+  The topic every open page listens on for a picture leaving the AI gate
+  (issue #1801).
+
+  **One** topic rather than one per waiting post, the arrangement
+  `counts_topic/0` makes and for the same reason: a verdict is rare (a few an
+  hour on a busy installation, against a counts refresh every couple of
+  minutes), and each listener keeps only the cards it is showing. The
+  alternative — subscribing per picture that happens to be waiting — makes
+  every one of those six surfaces walk its own entries at mount and again on
+  every page append, which is a great deal of bookkeeping for an event this
+  quiet.
+  """
+  def remote_images_topic, do: @remote_images_topic
+
+  @doc "Listen for pictures leaving the AI gate. See `remote_images_topic/0`."
+  def subscribe_remote_images, do: Phoenix.PubSub.subscribe(Vutuv.PubSub, @remote_images_topic)
+
+  @doc """
+  Tells every open page that one of a cached post's pictures has left the AI
+  gate (issue #1801).
+
+  **Both verdicts**, because both change the row a card was drawn from: an
+  approval swaps the picture in for the waiting tile, a rejection clears the
+  file. What the tile then *says* about a rejected picture is a separate
+  question and still the wrong answer — it goes on claiming a check is running
+  for a picture that will never arrive.
+
+  Until this existed the verdict was a database flip and nothing else. Every
+  other image kind announces itself through
+  `Vutuv.Activity.broadcast(scan.owner_user_id, …)`, and a picture we fetched
+  has no owner here, so a card kept whatever it was first drawn with. That is
+  not a corner case: a delivery records the picture and nudges the open feeds
+  in the same breath, a second before the bytes land, so the *first* draw of a
+  boosted photo post is the wordless "picture is being checked" tile — and
+  without this it was also the last.
+
+  **A remote account's avatar is deliberately not announced**, though it is the
+  other ownerless scan kind and goes just as quiet: an avatar the gate has not
+  cleared renders as the account's initials, which is a whole placeholder
+  rather than a promise, so nobody is left waiting on it. If that changes, this
+  is the topic it joins.
+
+  `nil` is a no-op, the way every notification chokepoint here takes a missing
+  recipient: the retention sweep can take the post while the model is still
+  looking at its picture.
+  """
+  def broadcast_remote_images_settled(remote_post_id) when is_binary(remote_post_id) do
+    Phoenix.PubSub.broadcast(
+      Vutuv.PubSub,
+      @remote_images_topic,
+      {:remote_images_settled, %{remote_post_id: remote_post_id}}
+    )
+  end
+
+  def broadcast_remote_images_settled(_remote_post_id), do: :ok
 
   @doc """
   The **cached reply** each of `post_ids` answers, keyed by post id (issue

--- a/lib/vutuv/moderation/image_subjects.ex
+++ b/lib/vutuv/moderation/image_subjects.ex
@@ -16,6 +16,7 @@ defmodule Vutuv.Moderation.ImageSubjects do
   import Ecto.Query
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemoteImage
   alias Vutuv.JobReferenceDocument
@@ -446,7 +447,11 @@ defmodule Vutuv.Moderation.ImageSubjects do
     # Before the flip, for the reason the gallery clause above gives. The
     # rejection path needs no such line: it wipes the directory.
     RemoteMedia.delete_post_image_pixelated(scan.subject_id)
-    verdict_applied(flip_remote(RemoteImage, scan, :file, :moderation, "approved"))
+
+    RemoteImage
+    |> flip_remote(scan, :file, :moderation, "approved")
+    |> verdict_applied()
+    |> announce_when_applied(scan)
   end
 
   def apply_approved(%ImageScan{kind: "remote_avatar"} = scan) do
@@ -469,7 +474,7 @@ defmodule Vutuv.Moderation.ImageSubjects do
         # announced once it is released (no quarantine move — covers are
         # served through the authorizing proxy, which checks this state).
         Vutuv.Posts.broadcast_review_cover_ready(review.post_id)
-        Vutuv.Fediverse.images_settled(review.post_id)
+        Fediverse.images_settled(review.post_id)
         :ok
 
       _ ->
@@ -609,7 +614,7 @@ defmodule Vutuv.Moderation.ImageSubjects do
              flip_remote(RemoteImage, scan, :file, :moderation, nil, clear_file: true)
            ) do
       RemoteMedia.delete_post_image(scan.subject_id)
-      :ok
+      announce_when_applied(:ok, scan)
     end
   end
 
@@ -633,7 +638,7 @@ defmodule Vutuv.Moderation.ImageSubjects do
         Vutuv.ReviewCover.delete_files(%PostReview{id: scan.subject_id})
         # The cover is settled (as gone), so a post held for it federates now.
         case Repo.get(PostReview, scan.subject_id) do
-          %PostReview{post_id: post_id} -> Vutuv.Fediverse.images_settled(post_id)
+          %PostReview{post_id: post_id} -> Fediverse.images_settled(post_id)
           nil -> :ok
         end
 
@@ -653,6 +658,25 @@ defmodule Vutuv.Moderation.ImageSubjects do
   # how a stale verdict would slip through.
   defp verdict_applied({1, _}), do: :ok
   defp verdict_applied(_other), do: :stale
+
+  # What every open card showing this cached post is waiting for (issue #1801).
+  # Takes the verdict's own answer and returns it unchanged, so a `:stale` one
+  # announces nothing: it changed no row, and sending every listener back to the
+  # database for an unchanged state is worse than silence.
+  #
+  # The post id is read after the flip because both verdicts leave the row
+  # standing (a rejection clears `file` and keeps it). A row the retention sweep
+  # has taken meanwhile reads as `nil`, which the broadcast takes as a no-op.
+  defp announce_when_applied(:ok, %ImageScan{subject_id: subject_id}) do
+    Fediverse.broadcast_remote_images_settled(remote_post_id_of(subject_id))
+    :ok
+  end
+
+  defp announce_when_applied(other, _scan), do: other
+
+  defp remote_post_id_of(image_id) do
+    Repo.one(from(i in RemoteImage, where: i.id == ^image_id, select: i.remote_post_id))
+  end
 
   defp flip_remote(schema, scan, file_field, state_field, state, opts \\ []) do
     sets =
@@ -690,7 +714,7 @@ defmodule Vutuv.Moderation.ImageSubjects do
   defp settled(nil), do: :ok
 
   defp settled(post_id) do
-    Vutuv.Fediverse.images_settled(post_id)
+    Fediverse.images_settled(post_id)
     Vutuv.Posts.broadcast_images_settled(post_id)
   end
 

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -2208,11 +2208,16 @@ defmodule VutuvWeb.PostComponents do
   @doc """
   The pictures on a post from another network (issue #1163).
 
-  Only released ones ever reach here (`Vutuv.Fediverse.list_remote_images/1`
-  filters on the AI gate), so this component's own job is the second, separate
-  condition: a picture its **author** flagged sensitive, or one under their
-  content warning, renders blurred behind a click. That is deliberately not
-  overridable by our verdict — our model judging a picture safe does not
+  **Unreleased ones reach here too.** `Vutuv.Fediverse.list_remote_images/1`
+  deliberately does not filter on the AI gate (this doc claimed the opposite
+  until issue #1801, while the waiting tile below was already the proof), so
+  `RemoteImage.released?/1` is asked here, per picture, and the tile is what a
+  reader gets meanwhile.
+
+  The gate is one of two independent conditions, and the second is this
+  component's own: a picture its **author** flagged sensitive, or one under
+  their content warning, renders blurred behind a click. That is deliberately
+  not overridable by our verdict — our model judging a picture safe does not
   overrule the person who published it asking for it to be covered.
 
   The alt text is the author's own, kept through the whole journey, because it

--- a/lib/vutuv_web/live/fediverse_account_live.ex
+++ b/lib/vutuv_web/live/fediverse_account_live.ex
@@ -53,6 +53,10 @@ defmodule VutuvWeb.FediverseAccountLive do
   # while this page is open (issue #1283). One line, no handler.
   on_mount(VutuvWeb.Live.RemoteCounts)
 
+  # And a picture on any of the cards appears the moment the AI gate releases it
+  # (issue #1801). One line, no handler: `@images` is the map keyed by post id.
+  on_mount({VutuvWeb.Live.RemoteImages, :assigns})
+
   @impl true
   def mount(%{"id" => id}, _session, socket) do
     case Fediverse.get_remote_account(id) do

--- a/lib/vutuv_web/live/fediverse_lookup_live.ex
+++ b/lib/vutuv_web/live/fediverse_lookup_live.ex
@@ -59,6 +59,10 @@ defmodule VutuvWeb.FediverseLookupLive do
   # while this page is open (issue #1283). One line, no handler.
   on_mount(VutuvWeb.Live.RemoteCounts)
 
+  # And a picture on the result appears the moment the AI gate releases it
+  # (issue #1801). One line, no handler: `@images` is a plain list.
+  on_mount({VutuvWeb.Live.RemoteImages, :assigns})
+
   @impl true
   def mount(_params, _session, socket) do
     {:ok,
@@ -167,7 +171,6 @@ defmodule VutuvWeb.FediverseLookupLive do
 
   defp load_result(socket, post) do
     viewer = socket.assigns.current_user
-    ids = [post.id]
 
     # No like/repost marks are read here: the card embeds `RemoteActionsComponent`,
     # which loads its own. Assigning them cost two queries per lookup for values
@@ -175,7 +178,7 @@ defmodule VutuvWeb.FediverseLookupLive do
     # could have read them without crashing on the empty state.
     socket
     |> assign(:post, post)
-    |> assign(:images, Map.get(Fediverse.list_remote_images(ids), post.id, []))
+    |> assign(:images, Fediverse.remote_images(post.id))
     |> assign(:follow, Fediverse.remote_follow_for(viewer, post.remote_account))
   end
 

--- a/lib/vutuv_web/live/fediverse_post_live.ex
+++ b/lib/vutuv_web/live/fediverse_post_live.ex
@@ -52,6 +52,11 @@ defmodule VutuvWeb.FediversePostLive do
   # while this page is open (issue #1283). One line, no handler.
   on_mount(VutuvWeb.Live.RemoteCounts)
 
+  # And its pictures appear the moment the AI gate releases them (issue #1801).
+  # This page is the one a reader opens *because* of the picture, so a tile that
+  # waits for a reload is the plainest form of the broken promise it prints.
+  on_mount({VutuvWeb.Live.RemoteImages, :assigns})
+
   @impl true
   def mount(%{"id" => id}, _session, socket) do
     viewer = socket.assigns.current_user
@@ -75,7 +80,7 @@ defmodule VutuvWeb.FediversePostLive do
       gettext("A post by %{name} (another network)", name: RemoteAccount.label(account))
     )
     |> assign(:remote_post, post)
-    |> assign(:images, Map.get(Fediverse.list_remote_images([post.id]), post.id, []))
+    |> assign(:images, Fediverse.remote_images(post.id))
     # Whether the ⋯ menu offers Mute and Unfollow at all. This page is reachable
     # for a public post whose author the reader does not follow (it is cached
     # because somebody else does), and acting on a follow that does not exist is

--- a/lib/vutuv_web/live/organization_live/feed.ex
+++ b/lib/vutuv_web/live/organization_live/feed.ex
@@ -32,10 +32,17 @@ defmodule VutuvWeb.OrganizationLive.Feed do
   import VutuvWeb.OrganizationComponents, only: [manage_header: 1]
   import VutuvWeb.PostComponents, only: [post_card: 1, remote_post_card: 1]
 
+  alias Vutuv.Fediverse
   alias Vutuv.Organizations
   alias Vutuv.Posts
   alias VutuvWeb.Live.InitAssigns
+  alias VutuvWeb.Live.RemoteImages
   alias VutuvWeb.Live.RemotePostActions
+
+  # A picture on a card from another network appears the moment the AI gate
+  # releases it (issue #1801). This page holds its entries in a plain assign,
+  # so the redraw below is a re-assign rather than a stream write.
+  on_mount(VutuvWeb.Live.RemoteImages)
 
   @impl true
   def mount(_params, session, socket) do
@@ -99,7 +106,25 @@ defmodule VutuvWeb.OrganizationLive.Feed do
   end
 
   @impl true
+  def handle_info({:remote_images_settled, %{remote_post_id: id}}, socket) do
+    {:noreply, restate_remote_images(socket, id)}
+  end
+
   def handle_info(_message, socket), do: {:noreply, socket}
+
+  # Every open page hears every verdict, so the cheap "is it even on this page"
+  # question comes before the read.
+  defp restate_remote_images(socket, remote_post_id) do
+    if Enum.any?(socket.assigns.entries, &RemoteImages.draws?(&1, remote_post_id)) do
+      images = Fediverse.remote_images(remote_post_id)
+
+      update(socket, :entries, fn entries ->
+        Enum.map(entries, &RemoteImages.restate_entry(&1, remote_post_id, images))
+      end)
+    else
+      socket
+    end
+  end
 
   @impl true
   def render(assigns) do

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -39,6 +39,7 @@ defmodule VutuvWeb.PostLive.Feed do
   alias Phoenix.LiveView.JS
   alias Vutuv.Activity
   alias Vutuv.ContentFilters
+  alias Vutuv.Fediverse
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Social
@@ -47,6 +48,7 @@ defmodule VutuvWeb.PostLive.Feed do
   alias VutuvWeb.Live.InitAssigns
   alias VutuvWeb.Live.MountHandoff
   alias VutuvWeb.Live.PostTranslations
+  alias VutuvWeb.Live.RemoteImages
   alias VutuvWeb.Live.RemotePostActions
   alias VutuvWeb.Live.RemoteReplyActions
   alias VutuvWeb.PostTeaser
@@ -55,6 +57,11 @@ defmodule VutuvWeb.PostLive.Feed do
   # The origin's like/repost figures on a card from another network tick
   # while this page is open (issue #1283). One line, no handler.
   on_mount(VutuvWeb.Live.RemoteCounts)
+
+  # A picture on such a card appears the moment the AI gate releases it (issue
+  # #1801). The timeline mode: the cards are in a stream, so this listens and
+  # `handle_info({:remote_images_settled, …}, …)` below does the redraw.
+  on_mount(VutuvWeb.Live.RemoteImages)
 
   # What a mount loads, and what every older page after it adds. The arrival
   # page is deliberately double the rest: it is the one page nobody asked for,
@@ -1433,6 +1440,14 @@ defmodule VutuvWeb.PostLive.Feed do
     {:noreply, refresh_shown_post(socket, post_id)}
   end
 
+  # The same for a picture on a cached post from another network (issue #1801).
+  # It matters more here than for a member's own photo: a delivery draws the
+  # card in the second between recording the picture and its bytes landing, so
+  # the reader's FIRST sight of a boosted photo post is the waiting tile.
+  def handle_info({:remote_images_settled, %{remote_post_id: id}}, socket) do
+    {:noreply, refresh_remote_images(socket, id)}
+  end
+
   # The worker finished a translation this reader asked for (issue #1462):
   # swap it into the one card, or clear the pending line on a failure.
   def handle_info({:translation_ready, translation}, socket) do
@@ -1608,6 +1623,32 @@ defmodule VutuvWeb.PostLive.Feed do
     else
       _ -> socket
     end
+  end
+
+  # Re-read one cached post's pictures into every card on the page that draws it
+  # (issue #1801). Every card, not the first: the same post can be on the page
+  # twice, once as itself and once as the parent another card nests, and both
+  # show the same waiting tile. One pass in the shape `drop_note/2` uses, so the
+  # retained list and the stream are written once each rather than per hit.
+  defp refresh_remote_images(socket, remote_post_id) do
+    if Enum.any?(socket.assigns.entries, &RemoteImages.draws?(&1, remote_post_id)),
+      do: restream_remote_images(socket, remote_post_id),
+      else: socket
+  end
+
+  defp restream_remote_images(socket, remote_post_id) do
+    images = Fediverse.remote_images(remote_post_id)
+
+    {entries, changed} =
+      Enum.map_reduce(socket.assigns.entries, [], fn entry, changed ->
+        case RemoteImages.restate_entry(entry, remote_post_id, images) do
+          ^entry -> {entry, changed}
+          updated -> {updated, [updated | changed]}
+        end
+      end)
+
+    socket = assign(socket, :entries, entries)
+    Enum.reduce(changed, socket, &stream_insert(&2, :posts, &1, update_only: true))
   end
 
   # Swap the refreshed entry into the retained list by its stable entry id.

--- a/lib/vutuv_web/live/remote_images.ex
+++ b/lib/vutuv_web/live/remote_images.ex
@@ -1,0 +1,123 @@
+defmodule VutuvWeb.Live.RemoteImages do
+  @moduledoc """
+  Makes a picture on a cached post appear the moment the AI gate releases it,
+  on every page that draws one (issue #1801).
+
+  The waiting tile prints a promise — "It appears here by itself once it is
+  through" — and `VutuvWeb.PostComponents.remote_post_images/1` prints it on
+  **six** surfaces: the feed, a cached post's own page, the account page, the
+  URL lookup, a tag timeline and an organization's feed. The promise was false
+  on all six, because `Vutuv.Moderation.ImageSubjects` announced these verdicts
+  to nobody (they are the ownerless scans, and its broadcast goes to the
+  uploader's topic). The card kept whatever it was first drawn with until the
+  reader pressed reload — which for a boosted photo post is the wordless tile,
+  the delivery drawing the card a second before the bytes land.
+
+  It is an `on_mount` hook for the reason `VutuvWeb.Live.RemoteCounts` is one: a
+  guarantee the shared component makes on six pages must not depend on six hosts
+  each remembering to subscribe, and a host that forgets simply never updates —
+  nothing fails and nothing logs.
+
+  ## Two modes, because the pictures are held in two shapes
+
+      on_mount({VutuvWeb.Live.RemoteImages, :assigns})
+
+  for a page whose pictures are one `@images` assign: a bare list where the page
+  is about a single cached post, or the `%{post_id => [picture]}` map a listing
+  holds. The hook owns it end to end and the host writes no `handle_info/2` at
+  all.
+
+      on_mount(VutuvWeb.Live.RemoteImages)
+
+  for a timeline, whose pictures ride each entry and whose cards live in a
+  stream. That cannot be done from here — the stream's name and the entry's
+  identity are the host's — so the hook only subscribes and the host writes one
+  `handle_info/2` clause over `restate_entry/3`.
+  """
+
+  import Phoenix.Component, only: [assign: 3]
+  import Phoenix.LiveView, only: [attach_hook: 4, connected?: 1]
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.RemotePost
+
+  # Connected sockets only, in both modes: the dead render is replaced the
+  # moment the socket joins, so subscribing for it would be a subscription
+  # nobody reads.
+  def on_mount(:default, _params, _session, socket) do
+    if connected?(socket), do: Fediverse.subscribe_remote_images()
+    {:cont, socket}
+  end
+
+  def on_mount(:assigns, _params, _session, socket) do
+    if connected?(socket) do
+      Fediverse.subscribe_remote_images()
+      {:cont, attach_hook(socket, :remote_images, :handle_info, &reload_assign/2)}
+    else
+      {:cont, socket}
+    end
+  end
+
+  defp reload_assign({:remote_images_settled, %{remote_post_id: id}}, socket) do
+    {:halt, assign(socket, :images, reload(socket.assigns.images, id))}
+  end
+
+  defp reload_assign(_other, socket), do: {:cont, socket}
+
+  @doc """
+  One page's pictures with `remote_post_id`'s set re-read, keeping the shape it
+  was given.
+
+  Answers the assign unchanged — and reads nothing — when this page is not
+  showing that post, which is the common case on a topic every page hears.
+  """
+  def reload(images, remote_post_id) when is_map(images) do
+    if Map.has_key?(images, remote_post_id),
+      do: Map.put(images, remote_post_id, Fediverse.remote_images(remote_post_id)),
+      else: images
+  end
+
+  def reload(images, remote_post_id) when is_list(images) do
+    if Enum.any?(images, &(&1.remote_post_id == remote_post_id)),
+      do: Fediverse.remote_images(remote_post_id),
+      else: images
+  end
+
+  @doc """
+  Whether one feed entry draws `remote_post_id` at all — as its own card, or as
+  the parent it nests.
+
+  The timeline twin of the check `reload/2` makes for itself, and it exists for
+  the same reason: every open page hears every verdict, so a host must be able
+  to answer "not mine" without going to the database.
+  """
+  def draws?(entry, remote_post_id),
+    do: Enum.any?(cards(entry), &match?(%{remote_post: %RemotePost{id: ^remote_post_id}}, &1))
+
+  @doc """
+  The same for one feed entry: the cached post it draws, plus any it nests as a
+  parent, which is a second card carrying a second copy of the same wait.
+
+  Returns the entry unchanged when it draws neither, so a caller can compare
+  identity to find the cards that really moved.
+  """
+  def restate_entry(entry, remote_post_id, images) do
+    entry
+    |> restate_card(remote_post_id, images)
+    |> Map.replace_lazy(:remote_parents, fn parents ->
+      Map.new(parents, fn {key, parent} -> {key, restate_card(parent, remote_post_id, images)} end)
+    end)
+  end
+
+  # One card, whether it is the entry itself or the parent another card nests:
+  # both are built by `Vutuv.Posts.attach_remote_images/1`, so both are the same
+  # shape.
+  defp restate_card(%{remote_post: %RemotePost{id: id}} = card, id, images),
+    do: Map.put(card, :images, images)
+
+  defp restate_card(card, _remote_post_id, _images), do: card
+
+  # An entry draws one cached post of its own at most, and nests at most one per
+  # thread post above it (`Vutuv.Posts.attach_remote_parents/3`).
+  defp cards(entry), do: [entry | Map.values(entry[:remote_parents] || %{})]
+end

--- a/lib/vutuv_web/live/tag_live/timeline.ex
+++ b/lib/vutuv_web/live/tag_live/timeline.ex
@@ -47,11 +47,17 @@ defmodule VutuvWeb.TagLive.Timeline do
   alias Vutuv.Tags.Tag
   alias Vutuv.Tags.Timeline
   alias VutuvWeb.Live.InitAssigns
+  alias VutuvWeb.Live.RemoteImages
   alias VutuvWeb.Live.RemotePostActions
 
   # The origin's like/repost figures on a card from another network tick
   # while this page is open (issue #1283). One line, no handler.
   on_mount(VutuvWeb.Live.RemoteCounts)
+
+  # And a picture on such a card appears the moment the AI gate releases it
+  # (issue #1801). The timeline mode: the cards are in a stream, so the redraw
+  # below is this page's own.
+  on_mount(VutuvWeb.Live.RemoteImages)
 
   @impl true
   def mount(_params, session, socket) do
@@ -114,6 +120,35 @@ defmodule VutuvWeb.TagLive.Timeline do
   # round trip rather than sitting there until the next load.
   def handle_event("report-remote-post", %{"id" => id}, socket) do
     RemotePostActions.report(socket, id, &drop_remote_entry(&1, id))
+  end
+
+  # A picture on a cached post left the AI gate (issue #1801): the tile the card
+  # is showing becomes the picture, with no reload. Every open page hears every
+  # verdict, so the cheap "is it even on this page" question comes first.
+  @impl true
+  def handle_info({:remote_images_settled, %{remote_post_id: id}}, socket) do
+    {:noreply, restate_remote_images(socket, id)}
+  end
+
+  defp restate_remote_images(socket, remote_post_id) do
+    if Enum.any?(socket.assigns.entries, &RemoteImages.draws?(&1, remote_post_id)),
+      do: restream_remote_images(socket, remote_post_id),
+      else: socket
+  end
+
+  defp restream_remote_images(socket, remote_post_id) do
+    images = Fediverse.remote_images(remote_post_id)
+
+    {entries, changed} =
+      Enum.map_reduce(socket.assigns.entries, [], fn entry, changed ->
+        case RemoteImages.restate_entry(entry, remote_post_id, images) do
+          ^entry -> {entry, changed}
+          updated -> {updated, [updated | changed]}
+        end
+      end)
+
+    socket = assign(socket, :entries, entries)
+    Enum.reduce(changed, socket, &stream_insert(&2, :entries, &1, update_only: true))
   end
 
   # ── Loading ───────────────────────────────────────────────────────────────

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.534.1",
+      version: "7.547.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/moderation/remote_image_settled_test.exs
+++ b/test/vutuv/moderation/remote_image_settled_test.exs
@@ -1,0 +1,89 @@
+defmodule Vutuv.Moderation.RemoteImageSettledTest do
+  @moduledoc """
+  A cached post's picture leaving the AI gate is announced on the post's topic,
+  so a card already on screen stops saying "picture is being checked".
+
+  Until this, `apply_approved/1` for `remote_post_image` was a bare
+  `update_all`. Every other kind announces its verdict through
+  `Vutuv.Activity.broadcast(scan.owner_user_id, …)`, and a picture fetched from
+  another network has no owner here, so nothing was sent at all: a card kept
+  the tile it was first drawn with until the reader reloaded the page. That is
+  not a corner case — the card is drawn in the second between the picture being
+  recorded and its bytes landing, so the grey tile is the *normal* first draw
+  of a boosted photo post.
+  """
+  use Vutuv.DataCase, async: true
+
+  import Vutuv.MastodonHelpers
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.RemoteImage
+  alias Vutuv.Moderation.ImageScan
+  alias Vutuv.Moderation.ImageSubjects
+
+  defp waiting_picture(attrs \\ []) do
+    post = remote_account() |> cached_post()
+
+    image =
+      Repo.insert!(%RemoteImage{
+        remote_post_id: post.id,
+        source_uri: "https://social.example/media/#{System.unique_integer([:positive])}.jpg",
+        file: attrs[:file] || "img-abc.avif",
+        moderation: "pending"
+      })
+
+    {post, image}
+  end
+
+  defp scan_for(%RemoteImage{} = image, fingerprint) do
+    %ImageScan{kind: "remote_post_image", subject_id: image.id, fingerprint: fingerprint}
+  end
+
+  test "an approved picture is announced with its post id" do
+    {post, image} = waiting_picture()
+    Fediverse.subscribe_remote_images()
+
+    assert :ok = ImageSubjects.apply_approved(scan_for(image, image.file))
+
+    assert_receive {:remote_images_settled, %{remote_post_id: id}}
+    assert id == post.id
+    assert Repo.get!(RemoteImage, image.id).moderation == "approved"
+  end
+
+  test "a rejected picture is announced too" do
+    # A rejection changes the row a card was drawn from just as much, so every
+    # card showing it has to re-read. What the tile then says about a picture
+    # that will never arrive is a separate wrong answer, not this one's.
+    {post, image} = waiting_picture()
+    Fediverse.subscribe_remote_images()
+
+    assert :ok = ImageSubjects.apply_rejected(scan_for(image, image.file))
+
+    assert_receive {:remote_images_settled, %{remote_post_id: id}}
+    assert id == post.id
+  end
+
+  test "a verdict that lost its race announces nothing" do
+    # The picture was refetched while the model was looking at the old bytes, so
+    # the flip touches no row. Announcing anyway would send every open card back
+    # to the database for a state that has not changed.
+    {_post, image} = waiting_picture()
+    Fediverse.subscribe_remote_images()
+
+    assert :stale = ImageSubjects.apply_approved(scan_for(image, "img-stale.avif"))
+
+    refute_receive {:remote_images_settled, _}
+  end
+
+  test "a picture whose post is already gone announces nothing and does not raise" do
+    # The retention sweep can take the post (and its pictures) while the model
+    # is still looking. There is then no post id to name and nothing to say.
+    {_post, image} = waiting_picture()
+    Fediverse.subscribe_remote_images()
+    Repo.delete!(image)
+
+    assert :stale = ImageSubjects.apply_approved(scan_for(image, image.file))
+
+    refute_receive {:remote_images_settled, _}
+  end
+end

--- a/test/vutuv_web/live/feed_remote_image_settles_test.exs
+++ b/test/vutuv_web/live/feed_remote_image_settles_test.exs
@@ -1,0 +1,126 @@
+defmodule VutuvWeb.FeedRemoteImageSettlesTest do
+  @moduledoc """
+  A picture on a cached post leaves the AI gate while a page is open, and the
+  card stops saying "picture is being checked" without a reload (issue #1801) —
+  on the feed and on the post's own page alike, the two of the six surfaces that
+  print the promise where a reader is most likely to be waiting.
+
+  The card's own line promises exactly that ("it appears here by itself once the
+  AI is through"), and for a picture from another network it was false: the
+  verdict was a database flip nobody was told about. It is the *normal* case,
+  not a corner one — a delivery records the picture and nudges the open feeds in
+  the same breath, a second before the bytes land, so the reader's first sight
+  of a boosted photo post is the wordless waiting tile.
+  """
+  use VutuvWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Vutuv.MastodonHelpers
+  import Vutuv.PostsHelpers
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.RemoteImage
+  alias Vutuv.Posts.PostRemoteReply
+
+  defp followed_post(user) do
+    account = remote_account()
+
+    Repo.insert!(%Follow{
+      user_id: user.id,
+      remote_account_id: account.id,
+      state: "accepted",
+      follow_activity_id: "https://vutuv.test/#{user.id}/actor#follows/1"
+    })
+
+    cached_post(account, content_text: "Ein Teil der hier markierten Felsnase.")
+  end
+
+  # The same cached post with nobody here following its author: it is held
+  # because somebody else does, so it reaches this reader only as the parent
+  # their own answer nests — which is the card this test is about.
+  defp unfollowed_post, do: cached_post(remote_account(), content_text: "Eine Skizze.")
+
+  defp waiting_picture(post) do
+    Repo.insert!(%RemoteImage{
+      remote_post_id: post.id,
+      source_uri: "https://social.example/media/nepal.png",
+      file: nil,
+      moderation: "pending"
+    })
+  end
+
+  # What the AI gate's verdict does to the row, without driving the whole scan:
+  # the bytes arrive, the column flips, the release is announced.
+  defp release(image) do
+    image
+    |> Ecto.Changeset.change(file: "img-abc.avif", moderation: "approved")
+    |> Repo.update!()
+
+    Fediverse.broadcast_remote_images_settled(image.remote_post_id)
+  end
+
+  test "the waiting tile becomes the picture with no reload", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    post = followed_post(user)
+    image = waiting_picture(post)
+
+    {:ok, view, html} = live(conn, ~p"/feed")
+
+    # The card is drawn before the bytes are here, so this is what the reader
+    # meets first — and until #1801 it was also what they were left with.
+    assert html =~ "data-remote-image-pending"
+    assert has_element?(view, "[data-remote-images-checking]")
+
+    release(image)
+
+    html = render(view)
+    refute html =~ "data-remote-image-pending"
+    refute has_element?(view, "[data-remote-images-checking]")
+    assert html =~ "/system/remote_media/posts/#{image.id}/img-abc.avif"
+  end
+
+  test "a cached post nested as the parent of a member's reply swaps in too", %{conn: conn} do
+    # The second card that draws the same wait: the reader's own answer to a
+    # photo post out there nests the post it answers, and that nested card
+    # carries the tile. Nothing about it is on `entry.remote_post`, so a refresh
+    # that walked only the entry's own card would leave it waiting for ever.
+    {conn, user} = create_and_login_user(conn)
+    post = unfollowed_post()
+    image = waiting_picture(post)
+
+    reply = create_post!(user, %{"body" => "Danke für die Skizze."})
+
+    Repo.insert!(%PostRemoteReply{
+      post_id: reply.id,
+      remote_post_id: post.id,
+      in_reply_to_uri: post.object_uri,
+      actor_uri: post.remote_account.actor_uri
+    })
+
+    {:ok, view, html} = live(conn, ~p"/feed")
+    assert html =~ "data-remote-image-pending"
+
+    release(image)
+
+    refute render(view) =~ "data-remote-image-pending"
+  end
+
+  test "the post's own page swaps the picture in too", %{conn: conn} do
+    # The other surface a reader waits on: they opened this URL *because* of the
+    # picture, so a page that keeps the tile until they press reload is the same
+    # broken promise the feed made.
+    {conn, user} = create_and_login_user(conn)
+    post = followed_post(user)
+    image = waiting_picture(post)
+
+    {:ok, view, html} = live(conn, ~p"/system/fediverse/post/#{post.id}")
+    assert html =~ "data-remote-image-pending"
+
+    release(image)
+
+    html = render(view)
+    refute html =~ "data-remote-image-pending"
+    assert html =~ "/system/remote_media/posts/#{image.id}/img-abc.avif"
+  end
+end


### PR DESCRIPTION
Closes #1801.

**Symptom.** A picture on a post from another network keeps its "Bild wird geprüft" tile until the reader reloads. On production the reported card was showing that tile 88 seconds after the picture had been approved.

**Cause.** `ImageSubjects.apply_approved/1` for `remote_post_image` was a bare `update_all`. Every other image kind announces its verdict on the uploader's activity topic, and a fetched picture has no uploader here, so nothing was sent at all. It is the ordinary path, not an edge: a delivery records the picture and nudges the open feeds in the same breath, a second before the bytes land, so the *first* draw of a boosted photo post is the wordless tile — and it was also the last.

**Change.** Both verdicts broadcast on one topic every open page hears (`Fediverse.remote_images_topic/0`, the shape `counts_topic/0` already uses for #1283). Listening is the new `on_mount` hook `VutuvWeb.Live.RemoteImages`, because `remote_post_images/1` prints that promise on **six** pages and a guarantee made in one place must not depend on six hosts each remembering to subscribe: `/feed`, `/system/fediverse/post/:id`, the account page, the URL lookup, a tag timeline, an organization's feed.

**Your call.** A remote account's *avatar* is the other ownerless scan and stays silent on purpose — it falls back to initials, which is a placeholder rather than a promise. Reasoning is in the docstring; say the word if you want it covered too.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01QFuuRgh65KXEkathyrGWT8
