### PR TITLE
fix(tags): a NUL in a topic name no longer takes the query down [5m]

### DIFF
--- a/lib/vutuv/tags/match_key.ex
+++ b/lib/vutuv/tags/match_key.ex
@@ -20,6 +20,16 @@ defmodule Vutuv.Tags.MatchKey do
     call and stays two names for a human to merge.
   - **Strip zero-width characters** before comparing. Two names in the catalog
     differ only by a U+200B: invisible to every reader, distinct to Postgres.
+    A **NUL** is stripped with them and is the one that bites hardest: it is
+    valid UTF-8, Postgres refuses it outright (`22021`), and the key is bound
+    into a `SELECT` — so a name carrying one does not miss its topic, it
+    **raises on the lookup**, which no changeset scrub can reach because
+    nothing has been written yet. A hashtag out of an ActivityPub `tag` array
+    is the path that reached it (issue #1825), and `Tag.find_by_value/1` was
+    the same raise for any other typed value. Only the Elixir side needs it:
+    a stored name can never hold a NUL, since that is the very byte Postgres
+    turned away, so `sql/1` below cannot meet one and the two sides stay in
+    step.
   - **A key with nothing to key on is no key.** A value with no `[a-z0-9]` left
     (`-`, `.`) answers `nil` and matches nothing, rather than bucketing every
     such name into one topic.
@@ -31,8 +41,8 @@ defmodule Vutuv.Tags.MatchKey do
   a Postgres expression for the stored column, so they cannot drift apart.
   """
 
-  # U+200B ZERO WIDTH SPACE, U+200C ZWNJ, U+200D ZWJ, U+FEFF BOM.
-  @zero_width ~r/[\x{200B}\x{200C}\x{200D}\x{FEFF}]/u
+  # NUL, then U+200B ZERO WIDTH SPACE, U+200C ZWNJ, U+200D ZWJ, U+FEFF BOM.
+  @zero_width ~r/[\x{0000}\x{200B}\x{200C}\x{200D}\x{FEFF}]/u
   @separators ~r/[\s_-]+/u
   @keyable ~r/[a-z0-9]/u
 

--- a/lib/vutuv/tags/tag.ex
+++ b/lib/vutuv/tags/tag.ex
@@ -6,6 +6,8 @@ defmodule Vutuv.Tags.Tag do
 
   require Vutuv.Tags.MatchKey
 
+  import Vutuv.ChangesetHelpers, only: [scrub_nul: 1]
+
   alias Vutuv.Accounts.User
   alias Vutuv.Repo
   alias Vutuv.Tags.MatchKey
@@ -104,6 +106,12 @@ defmodule Vutuv.Tags.Tag do
 
   defp shared_validations(changeset) do
     changeset
+    # A tag is remote-fed now — a hashtag out of an ActivityPub `tag` array
+    # mints one — so it needs the write-side guard the fediverse schemas took in
+    # #1767: a NUL is valid UTF-8, Postgres refuses it (22021), and it would
+    # reach the driver on the INSERT. Here rather than at the ingest door, and
+    # after the last cast so what is validated is what is stored (issue #1825).
+    |> scrub_nul()
     |> validate_required([:slug, :name])
     # A tag name is a single line that may contain spaces ("Ruby on Rails"):
     # multi-word tags are first-class again. `normalize_value/1` already
@@ -303,8 +311,19 @@ defmodule Vutuv.Tags.Tag do
   (`Vutuv.Search`) and the `Vutuv.Tags.preview_tag_names/1` batch build the same
   case-insensitive name-or-slug predicate inline, because they compose it into a
   larger query rather than fetching a single row.
+
+  Being that single place is also why the **NUL** comes off here rather than at
+  each caller: the match key is not the only thing bound into the query, the raw
+  value is bound too (`by_match_key/2` ranks an exact hit by it), and half the
+  callers hand over a string a person or another server typed without passing it
+  through `normalize_value/1` first (`Vutuv.Newsletters`, `Vutuv.Jobs`, the job
+  board). Postgres refuses that byte (`22021`), so such a value did not fail to
+  find its topic, it raised — issue #1825, reported as a `Create` delivery that
+  500ed. Dropping it can only help a match: a stored name cannot contain one.
   """
   def find_by_value(value) when is_binary(value) do
+    value = String.replace(value, <<0>>, "")
+
     case MatchKey.normalize(value) do
       nil -> nil
       key -> value |> by_match_key(key) |> follow_alias()

--- a/test/vutuv/hashtag_filing_test.exs
+++ b/test/vutuv/hashtag_filing_test.exs
@@ -284,6 +284,36 @@ defmodule Vutuv.HashtagFilingTest do
       assert Repo.get!(Tag, tag_id).name == name
     end
 
+    test "a NUL inside an AP hashtag name files the post instead of raising" do
+      # The reported delivery (#1825). The key is bound into a SELECT, so the
+      # byte took the query down before any write — see `Vutuv.Tags.MatchKey`
+      # for why it belongs with the zero-width characters.
+      tag = tag_named("berlin")
+      [head, tail] = String.split(tag.slug, "", parts: 2)
+      post = remote_post("Nothing in the text.")
+
+      Hashtags.sync(post, %{
+        "tag" => [%{"type" => "Hashtag", "name" => "#" <> head <> <<0>> <> tail}]
+      })
+
+      assert filed_tag_ids(post) == [tag.id]
+    end
+
+    test "a NUL in a hashtag that mints its tag is gone from the stored name" do
+      # The same delivery down the other branch: nothing answers to the name
+      # yet, so it is written rather than found. End to end on purpose — which
+      # of the two guards broke is what `Vutuv.Tags.TagTest` isolates.
+      name = "Fromoverthere#{System.unique_integer([:positive])}"
+      post = remote_post("Nothing in the text.")
+
+      Hashtags.sync(post, %{
+        "tag" => [%{"type" => "Hashtag", "name" => "#Fromoverthere" <> <<0>> <> name}]
+      })
+
+      assert [tag_id] = filed_tag_ids(post)
+      refute String.contains?(Repo.get!(Tag, tag_id).name, <<0>>)
+    end
+
     test "keeps the casing the AP tag array sent" do
       name = "Gr\u00fcne#{System.unique_integer([:positive])}"
       post = remote_post("Nothing in the text.")

--- a/test/vutuv/tags/separator_lookup_test.exs
+++ b/test/vutuv/tags/separator_lookup_test.exs
@@ -82,6 +82,17 @@ defmodule Vutuv.Tags.SeparatorLookupTest do
       assert id == tag.id
     end
 
+    test "a NUL is invisible too, and would otherwise raise on the lookup itself" do
+      # The same rule as the zero-width case above with a sharper edge: this
+      # one did not miss its topic, it took the query down (#1825). Here the
+      # ranking parameter is the raw value, so the key being clean is not
+      # enough — `find_by_value/1` drops the byte itself.
+      tag = seed("Nul Byte", "nul_byte_")
+
+      assert %Tag{id: id} = Tag.find_by_value(String.replace(tag.name, " ", <<0>> <> " "))
+      assert id == tag.id
+    end
+
     test "a name with nothing to key on matches nothing, rather than grouping" do
       # These normalize to an empty key. Bucketing them would make every one of
       # them the same topic as every other.

--- a/test/vutuv/tags/tag_test.exs
+++ b/test/vutuv/tags/tag_test.exs
@@ -11,6 +11,13 @@ defmodule Vutuv.Tags.TagTest do
       assert get_change(changeset, :slug) == "elixir"
     end
 
+    test "drops a NUL, which Postgres would refuse on the insert" do
+      # The write-side guard on its own, so a red run here names the changeset
+      # rather than the lookup that precedes it on the minting path (#1825).
+      changeset = Tag.changeset(%Tag{}, %{"value" => "Ber" <> <<0>> <> "lin"})
+      assert get_change(changeset, :name) == "Berlin"
+    end
+
     test "keeps a trailing # (C# stays C#)" do
       changeset = Tag.changeset(%Tag{}, %{"value" => "C#"})
       assert get_change(changeset, :name) == "C#"


### PR DESCRIPTION
**Symptom:** a `Create` whose `tag` array holds a Hashtag name with an embedded NUL made the delivery 500 with Postgres `22021` — on the **SELECT** in `Vutuv.Tags.resolution_by_key/1`, before any write, so the changeset scrub from #1813 could not reach it by construction. The sending server then retried the whole batch.

**Change:** the byte comes off at the three places that each own one representation of a tag value — `MatchKey.normalize/1` (the match key, folded into the existing zero-width class, so no extra pass), `Tag.find_by_value/1` (the raw value, which `by_match_key/2` binds separately as its ranking parameter), and `Tag`'s changeset via the existing `ChangesetHelpers.scrub_nul/1` (the stored name). A tag is remote-fed now, so it takes the same write-side guard the fediverse schemas took.

**Not the ingest door:** scrubbing in `hashtag_name/1` would leave `find_by_value/1` raising for `Vutuv.Newsletters`, `Vutuv.Jobs`, the job board and `Tags.Merge`, none of which normalize first.

**Verified:** four tests. Calibrated one guard at a time — each has a test that goes red alone. `mix precommit` green (9,324).

<!-- closing-note #1825 -->
Fixed. You had the mechanism exactly right, including why #1813 could not reach it, so the only thing worth adding is where the fix landed: not in `hashtag_name/1`, but on the three places that each own one representation of a tag value — the match key, the raw value (`by_match_key/2` binds it separately, which the report does not mention), and the changeset. Scrubbing at the ingest door would have left the same raise open for the newsletter, jobs and merge lookups, which is the door-by-door pattern #1813 spent a commit removing.

*An AI agent wrote this text in my name. I know that is problematic.*

Closes #1825.
