### PR TITLE
fix(fediverse): a LiveView page answers an ActivityPub Accept header with 406 [5m]

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -1155,6 +1155,20 @@ now, with the page's own gates in front of it: the page must federate, the post
 must not be held by moderation, and a page that switched federation off gets the
 same `410`/`404` refusal its actor endpoint gives.
 
+**Every other page of the `:browser` pipeline answers that header with 406.**
+The accept list exists for the four URLs above; on the rest of the site the
+format simply survived negotiation, and a page whose HTML is a LiveView has no
+template for it, so `Phoenix.LiveView.Static` handed `Plug.Conn.resp/3` a
+`{:safe, iodata}` body and `/feed`, `/organizations`, `/search`,
+`/notifications` — all of them — answered **500** (issue #1776). The refusal is
+`VutuvWeb.Plug.HtmlOnly`, asked once per page *shape* rather than once per page:
+routed LiveViews pipe it as the router's `:html_only` pipeline, the controllers
+that `live_render` their page get it inside
+`VutuvWeb.ControllerHelpers.render_live/3`. Both give exactly the 406
+`application/ld+json` has always got, which is not on the accept list at all.
+A URL that already named an agent document is exempt, so `/jobs.md` keeps
+answering Markdown whatever `Accept` rode along with it.
+
 ## Mentions on the way out
 
 A member writes `@ada`, and on the server this post lands on that names *their*

--- a/lib/vutuv_web/controllers/controller_helpers.ex
+++ b/lib/vutuv_web/controllers/controller_helpers.ex
@@ -14,6 +14,7 @@ defmodule VutuvWeb.ControllerHelpers do
   alias Vutuv.CodeStats
   alias Vutuv.Repo
   alias Vutuv.SocialFeed.Http
+  alias VutuvWeb.Plug.HtmlOnly
   alias VutuvWeb.RateLimit
 
   @doc """
@@ -165,9 +166,17 @@ defmodule VutuvWeb.ControllerHelpers do
   Note this is the *page is a LiveView* shape, not the embedded-child shape
   (`ShellLive` in the layout, `PostLive.Actions` in a card): those keep their
   surrounding chrome and pass their own session.
+
+  `VutuvWeb.Plug.HtmlOnly` is the other half worth having in one place: a page
+  reaching here did not answer the `application/activity+json` the `:browser`
+  pipeline admits for the ActivityPub URLs, so it refuses the format instead of
+  handing a LiveView one it has no template for and 500ing (issue #1776). It
+  runs after the caller's `AgentDocs.negotiate/1`, so the `.md`/`.txt` siblings
+  are untouched; the router's `:html_only` pipeline is the routed-LiveView half.
   """
   def render_live(%Conn{} = conn, live_view, extra \\ %{}) do
     conn
+    |> HtmlOnly.call([])
     |> Phoenix.Controller.put_layout(html: false)
     |> Phoenix.LiveView.Controller.live_render(live_view,
       session: Map.merge(live_render_session(conn), extra)

--- a/lib/vutuv_web/plugs/html_only.ex
+++ b/lib/vutuv_web/plugs/html_only.ex
@@ -24,6 +24,18 @@ defmodule VutuvWeb.Plug.HtmlOnly do
   (`VutuvWeb.Plug.AgentFormat`): `/jobs.md` is served from
   `VutuvWeb.AgentDocs` by the controller and never renders the LiveView, so the
   URL extension decides, not the header the client happened to send with it.
+  Dropping that exemption costs `/jobs.md` its Markdown (measured: 406), so it
+  is load-bearing rather than defensive.
+
+  It is also **wider than it should be**, and knowingly so. A `.md` URL whose
+  route is a LiveView that serves no document — `/notifications.md`,
+  `/search.md`, `/bookmarks.json` — is exempted here and then renders the
+  LiveView for whatever format the client asked for, i.e. the same 500 this
+  module exists to close. `AgentFormat` normalizes the `Accept` header on its
+  negotiation path and not on its extension path, which is where that belongs
+  and where issue #1823 fixes it. Until then the exemption stays as it is: the
+  hole predates this module (measured on `main`, identical), and narrowing it
+  here would only move the guess into a second plug.
   """
 
   @behaviour Plug

--- a/lib/vutuv_web/plugs/html_only.ex
+++ b/lib/vutuv_web/plugs/html_only.ex
@@ -1,0 +1,41 @@
+defmodule VutuvWeb.Plug.HtmlOnly do
+  @moduledoc """
+  Refuses a format the page cannot render, with the 406 `plug :accepts,
+  ["html"]` would have given — for the pages whose HTML is a LiveView.
+
+  The `:browser` pipeline admits `application/activity+json` beside HTML so an
+  ActivityPub fetch reaches the four URLs that answer one (the member and page
+  profiles and their post permalinks, which branch on
+  `VutuvWeb.FediverseController.ap_request?/1` — the raw header, not the
+  negotiated format). Every other page of that pipeline has no such
+  representation, and a LiveView has no template for the format either:
+  `Phoenix.LiveView.Static` answers `{:safe, iodata}`, which `Plug.Conn.resp/3`
+  cannot take as a body. That was a **500** on `/feed`, `/organizations`,
+  `/search`, `/notifications` and every other page of the shape (issue #1776),
+  while `application/ld+json` — never on the accept list — answered a clean 406
+  all along.
+
+  So the question is asked a second time, once per page shape rather than once
+  per page: the router's `:html_only` pipeline covers the routed LiveViews (the
+  two `live_session` blocks), `VutuvWeb.ControllerHelpers.render_live/3` the
+  controllers that `live_render` their page.
+
+  A request that already resolved to an **agent document** is left alone
+  (`VutuvWeb.Plug.AgentFormat`): `/jobs.md` is served from
+  `VutuvWeb.AgentDocs` by the controller and never renders the LiveView, so the
+  URL extension decides, not the header the client happened to send with it.
+  """
+
+  @behaviour Plug
+
+  alias Phoenix.Controller
+  alias VutuvWeb.Plug.AgentFormat
+
+  @impl Plug
+  def init(opts), do: opts
+
+  @impl Plug
+  def call(%Plug.Conn{} = conn, _opts) do
+    if AgentFormat.agent_format?(conn), do: conn, else: Controller.accepts(conn, ["html"])
+  end
+end

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -53,6 +53,16 @@ defmodule VutuvWeb.Router do
     plug(Plugs.NoIndex)
   end
 
+  # Routed LiveViews (the two `live_session` blocks below). A LiveView has one
+  # representation, so the `activity+json` the pipeline above admits for the
+  # ActivityPub URLs is refused here rather than 500ing on a page that never
+  # served it — see `VutuvWeb.Plug.HtmlOnly` for why the accept list cannot
+  # simply drop it, and `VutuvWeb.ControllerHelpers.render_live/3` for the
+  # controller-embedded half.
+  pipeline :html_only do
+    plug(Plugs.HtmlOnly)
+  end
+
   # The machine-facing documents (robots.txt, llms.txt, the sitemaps, the RSS
   # feeds, the .well-known files, the ActivityPub endpoints) run without the
   # :browser pipeline on purpose, so `accepts ["html"]` cannot turn away a
@@ -1036,7 +1046,7 @@ defmodule VutuvWeb.Router do
     on_mount: [{VutuvWeb.Live.InitAssigns, :default}],
     root_layout: {VutuvWeb.LayoutHTML, :root} do
     scope "/", VutuvWeb do
-      pipe_through(:browser)
+      pipe_through([:browser, :html_only])
 
       live("/notifications", NotificationLive.Index, :index)
 
@@ -1113,7 +1123,7 @@ defmodule VutuvWeb.Router do
     # dead UserTagController keeps only manage + delete (and the public
     # index/show/endorsers).
     scope "/settings", VutuvWeb do
-      pipe_through([:browser, :settings_pipe])
+      pipe_through([:browser, :settings_pipe, :html_only])
 
       live("/tags/new", TagNewLive, :new)
 
@@ -1288,7 +1298,7 @@ defmodule VutuvWeb.Router do
     ],
     root_layout: {VutuvWeb.LayoutHTML, :root} do
     scope "/admin", VutuvWeb.Admin, as: :admin do
-      pipe_through([:browser, :admin])
+      pipe_through([:browser, :admin, :html_only])
 
       # The member browser: a live, filterable, searchable, sortable list of
       # every account (default: PIN-registered, newest first).

--- a/test/vutuv_web/http_status_contract_test.exs
+++ b/test/vutuv_web/http_status_contract_test.exs
@@ -84,6 +84,63 @@ defmodule VutuvWeb.HttpStatusContractTest do
     end
   end
 
+  describe "an Accept header no page can answer" do
+    # `application/activity+json` rides the :browser pipeline's accepts list so
+    # ActivityPub requests reach the profile and permalink controllers. Every
+    # other page of that pipeline has no such representation, and a page whose
+    # HTML is a LiveView used to answer one with a 500: no template for the
+    # format, and `{:safe, iodata}` handed to `Plug.Conn.resp/3`. The honest
+    # answer is the one `application/ld+json` has always given — 406.
+    test "a LiveView page answers 406, exactly like it does for ld+json", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      # Both shapes: a controller that `live_render`s its page (/feed,
+      # /organizations) and a routed LiveView (/notifications, /search,
+      # /settings/tags/new).
+      for path <- ["/feed", "/organizations", "/notifications", "/search", "/settings/tags/new"],
+          type <- ["application/activity+json", "application/ld+json"] do
+        conn = conn |> recycle() |> put_req_header("accept", type)
+
+        assert_error_sent(406, fn -> get(conn, path) end)
+      end
+    end
+
+    # The URL extension decides, not whatever header rode along with it: a
+    # `.md` sibling is answered from `AgentDocs` by its controller and never
+    # renders the LiveView, so the refusal must not reach it.
+    test "an agent document is still served by its extension", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("accept", "application/activity+json")
+        |> get("/jobs.md")
+
+      assert conn.status == 200
+      assert List.first(get_resp_header(conn, "content-type")) =~ "text/markdown"
+    end
+
+    # Every routed LiveView, not a hand-picked five: the refusal is wired per
+    # scope (`pipe_through`), so the next `live_session` scope that forgets
+    # `:html_only` has to fail here rather than in production.
+    test "no routed LiveView answers one with a 500", %{conn: conn} do
+      {conn, _admin} = create_and_login_admin(conn)
+
+      paths =
+        for route <- VutuvWeb.Router.__routes__(),
+            route.plug == Phoenix.LiveView.Plug,
+            not String.contains?(route.path, ":"),
+            do: route.path
+
+      # Sanity: the sweep is only worth anything if it found the live routes.
+      assert length(paths) > 20
+
+      for path <- paths do
+        conn = conn |> recycle() |> put_req_header("accept", "application/activity+json")
+
+        assert_error_sent(406, fn -> get(conn, path) end)
+      end
+    end
+  end
+
   describe "rate limits" do
     test "the login email step answers 429 over the limit", %{conn: conn} do
       previous = Application.get_env(:vutuv, :rate_limit)

--- a/test/vutuv_web/http_status_contract_test.exs
+++ b/test/vutuv_web/http_status_contract_test.exs
@@ -121,7 +121,13 @@ defmodule VutuvWeb.HttpStatusContractTest do
     # Every routed LiveView, not a hand-picked five: the refusal is wired per
     # scope (`pipe_through`), so the next `live_session` scope that forgets
     # `:html_only` has to fail here rather than in production.
-    test "no routed LiveView answers one with a 500", %{conn: conn} do
+    # Extension-free paths only. A `.md`/`.json` URL on a LiveView route still
+    # 500s on a hostile Accept — `AgentFormat` normalizes the header on its
+    # negotiation path but not on its extension path, so `HtmlOnly` waves the
+    # request through and the LiveView renders for a format it has no template
+    # for. That is pre-existing on main (measured before and after this change,
+    # identically) and is issue #1823, not this fix.
+    test "no routed LiveView answers a bare-path one with a 500", %{conn: conn} do
       {conn, _admin} = create_and_login_admin(conn)
 
       paths =


### PR DESCRIPTION
**Symptom:** `curl -H "Accept: application/activity+json" /feed` answered **500**, and so did `/organizations`, `/search`, `/notifications` and every other page whose HTML is a LiveView. `application/ld+json` answered a clean 406 all along.

The `:browser` pipeline admits `activity+json` so an ActivityPub fetch reaches the four URLs that answer one (profiles and post permalinks, which branch on `FediverseController.ap_request?/1`). Anywhere else the format survived negotiation and reached a LiveView with no template for it, so `Plug.Conn.resp/3` was handed `{:safe, iodata}`.

New `VutuvWeb.Plug.HtmlOnly` asks the question once per page *shape*, not per page: routed LiveViews pipe it as `:html_only`, controller-embedded ones get it inside `ControllerHelpers.render_live/3`. A URL that already names an agent document (`/jobs.md`) is exempt. The four ActivityPub URLs are untouched.

Tests in `test/vutuv_web/http_status_contract_test.exs` sweep every routed LiveView, not a hand-picked few.

Closes #1776

<!-- closing-note #1776 -->
Good catch, and thank you for pinning it on the pipeline rather than on the fediverse code — that is exactly where it was. Those pages now answer 406, the same refusal `application/ld+json` already got, and it is asked once per page shape (a router pipeline for the routed LiveViews, `render_live/3` for the embedded ones) rather than per page. The accept list keeps `activity+json` so the profile and permalink URLs still serve their actor and Note documents.

An AI agent wrote this text in my name. I know that is problematic.
