### PR TITLE
fix(push): send legacy aesgcm so relay-backed iOS clients can decrypt the payload [5m]

### DIFF
--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -713,6 +713,29 @@ subscription and revoking an app takes it along. A push carries **no content**:
 the kind and the notification id, nothing else, so neither the push service nor
 a lock screen learns what was written.
 
+**Two content encodings, and the subscription picks.** `subscription[standard]`
+is stored per device and defaults to false, exactly as on Mastodon, in which
+case the body is the older `aesgcm` with its salt in `Encryption:` and the
+sender key in `Crypto-Key: dh=`. That is not legacy politeness: an iOS client
+subscribes through an APNs relay, and APNs forwards a payload rather than our
+headers, so the relay has to lift those two values out and put them in the
+payload itself — `aes128gcm` hides both inside the record and the phone shows
+"Unable to decrypt notification" (issue #1698). A client that sets the flag gets
+RFC 8291 `aes128gcm`. Both are checked against their specs' own test vectors in
+`web_push_test.exs`.
+
+**The false default is a compatibility decision, not an oversight, and it has to
+survive being moved.** Two things carry it: the `standard` column on the
+subscription, and `Vutuv.WebPush.content_encoding/1` with the `aesgcm` branch of
+`encode_body/4` beside it. The crypto has already moved once — it lived in this
+adapter until the installed app needed it too — and the encoding choice travelled
+with it, which is the point: a refactor that lifts it again has to take both, and
+nothing will say otherwise, because every test that would catch the loss lives
+beside the code being moved. `content_encoding/1` reads a bare map rather than a
+schema so the shared transport never has to ask a Mastodon module what to send.
+Flipping the default is a separate decision from moving the code, and belongs to
+whoever can confirm the relays no longer need the headers.
+
 **It needs no configuration.** A VAPID pair is self-signed, so an installation
 that pinned none derives its own from `secret_key_base` (the same
 domain-separated derivation as the login-PIN pepper: no table, no migration,

--- a/lib/vutuv/mastodon_api/push_subscription.ex
+++ b/lib/vutuv/mastodon_api/push_subscription.ex
@@ -20,6 +20,12 @@ defmodule Vutuv.MastodonApi.PushSubscription do
     field(:auth, :string)
     field(:alerts, :map, default: %{})
 
+    # Whether this device's client asked for the standard content encoding.
+    # False is Mastodon's own default and therefore ours; what the two
+    # encodings are, and why a phone needs the older one, is in
+    # `Vutuv.WebPush`, which reads this field through `content_encoding/1`.
+    field(:standard, :boolean, default: false)
+
     timestamps()
   end
 
@@ -27,7 +33,7 @@ defmodule Vutuv.MastodonApi.PushSubscription do
 
   def changeset(subscription, attrs) do
     subscription
-    |> cast(attrs, [:endpoint, :p256dh, :auth, :alerts])
+    |> cast(normalize_standard(attrs), [:endpoint, :p256dh, :auth, :alerts, :standard])
     |> validate_required([:endpoint, :p256dh, :auth])
     # Shared with the installed app's own subscriptions, which store the same
     # three values from the same browser API; see `Vutuv.WebPush.Validations`
@@ -37,6 +43,21 @@ defmodule Vutuv.MastodonApi.PushSubscription do
     |> update_change(:alerts, &normalize_alerts/1)
     |> unique_constraint(:api_token_id)
   end
+
+  # A client spells the flag however its HTTP library felt like — `true`, the
+  # string `"true"`, `"1"` — and a value Ecto refuses to cast would answer 422
+  # to a subscription that is otherwise perfectly good, leaving that device
+  # with no push at all.
+  #
+  # **Before `cast/3`, and that asymmetry with `normalize_alerts/1` below is
+  # load-bearing**: `alerts` is a `:map` field, so anything survives the cast
+  # and `update_change/3` can tidy it afterwards, while `"0"` against a
+  # `:boolean` field is refused *by* the cast — an `update_change/3` here would
+  # never run and would quietly restore the 422 this exists to prevent.
+  defp normalize_standard(%{"standard" => value} = attrs),
+    do: Map.put(attrs, "standard", truthy?(value))
+
+  defp normalize_standard(attrs), do: attrs
 
   defp normalize_alerts(alerts) when is_map(alerts) do
     Map.new(@alert_kinds, fn kind -> {kind, truthy?(Map.get(alerts, kind, true))} end)

--- a/lib/vutuv/web_push.ex
+++ b/lib/vutuv/web_push.ex
@@ -1,7 +1,18 @@
 defmodule Vutuv.WebPush do
   @moduledoc """
-  Web Push delivery: VAPID (RFC 8292) plus `aes128gcm` payload encryption
-  (RFC 8291 over RFC 8188).
+  Web Push delivery: VAPID (RFC 8292) plus payload encryption — RFC 8291's
+  `aes128gcm` over RFC 8188, or the `aesgcm` that came before it.
+
+  **Two encodings, because the phone clients need the older one.** Each
+  subscription carries a `standard` flag, defaulted to false as on Mastodon,
+  and `content_encoding/1` turns it into the encoding a send is built with.
+  `aesgcm` carries the salt in `Encryption:` and the sender's key in
+  `Crypto-Key: dh=`, which is where the APNs relays between us and an iOS
+  client read them, because APNs forwards a payload and not our headers.
+  `aes128gcm` hides both inside the record, so a relay has nothing to lift out
+  and the phone shows "Unable to decrypt notification" (issue #1698). A client
+  that never says otherwise therefore gets the legacy body, and both encodings
+  are checked against their own specs' test vectors in `web_push_test.exs`.
 
   **Two callers, one implementation.** This started life inside the
   Mastodon-compatible adapter, where a subscription hangs off an access token —
@@ -52,6 +63,7 @@ defmodule Vutuv.WebPush do
 
   alias Vutuv.Repo
   alias Vutuv.Ssrf
+  alias Vutuv.WebPush.Subscription
   alias VutuvWeb.Endpoint
 
   @curve :prime256v1
@@ -178,21 +190,43 @@ defmodule Vutuv.WebPush do
   Sends one push. Answers `:ok`, or `{:error, :gone}` when the subscription is
   dead. Prefer `push/2`, which acts on that answer; this is the bare transport.
   """
-  def send(%{endpoint: endpoint, p256dh: p256dh, auth: auth}, payload) do
+  def send(%{endpoint: _, p256dh: _, auth: _} = subscription, payload) do
     if enabled?() do
-      deliver(endpoint, p256dh, auth, Jason.encode!(payload))
+      deliver(subscription, Jason.encode!(payload))
     else
       {:error, :disabled}
     end
   end
 
-  defp deliver(endpoint, p256dh, auth, body) do
+  @doc """
+  Which content encoding a push to this subscription is built with.
+
+  **This installation's own app always gets `aes128gcm`**, and that is the
+  first clause rather than a default, because `Vutuv.WebPush.Subscription`
+  carries no flag to read: its client is our own service worker talking to the
+  browser's real push service, with no APNs relay in the middle rewriting the
+  payload — the case the legacy encoding exists for. Leaving it to the
+  catch-all would have quietly sent the installed app a body built for
+  somebody else's relay (issue #1729 landed while this was open).
+
+  An adapter subscription that says nothing gets the older `aesgcm`, which is
+  what Mastodon's own default means and what the phone clients were written
+  against. The last clause therefore catches a row loaded without the column
+  and a plain map that never had one, not only a stored false — the answer must
+  not depend on how completely the caller fetched the row.
+  """
+  def content_encoding(%Subscription{}), do: :aes128gcm
+  def content_encoding(%{standard: true}), do: :aes128gcm
+  def content_encoding(_legacy_or_unflagged), do: :aesgcm
+
+  defp deliver(%{endpoint: endpoint, p256dh: p256dh, auth: auth} = subscription, body) do
     with :ok <- check_target(endpoint),
          {:ok, ua_public} <- decode_key(p256dh),
          {:ok, auth_secret} <- decode_key(auth) do
-      {encrypted, _salt} = encrypt(body, ua_public, auth_secret)
+      {encrypted, encoding_headers} =
+        encode_body(body, ua_public, auth_secret, content_encoding(subscription))
 
-      case Req.post(endpoint, request_options(endpoint, encrypted)) do
+      case Req.post(endpoint, request_options(endpoint, encrypted, encoding_headers)) do
         {:ok, %{status: status}} when status in 200..299 -> :ok
         {:ok, %{status: status}} when status in [404, 410] -> {:error, :gone}
         {:ok, %{status: status}} -> {:error, {:status, status}}
@@ -216,17 +250,17 @@ defmodule Vutuv.WebPush do
   # (a `plug:`, the convention this app already uses for `Vutuv.Mastodon` and
   # the fediverse fetches). Nothing sets it outside the test environment, so a
   # real send is exactly the request written here.
-  defp request_options(endpoint, encrypted) do
+  defp request_options(endpoint, encrypted, encoding_headers) do
     Keyword.merge(
       [
         body: encrypted,
-        headers: [
-          {"content-encoding", "aes128gcm"},
-          {"content-type", "application/octet-stream"},
-          {"ttl", "2419200"},
-          {"urgency", "normal"},
-          {"authorization", authorization(endpoint)}
-        ],
+        headers:
+          [
+            {"content-type", "application/octet-stream"},
+            {"ttl", "2419200"},
+            {"urgency", "normal"},
+            {"authorization", authorization(endpoint)}
+          ] ++ encoding_headers,
         receive_timeout: 10_000,
         retry: false,
         # A push service has no business redirecting us, and following one would
@@ -237,6 +271,32 @@ defmodule Vutuv.WebPush do
       ],
       Application.get_env(:vutuv, :web_push_req_options, [])
     )
+  end
+
+  # `aes128gcm` is self-describing: salt and sender key sit in the record
+  # header, so nothing else has to be said.
+  defp encode_body(body, ua_public, auth_secret, :aes128gcm) do
+    {encrypted, _salt} = encrypt(body, ua_public, auth_secret)
+
+    {encrypted, [{"content-encoding", "aes128gcm"}]}
+  end
+
+  # `aesgcm` puts them in headers instead — unquoted and unpadded base64url,
+  # whatever the draft's own example prints, because that is what the relays
+  # parse. The VAPID key stays in the RFC 8292 `Authorization` header rather
+  # than joining `dh` as a `p256ecdsa` parameter: the draft spelling of VAPID
+  # is a separate thing from the draft spelling of the encoding, this one works
+  # against every push service today, and nothing between us and the phone
+  # reads it.
+  defp encode_body(body, ua_public, auth_secret, :aesgcm) do
+    {encrypted, salt, as_public} = encrypt_aesgcm(body, ua_public, auth_secret)
+
+    {encrypted,
+     [
+       {"content-encoding", "aesgcm"},
+       {"encryption", "salt=" <> encode(salt)},
+       {"crypto-key", "dh=" <> encode(as_public)}
+     ]}
   end
 
   # The resolving half of the SSRF pair. The changeset already refused an
@@ -300,6 +360,42 @@ defmodule Vutuv.WebPush do
 
     header = salt <> <<4096::unsigned-big-32, byte_size(as_public)::unsigned-8>> <> as_public
     {header <> ciphertext <> tag, salt}
+  end
+
+  @doc """
+  The encoding that came before it: `aesgcm`, from
+  draft-ietf-webpush-encryption-04. Answers `{body, salt, sender_public_key}`,
+  because unlike `aes128gcm` this record says nothing about itself — the salt
+  and the sender's key have to travel beside it, in `Encryption:` and
+  `Crypto-Key:`.
+
+  Three things differ from `encrypt/5` and each of them is a whole different
+  ciphertext: the first HKDF's info string is `Content-Encoding: auth`, the two
+  that follow take a **context** naming the curve and both public keys, and the
+  padding is two length octets in **front** of the plaintext rather than a
+  delimiter behind it.
+  """
+  def encrypt_aesgcm(plaintext, ua_public, auth_secret, salt \\ nil, keypair \\ nil) do
+    salt = salt || :crypto.strong_rand_bytes(16)
+    {as_public, as_private} = keypair || :crypto.generate_key(:ecdh, @curve)
+    shared = :crypto.compute_key(:ecdh, ua_public, as_private, @curve)
+
+    ikm = hkdf(auth_secret, shared, "Content-Encoding: auth" <> <<0>>, 32)
+
+    context =
+      "P-256" <>
+        <<0, byte_size(ua_public)::unsigned-big-16>> <>
+        ua_public <> <<byte_size(as_public)::unsigned-big-16>> <> as_public
+
+    cek = hkdf(salt, ikm, "Content-Encoding: aesgcm" <> <<0>> <> context, 16)
+    nonce = hkdf(salt, ikm, "Content-Encoding: nonce" <> <<0>> <> context, 12)
+
+    padded = <<0::unsigned-big-16>> <> plaintext
+
+    {ciphertext, tag} =
+      :crypto.crypto_one_time_aead(:aes_128_gcm, cek, nonce, padded, <<>>, true)
+
+    {ciphertext <> tag, salt, as_public}
   end
 
   # HKDF (RFC 5869) with the one-block expand every Web Push step needs.

--- a/lib/vutuv_web/controllers/mastodon_api/push_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/push_controller.ex
@@ -4,11 +4,15 @@ defmodule VutuvWeb.MastodonApi.PushController do
   instead of polling.
 
   Keyed on the access token, so one device is one subscription and revoking the
-  app takes it with it. The `server_key` a client needs to build the browser
-  subscription is this installation's VAPID public key, which every
-  installation has (`Vutuv.MastodonApi.WebPush` derives one where the operator
-  pinned none). Only an installation that switched push off answers 403, rather
-  than accepting a subscription that could never be delivered to.
+  app takes it with it. `subscription[standard]` rides along and decides which
+  content encoding the pushes to this device use; `Vutuv.MastodonApi.WebPush`
+  owns what that means and why leaving it out is the useful default.
+
+  The `server_key` a client needs to build the browser subscription is this
+  installation's VAPID public key, which every installation has (`WebPush`
+  derives one where the operator pinned none). Only an installation that
+  switched push off answers 403, rather than accepting a subscription that could
+  never be delivered to.
   """
 
   use VutuvWeb, :controller
@@ -29,7 +33,7 @@ defmodule VutuvWeb.MastodonApi.PushController do
       %PushSubscription{user_id: conn.assigns.current_user.id, api_token_id: token.id}
       |> PushSubscription.changeset(attrs)
       |> Repo.insert(
-        on_conflict: {:replace, [:endpoint, :p256dh, :auth, :alerts, :updated_at]},
+        on_conflict: {:replace, [:endpoint, :p256dh, :auth, :alerts, :standard, :updated_at]},
         conflict_target: :api_token_id
       )
       |> case do
@@ -86,14 +90,21 @@ defmodule VutuvWeb.MastodonApi.PushController do
 
   # Mastodon nests the browser's own PushSubscription under `subscription`, and
   # the alert preferences under `data`.
-  defp subscription_attrs(%{"subscription" => %{"endpoint" => endpoint, "keys" => keys}} = params)
+  defp subscription_attrs(
+         %{"subscription" => %{"endpoint" => endpoint, "keys" => keys} = subscription} = params
+       )
        when is_binary(endpoint) and is_map(keys) do
     {:ok,
      %{
        "endpoint" => endpoint,
        "p256dh" => keys["p256dh"],
        "auth" => keys["auth"],
-       "alerts" => params["data"]["alerts"] || %{}
+       "alerts" => params["data"]["alerts"] || %{},
+       # Written on every create and never left over from the row this one
+       # replaces: the same device can be resubscribed by a client that has
+       # since learned the standard encoding, or by an older build that has
+       # not. Absent reads as false — see `Vutuv.MastodonApi.WebPush`.
+       "standard" => subscription["standard"]
      }}
   end
 
@@ -104,6 +115,7 @@ defmodule VutuvWeb.MastodonApi.PushController do
       id: subscription.id,
       endpoint: subscription.endpoint,
       alerts: subscription.alerts,
+      standard: subscription.standard,
       server_key: WebPush.public_key(),
       policy: "all"
     }

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.569.2",
+      version: "7.575.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260827094500_add_standard_to_push_subscriptions.exs
+++ b/priv/repo/migrations/20260827094500_add_standard_to_push_subscriptions.exs
@@ -1,0 +1,13 @@
+defmodule Vutuv.Repo.Migrations.AddStandardToPushSubscriptions do
+  use Ecto.Migration
+
+  # Mastodon's own default is false, and it has to be ours too: a client that
+  # never sends the flag is a client that expects the legacy `aesgcm` body it
+  # was written against, so a row that predates this column must read as
+  # "legacy", not as "standard".
+  def change do
+    alter table(:mastodon_push_subscriptions) do
+      add(:standard, :boolean, null: false, default: false)
+    end
+  end
+end

--- a/test/vutuv/web_push_test.exs
+++ b/test/vutuv/web_push_test.exs
@@ -1,6 +1,9 @@
 defmodule Vutuv.WebPushTest do
   @moduledoc """
-  The Web Push payload encryption, against the test vector in **RFC 8291 §5**.
+  The Web Push payload encryption, against the test vectors both encodings
+  publish: **RFC 8291 §5** for `aes128gcm`, and
+  **draft-ietf-webpush-encryption-04 §5** for the `aesgcm` the phone clients
+  need (issue #1698).
 
   This is the one piece of the adapter written from a specification rather than
   from a running implementation to copy, and it is also the piece whose failure
@@ -13,6 +16,12 @@ defmodule Vutuv.WebPushTest do
 
   `salt` and the sender key pair are injected for exactly this reason; a real
   send draws both fresh, which one test here asserts.
+
+  Which of the two a send uses is the subscription's `standard` flag, and that
+  is checked through `send/2` itself rather than by reading a private function:
+  the encoding is only half of it, since `aesgcm` is unopenable without the
+  `Encryption:` and `Crypto-Key:` headers that carry what its record leaves
+  out.
 
   `async: false` because the `enabled?/0` group flips `:web_push_enabled` and
   `:web_push`, both global and both read by every push path in the app —
@@ -32,23 +41,16 @@ defmodule Vutuv.WebPushTest do
   @salt "DGv6ra1nlYgDCS1FRnbzlw"
   @expected_body "DGv6ra1nlYgDCS1FRnbzlwAAEABBBP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A_yl95bQpu6cVPTpK4Mqgkf1CXztLVBSt2Ks3oZwbuwXPXLWyouBWLVWGNWQexSgSxsj_Qulcy4a-fN"
 
-  defp decode!(value) do
-    {:ok, decoded} = Base.url_decode64(value, padding: false)
-    decoded
-  end
-
-  defp rfc_body do
-    {body, _salt} =
-      WebPush.encrypt(
-        @plaintext,
-        decode!(@ua_public),
-        decode!(@auth_secret),
-        decode!(@salt),
-        {decode!(@as_public), decode!(@as_private)}
-      )
-
-    body
-  end
+  # draft-ietf-webpush-encryption-04 §5 and Appendix A, verbatim. Its own keys,
+  # not RFC 8291's — a different example entirely.
+  @legacy_plaintext "I am the walrus"
+  @legacy_ua_public "BCEkBjzL8Z3C-oi2Q7oE5t2Np-p7osjGLg93qUP0wvqRT21EEWyf0cQDQcakQMqz4hQKYOQ3il2nNZct4HgAUQU"
+  @legacy_ua_private "9FWl15_QUQAWDaD3k3l50ZBZQJ4au27F1V4F0uLSD_M"
+  @legacy_auth_secret "R29vIGdvbyBnJyBqb29iIQ"
+  @legacy_as_public "BNoRDbb84JGm8g5Z5CFxurSqsXWJ11ItfXEWYVLE85Y7CYkDjXsIEc4aqxYaQ1G8BqkXCJ6DPpDrWtdWj_mugHU"
+  @legacy_as_private "nCScek-QpEjmOOlT-rQ38nZzvdPlqa00Zy0i6m2OJvY"
+  @legacy_salt "lngarbyKfMoi9Z75xYXmkg"
+  @legacy_ciphertext "6nqAQUME8hNqw5J3kl8cpVVJylXKYqZOeseZG8UueKpA"
 
   test "encrypts the RFC 8291 example to the byte the RFC prints" do
     assert Base.url_encode64(rfc_body(), padding: false) == @expected_body
@@ -78,18 +80,118 @@ defmodule Vutuv.WebPushTest do
     refute first == second
   end
 
+  test "encrypts the draft's aesgcm example to the byte the draft prints" do
+    {body, salt, as_public} =
+      WebPush.encrypt_aesgcm(
+        @legacy_plaintext,
+        decode!(@legacy_ua_public),
+        decode!(@legacy_auth_secret),
+        decode!(@legacy_salt),
+        {decode!(@legacy_as_public), decode!(@legacy_as_private)}
+      )
+
+    assert Base.url_encode64(body, padding: false) == @legacy_ciphertext
+    # The two values this record does *not* carry, which is the whole reason
+    # the encoding needs headers beside it.
+    assert salt == decode!(@legacy_salt)
+    assert as_public == decode!(@legacy_as_public)
+  end
+
+  describe "send/2" do
+    setup do
+      put_config(:web_push_enabled, true)
+
+      test = self()
+
+      # An `adapter:` and not the `plug:` seam the other outbound clients are
+      # stubbed with, because **Req's plug adapter deletes the request's
+      # `content-encoding` header**: it reads that header as transport
+      # compression, decompresses the body with it and drops it before the plug
+      # ever sees the conn. Here the header is not transport at all, it is the
+      # payload's own encoding and the whole subject of this test — so the stub
+      # has to sit one step earlier, where what would go on the wire is still
+      # intact.
+      put_config(:web_push_req_options,
+        adapter: fn request ->
+          send(test, {:pushed, request})
+          {request, %Req.Response{status: 201, body: ""}}
+        end
+      )
+
+      :ok
+    end
+
+    # The bug in issue #1698: an iOS client subscribes through an APNs relay,
+    # which can only pass on what stands in a header. `aes128gcm` keeps the salt
+    # and the sender key inside the body, so the phone is handed a record it has
+    # no keys for and shows "Unable to decrypt notification".
+    test "a subscription that never opted in gets aesgcm, salt and key in headers" do
+      assert WebPush.send(subscription(false), %{a: 1}) == :ok
+
+      assert_receive {:pushed, request}
+      assert header(request, "content-encoding") == "aesgcm"
+      assert "salt=" <> salt = header(request, "encryption")
+      assert "dh=" <> as_public = header(request, "crypto-key")
+
+      # Unpadded base64url, and unquoted whatever the draft's own example
+      # prints: a relay reads these with a raw base64url decoder, and a `=` or a
+      # `"` is what makes it hand the phone nothing.
+      assert {:ok, salt} = Base.url_decode64(salt, padding: false)
+      assert {:ok, as_public} = Base.url_decode64(as_public, padding: false)
+
+      # And the two really do open this body — the assertion the encoding itself
+      # cannot make, since a header naming the wrong salt or the wrong key is a
+      # push the service still answers 201 to.
+      assert decrypt_aesgcm(request.body, salt, as_public) == ~s({"a":1})
+    end
+
+    test "a subscription that opted in gets aes128gcm and no encoding headers" do
+      assert WebPush.send(subscription(true), %{a: 1}) == :ok
+
+      assert_receive {:pushed, request}
+      assert header(request, "content-encoding") == "aes128gcm"
+      refute header(request, "encryption")
+      refute header(request, "crypto-key")
+
+      # Nothing was left out: this record carries its own salt and key.
+      assert <<_salt::binary-size(16), 4096::unsigned-big-32, 65::unsigned-8, _rest::binary>> =
+               request.body
+    end
+
+    # Issue #1729 landed while this was open and brought a second subscription
+    # kind that carries no flag at all. It talks to the browser's real push
+    # service with no relay in between, so it must get the standard encoding —
+    # falling into the legacy catch-all would hand this installation's own app
+    # a body built for somebody else's relay, and every test would stay green.
+    test "the installation's own app subscription gets aes128gcm" do
+      subscription = %Vutuv.WebPush.Subscription{
+        endpoint: "https://push.example.invalid/1",
+        p256dh: @legacy_ua_public,
+        auth: @legacy_auth_secret
+      }
+
+      assert WebPush.content_encoding(subscription) == :aes128gcm
+      assert WebPush.send(subscription, %{a: 1}) == :ok
+
+      assert_receive {:pushed, request}
+      assert header(request, "content-encoding") == "aes128gcm"
+      refute header(request, "crypto-key")
+    end
+
+    # `PushDispatcher` hands over the row, but a caller with a plain map is a
+    # shape this module accepts, and "no flag" has to read the same as "false"
+    # or a device would quietly be sent a body it cannot open.
+    test "a subscription map without the flag is read as legacy" do
+      assert WebPush.send(Map.delete(subscription(false), :standard), %{a: 1}) == :ok
+
+      assert_receive {:pushed, request}
+      assert header(request, "content-encoding") == "aesgcm"
+    end
+  end
+
   describe "enabled?/0" do
     setup do
-      for key <- [:web_push, :web_push_enabled] do
-        original = Application.fetch_env(:vutuv, key)
-
-        on_exit(fn ->
-          case original do
-            {:ok, value} -> Application.put_env(:vutuv, key, value)
-            :error -> Application.delete_env(:vutuv, key)
-          end
-        end)
-      end
+      for key <- [:web_push, :web_push_enabled], do: keep_config(key)
 
       :ok
     end
@@ -156,5 +258,85 @@ defmodule Vutuv.WebPushTest do
 
     assert byte_size(decode!(public)) == 65
     assert byte_size(decode!(private)) == 32
+  end
+
+  # -- helpers --------------------------------------------------------------
+
+  defp decode!(value) do
+    {:ok, decoded} = Base.url_decode64(value, padding: false)
+    decoded
+  end
+
+  defp rfc_body do
+    {body, _salt} =
+      WebPush.encrypt(
+        @plaintext,
+        decode!(@ua_public),
+        decode!(@auth_secret),
+        decode!(@salt),
+        {decode!(@as_public), decode!(@as_private)}
+      )
+
+    body
+  end
+
+  defp header(request, name), do: List.first(Req.Request.get_header(request, name))
+
+  defp subscription(standard) do
+    %{
+      endpoint: "https://push.example.invalid/1",
+      p256dh: @legacy_ua_public,
+      auth: @legacy_auth_secret,
+      standard: standard
+    }
+  end
+
+  # The receiving half of draft-ietf-webpush-encryption-04 §3, written out here
+  # rather than borrowed from the module under test: this is the phone's side of
+  # the exchange, and the point of the assertion above is that what our headers
+  # carry is enough for somebody who only has the subscription's own keys.
+  defp decrypt_aesgcm(body, salt, as_public) do
+    size = byte_size(body) - 16
+    <<ciphertext::binary-size(^size), tag::binary-size(16)>> = body
+
+    ua_public = decode!(@legacy_ua_public)
+    shared = :crypto.compute_key(:ecdh, as_public, decode!(@legacy_ua_private), :prime256v1)
+    ikm = hkdf(decode!(@legacy_auth_secret), shared, "Content-Encoding: auth" <> <<0>>, 32)
+
+    context =
+      "P-256" <> <<0, 65::unsigned-big-16>> <> ua_public <> <<65::unsigned-big-16>> <> as_public
+
+    cek = hkdf(salt, ikm, "Content-Encoding: aesgcm" <> <<0>> <> context, 16)
+    nonce = hkdf(salt, ikm, "Content-Encoding: nonce" <> <<0>> <> context, 12)
+
+    <<pad::unsigned-big-16, padded::binary>> =
+      :crypto.crypto_one_time_aead(:aes_128_gcm, cek, nonce, ciphertext, <<>>, tag, false)
+
+    binary_part(padded, pad, byte_size(padded) - pad)
+  end
+
+  defp hkdf(salt, ikm, info, length) do
+    prk = :crypto.mac(:hmac, :sha256, salt, ikm)
+    binary_part(:crypto.mac(:hmac, :sha256, prk, info <> <<1>>), 0, length)
+  end
+
+  # `Application.fetch_env/2`, never `get_env/2`: a key this file deletes must
+  # come back deleted, not written back as a real `nil` (`:web_push_enabled`
+  # defaults to true where it is absent, so a stored `nil` is not the same
+  # thing at all).
+  defp keep_config(key) do
+    original = Application.fetch_env(:vutuv, key)
+
+    on_exit(fn ->
+      case original do
+        {:ok, was} -> Application.put_env(:vutuv, key, was)
+        :error -> Application.delete_env(:vutuv, key)
+      end
+    end)
+  end
+
+  defp put_config(key, value) do
+    keep_config(key)
+    Application.put_env(:vutuv, key, value)
   end
 end

--- a/test/vutuv_web/controllers/mastodon_api/push_streaming_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/push_streaming_test.exs
@@ -267,6 +267,79 @@ defmodule VutuvWeb.MastodonApi.PushStreamingTest do
       assert Repo.one(PushSubscription).endpoint == "https://push.example.com/two"
     end
 
+    # Issue #1698: the clients were written against Mastodon, which defaults
+    # this to false — so a client that says nothing has to be recorded as
+    # legacy, or its phone is sent a body it cannot open.
+    test "a client that sends no flag is recorded as legacy" do
+      pinned_keys()
+
+      user = insert(:activated_user)
+
+      body =
+        build_conn()
+        |> mastodon_conn(mastodon_token(user, ["push"]))
+        |> post("/api/v1/push/subscription", %{
+          "subscription" => %{
+            "endpoint" => "https://push.example.com/abc",
+            "keys" => browser_keys()
+          }
+        })
+        |> json_response(200)
+
+      assert body["standard"] == false
+      refute Repo.get_by!(PushSubscription, user_id: user.id).standard
+    end
+
+    # However the client's HTTP library felt like spelling a boolean. A value
+    # Ecto refuses to cast would answer 422 to a subscription that is otherwise
+    # perfectly good, leaving that device with no push at all.
+    test "the flag is read however the client spells it" do
+      pinned_keys()
+
+      for {sent, stored} <- [{true, true}, {"true", true}, {"1", true}, {"0", false}] do
+        user = insert(:activated_user)
+
+        body =
+          build_conn()
+          |> mastodon_conn(mastodon_token(user, ["push"]))
+          |> post("/api/v1/push/subscription", %{
+            "subscription" => %{
+              "endpoint" => "https://push.example.com/abc",
+              "keys" => browser_keys(),
+              "standard" => sent
+            }
+          })
+          |> json_response(200)
+
+        assert body["standard"] == stored, "#{inspect(sent)} answered #{body["standard"]}"
+        assert Repo.get_by!(PushSubscription, user_id: user.id).standard == stored
+      end
+    end
+
+    # The same device, resubscribed by a build that has since learned the
+    # standard encoding — or by an older one that has not. The flag has to
+    # follow the new subscription, never survive from the row it replaces.
+    test "re-registering rewrites the flag rather than keeping the old one" do
+      pinned_keys()
+
+      token = mastodon_token(insert(:activated_user), ["push"])
+
+      for standard <- [true, false] do
+        build_conn()
+        |> mastodon_conn(token)
+        |> post("/api/v1/push/subscription", %{
+          "subscription" => %{
+            "endpoint" => "https://push.example.com/abc",
+            "keys" => browser_keys(),
+            "standard" => standard
+          }
+        })
+        |> json_response(200)
+
+        assert Repo.one(PushSubscription).standard == standard
+      end
+    end
+
     test "reading and deleting the subscription", %{conn: conn} do
       pinned_keys()
 


### PR DESCRIPTION
**Symptom:** every push from us reaches Ivory on iOS as "Unable to decrypt notification". We always sent `Content-Encoding: aes128gcm`, which keeps the salt and the sender key inside the record. An iOS client sits behind an APNs relay, and APNs forwards a payload rather than our headers, so the relay has to lift those two values out of `Encryption:` and `Crypto-Key: dh=`. With `aes128gcm` there is nothing to lift.

**Change:** new column `mastodon_push_subscriptions.standard`, default false as on Mastodon. `Vutuv.WebPush.content_encoding/1` turns it into the encoding, `encode_body/4` builds it, and the new `encrypt_aesgcm/5` is the second ceremony. The installed app's own subscription carries no flag and gets `aes128gcm`, so #1752 is unaffected.

**Not included:** flipping the default. That needs someone who can confirm the relays no longer need the headers.

**Verified:** both encodings against their specs' own test vectors, plus an assertion that the shipped headers actually open the shipped body. Not verified on a physical device.

Supersedes #1771, which GitHub closed when this branch was renamed; the review is there.

Closes #1698.

