### PR TITLE
fix(mastodon-api): answer /api/v1/follow_requests with the empty list [2m]

### DIFF
--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -785,7 +785,15 @@ is invalid", which sends a member looking for a mistake in their own text.
   `filters` return `[]` (`MastodonApi.CompatibilityController`). Notifications,
   markers and followed tags no longer do. vutuv has real filters (muted words
   and tags) and real direct messages behind two of those, so they are the next
-  worthwhile ones.
+  worthwhile ones. `follow_requests` sits in the same controller and is **not**
+  a stub: a follow here needs no approval (`Vutuv.Social.Follow`), an inbound
+  remote `Follow` is accepted on arrival (`Vutuv.Fediverse.Follower`) and every
+  account is presented `locked: false`, so the list is empty by construction
+  with nothing to implement later. It answered 404 until Tokodon, which calls it
+  straight after the authorisation step, read that as a failed login (issue
+  #1692). The `requested` state a client does see is the other direction, this
+  member waiting on a remote server's answer, and Mastodon carries that on the
+  Relationship.
 - **A path this adapter does not implement answers JSON, on both hosts.** The
   subdomain always had a catch-all; the **main host** — the one a member types
   into a phone app, and so the one every client actually uses — did not, so an

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -352,6 +352,15 @@ defmodule VutuvWeb.Router do
       assigns: %{mastodon_scope: "read:lists"}
     )
 
+    # Permanently empty, and that is the whole answer: a follow here needs no
+    # approval (`Vutuv.Social.Follow`) and an inbound remote one is accepted on
+    # arrival, so nothing is ever pending — which is what every account already
+    # tells a client with `locked: false`. Tokodon asks for this immediately
+    # after the authorisation step and read the 404 as a failed login (#1692).
+    get("/api/v1/follow_requests", CompatibilityController, :empty,
+      assigns: %{mastodon_scope: "read:follows"}
+    )
+
     # vutuv has followed tags (issue #872); this used to answer a hardcoded
     # empty list, so a client showed none of them and offered "Follow" on every
     # topic the member already follows.

--- a/test/vutuv_web/controllers/mastodon_api/client_expectations_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/client_expectations_test.exs
@@ -139,6 +139,15 @@ defmodule VutuvWeb.MastodonApi.ClientExpectationsTest do
                "expected #{path} to answer an empty list"
       end
     end
+
+    test "the pending follow requests of a server that has none", %{conn: conn, token: token} do
+      # Empty rather than missing, and it can never be anything else: a follow
+      # here needs no approval, which is what every account already says about
+      # itself with `locked: false`. Tokodon asks right after the authorisation
+      # step and read the 404 as a failed login (issue #1692).
+      assert conn |> mastodon_conn(token) |> get("/api/v1/follow_requests") |> json_response(200) ==
+               []
+    end
   end
 
   describe "grouped notifications" do


### PR DESCRIPTION
Authorising vutuv in Tokodon completes, then the client asks for `GET /api/v1/follow_requests`, gets the adapter's JSON 404 and treats it as a failed login. Tuba and Tusky sign in against the same server without trouble.

There are no pending follow requests here and there never can be: a follow needs no approval (`Vutuv.Social.Follow`), an inbound remote `Follow` is accepted on arrival (`Vutuv.Fediverse.Follower`), and every account is already presented `locked: false`. So the endpoint answers the empty list the Mastodon spec shapes it as, through the existing `CompatibilityController.empty/2` under `read:follows`, like its neighbouring follow lists. No approval workflow invented, and none planned.

Route in `lib/vutuv_web/router.ex` beside `/api/v1/conversations`; the test in `client_expectations_test.exs` 404s without it.

<!-- closing-note #1692 -->
Thanks for tracking this down, and for the exact log line. `/api/v1/follow_requests` now answers `200 []` instead of 404: a follow on vutuv needs no approval, so that list is empty by construction rather than unimplemented. You were right on both counts, the crash is Tokodon's error handling and the endpoint is one the spec expects.

*An AI agent wrote this text in my name. I know that is problematic.*
