### PR TITLE
fix(shell): the new-version bar asks the browser, not the service worker

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -475,58 +475,58 @@ function serviceWorker() {
   if (!("serviceWorker" in navigator)) return Promise.resolve(null)
   if (swRegistration) return swRegistration
 
-  swRegistration = navigator.serviceWorker
-    .register("/sw.js")
-    .then((registration) => {
-      watchForNewVersion(registration)
-      return registration
-    })
-    .catch(() => null)
+  swRegistration = navigator.serviceWorker.register("/sw.js").catch(() => null)
 
   return swRegistration
 }
 
-// An installed app is reloaded even more rarely than a tab, and a deploy
-// reloads nothing at all - the LiveView socket simply reconnects to the new
-// release and patches into an hours-old document. The server-rendered bar in
-// the shell is what offers the way out; it ships `hidden` and is shown here.
+// "Reload" on the shell's update bar (issue #1729). WHETHER to offer it is the
+// server's answer - it is the only side that knows which release this document
+// came from - so all that is left here is carrying it out. Delegated at the
+// document, so it survives the patches that re-render the bar.
 //
-// Only ever on an UPDATE, never on the first install: `controller` is null
-// until a worker is in charge, and the very first one arriving is not news
-// anybody has to act on.
-let swUpdateReady = false
-
-function watchForNewVersion(registration) {
-  const offer = (worker) => {
-    if (!worker || !navigator.serviceWorker.controller) return
-    const announce = () => {
-      if (worker.state !== "installed") return
-      swUpdateReady = true
-      window.dispatchEvent(new CustomEvent("vutuv:sw-update"))
-    }
-    worker.addEventListener("statechange", announce)
-    announce()
-  }
-
-  offer(registration.waiting)
-  registration.addEventListener("updatefound", () => offer(registration.installing))
-}
-
-// Delegated at the document, so it survives the patches that re-render the bar
-// (the SwUpdate hook below owns whether it is shown, not whether it works).
+// **The control is an `<a href>` to the current page, and that is load-bearing
+// rather than tidiness.** The bar renders ONLY into a document running the
+// PREVIOUS release, so the handler that answers its click is the previous
+// release's, never this one. That handler posts `skip-waiting` to a waiting
+// worker and does nothing whatsoever when none is waiting - which is the common
+// case for exactly this reader, because a tab open across a deploy never
+// navigates and so never triggers the browser's own worker check. It does not
+// call `preventDefault` either, so the link's own navigation still carries them
+// to the new release. Without the href, the bar's primary control is dead for
+// most of the cohort it is shown to on the deploy that ships it. It also makes
+// the control work with no JavaScript at all.
 document.addEventListener("click", async (event) => {
   if (!event.target.closest("[data-sw-reload]")) return
 
-  const registration = await serviceWorker()
-  if (!registration) return
+  // Synchronously, before any await: one await later the browser has already
+  // followed the link and this handler is addressing a page that is leaving.
+  event.preventDefault()
+
+  // `reload()` rather than the href, which is the path without its query: once
+  // we are in JS the current URL is the better target.
+  const reload = () => window.location.reload()
+  const waiting = (await serviceWorker())?.waiting
+
+  // No worker waiting is the ordinary case, not a failure: the document is
+  // stale while the worker is not (it updates on its own schedule, which is not
+  // the deploy's), and then a plain reload is the whole errand.
+  if (!waiting) return reload()
 
   // The waiting worker takes over only when it is asked to, and the page
   // reloads only once it has - promoting it unasked would swap the assets
-  // under a half-written post.
-  navigator.serviceWorker.addEventListener("controllerchange", () => window.location.reload(), {
-    once: true,
-  })
-  registration.waiting?.postMessage({ type: "skip-waiting" })
+  // under a half-written post. If it never answers, go anyway after a moment:
+  // a control that visibly did nothing is worse than one that reloads twice.
+  const timer = setTimeout(reload, 2000)
+  navigator.serviceWorker.addEventListener(
+    "controllerchange",
+    () => {
+      clearTimeout(timer)
+      reload()
+    },
+    { once: true }
+  )
+  waiting.postMessage({ type: "skip-waiting" })
 })
 
 async function currentPushSubscription() {
@@ -949,32 +949,6 @@ const Hooks = {
       window.removeEventListener("vutuv:tab-teaser", this.onPreview)
       if (this.teaserTimer) clearTimeout(this.teaserTimer)
       if (this.observer) this.observer.disconnect()
-    },
-  },
-  // "A new version is available" (issue #1729). The bar itself is
-  // server-rendered in the shell (only the server knows the reader's
-  // language); this hook owns the one thing the server cannot know - whether
-  // the service worker has a newer release waiting.
-  //
-  // It needs a hook rather than a plain querySelector because the shell
-  // re-renders on every badge tick, presence diff and hourly clock, and each
-  // of those patches puts the server's `hidden` back. `updated()` is what
-  // takes it off again - the same shape WebNotify uses below, and for the same
-  // reason.
-  SwUpdate: {
-    mounted() {
-      this.onUpdate = () => this.apply()
-      window.addEventListener("vutuv:sw-update", this.onUpdate)
-      this.apply()
-    },
-    updated() {
-      this.apply()
-    },
-    destroyed() {
-      window.removeEventListener("vutuv:sw-update", this.onUpdate)
-    },
-    apply() {
-      this.el.hidden = !swUpdateReady
     },
   },
   // Browser notifications (issue #1249): a popup for activity that arrives while

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -71,10 +71,19 @@ carries **no content** — kind, id and destination — and the worker draws the
 line ("New message on vutuv"), because what a push turns into is text on a lock
 screen.
 
-While the worker exists, it also answers the stale-document problem
-`static_changed?/1` describes: a deploy reloads nothing, so `updatefound` shows
-the shell's `#sw-update` bar ("A new version of vutuv is ready"), and the
-waiting worker is promoted only when the member taps Reload.
+The worker does **not** decide when the "new version" bar appears, and that is
+worth saying because it looks like the obvious signal. `registration.waiting` is
+set from the moment a new worker installs until every vutuv tab is gone, so it
+is still true on a page that has *just* arrived from the new release — the bar
+came back on every page load until somebody pressed it, while the case it exists
+for (a tab open for hours) barely fired at all, nothing calling
+`registration.update()`. So the shell asks `static_changed?/1` instead:
+`phx-track-static` reports the bundle this browser is really running, and only a
+document that predates the deploy is offered `#sw-update` ("A new version is
+ready"). Dismissing it is socket state, so it lasts exactly as long as the
+document it applies to. The worker's remaining job is carrying the reload out —
+Reload posts `skip-waiting` to a waiting worker, or plainly reloads when there
+is none.
 
 **Which means a worker from the previous release keeps running, and nothing
 bounds how long.** This is the one asset that deliberately outlives a deploy,
@@ -82,13 +91,15 @@ so it is worth being exact about. A new worker appears only when `/sw.js`
 changes byte-for-byte, and its body is the config prelude plus the file: the
 `version` (the digested paths of the tracked assets, joined), the notification
 lines, and `sw.js` itself. A deploy that touches none of those three ships an
-identical worker, and no bar appears at all. When it does differ, the new
+identical worker, so the old one simply stays in charge. When it does differ, the new
 worker installs and then **waits**: the old one stays in charge of every open
 tab, serving `/assets/*` out of its own `vutuv-<version>` cache and handling
 that tab's `push` and `notificationclick` with the strings table baked into it
 at *its* release. It is replaced when the member taps
 Reload (which posts `skip-waiting`, and only then does `activate` drop the
 other caches and `clients.claim()`), or when every tab it controls is closed.
+Note this is about the **worker's** lifetime, not the bar's: whether anybody is
+offered a reload is the separate question answered above.
 An installed app on a phone is closed rarely and reloaded more rarely still,
 so "weeks" is the realistic upper bound, not "until the next deploy".
 

--- a/lib/vutuv_web/controllers/service_worker_controller.ex
+++ b/lib/vutuv_web/controllers/service_worker_controller.ex
@@ -20,10 +20,12 @@ defmodule VutuvWeb.ServiceWorkerController do
     * the **asset version**, which is what the worker keys its cache on. It is
       the digested paths of the two tracked assets, so the bytes of this
       response change exactly when a browser holding the old bundle has become
-      stale — which is what raises the "new version" bar (`updatefound` in
-      app.js) on the deploys where it means something, and on no others. The
-      same string is why the previous release's cached assets are thrown away
-      rather than accumulating.
+      stale, and the previous release's cached assets are thrown away rather
+      than accumulating. It does **not** raise the shell's "new version" bar:
+      that reads the same two tracked assets, but per browser and from the
+      server (`static_changed?/1`), because a worker waiting to take over says
+      nothing about whether *this* document is the stale one. See
+      `docs/architecture/realtime.md`.
 
     * the **generic notification lines**, one per kind per locale this
       installation serves. A push carries no content (see `Vutuv.WebPush`), so

--- a/lib/vutuv_web/live/shell_live.ex
+++ b/lib/vutuv_web/live/shell_live.ex
@@ -203,6 +203,22 @@ defmodule VutuvWeb.ShellLive do
   # second.
   defp assign_shell_defaults(socket, path) do
     socket
+    # "A new version is ready" (issue #1729) — see the bar in render/1 for why
+    # the service worker cannot answer this and `phx-track-static` can. Called
+    # here because it is mount-only (`connect_params` is dropped afterwards),
+    # which is also the right moment: a deploy drops the socket, so the
+    # reconnect that follows is when the answer changes.
+    #
+    # **The `connected?/1` is NOT redundant, however much it looks it.**
+    # `static_changed?/1` does open with the same check, and `Static.mount`
+    # seeds `connect_params: %{}` — so on a root dead render the bare call is
+    # indeed safe, which is exactly what makes this worth a comment. The shell
+    # is never a root: `app.html.heex` embeds it with `live_render`, so a dead
+    # controller page takes `Static.disconnected_nested_render/6`, which sets
+    # `conn_session` and **no** `connect_params` — and `static_changed?/1`
+    # raises rather than answering. Only the `and` short-circuit keeps it from
+    # being called there. Dropping it 500s every classic page in the app.
+    |> assign(:update_ready?, connected?(socket) and static_changed?(socket))
     |> assign(:self_online?, false)
     # Whether this member asked for browser notifications (issue #1249). False
     # for the anonymous shell and for the throwaway dead render, which raises
@@ -354,6 +370,13 @@ defmodule VutuvWeb.ShellLive do
   # there it deep-links to the member's own profile instead.
   defp brand_path(user_param, "/feed") when is_binary(user_param), do: ~p"/#{user_param}"
   defp brand_path(_user_param, _path), do: ~p"/"
+
+  # Where the update bar's Reload points when JavaScript does not take the click
+  # (see the bar in render/1). `@path` is `conn.request_path`, so a query is
+  # lost — the accepted cost of the control having a target at all, and only on
+  # the fallback path: app.js reloads the real URL where it can.
+  defp reload_path(path) when is_binary(path) and path != "", do: path
+  defp reload_path(_path), do: ~p"/"
 
   # Both badges recompute from the source of truth rather than adjusting a
   # running tally, so they can't drift. A bare +1 on :new_notification went
@@ -629,6 +652,23 @@ defmodule VutuvWeb.ShellLive do
      })}
   end
 
+  # "Later" on the update bar (issue #1729). Socket state and nothing more: the
+  # offer is about this document, so the dismissal is scoped to it too.
+  #
+  # Known limit, and a deliberate one: a reconnect re-mounts and the bar comes
+  # back. A socket drops for entirely ordinary reasons — a sleeping laptop, a
+  # backgrounded phone tab, a change of network — and the long-open tab this bar
+  # exists for is precisely the one that does that most, so "Later" can mean
+  # "until the next blip". Carrying it across would mean telling the SERVER what
+  # this browser has already put away (a LiveSocket connect param keyed on the
+  # tracked bundle, since the flag must not outlive the release it refers to),
+  # and that plumbing sits on every LiveView join in the app. Not worth it while
+  # the thing coming back is one quiet strip dismissed again in a single click —
+  # revisit if anybody actually reports it.
+  def handle_event("dismiss_update", _params, socket) do
+    {:noreply, assign(socket, :update_ready?, false)}
+  end
+
   # The member clicked a browser notification, so they have seen exactly the
   # event it announced — and nothing else on the bell. Recording it drops that
   # one from the unread tally; the recount then comes back through
@@ -835,35 +875,72 @@ defmodule VutuvWeb.ShellLive do
       writes a generated stylesheet that reveals each online member's
       [data-presence-user-id] dot, across classic controller pages too. Empty +
       phx-update="ignore": it manages a document-wide stylesheet, not children. --%>
-      <%!-- "A new version is available" (issue #1729). A deploy reloads
-      nothing: an open page keeps the bundle it downloaded, and an installed
-      app is reloaded rarer still, so the service worker's `updatefound` is the
-      one moment anybody learns. The bar is server-rendered because only the
-      server knows the reader's language, and it is shown for logged-out
-      visitors too - a stale document is stale whoever is reading it.
+      <%!-- "A new version is ready" (issue #1729). A deploy reloads nothing: an
+      open page keeps the bundle it downloaded, and an installed app is reloaded
+      rarer still. Shown for logged-out visitors too - a stale document is stale
+      whoever is reading it.
 
-      It ships carrying the plain `hidden` attribute and no display utility
-      (the issue #880 trap - a utility would out-cascade it). A document from
-      the PREVIOUS release meets this markup with the previous release's CSS
-      and JS, which is exactly the situation it exists for: that JS never
-      unhides it, so the old page shows nothing rather than something
-      unstyled. --%>
+      **The service worker is the wrong witness, which is why @update_ready?
+      comes from `static_changed?/1` instead.** `registration.waiting` is set
+      from the moment a new worker installs until every vutuv tab is gone, so it
+      is still true on a document that just arrived fresh from the new release -
+      and the bar came back on every page load until somebody pressed it. Nor
+      does the worker signal fire when it matters: nothing calls
+      `registration.update()`, so a tab that sits open for hours (the one reader
+      this is for) hears about the deploy from its socket long before the
+      browser's own 24-hour worker check. The tracked bundle answers both.
+
+      It is deliberately quiet: this is news, not a problem, and it stacks above
+      the header with two other bars of the same shape. A hairline strip, a text
+      link rather than the solid CTA, and a "Later" that takes it away - the
+      dismissal is plain socket state, so it lives exactly as long as the
+      document it applies to.
+
+      Every class here is one the app already ships. This markup is by
+      definition patched into a document running the PREVIOUS release's CSS
+      (that is who it is rendered for), so a utility making its first appearance
+      here would arrive unstyled - the shape that put an undismissable
+      200-character paragraph across the feed's tab bar in v7.347.0. --%>
       <div
+        :if={@update_ready?}
         id="sw-update"
-        phx-hook="SwUpdate"
-        hidden
-        class="border-b border-brand-100 bg-brand-50 dark:border-brand-900/60 dark:bg-brand-900/30"
+        class="border-b border-slate-200 bg-slate-50 dark:border-slate-800 dark:bg-slate-900"
       >
         <div class={[
-          "mx-auto flex max-w-6xl flex-wrap items-center gap-x-3 gap-y-2 py-2 text-sm",
+          "mx-auto flex max-w-6xl flex-wrap items-center gap-x-3 gap-y-1 py-1.5 text-sm",
           gutter_class()
         ]}>
-          <span class="text-slate-700 dark:text-slate-200">
-            {gettext("A new version of vutuv is ready.")}
+          <span class="text-slate-600 dark:text-slate-400">
+            {gettext("A new version is ready.")}
           </span>
-          <.button type="button" data-sw-reload class="min-h-10">
+          <%!-- The ghost variant, not the solid CTA this bar used to carry and
+          not a hand-rolled text link: `ui.ex` ships in every release, so a
+          previous-release stylesheet is guaranteed to have these classes (see
+          the note above), and it brings the padding a bare `min-h-10` button
+          would leave off.
+
+          A LINK to this very page, not a button and not a phx-click. The reader
+          seeing this bar is by definition running the previous release's
+          JavaScript, whose handler promotes a waiting worker and does nothing
+          at all when none waits - the common case here, since a tab open across
+          a deploy never navigates and so never checks for one. That handler
+          does not preventDefault, so the navigation carries them to the new
+          release anyway; app.js takes the click over only when it has a worker
+          to promote. Without the href this control is dead for most of the
+          people it is shown to. --%>
+          <.button variant="ghost" href={reload_path(@path)} data-sw-reload class="min-h-10">
             {gettext("Reload")}
           </.button>
+          <%!-- Its own msgid rather than the "Not now" the notification prompt
+          uses: that one answers a request for permission, this one postpones an
+          offer, and German says them differently. --%>
+          <button
+            type="button"
+            phx-click="dismiss_update"
+            class="ml-auto min-h-10 rounded-lg px-3 text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+          >
+            {gettext("Later")}
+          </button>
         </div>
       </div>
       <div :if={@user_id} id="presence-hook" phx-hook="Presence" phx-update="ignore" class="hidden"></div>

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -444,8 +444,8 @@ msgstr "Einloggen"
 msgid "Log Out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/live/shell_live.ex:1277
-#: lib/vutuv_web/live/shell_live.ex:1343
+#: lib/vutuv_web/live/shell_live.ex:1354
+#: lib/vutuv_web/live/shell_live.ex:1420
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -646,8 +646,8 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:49
 #: lib/vutuv_web/live/search_live.ex:570
-#: lib/vutuv_web/live/shell_live.ex:1142
-#: lib/vutuv_web/live/shell_live.ex:1326
+#: lib/vutuv_web/live/shell_live.ex:1219
+#: lib/vutuv_web/live/shell_live.ex:1403
 #: lib/vutuv_web/live/tag_live/timeline.ex:318
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -1183,7 +1183,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1249
+#: lib/vutuv_web/live/shell_live.ex:1326
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1625,7 +1625,7 @@ msgstr "Adressen von %{name}"
 msgid "Admin control panel"
 msgstr "Admin-Bereich"
 
-#: lib/vutuv_web/live/shell_live.ex:1329
+#: lib/vutuv_web/live/shell_live.ex:1406
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Mitteilungen"
@@ -1742,7 +1742,7 @@ msgstr ""
 " von jemandem, den Sie kennen oder interessant finden, und klicken Sie auf "
 "Folgen!"
 
-#: lib/vutuv_web/live/shell_live.ex:1268
+#: lib/vutuv_web/live/shell_live.ex:1345
 #: lib/vutuv_web/views/settings_html.ex:284
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1771,14 +1771,14 @@ msgstr "Nachricht"
 
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1160
-#: lib/vutuv_web/live/shell_live.ex:1328
+#: lib/vutuv_web/live/shell_live.ex:1237
+#: lib/vutuv_web/live/shell_live.ex:1405
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: lib/vutuv_web/live/shell_live.ex:1044
+#: lib/vutuv_web/live/shell_live.ex:1121
 #: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Network"
@@ -1804,7 +1804,7 @@ msgstr "Noch nichts Neues."
 #: lib/vutuv_web/components/ui.ex:4671
 #: lib/vutuv_web/live/notification_live/index.ex:140
 #: lib/vutuv_web/live/notification_live/index.ex:377
-#: lib/vutuv_web/live/shell_live.ex:1172
+#: lib/vutuv_web/live/shell_live.ex:1249
 #: lib/vutuv_web/templates/layout/app.html.heex:173
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2161,8 +2161,8 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/live/post_live/feed.ex:279
 #: lib/vutuv_web/live/post_live/feed.ex:2380
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1022
-#: lib/vutuv_web/live/shell_live.ex:1321
+#: lib/vutuv_web/live/shell_live.ex:1099
+#: lib/vutuv_web/live/shell_live.ex:1398
 #: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2338,7 +2338,7 @@ msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
 #: lib/vutuv_web/components/ui.ex:4971
-#: lib/vutuv_web/live/shell_live.ex:1215
+#: lib/vutuv_web/live/shell_live.ex:1292
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:231
@@ -2428,8 +2428,8 @@ msgstr "Lesezeichen setzen"
 #: lib/vutuv_web/agent_docs/markdown.ex:1116
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:1152
-#: lib/vutuv_web/live/shell_live.ex:1220
+#: lib/vutuv_web/live/shell_live.ex:1229
+#: lib/vutuv_web/live/shell_live.ex:1297
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2450,7 +2450,7 @@ msgstr "Gefällt mir"
 #: lib/vutuv_web/live/notification_live/index.ex:1022
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:1223
+#: lib/vutuv_web/live/shell_live.ex:1300
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -3220,8 +3220,8 @@ msgid "Private message"
 msgstr "Private Nachricht"
 
 #: lib/vutuv_web/components/ui.ex:4603
-#: lib/vutuv_web/live/shell_live.ex:1036
-#: lib/vutuv_web/live/shell_live.ex:1333
+#: lib/vutuv_web/live/shell_live.ex:1113
+#: lib/vutuv_web/live/shell_live.ex:1410
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -5536,7 +5536,7 @@ msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
 msgid "Content under review"
 msgstr "Inhalte in Prüfung"
 
-#: lib/vutuv_web/live/shell_live.ex:1202
+#: lib/vutuv_web/live/shell_live.ex:1279
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Kontomenü"
@@ -5558,7 +5558,7 @@ msgstr "Menüs und Dialoge schließen"
 msgid "General"
 msgstr "Allgemeines"
 
-#: lib/vutuv_web/live/shell_live.ex:1259
+#: lib/vutuv_web/live/shell_live.ex:1336
 #: lib/vutuv_web/templates/layout/app.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5577,7 +5577,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
-#: lib/vutuv_web/live/shell_live.ex:1239
+#: lib/vutuv_web/live/shell_live.ex:1316
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5631,8 +5631,8 @@ msgstr "Nächster Beitrag im Feed"
 msgid "Previous post in the feed"
 msgstr "Vorheriger Beitrag im Feed"
 
-#: lib/vutuv_web/live/shell_live.ex:1011
-#: lib/vutuv_web/live/shell_live.ex:1305
+#: lib/vutuv_web/live/shell_live.ex:1088
+#: lib/vutuv_web/live/shell_live.ex:1382
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Hauptnavigation"
@@ -12427,7 +12427,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1230
+#: lib/vutuv_web/live/shell_live.ex:1307
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:100
@@ -12770,7 +12770,7 @@ msgstr "Stellenbezeichnung"
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1052
+#: lib/vutuv_web/live/shell_live.ex:1129
 #: lib/vutuv_web/templates/layout/app.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -14472,7 +14472,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] "Empfohlen von %{name} und %{formatted} weiteren"
 msgstr[1] "Empfohlen von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/live/shell_live.ex:509
+#: lib/vutuv_web/live/shell_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -20684,7 +20684,7 @@ msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."
 msgid "A post in an organization's name is always public."
 msgstr "Ein Beitrag im Namen einer Organisation ist immer öffentlich."
 
-#: lib/vutuv_web/live/shell_live.ex:969
+#: lib/vutuv_web/live/shell_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr "Seite öffnen"
@@ -20704,7 +20704,7 @@ msgstr "Beendet, im Namen einer Organisation zu schreiben"
 msgid "Write as %{name} for now"
 msgstr "Vorerst als %{name} schreiben"
 
-#: lib/vutuv_web/live/shell_live.ex:979
+#: lib/vutuv_web/live/shell_live.ex:1056
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr "Wieder als ich selbst schreiben"
@@ -20714,7 +20714,7 @@ msgstr "Wieder als ich selbst schreiben"
 msgid "You are writing as %{name} now."
 msgstr "Sie schreiben jetzt als %{name}."
 
-#: lib/vutuv_web/live/shell_live.ex:955
+#: lib/vutuv_web/live/shell_live.ex:1032
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr "Sie schreiben als %{name}."
@@ -21078,21 +21078,21 @@ msgstr "Sie folgen #%{tag} hier bereits."
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr "Sie sind selbst auf diesem vutuv. Sie folgen #%{tag} jetzt direkt hier."
 
-#: lib/vutuv_web/live/shell_live.ex:539
+#: lib/vutuv_web/live/shell_live.ex:562
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] "%{formatted} Person"
 msgstr[1] "%{formatted} Personen"
 
-#: lib/vutuv_web/live/shell_live.ex:526
+#: lib/vutuv_web/live/shell_live.ex:549
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] "Person"
 msgstr[1] "Personen"
 
-#: lib/vutuv_web/live/shell_live.ex:561
+#: lib/vutuv_web/live/shell_live.ex:584
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -22187,7 +22187,7 @@ msgstr "%{handle} nicht mehr folgen? Die Beiträge verschwinden aus Ihrem Feed."
 msgid "Unfollowed. Their posts leave your feed."
 msgstr "Nicht mehr gefolgt. Die Beiträge verschwinden aus Ihrem Feed."
 
-#: lib/vutuv_web/live/shell_live.ex:925
+#: lib/vutuv_web/live/shell_live.ex:1002
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr "Erlauben"
@@ -22202,12 +22202,12 @@ msgstr "Jetzt fragen"
 msgid "Browser notifications"
 msgstr "Browser-Benachrichtigungen"
 
-#: lib/vutuv_web/live/shell_live.ex:822
+#: lib/vutuv_web/live/shell_live.ex:862
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr "Neue Nachricht"
 
-#: lib/vutuv_web/live/shell_live.ex:932
+#: lib/vutuv_web/live/shell_live.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Jetzt nicht"
@@ -22247,7 +22247,7 @@ msgstr "Dieser Browser zeigt sie an."
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr "Wenn etwas eintrifft, während vutuv in einem Tab offen ist, den Sie gerade nicht ansehen, kann Ihr Browser es als Benachrichtigung anzeigen. Aus, solange Sie es nicht einschalten."
 
-#: lib/vutuv_web/live/shell_live.ex:922
+#: lib/vutuv_web/live/shell_live.ex:999
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr "Sie haben Browser-Benachrichtigungen eingeschaltet. Dieser Browser wurde noch nicht um Erlaubnis gebeten."
@@ -22287,12 +22287,12 @@ msgstr "Test-Benachrichtigung senden"
 msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
 msgstr "Gesendet. Wenn nichts erschienen ist, hält Ihr System sie zurück. Prüfen Sie „Nicht stören“ und Ihre Benachrichtigungseinstellungen."
 
-#: lib/vutuv_web/live/shell_live.ex:625
+#: lib/vutuv_web/live/shell_live.ex:648
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr "Test-Benachrichtigung"
 
-#: lib/vutuv_web/live/shell_live.ex:626
+#: lib/vutuv_web/live/shell_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr "So sieht es aus, wenn auf vutuv etwas für Sie eintrifft."
@@ -22532,7 +22532,7 @@ msgstr "In %{language} übersetzen"
 msgid "Translated into %{language}."
 msgstr "Wird in %{language} übersetzt."
 
-#: lib/vutuv_web/live/shell_live.ex:758
+#: lib/vutuv_web/live/shell_live.ex:798
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -22637,11 +22637,6 @@ msgstr "Ihr LinkedIn-Profil kann mitkommen."
 msgid "Being checked"
 msgstr "Wird geprüft"
 
-#: lib/vutuv_web/live/shell_live.ex:862
-#, elixir-autogen, elixir-format
-msgid "A new version of vutuv is ready."
-msgstr "Eine neue Version von vutuv ist bereit."
-
 #: lib/vutuv_web/templates/settings/notifications.html.heex:225
 #, elixir-autogen, elixir-format
 msgid "Also notify me on this device when vutuv is closed"
@@ -22662,13 +22657,13 @@ msgstr "Entfernen"
 msgid "New message on vutuv"
 msgstr "Neue Nachricht auf vutuv"
 
-#: lib/vutuv_web/controllers/service_worker_controller.ex:138
+#: lib/vutuv_web/controllers/service_worker_controller.ex:140
 #: lib/vutuv_web/templates/service_worker/offline.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "No connection"
 msgstr "Keine Verbindung"
 
-#: lib/vutuv_web/live/shell_live.ex:865
+#: lib/vutuv_web/live/shell_live.ex:932
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr "Neu laden"
@@ -23153,3 +23148,13 @@ msgstr "Passwortmanager wie Bitwarden übernehmen daraus den ganzen Eintrag: Nam
 #, elixir-autogen, elixir-format
 msgid "Scan it with the device that has the app"
 msgstr "Mit dem Gerät scannen, auf dem die App läuft"
+
+#: lib/vutuv_web/live/shell_live.ex:914
+#, elixir-autogen, elixir-format
+msgid "A new version is ready."
+msgstr "Neue Version bereit."
+
+#: lib/vutuv_web/live/shell_live.ex:942
+#, elixir-autogen, elixir-format
+msgid "Later"
+msgstr "Später"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -444,8 +444,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1277
-#: lib/vutuv_web/live/shell_live.ex:1343
+#: lib/vutuv_web/live/shell_live.ex:1354
+#: lib/vutuv_web/live/shell_live.ex:1420
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -646,8 +646,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:49
 #: lib/vutuv_web/live/search_live.ex:570
-#: lib/vutuv_web/live/shell_live.ex:1142
-#: lib/vutuv_web/live/shell_live.ex:1326
+#: lib/vutuv_web/live/shell_live.ex:1219
+#: lib/vutuv_web/live/shell_live.ex:1403
 #: lib/vutuv_web/live/tag_live/timeline.ex:318
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -1161,7 +1161,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1249
+#: lib/vutuv_web/live/shell_live.ex:1326
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1329
+#: lib/vutuv_web/live/shell_live.ex:1406
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1709,7 +1709,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1268
+#: lib/vutuv_web/live/shell_live.ex:1345
 #: lib/vutuv_web/views/settings_html.ex:284
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1738,14 +1738,14 @@ msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1160
-#: lib/vutuv_web/live/shell_live.ex:1328
+#: lib/vutuv_web/live/shell_live.ex:1237
+#: lib/vutuv_web/live/shell_live.ex:1405
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1044
+#: lib/vutuv_web/live/shell_live.ex:1121
 #: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Network"
@@ -1771,7 +1771,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4671
 #: lib/vutuv_web/live/notification_live/index.ex:140
 #: lib/vutuv_web/live/notification_live/index.ex:377
-#: lib/vutuv_web/live/shell_live.ex:1172
+#: lib/vutuv_web/live/shell_live.ex:1249
 #: lib/vutuv_web/templates/layout/app.html.heex:173
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2120,8 +2120,8 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/feed.ex:279
 #: lib/vutuv_web/live/post_live/feed.ex:2380
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1022
-#: lib/vutuv_web/live/shell_live.ex:1321
+#: lib/vutuv_web/live/shell_live.ex:1099
+#: lib/vutuv_web/live/shell_live.ex:1398
 #: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2293,7 +2293,7 @@ msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4971
-#: lib/vutuv_web/live/shell_live.ex:1215
+#: lib/vutuv_web/live/shell_live.ex:1292
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:231
@@ -2383,8 +2383,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1116
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:1152
-#: lib/vutuv_web/live/shell_live.ex:1220
+#: lib/vutuv_web/live/shell_live.ex:1229
+#: lib/vutuv_web/live/shell_live.ex:1297
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2405,7 +2405,7 @@ msgstr ""
 #: lib/vutuv_web/live/notification_live/index.ex:1022
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:1223
+#: lib/vutuv_web/live/shell_live.ex:1300
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -3151,8 +3151,8 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4603
-#: lib/vutuv_web/live/shell_live.ex:1036
-#: lib/vutuv_web/live/shell_live.ex:1333
+#: lib/vutuv_web/live/shell_live.ex:1113
+#: lib/vutuv_web/live/shell_live.ex:1410
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -5315,7 +5315,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1202
+#: lib/vutuv_web/live/shell_live.ex:1279
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5337,7 +5337,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1259
+#: lib/vutuv_web/live/shell_live.ex:1336
 #: lib/vutuv_web/templates/layout/app.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5356,7 +5356,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
-#: lib/vutuv_web/live/shell_live.ex:1239
+#: lib/vutuv_web/live/shell_live.ex:1316
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5410,8 +5410,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1011
-#: lib/vutuv_web/live/shell_live.ex:1305
+#: lib/vutuv_web/live/shell_live.ex:1088
+#: lib/vutuv_web/live/shell_live.ex:1382
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -11799,7 +11799,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1230
+#: lib/vutuv_web/live/shell_live.ex:1307
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:100
@@ -12129,7 +12129,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1052
+#: lib/vutuv_web/live/shell_live.ex:1129
 #: lib/vutuv_web/templates/layout/app.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -13810,7 +13810,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:509
+#: lib/vutuv_web/live/shell_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -19929,7 +19929,7 @@ msgstr ""
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:969
+#: lib/vutuv_web/live/shell_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr ""
@@ -19949,7 +19949,7 @@ msgstr ""
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:979
+#: lib/vutuv_web/live/shell_live.ex:1056
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -19959,7 +19959,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:955
+#: lib/vutuv_web/live/shell_live.ex:1032
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -20323,21 +20323,21 @@ msgstr ""
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:539
+#: lib/vutuv_web/live/shell_live.ex:562
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:526
+#: lib/vutuv_web/live/shell_live.ex:549
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:561
+#: lib/vutuv_web/live/shell_live.ex:584
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -21413,7 +21413,7 @@ msgstr ""
 msgid "Unfollowed. Their posts leave your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:925
+#: lib/vutuv_web/live/shell_live.ex:1002
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr ""
@@ -21428,12 +21428,12 @@ msgstr ""
 msgid "Browser notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:822
+#: lib/vutuv_web/live/shell_live.ex:862
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:932
+#: lib/vutuv_web/live/shell_live.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
@@ -21473,7 +21473,7 @@ msgstr ""
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:922
+#: lib/vutuv_web/live/shell_live.ex:999
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -21513,12 +21513,12 @@ msgstr ""
 msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:625
+#: lib/vutuv_web/live/shell_live.ex:648
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:626
+#: lib/vutuv_web/live/shell_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr ""
@@ -21739,7 +21739,7 @@ msgstr ""
 msgid "Translated into %{language}."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:758
+#: lib/vutuv_web/live/shell_live.ex:798
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -21837,11 +21837,6 @@ msgstr ""
 msgid "Being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:862
-#, elixir-autogen, elixir-format
-msgid "A new version of vutuv is ready."
-msgstr ""
-
 #: lib/vutuv_web/templates/settings/notifications.html.heex:225
 #, elixir-autogen, elixir-format
 msgid "Also notify me on this device when vutuv is closed"
@@ -21862,13 +21857,13 @@ msgstr ""
 msgid "New message on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/controllers/service_worker_controller.ex:138
+#: lib/vutuv_web/controllers/service_worker_controller.ex:140
 #: lib/vutuv_web/templates/service_worker/offline.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "No connection"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:865
+#: lib/vutuv_web/live/shell_live.ex:932
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr ""
@@ -22348,4 +22343,14 @@ msgstr ""
 #: lib/vutuv_web/templates/totp/new.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Scan it with the device that has the app"
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:914
+#, elixir-autogen, elixir-format
+msgid "A new version is ready."
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:942
+#, elixir-autogen, elixir-format
+msgid "Later"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -442,8 +442,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1277
-#: lib/vutuv_web/live/shell_live.ex:1343
+#: lib/vutuv_web/live/shell_live.ex:1354
+#: lib/vutuv_web/live/shell_live.ex:1420
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -644,8 +644,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:49
 #: lib/vutuv_web/live/search_live.ex:570
-#: lib/vutuv_web/live/shell_live.ex:1142
-#: lib/vutuv_web/live/shell_live.ex:1326
+#: lib/vutuv_web/live/shell_live.ex:1219
+#: lib/vutuv_web/live/shell_live.ex:1403
 #: lib/vutuv_web/live/tag_live/timeline.ex:318
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -1159,7 +1159,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1249
+#: lib/vutuv_web/live/shell_live.ex:1326
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1593,7 +1593,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1329
+#: lib/vutuv_web/live/shell_live.ex:1406
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1707,7 +1707,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1268
+#: lib/vutuv_web/live/shell_live.ex:1345
 #: lib/vutuv_web/views/settings_html.ex:284
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1736,14 +1736,14 @@ msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1160
-#: lib/vutuv_web/live/shell_live.ex:1328
+#: lib/vutuv_web/live/shell_live.ex:1237
+#: lib/vutuv_web/live/shell_live.ex:1405
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1044
+#: lib/vutuv_web/live/shell_live.ex:1121
 #: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Network"
@@ -1769,7 +1769,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4671
 #: lib/vutuv_web/live/notification_live/index.ex:140
 #: lib/vutuv_web/live/notification_live/index.ex:377
-#: lib/vutuv_web/live/shell_live.ex:1172
+#: lib/vutuv_web/live/shell_live.ex:1249
 #: lib/vutuv_web/templates/layout/app.html.heex:173
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2118,8 +2118,8 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/feed.ex:279
 #: lib/vutuv_web/live/post_live/feed.ex:2380
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1022
-#: lib/vutuv_web/live/shell_live.ex:1321
+#: lib/vutuv_web/live/shell_live.ex:1099
+#: lib/vutuv_web/live/shell_live.ex:1398
 #: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2291,7 +2291,7 @@ msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4971
-#: lib/vutuv_web/live/shell_live.ex:1215
+#: lib/vutuv_web/live/shell_live.ex:1292
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:231
@@ -2381,8 +2381,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1116
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:1152
-#: lib/vutuv_web/live/shell_live.ex:1220
+#: lib/vutuv_web/live/shell_live.ex:1229
+#: lib/vutuv_web/live/shell_live.ex:1297
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2403,7 +2403,7 @@ msgstr ""
 #: lib/vutuv_web/live/notification_live/index.ex:1022
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:1223
+#: lib/vutuv_web/live/shell_live.ex:1300
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -3149,8 +3149,8 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4603
-#: lib/vutuv_web/live/shell_live.ex:1036
-#: lib/vutuv_web/live/shell_live.ex:1333
+#: lib/vutuv_web/live/shell_live.ex:1113
+#: lib/vutuv_web/live/shell_live.ex:1410
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -5313,7 +5313,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1202
+#: lib/vutuv_web/live/shell_live.ex:1279
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5335,7 +5335,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1259
+#: lib/vutuv_web/live/shell_live.ex:1336
 #: lib/vutuv_web/templates/layout/app.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5354,7 +5354,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
-#: lib/vutuv_web/live/shell_live.ex:1239
+#: lib/vutuv_web/live/shell_live.ex:1316
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5408,8 +5408,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1011
-#: lib/vutuv_web/live/shell_live.ex:1305
+#: lib/vutuv_web/live/shell_live.ex:1088
+#: lib/vutuv_web/live/shell_live.ex:1382
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -11797,7 +11797,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1230
+#: lib/vutuv_web/live/shell_live.ex:1307
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:100
@@ -12127,7 +12127,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1052
+#: lib/vutuv_web/live/shell_live.ex:1129
 #: lib/vutuv_web/templates/layout/app.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -13808,7 +13808,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:509
+#: lib/vutuv_web/live/shell_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -19927,7 +19927,7 @@ msgstr ""
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:969
+#: lib/vutuv_web/live/shell_live.ex:1046
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Open the page"
 msgstr ""
@@ -19947,7 +19947,7 @@ msgstr ""
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:979
+#: lib/vutuv_web/live/shell_live.ex:1056
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -19957,7 +19957,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:955
+#: lib/vutuv_web/live/shell_live.ex:1032
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -20321,21 +20321,21 @@ msgstr ""
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:539
+#: lib/vutuv_web/live/shell_live.ex:562
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:526
+#: lib/vutuv_web/live/shell_live.ex:549
 #, elixir-autogen, elixir-format, fuzzy
 msgid "person"
 msgid_plural "people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:561
+#: lib/vutuv_web/live/shell_live.ex:584
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -21411,7 +21411,7 @@ msgstr ""
 msgid "Unfollowed. Their posts leave your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:925
+#: lib/vutuv_web/live/shell_live.ex:1002
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr ""
@@ -21426,12 +21426,12 @@ msgstr ""
 msgid "Browser notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:822
+#: lib/vutuv_web/live/shell_live.ex:862
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:932
+#: lib/vutuv_web/live/shell_live.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
@@ -21471,7 +21471,7 @@ msgstr ""
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:922
+#: lib/vutuv_web/live/shell_live.ex:999
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -21511,12 +21511,12 @@ msgstr ""
 msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:625
+#: lib/vutuv_web/live/shell_live.ex:648
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:626
+#: lib/vutuv_web/live/shell_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr ""
@@ -21737,7 +21737,7 @@ msgstr ""
 msgid "Translated into %{language}."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:758
+#: lib/vutuv_web/live/shell_live.ex:798
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -21835,11 +21835,6 @@ msgstr ""
 msgid "Being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:862
-#, elixir-autogen, elixir-format
-msgid "A new version of vutuv is ready."
-msgstr ""
-
 #: lib/vutuv_web/templates/settings/notifications.html.heex:225
 #, elixir-autogen, elixir-format
 msgid "Also notify me on this device when vutuv is closed"
@@ -21860,13 +21855,13 @@ msgstr ""
 msgid "New message on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/controllers/service_worker_controller.ex:138
+#: lib/vutuv_web/controllers/service_worker_controller.ex:140
 #: lib/vutuv_web/templates/service_worker/offline.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "No connection"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:865
+#: lib/vutuv_web/live/shell_live.ex:932
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr ""
@@ -22346,4 +22341,14 @@ msgstr ""
 #: lib/vutuv_web/templates/totp/new.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Scan it with the device that has the app"
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:914
+#, elixir-autogen, elixir-format, fuzzy
+msgid "A new version is ready."
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:942
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Later"
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -446,8 +446,8 @@ msgstr "Accedi"
 msgid "Log Out"
 msgstr "Esci"
 
-#: lib/vutuv_web/live/shell_live.ex:1277
-#: lib/vutuv_web/live/shell_live.ex:1343
+#: lib/vutuv_web/live/shell_live.ex:1354
+#: lib/vutuv_web/live/shell_live.ex:1420
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -648,8 +648,8 @@ msgstr "Salva"
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:49
 #: lib/vutuv_web/live/search_live.ex:570
-#: lib/vutuv_web/live/shell_live.ex:1142
-#: lib/vutuv_web/live/shell_live.ex:1326
+#: lib/vutuv_web/live/shell_live.ex:1219
+#: lib/vutuv_web/live/shell_live.ex:1403
 #: lib/vutuv_web/live/tag_live/timeline.ex:318
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -1185,7 +1185,7 @@ msgstr "Aggiungi localizzazione"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1249
+#: lib/vutuv_web/live/shell_live.ex:1326
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1626,7 +1626,7 @@ msgstr "Indirizzi di %{name}"
 msgid "Admin control panel"
 msgstr "Pannello di amministrazione"
 
-#: lib/vutuv_web/live/shell_live.ex:1329
+#: lib/vutuv_web/live/shell_live.ex:1406
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Avvisi"
@@ -1742,7 +1742,7 @@ msgstr ""
 "Sembra che non segua ancora nessuno. Apra il profilo di una persona che "
 "conosce o che La incuriosisce e prema il pulsante «Segui»."
 
-#: lib/vutuv_web/live/shell_live.ex:1268
+#: lib/vutuv_web/live/shell_live.ex:1345
 #: lib/vutuv_web/views/settings_html.ex:284
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1771,14 +1771,14 @@ msgstr "Messaggio"
 
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1160
-#: lib/vutuv_web/live/shell_live.ex:1328
+#: lib/vutuv_web/live/shell_live.ex:1237
+#: lib/vutuv_web/live/shell_live.ex:1405
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Messaggi"
 
-#: lib/vutuv_web/live/shell_live.ex:1044
+#: lib/vutuv_web/live/shell_live.ex:1121
 #: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Network"
@@ -1804,7 +1804,7 @@ msgstr "Ancora nessuna novità."
 #: lib/vutuv_web/components/ui.ex:4671
 #: lib/vutuv_web/live/notification_live/index.ex:140
 #: lib/vutuv_web/live/notification_live/index.ex:377
-#: lib/vutuv_web/live/shell_live.ex:1172
+#: lib/vutuv_web/live/shell_live.ex:1249
 #: lib/vutuv_web/templates/layout/app.html.heex:173
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2163,8 +2163,8 @@ msgstr "Modifica il post"
 #: lib/vutuv_web/live/post_live/feed.ex:279
 #: lib/vutuv_web/live/post_live/feed.ex:2380
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1022
-#: lib/vutuv_web/live/shell_live.ex:1321
+#: lib/vutuv_web/live/shell_live.ex:1099
+#: lib/vutuv_web/live/shell_live.ex:1398
 #: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2340,7 +2340,7 @@ msgid "Upload failed."
 msgstr "Caricamento non riuscito."
 
 #: lib/vutuv_web/components/ui.ex:4971
-#: lib/vutuv_web/live/shell_live.ex:1215
+#: lib/vutuv_web/live/shell_live.ex:1292
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:231
@@ -2430,8 +2430,8 @@ msgstr "Salva"
 #: lib/vutuv_web/agent_docs/markdown.ex:1116
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:1152
-#: lib/vutuv_web/live/shell_live.ex:1220
+#: lib/vutuv_web/live/shell_live.ex:1229
+#: lib/vutuv_web/live/shell_live.ex:1297
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2452,7 +2452,7 @@ msgstr "Mi piace"
 #: lib/vutuv_web/live/notification_live/index.ex:1022
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:1223
+#: lib/vutuv_web/live/shell_live.ex:1300
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -3229,8 +3229,8 @@ msgid "Private message"
 msgstr "Messaggio privato"
 
 #: lib/vutuv_web/components/ui.ex:4603
-#: lib/vutuv_web/live/shell_live.ex:1036
-#: lib/vutuv_web/live/shell_live.ex:1333
+#: lib/vutuv_web/live/shell_live.ex:1113
+#: lib/vutuv_web/live/shell_live.ex:1410
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -5533,7 +5533,7 @@ msgstr "Non può più rispondere a questo post."
 msgid "Content under review"
 msgstr "Contenuto in esame"
 
-#: lib/vutuv_web/live/shell_live.ex:1202
+#: lib/vutuv_web/live/shell_live.ex:1279
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Menu dell'account"
@@ -5555,7 +5555,7 @@ msgstr "Chiudi menu e finestre"
 msgid "General"
 msgstr "Generale"
 
-#: lib/vutuv_web/live/shell_live.ex:1259
+#: lib/vutuv_web/live/shell_live.ex:1336
 #: lib/vutuv_web/templates/layout/app.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5574,7 +5574,7 @@ msgstr "Navigazione"
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
-#: lib/vutuv_web/live/shell_live.ex:1239
+#: lib/vutuv_web/live/shell_live.ex:1316
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5628,8 +5628,8 @@ msgstr "Post successivo nel feed"
 msgid "Previous post in the feed"
 msgstr "Post precedente nel feed"
 
-#: lib/vutuv_web/live/shell_live.ex:1011
-#: lib/vutuv_web/live/shell_live.ex:1305
+#: lib/vutuv_web/live/shell_live.ex:1088
+#: lib/vutuv_web/live/shell_live.ex:1382
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Navigazione principale"
@@ -12411,7 +12411,7 @@ msgstr "Organizzazione sbloccata."
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1230
+#: lib/vutuv_web/live/shell_live.ex:1307
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:100
@@ -12757,7 +12757,7 @@ msgstr "Titolo della posizione"
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1052
+#: lib/vutuv_web/live/shell_live.ex:1129
 #: lib/vutuv_web/templates/layout/app.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -14559,7 +14559,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] "Confermato da %{name} e da %{formatted} altro"
 msgstr[1] "Confermato da %{name} e da altri %{formatted}"
 
-#: lib/vutuv_web/live/shell_live.ex:509
+#: lib/vutuv_web/live/shell_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -21334,7 +21334,7 @@ msgstr "Non può più scrivere a nome di questa organizzazione."
 msgid "A post in an organization's name is always public."
 msgstr "Un post a nome di un'organizzazione è sempre pubblico."
 
-#: lib/vutuv_web/live/shell_live.ex:969
+#: lib/vutuv_web/live/shell_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr "Apri la pagina"
@@ -21354,7 +21354,7 @@ msgstr "Ha smesso di scrivere come organizzazione"
 msgid "Write as %{name} for now"
 msgstr "Scrivi come %{name} per ora"
 
-#: lib/vutuv_web/live/shell_live.ex:979
+#: lib/vutuv_web/live/shell_live.ex:1056
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr "Torna a scrivere come me stesso"
@@ -21364,7 +21364,7 @@ msgstr "Torna a scrivere come me stesso"
 msgid "You are writing as %{name} now."
 msgstr "Ora sta scrivendo come %{name}."
 
-#: lib/vutuv_web/live/shell_live.ex:955
+#: lib/vutuv_web/live/shell_live.ex:1032
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr "Sta scrivendo come %{name}."
@@ -21775,21 +21775,21 @@ msgstr "Segue già #%{tag} qui."
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr "Anche Lei è su questo vutuv, quindi ora segue #%{tag} proprio qui."
 
-#: lib/vutuv_web/live/shell_live.ex:539
+#: lib/vutuv_web/live/shell_live.ex:562
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] "%{formatted} persona"
 msgstr[1] "%{formatted} persone"
 
-#: lib/vutuv_web/live/shell_live.ex:526
+#: lib/vutuv_web/live/shell_live.ex:549
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] "persona"
 msgstr[1] "persone"
 
-#: lib/vutuv_web/live/shell_live.ex:561
+#: lib/vutuv_web/live/shell_live.ex:584
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -22982,7 +22982,7 @@ msgstr "Smettere di seguire %{handle}? I suoi post spariscono dal Suo feed."
 msgid "Unfollowed. Their posts leave your feed."
 msgstr "Non lo segue più. I suoi post spariscono dal Suo feed."
 
-#: lib/vutuv_web/live/shell_live.ex:925
+#: lib/vutuv_web/live/shell_live.ex:1002
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr "Consenti"
@@ -22997,12 +22997,12 @@ msgstr "Chiedi ora"
 msgid "Browser notifications"
 msgstr "Notifiche del browser"
 
-#: lib/vutuv_web/live/shell_live.ex:822
+#: lib/vutuv_web/live/shell_live.ex:862
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr "Nuovo messaggio"
 
-#: lib/vutuv_web/live/shell_live.ex:932
+#: lib/vutuv_web/live/shell_live.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Non ora"
@@ -23052,7 +23052,7 @@ msgstr ""
 "guardando, il Suo browser può mostrarlo come notifica. Disattivate finché "
 "non le attiva."
 
-#: lib/vutuv_web/live/shell_live.ex:922
+#: lib/vutuv_web/live/shell_live.ex:999
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -23098,12 +23098,12 @@ msgstr ""
 "Inviata. Se non è comparso nulla, è il Suo sistema a trattenerla. Controlli "
 "la modalità Non disturbare e le impostazioni delle notifiche."
 
-#: lib/vutuv_web/live/shell_live.ex:625
+#: lib/vutuv_web/live/shell_live.ex:648
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr "Notifica di prova"
 
-#: lib/vutuv_web/live/shell_live.ex:626
+#: lib/vutuv_web/live/shell_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr "Ecco come si presenta vutuv quando arriva qualcosa."
@@ -23333,7 +23333,7 @@ msgstr "Traducili in %{language}"
 msgid "Translated into %{language}."
 msgstr "Vengono tradotti in %{language}."
 
-#: lib/vutuv_web/live/shell_live.ex:758
+#: lib/vutuv_web/live/shell_live.ex:798
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -23437,11 +23437,6 @@ msgstr "Il suo profilo LinkedIn può venire con lei."
 msgid "Being checked"
 msgstr "In verifica"
 
-#: lib/vutuv_web/live/shell_live.ex:862
-#, elixir-autogen, elixir-format
-msgid "A new version of vutuv is ready."
-msgstr "È pronta una nuova versione di vutuv."
-
 #: lib/vutuv_web/templates/settings/notifications.html.heex:225
 #, elixir-autogen, elixir-format
 msgid "Also notify me on this device when vutuv is closed"
@@ -23462,13 +23457,13 @@ msgstr "Rimuovi"
 msgid "New message on vutuv"
 msgstr "Nuovo messaggio su vutuv"
 
-#: lib/vutuv_web/controllers/service_worker_controller.ex:138
+#: lib/vutuv_web/controllers/service_worker_controller.ex:140
 #: lib/vutuv_web/templates/service_worker/offline.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "No connection"
 msgstr "Nessuna connessione"
 
-#: lib/vutuv_web/live/shell_live.ex:865
+#: lib/vutuv_web/live/shell_live.ex:932
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr "Ricarica"
@@ -23953,3 +23948,13 @@ msgstr "I gestori di password come Bitwarden ne ricavano l'intera voce: nome, ac
 #, elixir-autogen, elixir-format
 msgid "Scan it with the device that has the app"
 msgstr "Da scansionare con il dispositivo su cui è installata l'app"
+
+#: lib/vutuv_web/live/shell_live.ex:914
+#, elixir-autogen, elixir-format
+msgid "A new version is ready."
+msgstr "È pronta una nuova versione."
+
+#: lib/vutuv_web/live/shell_live.ex:942
+#, elixir-autogen, elixir-format
+msgid "Later"
+msgstr "Più tardi"

--- a/test/support/endpoint_host_helper.ex
+++ b/test/support/endpoint_host_helper.ex
@@ -1,6 +1,6 @@
 defmodule Vutuv.EndpointHostHelper do
   @moduledoc """
-  Dresses the test endpoint in a real hostname for the duration of one test.
+  Swaps endpoint config for the duration of one test, hostname most often.
 
   Every "is this address on this very installation?" gate compares against
   `VutuvWeb.Endpoint.host()`, and the test endpoint answers "localhost" — not a
@@ -15,15 +15,29 @@ defmodule Vutuv.EndpointHostHelper do
   import ExUnit.Callbacks, only: [on_exit: 1]
 
   def with_endpoint_host(host) do
+    url = Application.get_env(:vutuv, VutuvWeb.Endpoint)[:url] || []
+
+    with_endpoint_config(:url, Keyword.put(url, :host, host))
+  end
+
+  @doc """
+  The same swap for any other endpoint key, restored on exit.
+
+  `:cache_static_manifest_latest` is the one the update bar's test needs — it is
+  what `static_changed?/1` compares a browser's reported bundle against, and the
+  test endpoint has none, so that gate can never answer "changed" without this.
+  Same `config_change/2` subtlety, so it lives here rather than being written
+  out a second time.
+  """
+  def with_endpoint_config(key, value) do
     original = Application.get_env(:vutuv, VutuvWeb.Endpoint)
-    changed = Keyword.put(original, :url, Keyword.put(original[:url] || [], :host, host))
 
-    Application.put_env(:vutuv, VutuvWeb.Endpoint, changed)
-    VutuvWeb.Endpoint.config_change([{VutuvWeb.Endpoint, changed}], [])
+    put_endpoint_config(Keyword.put(original, key, value))
+    on_exit(fn -> put_endpoint_config(original) end)
+  end
 
-    on_exit(fn ->
-      Application.put_env(:vutuv, VutuvWeb.Endpoint, original)
-      VutuvWeb.Endpoint.config_change([{VutuvWeb.Endpoint, original}], [])
-    end)
+  defp put_endpoint_config(config) do
+    Application.put_env(:vutuv, VutuvWeb.Endpoint, config)
+    VutuvWeb.Endpoint.config_change([{VutuvWeb.Endpoint, config}], [])
   end
 end

--- a/test/vutuv_web/live/shell_live_update_bar_test.exs
+++ b/test/vutuv_web/live/shell_live_update_bar_test.exs
@@ -1,0 +1,136 @@
+defmodule VutuvWeb.ShellLiveUpdateBarTest do
+  @moduledoc """
+  The "a new version is ready" bar (issue #1729).
+
+  What it is really about is **who gets asked to reload**. A deploy reloads
+  nothing: an open page keeps the bundle it downloaded, and an installed app is
+  reloaded rarer still. But a page loaded *after* the deploy is already on the
+  new release — its HTML came from the server and its digested assets came with
+  it — so offering that reader a reload is asking them to fix what is not
+  broken.
+
+  The service worker cannot tell those two apart. `registration.waiting` stays
+  set until every vutuv tab is gone, so it was still true on a document that had
+  just arrived from the new release, and the bar came back on every page load
+  until somebody pressed it. The server can tell them apart, because
+  `phx-track-static` reports the bundle this browser is actually running.
+
+  Not `async`: the stale branch needs the endpoint to claim a digest manifest,
+  and that is global.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  # A manifest the tracked assets below either match or miss on purpose.
+  @manifest %{"assets/app.js" => "assets/app-CURRENT.js"}
+  @current ["http://localhost/assets/app-CURRENT.js"]
+  @stale ["http://localhost/assets/app-PREVIOUS.js"]
+
+  setup do
+    Vutuv.EndpointHostHelper.with_endpoint_config(:cache_static_manifest_latest, @manifest)
+  end
+
+  defp mount_shell(conn, connect_params, session \\ %{}) do
+    {:ok, view, html} =
+      conn
+      |> put_connect_params(connect_params)
+      |> live_isolated(VutuvWeb.ShellLive, session: session)
+
+    {view, html}
+  end
+
+  describe "who gets offered the reload" do
+    test "a browser still running the previous release is offered it", %{conn: conn} do
+      {_view, html} = mount_shell(conn, %{"_track_static" => @stale})
+
+      assert html =~ ~s(id="sw-update")
+      assert html =~ "A new version is ready."
+    end
+
+    # Reload must be a LINK, not a button. This bar is only ever rendered into a
+    # document running the previous release's JavaScript, and that handler does
+    # nothing at all when no worker happens to be waiting — which is the usual
+    # case for a tab that has been open across the deploy. The href is what
+    # still carries the reader to the new release (and what makes the control
+    # work with JavaScript off), so a refactor to `<button>` is a regression.
+    test "the reload control is a link to the page itself", %{conn: conn} do
+      {_view, html} = mount_shell(conn, %{"_track_static" => @stale})
+
+      assert [reload] =
+               html
+               |> LazyHTML.from_document()
+               |> LazyHTML.query("[data-sw-reload]")
+               |> Enum.to_list()
+
+      assert LazyHTML.tag(reload) == ["a"]
+      assert LazyHTML.attribute(reload, "href") == ["/"]
+    end
+
+    # The regression this file exists for. Before the gate the bar was in every
+    # document, and the service worker unhid it whenever a worker was waiting —
+    # which it still is on a page that arrived fresh from the new release.
+    test "a browser already running the current release is not", %{conn: conn} do
+      {_view, html} = mount_shell(conn, %{"_track_static" => @current})
+
+      refute html =~ ~s(id="sw-update")
+    end
+
+    # A browser that reports no bundle (a page that lost the `phx-track-static`
+    # annotation) gives the gate nothing to judge by, and it must then stay
+    # quiet rather than guess — which is the whole complaint being fixed.
+    test "a browser that reports no bundle at all is not", %{conn: conn} do
+      {_view, html} = mount_shell(conn, %{})
+
+      refute html =~ ~s(id="sw-update")
+    end
+  end
+
+  # The shape that actually broke, and the reason this describe exists rather
+  # than the `live_isolated/3` cases above being thought sufficient. Those mount
+  # the shell as a ROOT LiveView, which is what it is on a classic controller
+  # page. But `app.html.heex` embeds it with `live_render`, so a LiveView page's
+  # first HTTP paint takes `Static.disconnected_nested_render/6` — which sets
+  # `conn_session` and **no** `connect_params`, and `static_changed?/1` raises
+  # there rather than answering false. Calling it without the `connected?/1`
+  # short-circuit 500s every one of these pages, and the raise's own message
+  # ("store the state in socket assigns") points nowhere near the cause.
+  describe "the disconnected render of a page embedding the shell" do
+    test "a classic controller page still paints", %{conn: conn} do
+      assert conn |> get(~p"/") |> html_response(200)
+    end
+
+    test "a LiveView page still paints", %{conn: conn} do
+      assert conn |> get(~p"/search") |> html_response(200)
+    end
+  end
+
+  describe "dismissing it" do
+    test "Later takes it away for this document", %{conn: conn} do
+      {view, html} = mount_shell(conn, %{"_track_static" => @stale})
+      assert html =~ ~s(id="sw-update")
+
+      html = view |> element(~s([phx-click="dismiss_update"])) |> render_click()
+
+      refute html =~ ~s(id="sw-update")
+    end
+  end
+
+  # Both translated locales, by name. A one-word msgid like "Later" is exactly
+  # what `gettext.extract --merge` fuzzy-fills from an unrelated string, and it
+  # did: German came back as "Letzter Fehler" (last error) and Italian as
+  # "Ultimo errore". Nothing failed the build, and English stayed green — so the
+  # only thing standing between that and a shipped button labelled "last error"
+  # is an assertion naming the words.
+  for {locale, expected} <- [
+        {"de", ["Neue Version bereit.", "Neu laden", "Später"]},
+        {"it", ["È pronta una nuova versione.", "Ricarica", "Più tardi"]}
+      ] do
+    test "the #{locale} render says all three lines in #{locale}", %{conn: conn} do
+      {_view, html} =
+        mount_shell(conn, %{"_track_static" => @stale}, %{"locale" => unquote(locale)})
+
+      for line <- unquote(expected), do: assert(html =~ line)
+    end
+  end
+end


### PR DESCRIPTION
**Where:** the `#sw-update` bar in `VutuvWeb.ShellLive`, plus `assets/js/app.js`.

The bar showed on pages already running the new release, and could not be
dismissed. It keyed on `registration.waiting`, which stays set from a worker
installing until the last tab closes — true even on a document that had just
arrived. Meanwhile the case it exists for barely fired, nothing calling
`registration.update()`. The server answers now, via `static_changed?/1`.

Quieter as asked: hairline strip, ghost link instead of the solid CTA, a "Later".

Two things worth your eye:

- Reload is an `<a href>`, not a button. This bar only ever renders into a
  document running the **previous** release, whose handler does nothing when no
  worker happens to be waiting.
- `connected?/1` before `static_changed?/1` is not redundant: the shell is a
  nested `live_render` and that dead render carries no `connect_params`.
  Dropping it 500s every page. There is a test.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01WBJyXoinFz1LqKmPimJMGu
