### PR TITLE
Remove the dismiss button from the new-version bar

### DIFF
--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -80,10 +80,11 @@ for (a tab open for hours) barely fired at all, nothing calling
 `registration.update()`. So the shell asks `static_changed?/1` instead:
 `phx-track-static` reports the bundle this browser is really running, and only a
 document that predates the deploy is offered `#sw-update` ("A new version is
-ready"). Dismissing it is socket state, so it lasts exactly as long as the
-document it applies to. The worker's remaining job is carrying the reload out —
-Reload posts `skip-waiting` to a waiting worker, or plainly reloads when there
-is none.
+ready"). There is no way to put that bar away: this reader's markup, CSS and
+JavaScript all come from a release that is gone, so postponing would leave them
+on it for as long as the tab stays open. The worker's remaining job is carrying
+the reload out — Reload posts `skip-waiting` to a waiting worker, or plainly
+reloads when there is none.
 
 **Which means a worker from the previous release keeps running, and nothing
 bounds how long.** This is the one asset that deliberately outlives a deploy,

--- a/lib/vutuv_web/live/shell_live.ex
+++ b/lib/vutuv_web/live/shell_live.ex
@@ -652,23 +652,6 @@ defmodule VutuvWeb.ShellLive do
      })}
   end
 
-  # "Later" on the update bar (issue #1729). Socket state and nothing more: the
-  # offer is about this document, so the dismissal is scoped to it too.
-  #
-  # Known limit, and a deliberate one: a reconnect re-mounts and the bar comes
-  # back. A socket drops for entirely ordinary reasons — a sleeping laptop, a
-  # backgrounded phone tab, a change of network — and the long-open tab this bar
-  # exists for is precisely the one that does that most, so "Later" can mean
-  # "until the next blip". Carrying it across would mean telling the SERVER what
-  # this browser has already put away (a LiveSocket connect param keyed on the
-  # tracked bundle, since the flag must not outlive the release it refers to),
-  # and that plumbing sits on every LiveView join in the app. Not worth it while
-  # the thing coming back is one quiet strip dismissed again in a single click —
-  # revisit if anybody actually reports it.
-  def handle_event("dismiss_update", _params, socket) do
-    {:noreply, assign(socket, :update_ready?, false)}
-  end
-
   # The member clicked a browser notification, so they have seen exactly the
   # event it announced — and nothing else on the bell. Recording it drops that
   # one from the unread tally; the recount then comes back through
@@ -891,10 +874,12 @@ defmodule VutuvWeb.ShellLive do
       browser's own 24-hour worker check. The tracked bundle answers both.
 
       It is deliberately quiet: this is news, not a problem, and it stacks above
-      the header with two other bars of the same shape. A hairline strip, a text
-      link rather than the solid CTA, and a "Later" that takes it away - the
-      dismissal is plain socket state, so it lives exactly as long as the
-      document it applies to.
+      the header with two other bars of the same shape. A hairline strip and a
+      text link rather than the solid CTA. Quiet, but not optional - it carries
+      no "Later" beside the reload and should not carry one again, for the
+      reason `docs/architecture/realtime.md` gives: this reader's whole document
+      predates the deploy, so putting the notice away would leave them on the
+      old release for as long as the tab stays open.
 
       Every class here is one the app already ships. This markup is by
       definition patched into a document running the PREVIOUS release's CSS
@@ -931,16 +916,6 @@ defmodule VutuvWeb.ShellLive do
           <.button variant="ghost" href={reload_path(@path)} data-sw-reload class="min-h-10">
             {gettext("Reload")}
           </.button>
-          <%!-- Its own msgid rather than the "Not now" the notification prompt
-          uses: that one answers a request for permission, this one postpones an
-          offer, and German says them differently. --%>
-          <button
-            type="button"
-            phx-click="dismiss_update"
-            class="ml-auto min-h-10 rounded-lg px-3 text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
-          >
-            {gettext("Later")}
-          </button>
         </div>
       </div>
       <div :if={@user_id} id="presence-hook" phx-hook="Presence" phx-update="ignore" class="hidden"></div>

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -444,8 +444,8 @@ msgstr "Einloggen"
 msgid "Log Out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/live/shell_live.ex:1354
-#: lib/vutuv_web/live/shell_live.ex:1420
+#: lib/vutuv_web/live/shell_live.ex:1329
+#: lib/vutuv_web/live/shell_live.ex:1395
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -646,8 +646,8 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:49
 #: lib/vutuv_web/live/search_live.ex:570
-#: lib/vutuv_web/live/shell_live.ex:1219
-#: lib/vutuv_web/live/shell_live.ex:1403
+#: lib/vutuv_web/live/shell_live.ex:1194
+#: lib/vutuv_web/live/shell_live.ex:1378
 #: lib/vutuv_web/live/tag_live/timeline.ex:318
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -1183,7 +1183,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1326
+#: lib/vutuv_web/live/shell_live.ex:1301
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1625,7 +1625,7 @@ msgstr "Adressen von %{name}"
 msgid "Admin control panel"
 msgstr "Admin-Bereich"
 
-#: lib/vutuv_web/live/shell_live.ex:1406
+#: lib/vutuv_web/live/shell_live.ex:1381
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Mitteilungen"
@@ -1742,7 +1742,7 @@ msgstr ""
 " von jemandem, den Sie kennen oder interessant finden, und klicken Sie auf "
 "Folgen!"
 
-#: lib/vutuv_web/live/shell_live.ex:1345
+#: lib/vutuv_web/live/shell_live.ex:1320
 #: lib/vutuv_web/views/settings_html.ex:284
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1771,14 +1771,14 @@ msgstr "Nachricht"
 
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1237
-#: lib/vutuv_web/live/shell_live.ex:1405
+#: lib/vutuv_web/live/shell_live.ex:1212
+#: lib/vutuv_web/live/shell_live.ex:1380
 #: lib/vutuv_web/templates/layout/app.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: lib/vutuv_web/live/shell_live.ex:1121
+#: lib/vutuv_web/live/shell_live.ex:1096
 #: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Network"
@@ -1804,7 +1804,7 @@ msgstr "Noch nichts Neues."
 #: lib/vutuv_web/components/ui.ex:4702
 #: lib/vutuv_web/live/notification_live/index.ex:140
 #: lib/vutuv_web/live/notification_live/index.ex:377
-#: lib/vutuv_web/live/shell_live.ex:1249
+#: lib/vutuv_web/live/shell_live.ex:1224
 #: lib/vutuv_web/templates/layout/app.html.heex:174
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2161,8 +2161,8 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/live/post_live/feed.ex:279
 #: lib/vutuv_web/live/post_live/feed.ex:2380
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1099
-#: lib/vutuv_web/live/shell_live.ex:1398
+#: lib/vutuv_web/live/shell_live.ex:1074
+#: lib/vutuv_web/live/shell_live.ex:1373
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2205,7 +2205,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2695
+#: lib/vutuv_web/live/post_live/feed.ex:2699
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2300,7 +2300,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2553
+#: lib/vutuv_web/live/post_live/feed.ex:2557
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2338,7 +2338,7 @@ msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
 #: lib/vutuv_web/components/ui.ex:5002
-#: lib/vutuv_web/live/shell_live.ex:1292
+#: lib/vutuv_web/live/shell_live.ex:1267
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:231
@@ -2428,8 +2428,8 @@ msgstr "Lesezeichen setzen"
 #: lib/vutuv_web/agent_docs/markdown.ex:1116
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:1229
-#: lib/vutuv_web/live/shell_live.ex:1297
+#: lib/vutuv_web/live/shell_live.ex:1204
+#: lib/vutuv_web/live/shell_live.ex:1272
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2450,7 +2450,7 @@ msgstr "Gefällt mir"
 #: lib/vutuv_web/live/notification_live/index.ex:1022
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:1300
+#: lib/vutuv_web/live/shell_live.ex:1275
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -3220,8 +3220,8 @@ msgid "Private message"
 msgstr "Private Nachricht"
 
 #: lib/vutuv_web/components/ui.ex:4634
-#: lib/vutuv_web/live/shell_live.ex:1113
-#: lib/vutuv_web/live/shell_live.ex:1410
+#: lib/vutuv_web/live/shell_live.ex:1088
+#: lib/vutuv_web/live/shell_live.ex:1385
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -4711,7 +4711,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2700
+#: lib/vutuv_web/live/post_live/feed.ex:2704
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -5536,7 +5536,7 @@ msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
 msgid "Content under review"
 msgstr "Inhalte in Prüfung"
 
-#: lib/vutuv_web/live/shell_live.ex:1279
+#: lib/vutuv_web/live/shell_live.ex:1254
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Kontomenü"
@@ -5558,7 +5558,7 @@ msgstr "Menüs und Dialoge schließen"
 msgid "General"
 msgstr "Allgemeines"
 
-#: lib/vutuv_web/live/shell_live.ex:1336
+#: lib/vutuv_web/live/shell_live.ex:1311
 #: lib/vutuv_web/templates/layout/app.html.heex:204
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5577,7 +5577,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
-#: lib/vutuv_web/live/shell_live.ex:1316
+#: lib/vutuv_web/live/shell_live.ex:1291
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5631,8 +5631,8 @@ msgstr "Nächster Beitrag im Feed"
 msgid "Previous post in the feed"
 msgstr "Vorheriger Beitrag im Feed"
 
-#: lib/vutuv_web/live/shell_live.ex:1088
-#: lib/vutuv_web/live/shell_live.ex:1382
+#: lib/vutuv_web/live/shell_live.ex:1063
+#: lib/vutuv_web/live/shell_live.ex:1357
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Hauptnavigation"
@@ -7758,7 +7758,7 @@ msgstr ""
 "der Versand läuft weiter."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:2963
+#: lib/vutuv_web/live/post_live/feed.ex:2967
 #, elixir-autogen
 msgid "Done"
 msgstr "Fertig"
@@ -12426,7 +12426,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1307
+#: lib/vutuv_web/live/shell_live.ex:1282
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:100
@@ -12769,7 +12769,7 @@ msgstr "Stellenbezeichnung"
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1129
+#: lib/vutuv_web/live/shell_live.ex:1104
 #: lib/vutuv_web/templates/layout/app.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -17996,7 +17996,7 @@ msgstr "Gehört Ihnen noch nicht."
 msgid "Nothing has changed yet."
 msgstr "Noch hat sich nichts geändert."
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:237
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:250
 #: lib/vutuv_web/templates/username/confirm.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Now"
@@ -19090,7 +19090,7 @@ msgstr "Ausstellungsdatum"
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2718
+#: lib/vutuv_web/live/post_live/feed.ex:2722
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -20683,7 +20683,7 @@ msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."
 msgid "A post in an organization's name is always public."
 msgstr "Ein Beitrag im Namen einer Organisation ist immer öffentlich."
 
-#: lib/vutuv_web/live/shell_live.ex:1046
+#: lib/vutuv_web/live/shell_live.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr "Seite öffnen"
@@ -20703,7 +20703,7 @@ msgstr "Beendet, im Namen einer Organisation zu schreiben"
 msgid "Write as %{name} for now"
 msgstr "Vorerst als %{name} schreiben"
 
-#: lib/vutuv_web/live/shell_live.ex:1056
+#: lib/vutuv_web/live/shell_live.ex:1031
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr "Wieder als ich selbst schreiben"
@@ -20713,7 +20713,7 @@ msgstr "Wieder als ich selbst schreiben"
 msgid "You are writing as %{name} now."
 msgstr "Sie schreiben jetzt als %{name}."
 
-#: lib/vutuv_web/live/shell_live.ex:1032
+#: lib/vutuv_web/live/shell_live.ex:1007
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr "Sie schreiben als %{name}."
@@ -22186,7 +22186,7 @@ msgstr "%{handle} nicht mehr folgen? Die Beiträge verschwinden aus Ihrem Feed."
 msgid "Unfollowed. Their posts leave your feed."
 msgstr "Nicht mehr gefolgt. Die Beiträge verschwinden aus Ihrem Feed."
 
-#: lib/vutuv_web/live/shell_live.ex:1002
+#: lib/vutuv_web/live/shell_live.ex:977
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr "Erlauben"
@@ -22201,12 +22201,12 @@ msgstr "Jetzt fragen"
 msgid "Browser notifications"
 msgstr "Browser-Benachrichtigungen"
 
-#: lib/vutuv_web/live/shell_live.ex:862
+#: lib/vutuv_web/live/shell_live.ex:845
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr "Neue Nachricht"
 
-#: lib/vutuv_web/live/shell_live.ex:1009
+#: lib/vutuv_web/live/shell_live.ex:984
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Jetzt nicht"
@@ -22246,7 +22246,7 @@ msgstr "Dieser Browser zeigt sie an."
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr "Wenn etwas eintrifft, während vutuv in einem Tab offen ist, den Sie gerade nicht ansehen, kann Ihr Browser es als Benachrichtigung anzeigen. Aus, solange Sie es nicht einschalten."
 
-#: lib/vutuv_web/live/shell_live.ex:999
+#: lib/vutuv_web/live/shell_live.ex:974
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr "Sie haben Browser-Benachrichtigungen eingeschaltet. Dieser Browser wurde noch nicht um Erlaubnis gebeten."
@@ -22302,7 +22302,7 @@ msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public po
 msgstr ""
 "Folgen Sie #%{tag} von Mastodon oder einer anderen Fediverse-App aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2876
+#: lib/vutuv_web/live/post_live/feed.ex:2880
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Andere Mitglieder begrüßen"
@@ -22531,7 +22531,7 @@ msgstr "In %{language} übersetzen"
 msgid "Translated into %{language}."
 msgstr "Wird in %{language} übersetzt."
 
-#: lib/vutuv_web/live/shell_live.ex:798
+#: lib/vutuv_web/live/shell_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -22662,7 +22662,7 @@ msgstr "Neue Nachricht auf vutuv"
 msgid "No connection"
 msgstr "Keine Verbindung"
 
-#: lib/vutuv_web/live/shell_live.ex:932
+#: lib/vutuv_web/live/shell_live.ex:917
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr "Neu laden"
@@ -22895,7 +22895,7 @@ msgstr "Beiträge mit einem dieser Tags werden genauso zugeklappt."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Beiträge mit einem dieser Wörter werden auf eine Zeile zugeklappt — nicht gelöscht, und mit einem Weg, sie doch zu lesen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2902
+#: lib/vutuv_web/live/post_live/feed.ex:2906
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Weggelegt:"
@@ -22974,8 +22974,8 @@ msgstr[1] "und %{formatted} weitere"
 
 #: lib/vutuv_web/live/post_live/feed.ex:2521
 #: lib/vutuv_web/live/post_live/feed.ex:2538
-#: lib/vutuv_web/live/post_live/feed.ex:2950
-#: lib/vutuv_web/live/post_live/feed.ex:2955
+#: lib/vutuv_web/live/post_live/feed.ex:2954
+#: lib/vutuv_web/live/post_live/feed.ex:2959
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -23025,31 +23025,31 @@ msgid_plural "You can upload at most %{count} files at a time."
 msgstr[0] "Sie können eine Datei auf einmal hochladen."
 msgstr[1] "Sie können höchstens %{count} Dateien auf einmal hochladen."
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:357
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:370
 #, elixir-autogen, elixir-format
 msgid "%{count} entry on %{day}"
 msgid_plural "%{count} entries on %{day}"
 msgstr[0] "%{count} Eintrag am %{day}"
 msgstr[1] "%{count} Einträge am %{day}"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:354
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:367
 #, elixir-autogen, elixir-format
 msgid "%{count} post on %{day}"
 msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} Beitrag am %{day}"
 msgstr[1] "%{count} Beiträge am %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2675
+#: lib/vutuv_web/live/post_live/feed.ex:2679
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Zurück zu jetzt"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:221
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:234
 #, elixir-autogen, elixir-format
 msgid "Busy month: the shading counts at least this much."
 msgstr "Voller Monat: die Färbung zählt mindestens so viel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2721
+#: lib/vutuv_web/live/post_live/feed.ex:2725
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -23061,38 +23061,38 @@ msgstr[1] "Ganzen Tag laden (%{formatted} Beiträge)"
 msgid "My posts"
 msgstr "Meine Beiträge"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:133
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:146
 #, elixir-autogen, elixir-format
 msgid "Next month"
 msgstr "Nächster Monat"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:139
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:152
 #, elixir-autogen, elixir-format
 msgid "Next year"
 msgstr "Nächstes Jahr"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2671
+#: lib/vutuv_web/live/post_live/feed.ex:2675
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Am %{day} ist nichts in Ihrem Feed angekommen."
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:100
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:113
 #, elixir-autogen, elixir-format
 msgid "Previous month"
 msgstr "Voriger Monat"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:96
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:109
 #, elixir-autogen, elixir-format
 msgid "Previous year"
 msgstr "Voriges Jahr"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:209
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:222
 #, elixir-autogen, elixir-format
 msgctxt "heatmap scale"
 msgid "Less"
 msgstr "Weniger"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:211
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:224
 #, elixir-autogen, elixir-format
 msgctxt "heatmap scale"
 msgid "More"
@@ -23148,15 +23148,10 @@ msgstr "Passwortmanager wie Bitwarden übernehmen daraus den ganzen Eintrag: Nam
 msgid "Scan it with the device that has the app"
 msgstr "Mit dem Gerät scannen, auf dem die App läuft"
 
-#: lib/vutuv_web/live/shell_live.ex:914
+#: lib/vutuv_web/live/shell_live.ex:899
 #, elixir-autogen, elixir-format
 msgid "A new version is ready."
 msgstr "Neue Version bereit."
-
-#: lib/vutuv_web/live/shell_live.ex:942
-#, elixir-autogen, elixir-format
-msgid "Later"
-msgstr "Später"
 
 #: lib/vutuv_web/live/organization_live/show.ex:703
 #, elixir-autogen, elixir-format

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -444,8 +444,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1354
-#: lib/vutuv_web/live/shell_live.ex:1420
+#: lib/vutuv_web/live/shell_live.ex:1329
+#: lib/vutuv_web/live/shell_live.ex:1395
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -646,8 +646,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:49
 #: lib/vutuv_web/live/search_live.ex:570
-#: lib/vutuv_web/live/shell_live.ex:1219
-#: lib/vutuv_web/live/shell_live.ex:1403
+#: lib/vutuv_web/live/shell_live.ex:1194
+#: lib/vutuv_web/live/shell_live.ex:1378
 #: lib/vutuv_web/live/tag_live/timeline.ex:318
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -1161,7 +1161,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1326
+#: lib/vutuv_web/live/shell_live.ex:1301
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1406
+#: lib/vutuv_web/live/shell_live.ex:1381
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1709,7 +1709,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1345
+#: lib/vutuv_web/live/shell_live.ex:1320
 #: lib/vutuv_web/views/settings_html.ex:284
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1738,14 +1738,14 @@ msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1237
-#: lib/vutuv_web/live/shell_live.ex:1405
+#: lib/vutuv_web/live/shell_live.ex:1212
+#: lib/vutuv_web/live/shell_live.ex:1380
 #: lib/vutuv_web/templates/layout/app.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1121
+#: lib/vutuv_web/live/shell_live.ex:1096
 #: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Network"
@@ -1771,7 +1771,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4702
 #: lib/vutuv_web/live/notification_live/index.ex:140
 #: lib/vutuv_web/live/notification_live/index.ex:377
-#: lib/vutuv_web/live/shell_live.ex:1249
+#: lib/vutuv_web/live/shell_live.ex:1224
 #: lib/vutuv_web/templates/layout/app.html.heex:174
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2120,8 +2120,8 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/feed.ex:279
 #: lib/vutuv_web/live/post_live/feed.ex:2380
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1099
-#: lib/vutuv_web/live/shell_live.ex:1398
+#: lib/vutuv_web/live/shell_live.ex:1074
+#: lib/vutuv_web/live/shell_live.ex:1373
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2164,7 +2164,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2695
+#: lib/vutuv_web/live/post_live/feed.ex:2699
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2255,7 +2255,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2553
+#: lib/vutuv_web/live/post_live/feed.ex:2557
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2293,7 +2293,7 @@ msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5002
-#: lib/vutuv_web/live/shell_live.ex:1292
+#: lib/vutuv_web/live/shell_live.ex:1267
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:231
@@ -2383,8 +2383,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1116
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:1229
-#: lib/vutuv_web/live/shell_live.ex:1297
+#: lib/vutuv_web/live/shell_live.ex:1204
+#: lib/vutuv_web/live/shell_live.ex:1272
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2405,7 +2405,7 @@ msgstr ""
 #: lib/vutuv_web/live/notification_live/index.ex:1022
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:1300
+#: lib/vutuv_web/live/shell_live.ex:1275
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -3151,8 +3151,8 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4634
-#: lib/vutuv_web/live/shell_live.ex:1113
-#: lib/vutuv_web/live/shell_live.ex:1410
+#: lib/vutuv_web/live/shell_live.ex:1088
+#: lib/vutuv_web/live/shell_live.ex:1385
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -4544,7 +4544,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2700
+#: lib/vutuv_web/live/post_live/feed.ex:2704
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -5315,7 +5315,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1279
+#: lib/vutuv_web/live/shell_live.ex:1254
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5337,7 +5337,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1336
+#: lib/vutuv_web/live/shell_live.ex:1311
 #: lib/vutuv_web/templates/layout/app.html.heex:204
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5356,7 +5356,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
-#: lib/vutuv_web/live/shell_live.ex:1316
+#: lib/vutuv_web/live/shell_live.ex:1291
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5410,8 +5410,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1088
-#: lib/vutuv_web/live/shell_live.ex:1382
+#: lib/vutuv_web/live/shell_live.ex:1063
+#: lib/vutuv_web/live/shell_live.ex:1357
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -7450,7 +7450,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:2963
+#: lib/vutuv_web/live/post_live/feed.ex:2967
 #, elixir-autogen
 msgid "Done"
 msgstr ""
@@ -11798,7 +11798,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1307
+#: lib/vutuv_web/live/shell_live.ex:1282
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:100
@@ -12128,7 +12128,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1129
+#: lib/vutuv_web/live/shell_live.ex:1104
 #: lib/vutuv_web/templates/layout/app.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -17264,7 +17264,7 @@ msgstr ""
 msgid "Nothing has changed yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:237
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:250
 #: lib/vutuv_web/templates/username/confirm.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Now"
@@ -18353,7 +18353,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2718
+#: lib/vutuv_web/live/post_live/feed.ex:2722
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -19928,7 +19928,7 @@ msgstr ""
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1046
+#: lib/vutuv_web/live/shell_live.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr ""
@@ -19948,7 +19948,7 @@ msgstr ""
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1056
+#: lib/vutuv_web/live/shell_live.ex:1031
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -19958,7 +19958,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1032
+#: lib/vutuv_web/live/shell_live.ex:1007
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -21412,7 +21412,7 @@ msgstr ""
 msgid "Unfollowed. Their posts leave your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1002
+#: lib/vutuv_web/live/shell_live.ex:977
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr ""
@@ -21427,12 +21427,12 @@ msgstr ""
 msgid "Browser notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:862
+#: lib/vutuv_web/live/shell_live.ex:845
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1009
+#: lib/vutuv_web/live/shell_live.ex:984
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
@@ -21472,7 +21472,7 @@ msgstr ""
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:999
+#: lib/vutuv_web/live/shell_live.ex:974
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -21527,7 +21527,7 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2876
+#: lib/vutuv_web/live/post_live/feed.ex:2880
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
@@ -21738,7 +21738,7 @@ msgstr ""
 msgid "Translated into %{language}."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:798
+#: lib/vutuv_web/live/shell_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -21862,7 +21862,7 @@ msgstr ""
 msgid "No connection"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:932
+#: lib/vutuv_web/live/shell_live.ex:917
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr ""
@@ -22095,7 +22095,7 @@ msgstr ""
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2902
+#: lib/vutuv_web/live/post_live/feed.ex:2906
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
@@ -22174,8 +22174,8 @@ msgstr[1] ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:2521
 #: lib/vutuv_web/live/post_live/feed.ex:2538
-#: lib/vutuv_web/live/post_live/feed.ex:2950
-#: lib/vutuv_web/live/post_live/feed.ex:2955
+#: lib/vutuv_web/live/post_live/feed.ex:2954
+#: lib/vutuv_web/live/post_live/feed.ex:2959
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -22221,31 +22221,31 @@ msgid_plural "You can upload at most %{count} files at a time."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:357
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:370
 #, elixir-autogen, elixir-format
 msgid "%{count} entry on %{day}"
 msgid_plural "%{count} entries on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:354
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:367
 #, elixir-autogen, elixir-format
 msgid "%{count} post on %{day}"
 msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2675
+#: lib/vutuv_web/live/post_live/feed.ex:2679
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:221
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:234
 #, elixir-autogen, elixir-format
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2721
+#: lib/vutuv_web/live/post_live/feed.ex:2725
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22257,38 +22257,38 @@ msgstr[1] ""
 msgid "My posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:133
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:146
 #, elixir-autogen, elixir-format
 msgid "Next month"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:139
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:152
 #, elixir-autogen, elixir-format
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2671
+#: lib/vutuv_web/live/post_live/feed.ex:2675
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:100
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:113
 #, elixir-autogen, elixir-format
 msgid "Previous month"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:96
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:109
 #, elixir-autogen, elixir-format
 msgid "Previous year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:209
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:222
 #, elixir-autogen, elixir-format
 msgctxt "heatmap scale"
 msgid "Less"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:211
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:224
 #, elixir-autogen, elixir-format
 msgctxt "heatmap scale"
 msgid "More"
@@ -22344,14 +22344,9 @@ msgstr ""
 msgid "Scan it with the device that has the app"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:914
+#: lib/vutuv_web/live/shell_live.ex:899
 #, elixir-autogen, elixir-format
 msgid "A new version is ready."
-msgstr ""
-
-#: lib/vutuv_web/live/shell_live.ex:942
-#, elixir-autogen, elixir-format
-msgid "Later"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/show.ex:703

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -442,8 +442,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1354
-#: lib/vutuv_web/live/shell_live.ex:1420
+#: lib/vutuv_web/live/shell_live.ex:1329
+#: lib/vutuv_web/live/shell_live.ex:1395
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -644,8 +644,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:49
 #: lib/vutuv_web/live/search_live.ex:570
-#: lib/vutuv_web/live/shell_live.ex:1219
-#: lib/vutuv_web/live/shell_live.ex:1403
+#: lib/vutuv_web/live/shell_live.ex:1194
+#: lib/vutuv_web/live/shell_live.ex:1378
 #: lib/vutuv_web/live/tag_live/timeline.ex:318
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -1159,7 +1159,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1326
+#: lib/vutuv_web/live/shell_live.ex:1301
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1593,7 +1593,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1406
+#: lib/vutuv_web/live/shell_live.ex:1381
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1707,7 +1707,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1345
+#: lib/vutuv_web/live/shell_live.ex:1320
 #: lib/vutuv_web/views/settings_html.ex:284
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1736,14 +1736,14 @@ msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1237
-#: lib/vutuv_web/live/shell_live.ex:1405
+#: lib/vutuv_web/live/shell_live.ex:1212
+#: lib/vutuv_web/live/shell_live.ex:1380
 #: lib/vutuv_web/templates/layout/app.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1121
+#: lib/vutuv_web/live/shell_live.ex:1096
 #: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Network"
@@ -1769,7 +1769,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4702
 #: lib/vutuv_web/live/notification_live/index.ex:140
 #: lib/vutuv_web/live/notification_live/index.ex:377
-#: lib/vutuv_web/live/shell_live.ex:1249
+#: lib/vutuv_web/live/shell_live.ex:1224
 #: lib/vutuv_web/templates/layout/app.html.heex:174
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2118,8 +2118,8 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/feed.ex:279
 #: lib/vutuv_web/live/post_live/feed.ex:2380
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1099
-#: lib/vutuv_web/live/shell_live.ex:1398
+#: lib/vutuv_web/live/shell_live.ex:1074
+#: lib/vutuv_web/live/shell_live.ex:1373
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2162,7 +2162,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2695
+#: lib/vutuv_web/live/post_live/feed.ex:2699
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2553
+#: lib/vutuv_web/live/post_live/feed.ex:2557
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2291,7 +2291,7 @@ msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5002
-#: lib/vutuv_web/live/shell_live.ex:1292
+#: lib/vutuv_web/live/shell_live.ex:1267
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:231
@@ -2381,8 +2381,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1116
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:1229
-#: lib/vutuv_web/live/shell_live.ex:1297
+#: lib/vutuv_web/live/shell_live.ex:1204
+#: lib/vutuv_web/live/shell_live.ex:1272
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2403,7 +2403,7 @@ msgstr ""
 #: lib/vutuv_web/live/notification_live/index.ex:1022
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:1300
+#: lib/vutuv_web/live/shell_live.ex:1275
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -3149,8 +3149,8 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4634
-#: lib/vutuv_web/live/shell_live.ex:1113
-#: lib/vutuv_web/live/shell_live.ex:1410
+#: lib/vutuv_web/live/shell_live.ex:1088
+#: lib/vutuv_web/live/shell_live.ex:1385
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -4542,7 +4542,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2700
+#: lib/vutuv_web/live/post_live/feed.ex:2704
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -5313,7 +5313,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1279
+#: lib/vutuv_web/live/shell_live.ex:1254
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5335,7 +5335,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1336
+#: lib/vutuv_web/live/shell_live.ex:1311
 #: lib/vutuv_web/templates/layout/app.html.heex:204
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5354,7 +5354,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
-#: lib/vutuv_web/live/shell_live.ex:1316
+#: lib/vutuv_web/live/shell_live.ex:1291
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5408,8 +5408,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1088
-#: lib/vutuv_web/live/shell_live.ex:1382
+#: lib/vutuv_web/live/shell_live.ex:1063
+#: lib/vutuv_web/live/shell_live.ex:1357
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -7448,7 +7448,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:2963
+#: lib/vutuv_web/live/post_live/feed.ex:2967
 #, elixir-autogen
 msgid "Done"
 msgstr ""
@@ -11796,7 +11796,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1307
+#: lib/vutuv_web/live/shell_live.ex:1282
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:100
@@ -12126,7 +12126,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1129
+#: lib/vutuv_web/live/shell_live.ex:1104
 #: lib/vutuv_web/templates/layout/app.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -17262,7 +17262,7 @@ msgstr ""
 msgid "Nothing has changed yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:237
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:250
 #: lib/vutuv_web/templates/username/confirm.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Now"
@@ -18351,7 +18351,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2718
+#: lib/vutuv_web/live/post_live/feed.ex:2722
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Loading…"
@@ -19926,7 +19926,7 @@ msgstr ""
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1046
+#: lib/vutuv_web/live/shell_live.ex:1021
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Open the page"
 msgstr ""
@@ -19946,7 +19946,7 @@ msgstr ""
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1056
+#: lib/vutuv_web/live/shell_live.ex:1031
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -19956,7 +19956,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1032
+#: lib/vutuv_web/live/shell_live.ex:1007
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -21410,7 +21410,7 @@ msgstr ""
 msgid "Unfollowed. Their posts leave your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1002
+#: lib/vutuv_web/live/shell_live.ex:977
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr ""
@@ -21425,12 +21425,12 @@ msgstr ""
 msgid "Browser notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:862
+#: lib/vutuv_web/live/shell_live.ex:845
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1009
+#: lib/vutuv_web/live/shell_live.ex:984
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
@@ -21470,7 +21470,7 @@ msgstr ""
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:999
+#: lib/vutuv_web/live/shell_live.ex:974
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -21525,7 +21525,7 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2876
+#: lib/vutuv_web/live/post_live/feed.ex:2880
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
@@ -21736,7 +21736,7 @@ msgstr ""
 msgid "Translated into %{language}."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:798
+#: lib/vutuv_web/live/shell_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -21860,7 +21860,7 @@ msgstr ""
 msgid "No connection"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:932
+#: lib/vutuv_web/live/shell_live.ex:917
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr ""
@@ -22093,7 +22093,7 @@ msgstr "Posts carrying one of these tags are folded the same way."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2902
+#: lib/vutuv_web/live/post_live/feed.ex:2906
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
@@ -22172,8 +22172,8 @@ msgstr[1] ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:2521
 #: lib/vutuv_web/live/post_live/feed.ex:2538
-#: lib/vutuv_web/live/post_live/feed.ex:2950
-#: lib/vutuv_web/live/post_live/feed.ex:2955
+#: lib/vutuv_web/live/post_live/feed.ex:2954
+#: lib/vutuv_web/live/post_live/feed.ex:2959
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -22219,31 +22219,31 @@ msgid_plural "You can upload at most %{count} files at a time."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:357
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:370
 #, elixir-autogen, elixir-format
 msgid "%{count} entry on %{day}"
 msgid_plural "%{count} entries on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:354
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:367
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} post on %{day}"
 msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2675
+#: lib/vutuv_web/live/post_live/feed.ex:2679
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to now"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:221
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:234
 #, elixir-autogen, elixir-format
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2721
+#: lib/vutuv_web/live/post_live/feed.ex:2725
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22255,38 +22255,38 @@ msgstr[1] ""
 msgid "My posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:133
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:146
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Next month"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:139
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:152
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2671
+#: lib/vutuv_web/live/post_live/feed.ex:2675
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:100
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:113
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous month"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:96
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:109
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:209
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:222
 #, elixir-autogen, elixir-format
 msgctxt "heatmap scale"
 msgid "Less"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:211
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:224
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "heatmap scale"
 msgid "More"
@@ -22342,14 +22342,9 @@ msgstr ""
 msgid "Scan it with the device that has the app"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:914
+#: lib/vutuv_web/live/shell_live.ex:899
 #, elixir-autogen, elixir-format, fuzzy
 msgid "A new version is ready."
-msgstr ""
-
-#: lib/vutuv_web/live/shell_live.ex:942
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Later"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/show.ex:703

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -446,8 +446,8 @@ msgstr "Accedi"
 msgid "Log Out"
 msgstr "Esci"
 
-#: lib/vutuv_web/live/shell_live.ex:1354
-#: lib/vutuv_web/live/shell_live.ex:1420
+#: lib/vutuv_web/live/shell_live.ex:1329
+#: lib/vutuv_web/live/shell_live.ex:1395
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -648,8 +648,8 @@ msgstr "Salva"
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:49
 #: lib/vutuv_web/live/search_live.ex:570
-#: lib/vutuv_web/live/shell_live.ex:1219
-#: lib/vutuv_web/live/shell_live.ex:1403
+#: lib/vutuv_web/live/shell_live.ex:1194
+#: lib/vutuv_web/live/shell_live.ex:1378
 #: lib/vutuv_web/live/tag_live/timeline.ex:318
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -1185,7 +1185,7 @@ msgstr "Aggiungi localizzazione"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1326
+#: lib/vutuv_web/live/shell_live.ex:1301
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1626,7 +1626,7 @@ msgstr "Indirizzi di %{name}"
 msgid "Admin control panel"
 msgstr "Pannello di amministrazione"
 
-#: lib/vutuv_web/live/shell_live.ex:1406
+#: lib/vutuv_web/live/shell_live.ex:1381
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Avvisi"
@@ -1742,7 +1742,7 @@ msgstr ""
 "Sembra che non segua ancora nessuno. Apra il profilo di una persona che "
 "conosce o che La incuriosisce e prema il pulsante «Segui»."
 
-#: lib/vutuv_web/live/shell_live.ex:1345
+#: lib/vutuv_web/live/shell_live.ex:1320
 #: lib/vutuv_web/views/settings_html.ex:284
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1771,14 +1771,14 @@ msgstr "Messaggio"
 
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1237
-#: lib/vutuv_web/live/shell_live.ex:1405
+#: lib/vutuv_web/live/shell_live.ex:1212
+#: lib/vutuv_web/live/shell_live.ex:1380
 #: lib/vutuv_web/templates/layout/app.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Messaggi"
 
-#: lib/vutuv_web/live/shell_live.ex:1121
+#: lib/vutuv_web/live/shell_live.ex:1096
 #: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Network"
@@ -1804,7 +1804,7 @@ msgstr "Ancora nessuna novità."
 #: lib/vutuv_web/components/ui.ex:4702
 #: lib/vutuv_web/live/notification_live/index.ex:140
 #: lib/vutuv_web/live/notification_live/index.ex:377
-#: lib/vutuv_web/live/shell_live.ex:1249
+#: lib/vutuv_web/live/shell_live.ex:1224
 #: lib/vutuv_web/templates/layout/app.html.heex:174
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2163,8 +2163,8 @@ msgstr "Modifica il post"
 #: lib/vutuv_web/live/post_live/feed.ex:279
 #: lib/vutuv_web/live/post_live/feed.ex:2380
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1099
-#: lib/vutuv_web/live/shell_live.ex:1398
+#: lib/vutuv_web/live/shell_live.ex:1074
+#: lib/vutuv_web/live/shell_live.ex:1373
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2207,7 +2207,7 @@ msgstr "Visitatori non connessi"
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2695
+#: lib/vutuv_web/live/post_live/feed.ex:2699
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2302,7 +2302,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Salvataggio…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2553
+#: lib/vutuv_web/live/post_live/feed.ex:2557
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2340,7 +2340,7 @@ msgid "Upload failed."
 msgstr "Caricamento non riuscito."
 
 #: lib/vutuv_web/components/ui.ex:5002
-#: lib/vutuv_web/live/shell_live.ex:1292
+#: lib/vutuv_web/live/shell_live.ex:1267
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:231
@@ -2430,8 +2430,8 @@ msgstr "Salva"
 #: lib/vutuv_web/agent_docs/markdown.ex:1116
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:1229
-#: lib/vutuv_web/live/shell_live.ex:1297
+#: lib/vutuv_web/live/shell_live.ex:1204
+#: lib/vutuv_web/live/shell_live.ex:1272
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2452,7 +2452,7 @@ msgstr "Mi piace"
 #: lib/vutuv_web/live/notification_live/index.ex:1022
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:1300
+#: lib/vutuv_web/live/shell_live.ex:1275
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -3229,8 +3229,8 @@ msgid "Private message"
 msgstr "Messaggio privato"
 
 #: lib/vutuv_web/components/ui.ex:4634
-#: lib/vutuv_web/live/shell_live.ex:1113
-#: lib/vutuv_web/live/shell_live.ex:1410
+#: lib/vutuv_web/live/shell_live.ex:1088
+#: lib/vutuv_web/live/shell_live.ex:1385
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -4722,7 +4722,7 @@ msgstr "Non ha bloccato nessuno."
 msgid "You unblocked @%{slug}."
 msgstr "Ha sbloccato @%{slug}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2700
+#: lib/vutuv_web/live/post_live/feed.ex:2704
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Scopra persone da seguire"
@@ -5533,7 +5533,7 @@ msgstr "Non può più rispondere a questo post."
 msgid "Content under review"
 msgstr "Contenuto in esame"
 
-#: lib/vutuv_web/live/shell_live.ex:1279
+#: lib/vutuv_web/live/shell_live.ex:1254
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Menu dell'account"
@@ -5555,7 +5555,7 @@ msgstr "Chiudi menu e finestre"
 msgid "General"
 msgstr "Generale"
 
-#: lib/vutuv_web/live/shell_live.ex:1336
+#: lib/vutuv_web/live/shell_live.ex:1311
 #: lib/vutuv_web/templates/layout/app.html.heex:204
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5574,7 +5574,7 @@ msgstr "Navigazione"
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
-#: lib/vutuv_web/live/shell_live.ex:1316
+#: lib/vutuv_web/live/shell_live.ex:1291
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5628,8 +5628,8 @@ msgstr "Post successivo nel feed"
 msgid "Previous post in the feed"
 msgstr "Post precedente nel feed"
 
-#: lib/vutuv_web/live/shell_live.ex:1088
-#: lib/vutuv_web/live/shell_live.ex:1382
+#: lib/vutuv_web/live/shell_live.ex:1063
+#: lib/vutuv_web/live/shell_live.ex:1357
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Navigazione principale"
@@ -7746,7 +7746,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr "Si aggiorna da sola. Può lasciare questa pagina: l'invio prosegue."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:2963
+#: lib/vutuv_web/live/post_live/feed.ex:2967
 #, elixir-autogen
 msgid "Done"
 msgstr "Fatto"
@@ -12410,7 +12410,7 @@ msgstr "Organizzazione sbloccata."
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1307
+#: lib/vutuv_web/live/shell_live.ex:1282
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:100
@@ -12756,7 +12756,7 @@ msgstr "Titolo della posizione"
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1129
+#: lib/vutuv_web/live/shell_live.ex:1104
 #: lib/vutuv_web/templates/layout/app.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -18352,7 +18352,7 @@ msgstr "Non ancora Suo."
 msgid "Nothing has changed yet."
 msgstr "Non è ancora cambiato nulla."
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:237
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:250
 #: lib/vutuv_web/templates/username/confirm.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Now"
@@ -19581,7 +19581,7 @@ msgstr "Rilasciato il"
 msgid "Label"
 msgstr "Etichetta"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2718
+#: lib/vutuv_web/live/post_live/feed.ex:2722
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -21333,7 +21333,7 @@ msgstr "Non può più scrivere a nome di questa organizzazione."
 msgid "A post in an organization's name is always public."
 msgstr "Un post a nome di un'organizzazione è sempre pubblico."
 
-#: lib/vutuv_web/live/shell_live.ex:1046
+#: lib/vutuv_web/live/shell_live.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr "Apri la pagina"
@@ -21353,7 +21353,7 @@ msgstr "Ha smesso di scrivere come organizzazione"
 msgid "Write as %{name} for now"
 msgstr "Scrivi come %{name} per ora"
 
-#: lib/vutuv_web/live/shell_live.ex:1056
+#: lib/vutuv_web/live/shell_live.ex:1031
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr "Torna a scrivere come me stesso"
@@ -21363,7 +21363,7 @@ msgstr "Torna a scrivere come me stesso"
 msgid "You are writing as %{name} now."
 msgstr "Ora sta scrivendo come %{name}."
 
-#: lib/vutuv_web/live/shell_live.ex:1032
+#: lib/vutuv_web/live/shell_live.ex:1007
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr "Sta scrivendo come %{name}."
@@ -22981,7 +22981,7 @@ msgstr "Smettere di seguire %{handle}? I suoi post spariscono dal Suo feed."
 msgid "Unfollowed. Their posts leave your feed."
 msgstr "Non lo segue più. I suoi post spariscono dal Suo feed."
 
-#: lib/vutuv_web/live/shell_live.ex:1002
+#: lib/vutuv_web/live/shell_live.ex:977
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr "Consenti"
@@ -22996,12 +22996,12 @@ msgstr "Chiedi ora"
 msgid "Browser notifications"
 msgstr "Notifiche del browser"
 
-#: lib/vutuv_web/live/shell_live.ex:862
+#: lib/vutuv_web/live/shell_live.ex:845
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr "Nuovo messaggio"
 
-#: lib/vutuv_web/live/shell_live.ex:1009
+#: lib/vutuv_web/live/shell_live.ex:984
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Non ora"
@@ -23051,7 +23051,7 @@ msgstr ""
 "guardando, il Suo browser può mostrarlo come notifica. Disattivate finché "
 "non le attiva."
 
-#: lib/vutuv_web/live/shell_live.ex:999
+#: lib/vutuv_web/live/shell_live.ex:974
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -23114,7 +23114,7 @@ msgstr ""
 "Segua #%{tag} da Mastodon o da qualsiasi altra app del Fediverso e i suoi "
 "post pubblici arriveranno nella Sua cronologia. Non serve un account vutuv."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2876
+#: lib/vutuv_web/live/post_live/feed.ex:2880
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Saluti gli altri membri"
@@ -23332,7 +23332,7 @@ msgstr "Traducili in %{language}"
 msgid "Translated into %{language}."
 msgstr "Vengono tradotti in %{language}."
 
-#: lib/vutuv_web/live/shell_live.ex:798
+#: lib/vutuv_web/live/shell_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -23462,7 +23462,7 @@ msgstr "Nuovo messaggio su vutuv"
 msgid "No connection"
 msgstr "Nessuna connessione"
 
-#: lib/vutuv_web/live/shell_live.ex:932
+#: lib/vutuv_web/live/shell_live.ex:917
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr "Ricarica"
@@ -23695,7 +23695,7 @@ msgstr "I post con uno di questi tag vengono ridotti allo stesso modo."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "I post che contengono una di queste parole vengono ridotti a una riga — non eliminati, e con un modo per aprirli comunque."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2902
+#: lib/vutuv_web/live/post_live/feed.ex:2906
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Messe da parte:"
@@ -23774,8 +23774,8 @@ msgstr[1] "e altri %{formatted}"
 
 #: lib/vutuv_web/live/post_live/feed.ex:2521
 #: lib/vutuv_web/live/post_live/feed.ex:2538
-#: lib/vutuv_web/live/post_live/feed.ex:2950
-#: lib/vutuv_web/live/post_live/feed.ex:2955
+#: lib/vutuv_web/live/post_live/feed.ex:2954
+#: lib/vutuv_web/live/post_live/feed.ex:2959
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -23825,31 +23825,31 @@ msgid_plural "You can upload at most %{count} files at a time."
 msgstr[0] "Può caricare un file per volta."
 msgstr[1] "Può caricare al massimo %{count} file per volta."
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:357
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:370
 #, elixir-autogen, elixir-format
 msgid "%{count} entry on %{day}"
 msgid_plural "%{count} entries on %{day}"
 msgstr[0] "%{count} voce il %{day}"
 msgstr[1] "%{count} voci il %{day}"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:354
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:367
 #, elixir-autogen, elixir-format
 msgid "%{count} post on %{day}"
 msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} post il %{day}"
 msgstr[1] "%{count} post il %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2675
+#: lib/vutuv_web/live/post_live/feed.ex:2679
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Torna al presente"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:221
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:234
 #, elixir-autogen, elixir-format
 msgid "Busy month: the shading counts at least this much."
 msgstr "Mese intenso: la tonalità indica almeno questo valore."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2721
+#: lib/vutuv_web/live/post_live/feed.ex:2725
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -23861,38 +23861,38 @@ msgstr[1] "Carica tutto il giorno (%{formatted} post)"
 msgid "My posts"
 msgstr "I miei post"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:133
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:146
 #, elixir-autogen, elixir-format
 msgid "Next month"
 msgstr "Mese successivo"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:139
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:152
 #, elixir-autogen, elixir-format
 msgid "Next year"
 msgstr "Anno successivo"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2671
+#: lib/vutuv_web/live/post_live/feed.ex:2675
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Il %{day} non è arrivato nulla nel Suo feed."
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:100
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:113
 #, elixir-autogen, elixir-format
 msgid "Previous month"
 msgstr "Mese precedente"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:96
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:109
 #, elixir-autogen, elixir-format
 msgid "Previous year"
 msgstr "Anno precedente"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:209
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:222
 #, elixir-autogen, elixir-format
 msgctxt "heatmap scale"
 msgid "Less"
 msgstr "Meno"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:211
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:224
 #, elixir-autogen, elixir-format
 msgctxt "heatmap scale"
 msgid "More"
@@ -23948,15 +23948,10 @@ msgstr "I gestori di password come Bitwarden ne ricavano l'intera voce: nome, ac
 msgid "Scan it with the device that has the app"
 msgstr "Da scansionare con il dispositivo su cui è installata l'app"
 
-#: lib/vutuv_web/live/shell_live.ex:914
+#: lib/vutuv_web/live/shell_live.ex:899
 #, elixir-autogen, elixir-format
 msgid "A new version is ready."
 msgstr "È pronta una nuova versione."
-
-#: lib/vutuv_web/live/shell_live.ex:942
-#, elixir-autogen, elixir-format
-msgid "Later"
-msgstr "Più tardi"
 
 #: lib/vutuv_web/live/organization_live/show.ex:703
 #, elixir-autogen, elixir-format

--- a/test/vutuv_web/live/shell_live_update_bar_test.exs
+++ b/test/vutuv_web/live/shell_live_update_bar_test.exs
@@ -32,17 +32,17 @@ defmodule VutuvWeb.ShellLiveUpdateBarTest do
   end
 
   defp mount_shell(conn, connect_params, session \\ %{}) do
-    {:ok, view, html} =
+    {:ok, _view, html} =
       conn
       |> put_connect_params(connect_params)
       |> live_isolated(VutuvWeb.ShellLive, session: session)
 
-    {view, html}
+    html
   end
 
   describe "who gets offered the reload" do
     test "a browser still running the previous release is offered it", %{conn: conn} do
-      {_view, html} = mount_shell(conn, %{"_track_static" => @stale})
+      html = mount_shell(conn, %{"_track_static" => @stale})
 
       assert html =~ ~s(id="sw-update")
       assert html =~ "A new version is ready."
@@ -55,7 +55,7 @@ defmodule VutuvWeb.ShellLiveUpdateBarTest do
     # still carries the reader to the new release (and what makes the control
     # work with JavaScript off), so a refactor to `<button>` is a regression.
     test "the reload control is a link to the page itself", %{conn: conn} do
-      {_view, html} = mount_shell(conn, %{"_track_static" => @stale})
+      html = mount_shell(conn, %{"_track_static" => @stale})
 
       assert [reload] =
                html
@@ -71,7 +71,7 @@ defmodule VutuvWeb.ShellLiveUpdateBarTest do
     # document, and the service worker unhid it whenever a worker was waiting —
     # which it still is on a page that arrived fresh from the new release.
     test "a browser already running the current release is not", %{conn: conn} do
-      {_view, html} = mount_shell(conn, %{"_track_static" => @current})
+      html = mount_shell(conn, %{"_track_static" => @current})
 
       refute html =~ ~s(id="sw-update")
     end
@@ -80,7 +80,7 @@ defmodule VutuvWeb.ShellLiveUpdateBarTest do
     # annotation) gives the gate nothing to judge by, and it must then stay
     # quiet rather than guess — which is the whole complaint being fixed.
     test "a browser that reports no bundle at all is not", %{conn: conn} do
-      {_view, html} = mount_shell(conn, %{})
+      html = mount_shell(conn, %{})
 
       refute html =~ ~s(id="sw-update")
     end
@@ -105,29 +105,37 @@ defmodule VutuvWeb.ShellLiveUpdateBarTest do
     end
   end
 
-  describe "dismissing it" do
-    test "Later takes it away for this document", %{conn: conn} do
-      {view, html} = mount_shell(conn, %{"_track_static" => @stale})
-      assert html =~ ~s(id="sw-update")
+  # The bar used to carry a "Later" beside the reload, and it should not come
+  # back — the reasoning is in `docs/architecture/realtime.md`. What this pins
+  # is the count: one control in the bar, and it is the reload. The selector
+  # names `[phx-click]` as well as the two control tags, because the shape to
+  # catch is a dismiss wired to any element at all, not one spelled `<button>`.
+  describe "there is no way to put it away" do
+    test "the reload is the only control in the bar", %{conn: conn} do
+      html = mount_shell(conn, %{"_track_static" => @stale})
 
-      html = view |> element(~s([phx-click="dismiss_update"])) |> render_click()
+      assert [reload] =
+               html
+               |> LazyHTML.from_document()
+               |> LazyHTML.query(~s(#sw-update a, #sw-update button, #sw-update [phx-click]))
+               |> Enum.to_list()
 
-      refute html =~ ~s(id="sw-update")
+      assert LazyHTML.attribute(reload, "data-sw-reload") == [""]
     end
   end
 
-  # Both translated locales, by name. A one-word msgid like "Later" is exactly
-  # what `gettext.extract --merge` fuzzy-fills from an unrelated string, and it
-  # did: German came back as "Letzter Fehler" (last error) and Italian as
-  # "Ultimo errore". Nothing failed the build, and English stayed green — so the
-  # only thing standing between that and a shipped button labelled "last error"
-  # is an assertion naming the words.
+  # Both translated locales, by name. A short msgid is exactly what
+  # `gettext.extract --merge` fuzzy-fills from an unrelated string, and it did
+  # to the "Later" this bar used to carry: German came back as "Letzter Fehler"
+  # (last error) and Italian as "Ultimo errore". Nothing failed the build, and
+  # English stayed green — so the only thing standing between that and a shipped
+  # button labelled "last error" is an assertion naming the words.
   for {locale, expected} <- [
-        {"de", ["Neue Version bereit.", "Neu laden", "Später"]},
-        {"it", ["È pronta una nuova versione.", "Ricarica", "Più tardi"]}
+        {"de", ["Neue Version bereit.", "Neu laden"]},
+        {"it", ["È pronta una nuova versione.", "Ricarica"]}
       ] do
-    test "the #{locale} render says all three lines in #{locale}", %{conn: conn} do
-      {_view, html} =
+    test "the #{locale} render says both lines in #{locale}", %{conn: conn} do
+      html =
         mount_shell(conn, %{"_track_static" => @stale}, %{"locale" => unquote(locale)})
 
       for line <- unquote(expected), do: assert(html =~ line)


### PR DESCRIPTION
**TL;DR** The "A new version is ready" bar carried a "Später" next to the reload. Reloading is not optional, so the dismiss is gone.

Whoever sees that bar is reading a document from a release that is gone: its markup, CSS and JavaScript all predate the deploy, and every bug the deploy fixed is still in front of them. "Später" did not postpone that, only the notice about it.

**Where:** `VutuvWeb.ShellLive`, the `#sw-update` strip above the header on every page. Gone with the button: the `dismiss_update` handler and the `Later` msgid in all four catalogs. `docs/architecture/realtime.md` owns the reasoning now.

**Test:** the bar is pinned to one control, the reload link, matching any `phx-click` rather than just `a`/`button`. Calibrated red twice: against the old markup, and against a dismiss re-added as a `<span phx-click>`.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01B5CfFHYzjhU24x6u5yd2Ph
