### PR TITLE
fix(mastodon-api): list fediverse statuses in bookmarks and favourites [15m]

### DIFF
--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -98,7 +98,14 @@ Server discovery, login and the core social workflow:
   no id, so the boundary rides the `Link` header, as it does in Mastodon.
 - `GET` and `POST /api/v1/markers` — where a client left off reading
 - `GET /api/v1/bookmarks`, `/favourites`, `/blocks`, `/mutes`,
-  `/accounts/:id/followers`, `/statuses/:id/favourited_by` and `/reblogged_by`
+  `/accounts/:id/followers`, `/statuses/:id/favourited_by` and `/reblogged_by`.
+  The first two carry **both worlds** (issue #1597): a client may save or
+  favourite a cached post or reply, so the vutuv half
+  (`Posts.bookmarked_statuses/2`) and the fediverse half
+  (`Fediverse.bookmarked_statuses/2`) are merged by `Keyset.merge/2`, the way
+  `/timelines/public` merges its own two. Half those ids are prefixed, so the
+  boundary read out of the request and the one written into the `Link` header
+  are both the bare uuid underneath.
 - `PATCH /api/v1/accounts/update_credentials` and `POST /api/v1/reports`
 - `POST|GET|PUT|DELETE /api/v1/push/subscription`
 - the streaming websocket at `/api/v1/streaming`

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -7251,6 +7251,76 @@ defmodule Vutuv.Fediverse do
   def saved_from_networks_count(%User{id: user_id}),
     do: Repo.aggregate(from(b in Bookmark, where: b.user_id == ^user_id), :count)
 
+  @doc """
+  What this member saved from other networks, as a **walkable** list — the
+  fediverse half of a Mastodon client's `/bookmarks`
+  (`Vutuv.Posts.bookmarked_statuses/2` is the vutuv half, and
+  `VutuvWeb.MastodonApi.ListController` merges them).
+
+  `saved_from_networks/2` above answers the same rows for the website: newest
+  **saved** first, offset paged, with a search box over them. A client walks by
+  the id it was handed instead, which here is the cached post's or the reply's
+  own, so this one is ordered by that id and bounded by `Vutuv.Keyset` — a list
+  ordered by one column while paged by another is what repeats rows and skips
+  others. Two readers rather than options on one: only the ids can be walked.
+
+  Answers bare `%RemotePost{}` and `%Note{}` structs, newest first, which is
+  what `Vutuv.MastodonApi.Presenter` renders anything from another network from.
+  """
+  def bookmarked_statuses(%User{id: user_id}, opts \\ []),
+    do: engaged_objects(Bookmark, Bookmark, user_id, opts)
+
+  @doc """
+  What this member liked out there, walkable the same way — the fediverse half
+  of `/favourites`.
+
+  There is no website page for this and that is deliberate (see
+  `VutuvWeb.PostLive.Saved`): a like out there is a message to its author, not a
+  shelf of your own. A Mastodon client offers the tab regardless, and answering
+  it with the vutuv posts alone told a member their like of a cached post had
+  gone nowhere.
+  """
+  def liked_statuses(%User{id: user_id}, opts \\ []),
+    do: engaged_objects(PostLike, NoteLike, user_id, opts)
+
+  # A cached post and a reply are two tables and share no query, so each marker
+  # is bounded by the same window first and `Keyset.merge/2` cuts afterwards —
+  # what keeps the deepest page reading as few rows as the first.
+  #
+  # The two marker schemas name the same two columns, so they are the only
+  # parameter. On `fediverse_bookmarks` those columns are nullable (a row names
+  # a cached post **or** a reply) and the inner join on them is the point rather
+  # than the trap: a NULL never matches, so each leg picks up exactly its own
+  # kind and the other leg picks up the rest. No `NOT IN`, and no `nil` reaches
+  # a `Repo.get/2`.
+  defp engaged_objects(remote_post_schema, note_schema, user_id, opts) do
+    remote_posts =
+      from(p in RemotePost,
+        join: e in ^remote_post_schema,
+        on: e.remote_post_id == p.id,
+        where: e.user_id == ^user_id,
+        preload: [:remote_account]
+      )
+      |> Keyset.scope(opts)
+      |> Repo.all()
+
+    # Through `notes_with_account/0` like every other loader of a note: the
+    # virtual `account_id` it joins in is what decides whether the reply's
+    # author reads as an account this installation holds or as a stranger, and
+    # one reply answering with two identities depending on the list it came
+    # from is exactly the drift that chokepoint exists to prevent.
+    notes =
+      from(n in subquery(notes_with_account()),
+        join: e in ^note_schema,
+        on: e.note_id == n.id,
+        where: e.user_id == ^user_id
+      )
+      |> Keyset.scope(opts)
+      |> Repo.all()
+
+    Keyset.merge([remote_posts, notes], opts)
+  end
+
   defp saved_matching(query, q) when is_binary(q) and q != "" do
     like = "%" <> String.replace(q, ~r/[%_]/, "") <> "%"
 

--- a/lib/vutuv/keyset.ex
+++ b/lib/vutuv/keyset.ex
@@ -91,6 +91,41 @@ defmodule Vutuv.Keyset do
     if opts[:min_id], do: Enum.reverse(rows), else: rows
   end
 
+  @doc """
+  One page out of several sources that were each `scope/3`d by the same window.
+
+  The in-memory half of the merged list this module's own note describes: no
+  single query can order rows from two tables, but every id here is a
+  `Vutuv.UUIDv7`, so sorting the union by id *is* sorting it by age. Each source
+  is bounded first, so this cuts a page's worth of rows however deep the walk
+  has gone — it is not the unbounded read the note warns about.
+
+  Answers newest-first whichever boundary was asked for, so `restore/2` neither
+  precedes nor follows it.
+  """
+  def merge(lists, opts) when is_list(lists) do
+    lists
+    |> Enum.concat()
+    |> Enum.sort_by(& &1.id, :desc)
+    |> take_page(opts)
+  end
+
+  @doc """
+  Cuts an already-ordered, newest-first list to the page that was asked for.
+
+  One owner for what the three boundaries mean at the *end* of a merged read:
+  `:max_id` and `:since_id` want the newest of what is left, `:min_id` the
+  **oldest** — which over a merged list is its tail rather than a reversal, so
+  `restore/2` is the wrong tool and must not follow.
+  `VutuvWeb.MastodonApi.Pagination.window/3` finishes with this too, having
+  filtered rows that no query could bound.
+  """
+  def take_page(rows, opts) when is_list(rows) do
+    limit = page_size(opts)
+
+    if opts[:min_id], do: Enum.take(rows, -limit), else: Enum.take(rows, limit)
+  end
+
   @doc "The page size a reader should ask for."
   def page_size(opts), do: Keyword.get(opts, :limit) || @default_limit
 

--- a/lib/vutuv_web/controllers/mastodon_api/list_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/list_controller.ex
@@ -23,6 +23,7 @@ defmodule VutuvWeb.MastodonApi.ListController do
 
   alias Vutuv.Accounts
   alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse
   alias Vutuv.Keyset
   alias Vutuv.MastodonApi.Presenter
   alias Vutuv.Posts
@@ -33,8 +34,24 @@ defmodule VutuvWeb.MastodonApi.ListController do
   alias VutuvWeb.MastodonApi.Pagination
   alias VutuvWeb.MastodonApi.Statuses
 
-  def bookmarks(conn, params), do: engaged(conn, params, &Posts.bookmarked_statuses/2)
-  def favourites(conn, params), do: engaged(conn, params, &Posts.liked_statuses/2)
+  @doc """
+  What the member saved, and what they liked — **from both worlds**.
+
+  A client can bookmark or favourite a status that came from another network,
+  and since #1588 that answers 200 — while these two lists read the vutuv half
+  alone, so the thing the client had just been told was saved was not in the
+  place it puts saved things. The act looked done and the object looked gone,
+  which reads as data loss rather than as a missing feature (issue #1597).
+
+  The two halves are merged the way the public timeline merges its own two:
+  each bounded by the same window, then cut together (`Vutuv.Keyset.merge/2`).
+  """
+  def bookmarks(conn, params),
+    do: engaged(conn, params, [&Posts.bookmarked_statuses/2, &Fediverse.bookmarked_statuses/2])
+
+  @doc "The same list for what the member liked, both worlds included — see `bookmarks/2`."
+  def favourites(conn, params),
+    do: engaged(conn, params, [&Posts.liked_statuses/2, &Fediverse.liked_statuses/2])
 
   def followers(conn, %{"id" => id} = params) do
     page = Pagination.params(params)
@@ -121,16 +138,24 @@ defmodule VutuvWeb.MastodonApi.ListController do
   """
   def custom_emojis(conn, _params), do: json(conn, [])
 
-  defp engaged(conn, params, reader) do
-    page = Pagination.params(params)
+  # Half this list is now spelled `remote-<uuid>`, so **both** boundaries are
+  # the bare uuid underneath: the one read out of the request (see
+  # `Pagination.params/2`) and the one advertised in the `Link` header, whose
+  # comparison would otherwise sort by the prefix rather than by age and offer a
+  # next page that repeats what the client already holds.
+  defp engaged(conn, params, readers) do
+    page = Pagination.params(params, strip: &Pagination.bare_id/1)
+    user = conn.assigns.current_user
+    opts = Pagination.opts(page)
 
     statuses =
-      conn.assigns.current_user
-      |> reader.(Pagination.opts(page))
-      |> Presenter.statuses(conn.assigns.current_user)
+      readers
+      |> Enum.map(& &1.(user, opts))
+      |> Keyset.merge(opts)
+      |> Presenter.statuses(user)
 
     conn
-    |> Pagination.link_header(Enum.map(statuses, & &1.id), page)
+    |> Pagination.link_header(Enum.map(statuses, &Pagination.bare_id(&1.id)), page)
     |> json(statuses)
   end
 

--- a/lib/vutuv_web/controllers/mastodon_api/timeline_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/timeline_controller.ex
@@ -14,6 +14,7 @@ defmodule VutuvWeb.MastodonApi.TimelineController do
   use VutuvWeb, :controller
 
   alias Vutuv.Fediverse
+  alias Vutuv.Keyset
   alias Vutuv.MastodonApi.Presenter
   alias Vutuv.Posts
   alias Vutuv.Tags
@@ -83,10 +84,10 @@ defmodule VutuvWeb.MastodonApi.TimelineController do
   defp public_items(:all, page) do
     opts = Pagination.opts(page)
 
-    (Posts.recent_public_posts(:all, opts) ++ Fediverse.recent_public_remote_posts(opts))
-    |> Enum.sort_by(& &1.id, :desc)
-    |> then(fn merged -> if page.min_id, do: Enum.take(merged, -page.limit), else: merged end)
-    |> Enum.take(page.limit)
+    Keyset.merge(
+      [Posts.recent_public_posts(:all, opts), Fediverse.recent_public_remote_posts(opts)],
+      opts
+    )
   end
 
   @doc """

--- a/lib/vutuv_web/mastodon_api/pagination.ex
+++ b/lib/vutuv_web/mastodon_api/pagination.ex
@@ -169,8 +169,7 @@ defmodule VutuvWeb.MastodonApi.Pagination do
   def window(entries, %__MODULE__{} = page, id_fun) when is_function(id_fun, 1) do
     entries
     |> Enum.filter(&in_window?(id_fun.(&1), page))
-    |> then(fn kept -> if page.min_id, do: Enum.take(kept, -page.limit), else: kept end)
-    |> Enum.take(page.limit)
+    |> Keyset.take_page(opts(page))
   end
 
   defp in_window?(nil, _page), do: false

--- a/test/vutuv_web/controllers/mastodon_api/deep_pagination_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/deep_pagination_test.exs
@@ -23,6 +23,7 @@ defmodule VutuvWeb.MastodonApi.DeepPaginationTest do
   import Vutuv.MastodonHelpers
   import Vutuv.OrganizationsHelpers
 
+  alias Vutuv.Fediverse
   alias Vutuv.Organizations
   alias Vutuv.Posts
   alias Vutuv.Social
@@ -36,9 +37,10 @@ defmodule VutuvWeb.MastodonApi.DeepPaginationTest do
 
   # One request per row plus one, so the walk has to survive going past the end
   # as well as getting there. Stops early if the endpoint repeats itself, which
-  # would otherwise spin.
-  defp walk(token, path) do
-    Enum.reduce_while(1..(@rows + 1), {[], nil}, fn _step, {seen, cursor} ->
+  # would otherwise spin. `rows` is the list's length where a test put something
+  # extra on it.
+  defp walk(token, path, rows) do
+    Enum.reduce_while(1..(rows + 1), {[], nil}, fn _step, {seen, cursor} ->
       separator = if String.contains?(path, "?"), do: "&", else: "?"
       query = separator <> "limit=1" <> if(cursor, do: "&max_id=#{cursor}", else: "")
 
@@ -50,13 +52,13 @@ defmodule VutuvWeb.MastodonApi.DeepPaginationTest do
     |> elem(0)
   end
 
-  defp assert_walks_everything(token, path) do
-    ids = walk(token, path)
+  defp assert_walks_everything(token, path, rows \\ @rows) do
+    ids = walk(token, path, rows)
 
-    assert length(ids) == @rows,
-           "#{path} stopped after #{length(ids)} of #{@rows} rows"
+    assert length(ids) == rows,
+           "#{path} stopped after #{length(ids)} of #{rows} rows"
 
-    assert length(Enum.uniq(ids)) == @rows, "#{path} served the same row twice"
+    assert length(Enum.uniq(ids)) == rows, "#{path} served the same row twice"
     ids
   end
 
@@ -88,10 +90,19 @@ defmodule VutuvWeb.MastodonApi.DeepPaginationTest do
       )
     end
 
-    test "bookmarks walk past the first read", %{reader: reader, posts: posts} do
+    # With one cached post saved among them (issue #1597) the list has two
+    # sources and a prefixed id in the middle of the walk. A boundary that does
+    # not survive that prefix is no boundary, and no boundary is the newest page
+    # — so the walk stops making progress at the remote row rather than at the
+    # end, and comes back holding the same id many times over.
+    test "bookmarks walk past the first read, remote ones included", %{
+      reader: reader,
+      posts: posts
+    } do
       Enum.each(posts, &Posts.bookmark_post(reader, &1))
+      {:ok, :bookmarked} = Fediverse.bookmark_remote_post(reader, cached_post(remote_account()))
 
-      assert_walks_everything(mastodon_token(reader, ["read"]), "/api/v1/bookmarks")
+      assert_walks_everything(mastodon_token(reader, ["read"]), "/api/v1/bookmarks", @rows + 1)
     end
 
     test "favourites walk past the first read", %{reader: reader, posts: posts} do

--- a/test/vutuv_web/controllers/mastodon_api/list_controller_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/list_controller_test.exs
@@ -7,10 +7,16 @@ defmodule VutuvWeb.MastodonApi.ListControllerTest do
 
   import Vutuv.MastodonHelpers
 
+  alias Vutuv.Fediverse
   alias Vutuv.Posts
   alias Vutuv.Social
 
   @mastodon_host "mastodon.localhost"
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    :ok
+  end
 
   test "what you bookmarked and what you liked come back", %{conn: conn} do
     member = insert(:activated_user)
@@ -30,6 +36,113 @@ defmodule VutuvWeb.MastodonApi.ListControllerTest do
       build_conn() |> mastodon_conn(token) |> get("/api/v1/favourites") |> json_response(200)
 
     assert Enum.map(favourites, & &1["id"]) == [liked.id]
+  end
+
+  # Issue #1597. Saving or liking something from another network answers 200
+  # (#1588) — and then the list it went into has to hold it, or the client shows
+  # the act as done and the thing as gone, which reads as data loss rather than
+  # as a missing feature.
+  describe "the lists hold what came from another network" do
+    test "a cached post and a cached reply are in /bookmarks", %{conn: conn} do
+      member = insert(:activated_user)
+      author = insert(:activated_user)
+      {:ok, own} = Posts.create_post(author, %{body: "Von hier"})
+      account = remote_account()
+      remote = cached_post(account)
+      reply = insert(:note, actor_uri: account.actor_uri)
+
+      :ok = Posts.bookmark_post(member, own)
+      assert {:ok, :bookmarked} = Fediverse.bookmark_remote_post(member, remote)
+      assert {:ok, :bookmarked} = Fediverse.bookmark_note(member, reply)
+
+      statuses =
+        conn
+        |> mastodon_conn(mastodon_token(member, ["read"]))
+        |> get("/api/v1/bookmarks")
+        |> json_response(200)
+
+      ids = Enum.map(statuses, & &1["id"])
+      assert own.id in ids
+      assert ("remote-" <> remote.id) in ids
+      assert ("remote-note-" <> reply.id) in ids
+
+      # Read through `notes_with_account/0` like every other loader of a reply,
+      # so its author is the account this installation holds rather than the
+      # stand-in a stranger gets — one reply, one identity, whichever list it
+      # was reached from.
+      saved_reply = Enum.find(statuses, &(&1["id"] == "remote-note-" <> reply.id))
+      assert saved_reply["account"]["id"] == "remote-" <> account.id
+    end
+
+    test "a cached post and a cached reply are in /favourites", %{conn: conn} do
+      member = federating_member()
+      author = insert(:activated_user)
+      {:ok, own} = Posts.create_post(author, %{body: "Von hier"})
+      remote = cached_post(remote_account())
+      reply = insert(:note)
+
+      :ok = Posts.like_post(member, own)
+      assert {:ok, :liked} = Fediverse.like_remote_post(member, remote)
+      assert {:ok, :liked} = Fediverse.like_note(member, reply)
+
+      ids =
+        conn
+        |> mastodon_conn(mastodon_token(member, ["read"]))
+        |> get("/api/v1/favourites")
+        |> json_response(200)
+        |> Enum.map(& &1["id"])
+
+      assert own.id in ids
+      assert ("remote-" <> remote.id) in ids
+      assert ("remote-note-" <> reply.id) in ids
+    end
+
+    # The boundary a client hands back is the id it was given, and for anything
+    # from another network that is `remote-<uuid>`. Without the strip it casts
+    # to nil, a nil boundary is no boundary, and no boundary is the newest page
+    # — so "load more" serves the same page for ever.
+    test "walking past a remote bookmark reaches the older ones", %{conn: conn} do
+      member = insert(:activated_user)
+      author = insert(:activated_user)
+      {:ok, older} = Posts.create_post(author, %{body: "Älter"})
+      remote = cached_post(remote_account())
+
+      :ok = Posts.bookmark_post(member, older)
+      {:ok, :bookmarked} = Fediverse.bookmark_remote_post(member, remote)
+
+      ids =
+        conn
+        |> mastodon_conn(mastodon_token(member, ["read"]))
+        |> get("/api/v1/bookmarks", %{"max_id" => "remote-" <> remote.id})
+        |> json_response(200)
+        |> Enum.map(& &1["id"])
+
+      assert ids == [older.id]
+    end
+
+    # The other half of the same strip: the `Link` header names the boundary by
+    # comparing the ids on the page, and a prefixed id sorts by its prefix — so
+    # the oldest entry on a mixed page is not the one a raw comparison picks,
+    # and the next page repeats what the client already has.
+    test "the next link names the oldest entry even when it is a remote one", %{conn: conn} do
+      member = insert(:activated_user)
+      author = insert(:activated_user)
+      remote = cached_post(remote_account())
+      {:ok, newer} = Posts.create_post(author, %{body: "Neuer"})
+
+      {:ok, :bookmarked} = Fediverse.bookmark_remote_post(member, remote)
+      :ok = Posts.bookmark_post(member, newer)
+
+      conn =
+        conn
+        |> mastodon_conn(mastodon_token(member, ["read"]))
+        |> get("/api/v1/bookmarks", %{"limit" => "2"})
+
+      assert [link] = Plug.Conn.get_resp_header(conn, "link")
+      assert [_next, _prev] = String.split(link, ", ")
+      assert link =~ "max_id=#{remote.id}"
+      refute link =~ "max_id=#{newer.id}"
+    end
   end
 
   test "the follower list", %{conn: conn} do

--- a/test/vutuv_web/controllers/mastodon_api/list_controller_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/list_controller_test.exs
@@ -120,6 +120,40 @@ defmodule VutuvWeb.MastodonApi.ListControllerTest do
       assert ids == [older.id]
     end
 
+    # `min_id` asks for what is newer than the boundary and answers with the
+    # OLDEST of those, so a client can walk forward. `Keyset.take_page/2` is now
+    # the only place that rule lives, for this list and for the public timeline
+    # both — and a merged list is where losing it would hide: four entries, a
+    # limit of two, and taking the tail against taking the head give different
+    # pages. Without this, dropping the branch serves the newest page for ever
+    # while the whole suite stays green.
+    test "min_id over a merged list answers the oldest above the boundary", %{conn: conn} do
+      member = insert(:activated_user)
+      author = insert(:activated_user)
+
+      {:ok, oldest} = Posts.create_post(author, %{body: "Eins"})
+      remote = cached_post(remote_account())
+      {:ok, third} = Posts.create_post(author, %{body: "Drei"})
+      {:ok, newest} = Posts.create_post(author, %{body: "Vier"})
+
+      :ok = Posts.bookmark_post(member, oldest)
+      {:ok, :bookmarked} = Fediverse.bookmark_remote_post(member, remote)
+      :ok = Posts.bookmark_post(member, third)
+      :ok = Posts.bookmark_post(member, newest)
+
+      ids =
+        conn
+        |> mastodon_conn(mastodon_token(member, ["read"]))
+        |> get("/api/v1/bookmarks", %{"min_id" => oldest.id, "limit" => "2"})
+        |> json_response(200)
+        |> Enum.map(& &1["id"])
+
+      # Newest-first within the page, but the page itself is the two entries
+      # sitting just above the boundary — not the two newest of the four.
+      assert ids == [third.id, "remote-" <> remote.id]
+      refute newest.id in ids
+    end
+
     # The other half of the same strip: the `Link` header names the boundary by
     # comparing the ids on the page, and a prefixed id sorts by its prefix — so
     # the oldest entry on a mixed page is not the one a raw comparison picks,


### PR DESCRIPTION
Bookmarking or favouriting a status from another network has answered `200` with `bookmarked: true` since #1588, but `GET /api/v1/bookmarks` and `/api/v1/favourites` listed vutuv posts only. To a client the act looked done and the thing was gone — that reads as data loss, not as a missing feature.

`VutuvWeb.MastodonApi.ListController.bookmarks/2` and `favourites/2` now read a fediverse half beside the vutuv one (`Vutuv.Fediverse.bookmarked_statuses/2`, `liked_statuses/2`, covering both cached posts and cached replies). Each half is bounded by the same window and the two are cut together by the new `Vutuv.Keyset.merge/2` — the shape `/timelines/public` already merged its own two sources with, now shared rather than copied.

Half those ids are spelled `remote-<uuid>`, so both boundaries take the bare uuid underneath: unstripped, the incoming one casts to `nil` and "load more" repeats page one for ever, and the outgoing one sorts by prefix and offers a next page that repeats a row. Both are covered by tests calibrated red without the fix.

Fixes #1597

An AI agent wrote this text in my name. I know that is problematic.
