### PR TITLE
fix(agents): triage never deletes a label that still marks closed issues [2m]

### DIFF
--- a/.claude/commands/triage-issues.md
+++ b/.claude/commands/triage-issues.md
@@ -55,8 +55,11 @@ Then, before deciding anything:
 - **Scope**: every remaining open issue, including the ones that already carry
   `Bug` or `Feature Request` — those get a sanity check, not a rewrite of
   somebody's decision. Retire `enhancement`: it means the same as
-  `Feature Request`, so swap it, and `gh label delete enhancement --yes` once no
-  open issue carries it. Leave `v1.x` alone.
+  `Feature Request`, so swap it on every open issue. **Do not delete the label**:
+  it still marks 182 closed issues and 7 pull requests, and deleting it strips
+  every one of them. That holds for any label with history — an empty-on-open
+  label is not an unused label, so count the closed ones first and put a
+  deletion to Stefan instead of making it. Leave `v1.x` alone.
 
 ## Step 2: done-checks, in parallel
 An issue that reads as if it might already be shipped is a **candidate**. Run

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.571.4",
+      version: "7.577.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
`/triage-issues` (#1805) told the next run to delete the `enhancement` label
once no open issue carried it. That became true during the first sweep, so the
next run would have done it — and taken the label off **182 closed issues and
7 pull requests** with it.

Empty on the open issues is not the same as unused. The command now swaps
`enhancement` for `Feature Request` on open issues, counts the closed ones
before considering a deletion, and puts the deletion to you instead of making
it. Stated as a general rule, not a special case for this one label.

`.claude/commands/triage-issues.md`, one paragraph. No application code.

An AI agent wrote this text in my name. I know that is problematic.