### PR TITLE
fix(agents): an extension URL decides the format, not the Accept header [5m]

### DIFF
--- a/lib/vutuv_web/plugs/agent_format.ex
+++ b/lib/vutuv_web/plugs/agent_format.ex
@@ -35,6 +35,18 @@ defmodule VutuvWeb.Plug.AgentFormat do
   `text/html` so the browser pipeline's `accepts ["html"]` admits the
   request. Header-negotiated requests are best-effort: a page without agent
   documents simply answers HTML, no 404 guard.
+
+  **Both branches normalize the header**, and for the same reason: once the
+  format is settled, whatever the client sent must not still steer the render.
+  On the extension branch that is the URL's decision, so it outranks the
+  header outright — `/:slug.md` sent with `application/activity+json` is the
+  Markdown document, not the actor. Leaving the header alone there let a
+  hostile Accept reach a route whose HTML is a LiveView, which then rendered
+  for a format it has no template for and handed `{:safe, iodata}` to
+  `Plug.Conn.resp/3`: a **500** on `/notifications.md`, `/search.md` and
+  `/bookmarks.json` (issue #1823). Normalized, `enforce_handled/1` gives those
+  the documented 404 instead, and `VutuvWeb.Plug.HtmlOnly`'s agent-format
+  exemption is no longer wider than it reads.
   """
 
   @behaviour Plug
@@ -85,6 +97,7 @@ defmodule VutuvWeb.Plug.AgentFormat do
 
           %{conn | path_info: rewritten, request_path: "/" <> Enum.join(rewritten, "/")}
           |> put_private(:vutuv_agent_format, format)
+          |> normalize_accept()
           |> register_before_send(&enforce_handled/1)
 
         nil ->
@@ -135,11 +148,15 @@ defmodule VutuvWeb.Plug.AgentFormat do
     if format do
       conn
       |> put_private(:vutuv_agent_accept, format)
-      |> put_req_header("accept", "text/html")
+      |> normalize_accept()
     else
       conn
     end
   end
+
+  # Both branches end here, and that is the point: once the format is settled,
+  # the header has had its say and must not steer the render as well.
+  defp normalize_accept(conn), do: put_req_header(conn, "accept", "text/html")
 
   # The first listed media type the header contains, returning its mapped
   # format (which may be `nil`, e.g. text/html). `Enum.find` (not find_value)

--- a/lib/vutuv_web/plugs/html_only.ex
+++ b/lib/vutuv_web/plugs/html_only.ex
@@ -27,15 +27,14 @@ defmodule VutuvWeb.Plug.HtmlOnly do
   Dropping that exemption costs `/jobs.md` its Markdown (measured: 406), so it
   is load-bearing rather than defensive.
 
-  It is also **wider than it should be**, and knowingly so. A `.md` URL whose
-  route is a LiveView that serves no document — `/notifications.md`,
-  `/search.md`, `/bookmarks.json` — is exempted here and then renders the
-  LiveView for whatever format the client asked for, i.e. the same 500 this
-  module exists to close. `AgentFormat` normalizes the `Accept` header on its
-  negotiation path and not on its extension path, which is where that belongs
-  and where issue #1823 fixes it. Until then the exemption stays as it is: the
-  hole predates this module (measured on `main`, identical), and narrowing it
-  here would only move the guess into a second plug.
+  The exemption used to be **wider than it reads**: a `.md` URL whose route is
+  a LiveView that serves no document — `/notifications.md`, `/search.md`,
+  `/bookmarks.json` — was waved through here and then rendered the LiveView for
+  whatever format the client asked for, i.e. the same 500 this module exists to
+  close. That was never this module's to narrow: `AgentFormat` now normalizes
+  the `Accept` header on its extension path as well as its negotiation path
+  (issue #1823), so by the time the exemption applies the header says
+  `text/html` and there is no second format left to render for.
   """
 
   @behaviour Plug

--- a/test/vutuv_web/http_status_contract_test.exs
+++ b/test/vutuv_web/http_status_contract_test.exs
@@ -107,26 +107,30 @@ defmodule VutuvWeb.HttpStatusContractTest do
 
     # The URL extension decides, not whatever header rode along with it: a
     # `.md` sibling is answered from `AgentDocs` by its controller and never
-    # renders the LiveView, so the refusal must not reach it.
+    # renders the LiveView, so the refusal must not reach it. `/:slug.md` is the
+    # second path because it is the one where the two genuinely compete — the
+    # bare `/:slug` answers an ActivityPub fetch, so before #1823 that branch
+    # took the request and `enforce_handled/1` flipped it to an empty 404.
     test "an agent document is still served by its extension", %{conn: conn} do
-      conn =
-        conn
-        |> put_req_header("accept", "application/activity+json")
-        |> get("/jobs.md")
+      insert_activated_user(username: "extension_wins", first_name: "Agatha")
 
-      assert conn.status == 200
-      assert List.first(get_resp_header(conn, "content-type")) =~ "text/markdown"
+      for path <- ["/jobs.md", "/extension_wins.md"] do
+        conn =
+          conn
+          |> recycle()
+          |> put_req_header("accept", "application/activity+json")
+          |> get(path)
+
+        assert conn.status == 200, "expected 200 for #{path}"
+        assert List.first(get_resp_header(conn, "content-type")) =~ "text/markdown"
+      end
     end
 
     # Every routed LiveView, not a hand-picked five: the refusal is wired per
     # scope (`pipe_through`), so the next `live_session` scope that forgets
-    # `:html_only` has to fail here rather than in production.
-    # Extension-free paths only. A `.md`/`.json` URL on a LiveView route still
-    # 500s on a hostile Accept — `AgentFormat` normalizes the header on its
-    # negotiation path but not on its extension path, so `HtmlOnly` waves the
-    # request through and the LiveView renders for a format it has no template
-    # for. That is pre-existing on main (measured before and after this change,
-    # identically) and is issue #1823, not this fix.
+    # `:html_only` has to fail here rather than in production. Bare paths, so
+    # this measures the pipeline; the extension siblings answer 404 by a
+    # different route and are covered below.
     test "no routed LiveView answers a bare-path one with a 500", %{conn: conn} do
       {conn, _admin} = create_and_login_admin(conn)
 
@@ -143,6 +147,22 @@ defmodule VutuvWeb.HttpStatusContractTest do
         conn = conn |> recycle() |> put_req_header("accept", "application/activity+json")
 
         assert_error_sent(406, fn -> get(conn, path) end)
+      end
+    end
+
+    # The extension URL of a LiveView route that serves no agent document.
+    # `AgentFormat` has already read the format off the URL, so the header the
+    # client happened to send with it must not still steer the render: the
+    # documented answer is `enforce_handled/1`'s 404, never a 500 from a
+    # LiveView rendering for a format it has no template for.
+    test "an extension URL on a LiveView route 404s whatever the client asked for", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      for path <- ["/notifications.md", "/search.md", "/bookmarks.json"],
+          type <- ["application/activity+json", "application/ld+json"] do
+        conn = conn |> recycle() |> put_req_header("accept", type) |> get(path)
+
+        assert conn.status == 404, "expected 404 for #{path} with #{type}"
       end
     end
   end


### PR DESCRIPTION
**Symptom:** `GET /notifications.md` with `Accept: application/activity+json` answered **500**, unauthenticated-reachable. Same for `/search.md` and `/bookmarks.json`. The LiveView rendered for a format it has no template for and handed `{:safe, iodata}` to `Plug.Conn.resp/3`.

**Change:** `VutuvWeb.Plug.AgentFormat` normalizes the `Accept` header on its **extension** branch too, not only on negotiation — both now go through one private `normalize_accept/1`. `enforce_handled/1` then gives those URLs the documented 404. `VutuvWeb.Plug.HtmlOnly`'s exemption is unchanged; it is simply no longer wider than it reads, and its moduledoc stops describing an open hole.

**Also fixed, same root cause:** `/:slug.md` sent with an ActivityPub `Accept` used to take the actor branch and then be flipped to an **empty 404**. It now serves the Markdown document — the extension decides, which is what the module always claimed.

**Verified:** a new test pins both directions. Calibrated: with the one line reverted, both go red and the eleven pre-existing tests stay green. `mix precommit` green (9,318).

<!-- closing-note #1823 -->
Fixed. The extension branch now normalizes the header the way negotiation always did, so those three URLs give the 404 you documented instead of a 500. Your measurement carried the whole diagnosis, thank you — the only thing it did not name is the second half that fell out with it: `/:slug.md` with an ActivityPub Accept was taking the actor branch and then being flipped to an empty 404, so it now serves Markdown for the first time.

*An AI agent wrote this text in my name. I know that is problematic.*

Closes #1823.
