### PR TITLE
The feed calendar takes the day rollover instead of sleeping through it

### DIFF
--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -186,6 +186,23 @@ with no reload. Berlin midnight is itself a whole UTC hour, so the one consumer
 that really does count German days — the admin "new members today" pill — still
 empties exactly then.
 
+**Anything that renders a calendar day has to hold it as state, not read the
+clock while rendering.** A clock read inside a component is only ever refreshed
+by a render, and at midnight nothing asks for one: the tick has to change an
+assign or the component is never re-invoked. The feed calendar
+(`VutuvWeb.PostLive.FeedCalendar`) learnt this the hard way — it took its
+`today` from `Vutuv.ViewerClock` inside the card, so a page left open past
+midnight kept yesterday's date in the folded card, kept the today ring on
+yesterday, and **greyed the new day out as a future day**, locking the reader out
+of the day they were in. `today` is an assign the feed owns now
+(`:cal_today`, moved by the same `:day_changed` handler that re-streams the post
+stamps), and the notifications page has always done it this way (`:today` +
+`assign_sections/1`). Rolling the clock over is testable rather than something
+to find out about at midnight: `Vutuv.ViewerClock.today/0` reads
+`:viewer_clock_now` from application env when it is set, which
+`test/vutuv_web/live/feed_calendar_midnight_test.exs` moves (`async: false` — it
+is global, and every timestamp in the app reads it).
+
 The layout is split into `root.html.heex` (document shell) and `app.html.heex`
 (chrome), shared by classic controller pages and LiveViews.
 

--- a/lib/vutuv/viewer_clock.ex
+++ b/lib/vutuv/viewer_clock.ex
@@ -97,7 +97,25 @@ defmodule Vutuv.ViewerClock do
   def date(at), do: at |> naive() |> NaiveDateTime.to_date()
 
   @doc "Today, as this viewer's calendar day."
-  def today, do: date(DateTime.utc_now())
+  def today, do: date(now())
+
+  # The instant every calendar day here is read off, and the one seam a test has
+  # for moving it. A feature gated on the wall clock that only ever reads the
+  # real one passes all day and fails at night — and the day rollover this
+  # feeds (`Vutuv.DayClock` -> the feed calendar's today ring, its folded date
+  # and its future-day gate) is exactly such a feature: waiting until midnight
+  # is not a test.
+  #
+  # Application env rather than the process dictionary the rest of this module
+  # uses, because the process that has to see the moved clock is a LiveView, not
+  # the test's own. Unset in every other environment, so production pays one
+  # ETS read.
+  defp now do
+    case Application.get_env(:vutuv, :viewer_clock_now) do
+      %DateTime{} = at -> at
+      _unset -> DateTime.utc_now()
+    end
+  end
 
   @doc """
   One of this viewer's calendar days as the pair of UTC naive instants that

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -45,6 +45,7 @@ defmodule VutuvWeb.PostLive.Feed do
   alias Vutuv.Posts.Post
   alias Vutuv.Social
   alias Vutuv.Tags.UserTag
+  alias Vutuv.ViewerClock
   alias VutuvWeb.Live.DayClockRestream
   alias VutuvWeb.Live.FeedTimeTravel
   alias VutuvWeb.Live.InitAssigns
@@ -302,6 +303,11 @@ defmodule VutuvWeb.PostLive.Feed do
     |> assign(:cal_month, FeedTimeTravel.month_of(day))
     |> assign(:cal_metric, "feed")
     |> assign(:cal_day, day)
+    # The reader's own calendar day, held as state rather than read inside the
+    # card: it decides the date the folded card shows, which cell wears the
+    # today ring and which cells are refused as future, and a page left open
+    # past midnight has to be told. `:day_changed` below moves it.
+    |> assign(:cal_today, ViewerClock.today())
     |> defer_calendar_counts()
     |> assign(:draft, payload.draft)
     # The composer starts collapsed to a single "What's new?" button; posting
@@ -1800,8 +1806,18 @@ defmodule VutuvWeb.PostLive.Feed do
   # shown post's stamp so "today" wording becomes "Gestern" and yesterday's
   # falls back to a full date. Shared with notifications + the saved hub; see
   # VutuvWeb.Live.DayClockRestream.
+  # `Vutuv.DayClock` ticks on every whole UTC hour, which is when some reader's
+  # midnight falls. Two things on this page are written in calendar days and
+  # both have to move: every post stamp ("09:50 Uhr" becomes "Gestern, 09:50
+  # Uhr"), and the calendar, whose today ring, folded date and future-day gate
+  # would otherwise hold yesterday until the next reload — with the new day's
+  # own cell greyed out, so the reader could not even click their way back to
+  # it.
   def handle_info(:day_changed, socket) do
-    {:noreply, DayClockRestream.restream(socket, :entries, :posts)}
+    {:noreply,
+     socket
+     |> assign(:cal_today, ViewerClock.today())
+     |> DayClockRestream.restream(:entries, :posts)}
   end
 
   # A post's link screenshot finished capturing (fan-out reaches the viewer over
@@ -2657,6 +2673,7 @@ defmodule VutuvWeb.PostLive.Feed do
                 metric={@cal_metric}
                 counts={@cal_counts}
                 capped?={@cal_capped?}
+                today={@cal_today}
               />
             </div>
 
@@ -2791,7 +2808,7 @@ defmodule VutuvWeb.PostLive.Feed do
           <.card :if={@empty? && !at_now?(assigns)} class="text-center">
             <p class="text-slate-600 dark:text-slate-400">
               {gettext("Nothing reached your feed on %{day}.",
-                day: Vutuv.ViewerClock.format(@cal_day, :date)
+                day: ViewerClock.format(@cal_day, :date)
               )}
             </p>
             <.button phx-click="travel-now" class="mt-3">{gettext("Back to now")}</.button>
@@ -2881,6 +2898,7 @@ defmodule VutuvWeb.PostLive.Feed do
             metric={@cal_metric}
             counts={@cal_counts}
             capped?={@cal_capped?}
+            today={@cal_today}
           />
 
           <%!-- Every card is dragged by its own grip and the hook pushes the

--- a/lib/vutuv_web/live/post_live/feed_calendar.ex
+++ b/lib/vutuv_web/live/post_live/feed_calendar.ex
@@ -63,11 +63,26 @@ defmodule VutuvWeb.PostLive.FeedCalendar do
   attr(:capped?, :boolean, default: false)
   attr(:class, :string, default: nil)
 
+  attr(
+    :today,
+    :any,
+    required: true,
+    doc: """
+    The reader's calendar day. Passed in rather than read from
+    `Vutuv.ViewerClock` here, because it decides three things that go stale on a
+    page left open past midnight — the date this card shows folded, which cell
+    wears the today ring, and which cells are refused as future — and a clock
+    read at render time is only ever refreshed by a render, which nothing asks
+    for at midnight. As an assign it is state the feed owns and the
+    `Vutuv.DayClock` tick can move (`VutuvWeb.PostLive.Feed`), which is what
+    makes the rollover reach an open page.
+    """
+  )
+
   def feed_calendar(assigns) do
     assigns =
       assign(assigns,
         cells: FeedTimeTravel.month_grid(assigns.month),
-        today: Vutuv.ViewerClock.today(),
         peak: assigns.counts |> Map.values() |> Enum.max(fn -> 0 end)
       )
 
@@ -144,14 +159,14 @@ defmodule VutuvWeb.PostLive.FeedCalendar do
           :if={@open?}
           n={1}
           label={gettext("Next month")}
-          disabled={at_this_month?(@month)}
+          disabled={at_this_month?(@month, @today)}
         />
         <.month_arrow
           :if={@open?}
           n={12}
           label={gettext("Next year")}
           wide
-          disabled={at_this_month?(@month)}
+          disabled={at_this_month?(@month, @today)}
         />
 
         <%!-- Folded and away from today, the way back has to be on the one line
@@ -327,8 +342,11 @@ defmodule VutuvWeb.PostLive.FeedCalendar do
     """
   end
 
-  defp at_this_month?(month),
-    do: Date.compare(month, FeedTimeTravel.month_of(nil)) != :lt
+  # From the `today` above rather than from the clock, so that on the night a
+  # month rolls over the forward arrows unlock with the rest of the card instead
+  # of holding the reader in last month until they reload.
+  defp at_this_month?(month, today),
+    do: Date.compare(month, FeedTimeTravel.month_of(today)) != :lt
 
   # Five steps, GitHub's scale, keyed to the busiest day of the month SHOWN
   # rather than to a fixed count. An absolute scale would paint a normal month

--- a/test/vutuv_web/live/feed_calendar_midnight_test.exs
+++ b/test/vutuv_web/live/feed_calendar_midnight_test.exs
@@ -1,0 +1,110 @@
+defmodule VutuvWeb.FeedCalendarMidnightTest do
+  @moduledoc """
+  The reader's day rolling over under a page that is already open.
+
+  `Vutuv.DayClock` broadcasts on every whole UTC hour, which is when somebody's
+  midnight falls, and the feed has listened to it for as long as post stamps
+  have said "Gestern". The calendar did not: it read the clock inside the card,
+  where only a render can refresh it and nothing asks for one at midnight. What
+  that cost was not merely a stale date — the new day's own cell stayed greyed
+  out as a future day, so the reader could not click their way into the day they
+  were in.
+
+  `async: false`, and its own file: these tests move `:viewer_clock_now`, which
+  is application env the SQL sandbox does not roll back and **every** timestamp
+  in the app reads (`Vutuv.ViewerClock.today/0`, so post stamps and the
+  notifications sections too). A concurrent test would see the moved clock.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.PostsHelpers
+  alias Vutuv.Social
+  alias Vutuv.ViewerClock
+
+  defp feed_with_history(viewer) do
+    author = insert(:activated_user)
+    Social.follow(viewer, author.id)
+
+    post = PostsHelpers.create_post!(author, %{body: "from this morning"})
+    PostsHelpers.backdate_post!(post, 3_600)
+
+    author
+  end
+
+  # Moves the clock every calendar day in the app is read off, and puts it back.
+  #
+  # `fetch_env/2` and not `get_env/2`: the latter answers `nil` both for
+  # "absent" and for "holds nil", so a naive restore writes `nil` back as a real
+  # value and every later reader gets it instead of the real clock.
+  defp travel_to(%DateTime{} = at) do
+    original = Application.fetch_env(:vutuv, :viewer_clock_now)
+    Application.put_env(:vutuv, :viewer_clock_now, at)
+
+    on_exit(fn ->
+      case original do
+        {:ok, was} -> Application.put_env(:vutuv, :viewer_clock_now, was)
+        :error -> Application.delete_env(:vutuv, :viewer_clock_now)
+      end
+    end)
+  end
+
+  defp tick(view) do
+    send(view.pid, :day_changed)
+    render(view)
+  end
+
+  defp calendar(view), do: render(element(view, "#feed-calendar-rail"))
+  defp iso(date), do: Date.to_iso8601(date)
+
+  describe "the day rolls over under an open page" do
+    setup %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      feed_with_history(user)
+
+      today = ViewerClock.today()
+      %{conn: conn, today: today, tomorrow: Date.add(today, 1)}
+    end
+
+    test "the folded card takes the new date", ctx do
+      {:ok, view, _html} = live(ctx.conn, ~p"/feed")
+
+      assert calendar(view) =~ ViewerClock.format(ctx.today, :date)
+
+      travel_to(DateTime.add(DateTime.utc_now(), 1, :day))
+      tick(view)
+
+      assert calendar(view) =~ ViewerClock.format(ctx.tomorrow, :date)
+      refute calendar(view) =~ ViewerClock.format(ctx.today, :date)
+    end
+
+    test "the new day stops being a future day nobody may click", ctx do
+      # The one that is not merely cosmetic: the grid refuses a day it reads as
+      # future, so before the rollover reached the card the reader was locked
+      # out of the very day they were in.
+      {:ok, view, _html} = live(ctx.conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+
+      assert has_element?(view, ~s([phx-value-date="#{iso(ctx.tomorrow)}"][disabled]))
+
+      travel_to(DateTime.add(DateTime.utc_now(), 1, :day))
+      tick(view)
+
+      refute has_element?(view, ~s([phx-value-date="#{iso(ctx.tomorrow)}"][disabled]))
+    end
+
+    test "the today ring moves with it", ctx do
+      {:ok, view, _html} = live(ctx.conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+
+      assert has_element?(view, ~s([phx-value-date="#{iso(ctx.today)}"].ring-slate-400))
+
+      travel_to(DateTime.add(DateTime.utc_now(), 1, :day))
+      tick(view)
+
+      assert has_element?(view, ~s([phx-value-date="#{iso(ctx.tomorrow)}"].ring-slate-400))
+      refute has_element?(view, ~s([phx-value-date="#{iso(ctx.today)}"].ring-slate-400))
+    end
+  end
+end


### PR DESCRIPTION
A `/feed` tab left open past midnight kept yesterday in the calendar. `Vutuv.DayClock` has broadcast `:day_changed` hourly for a long time and the feed already listens, but only to re-stream post stamps — `VutuvWeb.PostLive.FeedCalendar` read its `today` from `Vutuv.ViewerClock` inside the card, and a clock read while rendering is only refreshed by a render, which nothing asks for at midnight.

Not just a stale date. The today ring stayed on yesterday, and the new day's cell stayed `disabled` as a future day, so the reader was locked out of the day they were in; on a month rollover the forward arrows stayed greyed too.

`today` is now an assign the feed owns (`:cal_today`), passed into the card and moved by the same `:day_changed` handler. That is the shape `/notifications` has always used.

`ViewerClock.today/0` also gained a config seam (`:viewer_clock_now`), because a wall-clock bug that only shows at midnight is not otherwise testable. Three tests, calibrated — without the refresh they fail.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_017X8HyDAzGmkMfKGZ1BvQYS
