### PR TITLE
Feed: shorten the new-posts pill label so the quote gets the line

### DIFF
--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -569,9 +569,14 @@ defmodule VutuvWeb.PostLive.Feed do
   # each entry carries a `%{post_id => engagement}` submap for those cards' bars.
   # Live-arriving single posts carry `engagement: nil` (falls back to the bar's
   # own query) and get their follow edge in `insert_entry/3`.
-  # The one-line stand-in for a content-filtered post (issue #940): says which
   # The newest waiting post as the pair the pill quotes, or nil when there is
-  # nothing to quote (a photo with no caption, an author we cannot name).
+  # nothing to quote: a photo with no caption, an author we cannot name, or a
+  # post this reader's own filters hide. The row below it folds to a placeholder
+  # (`hidden_by_filter?/2`) while the pill above it read the muted words out —
+  # and a teaser is the one place they cannot scroll past them (issue #940).
+  # Both read the same `:filtered_by` stamp, so the two cannot disagree.
+  defp newest_quote([%{filtered_by: pattern} | _rest]) when is_binary(pattern), do: nil
+
   defp newest_quote([newest | _rest]) do
     case {PostTeaser.who(newest), PostTeaser.text(newest)} do
       {nil, _text} -> nil
@@ -946,6 +951,7 @@ defmodule VutuvWeb.PostLive.Feed do
     """
   end
 
+  # The one-line stand-in for a content-filtered post (issue #940): says which
   # filter hid it and offers to show it anyway, in place.
   attr(:pattern, :string, required: true)
 
@@ -1893,6 +1899,88 @@ defmodule VutuvWeb.PostLive.Feed do
   # How many posts are waiting, drawn or not — what the card and the pill count.
   defp pending_count(assigns), do: length(assigns.pending_posts) + assigns.pending_overflow
 
+  attr(:pending_posts, :list, required: true)
+  attr(:pending_overflow, :integer, required: true)
+
+  attr(:cal_day, :any,
+    required: true,
+    doc: "the travelled-to day, or nil — decides whether the press can be a browser-side reveal"
+  )
+
+  # Fades in as the calendar folds out of the way, so the two read as one
+  # movement rather than as a pop over a jump. An insert plays a keyframe on its
+  # own; a later count tick only patches this node's text, so it does not replay.
+  #
+  # `h-10` and not vertical padding: it stands beside the filter button, which is
+  # `h-10`, and a pill sized by its own line height came out four pixels short of
+  # it.
+  #
+  # A component and not markup in `render/1` so that the quote is flattened once
+  # per arrival rather than once per render: everything below reads `@quote`, and
+  # the whole subtree leaves the diff on any render that did not touch the three
+  # attributes above (a translation landing, the five-minute suggestions
+  # refresh). Computing it into `render/1`'s own assigns would do the opposite —
+  # a key that is not in the incoming assigns is force-assigned, so it would be
+  # dirty on every render, for a pipeline run of about 150 µs each time.
+  defp new_posts_pill(assigns) do
+    assigns = assign(assigns, :quote, newest_quote(assigns.pending_posts))
+
+    ~H"""
+    <div class="feed-teaser-in min-w-0 flex-1 text-center">
+      <button
+        id="show-new-posts"
+        type="button"
+        phx-click={show_pending(assigns)}
+        class="mx-auto flex h-10 w-full max-w-full items-center gap-2 rounded-full bg-brand-50 px-4 text-sm font-semibold text-brand-700 shadow-sm hover:bg-brand-100 sm:w-auto dark:bg-brand-900/40 dark:text-brand-100 dark:hover:bg-brand-900/70"
+      >
+        <span class="shrink-0 tabular-nums">
+          <%!-- An sr-only span and not an `aria-label` on the button: the label
+          would become the whole accessible name and swallow the quote, while
+          this leaves it "Show 3 new posts, @ada, breaking news". --%>
+          <span :if={@quote} class="sr-only">{pending_sentence(assigns)}</span>
+          <span aria-hidden={@quote && "true"}>{pending_label(assigns)}</span>
+        </span>
+        <span
+          :if={@quote}
+          class="flex min-w-0 flex-1 items-baseline gap-1 font-normal text-brand-600 dark:text-brand-200"
+        >
+          <span class="min-w-0 max-w-[45%] shrink truncate">{@quote.who}</span>
+          <span class="min-w-0 flex-1 truncate">{@quote.text}</span>
+        </span>
+      </button>
+    </div>
+    """
+  end
+
+  # What the pill shows. Beside a quote the label is only what introduces it,
+  # "Neu:" or "Neu (3):", because on a phone the whole sentence took the line and
+  # left the quote three letters (Stefan, on a screenshot). The sentence is not
+  # lost: it stays as the button's screen-reader name, where it costs no width.
+  # With nothing to quote there is no colon to hang, so it is said in full.
+  #
+  # A desktop has the room, and takes the short label anyway: the rail's "Not
+  # read yet" card (`unread_body/1`) already lists what is waiting there, so the
+  # pill is not the only teller, and a `md:`-swapped label would put two copies
+  # in the DOM and change the button's accessible name with the viewport.
+  defp pending_label(%{quote: nil} = assigns), do: pending_sentence(assigns)
+
+  defp pending_label(assigns) do
+    count = pending_count(assigns)
+
+    ngettext("New:", "New (%{formatted}):", count, formatted: compact_count(count))
+  end
+
+  defp pending_sentence(assigns) do
+    count = pending_count(assigns)
+
+    ngettext(
+      "Show %{formatted} new post",
+      "Show %{formatted} new posts",
+      count,
+      formatted: compact_count(count)
+    )
+  end
+
   # Showing the waiting posts, in the browser, before the server hears about it.
   #
   # The rows are already drawn (`queue/2`); this drops the marker that hid them
@@ -2538,40 +2626,12 @@ defmodule VutuvWeb.PostLive.Feed do
               <span :if={@pending_posts == []}>{pgettext("feed filter sheet", "Filter")}</span>
             </button>
 
-            <%!-- Fades in as the calendar folds out of the way, so the two read
-            as one movement rather than as a pop over a jump. An insert plays a
-            keyframe on its own; a later count tick only patches this node's
-            text, so it does not replay.
-
-            `h-10` and not vertical padding: it stands beside the filter button,
-            which is `h-10`, and a pill sized by its own line height came out
-            four pixels short of it. --%>
-            <div :if={@pending_posts != []} class="feed-teaser-in min-w-0 flex-1 text-center">
-              <button
-                id="show-new-posts"
-                type="button"
-                phx-click={show_pending(assigns)}
-                class="mx-auto flex h-10 w-full max-w-full items-center gap-2 rounded-full bg-brand-50 px-4 text-sm font-semibold text-brand-700 shadow-sm hover:bg-brand-100 sm:w-auto dark:bg-brand-900/40 dark:text-brand-100 dark:hover:bg-brand-900/70"
-              >
-                <span class="shrink-0 tabular-nums">
-                  {ngettext(
-                    "Show %{formatted} new post",
-                    "Show %{formatted} new posts",
-                    pending_count(assigns),
-                    formatted: compact_count(pending_count(assigns))
-                  )}
-                </span>
-                <span
-                  :if={newest_quote(@pending_posts)}
-                  class="flex min-w-0 flex-1 items-baseline gap-1 font-normal text-brand-600 dark:text-brand-200"
-                >
-                  <span class="min-w-0 max-w-[45%] shrink truncate">
-                    {newest_quote(@pending_posts).who}
-                  </span>
-                  <span class="min-w-0 flex-1 truncate">{newest_quote(@pending_posts).text}</span>
-                </span>
-              </button>
-            </div>
+            <.new_posts_pill
+              :if={@pending_posts != []}
+              pending_posts={@pending_posts}
+              pending_overflow={@pending_overflow}
+              cal_day={@cal_day}
+            />
           </div>
 
           <%!-- The timeline is one card of flat divide-y rows — the same

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -2159,7 +2159,7 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:139
 #: lib/vutuv_web/live/post_live/feed.ex:279
-#: lib/vutuv_web/live/post_live/feed.ex:2380
+#: lib/vutuv_web/live/post_live/feed.ex:2468
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1074
 #: lib/vutuv_web/live/shell_live.ex:1373
@@ -2205,7 +2205,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2699
+#: lib/vutuv_web/live/post_live/feed.ex:2759
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2300,7 +2300,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2557
+#: lib/vutuv_web/live/post_live/feed.ex:1976
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2516,7 +2516,7 @@ msgstr "Gefällt mir entfernen"
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:640
-#: lib/vutuv_web/live/post_live/feed.ex:806
+#: lib/vutuv_web/live/post_live/feed.ex:811
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2809,7 +2809,7 @@ msgstr "Ersten Beitrag schreiben"
 msgid "Manage"
 msgstr "Verwalten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2418
+#: lib/vutuv_web/live/post_live/feed.ex:2506
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2830,7 +2830,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] "1 Vernetzung"
 msgstr[1] "%{formatted} Vernetzungen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:934
+#: lib/vutuv_web/live/post_live/feed.ex:939
 #: lib/vutuv_web/templates/user/card_list.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -4711,7 +4711,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2704
+#: lib/vutuv_web/live/post_live/feed.ex:2764
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -7758,7 +7758,7 @@ msgstr ""
 "der Versand läuft weiter."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:2967
+#: lib/vutuv_web/live/post_live/feed.ex:3027
 #, elixir-autogen
 msgid "Done"
 msgstr "Fertig"
@@ -8234,7 +8234,7 @@ msgid "Admins"
 msgstr "Administratoren"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:943
+#: lib/vutuv_web/live/post_live/feed.ex:948
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Alle Mitglieder"
@@ -14125,7 +14125,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4724
 #: lib/vutuv_web/controllers/settings_controller.ex:634
-#: lib/vutuv_web/live/post_live/feed.ex:628
+#: lib/vutuv_web/live/post_live/feed.ex:633
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -15059,7 +15059,7 @@ msgstr ""
 "Wählen Sie unten einen Abschluss oder eine Schule, um ihn statt eines "
 "Jobtitels oben in Ihrem Profil anzuzeigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1002
+#: lib/vutuv_web/live/post_live/feed.ex:1008
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Trotzdem anzeigen"
@@ -17103,8 +17103,8 @@ msgstr "Fotos hinzufügen"
 msgid "Licence"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2427
-#: lib/vutuv_web/live/post_live/feed.ex:2428
+#: lib/vutuv_web/live/post_live/feed.ex:2515
+#: lib/vutuv_web/live/post_live/feed.ex:2516
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr "Fotos posten"
@@ -19090,7 +19090,7 @@ msgstr "Ausstellungsdatum"
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2722
+#: lib/vutuv_web/live/post_live/feed.ex:2782
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -21682,7 +21682,7 @@ msgstr "Empfohlen: %{width} × %{height} Pixel (%{ratio})."
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Empfohlen: quadratisch, mindestens %{width} × %{height} Pixel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:880
+#: lib/vutuv_web/live/post_live/feed.ex:885
 #: lib/vutuv_web/views/user_html.ex:338
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -22302,12 +22302,12 @@ msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public po
 msgstr ""
 "Folgen Sie #%{tag} von Mastodon oder einer anderen Fediverse-App aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2880
+#: lib/vutuv_web/live/post_live/feed.ex:2940
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Andere Mitglieder begrüßen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:629
+#: lib/vutuv_web/live/post_live/feed.ex:634
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr "Neu dabei"
@@ -22353,7 +22353,7 @@ msgstr "Der beste Weg: Folgen Sie %{name} hier. Neue Beiträge landen in Ihrem F
 msgid "With a vutuv account"
 msgstr "Mit einem vutuv-Konto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:872
+#: lib/vutuv_web/live/post_live/feed.ex:877
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
@@ -22755,7 +22755,7 @@ msgstr "Alle vutuv Mitglieder, alphabetisch nach Nachname sortiert."
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr "Alle vutuv Mitglieder, gruppiert nach dem Anfangsbuchstaben des Nachnamens."
 
-#: lib/vutuv_web/live/post_live/feed.ex:753
+#: lib/vutuv_web/live/post_live/feed.ex:758
 #: lib/vutuv_web/live/post_live/filter_band.ex:292
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -22771,7 +22771,7 @@ msgstr "Auch in längeren Wörtern: %{word} trifft auch %{example}."
 msgid "A–Z"
 msgstr "A–Z"
 
-#: lib/vutuv_web/live/post_live/feed.ex:835
+#: lib/vutuv_web/live/post_live/feed.ex:840
 #, elixir-autogen, elixir-format
 msgid "Browse the tags"
 msgstr "Alle Tags ansehen"
@@ -22786,7 +22786,7 @@ msgstr "Aktivste zuerst"
 msgid "Clear all"
 msgstr "Alle löschen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:666
+#: lib/vutuv_web/live/post_live/feed.ex:671
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr "Ziehen, oder die Pfeiltasten benutzen"
@@ -22801,13 +22801,13 @@ msgstr "Auf- und zuklappen"
 msgid "Find an account or a server …"
 msgstr "Konto oder Server suchen …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:690
+#: lib/vutuv_web/live/post_live/feed.ex:695
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr "%{card} einklappen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:817
-#: lib/vutuv_web/live/post_live/feed.ex:818
+#: lib/vutuv_web/live/post_live/feed.ex:822
+#: lib/vutuv_web/live/post_live/feed.ex:823
 #, elixir-autogen, elixir-format
 msgid "Follow a tag …"
 msgstr "Einem Tag folgen …"
@@ -22824,17 +22824,17 @@ msgstr "Tag ausblenden …"
 msgid "Hide a word or a whole phrase …"
 msgstr "Wort oder ganzen Satz ausblenden …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:627
+#: lib/vutuv_web/live/post_live/feed.ex:632
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Tags ausblenden"
 
-#: lib/vutuv_web/live/post_live/feed.ex:626
+#: lib/vutuv_web/live/post_live/feed.ex:631
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Wörter ausblenden"
 
-#: lib/vutuv_web/live/post_live/feed.ex:841
+#: lib/vutuv_web/live/post_live/feed.ex:846
 #: lib/vutuv_web/live/post_live/filter_band.ex:331
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -22850,7 +22850,7 @@ msgstr "Trifft gerade nichts in Ihrem Feed — für alles Neue gilt die Regel tr
 msgid "More of your %{formatted} accounts"
 msgstr "Mehr Ihrer %{formatted} Konten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:665
+#: lib/vutuv_web/live/post_live/feed.ex:670
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr "%{card} verschieben"
@@ -22860,12 +22860,12 @@ msgstr "%{card} verschieben"
 msgid "No account found."
 msgstr "Kein Konto gefunden."
 
-#: lib/vutuv_web/live/post_live/feed.ex:830
+#: lib/vutuv_web/live/post_live/feed.ex:835
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr "Noch kein Tag namens %{name}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:619
+#: lib/vutuv_web/live/post_live/feed.ex:624
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr "Noch nicht gelesen"
@@ -22895,13 +22895,13 @@ msgstr "Beiträge mit einem dieser Tags werden genauso zugeklappt."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Beiträge mit einem dieser Wörter werden auf eine Zeile zugeklappt — nicht gelöscht, und mit einem Weg, sie doch zu lesen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2906
+#: lib/vutuv_web/live/post_live/feed.ex:2966
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Weggelegt:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:711
-#: lib/vutuv_web/live/post_live/feed.ex:712
+#: lib/vutuv_web/live/post_live/feed.ex:716
+#: lib/vutuv_web/live/post_live/feed.ex:717
 #, elixir-autogen, elixir-format
 msgid "Remove %{card}"
 msgstr "%{card} entfernen"
@@ -22933,7 +22933,7 @@ msgstr "Nur %{source} anzeigen"
 msgid "Show posts by %{name}"
 msgstr "Beiträge von %{name} anzeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:625
+#: lib/vutuv_web/live/post_live/feed.ex:630
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr "Quellen"
@@ -22943,12 +22943,12 @@ msgstr "Quellen"
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr "Ausschalten heißt stumm schalten, nicht entfolgen. Sie folgen weiter, die Beiträge bleiben nur aus Ihrem Feed: dauerhaft und auf allen Geräten, bis Sie hier wieder einschalten."
 
-#: lib/vutuv_web/live/post_live/feed.ex:689
+#: lib/vutuv_web/live/post_live/feed.ex:694
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr "%{card} ausklappen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:807
+#: lib/vutuv_web/live/post_live/feed.ex:812
 #, elixir-autogen, elixir-format
 msgid "Unfollow the tag %{tag}"
 msgstr "Dem Tag %{tag} nicht mehr folgen"
@@ -22972,22 +22972,22 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "und 1 weiterer"
 msgstr[1] "und %{formatted} weitere"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2521
-#: lib/vutuv_web/live/post_live/feed.ex:2538
-#: lib/vutuv_web/live/post_live/feed.ex:2954
-#: lib/vutuv_web/live/post_live/feed.ex:2959
+#: lib/vutuv_web/live/post_live/feed.ex:2609
+#: lib/vutuv_web/live/post_live/feed.ex:2626
+#: lib/vutuv_web/live/post_live/feed.ex:3014
+#: lib/vutuv_web/live/post_live/feed.ex:3019
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr "Filter"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1010
+#: lib/vutuv_web/live/post_live/feed.ex:1016
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr "Ausgeblendet:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:763
+#: lib/vutuv_web/live/post_live/feed.ex:768
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
@@ -23039,7 +23039,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} Beitrag am %{day}"
 msgstr[1] "%{count} Beiträge am %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2679
+#: lib/vutuv_web/live/post_live/feed.ex:2739
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Zurück zu jetzt"
@@ -23049,7 +23049,7 @@ msgstr "Zurück zu jetzt"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Voller Monat: die Färbung zählt mindestens so viel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2725
+#: lib/vutuv_web/live/post_live/feed.ex:2785
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -23071,7 +23071,7 @@ msgstr "Nächster Monat"
 msgid "Next year"
 msgstr "Nächstes Jahr"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2675
+#: lib/vutuv_web/live/post_live/feed.ex:2735
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Am %{day} ist nichts in Ihrem Feed angekommen."
@@ -23157,3 +23157,10 @@ msgstr "Neue Version bereit."
 #, elixir-autogen, elixir-format
 msgid "Page management"
 msgstr "Verwaltung"
+
+#: lib/vutuv_web/live/post_live/feed.ex:1970
+#, elixir-autogen, elixir-format
+msgid "New:"
+msgid_plural "New (%{formatted}):"
+msgstr[0] "Neu:"
+msgstr[1] "Neu (%{formatted}):"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -2118,7 +2118,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:139
 #: lib/vutuv_web/live/post_live/feed.ex:279
-#: lib/vutuv_web/live/post_live/feed.ex:2380
+#: lib/vutuv_web/live/post_live/feed.ex:2468
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1074
 #: lib/vutuv_web/live/shell_live.ex:1373
@@ -2164,7 +2164,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2699
+#: lib/vutuv_web/live/post_live/feed.ex:2759
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2255,7 +2255,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2557
+#: lib/vutuv_web/live/post_live/feed.ex:1976
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2471,7 +2471,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:640
-#: lib/vutuv_web/live/post_live/feed.ex:806
+#: lib/vutuv_web/live/post_live/feed.ex:811
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2762,7 +2762,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2418
+#: lib/vutuv_web/live/post_live/feed.ex:2506
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2783,7 +2783,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:934
+#: lib/vutuv_web/live/post_live/feed.ex:939
 #: lib/vutuv_web/templates/user/card_list.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -4544,7 +4544,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2704
+#: lib/vutuv_web/live/post_live/feed.ex:2764
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -7450,7 +7450,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:2967
+#: lib/vutuv_web/live/post_live/feed.ex:3027
 #, elixir-autogen
 msgid "Done"
 msgstr ""
@@ -7890,7 +7890,7 @@ msgid "Admins"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:943
+#: lib/vutuv_web/live/post_live/feed.ex:948
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -13465,7 +13465,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4724
 #: lib/vutuv_web/controllers/settings_controller.ex:634
-#: lib/vutuv_web/live/post_live/feed.ex:628
+#: lib/vutuv_web/live/post_live/feed.ex:633
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14373,7 +14373,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1002
+#: lib/vutuv_web/live/post_live/feed.ex:1008
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -16393,8 +16393,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2427
-#: lib/vutuv_web/live/post_live/feed.ex:2428
+#: lib/vutuv_web/live/post_live/feed.ex:2515
+#: lib/vutuv_web/live/post_live/feed.ex:2516
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr ""
@@ -18353,7 +18353,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2722
+#: lib/vutuv_web/live/post_live/feed.ex:2782
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -20908,7 +20908,7 @@ msgstr ""
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:880
+#: lib/vutuv_web/live/post_live/feed.ex:885
 #: lib/vutuv_web/views/user_html.ex:338
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -21527,12 +21527,12 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2880
+#: lib/vutuv_web/live/post_live/feed.ex:2940
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:629
+#: lib/vutuv_web/live/post_live/feed.ex:634
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr ""
@@ -21578,7 +21578,7 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:872
+#: lib/vutuv_web/live/post_live/feed.ex:877
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
@@ -21955,7 +21955,7 @@ msgstr ""
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:753
+#: lib/vutuv_web/live/post_live/feed.ex:758
 #: lib/vutuv_web/live/post_live/filter_band.ex:292
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -21971,7 +21971,7 @@ msgstr ""
 msgid "A–Z"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:835
+#: lib/vutuv_web/live/post_live/feed.ex:840
 #, elixir-autogen, elixir-format
 msgid "Browse the tags"
 msgstr ""
@@ -21986,7 +21986,7 @@ msgstr ""
 msgid "Clear all"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:666
+#: lib/vutuv_web/live/post_live/feed.ex:671
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr ""
@@ -22001,13 +22001,13 @@ msgstr ""
 msgid "Find an account or a server …"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:690
+#: lib/vutuv_web/live/post_live/feed.ex:695
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:817
-#: lib/vutuv_web/live/post_live/feed.ex:818
+#: lib/vutuv_web/live/post_live/feed.ex:822
+#: lib/vutuv_web/live/post_live/feed.ex:823
 #, elixir-autogen, elixir-format
 msgid "Follow a tag …"
 msgstr ""
@@ -22024,17 +22024,17 @@ msgstr ""
 msgid "Hide a word or a whole phrase …"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:627
+#: lib/vutuv_web/live/post_live/feed.ex:632
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:626
+#: lib/vutuv_web/live/post_live/feed.ex:631
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:841
+#: lib/vutuv_web/live/post_live/feed.ex:846
 #: lib/vutuv_web/live/post_live/filter_band.ex:331
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -22050,7 +22050,7 @@ msgstr ""
 msgid "More of your %{formatted} accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:665
+#: lib/vutuv_web/live/post_live/feed.ex:670
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr ""
@@ -22060,12 +22060,12 @@ msgstr ""
 msgid "No account found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:830
+#: lib/vutuv_web/live/post_live/feed.ex:835
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:619
+#: lib/vutuv_web/live/post_live/feed.ex:624
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr ""
@@ -22095,13 +22095,13 @@ msgstr ""
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2906
+#: lib/vutuv_web/live/post_live/feed.ex:2966
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:711
-#: lib/vutuv_web/live/post_live/feed.ex:712
+#: lib/vutuv_web/live/post_live/feed.ex:716
+#: lib/vutuv_web/live/post_live/feed.ex:717
 #, elixir-autogen, elixir-format
 msgid "Remove %{card}"
 msgstr ""
@@ -22133,7 +22133,7 @@ msgstr ""
 msgid "Show posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:625
+#: lib/vutuv_web/live/post_live/feed.ex:630
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr ""
@@ -22143,12 +22143,12 @@ msgstr ""
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:689
+#: lib/vutuv_web/live/post_live/feed.ex:694
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:807
+#: lib/vutuv_web/live/post_live/feed.ex:812
 #, elixir-autogen, elixir-format
 msgid "Unfollow the tag %{tag}"
 msgstr ""
@@ -22172,22 +22172,22 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2521
-#: lib/vutuv_web/live/post_live/feed.ex:2538
-#: lib/vutuv_web/live/post_live/feed.ex:2954
-#: lib/vutuv_web/live/post_live/feed.ex:2959
+#: lib/vutuv_web/live/post_live/feed.ex:2609
+#: lib/vutuv_web/live/post_live/feed.ex:2626
+#: lib/vutuv_web/live/post_live/feed.ex:3014
+#: lib/vutuv_web/live/post_live/feed.ex:3019
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1010
+#: lib/vutuv_web/live/post_live/feed.ex:1016
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:763
+#: lib/vutuv_web/live/post_live/feed.ex:768
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
@@ -22235,7 +22235,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2679
+#: lib/vutuv_web/live/post_live/feed.ex:2739
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr ""
@@ -22245,7 +22245,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2725
+#: lib/vutuv_web/live/post_live/feed.ex:2785
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22267,7 +22267,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2675
+#: lib/vutuv_web/live/post_live/feed.ex:2735
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -22353,3 +22353,10 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Page management"
 msgstr ""
+
+#: lib/vutuv_web/live/post_live/feed.ex:1970
+#, elixir-autogen, elixir-format
+msgid "New:"
+msgid_plural "New (%{formatted}):"
+msgstr[0] ""
+msgstr[1] ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -2116,7 +2116,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:139
 #: lib/vutuv_web/live/post_live/feed.ex:279
-#: lib/vutuv_web/live/post_live/feed.ex:2380
+#: lib/vutuv_web/live/post_live/feed.ex:2468
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1074
 #: lib/vutuv_web/live/shell_live.ex:1373
@@ -2162,7 +2162,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2699
+#: lib/vutuv_web/live/post_live/feed.ex:2759
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2557
+#: lib/vutuv_web/live/post_live/feed.ex:1976
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2469,7 +2469,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:640
-#: lib/vutuv_web/live/post_live/feed.ex:806
+#: lib/vutuv_web/live/post_live/feed.ex:811
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2418
+#: lib/vutuv_web/live/post_live/feed.ex:2506
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2781,7 +2781,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:934
+#: lib/vutuv_web/live/post_live/feed.ex:939
 #: lib/vutuv_web/templates/user/card_list.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -4542,7 +4542,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2704
+#: lib/vutuv_web/live/post_live/feed.ex:2764
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -7448,7 +7448,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:2967
+#: lib/vutuv_web/live/post_live/feed.ex:3027
 #, elixir-autogen
 msgid "Done"
 msgstr ""
@@ -7888,7 +7888,7 @@ msgid "Admins"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:943
+#: lib/vutuv_web/live/post_live/feed.ex:948
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -13463,7 +13463,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4724
 #: lib/vutuv_web/controllers/settings_controller.ex:634
-#: lib/vutuv_web/live/post_live/feed.ex:628
+#: lib/vutuv_web/live/post_live/feed.ex:633
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14371,7 +14371,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1002
+#: lib/vutuv_web/live/post_live/feed.ex:1008
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -16391,8 +16391,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2427
-#: lib/vutuv_web/live/post_live/feed.ex:2428
+#: lib/vutuv_web/live/post_live/feed.ex:2515
+#: lib/vutuv_web/live/post_live/feed.ex:2516
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post photos"
 msgstr ""
@@ -18351,7 +18351,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2722
+#: lib/vutuv_web/live/post_live/feed.ex:2782
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Loading…"
@@ -20906,7 +20906,7 @@ msgstr ""
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:880
+#: lib/vutuv_web/live/post_live/feed.ex:885
 #: lib/vutuv_web/views/user_html.ex:338
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -21525,12 +21525,12 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2880
+#: lib/vutuv_web/live/post_live/feed.ex:2940
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:629
+#: lib/vutuv_web/live/post_live/feed.ex:634
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr ""
@@ -21576,7 +21576,7 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:872
+#: lib/vutuv_web/live/post_live/feed.ex:877
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
@@ -21953,7 +21953,7 @@ msgstr ""
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:753
+#: lib/vutuv_web/live/post_live/feed.ex:758
 #: lib/vutuv_web/live/post_live/filter_band.ex:292
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -21969,7 +21969,7 @@ msgstr ""
 msgid "A–Z"
 msgstr "A–Z"
 
-#: lib/vutuv_web/live/post_live/feed.ex:835
+#: lib/vutuv_web/live/post_live/feed.ex:840
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Browse the tags"
 msgstr ""
@@ -21984,7 +21984,7 @@ msgstr "Busiest first"
 msgid "Clear all"
 msgstr "Clear all"
 
-#: lib/vutuv_web/live/post_live/feed.ex:666
+#: lib/vutuv_web/live/post_live/feed.ex:671
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr ""
@@ -21999,13 +21999,13 @@ msgstr "Expand or collapse"
 msgid "Find an account or a server …"
 msgstr "Find an account …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:690
+#: lib/vutuv_web/live/post_live/feed.ex:695
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:817
-#: lib/vutuv_web/live/post_live/feed.ex:818
+#: lib/vutuv_web/live/post_live/feed.ex:822
+#: lib/vutuv_web/live/post_live/feed.ex:823
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow a tag …"
 msgstr ""
@@ -22022,17 +22022,17 @@ msgstr "Hide a tag …"
 msgid "Hide a word or a whole phrase …"
 msgstr "Hide a word or a whole phrase …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:627
+#: lib/vutuv_web/live/post_live/feed.ex:632
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Hide tags"
 
-#: lib/vutuv_web/live/post_live/feed.ex:626
+#: lib/vutuv_web/live/post_live/feed.ex:631
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Hide words"
 
-#: lib/vutuv_web/live/post_live/feed.ex:841
+#: lib/vutuv_web/live/post_live/feed.ex:846
 #: lib/vutuv_web/live/post_live/filter_band.ex:331
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -22048,7 +22048,7 @@ msgstr "Matches nothing in your feed right now — the rule still holds for what
 msgid "More of your %{formatted} accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:665
+#: lib/vutuv_web/live/post_live/feed.ex:670
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr ""
@@ -22058,12 +22058,12 @@ msgstr ""
 msgid "No account found."
 msgstr "No account found."
 
-#: lib/vutuv_web/live/post_live/feed.ex:830
+#: lib/vutuv_web/live/post_live/feed.ex:835
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:619
+#: lib/vutuv_web/live/post_live/feed.ex:624
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr "Not read yet"
@@ -22093,13 +22093,13 @@ msgstr "Posts carrying one of these tags are folded the same way."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2906
+#: lib/vutuv_web/live/post_live/feed.ex:2966
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:711
-#: lib/vutuv_web/live/post_live/feed.ex:712
+#: lib/vutuv_web/live/post_live/feed.ex:716
+#: lib/vutuv_web/live/post_live/feed.ex:717
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove %{card}"
 msgstr ""
@@ -22131,7 +22131,7 @@ msgstr ""
 msgid "Show posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:625
+#: lib/vutuv_web/live/post_live/feed.ex:630
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sources"
 msgstr ""
@@ -22141,12 +22141,12 @@ msgstr ""
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:689
+#: lib/vutuv_web/live/post_live/feed.ex:694
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:807
+#: lib/vutuv_web/live/post_live/feed.ex:812
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unfollow the tag %{tag}"
 msgstr ""
@@ -22170,22 +22170,22 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2521
-#: lib/vutuv_web/live/post_live/feed.ex:2538
-#: lib/vutuv_web/live/post_live/feed.ex:2954
-#: lib/vutuv_web/live/post_live/feed.ex:2959
+#: lib/vutuv_web/live/post_live/feed.ex:2609
+#: lib/vutuv_web/live/post_live/feed.ex:2626
+#: lib/vutuv_web/live/post_live/feed.ex:3014
+#: lib/vutuv_web/live/post_live/feed.ex:3019
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1010
+#: lib/vutuv_web/live/post_live/feed.ex:1016
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:763
+#: lib/vutuv_web/live/post_live/feed.ex:768
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
@@ -22233,7 +22233,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2679
+#: lib/vutuv_web/live/post_live/feed.ex:2739
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to now"
 msgstr ""
@@ -22243,7 +22243,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2725
+#: lib/vutuv_web/live/post_live/feed.ex:2785
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22265,7 +22265,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2675
+#: lib/vutuv_web/live/post_live/feed.ex:2735
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -22351,3 +22351,10 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Page management"
 msgstr ""
+
+#: lib/vutuv_web/live/post_live/feed.ex:1970
+#, elixir-autogen, elixir-format
+msgid "New:"
+msgid_plural "New (%{formatted}):"
+msgstr[0] ""
+msgstr[1] ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -2161,7 +2161,7 @@ msgstr "Modifica il post"
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:139
 #: lib/vutuv_web/live/post_live/feed.ex:279
-#: lib/vutuv_web/live/post_live/feed.ex:2380
+#: lib/vutuv_web/live/post_live/feed.ex:2468
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1074
 #: lib/vutuv_web/live/shell_live.ex:1373
@@ -2207,7 +2207,7 @@ msgstr "Visitatori non connessi"
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2699
+#: lib/vutuv_web/live/post_live/feed.ex:2759
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2302,7 +2302,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Salvataggio…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2557
+#: lib/vutuv_web/live/post_live/feed.ex:1976
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2518,7 +2518,7 @@ msgstr "Togli Mi piace"
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:640
-#: lib/vutuv_web/live/post_live/feed.ex:806
+#: lib/vutuv_web/live/post_live/feed.ex:811
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2816,7 +2816,7 @@ msgstr "Scriva il Suo primo post"
 msgid "Manage"
 msgstr "Gestisci"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2418
+#: lib/vutuv_web/live/post_live/feed.ex:2506
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2837,7 +2837,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] "1 collegamento"
 msgstr[1] "%{formatted} collegamenti"
 
-#: lib/vutuv_web/live/post_live/feed.ex:934
+#: lib/vutuv_web/live/post_live/feed.ex:939
 #: lib/vutuv_web/templates/user/card_list.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -4722,7 +4722,7 @@ msgstr "Non ha bloccato nessuno."
 msgid "You unblocked @%{slug}."
 msgstr "Ha sbloccato @%{slug}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2704
+#: lib/vutuv_web/live/post_live/feed.ex:2764
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Scopra persone da seguire"
@@ -7746,7 +7746,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr "Si aggiorna da sola. Può lasciare questa pagina: l'invio prosegue."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:2967
+#: lib/vutuv_web/live/post_live/feed.ex:3027
 #, elixir-autogen
 msgid "Done"
 msgstr "Fatto"
@@ -8223,7 +8223,7 @@ msgid "Admins"
 msgstr "Amministratori"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:943
+#: lib/vutuv_web/live/post_live/feed.ex:948
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Tutti i membri"
@@ -14202,7 +14202,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4724
 #: lib/vutuv_web/controllers/settings_controller.ex:634
-#: lib/vutuv_web/live/post_live/feed.ex:628
+#: lib/vutuv_web/live/post_live/feed.ex:633
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -15182,7 +15182,7 @@ msgstr ""
 "Scelga qui sotto un titolo di studio o un istituto da mostrare in cima al "
 "Suo profilo al posto di una qualifica."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1002
+#: lib/vutuv_web/live/post_live/feed.ex:1008
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Mostra comunque"
@@ -17367,8 +17367,8 @@ msgstr "Aggiungi foto"
 msgid "Licence"
 msgstr "Licenza"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2427
-#: lib/vutuv_web/live/post_live/feed.ex:2428
+#: lib/vutuv_web/live/post_live/feed.ex:2515
+#: lib/vutuv_web/live/post_live/feed.ex:2516
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr "Pubblica foto"
@@ -19581,7 +19581,7 @@ msgstr "Rilasciato il"
 msgid "Label"
 msgstr "Etichetta"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2722
+#: lib/vutuv_web/live/post_live/feed.ex:2782
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -22419,7 +22419,7 @@ msgstr "Consigliato: %{width} × %{height} pixel (%{ratio})."
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Consigliato: quadrata, almeno %{width} × %{height} pixel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:880
+#: lib/vutuv_web/live/post_live/feed.ex:885
 #: lib/vutuv_web/views/user_html.ex:338
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -23114,12 +23114,12 @@ msgstr ""
 "Segua #%{tag} da Mastodon o da qualsiasi altra app del Fediverso e i suoi "
 "post pubblici arriveranno nella Sua cronologia. Non serve un account vutuv."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2880
+#: lib/vutuv_web/live/post_live/feed.ex:2940
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Saluti gli altri membri"
 
-#: lib/vutuv_web/live/post_live/feed.ex:629
+#: lib/vutuv_web/live/post_live/feed.ex:634
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr "Nuovi qui"
@@ -23169,7 +23169,7 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr "Con un account vutuv"
 
-#: lib/vutuv_web/live/post_live/feed.ex:872
+#: lib/vutuv_web/live/post_live/feed.ex:877
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr "Alcuni fra i membri più recenti. Seguirli è un bel benvenuto."
@@ -23555,7 +23555,7 @@ msgstr "Tutti i membri vutuv, in ordine alfabetico per cognome."
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr "Tutti i membri vutuv, raggruppati per la prima lettera del cognome."
 
-#: lib/vutuv_web/live/post_live/feed.ex:753
+#: lib/vutuv_web/live/post_live/feed.ex:758
 #: lib/vutuv_web/live/post_live/filter_band.ex:292
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -23571,7 +23571,7 @@ msgstr "Anche dentro parole più lunghe: %{word} trova anche %{example}."
 msgid "A–Z"
 msgstr "A–Z"
 
-#: lib/vutuv_web/live/post_live/feed.ex:835
+#: lib/vutuv_web/live/post_live/feed.ex:840
 #, elixir-autogen, elixir-format
 msgid "Browse the tags"
 msgstr "Sfoglia i tag"
@@ -23586,7 +23586,7 @@ msgstr "Più attivi per primi"
 msgid "Clear all"
 msgstr "Cancella tutto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:666
+#: lib/vutuv_web/live/post_live/feed.ex:671
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr "Trascina, oppure usa i tasti freccia"
@@ -23601,13 +23601,13 @@ msgstr "Espandi o comprimi"
 msgid "Find an account or a server …"
 msgstr "Cerca un account o un server …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:690
+#: lib/vutuv_web/live/post_live/feed.ex:695
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr "Riduci %{card}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:817
-#: lib/vutuv_web/live/post_live/feed.ex:818
+#: lib/vutuv_web/live/post_live/feed.ex:822
+#: lib/vutuv_web/live/post_live/feed.ex:823
 #, elixir-autogen, elixir-format
 msgid "Follow a tag …"
 msgstr "Segui un tag …"
@@ -23624,17 +23624,17 @@ msgstr "Nascondi un tag …"
 msgid "Hide a word or a whole phrase …"
 msgstr "Nascondi una parola o un'intera frase …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:627
+#: lib/vutuv_web/live/post_live/feed.ex:632
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Nascondi tag"
 
-#: lib/vutuv_web/live/post_live/feed.ex:626
+#: lib/vutuv_web/live/post_live/feed.ex:631
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Nascondi parole"
 
-#: lib/vutuv_web/live/post_live/feed.ex:841
+#: lib/vutuv_web/live/post_live/feed.ex:846
 #: lib/vutuv_web/live/post_live/filter_band.ex:331
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -23650,7 +23650,7 @@ msgstr "Ora non corrisponde a nulla nel suo feed — la regola vale comunque per
 msgid "More of your %{formatted} accounts"
 msgstr "Altri dei tuoi %{formatted} account"
 
-#: lib/vutuv_web/live/post_live/feed.ex:665
+#: lib/vutuv_web/live/post_live/feed.ex:670
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr "Sposta %{card}"
@@ -23660,12 +23660,12 @@ msgstr "Sposta %{card}"
 msgid "No account found."
 msgstr "Nessun account trovato."
 
-#: lib/vutuv_web/live/post_live/feed.ex:830
+#: lib/vutuv_web/live/post_live/feed.ex:835
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr "Nessun tag chiamato %{name} finora."
 
-#: lib/vutuv_web/live/post_live/feed.ex:619
+#: lib/vutuv_web/live/post_live/feed.ex:624
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr "Non ancora letti"
@@ -23695,13 +23695,13 @@ msgstr "I post con uno di questi tag vengono ridotti allo stesso modo."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "I post che contengono una di queste parole vengono ridotti a una riga — non eliminati, e con un modo per aprirli comunque."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2906
+#: lib/vutuv_web/live/post_live/feed.ex:2966
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Messe da parte:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:711
-#: lib/vutuv_web/live/post_live/feed.ex:712
+#: lib/vutuv_web/live/post_live/feed.ex:716
+#: lib/vutuv_web/live/post_live/feed.ex:717
 #, elixir-autogen, elixir-format
 msgid "Remove %{card}"
 msgstr "Rimuovi %{card}"
@@ -23733,7 +23733,7 @@ msgstr "Mostra solo %{source}"
 msgid "Show posts by %{name}"
 msgstr "Mostra i post di %{name}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:625
+#: lib/vutuv_web/live/post_live/feed.ex:630
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr "Fonti"
@@ -23743,12 +23743,12 @@ msgstr "Fonti"
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr "Disattivare significa silenziare, non smettere di seguire. Continui a seguire, ma i post non arrivano più nel tuo feed: in modo permanente e su tutti i dispositivi, finché non li riattivi qui."
 
-#: lib/vutuv_web/live/post_live/feed.ex:689
+#: lib/vutuv_web/live/post_live/feed.ex:694
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr "Espandi %{card}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:807
+#: lib/vutuv_web/live/post_live/feed.ex:812
 #, elixir-autogen, elixir-format
 msgid "Unfollow the tag %{tag}"
 msgstr "Smetti di seguire il tag %{tag}"
@@ -23772,22 +23772,22 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "e 1 altro"
 msgstr[1] "e altri %{formatted}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2521
-#: lib/vutuv_web/live/post_live/feed.ex:2538
-#: lib/vutuv_web/live/post_live/feed.ex:2954
-#: lib/vutuv_web/live/post_live/feed.ex:2959
+#: lib/vutuv_web/live/post_live/feed.ex:2609
+#: lib/vutuv_web/live/post_live/feed.ex:2626
+#: lib/vutuv_web/live/post_live/feed.ex:3014
+#: lib/vutuv_web/live/post_live/feed.ex:3019
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr "Filtri"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1010
+#: lib/vutuv_web/live/post_live/feed.ex:1016
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr "Nascosto:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:763
+#: lib/vutuv_web/live/post_live/feed.ex:768
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
@@ -23839,7 +23839,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} post il %{day}"
 msgstr[1] "%{count} post il %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2679
+#: lib/vutuv_web/live/post_live/feed.ex:2739
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Torna al presente"
@@ -23849,7 +23849,7 @@ msgstr "Torna al presente"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Mese intenso: la tonalità indica almeno questo valore."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2725
+#: lib/vutuv_web/live/post_live/feed.ex:2785
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -23871,7 +23871,7 @@ msgstr "Mese successivo"
 msgid "Next year"
 msgstr "Anno successivo"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2675
+#: lib/vutuv_web/live/post_live/feed.ex:2735
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Il %{day} non è arrivato nulla nel Suo feed."
@@ -23957,3 +23957,10 @@ msgstr "È pronta una nuova versione."
 #, elixir-autogen, elixir-format
 msgid "Page management"
 msgstr "Gestione"
+
+#: lib/vutuv_web/live/post_live/feed.ex:1970
+#, elixir-autogen, elixir-format
+msgid "New:"
+msgid_plural "New (%{formatted}):"
+msgstr[0] "Nuovo:"
+msgstr[1] "Nuovi (%{formatted}):"

--- a/test/vutuv_web/live/post_feed_live_test.exs
+++ b/test/vutuv_web/live/post_feed_live_test.exs
@@ -978,6 +978,54 @@ defmodule VutuvWeb.PostFeedLiveTest do
       assert render(live) =~ "breaking news"
     end
 
+    test "beside a quote the pill's visible label is only the prefix to it", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      friend = other_user()
+      insert(:follow, follower: user, followee: friend)
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+      {:ok, _} = Posts.create_post(friend, %{body: "breaking news"})
+
+      pill = live |> element("#show-new-posts") |> render()
+
+      # On a phone the whole sentence took the line and left the quote three
+      # letters, so beside a quote the label shrinks to what introduces it.
+      assert pill =~ "New:"
+      assert pill =~ "breaking news"
+
+      # It is not lost, and not doubled either: it is said once, where a screen
+      # reader hears it and no width is spent on it.
+      assert pill =~ ~r{class="sr-only">Show 1 new post}
+      assert length(Regex.scan(~r/Show 1 new post/, pill)) == 1
+
+      # More than one and the count moves into the label, still short.
+      for n <- 2..3, do: {:ok, _} = Posts.create_post(friend, %{body: "arrival #{n}"})
+
+      pill = live |> element("#show-new-posts") |> render()
+      assert pill =~ "New (3):"
+      assert pill =~ ~r{class="sr-only">Show 3 new posts}
+    end
+
+    test "with nothing to quote the pill says the whole sentence", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      friend = other_user()
+      insert(:follow, follower: user, followee: friend)
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      # A photo without a caption: no line to quote, so a bare "New:" would
+      # hang its colon on nothing.
+      image = insert(:post_image, user: friend)
+      {:ok, _} = Posts.create_post(friend, %{body: "", image_ids: [image.id]})
+
+      pill = live |> element("#show-new-posts") |> render()
+
+      assert pill =~ "Show 1 new post"
+      refute pill =~ "New:"
+      # Said once: with no prefix to introduce there is no second, hidden copy.
+      assert length(Regex.scan(~r/Show 1 new post/, pill)) == 1
+    end
+
     test "a tab left open for days stops drawing and starts counting", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       friend = other_user()
@@ -1543,6 +1591,25 @@ defmodule VutuvWeb.PostFeedLiveTest do
       assert has_element?(live, "[data-filtered-post='crypto']")
       # The body itself is not on the page until revealed.
       refute html =~ "buy crypto now"
+    end
+
+    test "the pill never quotes a post the reader muted", %{
+      conn: conn,
+      user: user,
+      friend: friend
+    } do
+      {:ok, _} =
+        Vutuv.ContentFilters.create_filter(user, %{"kind" => "keyword", "pattern" => "crypto"})
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+      {:ok, _} = Posts.create_post(friend, %{body: "buy crypto now"})
+
+      pill = live |> element("#show-new-posts") |> render()
+
+      # The row folds to a placeholder; a pill quoting its opening line would
+      # read out the very words they muted.
+      refute pill =~ "crypto"
+      assert pill =~ "Show 1 new post"
     end
 
     test "'Show anyway' reveals the post in place", %{conn: conn, user: user, friend: friend} do


### PR DESCRIPTION
**Symptom:** on a phone the new-posts pill on `/feed` spent the whole line on
"1 neuen Beitrag anzeigen" and left the quote beside it three letters.

**Change:** beside a quote the pill's visible label is now only what introduces
it, "Neu:" / "Neu (2):". The full sentence stays as the button's screen-reader
name, so nothing is lost for assistive tech; with nothing to quote (a photo
without a caption) the colon would hang, so the sentence still shows. Measured
in the browser at a 358 px column: the label went from ~230 px to 55 px and the
row stays one line.

Found and fixed alongside: the pill also quoted a post the reader's own content
filters hide (#940), reading out the very words they muted while the row below
folded to a placeholder.

`VutuvWeb.PostLive.Feed` — `new_posts_pill/1`, `pending_label/1`,
`newest_quote/1`.

**To decide:** the short label applies on desktop too, where the line was never
tight. Say the word and I will gate it behind `md:`.

*An AI agent wrote this text in my name. I know that is problematic.*
