### PR TITLE
fix(fediverse): scrub a NUL byte at the write, not at each ingest door [15m]

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -295,6 +295,17 @@ every activity of a member it finds no key for, silently.
     (`Vutuv.Mastodon.post_text/1`, which the REST API sends as text). Together
     with `to_text/3` those three are every path from a remote server's words
     into a column here.
+  - **A NUL byte is scrubbed at the write, not at each door.** A NUL is valid
+    UTF-8 and Postgres refuses it (`22021 character_not_in_repertoire`), so one
+    in stored text raises on `Repo.insert` — a delivery any server can make
+    fail. `to_text/3` scrubs the bodies it reduces, but the strings *beside* a
+    body never go near it: an actor's `preferredUsername` and `name`, an
+    attachment's `alt`, the object and inbox URIs are copied out of the JSON,
+    truncated and cast. So the guard sits in the changesets instead
+    (`Vutuv.ChangesetHelpers.scrub_nul/1`, walking every `:string` change on
+    `RemoteAccount`, `Follower`, `Note`, `RemotePost`, `Reaction` and
+    `RemoteImage`), and a new remote-fed column is covered the moment it is
+    cast (issue #1767).
   - **Cleaned on the way in, unlike a display name.** A name is re-derived from
     its column on every render; this text *is* the column, and every reader of
     it (the card, the agent formats, the Mastodon adapter, the teaser, the

--- a/lib/vutuv/changeset_helpers.ex
+++ b/lib/vutuv/changeset_helpers.ex
@@ -83,6 +83,38 @@ defmodule Vutuv.ChangesetHelpers do
 
   defp trim_or_nil(value), do: value
 
+  @nul <<0>>
+
+  @doc """
+  Takes the NUL bytes out of every `:string` change on the changeset.
+
+  A NUL is valid UTF-8 and Postgres refuses it (`22021
+  character_not_in_repertoire`), so one in a value we store is not a display
+  glitch — it is a raise on `Repo.insert`, which any server that can hand us a
+  string can trigger (issue #1767).
+
+  `Vutuv.RemoteHtml` already scrubs the bodies it reduces to text, but that
+  guards one door. The display strings beside a body — an actor's handle and
+  name, an attachment's alt text, the URIs — are copied straight out of the
+  JSON, truncated and cast, and each new ingest path would have to remember the
+  scrub again. So it goes at the write instead, where the byte would reach the
+  driver: run it after the last `cast/3` and before the validations, so what is
+  measured is what is stored.
+
+  Only `:string` changes are walked. A `:binary` column holds bytes, and a NUL
+  in those is data, not a mistake — silently rewriting one would corrupt it.
+  """
+  def scrub_nul(%Ecto.Changeset{changes: changes, types: types} = changeset) do
+    Enum.reduce(changes, changeset, fn {field, value}, acc ->
+      if is_binary(value) and Map.get(types, field) == :string and
+           String.contains?(value, @nul) do
+        put_change(acc, field, String.replace(value, @nul, ""))
+      else
+        acc
+      end
+    end)
+  end
+
   def normalize_name(string) do
     string
     |> String.normalize(:nfd)

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -3914,8 +3914,13 @@ defmodule Vutuv.Fediverse do
   # A redelivery is `{:exists, post}`, which the `Create` path drops so a post's
   # pictures are recorded exactly once, while the announce path (issue #1167)
   # takes the row it names instead of asking for it a second time.
-  defp stored_post({:ok, %RemotePost{id: minted_id}}, uri) do
-    case Repo.get_by(RemotePost, object_uri: uri) do
+  # Read back by the uri the row actually CARRIES, not by the one the delivery
+  # named: `scrub_nul/1` may have changed it on the way in, and a lookup by the
+  # raw string then misses a row that is really there — which is not a crash but
+  # a post stored with its hashtags never filed, its pictures never attached and
+  # nothing broadcast. A loud failure turned into a silent partial ingest.
+  defp stored_post({:ok, %RemotePost{id: minted_id, object_uri: stored_uri}}, _uri) do
+    case Repo.get_by(RemotePost, object_uri: stored_uri) do
       %RemotePost{id: ^minted_id} = post -> {:ok, post}
       %RemotePost{} = post -> {:exists, post}
       nil -> :error

--- a/lib/vutuv/fediverse/follower.ex
+++ b/lib/vutuv/fediverse/follower.ex
@@ -16,6 +16,8 @@ defmodule Vutuv.Fediverse.Follower do
 
   use VutuvWeb, :model
 
+  import Vutuv.ChangesetHelpers, only: [scrub_nul: 1]
+
   alias Vutuv.Fediverse.Handle
 
   # Remote URIs are unbounded in theory; cap generously (they are `text`
@@ -48,6 +50,8 @@ defmodule Vutuv.Fediverse.Follower do
   def changeset(%__MODULE__{} = follower, attrs) do
     follower
     |> cast(attrs, [:actor_uri, :inbox_uri, :shared_inbox_uri, :handle, :name])
+    # Remote strings, and a NUL in one raises on insert (issue #1767).
+    |> scrub_nul()
     |> validate_required([:actor_uri, :inbox_uri])
     |> validate_length(:actor_uri, max: @max_uri)
     |> validate_length(:inbox_uri, max: @max_uri)

--- a/lib/vutuv/fediverse/note.ex
+++ b/lib/vutuv/fediverse/note.ex
@@ -30,6 +30,8 @@ defmodule Vutuv.Fediverse.Note do
 
   use VutuvWeb, :model
 
+  import Vutuv.ChangesetHelpers, only: [scrub_nul: 1]
+
   alias Vutuv.Fediverse.Handle
   alias Vutuv.Translations
 
@@ -174,6 +176,8 @@ defmodule Vutuv.Fediverse.Note do
       :checked_at,
       :expires_at
     ])
+    # Remote strings, and a NUL in one raises on insert (issue #1767).
+    |> scrub_nul()
     |> validate_required([
       :object_uri,
       :actor_uri,

--- a/lib/vutuv/fediverse/post_boost.ex
+++ b/lib/vutuv/fediverse/post_boost.ex
@@ -31,6 +31,8 @@ defmodule Vutuv.Fediverse.PostBoost do
 
   use VutuvWeb, :model
 
+  import Vutuv.ChangesetHelpers, only: [scrub_nul: 1]
+
   # Remote URIs are unbounded in theory; capped in bytes like every other one
   # here, so a hostile value fails the changeset rather than the insert.
   @max_uri_bytes 2_048
@@ -49,6 +51,7 @@ defmodule Vutuv.Fediverse.PostBoost do
   def changeset(%__MODULE__{} = boost, attrs) do
     boost
     |> cast(attrs, [:remote_post_id, :post_id, :activity_id, :announced_at])
+    |> scrub_nul()
     # `activity_id` is required, not merely capped: it is the only thing an
     # `Undo(Announce)` can match on, so a row without one could never be
     # withdrawn and would stand until its post or its account went.

--- a/lib/vutuv/fediverse/reaction.ex
+++ b/lib/vutuv/fediverse/reaction.ex
@@ -20,6 +20,8 @@ defmodule Vutuv.Fediverse.Reaction do
 
   use VutuvWeb, :model
 
+  import Vutuv.ChangesetHelpers, only: [scrub_nul: 1]
+
   alias Vutuv.Fediverse.Handle
 
   @kinds ~w(like announce)
@@ -53,6 +55,10 @@ defmodule Vutuv.Fediverse.Reaction do
   def changeset(%__MODULE__{} = reaction, attrs) do
     reaction
     |> cast(attrs, [:actor_uri, :handle, :kind, :received_at])
+    # Remote strings, and a NUL in one raises on insert (issue #1767). This row
+    # is written with `insert_all` from the applied changeset, so the scrub has
+    # to sit here or nothing sees it.
+    |> scrub_nul()
     |> validate_required([:actor_uri, :kind, :received_at])
     |> validate_inclusion(:kind, @kinds)
     |> validate_length(:actor_uri, max: @max_uri_bytes, count: :bytes)

--- a/lib/vutuv/fediverse/remote_account.ex
+++ b/lib/vutuv/fediverse/remote_account.ex
@@ -22,6 +22,8 @@ defmodule Vutuv.Fediverse.RemoteAccount do
 
   use VutuvWeb, :model
 
+  import Vutuv.ChangesetHelpers, only: [scrub_nul: 1]
+
   alias Vutuv.Fediverse.Handle
 
   # Remote URIs are unbounded in theory; cap generously (they are `text`
@@ -84,6 +86,8 @@ defmodule Vutuv.Fediverse.RemoteAccount do
       :refreshed_at,
       :moved_to
     ])
+    # Remote strings, and a NUL in one raises on insert (issue #1767).
+    |> scrub_nul()
     |> validate_required([:actor_uri, :host, :inbox_uri])
     |> validate_length(:actor_uri, max: @max_uri, count: :bytes)
     |> validate_length(:inbox_uri, max: @max_uri, count: :bytes)

--- a/lib/vutuv/fediverse/remote_image.ex
+++ b/lib/vutuv/fediverse/remote_image.ex
@@ -27,6 +27,8 @@ defmodule Vutuv.Fediverse.RemoteImage do
 
   use VutuvWeb, :model
 
+  import Vutuv.ChangesetHelpers, only: [scrub_nul: 1]
+
   # Four is what the networks out there let an author attach, and it is as many
   # as a card can show without becoming a gallery page.
   @max_per_post 4
@@ -146,6 +148,9 @@ defmodule Vutuv.Fediverse.RemoteImage do
       :fetch_failures,
       :fetch_attempted_at
     ])
+    # `source_uri` and the author's `alt` come out of the attachment JSON, and a
+    # NUL in either raises on insert (issue #1767).
+    |> scrub_nul()
     |> validate_required([:source_uri])
     |> validate_length(:source_uri, max: @max_uri_bytes, count: :bytes)
     |> validate_length(:alt, max: @max_alt)

--- a/lib/vutuv/fediverse/remote_post.ex
+++ b/lib/vutuv/fediverse/remote_post.ex
@@ -31,6 +31,8 @@ defmodule Vutuv.Fediverse.RemotePost do
 
   use VutuvWeb, :model
 
+  import Vutuv.ChangesetHelpers, only: [scrub_nul: 1]
+
   alias Vutuv.Translations
 
   # `public` — addressed to the public collection: on the timelines of that
@@ -176,6 +178,9 @@ defmodule Vutuv.Fediverse.RemotePost do
     # string. Ecto's default `:empty_values` reads "" as "not given", which
     # would drop the change and leave the NOT NULL column with a nil.
     |> cast(attrs, [:content_text], empty_values: [])
+    # After both casts, before the validations: remote strings, and a NUL in one
+    # raises on insert (issue #1767).
+    |> scrub_nul()
     # And so it cannot be `validate_required` either (which reads "" as missing
     # too). The column stays NOT NULL, and both write paths in `Vutuv.Fediverse`
     # compute the body through one `is_binary` gate, so it is never nil.

--- a/test/vutuv/remote_nul_bytes_test.exs
+++ b/test/vutuv/remote_nul_bytes_test.exs
@@ -1,0 +1,165 @@
+defmodule Vutuv.RemoteNulBytesTest do
+  @moduledoc """
+  A NUL byte is valid UTF-8 and Postgres refuses it (`22021
+  character_not_in_repertoire`), so one in a stored string is not a display
+  glitch — it is a raise on `Repo.insert`, and every column here is written
+  from a document a stranger's server wrote (issue #1767).
+
+  `Vutuv.RemoteHtml` scrubs the *bodies* it reduces to text. The display
+  strings beside them (an actor's handle and name, a reaction's emoji, the
+  URIs) never go near it: they are copied out of the JSON, truncated, and cast.
+  So the guard belongs at the write, and this asserts it there — through the
+  real changeset and a real insert, because a changeset-only assertion would
+  pass on the unguarded code too.
+  """
+  use Vutuv.DataCase
+
+  alias Vutuv.Fediverse.Follower
+  alias Vutuv.Fediverse.Note
+  alias Vutuv.Fediverse.Reaction
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemoteImage
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.UUIDv7
+
+  # What a hostile actor document puts in `preferredUsername`, `name` or an
+  # `EmojiReact` content: a raw NUL, not the `&#0;` entity the HTML path
+  # already defuses.
+  @nul <<0>>
+
+  test "a remote actor's handle and name reach the accounts table clean" do
+    assert {:ok, account} =
+             %RemoteAccount{}
+             |> RemoteAccount.changeset(%{
+               actor_uri: "https://remote.example/users/nul",
+               host: "remote.example",
+               handle: "nul" <> @nul <> "user",
+               name: "Nul" <> @nul <> "Name",
+               summary: "Ein" <> @nul <> "Text",
+               inbox_uri: "https://remote.example/users/nul/inbox"
+             })
+             |> Repo.insert()
+
+    assert account.handle == "nuluser"
+    assert account.name == "NulName"
+    assert account.summary == "EinText"
+  end
+
+  test "so do a follower's" do
+    user = insert(:user)
+
+    assert {:ok, follower} =
+             %Follower{user_id: user.id}
+             |> Follower.changeset(%{
+               actor_uri: "https://remote.example/users/nulf",
+               inbox_uri: "https://remote.example/users/nulf/inbox",
+               handle: "nul" <> @nul <> "f",
+               name: "Nul" <> @nul <> "F"
+             })
+             |> Repo.insert()
+
+    assert follower.handle == "nulf"
+    assert follower.name == "NulF"
+  end
+
+  test "and a stored reply's actor strings" do
+    post = insert(:post)
+    received = DateTime.utc_now(:second)
+
+    assert {:ok, note} =
+             %Note{post_id: post.id}
+             |> Note.changeset(%{
+               object_uri: "https://remote.example/notes/nul",
+               actor_uri: "https://remote.example/users/nul",
+               handle: "nul" <> @nul <> "user",
+               display_name: "Nul" <> @nul <> "Name",
+               content_text: "Eine Antwort",
+               audience: "public",
+               received_at: received,
+               expires_at: DateTime.add(received, 86_400)
+             })
+             |> Repo.insert()
+
+    assert note.handle == "nuluser"
+    assert note.display_name == "NulName"
+  end
+
+  test "and a reaction's handle, which the changeset only validates" do
+    post = insert(:post)
+
+    changeset =
+      %Reaction{post_id: post.id}
+      |> Reaction.changeset(%{
+        actor_uri: "https://remote.example/users/nul",
+        handle: "nul" <> @nul <> "user",
+        kind: "like",
+        received_at: DateTime.utc_now(:second)
+      })
+
+    # This path validates with the changeset and then writes the applied struct
+    # with `insert_all`, so whatever the changeset holds is what Postgres sees —
+    # a scrub that only ran inside `Repo.insert/1` would miss it.
+    assert {:ok, reaction} = Ecto.Changeset.apply_action(changeset, :insert)
+    assert reaction.handle == "nuluser"
+
+    assert {1, _rows} =
+             Repo.insert_all(Reaction, [
+               %{
+                 id: UUIDv7.generate(),
+                 post_id: post.id,
+                 actor_uri: reaction.actor_uri,
+                 handle: reaction.handle,
+                 kind: reaction.kind,
+                 received_at: reaction.received_at
+               }
+             ])
+  end
+
+  test "and a cached post's own URIs" do
+    assert {:ok, remote_post} = insert_remote_post(@nul)
+
+    assert remote_post.object_uri == "https://remote.example/posts/nul"
+    assert remote_post.origin_url == "https://remote.example/@nul/1"
+  end
+
+  test "and an attachment's alt text, which its author writes" do
+    {:ok, remote_post} = insert_remote_post("")
+
+    assert {:ok, image} =
+             %RemoteImage{remote_post_id: remote_post.id}
+             |> RemoteImage.changeset(%{
+               source_uri: "https://remote.example/media/1.jpg",
+               alt: "Eine" <> @nul <> "Beschreibung"
+             })
+             |> Repo.insert()
+
+    assert image.alt == "EineBeschreibung"
+  end
+
+  defp insert_remote_post(suffix) do
+    received = DateTime.utc_now(:second)
+    n = System.unique_integer([:positive])
+
+    {:ok, account} =
+      %RemoteAccount{}
+      |> RemoteAccount.changeset(%{
+        actor_uri: "https://remote.example/users/author#{n}",
+        host: "remote.example",
+        inbox_uri: "https://remote.example/users/author#{n}/inbox"
+      })
+      |> Repo.insert()
+
+    %RemotePost{remote_account_id: account.id}
+    |> RemotePost.changeset(%{
+      object_uri: "https://remote.example/posts/nul" <> suffix,
+      origin_url: "https://remote.example/@nul/1" <> suffix,
+      content_text: "Ein Beitrag",
+      audience: "public",
+      kind: "note",
+      published_at: received,
+      received_at: received,
+      expires_at: DateTime.add(received, 86_400)
+    })
+    |> Repo.insert()
+  end
+end


### PR DESCRIPTION
A remote server can put a raw NUL in an actor's `preferredUsername` or `name`, or in an attachment's `alt`. Postgres refuses it (`22021 character_not_in_repertoire`), so the delivery raises on `Repo.insert` and any federating instance can stop an ingest that way.

`RemoteHtml.to_text/3` scrubs the bodies it reduces. The strings beside a body never reach it: they are copied out of the JSON, truncated, cast. The guard therefore moved to the write — `Vutuv.ChangesetHelpers.scrub_nul/1` walks every `:string` change, applied in `RemoteAccount`, `Follower`, `Note`, `RemotePost`, `Reaction` and `RemoteImage`.

`test/vutuv/remote_nul_bytes_test.exs` inserts a NUL through each real changeset. On `main` five of its six cases fail with 22021.

Two doors the issue names are gone: `youtube_thumbnail.ex` no longer stores the oEmbed strings, and `link_summary.ex` is not on `main`. `Follower`, `Reaction` and `RemoteImage` are doors it did not name.

<!-- closing-note #1767 -->
Good catch — the actor's display strings really were unguarded, and the same held for a follower row, a reaction and an attachment's alt text. I put the scrub in the changesets rather than at each door, so all six remote-fed schemas are covered and a new column inherits it the moment it is cast. Two of the three places you listed are gone in the meantime: `youtube_thumbnail.ex` stopped storing the oEmbed `title`/`provider_name`, and `link_summary.ex` is not on `main`.

An AI agent wrote this text in my name. I know that is problematic.
