### PR TITLE
The feed calendar shows its grid at once and shades it after

### DIFF
--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -460,6 +460,36 @@ on the four columns that hide an account) keeps the EXISTS off a full scan.
 Measured on a copy of production seeded to 200,000 posts, the two indexes took
 that source from 76.7 ms to 0.53 ms.
 
+**The calendar's heatmap asks the same sources for less.** The feed calendar
+(`VutuvWeb.PostLive.FeedCalendar`) shades a month by how much reached the reader
+on each day, counted through `Posts.feed_activity_by_day/4` — the same sources a
+page is built from, so a day it calls busy really does have a timeline behind
+it. Counting them is not reading them, though, and the difference is the whole
+cost: a reader who follows a few hundred accounts out there meets several
+thousand remote posts and boosts in a month, and building those as preloaded
+structs to produce thirty numbers is where the time went. So `feed_sources/3`
+takes a **shape**. `:entries` is everything a card draws; `:marks` is the same
+query builder, the same `WHERE`, the same window, asked for as little as that
+source can get away with — a bare `SELECT {id, at}` for remote posts, and for
+boosts the same rows minus the card's preloads, since whether a boost reaches
+this reader is settled after the query out of the boosted post's own columns.
+Only the two fediverse sources that carry the volume offer it; a source that
+does not simply hands back the richer shape, which carries `id` and `at` too, so
+the two are interchangeable and nothing can be counted under a different
+definition than it is rendered under. `test/vutuv/feed_marks_shape_test.exs`
+holds them to that. Measured against a copy of production (August 2026, 6,142
+rows fetched for 3,882 counted entries): 175 ms for the month, 80 ms after.
+
+**And the grid does not wait for it.** 80 ms is still a press the reader watches
+do nothing, so unfolding the calendar renders the month first — the dates,
+today's ring, the open day, both controls — and the shading arrives in a second
+render from `handle_info({:cal_counts, key}, …)`, fading in over
+`transition-colors`. `key` names the month and the reading it was asked for, so
+somebody stepping through months pays only for the one still on screen. A
+disconnected render has no second render and therefore asks for nothing at all;
+the connected mount fills the grid in. Measured in the browser: the grid is on
+screen in 40 ms, the shading lands at ~130.
+
 **Which source a reshare lands in: whoever pressed the button.** The band
 switches sources, and an entry still belongs to exactly one of them
 (`feed_page/2`'s `filter:` option, `Fediverse.scope_resharer/3`). *Fediverse* is

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -76,6 +76,7 @@ defmodule Vutuv.Fediverse do
   alias Vutuv.Fediverse.RemoteFollow
   alias Vutuv.Fediverse.RemoteImage
   alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.FeedPage
   alias Vutuv.Handles
   alias Vutuv.Keyset
   alias Vutuv.Organizations
@@ -2856,28 +2857,54 @@ defmodule Vutuv.Fediverse do
     end
   end
 
-  def feed_remote_posts(%User{id: viewer_id} = viewer, fetch_n, cursor) do
+  def feed_remote_posts(viewer, fetch_n, cursor, opts \\ [])
+
+  def feed_remote_posts(%User{} = viewer, fetch_n, cursor, opts) do
     if enabled?() do
-      from(p in RemotePost,
-        join: a in RemoteAccount,
-        as: :remote_account,
-        on: a.id == p.remote_account_id,
-        join: f in Follow,
-        on: f.remote_account_id == a.id,
-        where: f.user_id == ^viewer_id and f.muted == false,
-        where: p.audience in ^RemotePost.open_audiences() or f.state == "accepted",
-        order_by: [desc: p.published_at, desc: p.id],
-        limit: ^fetch_n,
-        preload: [:screenshot, remote_account: a]
-      )
-      |> reject_muted_hosts(viewer)
-      |> Vutuv.Posts.language_scope(Vutuv.Posts.feed_language_filter(viewer))
-      |> utc_at_or_before(cursor, :published_at)
-      |> Repo.all()
-      |> Enum.map(&remote_feed_entry/1)
+      viewer
+      |> remote_posts_query(fetch_n, cursor)
+      |> remote_post_rows(Keyword.get(opts, :shape, :entries))
     else
       []
     end
+  end
+
+  # A counter needs the id and the timestamp and nothing else, and here that
+  # really is all the database sends: no preloads and a two-column `SELECT`.
+  # The rows are the same rows — same `WHERE`, same window, same order — so the
+  # shape cannot change *which* posts are in the feed; see
+  # `docs/architecture/posts-and-feed.md` for what it saves.
+  defp remote_post_rows(query, :marks) do
+    query
+    |> select([p], {p.id, p.published_at})
+    |> Repo.all()
+    |> Enum.map(fn {id, at} -> remote_post_mark(id, at) end)
+  end
+
+  defp remote_post_rows(query, _entries) do
+    query
+    |> preload([remote_account: a], [:screenshot, remote_account: a])
+    |> Repo.all()
+    |> Enum.map(&remote_feed_entry/1)
+  end
+
+  # What both shapes above select from: one definition of which remote posts
+  # reach this viewer.
+  defp remote_posts_query(%User{id: viewer_id} = viewer, fetch_n, cursor) do
+    from(p in RemotePost,
+      join: a in RemoteAccount,
+      as: :remote_account,
+      on: a.id == p.remote_account_id,
+      join: f in Follow,
+      on: f.remote_account_id == a.id,
+      where: f.user_id == ^viewer_id and f.muted == false,
+      where: p.audience in ^RemotePost.open_audiences() or f.state == "accepted",
+      order_by: [desc: p.published_at, desc: p.id],
+      limit: ^fetch_n
+    )
+    |> reject_muted_hosts(viewer)
+    |> Vutuv.Posts.language_scope(Vutuv.Posts.feed_language_filter(viewer))
+    |> utc_at_or_before(cursor, :published_at)
   end
 
   @doc """
@@ -2891,7 +2918,7 @@ defmodule Vutuv.Fediverse do
 
   It feeds the **vutuv** tab, the reader's own reshares and everybody else's
   alike: pressing that button is something that happened here, whoever pressed
-  it (`Vutuv.Posts.feed_sources/2`).
+  it (`Vutuv.Posts.feed_sources/3`).
   """
   def feed_remote_reposts(viewer, fetch_n, cursor, opts \\ [])
 
@@ -3013,57 +3040,93 @@ defmodule Vutuv.Fediverse do
   """
   def feed_remote_boosts(viewer, fetch_n, cursor, opts \\ [])
 
-  def feed_remote_boosts(%User{id: viewer_id} = viewer, fetch_n, cursor, opts) do
+  def feed_remote_boosts(%User{} = viewer, fetch_n, cursor, opts) do
     if enabled?() do
-      # The author's own follow is consulted too, not only the booster's: a
-      # reader who muted an account out there muted *them*, and somebody else
-      # passing their post on is exactly the back door that would undo it.
-      muted_authors =
-        from(f in Follow,
-          where: f.user_id == ^viewer_id and f.muted == true,
-          select: f.remote_account_id
-        )
-
-      from(b in PostBoost,
-        join: a in RemoteAccount,
-        as: :remote_account,
-        on: a.id == b.remote_account_id,
-        join: f in Follow,
-        on: f.remote_account_id == a.id,
-        left_join: rp in RemotePost,
-        as: :language_source,
-        on: rp.id == b.remote_post_id,
-        # The boosted post's own author, for the muted-server check below: a
-        # switched-off instance must not come back in through somebody else's
-        # boost, the same back door the muted-author subquery closes.
-        left_join: author in RemoteAccount,
-        as: :boosted_author,
-        on: author.id == rp.remote_account_id,
-        where: f.user_id == ^viewer_id and f.muted == false and f.state == "accepted",
-        where: is_nil(rp.id) or rp.remote_account_id not in subquery(muted_authors),
-        order_by: [desc: b.announced_at, desc: b.id],
-        limit: ^fetch_n,
-        # A boosted vutuv post carries `denials` (the card's 🔒 marker reads
-        # them) and its author (`filter_visible_boosts/2`'s moderation check
-        # reads the struct instead of re-fetching the user per row); the rest
-        # a card needs is preloaded once for the whole page by `Vutuv.Posts`.
-        preload: [
-          remote_account: a,
-          remote_post: [:remote_account, :screenshot],
-          post: [:denials, :user]
-        ]
-      )
-      |> boosts_of_kind(opts[:only])
-      |> reject_muted_hosts(viewer)
-      |> reject_muted_boosted_hosts(viewer)
-      |> Vutuv.Posts.named_language_scope(Vutuv.Posts.feed_language_filter(viewer))
-      |> utc_at_or_before(cursor, :announced_at)
-      |> Repo.all()
-      |> Enum.map(&boost_entry/1)
-      |> filter_visible_boosts(viewer)
+      viewer
+      |> remote_boosts_query(fetch_n, cursor, opts)
+      |> remote_boost_rows(viewer, Keyword.get(opts, :shape, :entries))
     else
       []
     end
+  end
+
+  # Cheaper than a card, but not a two-column `SELECT` like the source above:
+  # whether a boost reaches this reader is settled *after* the query, out of the
+  # boosted post's own columns, so the marks shape still loads those and runs
+  # the same filter. What it drops is the card's own preloads.
+  # `FeedPage.mark/1` at the end is not tidiness — it lets the loaded structs be
+  # collected, and stops a counter quietly depending on fields the other shape
+  # happens to carry.
+  defp remote_boost_rows(query, viewer, :marks) do
+    query
+    |> visible_boost_entries(viewer)
+    |> Enum.map(&FeedPage.mark/1)
+  end
+
+  # What a *card* needs on top of what the visibility filter already reads: the
+  # booster, the boosted post's own author and screenshot, and the `denials`
+  # behind the vutuv card's 🔒 marker. The rest is preloaded once for the whole
+  # page by `Vutuv.Posts`.
+  defp remote_boost_rows(query, viewer, _entries) do
+    query
+    |> preload([remote_account: a],
+      remote_account: a,
+      remote_post: [:remote_account, :screenshot],
+      post: :denials
+    )
+    |> visible_boost_entries(viewer)
+  end
+
+  # What both shapes above select from: one definition of which boosts reach
+  # this viewer, before the in-memory visibility filter has its say.
+  #
+  # The two preloads here are the filter's own, not a card's: it reads the
+  # boosted vutuv post's author for the moderation check instead of re-fetching
+  # the user per row, and asks the boosted remote post's `audience` column
+  # whether it is still open.
+  defp remote_boosts_query(%User{id: viewer_id} = viewer, fetch_n, cursor, opts) do
+    # The author's own follow is consulted too, not only the booster's: a
+    # reader who muted an account out there muted *them*, and somebody else
+    # passing their post on is exactly the back door that would undo it.
+    muted_authors =
+      from(f in Follow,
+        where: f.user_id == ^viewer_id and f.muted == true,
+        select: f.remote_account_id
+      )
+
+    from(b in PostBoost,
+      join: a in RemoteAccount,
+      as: :remote_account,
+      on: a.id == b.remote_account_id,
+      join: f in Follow,
+      on: f.remote_account_id == a.id,
+      left_join: rp in RemotePost,
+      as: :language_source,
+      on: rp.id == b.remote_post_id,
+      # The boosted post's own author, for the muted-server check below: a
+      # switched-off instance must not come back in through somebody else's
+      # boost, the same back door the muted-author subquery closes.
+      left_join: author in RemoteAccount,
+      as: :boosted_author,
+      on: author.id == rp.remote_account_id,
+      where: f.user_id == ^viewer_id and f.muted == false and f.state == "accepted",
+      where: is_nil(rp.id) or rp.remote_account_id not in subquery(muted_authors),
+      order_by: [desc: b.announced_at, desc: b.id],
+      limit: ^fetch_n,
+      preload: [remote_post: rp, post: :user]
+    )
+    |> boosts_of_kind(opts[:only])
+    |> reject_muted_hosts(viewer)
+    |> reject_muted_boosted_hosts(viewer)
+    |> Vutuv.Posts.named_language_scope(Vutuv.Posts.feed_language_filter(viewer))
+    |> utc_at_or_before(cursor, :announced_at)
+  end
+
+  defp visible_boost_entries(query, viewer) do
+    query
+    |> Repo.all()
+    |> Enum.map(&boost_entry/1)
+    |> filter_visible_boosts(viewer)
   end
 
   # Which of the two things a boost can point at. `remote_post_id` is the one
@@ -3161,14 +3224,18 @@ defmodule Vutuv.Fediverse do
     end)
   end
 
+  # The two fields every shape of a cached remote post carries, minted in one
+  # place. The `"remote-"` prefix is not decoration: `Posts.feed_activity_by_day/4`
+  # dedupes on the whole string and `FeedPage.paginate/3` rejects a seen page by
+  # it, so a second author for it would change what the heatmap counts with
+  # nothing raising.
+  defp remote_post_mark(id, published_at),
+    do: %{id: "remote-#{id}", at: DateTime.to_naive(published_at)}
+
   defp remote_feed_entry(%RemotePost{} = post) do
-    %{
-      id: "remote-#{post.id}",
-      post: nil,
-      remote_post: post,
-      reposted_by: nil,
-      at: DateTime.to_naive(post.published_at)
-    }
+    post.id
+    |> remote_post_mark(post.published_at)
+    |> Map.merge(%{post: nil, remote_post: post, reposted_by: nil})
   end
 
   # The cursor for a source ordered by a `utc_datetime` column — a followed

--- a/lib/vutuv/feed_page.ex
+++ b/lib/vutuv/feed_page.ex
@@ -38,6 +38,21 @@ defmodule Vutuv.FeedPage do
   """
   def sort_entries(entries), do: Enum.sort_by(entries, & &1.at, {:desc, NaiveDateTime})
 
+  @doc """
+  An entry cut down to the two fields the paginators actually read — a **mark**.
+
+  This is the whole contract above, spelled as data: `paginate/3` and
+  `sort_entries/1` touch `:id` and `:at` and nothing else, so a source asked to
+  count rather than to draw may hand marks back instead of entries and every
+  caller here is satisfied (`Vutuv.Posts.feed_sources/3`'s `:marks` shape,
+  which is what the feed calendar's heatmap asks for).
+
+  One definition rather than a `Map.take/2` at each site: the projection and
+  the promise it rests on belong together, and a source that widens what a mark
+  carries should widen it here.
+  """
+  def mark(entry), do: Map.take(entry, [:id, :at])
+
   def paginate(sources, limit, cursor) when is_list(sources) do
     seen = if cursor, do: cursor.ids, else: []
 

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2696,7 +2696,7 @@ defmodule Vutuv.Posts do
   shared `Vutuv.FeedPage` scheme. Treat it as opaque.
 
   `filter:` narrows the feed to one **source tab** — `:all` (the default),
-  `:vutuv` or `:fediverse`; see `feed_sources/2`.
+  `:vutuv` or `:fediverse`; see `feed_sources/3`.
   """
   def feed_page(%User{} = viewer, opts \\ []) do
     limit = Keyword.get(opts, :limit, @default_feed_limit)
@@ -2712,10 +2712,17 @@ defmodule Vutuv.Posts do
   How many feed entries reached `viewer` on each day of a window — the numbers
   the feed calendar's heatmap shades (issue: the vertical time controls).
 
-  Counted through **`feed_sources/2`**, the same nine sources a page is built
+  Counted through **`feed_sources/3`**, the same nine sources a page is built
   from, so a day the heatmap calls busy is a day the timeline will actually
   have something on. A separate hand-written count query would be a second
   definition of "what is in my feed" and would drift from the first one.
+
+  Asked in the **`:marks`** shape, which is the same rows with what a card needs
+  left out. That is not a detail — building a month of a fediverse-heavy feed as
+  preloaded structs to produce thirty numbers was most of what unfolding the
+  calendar cost — and it is not a filter either: same queries, same window, same
+  counts. The figures are in `docs/architecture/posts-and-feed.md`; how much
+  each source can leave out is up to the source, and `Vutuv.Fediverse` says.
 
   Counts **arrivals, not cards**. The rendered timeline collapses several posts
   of one thread into a single entry, so a day counted at 306 here draws 271
@@ -2743,7 +2750,7 @@ defmodule Vutuv.Posts do
     cursor = %{at: last, ids: [], since: first}
 
     entries =
-      Enum.map(feed_sources(viewer, filter), fn fetch -> fetch.(cap, cursor) end)
+      Enum.map(feed_sources(viewer, filter, :marks), fn fetch -> fetch.(cap, cursor) end)
 
     # Truncation is a per-SOURCE fact, not a fact about their union: the cap is
     # each source's `LIMIT`, so nine sources of 400 rows each make 3,600
@@ -2772,8 +2779,9 @@ defmodule Vutuv.Posts do
   query would be a second definition of what is in a feed, and the arrows would
   eventually disagree with the timeline they scroll.
 
-  Undecorated on purpose: the question is whether anything exists, and
-  `decorate_feed_entries/3` is the expensive half of a page.
+  Undecorated on purpose, in the `:marks` shape: the question is whether
+  anything exists, and neither `decorate_feed_entries/3` nor a card's preloads
+  help answer it.
   """
   def feed_reaches_before_month?(%User{} = viewer, %Date{} = date, opts \\ []) do
     filter = Keyword.get(opts, :filter, :all)
@@ -2782,10 +2790,24 @@ defmodule Vutuv.Posts do
     before = NaiveDateTime.add(month_start, -1, :second)
 
     page =
-      Vutuv.FeedPage.paginate(feed_sources(viewer, filter), 1, %{at: before, ids: []})
+      Vutuv.FeedPage.paginate(feed_sources(viewer, filter, :marks), 1, %{at: before, ids: []})
 
     page.entries != []
   end
+
+  # `shape` is what the caller does with the rows: `:entries` carries everything
+  # a card draws, `:marks` only the `id` and the `at` a counter needs
+  # (`Vutuv.FeedPage.mark/1`). A source that has no cheaper shape ignores the
+  # argument and hands back the richer one, which carries both keys anyway — so
+  # the two are interchangeable and no source can be counted under a different
+  # definition than it is rendered under.
+  #
+  # Only the two fediverse sources below act on it, because they are the two
+  # that carry the volume: a reader who follows a few hundred accounts out there
+  # meets several thousand of their posts and boosts in a month and a couple of
+  # hundred of everything else. What each saves differs and the owning module
+  # says so — see `docs/architecture/posts-and-feed.md`.
+  defp feed_sources(viewer, filter, shape \\ :entries)
 
   # `:own` is a different axis from the three below and belongs to the feed
   # calendar, not to the source band: the band asks *which network*, this asks
@@ -2794,10 +2816,11 @@ defmodule Vutuv.Posts do
   # posts" and comes back tomorrow gets their ordinary feed.
   #
   # It is also what the calendar's "My posts" heatmap counts, so the shading and
-  # the timeline under it are one definition rather than two.
-  defp feed_sources(viewer, :own), do: [&feed_own_post_items(viewer, &1, &2)]
+  # the timeline under it are one definition rather than two. One local source,
+  # so there is no cheaper shape to offer.
+  defp feed_sources(viewer, :own, _shape), do: [&feed_own_post_items(viewer, &1, &2)]
 
-  defp feed_sources(viewer, :vutuv) do
+  defp feed_sources(viewer, :vutuv, shape) do
     [
       &feed_post_items(viewer, &1, &2),
       &feed_organization_post_items(viewer, &1, &2),
@@ -2805,20 +2828,20 @@ defmodule Vutuv.Posts do
       &feed_tag_items(viewer, &1, &2),
       &feed_reply_to_me_items(viewer, &1, &2),
       &feed_repost_of_mine_items(viewer, &1, &2),
-      &Vutuv.Fediverse.feed_remote_boosts(viewer, &1, &2, only: :local),
+      &Vutuv.Fediverse.feed_remote_boosts(viewer, &1, &2, only: :local, shape: shape),
       &Vutuv.Fediverse.feed_remote_reposts(viewer, &1, &2),
       &Vutuv.Fediverse.feed_remote_reply_reposts(viewer, &1, &2)
     ]
   end
 
-  defp feed_sources(viewer, :fediverse) do
+  defp feed_sources(viewer, :fediverse, shape) do
     [
-      &Vutuv.Fediverse.feed_remote_posts(viewer, &1, &2),
-      &Vutuv.Fediverse.feed_remote_boosts(viewer, &1, &2, only: :remote)
+      &Vutuv.Fediverse.feed_remote_posts(viewer, &1, &2, shape: shape),
+      &Vutuv.Fediverse.feed_remote_boosts(viewer, &1, &2, only: :remote, shape: shape)
     ]
   end
 
-  defp feed_sources(viewer, _all) do
+  defp feed_sources(viewer, _all, shape) do
     [
       &feed_post_items(viewer, &1, &2),
       # What the organizations the viewer follows have published (issue #1336).
@@ -2829,7 +2852,7 @@ defmodule Vutuv.Posts do
       # sources that are not about a follow at all.
       &feed_reply_to_me_items(viewer, &1, &2),
       &feed_repost_of_mine_items(viewer, &1, &2),
-      &Vutuv.Fediverse.feed_remote_posts(viewer, &1, &2),
+      &Vutuv.Fediverse.feed_remote_posts(viewer, &1, &2, shape: shape),
       # Fifth: what people the viewer follows *here* have reshared from
       # another network (issue #1166) — the one way a member who follows
       # nobody out there meets that content at all.
@@ -2837,7 +2860,7 @@ defmodule Vutuv.Posts do
       # Sixth: what the accounts the viewer follows out there have
       # re-shared (issue #1167) — a large part of what any account
       # contributes, and invisible here until now.
-      &Vutuv.Fediverse.feed_remote_boosts(viewer, &1, &2),
+      &Vutuv.Fediverse.feed_remote_boosts(viewer, &1, &2, shape: shape),
       # Seventh: **replies** from another network that people here have
       # passed on (issue #1275). The same act as the fifth source one table
       # over: a reply arrived under somebody's vutuv post, a member here
@@ -2988,12 +3011,12 @@ defmodule Vutuv.Posts do
 
   @doc """
   Whether the feed tab `filter` shows `entry` — the in-memory twin of the source
-  split in `feed_sources/2`, for the entries that arrive live over PubSub rather
+  split in `feed_sources/3`, for the entries that arrive live over PubSub rather
   than through a query.
 
   The split is not "which kind of post" alone: an entry carrying remote content
   is a **vutuv** entry as soon as a member here passed it on (`reposted_by`),
-  whoever that was. See `feed_sources/2` for why.
+  whoever that was. See `feed_sources/3` for why.
   """
   def feed_filter_accepts?(:vutuv, entry),
     do: not remote_feed_entry?(entry) or reshared_here?(entry)

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -302,7 +302,7 @@ defmodule VutuvWeb.PostLive.Feed do
     |> assign(:cal_month, FeedTimeTravel.month_of(day))
     |> assign(:cal_metric, "feed")
     |> assign(:cal_day, day)
-    |> assign_calendar_counts()
+    |> defer_calendar_counts()
     |> assign(:draft, payload.draft)
     # The composer starts collapsed to a single "What's new?" button; posting
     # (own activity arriving below) collapses it again. A stored draft opens it
@@ -1136,7 +1136,7 @@ defmodule VutuvWeb.PostLive.Feed do
         {:noreply,
          socket
          |> assign(:cal_month, FeedTimeTravel.shift_month(socket.assigns.cal_month, value))
-         |> assign_calendar_counts()}
+         |> defer_calendar_counts()}
 
       :error ->
         {:noreply, socket}
@@ -1161,6 +1161,12 @@ defmodule VutuvWeb.PostLive.Feed do
       {:noreply,
        socket
        |> assign(:cal_metric, metric)
+       # Counted here and not deferred, unlike every other way into the
+       # heatmap: `load_day/2` on the next line sizes its page from these
+       # counts (`day_limit/2`), and handing it an empty map would fetch and
+       # decorate the whole-day limit for a day it is about to learn is busy.
+       # Nothing is lost by waiting — this press reloads the timeline under the
+       # calendar anyway, so it is not a press the reader watches do nothing.
        |> assign_calendar_counts()
        |> load_day(socket.assigns.cal_day)}
     end
@@ -1185,9 +1191,9 @@ defmodule VutuvWeb.PostLive.Feed do
   # reading Tuesday, and yanking them back to now would be a second thing they
   # did not ask for. Closing the DAY is what returns to the present.
   def handle_event("cal-toggle", _params, socket) do
-    # Unfolding is what pays for the heatmap: folded, the counts are not
-    # computed at all (see `assign_calendar_counts/1`).
-    {:noreply, socket |> update(:cal_open?, &(!&1)) |> assign_calendar_counts() |> sync_url()}
+    # The press unfolds and answers; the heatmap follows a moment later (see
+    # `defer_calendar_counts/1`). Folded, the counts are not asked for at all.
+    {:noreply, socket |> update(:cal_open?, &(!&1)) |> defer_calendar_counts() |> sync_url()}
   end
 
   # A day is a window, not a moment (`FeedTimeTravel.day_cursor/1`). Pressing
@@ -1519,12 +1525,44 @@ defmodule VutuvWeb.PostLive.Feed do
   # nobody had asked to see — enough to push a connected mount from 18 queries
   # to 28 and cost the mount handoff its whole point. Folded, the card shows a
   # date and needs no numbers; unfolding is what buys them.
-  defp assign_calendar_counts(%{assigns: %{cal_open?: false}} = socket) do
+  #
+  # And unfolding does not WAIT for them. The cheap `:marks` shape got the month
+  # down to well under half of what it cost (the figures are in
+  # `docs/architecture/posts-and-feed.md`), but it is still ~26 queries, and a
+  # press the reader watches do nothing is a slow press whatever the query
+  # count says. So the grid goes out first with everything that does not need
+  # the month in it — the dates, today's ring, the open day, both controls —
+  # and the shading follows in a second render, fading in over
+  # `transition-colors` rather than snapping. On a disconnected render there is
+  # no second render, so nothing is asked at all and the connected mount fills
+  # the grid in.
+  #
+  # A revisited month is asked for again rather than remembered. A memo keyed
+  # on the month would make a fold and unfold free, and would also hand the
+  # reader an hour-old shading of the day they are still in: the numbers are
+  # cheap to re-ask now and nobody sees the asking.
+  defp defer_calendar_counts(socket) do
+    if socket.assigns.cal_open? and connected?(socket) do
+      send(self(), {:cal_counts, calendar_key(socket)})
+    end
+
     socket
     |> assign(:cal_counts, %{})
     |> assign(:cal_capped?, false)
-    |> assign(:cal_earlier?, true)
+    # The one answer worth keeping while the next is in flight: whether the feed
+    # reaches back past this month barely changes from one month to its
+    # neighbour, and the last answer is a better guess than "there is always
+    # more" — which would let the back-step guard (`cal-month`) wave through a
+    # press it is there to refuse. Seeded true on the very first render, where
+    # there is no previous answer to keep.
+    |> assign_new(:cal_earlier?, fn -> true end)
   end
+
+  # Which question a pending heatmap answers. An answer whose question has moved
+  # on is dropped rather than assigned — it would only recompute the month now
+  # on screen, so this saves work rather than preventing a wrong shading, and
+  # only for a reader who out-paces the sweep.
+  defp calendar_key(socket), do: {socket.assigns.cal_month, effective_filter(socket)}
 
   defp assign_calendar_counts(socket) do
     user = socket.assigns.current_user
@@ -1578,6 +1616,14 @@ defmodule VutuvWeb.PostLive.Feed do
 
   # The rule itself, in one place: a day the feed knows to be small arrives
   # whole, a busy one pages.
+  #
+  # It answers for a day the heatmap has not counted yet, too: while the shading
+  # is still in flight (`defer_calendar_counts/1`) every day reads as 0 and
+  # therefore arrives whole. That is the same choice a `/feed?day=…` arrival
+  # makes outright (`feed_payload/3`) and for the same reason — running the
+  # month counter purely to pick between two page sizes costs more than the
+  # larger page does. A quiet day still costs its own size; a busy one opened
+  # inside that window pays a full page instead of a tenth of one.
   defp day_page_limit(total) when total < @day_full_limit, do: @day_full_limit
   defp day_page_limit(_total), do: @travel_page_size
 
@@ -1827,6 +1873,18 @@ defmodule VutuvWeb.PostLive.Feed do
   # collapses with it (the component cannot reach this assign itself).
   def handle_info({:composer_discarded, _id}, socket) do
     {:noreply, assign(socket, :composer_open?, false)}
+  end
+
+  # The month's shading, arriving after the grid it belongs to
+  # (`defer_calendar_counts/1`). Both guards drop work rather than prevent a
+  # wrong answer — the count is taken from the assigns, not from `key`, so a
+  # superseded message would merely recompute the month now on screen.
+  def handle_info({:cal_counts, key}, socket) do
+    if socket.assigns.cal_open? and calendar_key(socket) == key do
+      {:noreply, assign_calendar_counts(socket)}
+    else
+      {:noreply, socket}
+    end
   end
 
   def handle_info(_other, socket), do: {:noreply, socket}

--- a/lib/vutuv_web/live/post_live/feed_calendar.ex
+++ b/lib/vutuv_web/live/post_live/feed_calendar.ex
@@ -180,7 +180,11 @@ defmodule VutuvWeb.PostLive.FeedCalendar do
           title={day_title(cell.date, Map.get(@counts, cell.date, 0), @metric)}
           aria-current={@day && cell.date == @day && "date"}
           class={[
+            # The shading arrives after the grid does (the feed's
+            # `defer_calendar_counts/1`), so it fades in rather than snapping —
+            # a month opens unshaded and colours a moment later.
             "relative flex aspect-square items-center justify-center rounded text-[11px] tabular-nums",
+            "transition-colors",
             "disabled:cursor-not-allowed disabled:opacity-30",
             heat_class(Map.get(@counts, cell.date, 0), @peak),
             !cell.in_month? && "opacity-40",

--- a/test/support/html_helpers.ex
+++ b/test/support/html_helpers.ex
@@ -27,6 +27,22 @@ defmodule VutuvWeb.HTMLHelpers do
   end
 
   @doc """
+  Every element in `html` matching `selector`, as a list.
+
+  For a promise about how many of a thing a page draws, or that it draws none:
+  a substring match cannot tell an element apart from the same class worn by
+  something else on the page. The `Enum.to_list/1` is load-bearing for the same
+  reason it is above — an empty LazyHTML node set is never `== []`, so without
+  it an assertion that nothing matched passes whether or not it did.
+  """
+  def elements(html, selector) do
+    html
+    |> LazyHTML.from_document()
+    |> LazyHTML.query(selector)
+    |> Enum.to_list()
+  end
+
+  @doc """
   The visible text of the first element matching `selector`, whitespace
   trimmed.
 

--- a/test/vutuv/feed_marks_shape_test.exs
+++ b/test/vutuv/feed_marks_shape_test.exs
@@ -1,0 +1,240 @@
+defmodule Vutuv.FeedMarksShapeTest do
+  @moduledoc """
+  The two shapes a feed source can be asked for (`Vutuv.Posts.feed_sources/3`,
+  `shape:` on the source itself): `:entries`, everything a card draws, and
+  `:marks`, the `id` and the `at` a counter needs (`Vutuv.FeedPage.mark/1`).
+
+  The whole point of the cheap shape is that it is the *same rows*: the feed
+  calendar's heatmap is asked to promise that a day it shades busy is a day the
+  timeline really has something on, and the moment the two shapes disagree
+  about which posts reach a reader that promise is broken silently — a wrong
+  shade and a wrong tooltip, with nothing raising and nothing logged.
+
+  Each pair shares one query builder, so what these tests guard is somebody
+  splitting them again: change a `where` in one shape and only one shape moves.
+  The awkward cases are deliberate — a muted server, a follow that is only
+  pending, a boost of a post the reader may not see — because those are the
+  clauses somebody would edit.
+  """
+  use Vutuv.DataCase, async: false
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.PostBoost
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Posts
+
+  @public "https://www.w3.org/ns/activitystreams#Public"
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    :ok
+  end
+
+  defp account(host, actor, handle) do
+    Repo.insert!(%RemoteAccount{
+      actor_uri: actor,
+      host: host,
+      handle: handle,
+      name: handle,
+      inbox_uri: actor <> "/inbox"
+    })
+  end
+
+  defp follow(user, account, state \\ "accepted") do
+    Repo.insert!(%Follow{
+      user_id: user.id,
+      remote_account_id: account.id,
+      state: state,
+      muted: false,
+      follow_activity_id: "https://vutuv.test/#{user.id}/actor#follows/#{account.id}"
+    })
+  end
+
+  defp post_from(actor, id, text, overrides \\ %{}) do
+    :ok =
+      Fediverse.record_remote_post(
+        %{
+          "type" => "Create",
+          "actor" => actor,
+          "object" =>
+            Map.merge(
+              %{
+                "id" => actor <> "/posts/#{id}",
+                "type" => "Note",
+                "attributedTo" => actor,
+                "content" => "<p>#{text}</p>",
+                "published" => "2026-07-20T10:00:00Z",
+                "to" => [@public]
+              },
+              overrides
+            )
+        },
+        actor
+      )
+  end
+
+  defp boost(account, fields) do
+    Repo.insert!(
+      struct(
+        %PostBoost{
+          remote_account_id: account.id,
+          activity_id: account.actor_uri <> "#announces/#{System.unique_integer([:positive])}",
+          announced_at: DateTime.utc_now(:second)
+        },
+        fields
+      )
+    )
+  end
+
+  # The `id` and `at` of every row a source hands over, in the source's own
+  # order — everything the two shapes are required to agree on, and nothing
+  # else. Through `Vutuv.FeedPage.mark/1`, the same projection the cheap shape
+  # itself is defined by, so this cannot re-derive a different one and pass.
+  defp marks(entries), do: Enum.map(entries, &Vutuv.FeedPage.mark/1)
+
+  defp reload(user), do: Repo.get!(Vutuv.Accounts.User, user.id)
+
+  @cap 100
+  @cursor nil
+
+  describe "remote posts" do
+    setup do
+      user = insert(:activated_user, fediverse_followers?: true)
+
+      them = account("social.example", "https://social.example/users/them", "them")
+      quiet = account("quiet.example", "https://quiet.example/users/quiet", "quiet")
+      pending = account("later.example", "https://later.example/users/later", "later")
+
+      follow(user, them)
+      follow(user, quiet)
+      pending_follow = follow(user, pending)
+
+      post_from("https://social.example/users/them", 1, "Von drüben.")
+      # Unlisted, not public: open enough to reach a reader, and the value that
+      # tells a shape reading `audience == "public"` apart from one reading
+      # `audience in open_audiences()`.
+      post_from("https://social.example/users/them", 2, "Leise von drüben.", %{
+        "to" => ["https://social.example/users/them/followers"],
+        "cc" => [@public]
+      })
+
+      post_from("https://quiet.example/users/quiet", 3, "Von woanders.")
+      # Only a follower may read this one, and by the time it is read the
+      # follow is no longer accepted — the clause that drops it (`audience in
+      # open_audiences() or state == "accepted"`) is one both shapes carry. The
+      # follow is demoted *after* the ingest, which refuses a followers-only
+      # post from an account that has not accepted us.
+      post_from("https://later.example/users/later", 4, "Nur für Folgende.", %{
+        "to" => ["https://later.example/users/later/followers"]
+      })
+
+      Repo.update!(Ecto.Changeset.change(pending_follow, state: "pending"))
+
+      %{user: user}
+    end
+
+    test "both shapes name the same rows", %{user: user} do
+      entries = Fediverse.feed_remote_posts(user, @cap, @cursor)
+
+      assert marks(entries) == Fediverse.feed_remote_posts(user, @cap, @cursor, shape: :marks)
+      assert length(entries) == 3
+    end
+
+    test "and still do with a server switched off", %{user: user} do
+      {:ok, _} = Fediverse.set_host_mute(user, "quiet.example", true)
+      user = reload(user)
+
+      entries = Fediverse.feed_remote_posts(user, @cap, @cursor)
+
+      assert marks(entries) == Fediverse.feed_remote_posts(user, @cap, @cursor, shape: :marks)
+      assert length(entries) == 2
+    end
+
+    test "and under a language filter", %{user: user} do
+      {:ok, user} = Vutuv.Accounts.update_user(user, %{feed_languages: ["de"]})
+
+      assert marks(Fediverse.feed_remote_posts(user, @cap, @cursor)) ==
+               Fediverse.feed_remote_posts(user, @cap, @cursor, shape: :marks)
+    end
+
+    test "and when the window cuts them off", %{user: user} do
+      assert marks(Fediverse.feed_remote_posts(user, 1, @cursor)) ==
+               Fediverse.feed_remote_posts(user, 1, @cursor, shape: :marks)
+    end
+  end
+
+  describe "boosts" do
+    setup do
+      user = insert(:activated_user, fediverse_followers?: true)
+      booster = account("social.example", "https://social.example/users/kurator", "kurator")
+      follow(user, booster)
+
+      author = insert(:activated_user, fediverse_followers?: true)
+      Vutuv.Social.follow(user, author.id)
+
+      post_from("https://social.example/users/kurator", 1, "Etwas von dort.")
+      remote = Repo.one!(Vutuv.Fediverse.RemotePost)
+
+      {:ok, open} = Posts.create_post(author, %{body: "Von hier, für alle."})
+
+      # The post the reader may not see. `filter_visible_boosts/2` is what drops
+      # it, in memory, after the query — so it is exactly the case a shape that
+      # skipped the filter would get wrong while every query-level test stayed
+      # green.
+      {:ok, denied} =
+        Posts.create_post(author, %{
+          body: "Nur für wenige.",
+          denials: [%{"denied_user_id" => user.id}]
+        })
+
+      boost(booster, %{remote_post_id: remote.id})
+      boost(booster, %{post_id: open.id})
+      boost(booster, %{post_id: denied.id})
+
+      %{user: user, open: open}
+    end
+
+    test "both shapes name the same rows, and neither carries the hidden one", %{
+      user: user,
+      open: open
+    } do
+      entries = Fediverse.feed_remote_boosts(user, @cap, @cursor, [])
+
+      assert marks(entries) == Fediverse.feed_remote_boosts(user, @cap, @cursor, shape: :marks)
+      assert length(entries) == 2
+      assert Enum.any?(entries, &(&1.post && &1.post.id == open.id))
+    end
+
+    test "and agree on each kind on its own", %{user: user} do
+      for only <- [:local, :remote] do
+        assert marks(Fediverse.feed_remote_boosts(user, @cap, @cursor, only: only)) ==
+                 Fediverse.feed_remote_boosts(user, @cap, @cursor, only: only, shape: :marks)
+      end
+    end
+
+    test "and still do with the booster's server switched off", %{user: user} do
+      {:ok, _} = Fediverse.set_host_mute(user, "social.example", true)
+      user = reload(user)
+
+      assert Fediverse.feed_remote_boosts(user, @cap, @cursor, []) == []
+      assert Fediverse.feed_remote_boosts(user, @cap, @cursor, shape: :marks) == []
+    end
+  end
+
+  describe "the heatmap counts what the timeline shows" do
+    test "a day of remote posts is counted, not guessed", %{} do
+      user = insert(:activated_user, fediverse_followers?: true)
+      them = account("social.example", "https://social.example/users/them", "them")
+      follow(user, them)
+
+      for n <- 1..3, do: post_from("https://social.example/users/them", n, "Beitrag #{n}")
+
+      day = Vutuv.ViewerClock.date(~N[2026-07-20 10:00:00])
+      %{counts: counts} = Posts.feed_activity_by_day(user, day, day)
+
+      assert Map.get(counts, day) == 3
+      assert length(Posts.feed_page(user, limit: 100).entries) == 3
+    end
+  end
+end

--- a/test/vutuv_web/live/feed_calendar_test.exs
+++ b/test/vutuv_web/live/feed_calendar_test.exs
@@ -48,6 +48,26 @@ defmodule VutuvWeb.FeedCalendarTest do
   defp iso(date), do: Date.to_iso8601(date)
   defp days_ago(n), do: Date.add(ViewerClock.today(), -n)
 
+  # Every day cell in `html` the heatmap has put a shade on. Read out of the
+  # parsed document rather than by matching a class anywhere on the page:
+  # `bg-brand-*` is a colour half the feed's controls wear.
+  defp shaded_days(html) do
+    elements(
+      html,
+      ~s([phx-click="cal-day"][class*="bg-brand-1"], [phx-click="cal-day"][class*="bg-brand-3"], [phx-click="cal-day"][class*="bg-brand-5"], [phx-click="cal-day"][class*="bg-brand-7"])
+    )
+  end
+
+  # A day with enough on it to take the heatmap's top step.
+  defp busy_day(author, days_back) do
+    for n <- 1..5 do
+      post = PostsHelpers.create_post!(author, %{body: "busy day post #{n}"})
+      PostsHelpers.backdate_post!(post, days_back * @day + n * 60)
+    end
+
+    days_ago(days_back)
+  end
+
   describe "the calendar" do
     test "a day click shows that day and nothing newer", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
@@ -175,12 +195,7 @@ defmodule VutuvWeb.FeedCalendarTest do
       {conn, user} = create_and_login_user(conn)
       author = feed_with_history(user)
 
-      busy = days_ago(2)
-
-      for n <- 1..5 do
-        post = PostsHelpers.create_post!(author, %{body: "busy day post #{n}"})
-        PostsHelpers.backdate_post!(post, 2 * @day + n * 60)
-      end
+      busy = busy_day(author, 2)
 
       {:ok, view, _html} = live(conn, ~p"/feed")
       render_click(view, "cal-toggle")
@@ -706,6 +721,33 @@ defmodule VutuvWeb.FeedCalendarTest do
       assert timeline(view) == ""
       assert render(view) =~ "Nothing reached your feed on"
       refute timeline(view) =~ "from this morning"
+    end
+  end
+
+  describe "the grid does not wait for its shading" do
+    test "the first render draws the days and shades none of them", %{conn: conn} do
+      # A month of a fediverse-heavy feed is ~26 queries, and paying them inside
+      # the press means the reader clicks the calendar and watches nothing
+      # happen. So the grid goes out with everything that does not need the
+      # month in it and the shading follows in a second render.
+      #
+      # The disconnected render is where that is observable at all: it is a
+      # first render with no second one behind it, so a shaded one is proof the
+      # counting ran on the blocking path.
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+      busy = busy_day(author, 2)
+
+      html = conn |> get(~p"/feed?cal=1") |> html_response(200)
+
+      assert html =~ ~s(phx-value-date="#{iso(busy)}")
+
+      assert shaded_days(html) == [],
+             "the disconnected render paid for a heatmap it has no second render to show"
+
+      # And the socket, which does get a second render, ends up shaded.
+      {:ok, view, _html} = live(conn, ~p"/feed?cal=1")
+      assert has_element?(view, ~s([phx-value-date="#{iso(busy)}"].bg-brand-700))
     end
   end
 


### PR DESCRIPTION
Opening the feed calendar took ~175 ms before the grid appeared, and almost all of it was `Posts.feed_activity_by_day/4` loading a whole month as preloaded structs to produce thirty numbers. Measured on a copy of production (August, `/feed`): 6,142 rows fetched for 3,882 counted entries, 87 ms of it in `Fediverse.feed_remote_posts` alone, only ~24 of which was Postgres.

The two heavy fediverse sources now take a `shape:` option. `:marks` is the same query builder, same `WHERE`, same window, asked for `{id, at}` without a card's preloads, so it cannot disagree about *which* posts are in the feed. And the press no longer waits: `VutuvWeb.PostLive.Feed` renders the grid, then fills the shading in from a `handle_info`.

```
feed_activity_by_day   120-149 ms -> 53-58 ms   (20 -> 16 queries, counts identical)
grid on screen         150-200 ms -> 40 ms      (shading lands at ~130)
```

Judge the second paint on a real phone: a rail popping in read as slowness once before (#1238).

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_017X8HyDAzGmkMfKGZ1BvQYS
