### PR TITLE
Time travel in the feed via a month calendar

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -674,9 +674,30 @@ document.addEventListener("click", (event) => {
   window.dispatchEvent(new CustomEvent("vutuv:tab-teaser", { detail: { frames: frames } }))
 })
 
+// Keeps /feed's address bar in step with the calendar, so the day on screen is
+// the day a copied link reopens.
+//
+// The feed LiveView is `live_render`ed by the controller that owns the
+// agent-format siblings rather than routed, so it has no `push_patch/2` and
+// this is the only way it can touch the URL. `replaceState`, never `pushState`:
+// a reader stepping through a fortnight of days would otherwise have to press
+// Back fourteen times to leave the feed.
+const FeedUrl = {
+  mounted() {
+    this.handleEvent("feed:url", ({ query }) => {
+      const url = query ? `${location.pathname}?${query}` : location.pathname
+
+      if (url !== location.pathname + location.search) {
+        history.replaceState(history.state, "", url)
+      }
+    })
+  },
+}
+
 const Hooks = {
   MarkdownEditor,
   TagInput,
+  FeedUrl,
   LocalTime: {
     mounted() {
       localizeTime(this.el)

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -2917,7 +2917,7 @@ defmodule Vutuv.Fediverse do
       |> scope_resharer(viewer_id, Keyword.get(opts, :only))
       |> reject_muted_hosts(viewer)
       |> Vutuv.Posts.named_language_scope(Vutuv.Posts.feed_language_filter(viewer))
-      |> remote_reposts_at_or_before(cursor)
+      |> repost_rows_at_or_before(cursor)
       |> Repo.all()
       |> Enum.map(&remote_repost_entry/1)
     else
@@ -2980,9 +2980,17 @@ defmodule Vutuv.Fediverse do
     }
   end
 
-  defp remote_reposts_at_or_before(query, nil), do: query
+  # The cursor window on a repost row, for both repost sources: the boost of a
+  # remote post and the reshare of a remote reply. Both bind the repost row
+  # first and order by its `inserted_at`, so one helper covers them — they were
+  # two identical copies 4,600 lines apart until the `:since` bound would have
+  # made it three clauses each.
+  defp repost_rows_at_or_before(query, nil), do: query
 
-  defp remote_reposts_at_or_before(query, %{at: at}),
+  defp repost_rows_at_or_before(query, %{at: at, since: since}) when not is_nil(since),
+    do: where(query, [r], r.inserted_at <= ^at and r.inserted_at >= ^since)
+
+  defp repost_rows_at_or_before(query, %{at: at}),
     do: where(query, [r], r.inserted_at <= ^at)
 
   @doc """
@@ -3169,6 +3177,15 @@ defmodule Vutuv.Fediverse do
   # these columns carry a zone, so the conversion lives here once instead of
   # once per source.
   defp utc_at_or_before(query, nil, _field), do: query
+
+  defp utc_at_or_before(query, %{at: at, since: since}, field) when not is_nil(since),
+    do:
+      where(
+        query,
+        [r],
+        field(r, ^field) <= ^DateTime.from_naive!(at, "Etc/UTC") and
+          field(r, ^field) >= ^DateTime.from_naive!(since, "Etc/UTC")
+      )
 
   defp utc_at_or_before(query, %{at: at}, field),
     do: where(query, [r], field(r, ^field) <= ^DateTime.from_naive!(at, "Etc/UTC"))
@@ -7661,18 +7678,13 @@ defmodule Vutuv.Fediverse do
       |> reject_muted_note_hosts(viewer)
       |> Vutuv.Posts.named_language_scope(Vutuv.Posts.feed_language_filter(viewer))
       |> limit(^fetch_n)
-      |> note_reposts_at_or_before(cursor)
+      |> repost_rows_at_or_before(cursor)
       |> Repo.all()
       |> Enum.map(&remote_reply_repost_entry/1)
     else
       []
     end
   end
-
-  defp note_reposts_at_or_before(query, nil), do: query
-
-  defp note_reposts_at_or_before(query, %{at: at}),
-    do: where(query, [r], r.inserted_at <= ^at)
 
   defp remote_reply_repost_entry(%NoteRepost{} = repost) do
     %{

--- a/lib/vutuv/feed_page.ex
+++ b/lib/vutuv/feed_page.ex
@@ -15,7 +15,10 @@ defmodule Vutuv.FeedPage do
     * `paginate/3` — **cursor**, for an endless "Load more" list that appends
       (the newsfeed, the API). The cursor is `%{at: timestamp, ids: [...]}` —
       the boundary timestamp plus every already-shown item id *at* that
-      timestamp. Timestamps have second precision, so several items (across
+      timestamp, and optionally `since:` — a **lower** bound that turns the walk
+      into a window (the feed calendar's one-day view). A source that honours
+      `at` but forgets `since` does not crash, it silently widens, so any new
+      source has to apply both. Timestamps have second precision, so several items (across
       all sources) can tie at a page boundary; fetching `<= at` and rejecting
       the seen ids means ties neither skip items nor repeat them. Treat the
       cursor as opaque.
@@ -93,6 +96,10 @@ defmodule Vutuv.FeedPage do
     # at that timestamp along — they are still "already shown".
     carried = if prev && NaiveDateTime.compare(prev.at, at) == :eq, do: prev.ids, else: []
 
-    %{at: at, ids: carried ++ boundary_ids}
+    # A window's lower bound (`:since`, the feed calendar's day pick) belongs to
+    # the whole walk, not to one page, so it is carried rather than recomputed.
+    # Dropped here, "Load more" inside a single day would silently widen to
+    # every earlier day the moment the reader pressed it.
+    %{at: at, ids: carried ++ boundary_ids, since: prev && prev[:since]}
   end
 end

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2708,28 +2708,95 @@ defmodule Vutuv.Posts do
     %{page | entries: decorate_feed_entries(page.entries, viewer, threads: true)}
   end
 
-  # The six sources the merged feed pulls from, narrowed to the reader's tab.
+  @doc """
+  How many feed entries reached `viewer` on each day of a window — the numbers
+  the feed calendar's heatmap shades (issue: the vertical time controls).
+
+  Counted through **`feed_sources/2`**, the same nine sources a page is built
+  from, so a day the heatmap calls busy is a day the timeline will actually
+  have something on. A separate hand-written count query would be a second
+  definition of "what is in my feed" and would drift from the first one.
+
+  Counts **arrivals, not cards**. The rendered timeline collapses several posts
+  of one thread into a single entry, so a day counted at 306 here draws 271
+  cards (measured, 2026-08-18); the shading is "how much reached you", which is
+  the question a heatmap answers and the same one GitHub's contribution graph
+  answers. The relationship only ever goes one way — collapsing reduces — so
+  the count is an upper bound on cards and never undersells a day.
+
+  Returns `%{Date.t() => pos_integer}` in the **caller's** current viewer clock
+  (`Vutuv.ViewerClock`), because the calendar draws the reader's calendar days,
+  not UTC ones. Days with nothing are absent rather than zero.
+
+  Bounded by `cap`: a month of a busy feed is thousands of rows and this runs
+  on every month the reader pages to. Past the cap the counts are a **lower
+  bound**, which the caller is told about (`capped?`) rather than left to
+  believe a quiet-looking month. The entries are counted, never decorated: the
+  heatmap needs numbers, and `decorate_feed_entries/3` is the expensive half.
+  """
+  def feed_activity_by_day(%User{} = viewer, %Date{} = from, %Date{} = to, opts \\ []) do
+    filter = Keyword.get(opts, :filter, :all)
+    cap = Keyword.get(opts, :cap, 3_000)
+
+    {first, _} = Vutuv.ViewerClock.day_window(from)
+    {_, last} = Vutuv.ViewerClock.day_window(to)
+    cursor = %{at: last, ids: [], since: first}
+
+    entries =
+      Enum.map(feed_sources(viewer, filter), fn fetch -> fetch.(cap, cursor) end)
+
+    # Truncation is a per-SOURCE fact, not a fact about their union: the cap is
+    # each source's `LIMIT`, so nine sources of 400 rows each make 3,600
+    # entries without a single one having been cut short. Testing the union
+    # against the cap cried "incomplete" on every ordinary busy month.
+    capped? = Enum.any?(entries, &(length(&1) >= cap))
+
+    counts =
+      entries
+      |> Enum.concat()
+      |> Enum.uniq_by(& &1.id)
+      |> Enum.frequencies_by(&Vutuv.ViewerClock.date(&1.at))
+      |> Map.filter(fn {date, _n} ->
+        Date.compare(date, from) != :lt and Date.compare(date, to) != :gt
+      end)
+
+    %{counts: counts, capped?: capped?}
+  end
+
+  @doc """
+  Whether `viewer`'s feed reaches back past the start of `date`'s month — what
+  decides when the calendar's back arrows stop.
+
+  One row is all it takes to answer, so this asks for exactly one through the
+  **same nine sources** a page is built from. A hand-written "oldest post"
+  query would be a second definition of what is in a feed, and the arrows would
+  eventually disagree with the timeline they scroll.
+
+  Undecorated on purpose: the question is whether anything exists, and
+  `decorate_feed_entries/3` is the expensive half of a page.
+  """
+  def feed_reaches_before_month?(%User{} = viewer, %Date{} = date, opts \\ []) do
+    filter = Keyword.get(opts, :filter, :all)
+
+    {month_start, _} = date |> Date.beginning_of_month() |> Vutuv.ViewerClock.day_window()
+    before = NaiveDateTime.add(month_start, -1, :second)
+
+    page =
+      Vutuv.FeedPage.paginate(feed_sources(viewer, filter), 1, %{at: before, ids: []})
+
+    page.entries != []
+  end
+
+  # `:own` is a different axis from the three below and belongs to the feed
+  # calendar, not to the source band: the band asks *which network*, this asks
+  # *whose posts*. It is never written to `users.feed_source` (only the band's
+  # checkboxes do that, and they cannot produce it), so a reader who picks "My
+  # posts" and comes back tomorrow gets their ordinary feed.
   #
-  # The two tabs partition the feed by **whether somebody here did something**.
-  # "Fediverse" is what arrives from another network without anybody on this
-  # site lifting a finger: the posts of accounts the reader follows out there,
-  # and what those accounts boosted. Everything a member here did is "vutuv" —
-  # their posts, their replies, and every **reshare**, whoever pressed the
-  # button and whatever they passed on.
-  #
-  # The reshare is the whole point of the split. Filing a friend's reshare under
-  # "Fediverse" because the *content* came from there sent the reader looking
-  # for their own network's activity under the other network's name — and left
-  # a member with no fediverse follows of their own with a permanently empty
-  # Fediverse tab beside a vutuv tab that was simply "All" again.
-  #
-  # One source produces both kinds and is narrowed by `:only` **inside its own
-  # query** rather than by dropping rows afterwards, so a page is never short of
-  # what the paginator fetched for it (which is what decides `more?`):
-  # `feed_remote_boosts/4` (issue #1167) carries a cached remote post when the
-  # boosted thing lives out there — nobody here did that — and a plain vutuv
-  # post when a followed account passed a member's post on, which *is* a vutuv
-  # post however it arrived.
+  # It is also what the calendar's "My posts" heatmap counts, so the shading and
+  # the timeline under it are one definition rather than two.
+  defp feed_sources(viewer, :own), do: [&feed_own_post_items(viewer, &1, &2)]
+
   defp feed_sources(viewer, :vutuv) do
     [
       &feed_post_items(viewer, &1, &2),
@@ -2934,6 +3001,9 @@ defmodule Vutuv.Posts do
   def feed_filter_accepts?(:fediverse, entry),
     do: remote_feed_entry?(entry) and not reshared_here?(entry)
 
+  # `:own` is deliberately not answered here and falls through to `true`: whose
+  # post it is cannot be read off the entry alone, and the caller that knows the
+  # viewer decides it instead (`VutuvWeb.PostLive.Feed`'s `view_accepts?/3`).
   def feed_filter_accepts?(_all, _entry), do: true
 
   # Whether a member here put this entry in front of the reader. `boosted_by` is
@@ -3342,6 +3412,30 @@ defmodule Vutuv.Posts do
   card, the content filter and the id all come from `entry.note` instead.
   """
   def remote_reply_entry?(entry), do: not is_nil(entry[:note])
+
+  # The reader's own posts, and nothing else — what the feed calendar's
+  # "My posts" reading shows in the timeline as well as in the shading.
+  #
+  # Deliberately the same set `own_post_counts_by_day/3` counts: a day the
+  # heatmap shades under "My posts" has to be a day this timeline can fill, and
+  # two definitions of "mine" would drift the first time one of them learned
+  # about reshares. It is therefore posts the member WROTE, not posts they
+  # passed on.
+  #
+  # No visibility scoping and no language filter: every one of these is the
+  # reader's own, they may always see it, and a member who wrote in a language
+  # they do not follow still wrote it.
+  defp feed_own_post_items(%User{id: viewer_id}, fetch_n, cursor) do
+    from(p in Post,
+      as: :post,
+      where: p.user_id == ^viewer_id,
+      order_by: [desc: p.inserted_at, desc: p.id],
+      limit: ^fetch_n
+    )
+    |> posts_at_or_before(cursor)
+    |> Repo.all()
+    |> Enum.map(&%{id: "post-#{&1.id}", post: &1, reposted_by: nil, at: &1.inserted_at})
+  end
 
   defp feed_post_items(%User{id: viewer_id} = viewer, fetch_n, cursor) do
     from(p in Post,
@@ -3792,10 +3886,27 @@ defmodule Vutuv.Posts do
     user_id != author_id and Vutuv.Social.blocked_between?(user_id, author_id)
   end
 
+  # The cursor's upper bound, and optionally its lower one.
+  #
+  # `since` is what makes "show me Tuesday" a *window* rather than "Tuesday and
+  # everything before it" (the calendar's day pick, `Vutuv.Posts.feed_page/2`'s
+  # `:since`). It rides in the cursor map on purpose: the cursor is the one
+  # thing already threaded through every source and carried across pages by
+  # `Vutuv.FeedPage`, so the bound survives "Load more" without a second
+  # parameter to remember. A page whose rows have run out of the window simply
+  # comes back short, which is what tells the paginator there is no more — no
+  # row is ever fetched and then dropped, so `more?` cannot lie.
   defp posts_at_or_before(query, nil), do: query
+
+  defp posts_at_or_before(query, %{at: at, since: since}) when not is_nil(since),
+    do: where(query, [p], p.inserted_at <= ^at and p.inserted_at >= ^since)
+
   defp posts_at_or_before(query, %{at: at}), do: where(query, [p], p.inserted_at <= ^at)
 
   defp reposts_at_or_before(query, nil), do: query
+
+  defp reposts_at_or_before(query, %{at: at, since: since}) when not is_nil(since),
+    do: where(query, [repost: r], r.inserted_at <= ^at and r.inserted_at >= ^since)
 
   defp reposts_at_or_before(query, %{at: at}),
     do: where(query, [repost: r], r.inserted_at <= ^at)

--- a/lib/vutuv/viewer_clock.ex
+++ b/lib/vutuv/viewer_clock.ex
@@ -100,6 +100,40 @@ defmodule Vutuv.ViewerClock do
   def today, do: date(DateTime.utc_now())
 
   @doc """
+  One of this viewer's calendar days as the pair of UTC naive instants that
+  bound it — the inverse of `naive/1`, and the only place that conversion is
+  written.
+
+  Every `inserted_at` in the app is UTC naive, so anything that asks "what
+  happened on my Tuesday" (the feed calendar's day window and its heatmap
+  counts) has to turn the reader's day into that pair. `Vutuv.BerlinTime`'s
+  `day_bounds_utc/1` is the same idea for the **installation's** clock; this is
+  the per-reader twin.
+
+  A day boundary never falls in a DST gap (transitions run at 02:00/03:00) and
+  an ambiguous one still names the right day, so both odd shapes take the first
+  offset rather than refusing the answer: an hour's skew at midnight is a
+  nuisance, a 500 on the feed is not.
+  """
+  def day_window(%Date{} = date) do
+    {edge(date, ~T[00:00:00]), edge(date, ~T[23:59:59])}
+  end
+
+  defp edge(%Date{} = date, %Time{} = time) do
+    naive = NaiveDateTime.new!(date, time)
+
+    case DateTime.from_naive(naive, zone()) do
+      {:ok, at} -> to_utc_naive(at)
+      {:ambiguous, first, _second} -> to_utc_naive(first)
+      {:gap, just_before, _just_after} -> to_utc_naive(just_before)
+      {:error, _reason} -> naive
+    end
+  end
+
+  defp to_utc_naive(%DateTime{} = at),
+    do: at |> DateTime.shift_zone!("Etc/UTC") |> DateTime.to_naive()
+
+  @doc """
   A UTC instant written in this viewer's shape. The styles are `:date`,
   `:short_date`, `:day_month`, `:time`, `:seconds`, `:datetime` (date and
   time), `:short_datetime` (the post-stamp form, comma-separated) and

--- a/lib/vutuv_web/components/ui.ex
+++ b/lib/vutuv_web/components/ui.ex
@@ -3172,6 +3172,32 @@ defmodule VutuvWeb.UI do
   def month_name(12), do: gettext("December")
 
   @doc """
+  The two-letter names of the weekdays, Monday first — the column headings of
+  any calendar grid.
+
+  Here for the same reason `month_name/1` is: one home for the seven strings
+  rather than a copy per view. Moved up from `VutuvWeb.AdHTML`, which shipped
+  them for the ad booking calendar long before the feed calendar wanted the
+  same row; both call this now.
+
+  Deliberately whole msgids and not `String.slice/3` on the full weekday names:
+  the abbreviation is a translator's decision, not a substring, and slicing
+  would have added seven more one-word msgids of exactly the kind
+  `gettext.extract --merge` likes to fuzzy-fill.
+  """
+  def weekday_initials do
+    [
+      gettext("Mo"),
+      gettext("Tu"),
+      gettext("We"),
+      gettext("Th"),
+      gettext("Fr"),
+      gettext("Sa"),
+      gettext("Su")
+    ]
+  end
+
+  @doc """
   Exact, thousands-grouped form of a count (`60123` -> `"60,123"`, or
   `"60.123"` under the German locale), for the rare place that wants the full
   number rather than the floored `compact_count/1` — the live member counter on

--- a/lib/vutuv_web/controllers/newsfeed_controller.ex
+++ b/lib/vutuv_web/controllers/newsfeed_controller.ex
@@ -26,7 +26,7 @@ defmodule VutuvWeb.NewsfeedController do
 
   def index(conn, params) do
     case AgentDocs.negotiate(conn) do
-      :html -> show_html(conn)
+      :html -> show_html(conn, params)
       format -> send_feed_doc(conn, format, params)
     end
   end
@@ -36,10 +36,21 @@ defmodule VutuvWeb.NewsfeedController do
   # document <head>, with the agent-format alternates) still applies. The feed
   # is outside the `live_session`, so its session values are passed explicitly
   # (mirrors VutuvWeb.UserController.show).
-  defp show_html(conn) do
+  #
+  # `?day=` and `?cal=` are the feed calendar's state (issue: time travel). The
+  # LiveView is `live_render`ed rather than routed, so it has no
+  # `handle_params/3` to read them itself — the controller is the only side
+  # that sees the query string, and it hands the two values on through the
+  # session map. They are display state, not identity: that map is signed but
+  # **not encrypted**, so nothing that decides who the viewer is may ever
+  # travel this way.
+  defp show_html(conn, params) do
     conn
     |> AgentDocs.put_html_alternates()
-    |> ControllerHelpers.render_live(Feed)
+    |> ControllerHelpers.render_live(Feed, %{
+      "cal_day" => params["day"],
+      "cal_open" => params["cal"]
+    })
   end
 
   defp send_feed_doc(conn, format, params) do

--- a/lib/vutuv_web/live/feed_time_travel.ex
+++ b/lib/vutuv_web/live/feed_time_travel.ex
@@ -1,0 +1,124 @@
+defmodule VutuvWeb.Live.FeedTimeTravel do
+  @moduledoc """
+  Opening one calendar day in `/feed` — the arithmetic behind
+  `VutuvWeb.PostLive.FeedCalendar`.
+
+  ## Why this is nearly free
+
+  `Vutuv.FeedPage.paginate/3` already walks the merged feed by a cursor, and
+  every source applies its `at` as `inserted_at <= ^at`. Travelling is
+  therefore not a new query shape at all: it is a **synthetic first cursor**
+  handed to the same `Vutuv.Posts.feed_page/2` a normal mount calls. "Load
+  more" chains from there without knowing anything happened, and every
+  visibility, block, language and content filter keeps applying, because none
+  of them were bypassed.
+
+  ## A day is a window
+
+  The cursor carries a **lower** bound too (`:since`), which is what makes
+  "show me Tuesday" mean Tuesday rather than Tuesday and all of history under
+  it. That bound rides in the cursor rather than beside it precisely so it
+  survives pagination: `Vutuv.FeedPage` carries it from page to page, so
+  pressing "Load more" inside a day stops at the day's own edge.
+
+  A day of `nil` means *now*, and now is the only state that takes live
+  arrivals. There is no window on a day that has not happened.
+
+  ## The reader's calendar, not the server's
+
+  Every boundary here is computed in the reader's own zone
+  (`Vutuv.ViewerClock`), so a member in Auckland opens their Tuesday and not
+  Berlin's. What is stored and handed to the query is always UTC naive,
+  matching every `inserted_at` in the app.
+  """
+
+  alias Vutuv.ViewerClock
+
+  @doc "Now, in the same shape every `inserted_at` carries."
+  def now, do: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+  @doc """
+  The window that shows one whole calendar day: its first and last instant in
+  the reader's zone, as the UTC naive pair the cursor carries.
+  """
+  defdelegate day_window(date), to: ViewerClock
+
+  @doc """
+  The feed cursor for one whole day, or `nil` for no day (the live present).
+
+  Today is bounded at **now** rather than at a midnight that has not happened
+  yet, and a future day has no window at all.
+  """
+  def day_cursor(nil), do: nil
+
+  def day_cursor(%Date{} = date) do
+    {first, last} = day_window(date)
+    now = now()
+
+    if NaiveDateTime.compare(first, now) == :gt do
+      nil
+    else
+      %{at: min_naive(last, now), ids: [], since: first}
+    end
+  end
+
+  @doc """
+  The grid a month calendar draws: whole weeks, Monday first, each cell a date
+  plus whether it belongs to the month being shown.
+
+  Always six rows of seven. A month that would fit in five still gets six, so
+  the calendar does not change height as the reader pages through months and
+  push the rail cards below it up and down.
+  """
+  def month_grid(%Date{} = month) do
+    first = Date.beginning_of_month(month)
+    start = Date.add(first, -(Date.day_of_week(first) - 1))
+
+    Enum.map(0..41, fn offset ->
+      date = Date.add(start, offset)
+      %{date: date, in_month?: date.month == month.month and date.year == month.year}
+    end)
+  end
+
+  @doc "The month a date sits in (this month, for `nil`)."
+  def month_of(nil), do: Date.beginning_of_month(ViewerClock.today())
+  def month_of(%Date{} = date), do: Date.beginning_of_month(date)
+
+  @doc """
+  Steps a shown month by `n` months (or `n * 12` for the year arrows), never
+  past the current month: there is nothing to show in the future, and a
+  calendar that pages into it is offering days that cannot be clicked.
+  """
+  def shift_month(%Date{} = month, n) when is_integer(n) do
+    shifted = month |> Date.beginning_of_month() |> add_months(n)
+    this_month = Date.beginning_of_month(ViewerClock.today())
+
+    if Date.compare(shifted, this_month) == :gt, do: this_month, else: shifted
+  end
+
+  @doc "Whether a date can be opened at all (today or earlier)."
+  def reachable?(%Date{} = date), do: Date.compare(date, ViewerClock.today()) != :gt
+
+  @doc "Reads a `YYYY-MM-DD` phx-value back into a date."
+  def parse_date(value) when is_binary(value) do
+    case Date.from_iso8601(value) do
+      {:ok, date} -> {:ok, date}
+      {:error, _reason} -> :error
+    end
+  end
+
+  def parse_date(_other), do: :error
+
+  defp min_naive(a, b), do: if(NaiveDateTime.compare(a, b) == :lt, do: a, else: b)
+
+  # `Date.add/2` walks days, so month arithmetic has to normalise the day of the
+  # month itself: stepping back a month from the 31st has to land on the 28th in
+  # February rather than overflowing into March.
+  defp add_months(%Date{} = date, n) do
+    months = date.year * 12 + (date.month - 1) + n
+    year = div(months, 12)
+    month = rem(months, 12) + 1
+
+    Date.new!(year, month, min(date.day, Date.days_in_month(Date.new!(year, month, 1))))
+  end
+end

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -35,6 +35,7 @@ defmodule VutuvWeb.PostLive.Feed do
   use VutuvWeb, :live_view
 
   import VutuvWeb.PostComponents
+  import VutuvWeb.PostLive.FeedCalendar
 
   alias Phoenix.LiveView.JS
   alias Vutuv.Activity
@@ -45,12 +46,14 @@ defmodule VutuvWeb.PostLive.Feed do
   alias Vutuv.Social
   alias Vutuv.Tags.UserTag
   alias VutuvWeb.Live.DayClockRestream
+  alias VutuvWeb.Live.FeedTimeTravel
   alias VutuvWeb.Live.InitAssigns
   alias VutuvWeb.Live.MountHandoff
   alias VutuvWeb.Live.PostTranslations
   alias VutuvWeb.Live.RemoteImages
   alias VutuvWeb.Live.RemotePostActions
   alias VutuvWeb.Live.RemoteReplyActions
+  alias VutuvWeb.PostLive.FeedCalendar
   alias VutuvWeb.PostTeaser
   alias VutuvWeb.UserHelpers
 
@@ -74,6 +77,24 @@ defmodule VutuvWeb.PostLive.Feed do
   # smaller than either, because that press is a wait with nothing on screen to
   # read while it lasts.
   @filter_page_size 10
+  # What opening a *busy* calendar day loads (see `load_day/2`). Sized like a
+  # source switch and for the same reason: the reader is waiting on an empty
+  # column.
+  @travel_page_size 10
+  # A day with fewer entries than this is loaded whole on the first press, so
+  # the ordinary case has no "Load more" under it at all. A day is a bounded
+  # thing the reader asked to see, not an endless timeline, and paging through
+  # a Tuesday ten posts at a time is busywork the feed can just do for them.
+  #
+  # The number is an upper bound handed to `feed_page/2`, not a fetch of a
+  # hundred rows: a day holding three costs three. What decides which branch a
+  # day takes is the heatmap's own count for it, which is already on the socket
+  # (`@cal_counts`) — so knowing the day's size costs no query of its own.
+  @day_full_limit 100
+  # …and the ceiling on "load the whole day" for the days above that. Somebody
+  # opening a day with four thousand entries wants to read it, not to render it,
+  # so the button stops here and leaves "Load more" for the rest.
+  @day_all_limit 1_000
   # "New here" rail: how many newcomers to greet, the size of the newest-members
   # pool they are drawn out of, how many of each one's tags the card shows, and
   # how often an open feed redraws. Defined here (not beside
@@ -136,7 +157,7 @@ defmodule VutuvWeb.PostLive.Feed do
     socket = InitAssigns.assign_embedded(socket, session)
 
     if user = socket.assigns.current_user do
-      {:ok, mount_feed(socket, user)}
+      {:ok, mount_feed(socket, user, calendar_from_url(session))}
     else
       {:ok,
        socket
@@ -145,7 +166,7 @@ defmodule VutuvWeb.PostLive.Feed do
     end
   end
 
-  defp mount_feed(socket, user) do
+  defp mount_feed(socket, user, {day, open?}) do
     # The sources they left on (issue #1499). It opens the page *and* keys the
     # handoff below: the stash holds one entry per member, so two devices
     # opening /feed within its 15s TTL would otherwise let one take a page the
@@ -164,20 +185,20 @@ defmodule VutuvWeb.PostLive.Feed do
       # The dead render stashed its computed page seconds ago
       # (VutuvWeb.Live.MountHandoff); take it and skip re-running the same
       # queries. Any miss (expired, consumed, a reconnect) recomputes.
-      case MountHandoff.take(user.id, {:feed, remembered}) do
-        {:ok, payload} -> apply_feed_payload(socket, payload)
-        :error -> apply_feed_payload(socket, feed_payload(user, remembered))
+      case MountHandoff.take(user.id, {:feed, remembered, day}) do
+        {:ok, payload} -> apply_feed_payload(socket, payload, day, open?)
+        :error -> apply_feed_payload(socket, feed_payload(user, remembered, day), day, open?)
       end
     else
-      payload = feed_payload(user, remembered)
-      MountHandoff.stash(user.id, {:feed, remembered}, payload)
-      apply_feed_payload(socket, payload)
+      payload = feed_payload(user, remembered, day)
+      MountHandoff.stash(user.id, {:feed, remembered, day}, payload)
+      apply_feed_payload(socket, payload, day, open?)
     end
   end
 
   # Everything a feed mount computes, as data — what the dead render hands the
   # connected mount through the single-use stash.
-  defp feed_payload(user, remembered) do
+  defp feed_payload(user, remembered, day) do
     # The member's private content filters (issue #940): compiled once, applied
     # to every page, and the set of posts they chose to reveal anyway.
     compiled = ContentFilters.compile_for(user)
@@ -192,7 +213,23 @@ defmodule VutuvWeb.PostLive.Feed do
     # same fold `fediverse_feed_available?/1` did for the tab bar.
     filter = if Posts.fediverse_feed_available?(user), do: remembered, else: :all
 
-    page = Posts.feed_page(user, limit: @first_page_size, filter: filter)
+    # A day-link arrival (`/feed?day=…`) fetches THAT day's page here rather
+    # than fetching the present and re-fetching a moment later: mounting at now
+    # and then re-streaming the day leaves both pages on the client, because a
+    # stream reset in the same mount that populated it does not take.
+    #
+    # A named day asks for the whole-day limit outright. That is an upper bound,
+    # so a quiet day still costs its own size; what it buys is not having to run
+    # the nine-source counter here purely to choose between two page sizes,
+    # which is the most expensive query on the page and was being run twice per
+    # arrival for one number.
+    page =
+      Posts.feed_page(user,
+        limit: if(day, do: @day_full_limit, else: @first_page_size),
+        cursor: FeedTimeTravel.day_cursor(day),
+        filter: filter
+      )
+
     entries = page.entries |> with_engagement(user) |> mark_filtered(compiled, user.id)
 
     # Read the stored draft once and hand it to the composer below, which then
@@ -231,7 +268,7 @@ defmodule VutuvWeb.PostLive.Feed do
   # %Phoenix.LiveView.LiveStream{} carries per-socket insert state that the
   # dead render already consumed, so handing the struct itself to the
   # connected socket would replay as an empty feed.
-  defp apply_feed_payload(socket, payload) do
+  defp apply_feed_payload(socket, payload, day, open?) do
     socket
     # On-demand translations (issue #1462): the per-card view state. A map
     # means this viewer gets the controls, nil means they do not — the cards
@@ -251,6 +288,21 @@ defmodule VutuvWeb.PostLive.Feed do
     # How many arrivals the cap turned away. Nonzero means the timeline no longer
     # holds a row for every waiting post, so the press has to load a page.
     |> assign(:pending_overflow, 0)
+    # The calendar's own state: whether it is unfolded, which month is on
+    # screen, which reading its heatmap shades, and which day (if any) the
+    # reader opened. `cal_day` is a Date rather than a moment because it names a
+    # WINDOW — a whole day, first minute to last.
+    #
+    # Folded and on today by default. The calendar is a way *out* of the
+    # present, and most visits to a feed are not that: unfolded by default it
+    # would put six rows of month between the composer and the first post for
+    # every reader who never travels. `restore_calendar/2` unfolds it again for
+    # an arrival that names a day in the URL.
+    |> assign(:cal_open?, open?)
+    |> assign(:cal_month, FeedTimeTravel.month_of(day))
+    |> assign(:cal_metric, "feed")
+    |> assign(:cal_day, day)
+    |> assign_calendar_counts()
     |> assign(:draft, payload.draft)
     # The composer starts collapsed to a single "What's new?" button; posting
     # (own activity arriving below) collapses it again. A stored draft opens it
@@ -1028,7 +1080,7 @@ defmodule VutuvWeb.PostLive.Feed do
       Posts.feed_page(socket.assigns.current_user,
         limit: @page_size,
         cursor: socket.assigns.cursor,
-        filter: socket.assigns.feed_filter
+        filter: effective_filter(socket)
       )
 
     # A post shown higher up (as a newer repost, or nested in a shown thread)
@@ -1056,6 +1108,94 @@ defmodule VutuvWeb.PostLive.Feed do
      |> stream(:posts, entries, at: -1)
      |> watch_pending_photos(entries)
      |> auto_translate_entries(entries)}
+  end
+
+  # Time travel (`VutuvWeb.Live.FeedTimeTravel`), all of it driven by the feed
+  # calendar: closing the open day is the only way back to the live present.
+  def handle_event("travel-now", _params, socket),
+    do: {:noreply, socket |> load_day(nil) |> sync_url()}
+
+  # Paging the calendar does not move the reader: it changes which month they
+  # are looking at. Only a day-click travels, which is what lets somebody hunt
+  # for a busy week without their timeline lurching about under them.
+  def handle_event("cal-month", %{"n" => n}, socket) do
+    case Integer.parse(to_string(n)) do
+      # Backwards is refused once the feed no longer reaches past this month —
+      # the same rule that greys the arrow out, applied where it is enforceable.
+      # A disabled button is a hint; this is the answer.
+      {value, _rest} when value < 0 and not socket.assigns.cal_earlier? ->
+        {:noreply, socket}
+
+      {value, _rest} ->
+        {:noreply,
+         socket
+         |> assign(:cal_month, FeedTimeTravel.shift_month(socket.assigns.cal_month, value))
+         |> assign_calendar_counts()}
+
+      :error ->
+        {:noreply, socket}
+    end
+  end
+
+  # The reading is not just a shading: "My posts" narrows the **timeline** to
+  # what this member wrote, so switching it reloads the page under the calendar
+  # as well as the numbers in it. Shading a month by one rule while the feed
+  # below showed another would be two answers to one question.
+  def handle_event("cal-metric", %{"metric" => metric}, socket) do
+    known = Enum.map(FeedCalendar.metrics(), & &1.key)
+    metric = if metric in known, do: metric, else: "feed"
+
+    # Pressing the reading already showed is a no-op, and has to say so here:
+    # the two buttons are `aria-pressed`, never disabled, so the press arrives
+    # like any other and would otherwise re-run the month union, the floor check
+    # and a full page load with a stream reset for nothing.
+    if metric == socket.assigns.cal_metric do
+      {:noreply, socket}
+    else
+      {:noreply,
+       socket
+       |> assign(:cal_metric, metric)
+       |> assign_calendar_counts()
+       |> load_day(socket.assigns.cal_day)}
+    end
+  end
+
+  # "Load the whole day" — the button beside "Load more" on a busy day.
+  #
+  # Re-fetches the day in one page rather than chaining "Load more" until it
+  # runs out: the reader has said they want all of it, and walking there ten at
+  # a time is the same rows over more round trips. Capped at `@day_all_limit`,
+  # so a day with thousands still ends with a "Load more" under it instead of
+  # trying to render the lot.
+  def handle_event("load-day-all", _params, socket) do
+    case socket.assigns.cal_day do
+      nil -> {:noreply, socket}
+      day -> {:noreply, load_day(socket, day, @day_all_limit)}
+    end
+  end
+
+  # Folding the calendar away does not send the reader home: somebody who
+  # opened last Tuesday and wants the month grid out of the way is still
+  # reading Tuesday, and yanking them back to now would be a second thing they
+  # did not ask for. Closing the DAY is what returns to the present.
+  def handle_event("cal-toggle", _params, socket) do
+    # Unfolding is what pays for the heatmap: folded, the counts are not
+    # computed at all (see `assign_calendar_counts/1`).
+    {:noreply, socket |> update(:cal_open?, &(!&1)) |> assign_calendar_counts() |> sync_url()}
+  end
+
+  # A day is a window, not a moment (`FeedTimeTravel.day_cursor/1`). Pressing
+  # the day already open closes it and returns to now, so the same control both
+  # opens and closes a day rather than stranding the reader in one.
+  def handle_event("cal-day", %{"date" => date}, socket) do
+    with {:ok, day} <- FeedTimeTravel.parse_date(date),
+         true <- FeedTimeTravel.reachable?(day) do
+      day = if socket.assigns.cal_day == day, do: nil, else: day
+
+      {:noreply, socket |> load_day(day) |> sync_url()}
+    else
+      _unreachable -> {:noreply, socket}
+    end
   end
 
   def handle_event("open-composer", _params, socket) do
@@ -1249,8 +1389,13 @@ defmodule VutuvWeb.PostLive.Feed do
     # control knows this too and does not run the browser-side reveal in that
     # mode, or the kept rows would flash into view a moment before the reload
     # replaced the whole list.
-    if socket.assigns.pending_overflow > 0 do
-      {:noreply, load_source_filter(socket, socket.assigns.feed_filter)}
+    # A third way in, and it is the one the calendar adds: with a day open there
+    # are no rows either, because the waiting posts belong to today and the
+    # timeline is showing some other day. Pressing the pill is then the reader
+    # saying "take me to those posts", so it closes the day and comes home —
+    # which is exactly the reload the overflow case already wanted.
+    if socket.assigns.pending_overflow > 0 or not at_now?(socket.assigns) do
+      {:noreply, socket |> load_day(nil) |> sync_url()}
     else
       {:noreply, socket |> assign(:pending_posts, []) |> assign(:empty?, false)}
     end
@@ -1286,6 +1431,193 @@ defmodule VutuvWeb.PostLive.Feed do
     |> assign(:entries, entries)
     |> stream(:posts, entries, reset: true)
     |> watch_pending_photos(entries)
+  end
+
+  # Whether the reader is looking at the live present. One way to leave it, the
+  # calendar's open day, and every gate that cares asks the same question: the
+  # arrival guard, the three empty states and the amber paint.
+  defp at_now?(assigns), do: is_nil(assigns.cal_day)
+
+  # What the URL asked the calendar to show (`/feed?day=2026-08-21`,
+  # `/feed?cal=1`), as `{day_or_nil, unfolded?}`.
+  #
+  # The controller reads the query string and passes the two values through the
+  # `live_render` session, because this LiveView is embedded rather than routed
+  # and so has no `handle_params/3` of its own. An unreadable or future date is
+  # simply ignored: a link somebody mangled should land on the feed, not on an
+  # error, and a day that has not happened has nothing to show.
+  #
+  # A named day implies an unfolded calendar — arriving at a day with the grid
+  # folded away would hide the only control that explains where the reader is.
+  defp calendar_from_url(session) do
+    with {:ok, day} <- FeedTimeTravel.parse_date(session["cal_day"] || ""),
+         true <- FeedTimeTravel.reachable?(day) do
+      {day, true}
+    else
+      _no_day -> {nil, session["cal_open"] in ~w(1 open true)}
+    end
+  end
+
+  # Keeps the address bar in step with the calendar, so the day on screen is
+  # always the day a copied link reopens.
+  #
+  # `replaceState` from a hook rather than `push_patch/2`: patching needs a
+  # routed LiveView, and this one is `live_render`ed by the controller that
+  # owns the agent-format siblings. It is deliberately *replace* and not
+  # *push* — a reader stepping through a fortnight would otherwise have to
+  # press Back fourteen times to leave the feed.
+  defp sync_url(socket) do
+    query =
+      %{}
+      |> put_param("day", socket.assigns.cal_day && Date.to_iso8601(socket.assigns.cal_day))
+      |> put_param("cal", if(socket.assigns.cal_open? && !socket.assigns.cal_day, do: "1"))
+
+    push_event(socket, "feed:url", %{query: URI.encode_query(query)})
+  end
+
+  defp put_param(params, _key, nil), do: params
+  defp put_param(params, key, value), do: Map.put(params, key, value)
+
+  # The heatmap's numbers for the month on screen. Recomputed whenever the
+  # month or the reading changes, and never on an ordinary timeline patch:
+  # the feed reading is a nine-source union over a month and is by far the most
+  # expensive thing this page asks for.
+  # What the timeline is currently narrowed to.
+  #
+  # Two axes meet here and only one of them is remembered. `feed_filter` is the
+  # source band's stored setting (`users.feed_source`, which network); the
+  # calendar's "My posts" reading is a view the reader is in right now and is
+  # never written down. So this composes them for the query without the second
+  # one ever reaching the member's saved preference.
+  defp effective_filter(%{assigns: assigns}), do: effective_filter(assigns)
+  defp effective_filter(%{cal_metric: "own"}), do: :own
+  defp effective_filter(assigns), do: assigns.feed_filter
+
+  # Whether a live arrival belongs in the timeline as it is currently narrowed.
+  #
+  # Under "My posts" that is a question about the AUTHOR, which the entry alone
+  # cannot answer — so it is asked here, where the viewer is known, rather than
+  # in `Posts.feed_filter_accepts?/2`.
+  defp view_accepts?(socket, entry, actor_id) do
+    case effective_filter(socket) do
+      :own -> actor_id == socket.assigns.current_user.id
+      filter -> Posts.feed_filter_accepts?(filter, entry)
+    end
+  end
+
+  # Nothing at all while the calendar is folded away, which is how it opens and
+  # how most readers leave it.
+  #
+  # The heatmap is a nine-source union over a month and the floor check is a
+  # tenth query, and both were being paid on **every** feed mount for a grid
+  # nobody had asked to see — enough to push a connected mount from 18 queries
+  # to 28 and cost the mount handoff its whole point. Folded, the card shows a
+  # date and needs no numbers; unfolding is what buys them.
+  defp assign_calendar_counts(%{assigns: %{cal_open?: false}} = socket) do
+    socket
+    |> assign(:cal_counts, %{})
+    |> assign(:cal_capped?, false)
+    |> assign(:cal_earlier?, true)
+  end
+
+  defp assign_calendar_counts(socket) do
+    user = socket.assigns.current_user
+    month = socket.assigns.cal_month
+    # The same narrowing the timeline is under, so the shading and the feed
+    # below it can never answer one question two ways. Under "My posts" that is
+    # `:own`, whose source list is the single query counting them used to be.
+    filter = effective_filter(socket)
+
+    %{counts: counts, capped?: capped?} =
+      Posts.feed_activity_by_day(
+        user,
+        Date.beginning_of_month(month),
+        Date.end_of_month(month),
+        filter: filter
+      )
+
+    socket
+    |> assign(:cal_counts, counts)
+    |> assign(:cal_capped?, capped?)
+    # Where the back arrows stop. Asked per month rather than resolved once,
+    # because "is there anything before this month" is one row and a member's
+    # true earliest entry is a nine-source minimum nobody needs.
+    |> assign(:cal_earlier?, Posts.feed_reaches_before_month?(user, month, filter: filter))
+  end
+
+  # Moves the timeline to a point in time — where both controls land. `nil` is
+  # now, and the reload is the *same* `feed_page/2` a mount calls, just handed a
+  # synthetic first cursor: no second query path, so no visibility, block,
+  # language or content filter can be true of one and not the other.
+  #
+  # `day:` is the calendar's shape and carries a lower bound as well, so the
+  # page is one whole day rather than everything up to the end of it. It rides
+  # the cursor, so "Load more" inside a day stops at the day's own edge.
+  #
+  # The pending queue is emptied rather than carried. What was waiting behind
+  # the pill is "new since you got here", which is a claim about **now** and
+  # says nothing on a timeline showing last Tuesday; and the return trip
+  # reloads from the top anyway, so nothing is actually lost by dropping it.
+  # How big a page opening this day should ask for.
+  #
+  # A day the heatmap already knows to be small is fetched **whole**, so the
+  # ordinary case has no "Load more" under it at all — a day is a bounded thing
+  # the reader asked to see, not an endless timeline. Only the busy ones page.
+  # The limit is an upper bound, so a day holding three entries costs three
+  # however generous the number here is.
+  defp day_limit(_socket, nil), do: @travel_page_size
+
+  defp day_limit(socket, day),
+    do: day_page_limit(day_total(socket.assigns.cal_counts, day))
+
+  # The rule itself, in one place: a day the feed knows to be small arrives
+  # whole, a busy one pages.
+  defp day_page_limit(total) when total < @day_full_limit, do: @day_full_limit
+  defp day_page_limit(_total), do: @travel_page_size
+
+  # The day's size, read straight off the heatmap counts, so knowing it costs no
+  # query of its own.
+  #
+  # Derived on every read rather than stored: it is a `Map.get` on two assigns
+  # that both move on their own (a month step replaces the counts, a day click
+  # replaces the day), and a copy would have had to be refreshed on each of
+  # those paths or quietly disagree with the grid it was read from.
+  # `Map.get` answers 0 for a nil day as readily as for a day nothing happened
+  # on, so this needs no clause of its own for "no day open".
+  defp day_total(counts, day), do: Map.get(counts, day, 0)
+
+  defp load_day(socket, day, limit \\ nil) do
+    user = socket.assigns.current_user
+
+    page =
+      Posts.feed_page(user,
+        limit: limit || day_limit(socket, day),
+        cursor: FeedTimeTravel.day_cursor(day),
+        filter: effective_filter(socket)
+      )
+
+    entries =
+      page.entries
+      |> with_engagement(user)
+      |> mark_filtered(socket.assigns.content_filters, user.id)
+
+    socket
+    |> assign(:cal_day, day)
+    # Opening a day from another month moves the calendar to it, or the reader
+    # is looking at a highlighted day that is not on the grid in front of them.
+    |> assign(
+      :cal_month,
+      if(day, do: FeedTimeTravel.month_of(day), else: socket.assigns.cal_month)
+    )
+    |> assign(:more?, page.more?)
+    |> assign(:cursor, page.next_cursor)
+    |> assign(:empty?, entries == [])
+    |> assign(:pending_posts, [])
+    |> assign(:pending_overflow, 0)
+    |> assign(:entries, entries)
+    |> stream(:posts, entries, reset: true)
+    |> watch_pending_photos(entries)
+    |> auto_translate_entries(entries)
   end
 
   @impl true
@@ -1581,6 +1913,7 @@ defmodule VutuvWeb.PostLive.Feed do
   # What a "show me" control fires. Past the cap it is the plain event and the
   # server loads a page; under it, the browser does the work first.
   defp show_pending(%{pending_overflow: overflow}) when overflow > 0, do: "show-new"
+  defp show_pending(%{cal_day: %Date{}}), do: "show-new"
   defp show_pending(_assigns), do: reveal_pending()
 
   defp reveal_pending do
@@ -1659,6 +1992,62 @@ defmodule VutuvWeb.PostLive.Feed do
   defp insert_entry(socket, nil, _actor_id), do: {:noreply, socket}
 
   defp insert_entry(socket, entry, actor_id) do
+    if at_now?(socket.assigns) do
+      insert_at_now(socket, entry, actor_id)
+    else
+      insert_while_travelling(socket, entry, actor_id)
+    end
+  end
+
+  # An arrival that reaches a reader with a calendar day open. Its own function
+  # rather than more branches in the `cond` below, because the two situations
+  # take a different action on the same facts.
+  #
+  # It is still **counted**: a reader who went to look at last Tuesday wants to
+  # know the present is filling up behind them, and the pill is how the feed
+  # has always said so. What it must not do is draw the row — that post is not
+  # part of the day on screen, and a hidden card belonging to another day sitting
+  # in this day's stream is a card that appears in the wrong place the moment
+  # anything reveals it. So the entry joins the waiting list without a row, and
+  # `show_pending/1` knows there is nothing to reveal and asks the server
+  # instead (which brings the reader home; see the "show-new" handler).
+  #
+  # The viewer's own post is the exception, as everywhere else: text that
+  # disappears on submit reads as a post that was lost, so writing one is itself
+  # the trip home and that reload carries it.
+  defp insert_while_travelling(socket, entry, actor_id) do
+    user = socket.assigns.current_user
+
+    cond do
+      actor_id == user.id ->
+        {:noreply, socket |> assign(:composer_open?, false) |> load_day(nil) |> sync_url()}
+
+      # The same two gates a queued arrival passes at now: can this post reach
+      # this reader at all, and did they switch its source off.
+      not Posts.reaches_feed?(entry.post, user) ->
+        {:noreply, socket}
+
+      not view_accepts?(socket, entry, actor_id) ->
+        {:noreply, socket}
+
+      true ->
+        # `mark_one/3` and not `decorate/3`: nothing here is streamed, and the
+        # pill only reads the author and the opening line. Decorating would buy
+        # a follow edge and an engagement count per arrival, two queries, for a
+        # card that is never drawn — including the ones the cap throws away.
+        {:noreply, count_away(socket, mark_one(entry, socket.assigns.content_filters, user.id))}
+    end
+  end
+
+  # Waiting posts with no row on the page, because the page is showing another
+  # day. The cap is `trim_pending/1`'s, so the valve has one owner: its
+  # `stream_delete/2` and `Enum.reject/2` are no-ops for an entry that was never
+  # streamed and never added to `@entries`, which is exactly this case.
+  defp count_away(socket, entry) do
+    socket |> update(:pending_posts, &[entry | &1]) |> trim_pending()
+  end
+
+  defp insert_at_now(socket, entry, actor_id) do
     user = socket.assigns.current_user
 
     cond do
@@ -1667,7 +2056,7 @@ defmodule VutuvWeb.PostLive.Feed do
       # feed switches back to All and reloads rather than swallowing the post,
       # which from the composer reads as the post having been lost.
       actor_id == user.id and
-          not Posts.feed_filter_accepts?(socket.assigns.feed_filter, entry) ->
+          not view_accepts?(socket, entry, actor_id) ->
         {:noreply,
          socket
          |> assign(:composer_open?, false)
@@ -1699,7 +2088,7 @@ defmodule VutuvWeb.PostLive.Feed do
       # A post nobody on this tab asked for must not be counted by the pill
       # either: the pill's whole promise is that clicking it shows those posts
       # right here.
-      Posts.feed_filter_accepts?(socket.assigns.feed_filter, entry) ->
+      view_accepts?(socket, entry, actor_id) ->
         {:noreply, queue(socket, decorate(entry, user, socket))}
 
       # It belongs to a source this reader has switched off in the band, so it
@@ -1962,7 +2351,11 @@ defmodule VutuvWeb.PostLive.Feed do
   @impl true
   def render(assigns) do
     ~H"""
-    <div id="feed" class="py-6">
+    <%!-- `FeedUrl` writes the calendar's day into the address bar (see
+    `sync_url/1`). It hangs off the page root rather than off the calendar
+    because there are two calendars, one per breakpoint, and the URL has one
+    owner. --%>
+    <div id="feed" phx-hook="FeedUrl" class="py-6">
       <%!-- Two columns on desktop: the feed, plus the rail that uses the
       otherwise-empty side space. The rail is desktop-only (the grid collapses
       to one column under md, and the rail is hidden anyway). --%>
@@ -2070,6 +2463,24 @@ defmodule VutuvWeb.PostLive.Feed do
               preloaded_draft={{:loaded, @draft}}
             />
           </div>
+
+          <%!-- The phone's copy of the calendar. There is no filter column
+          under `md`, and a control that exists only on a desktop is not a
+          control this site ships — the rest of the feed's rail is genuinely
+          optional, but the way back from an opened day is not. Same component,
+          its own id, and it disappears at `md` where the rail's copy takes
+          over. --%>
+          <.feed_calendar
+            id="feed-calendar-mobile"
+            open?={@cal_open?}
+            earlier?={@cal_earlier?}
+            month={@cal_month}
+            day={@cal_day}
+            metric={@cal_metric}
+            counts={@cal_counts}
+            capped?={@cal_capped?}
+            class="md:hidden"
+          />
 
           <%!-- One line, two controls, and on a phone it is the only way to
           either of them. The filter button opens the band as a sheet, because
@@ -2227,15 +2638,35 @@ defmodule VutuvWeb.PostLive.Feed do
           empty page with no hint that they emptied it themselves. A feed that
           is empty with both halves on keeps the general invitation, which is
           the one that helps a new member. --%>
+          <%!-- Travelled back past the beginning of this member's feed. Neither
+          sentence below fits that: one blames a source switch and the other
+          tells somebody with a full timeline to go find people to follow. What
+          is actually true is that nothing had reached them yet by then, and the
+          only useful control is the way back. --%>
+          <.card :if={@empty? && !at_now?(assigns)} class="text-center">
+            <p class="text-slate-600 dark:text-slate-400">
+              {gettext("Nothing reached your feed on %{day}.",
+                day: Vutuv.ViewerClock.format(@cal_day, :date)
+              )}
+            </p>
+            <.button phx-click="travel-now" class="mt-3">{gettext("Back to now")}</.button>
+          </.card>
+
           <p
-            :if={@empty? && @pending_posts == [] && @feed_filter != :all}
+            :if={
+              @empty? && @pending_posts == [] && @feed_filter != :all &&
+                at_now?(assigns)
+            }
             class="text-slate-600 dark:text-slate-400"
           >
             {feed_filter_empty_text(to_string(@feed_filter))}
           </p>
 
           <p
-            :if={@empty? && @pending_posts == [] && @feed_filter == :all}
+            :if={
+              @empty? && @pending_posts == [] && @feed_filter == :all &&
+                at_now?(assigns)
+            }
             class="text-slate-600 dark:text-slate-400"
           >
             {gettext("Nothing here yet. Follow people to fill your feed, or write your first post.")}
@@ -2248,6 +2679,30 @@ defmodule VutuvWeb.PostLive.Feed do
           </p>
 
           <.load_more :if={@more?} />
+
+          <%!-- On a busy day, the second way out: the reader opened a bounded
+          thing and "Load more" walks it ten at a time. Only shown when there is
+          actually more of the day left, and only for a day — at now there is no
+          "all", the feed goes back forever. --%>
+          <%!-- `day_total > 0` as well: the count comes from the heatmap, which
+          is only computed while the calendar is unfolded, and a button offering
+          "the whole day (0 posts)" would be worse than no button. --%>
+          <div :if={@more? && @cal_day && day_total(@cal_counts, @cal_day) > 0} class="text-center">
+            <button
+              type="button"
+              id="load-day-all"
+              phx-click="load-day-all"
+              phx-disable-with={gettext("Loading…")}
+              class="text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+            >
+              {ngettext(
+                "Load the whole day (%{formatted} post)",
+                "Load the whole day (%{formatted} posts)",
+                day_total(@cal_counts, @cal_day),
+                formatted: delimited_count(day_total(@cal_counts, @cal_day))
+              )}
+            </button>
+          </div>
 
           <%!-- On mobile (where the desktop rail is hidden) the "Other formats"
           card drops to the bottom of the page; the rail itself stays
@@ -2266,6 +2721,23 @@ defmodule VutuvWeb.PostLive.Feed do
         WITH the page on purpose: a lazily loaded rail popped in after the paint
         and read as slowness (the v7.200.3 laziness was undone). --%>
         <aside id="feed-rail" class="hidden space-y-6 md:block">
+          <%!-- The calendar variant lives here, at the top of the filter
+          column, because that is where a month grid belongs: beside the
+          timeline it describes rather than on top of it. Deliberately ABOVE
+          the arrangeable cards and not one of them — it is a navigation
+          control, not a card the reader curates away, and putting it in the
+          rail's stored order would let somebody hide the only way back. --%>
+          <.feed_calendar
+            id="feed-calendar-rail"
+            open?={@cal_open?}
+            earlier?={@cal_earlier?}
+            month={@cal_month}
+            day={@cal_day}
+            metric={@cal_metric}
+            counts={@cal_counts}
+            capped?={@cal_capped?}
+          />
+
           <%!-- Every card is dragged by its own grip and the hook pushes the
           sequence they were dropped into. That sequence lists only what is on
           screen — half these cards are conditional — which is why

--- a/lib/vutuv_web/live/post_live/feed_calendar.ex
+++ b/lib/vutuv_web/live/post_live/feed_calendar.ex
@@ -1,0 +1,360 @@
+defmodule VutuvWeb.PostLive.FeedCalendar do
+  @moduledoc """
+  An ordinary month calendar in the feed's right-hand column, with each day
+  shaded by how much happened on it, and a click on a day opening that whole
+  day in the timeline.
+
+  It answers **which day**, and it is the only feed control that shows where
+  the timeline is worth going before you go there. The shading is the point: a
+  month of a quiet feed is mostly pale, and the two or three days that are not
+  are exactly the days to open.
+
+  Two readings, and they are different questions rather than a filter of one
+  another. **Feed** counts what reached the reader, through the same nine
+  sources a page is built from (`Vutuv.Posts.feed_activity_by_day/4`), so a day
+  the heatmap calls busy really does have a timeline behind it. **My posts**
+  counts what the reader published, which is one table and no visibility
+  question at all.
+
+  ## A day is a window, not a vantage
+
+  Clicking a date shows that day **from its first minute to its last**
+  (`VutuvWeb.Live.FeedTimeTravel.day_cursor/1`), and "Load more" inside it
+  stops at the day's own edge instead of sliding into the day before. That
+  lower bound rides in the feed cursor, so it survives pagination — which is
+  the whole reason a day reads as a day rather than as "this day and all of
+  history under it".
+
+  ## Where it lives
+
+  Rendered twice, with different ids: in the rail column on a desktop, and
+  above the timeline on a phone, which has no rail column at all. The month
+  grid is always six rows so paging through months does not change the card's
+  height and shove the rail cards below it up and down.
+  """
+
+  use Phoenix.Component
+  use Gettext, backend: VutuvWeb.Gettext
+
+  import VutuvWeb.UI, only: [month_name: 1, weekday_initials: 0]
+
+  alias VutuvWeb.Live.FeedTimeTravel
+
+  @doc "The two readings the heatmap offers."
+  def metrics do
+    [
+      %{key: "feed", label: gettext("Feed")},
+      %{key: "own", label: gettext("My posts")}
+    ]
+  end
+
+  @doc """
+  The month grid, its heatmap and the two controls under it.
+
+  `id` is required because the calendar renders twice, once per breakpoint.
+  """
+  attr(:id, :string, required: true)
+  attr(:open?, :boolean, default: false, doc: "whether the month grid is unfolded")
+  attr(:earlier?, :boolean, default: true, doc: "whether the feed reaches back past this month")
+  attr(:month, :any, required: true, doc: "the shown month, a Date at its first day")
+  attr(:day, :any, default: nil, doc: "the selected day, a Date, or nil")
+  attr(:metric, :string, default: "feed")
+  attr(:counts, :map, default: %{})
+  attr(:capped?, :boolean, default: false)
+  attr(:class, :string, default: nil)
+
+  def feed_calendar(assigns) do
+    assigns =
+      assign(assigns,
+        cells: FeedTimeTravel.month_grid(assigns.month),
+        today: Vutuv.ViewerClock.today(),
+        peak: assigns.counts |> Map.values() |> Enum.max(fn -> 0 end)
+      )
+
+    ~H"""
+    <div
+      id={@id}
+      class={[
+        "rounded-2xl bg-white shadow-sm ring-1 dark:bg-slate-900",
+        if(@open?, do: "p-4", else: "p-2"),
+        @day && "ring-amber-400 dark:ring-amber-500/60",
+        !@day && "ring-slate-200 dark:ring-slate-800",
+        @class
+      ]}
+    >
+      <%!-- ONE row in both states, because two would not line up with anything
+      else in the column: the fold toggle IS the month (or, folded, the day), so
+      the centre of the row never moves and only the month arrows come and go
+      around it.
+
+      Folded, this is the whole card and the only thing a reader who never
+      travels ever sees: which day the timeline is showing, and a way in. --%>
+      <div class="flex items-center gap-0.5">
+        <.month_arrow
+          :if={@open?}
+          n={-12}
+          label={gettext("Previous year")}
+          wide
+          disabled={!@earlier?}
+        />
+        <.month_arrow :if={@open?} n={-1} label={gettext("Previous month")} disabled={!@earlier?} />
+
+        <button
+          type="button"
+          phx-click="cal-toggle"
+          aria-expanded={to_string(@open?)}
+          class="flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded-lg px-1 py-1 hover:bg-slate-50 dark:hover:bg-slate-800"
+        >
+          <.calendar_glyph travelling?={!is_nil(@day)} />
+
+          <span class="min-w-0 truncate text-sm font-semibold text-slate-900 tabular-nums dark:text-slate-100">
+            <%= if @open? do %>
+              {month_name(@month.month)} {@month.year}
+            <% else %>
+              {Vutuv.ViewerClock.format(@day || @today, :date)}
+            <% end %>
+          </span>
+
+          <svg
+            class={["h-4 w-4 shrink-0 text-slate-400", @open? && "rotate-180"]}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="2"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+          </svg>
+        </button>
+
+        <.month_arrow
+          :if={@open?}
+          n={1}
+          label={gettext("Next month")}
+          disabled={at_this_month?(@month)}
+        />
+        <.month_arrow
+          :if={@open?}
+          n={12}
+          label={gettext("Next year")}
+          wide
+          disabled={at_this_month?(@month)}
+        />
+
+        <%!-- Folded and away from today, the way back has to be on the one line
+        there is. Unfolded it sits below, beside the legend, where there is room
+        and the arrows already fill this row. --%>
+        <.now_button :if={!@open? && @day} />
+      </div>
+
+      <%!-- The same seven headings the ad booking calendar has always drawn
+      (`VutuvWeb.UI.weekday_initials/0`), already translated in every locale
+      this site ships. --%>
+      <div
+        :if={@open?}
+        class="mt-3 grid grid-cols-7 gap-1 text-center text-[10px] font-semibold uppercase text-slate-400 dark:text-slate-500"
+      >
+        <span :for={initial <- weekday_initials()}>{initial}</span>
+      </div>
+
+      <div :if={@open?} class="mt-1 grid grid-cols-7 gap-1">
+        <button
+          :for={cell <- @cells}
+          type="button"
+          phx-click="cal-day"
+          phx-value-date={Date.to_iso8601(cell.date)}
+          disabled={Date.compare(cell.date, @today) == :gt}
+          title={day_title(cell.date, Map.get(@counts, cell.date, 0), @metric)}
+          aria-current={@day && cell.date == @day && "date"}
+          class={[
+            "relative flex aspect-square items-center justify-center rounded text-[11px] tabular-nums",
+            "disabled:cursor-not-allowed disabled:opacity-30",
+            heat_class(Map.get(@counts, cell.date, 0), @peak),
+            !cell.in_month? && "opacity-40",
+            @day && cell.date == @day && "ring-2 ring-amber-500",
+            cell.date == @today && (!@day || cell.date != @day) &&
+              "ring-1 ring-slate-400 dark:ring-slate-500"
+          ]}
+        >
+          {cell.date.day}
+        </button>
+      </div>
+
+      <div :if={@open?} class="mt-3 flex gap-1 rounded-full bg-slate-100 p-1 dark:bg-slate-800">
+        <button
+          :for={m <- metrics()}
+          type="button"
+          phx-click="cal-metric"
+          phx-value-metric={m.key}
+          aria-pressed={to_string(m.key == @metric)}
+          class={[
+            "h-8 flex-1 rounded-full text-[11px] font-semibold",
+            m.key == @metric &&
+              "bg-white text-slate-900 shadow-sm dark:bg-slate-900 dark:text-slate-100",
+            m.key != @metric &&
+              "text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
+          ]}
+        >
+          {m.label}
+        </button>
+      </div>
+
+      <div :if={@open?} class="mt-2 flex items-center justify-between gap-2">
+        <%!-- The scale, so a shade means something. Without it a pale month and
+        a busy one look the same to somebody who has not seen the other. --%>
+        <div class="flex items-center gap-1 text-[10px] text-slate-500 dark:text-slate-400">
+          <%!-- Their own context, not the bare "More" the notifications page
+          uses for a show-more control: here the word is one END OF A SCALE, and
+          a msgid is a key rather than a phrase. --%>
+          <span>{pgettext("heatmap scale", "Less")}</span>
+          <span :for={level <- 0..4} class={["h-3 w-3 rounded-sm", heat_level_class(level)]}></span>
+          <span>{pgettext("heatmap scale", "More")}</span>
+        </div>
+
+        <.now_button :if={@day} />
+      </div>
+
+      <%!-- Said out loud rather than left to look like a quiet month: past the
+      cap the counts are a floor, and a heatmap that silently under-reports is
+      worse than one that admits it. --%>
+      <p :if={@open? && @capped?} class="mt-2 text-[10px] text-slate-500 dark:text-slate-400">
+        {gettext("Busy month: the shading counts at least this much.")}
+      </p>
+    </div>
+    """
+  end
+
+  # The way back to the present. Rendered folded (beside the date) and unfolded
+  # (beside the legend); it was the same markup twice, differing only in a type
+  # size nobody had chosen on purpose.
+  defp now_button(assigns) do
+    ~H"""
+    <button
+      type="button"
+      phx-click="travel-now"
+      class="h-8 shrink-0 rounded-lg bg-amber-600 px-3 text-xs font-semibold text-white hover:bg-amber-700"
+    >
+      {gettext("Now")}
+    </button>
+    """
+  end
+
+  attr(:n, :integer, required: true)
+  attr(:label, :string, required: true)
+  attr(:wide, :boolean, default: false)
+  attr(:disabled, :boolean, default: false)
+
+  defp month_arrow(assigns) do
+    ~H"""
+    <button
+      type="button"
+      phx-click="cal-month"
+      phx-value-n={@n}
+      disabled={@disabled}
+      title={@label}
+      aria-label={@label}
+      class="inline-flex h-7 w-6 shrink-0 items-center justify-center rounded text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-transparent dark:text-slate-300 dark:hover:bg-slate-800"
+    >
+      <svg
+        class="h-4 w-4"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width="2"
+        stroke="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          :if={@n < 0}
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d={if(@wide, do: "M18.75 19.5l-7.5-7.5 7.5-7.5m-6 15L5.25 12l7.5-7.5", else: "M15.75 19.5L8.25 12l7.5-7.5")}
+        />
+        <path
+          :if={@n > 0}
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d={if(@wide, do: "M5.25 4.5l7.5 7.5-7.5 7.5m6-15l7.5 7.5-7.5 7.5", else: "M8.25 4.5l7.5 7.5-7.5 7.5")}
+        />
+      </svg>
+    </button>
+    """
+  end
+
+  # Amber the moment the timeline is showing some other day. The one failure
+  # this feature can produce is a member reading last Tuesday believing it is
+  # today, and folded away the calendar has only this to say so with.
+  attr(:travelling?, :boolean, required: true)
+
+  defp calendar_glyph(assigns) do
+    ~H"""
+    <svg
+      class={[
+        "h-5 w-5 shrink-0",
+        if(@travelling?,
+          do: "text-amber-600 dark:text-amber-400",
+          else: "text-slate-400 dark:text-slate-500"
+        )
+      ]}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke-width="1.5"
+      stroke="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5"
+      />
+    </svg>
+    """
+  end
+
+  defp at_this_month?(month),
+    do: Date.compare(month, FeedTimeTravel.month_of(nil)) != :lt
+
+  # Five steps, GitHub's scale, keyed to the busiest day of the month SHOWN
+  # rather than to a fixed count. An absolute scale would paint a normal month
+  # of a small feed uniformly pale and tell the reader nothing; relative
+  # shading answers the question they are actually asking, which is "where in
+  # this month did things happen".
+  defp heat_class(0, _peak), do: heat_level_class(0)
+  defp heat_class(_count, 0), do: heat_level_class(0)
+
+  defp heat_class(count, peak) do
+    count |> heat_level(peak) |> heat_level_class()
+  end
+
+  defp heat_level(count, peak) do
+    cond do
+      count >= peak -> 4
+      count >= peak * 0.6 -> 3
+      count >= peak * 0.3 -> 2
+      true -> 1
+    end
+  end
+
+  defp heat_level_class(0),
+    do: "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400"
+
+  defp heat_level_class(1),
+    do: "bg-brand-100 text-brand-800 dark:bg-brand-900/50 dark:text-brand-100"
+
+  defp heat_level_class(2),
+    do: "bg-brand-300 text-brand-900 dark:bg-brand-800 dark:text-brand-100"
+
+  defp heat_level_class(3), do: "bg-brand-500 text-white dark:bg-brand-600"
+  defp heat_level_class(4), do: "bg-brand-700 text-white dark:bg-brand-400 dark:text-brand-900"
+
+  defp day_title(date, count, metric) do
+    day = Vutuv.ViewerClock.format(date, :date)
+
+    case metric do
+      "own" ->
+        ngettext("%{count} post on %{day}", "%{count} posts on %{day}", count, day: day)
+
+      _feed ->
+        ngettext("%{count} entry on %{day}", "%{count} entries on %{day}", count, day: day)
+    end
+  end
+end

--- a/lib/vutuv_web/views/ad_html.ex
+++ b/lib/vutuv_web/views/ad_html.ex
@@ -55,17 +55,7 @@ defmodule VutuvWeb.AdHTML do
   end
 
   @doc "Monday-first weekday initials for the calendar header."
-  def weekday_initials do
-    [
-      gettext("Mo"),
-      gettext("Tu"),
-      gettext("We"),
-      gettext("Th"),
-      gettext("Fr"),
-      gettext("Sa"),
-      gettext("Su")
-    ]
-  end
+  defdelegate weekday_initials, to: VutuvWeb.UI
 
   def status_label(%Ad{approved_at: nil}), do: gettext("Waiting for approval")
   def status_label(%Ad{}), do: gettext("Approved")

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.577.1",
+      version: "7.585.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -23027,3 +23027,75 @@ msgstr[1] "%{formatted} Beiträge im Feed anzeigen"
 #, elixir-autogen, elixir-format
 msgid "Picture unavailable"
 msgstr "Bild nicht verfügbar"
+
+#: lib/vutuv_web/live/post_live/feed.ex
+#, elixir-autogen, elixir-format
+msgid "Back to now"
+msgstr "Zurück zu jetzt"
+
+#: lib/vutuv_web/live/post_live/feed_calendar.ex
+#, elixir-autogen, elixir-format
+msgid "My posts"
+msgstr "Meine Beiträge"
+
+#: lib/vutuv_web/live/post_live/feed_calendar.ex
+#, elixir-autogen, elixir-format
+msgid "Previous month"
+msgstr "Voriger Monat"
+
+#: lib/vutuv_web/live/post_live/feed_calendar.ex
+#, elixir-autogen, elixir-format
+msgid "Next month"
+msgstr "Nächster Monat"
+
+#: lib/vutuv_web/live/post_live/feed_calendar.ex
+#, elixir-autogen, elixir-format
+msgid "Previous year"
+msgstr "Voriges Jahr"
+
+#: lib/vutuv_web/live/post_live/feed_calendar.ex
+#, elixir-autogen, elixir-format
+msgid "Next year"
+msgstr "Nächstes Jahr"
+
+#: lib/vutuv_web/live/post_live/feed_calendar.ex
+#, elixir-autogen, elixir-format
+msgid "Busy month: the shading counts at least this much."
+msgstr "Voller Monat: die Färbung zählt mindestens so viel."
+
+#: lib/vutuv_web/live/post_live/feed_calendar.ex
+#, elixir-autogen, elixir-format
+msgctxt "heatmap scale"
+msgid "Less"
+msgstr "Weniger"
+
+#: lib/vutuv_web/live/post_live/feed_calendar.ex
+#, elixir-autogen, elixir-format
+msgctxt "heatmap scale"
+msgid "More"
+msgstr "Mehr"
+
+#: lib/vutuv_web/live/post_live/feed_calendar.ex
+#, elixir-autogen, elixir-format
+msgid "%{count} entry on %{day}"
+msgid_plural "%{count} entries on %{day}"
+msgstr[0] "%{count} Eintrag am %{day}"
+msgstr[1] "%{count} Einträge am %{day}"
+
+#: lib/vutuv_web/live/post_live/feed_calendar.ex
+#, elixir-autogen, elixir-format
+msgid "%{count} post on %{day}"
+msgid_plural "%{count} posts on %{day}"
+msgstr[0] "%{count} Beitrag am %{day}"
+msgstr[1] "%{count} Beiträge am %{day}"
+
+#: lib/vutuv_web/live/post_live/feed.ex
+#, elixir-autogen, elixir-format
+msgid "Nothing reached your feed on %{day}."
+msgstr "Am %{day} ist nichts in Ihrem Feed angekommen."
+#: lib/vutuv_web/live/post_live/feed.ex
+#, elixir-autogen, elixir-format
+msgid "Load the whole day (%{formatted} post)"
+msgid_plural "Load the whole day (%{formatted} posts)"
+msgstr[0] "Ganzen Tag laden (%{formatted} Beitrag)"
+msgstr[1] "Ganzen Tag laden (%{formatted} Beiträge)"

--- a/test/vutuv_web/live/feed_calendar_test.exs
+++ b/test/vutuv_web/live/feed_calendar_test.exs
@@ -1,0 +1,861 @@
+defmodule VutuvWeb.FeedCalendarTest do
+  @moduledoc """
+  The feed calendar: the timeline really moves to the day you click, that day
+  is a **window** rather than an upper bound, and the live present stops
+  leaking into it while it is open.
+
+  The window is the claim worth guarding hardest, and it only shows up when the
+  reader presses "Load more" — without a lower bound the second page quietly
+  slides into the day before and keeps going.
+
+  The other half is the PubSub path, which never touches the query: it prepends
+  the viewer's own posts and queues everybody else's behind the "N new posts"
+  pill. Left alone it drops a post from thirty seconds ago into a timeline
+  showing last week, with no query involved and nothing to notice it.
+  """
+  use VutuvWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Posts
+  alias Vutuv.PostsHelpers
+  alias Vutuv.Social
+  alias Vutuv.ViewerClock
+  alias VutuvWeb.Live.FeedTimeTravel, as: Travel
+
+  @day 86_400
+
+  # A followed author plus two posts placed by hand on either side of a
+  # three-day boundary. Second precision everywhere, so nothing here may rely
+  # on two events in the same second (see `Vutuv.PostsHelpers.backdate_post!`).
+  defp feed_with_history(viewer) do
+    author = insert(:activated_user)
+    Social.follow(viewer, author.id)
+
+    recent = PostsHelpers.create_post!(author, %{body: "from this morning"})
+    PostsHelpers.backdate_post!(recent, 3_600)
+
+    old = PostsHelpers.create_post!(author, %{body: "from a week ago"})
+    PostsHelpers.backdate_post!(old, 7 * @day)
+
+    author
+  end
+
+  defp timeline(view) do
+    if has_element?(view, "#feed-posts"), do: render(element(view, "#feed-posts")), else: ""
+  end
+
+  defp iso(date), do: Date.to_iso8601(date)
+  defp days_ago(n), do: Date.add(ViewerClock.today(), -n)
+
+  describe "the calendar" do
+    test "a day click shows that day and nothing newer", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      three = PostsHelpers.create_post!(author, %{body: "from three days ago"})
+      PostsHelpers.backdate_post!(three, 3 * @day)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
+
+      assert timeline(view) =~ "from three days ago"
+      refute timeline(view) =~ "from this morning"
+    end
+
+    test "and nothing OLDER either, which is what makes it a window",
+         %{conn: conn} do
+      # An upper bound alone would have shown the week-old post underneath; a
+      # day must not. This is the lower bound riding in the cursor.
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      three = PostsHelpers.create_post!(author, %{body: "from three days ago"})
+      PostsHelpers.backdate_post!(three, 3 * @day)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
+
+      refute timeline(view) =~ "from a week ago"
+    end
+
+    test "'Load more' inside a day does not escape it", %{conn: conn} do
+      # The lower bound has to survive pagination, or the second page walks
+      # straight out of the day the reader opened.
+      #
+      # Past `@day_full_limit` posts, or the day would arrive whole and there
+      # would be no second page to get wrong.
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      for n <- 1..120 do
+        post = PostsHelpers.create_post!(author, %{body: "day three post #{n}"})
+        PostsHelpers.backdate_post!(post, 3 * @day + n * 10)
+      end
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
+
+      # More than one page of them exists, so there is a second page to get
+      # wrong in the first place.
+      assert has_element?(view, "#load-more, [phx-click='load-more']")
+      render_click(view, "load-more")
+
+      assert timeline(view) =~ "day three post 1"
+      refute timeline(view) =~ "from a week ago"
+      refute timeline(view) =~ "from this morning"
+    end
+
+    test "clicking the open day again closes it and returns to now",
+         %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
+      refute timeline(view) =~ "from this morning"
+
+      render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
+
+      assert timeline(view) =~ "from this morning"
+    end
+
+    test "a future day cannot be opened", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-day", %{"date" => iso(Date.add(ViewerClock.today(), 5))})
+
+      assert timeline(view) =~ "from this morning"
+    end
+
+    test "an unreadable date leaves the reader where they are", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
+
+      render_click(view, "cal-day", %{"date" => "../../etc/passwd"})
+
+      refute timeline(view) =~ "from this morning"
+    end
+
+    test "paging months does not move the reader", %{conn: conn} do
+      # Hunting for a busy week must not lurch the timeline about; only a day
+      # click travels.
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+
+      render_click(view, "cal-month", %{"n" => "-1"})
+      render_click(view, "cal-month", %{"n" => "-12"})
+
+      assert timeline(view) =~ "from this morning"
+      refute has_element?(view, "#feed-calendar-rail.ring-amber-400")
+    end
+
+    test "never pages into the future", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+
+      # At this month the forward arrows are disabled rather than absent, so
+      # the arrow beside them does not move under the reader's finger.
+      assert has_element?(view, "#feed-calendar-rail button[phx-value-n='1'][disabled]")
+      assert has_element?(view, "#feed-calendar-rail button[phx-value-n='12'][disabled]")
+    end
+
+    test "the heatmap shades the days something happened on", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      busy = days_ago(2)
+
+      for n <- 1..5 do
+        post = PostsHelpers.create_post!(author, %{body: "busy day post #{n}"})
+        PostsHelpers.backdate_post!(post, 2 * @day + n * 60)
+      end
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+
+      # The busiest day of the month gets the top step; an empty day gets none.
+      assert has_element?(view, ~s([phx-value-date="#{iso(busy)}"].bg-brand-700))
+      assert has_element?(view, ~s([phx-value-date="#{iso(days_ago(20))}"].bg-slate-100))
+    end
+
+    test "the heatmap counts arrivals, which is never fewer than the cards",
+         %{conn: conn} do
+      # Validated against the real dev feed before it was written down: a day
+      # counted at 306 drew 271 cards, the difference being a thread's posts
+      # collapsing into one entry. The count is therefore an upper bound on
+      # cards, never an undersell, and the invariant is what this pins — a
+      # heatmap that shaded a day the timeline then showed as empty would be
+      # worse than no heatmap.
+      {_conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      day = days_ago(2)
+      parent = PostsHelpers.create_post!(author, %{body: "thread root"})
+      PostsHelpers.backdate_post!(parent, 2 * @day + 300)
+
+      reply = PostsHelpers.create_post!(author, %{body: "thread reply", parent_id: parent.id})
+      PostsHelpers.backdate_post!(reply, 2 * @day + 60)
+
+      %{counts: counts} = Posts.feed_activity_by_day(user, day, day)
+      counted = Map.get(counts, day, 0)
+
+      page = Posts.feed_page(user, limit: 100, cursor: Travel.day_cursor(day))
+
+      assert counted >= length(page.entries)
+      assert counted > 0
+      refute page.entries == []
+    end
+
+    test "the two readings are different questions, not a filter", %{conn: conn} do
+      # "My posts" counts what the reader published; "Feed" counts what reached
+      # them. A day where a followed author posted and the reader did not is the
+      # case that tells the two apart.
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      quiet = days_ago(2)
+      theirs = PostsHelpers.create_post!(author, %{body: "their post"})
+      PostsHelpers.backdate_post!(theirs, 2 * @day)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+
+      assert has_element?(view, ~s([phx-value-date="#{iso(quiet)}"].bg-brand-700))
+
+      render_click(view, "cal-metric", %{"metric" => "own"})
+
+      assert has_element?(view, ~s([phx-value-date="#{iso(quiet)}"].bg-slate-100))
+    end
+
+    test "an unknown metric falls back rather than blanking the heatmap",
+         %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+      render_click(view, "cal-metric", %{"metric" => "../../etc/passwd"})
+
+      assert has_element?(
+               view,
+               "#feed-calendar-rail button[phx-value-metric='feed'][aria-pressed='true']"
+             )
+    end
+
+    test "renders in the filter column and on a phone", %{conn: conn} do
+      # The rail column is `hidden md:block`, so a calendar that lived only
+      # there would not exist on a phone at all.
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+
+      assert has_element?(view, "#feed-rail #feed-calendar-rail")
+      assert has_element?(view, "#feed-calendar-mobile.md\\:hidden")
+    end
+  end
+
+  describe "the live present while a day is open" do
+    test "an arrival never lands in the day on screen", %{conn: conn} do
+      # It belongs to today. A card from another day drawn into this day's
+      # stream is a card that appears in the wrong place the moment anything
+      # reveals it. (It is still COUNTED — see "the pill while a day is open".)
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
+
+      {:ok, _fresh} = Posts.create_post(author, %{body: "arriving while I am in the past"})
+
+      refute timeline(view) =~ "arriving while I am in the past"
+    end
+
+    test "a post the reader may not see is not counted either", %{conn: conn} do
+      # The waiting count passes the same audience gate a drawn arrival does, or
+      # the pill would promise posts that vanish the moment it is pressed.
+      {conn, user} = create_and_login_user(conn)
+      stranger = insert(:activated_user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
+
+      {:ok, _fresh} = Posts.create_post(stranger, %{body: "from somebody I do not follow"})
+
+      refute has_element?(view, "#show-new-posts")
+    end
+
+    test "the same arrival lands normally at now", %{conn: conn} do
+      # Calibration: without this, the tests above pass just as well if
+      # arrivals are broken outright.
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      {:ok, _fresh} = Posts.create_post(author, %{body: "arriving at now"})
+
+      assert has_element?(view, "#show-new-posts")
+    end
+
+    test "writing a post takes the reader home to see it", %{conn: conn} do
+      # Text that vanishes on submit reads as a post that was lost, so the
+      # viewer's own post is the one arrival that ends the trip.
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
+
+      {:ok, _mine} = Posts.create_post(user, %{body: "written from the past"})
+
+      assert timeline(view) =~ "written from the past"
+      assert timeline(view) =~ "from this morning"
+    end
+  end
+
+  describe "how much of a day loads" do
+    test "a small day arrives whole, with nothing left to load", %{conn: conn} do
+      # A day is a bounded thing the reader asked to see, not an endless
+      # timeline: paging through a quiet Tuesday ten posts at a time is
+      # busywork the feed can just do for them.
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      for n <- 1..12 do
+        post = PostsHelpers.create_post!(author, %{body: "quiet day post #{n}"})
+        PostsHelpers.backdate_post!(post, 3 * @day + n * 60)
+      end
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
+
+      assert timeline(view) =~ "quiet day post 1"
+      assert timeline(view) =~ "quiet day post 12"
+      refute has_element?(view, "#load-more")
+      refute has_element?(view, "#load-day-all")
+    end
+
+    test "a busy day pages, and offers the whole day beside 'Load more'",
+         %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      for n <- 1..120 do
+        post = PostsHelpers.create_post!(author, %{body: "busy day post #{n}"})
+        PostsHelpers.backdate_post!(post, 3 * @day + n * 10)
+      end
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      # Unfold first, as a reader must: the grid is what a day is clicked from,
+      # and unfolding is what computes the counts the button names.
+      render_click(view, "cal-toggle")
+      render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
+
+      assert has_element?(view, "#load-more")
+      assert has_element?(view, "#load-day-all")
+      # The button names the size of the day, taken from the heatmap's count.
+      assert render(view) =~ "120"
+    end
+
+    test "'load the whole day' brings the rest in one go", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      for n <- 1..120 do
+        post = PostsHelpers.create_post!(author, %{body: "busy day post #{n}"})
+        PostsHelpers.backdate_post!(post, 3 * @day + n * 10)
+      end
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
+      refute timeline(view) =~ "busy day post 120"
+
+      render_click(view, "load-day-all")
+
+      assert timeline(view) =~ "busy day post 120"
+      assert timeline(view) =~ "busy day post 1"
+      # And still only that day.
+      refute timeline(view) =~ "from this morning"
+      refute timeline(view) =~ "from a week ago"
+    end
+
+    test "the whole-day button is a day thing, never offered at now",
+         %{conn: conn} do
+      # At now there is no "all": the feed goes back forever.
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      for n <- 1..40 do
+        post = PostsHelpers.create_post!(author, %{body: "recent post #{n}"})
+        PostsHelpers.backdate_post!(post, n * 60)
+      end
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      assert has_element?(view, "#load-more")
+      refute has_element?(view, "#load-day-all")
+    end
+
+    test "pressing it with no day open does nothing", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "load-day-all")
+
+      assert timeline(view) =~ "from this morning"
+    end
+  end
+
+  describe "'My posts' narrows the timeline, not just the shading" do
+    test "the feed shows only what this member wrote", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+      PostsHelpers.create_post!(user, %{body: "something I wrote"})
+      PostsHelpers.create_post!(author, %{body: "something they wrote"})
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+
+      assert timeline(view) =~ "something they wrote"
+
+      render_click(view, "cal-metric", %{"metric" => "own"})
+
+      assert timeline(view) =~ "something I wrote"
+      refute timeline(view) =~ "something they wrote"
+      refute timeline(view) =~ "from this morning"
+    end
+
+    test "switching back to Feed brings everybody else back", %{conn: conn} do
+      # Calibration: without this, the test above passes just as well if the
+      # timeline were simply emptied.
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+      PostsHelpers.create_post!(user, %{body: "something I wrote"})
+      PostsHelpers.create_post!(author, %{body: "something they wrote"})
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+      render_click(view, "cal-metric", %{"metric" => "own"})
+      refute timeline(view) =~ "something they wrote"
+
+      render_click(view, "cal-metric", %{"metric" => "feed"})
+
+      assert timeline(view) =~ "something they wrote"
+      assert timeline(view) =~ "something I wrote"
+    end
+
+    test "it narrows an open day too", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      mine = PostsHelpers.create_post!(user, %{body: "mine on that day"})
+      PostsHelpers.backdate_post!(mine, 3 * @day)
+      theirs = PostsHelpers.create_post!(author, %{body: "theirs on that day"})
+      PostsHelpers.backdate_post!(theirs, 3 * @day + 60)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+      render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
+      assert timeline(view) =~ "theirs on that day"
+
+      render_click(view, "cal-metric", %{"metric" => "own"})
+
+      assert timeline(view) =~ "mine on that day"
+      refute timeline(view) =~ "theirs on that day"
+    end
+
+    test "somebody else's arrival does not fill the pill under it",
+         %{conn: conn} do
+      # The pill promises that pressing it shows those posts here, and here is
+      # "only mine".
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+      render_click(view, "cal-metric", %{"metric" => "own"})
+
+      {:ok, _fresh} = Posts.create_post(author, %{body: "arriving from them"})
+
+      refute has_element?(view, "#show-new-posts")
+      refute timeline(view) =~ "arriving from them"
+    end
+
+    test "but my own post still lands straight on it", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+      render_click(view, "cal-metric", %{"metric" => "own"})
+
+      {:ok, _mine} = Posts.create_post(user, %{body: "written under my-posts"})
+
+      assert timeline(view) =~ "written under my-posts"
+    end
+
+    test "it never becomes the member's remembered source setting",
+         %{conn: conn} do
+      # The band's stored `users.feed_source` is which NETWORK; this reading is
+      # a view the reader is in right now. Writing it down would hand them a
+      # feed of only their own posts on their next visit.
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+      render_click(view, "cal-metric", %{"metric" => "own"})
+
+      assert Posts.remembered_feed_filter(Vutuv.Repo.reload!(user)) == :all
+    end
+
+    test "an unknown reading falls back rather than emptying the feed",
+         %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+      render_click(view, "cal-metric", %{"metric" => "../../etc/passwd"})
+
+      assert timeline(view) =~ "from this morning"
+    end
+  end
+
+  describe "where the calendar stops going back" do
+    test "the back arrows are dead once the feed reaches no further",
+         %{conn: conn} do
+      # Everything this member can see happens this month, so there is no
+      # earlier month to page to.
+      {conn, user} = create_and_login_user(conn)
+      author = insert(:activated_user)
+      Social.follow(user, author.id)
+      PostsHelpers.create_post!(author, %{body: "the only post"})
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+
+      assert has_element?(view, "#feed-calendar-rail button[phx-value-n='-1'][disabled]")
+      assert has_element?(view, "#feed-calendar-rail button[phx-value-n='-12'][disabled]")
+    end
+
+    test "and alive again when there is something behind", %{conn: conn} do
+      # Calibration: without this, the test above passes just as well if the
+      # arrows were disabled outright.
+      {conn, user} = create_and_login_user(conn)
+      author = insert(:activated_user)
+      Social.follow(user, author.id)
+
+      old = PostsHelpers.create_post!(author, %{body: "from long ago"})
+      PostsHelpers.backdate_post!(old, 200 * @day)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+
+      refute has_element?(view, "#feed-calendar-rail button[phx-value-n='-1'][disabled]")
+    end
+
+    test "a backward press is refused at the floor, not just greyed out",
+         %{conn: conn} do
+      # A disabled button is a hint; the handler is the answer.
+      {conn, user} = create_and_login_user(conn)
+      author = insert(:activated_user)
+      Social.follow(user, author.id)
+      PostsHelpers.create_post!(author, %{body: "the only post"})
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+      shown = render(view)
+
+      render_click(view, "cal-month", %{"n" => "-1"})
+      render_click(view, "cal-month", %{"n" => "-12"})
+
+      this_month = Travel.month_of(nil)
+      assert render(view) =~ "#{this_month.year}"
+      assert shown =~ "#{this_month.year}"
+    end
+
+    test "a URL reaching past it shows an empty feed rather than an error",
+         %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed?day=1999-01-04")
+
+      assert timeline(view) == ""
+      assert render(view) =~ "Nothing reached your feed on"
+      refute timeline(view) =~ "from this morning"
+    end
+  end
+
+  describe "folded by default" do
+    test "opens folded, on today, with no month grid", %{conn: conn} do
+      # The calendar is a way *out* of the present, and most visits are not
+      # that: unfolded by default it would put six rows of month between the
+      # composer and the first post for every reader who never travels.
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      assert has_element?(
+               view,
+               "#feed-calendar-rail button[phx-click='cal-toggle'][aria-expanded='false']"
+             )
+
+      refute has_element?(view, "#feed-calendar-rail [phx-value-date]")
+      assert render(view) =~ Vutuv.ViewerClock.format(ViewerClock.today(), :date)
+    end
+
+    test "the toggle unfolds the grid and folds it away again", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      render_click(view, "cal-toggle")
+      assert has_element?(view, "#feed-calendar-rail [phx-value-date]")
+
+      render_click(view, "cal-toggle")
+      refute has_element?(view, "#feed-calendar-rail [phx-value-date]")
+    end
+
+    test "folding it away does not send the reader home", %{conn: conn} do
+      # Somebody who opened last Tuesday and wants the grid out of the way is
+      # still reading Tuesday; yanking them back to now would be a second thing
+      # they did not ask for. Closing the DAY is what returns to the present.
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+      render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
+      refute timeline(view) =~ "from this morning"
+
+      render_click(view, "cal-toggle")
+
+      refute timeline(view) =~ "from this morning"
+      # And folded away it still says which day, since that is now the only
+      # thing on screen that can.
+      assert render(view) =~ Vutuv.ViewerClock.format(days_ago(3), :date)
+    end
+  end
+
+  describe "the pill while a day is open" do
+    test "arrivals still fill it", %{conn: conn} do
+      # A reader who went to look at last Tuesday wants to know the present is
+      # filling up behind them. This reverses the earlier behaviour, where an
+      # arrival reaching a travelling reader was dropped entirely.
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
+
+      {:ok, _fresh} = Posts.create_post(author, %{body: "arriving while I read Tuesday"})
+
+      assert has_element?(view, "#show-new-posts")
+    end
+
+    test "but the post is not drawn into the day on screen", %{conn: conn} do
+      # It belongs to today. A hidden card from another day sitting in this
+      # day's stream is a card that appears in the wrong place the moment
+      # anything reveals it.
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
+
+      {:ok, _fresh} = Posts.create_post(author, %{body: "arriving while I read Tuesday"})
+
+      refute timeline(view) =~ "arriving while I read Tuesday"
+    end
+
+    test "pressing it closes the day and comes home", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+      render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
+
+      {:ok, _fresh} = Posts.create_post(author, %{body: "arriving while I read Tuesday"})
+      render_click(view, "show-new")
+
+      assert timeline(view) =~ "arriving while I read Tuesday"
+      assert timeline(view) =~ "from this morning"
+      # Back on today, so the grid no longer marks a day as open.
+      refute has_element?(view, "#feed-calendar-rail [aria-current='date']")
+    end
+
+    test "the pill asks the server rather than revealing rows that do not exist",
+         %{conn: conn} do
+      # Under the cap and at now the control reveals the already-drawn rows in
+      # the browser. With a day open there are no rows, so it has to be the
+      # plain event or the press would do nothing at all.
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
+      {:ok, _fresh} = Posts.create_post(author, %{body: "arriving while I read Tuesday"})
+
+      assert has_element?(view, "#show-new-posts[phx-click='show-new']")
+    end
+  end
+
+  describe "the URL" do
+    test "a day link is sized by the same rule a day click is", %{conn: conn} do
+      # A shared link and a press on the grid have to open the same thing. The
+      # mount cannot read the calendar's counts (they do not exist yet), so it
+      # pays for a single-day count rather than falling back to the arrival
+      # page size — which left a `?day=` link showing part of a small day with
+      # a "Load more" under it, where a click on the grid showed all of it.
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      # Sized to sit BETWEEN the arrival page (40) and the whole-day limit
+      # (100): fewer, and both rules would load the day whole and the test
+      # would prove nothing.
+      for n <- 1..60 do
+        post = PostsHelpers.create_post!(author, %{body: "quiet day post #{n}"})
+        PostsHelpers.backdate_post!(post, 3 * @day + n * 60)
+      end
+
+      {:ok, view, _html} = live(conn, ~p"/feed?day=#{iso(days_ago(3))}")
+
+      assert timeline(view) =~ "quiet day post 1"
+      assert timeline(view) =~ "quiet day post 60"
+      refute has_element?(view, "#load-more")
+    end
+
+    test "a day link opens that day with the calendar unfolded", %{conn: conn} do
+      # The whole point: a specific URL for a specific day.
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      three = PostsHelpers.create_post!(author, %{body: "from three days ago"})
+      PostsHelpers.backdate_post!(three, 3 * @day)
+
+      {:ok, view, _html} = live(conn, ~p"/feed?day=#{iso(days_ago(3))}")
+
+      assert timeline(view) =~ "from three days ago"
+      refute timeline(view) =~ "from this morning"
+      assert has_element?(view, "#feed-calendar-rail [phx-value-date]")
+    end
+
+    test "?cal=1 unfolds it without opening a day", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed?cal=1")
+
+      assert has_element?(view, "#feed-calendar-rail [phx-value-date]")
+      assert timeline(view) =~ "from this morning"
+    end
+
+    test "a mangled or future date lands on the feed, not on an error",
+         %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      for bad <- ["not-a-date", "../../etc/passwd", iso(Date.add(ViewerClock.today(), 5))] do
+        {:ok, view, _html} = live(conn, ~p"/feed?day=#{bad}")
+
+        assert timeline(view) =~ "from this morning"
+      end
+    end
+
+    test "the plain URL is untouched at the default state", %{conn: conn} do
+      # `/feed` has to stay `/feed` for the reader who never travels.
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      {:ok, _view, html} = live(conn, ~p"/feed")
+
+      assert html =~ ~s(phx-hook="FeedUrl")
+    end
+  end
+
+  describe "the page around it" do
+    test "an empty day says so instead of blaming a source switch", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      # A day far enough back that nothing had reached this member yet.
+      render_click(view, "cal-day", %{"date" => iso(days_ago(300))})
+
+      html = render(view)
+
+      # Neither of the two "now" empty states: one blames a source switch, the
+      # other tells somebody with a full timeline to go find people to follow.
+      assert html =~ "Nothing reached your feed on"
+      refute html =~ "Follow people to fill your feed"
+    end
+
+    test "the German labels are translated, short ones included", %{conn: conn} do
+      # vutuv is a German site and `Phoenix.ConnTest` defaults to English, so a
+      # feature checked only in the default locale is checked in the language
+      # almost nobody here reads. The one-word labels are the point: likeliest
+      # to have been fuzzy-filled, least likely to be noticed on screen.
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      conn = conn |> recycle() |> put_req_header("accept-language", "de-DE,de")
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+
+      html = render(view)
+
+      for label <- [
+            "Meine Beiträge",
+            "Weniger",
+            "Mehr",
+            "Voriger Monat",
+            "Nächstes Jahr",
+            "Mo",
+            "So"
+          ] do
+        assert html =~ label, ~s(the German label "#{label}" is missing from /feed)
+      end
+
+      render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
+
+      assert render(view) =~ "Jetzt"
+    end
+
+    test "the whole-day button is German too", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      for n <- 1..120 do
+        post = PostsHelpers.create_post!(author, %{body: "busy day post #{n}"})
+        PostsHelpers.backdate_post!(post, 3 * @day + n * 10)
+      end
+
+      conn = conn |> recycle() |> put_req_header("accept-language", "de-DE,de")
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+      render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
+
+      assert render(view) =~ "Ganzen Tag laden"
+    end
+  end
+end

--- a/test/vutuv_web/live/feed_time_travel_test.exs
+++ b/test/vutuv_web/live/feed_time_travel_test.exs
@@ -1,0 +1,123 @@
+defmodule VutuvWeb.Live.FeedTimeTravelTest do
+  @moduledoc """
+  The `/feed` time-travel arithmetic. Pure functions, no database.
+
+  The claim worth stating up front: a calendar day is a **window**, not an
+  upper bound. `day_cursor/1` carries a lower bound as well, which is what
+  makes "show me Tuesday" mean Tuesday rather than Tuesday and all of history
+  under it — and the bound rides in the cursor so that it survives pagination.
+  """
+  use ExUnit.Case, async: true
+
+  alias Vutuv.ViewerClock
+  alias VutuvWeb.Live.FeedTimeTravel, as: Travel
+
+  describe "the calendar's day window" do
+    test "a day is bounded at both ends, unlike a rail vantage" do
+      # The whole difference between clicking a date and dragging the rail to
+      # it. Without the lower bound, "show me Tuesday" shows Tuesday and then
+      # every earlier day under it as the reader scrolls.
+      yesterday = Date.add(ViewerClock.today(), -1)
+
+      cursor = Travel.day_cursor(yesterday)
+
+      assert %{at: last, since: first, ids: []} = cursor
+      assert ViewerClock.date(first) == yesterday
+      assert ViewerClock.date(last) == yesterday
+      assert NaiveDateTime.compare(first, last) == :lt
+    end
+
+    test "the window really is the whole day, not a slice of it" do
+      day = Date.add(ViewerClock.today(), -3)
+
+      {first, last} = Travel.day_window(day)
+
+      # A whole day, allowing for the second `23:59:59` leaves off and for a
+      # DST day that is an hour shorter or longer than the other 364.
+      seconds = NaiveDateTime.diff(last, first, :second)
+      assert seconds in [82_799, 86_399, 89_999]
+    end
+
+    test "today is bounded at now, not at a midnight that has not happened" do
+      cursor = Travel.day_cursor(ViewerClock.today())
+
+      assert NaiveDateTime.compare(cursor.at, Travel.now()) != :gt
+    end
+
+    test "a future day has no window" do
+      assert Travel.day_cursor(Date.add(ViewerClock.today(), 3)) == nil
+      assert Travel.day_cursor(nil) == nil
+    end
+
+    test "reachable?/1 refuses tomorrow" do
+      today = ViewerClock.today()
+
+      assert Travel.reachable?(today)
+      assert Travel.reachable?(Date.add(today, -400))
+      refute Travel.reachable?(Date.add(today, 1))
+    end
+
+    test "parse_date/1 refuses anything that is not a date" do
+      assert Travel.parse_date("2026-08-25") == {:ok, ~D[2026-08-25]}
+      assert Travel.parse_date("../../etc/passwd") == :error
+      assert Travel.parse_date("") == :error
+      assert Travel.parse_date(nil) == :error
+    end
+  end
+
+  describe "the calendar's month grid" do
+    test "is always six whole weeks, Monday first" do
+      # Fixed height on purpose: a month that would fit in five rows still gets
+      # six, so paging months does not resize the card and shove the rail
+      # cards below it up and down.
+      for month <- [~D[2026-02-01], ~D[2026-08-01], ~D[2026-11-01]] do
+        grid = Travel.month_grid(month)
+
+        assert length(grid) == 42
+        assert Date.day_of_week(hd(grid).date) == 1
+        assert Enum.map(grid, & &1.date) == Enum.sort(Enum.map(grid, & &1.date), Date)
+      end
+    end
+
+    test "marks which cells belong to the month being shown" do
+      grid = Travel.month_grid(~D[2026-08-01])
+      in_month = Enum.filter(grid, & &1.in_month?)
+
+      assert length(in_month) == 31
+      assert hd(in_month).date == ~D[2026-08-01]
+      assert List.last(in_month).date == ~D[2026-08-31]
+    end
+
+    test "a February grid still spans six weeks" do
+      grid = Travel.month_grid(~D[2026-02-01])
+
+      assert Enum.count(grid, & &1.in_month?) == 28
+      assert length(grid) == 42
+    end
+  end
+
+  describe "shift_month/2" do
+    test "steps months and years without overflowing a short month" do
+      # `Date.add/2` walks days, so a naive month step from the 31st lands in
+      # the wrong month. `month_of/1` normalises to the first, but the
+      # arithmetic underneath still has to be day-safe.
+      assert Travel.shift_month(~D[2026-03-01], -1) == ~D[2026-02-01]
+      assert Travel.shift_month(~D[2026-01-01], -1) == ~D[2025-12-01]
+      assert Travel.shift_month(~D[2026-03-01], -12) == ~D[2025-03-01]
+    end
+
+    test "never pages into the future" do
+      # A calendar that offers next month is offering days nobody can click.
+      this_month = Travel.month_of(nil)
+
+      assert Travel.shift_month(this_month, 1) == this_month
+      assert Travel.shift_month(this_month, 12) == this_month
+      assert Travel.shift_month(Travel.shift_month(this_month, -1), 1) == this_month
+    end
+
+    test "month_of/1 normalises whatever it is handed" do
+      assert Travel.month_of(~D[2026-08-25]) == ~D[2026-08-01]
+      assert Travel.month_of(nil) == Date.beginning_of_month(ViewerClock.today())
+    end
+  end
+end

--- a/test/vutuv_web/live/post_feed_live_test.exs
+++ b/test/vutuv_web/live/post_feed_live_test.exs
@@ -17,8 +17,18 @@ defmodule VutuvWeb.PostFeedLiveTest do
   # How many timeline rows are drawn but hidden — the waiting posts. Counted off
   # the row wrapper's own class, so it cannot catch a `hidden` somewhere inside
   # a card.
+  # Timeline rows currently drawn but hidden (the pending-arrival valve).
+  #
+  # Two lookaheads rather than one literal `class="…" hidden`: that spelling
+  # asserted the two attributes were ADJACENT in the rendered tag, so adding any
+  # third attribute to the row between them (the day marker's `data-post-day`)
+  # dropped the count to zero while the feed behaved perfectly. Attribute order
+  # is HEEx's business, not this test's. `[\s=>]` because a boolean attribute
+  # renders as `hidden=""`, not bare `hidden`.
   defp hidden_rows(html) do
-    Regex.scan(~r/class="py-4 first:pt-0 last:pb-0" hidden/, html) |> length()
+    ~r/<div(?=[^>]*class="py-4 first:pt-0 last:pb-0")(?=[^>]*\shidden[\s=>])[^>]*>/
+    |> Regex.scan(html)
+    |> length()
   end
 
   # Where `text` first shows up in the rendered feed — how the thread tests
@@ -125,6 +135,12 @@ defmodule VutuvWeb.PostFeedLiveTest do
       # 20 rather than the 15 it did before v7.371. What actually proves the
       # stash was used is the comparison below: the same page, with and without
       # it, is immune to whatever else the rail costs.
+      #
+      # It also guards the feed calendar's laziness, which is what made this go
+      # red once: computing the heatmap (a nine-source union over a month) and
+      # its floor check on every mount, for a grid that ships folded and most
+      # readers never open, took a connected mount from 18 queries to 28. The
+      # counts are bought by unfolding now, not by arriving.
       assert hit <= 20, "handoff-hit feed connect ran #{hit} queries; the handoff was not used"
 
       assert miss >= hit + 10,


### PR DESCRIPTION
Scrolling was the only way back through `/feed`. This adds a month calendar to the right-hand column that shades each day by how much reached you, so you can see where reading is worth it before clicking.

**A day is a window, not a vantage.** The feed cursor gained a lower bound (`:since`) that `Vutuv.FeedPage` carries between pages, so "Load more" inside a day stops at the day's edge instead of sliding into the day before. Days under 100 entries arrive whole; busier ones also offer "load the whole day".

The calendar ships folded on today — most visits are not time travel. Month arrows stop where the member's feed has nothing older. The "Feed / My posts" toggle narrows the timeline as well as the shading, and is never written to the stored source preference.

State lives in the URL (`/feed?day=2026-08-18`), so a day is shareable and survives a reload. The new-posts pill keeps counting while you are away and brings you home when pressed.

**Hot deploy.** No migrations, no config or supervision changes. Version 7.585.0.

*An AI agent wrote this text in my name. I know that is problematic.*
