### PR TITLE
Calendar test fixtures anchor their posts inside the target day

### DIFF
--- a/test/support/posts_helpers.ex
+++ b/test/support/posts_helpers.ex
@@ -8,6 +8,7 @@ defmodule Vutuv.PostsHelpers do
   alias Vutuv.Posts.PostLike
   alias Vutuv.Posts.PostRepost
   alias Vutuv.Repo
+  alias Vutuv.ViewerClock
 
   @doc """
   Creates a post for `author`, unwrapping the `{:ok, post}` tuple so tests can
@@ -28,6 +29,31 @@ defmodule Vutuv.PostsHelpers do
   """
   def backdate_post!(post, seconds) do
     at = NaiveDateTime.add(NaiveDateTime.utc_now(:second), -seconds)
+    Repo.update_all(from(p in Post, where: p.id == ^post.id), set: [inserted_at: at])
+    %{post | inserted_at: at}
+  end
+
+  @doc """
+  Puts `post` **inside** `date`, the viewer's calendar day, `index` seconds
+  before that day's midday — so a batch placed this way is ordered (index 1 the
+  newest) and every member of it really is on the day the test then opens.
+
+  Reach for this instead of `backdate_post!/2` whenever the test asserts on a
+  **day**. "Three days and a bit more ago" subtracts the bit more from the
+  current *time of day*, so a fixture spreading sixty posts over an hour walks
+  the tail of that batch into the day before whenever the suite runs in the hour
+  after the reader's midnight: green all day, red at 00:06, and read as a flake
+  rather than as the arithmetic it is. Midday is the safe anchor, no offset a
+  fixture plausibly spreads over reaches either edge of the day from there.
+
+  The day is the **viewer's** (`Vutuv.ViewerClock.day_window/1`), the same clock
+  the feed calendar counts and shades by, so the placement and the assertion
+  cannot disagree about which day a post is on.
+  """
+  def place_post_on_day!(post, %Date{} = date, index \\ 0) do
+    {day_start, _day_end} = ViewerClock.day_window(date)
+    at = NaiveDateTime.add(day_start, 12 * 60 * 60 - index, :second)
+
     Repo.update_all(from(p in Post, where: p.id == ^post.id), set: [inserted_at: at])
     %{post | inserted_at: at}
   end

--- a/test/vutuv_web/live/feed_calendar_test.exs
+++ b/test/vutuv_web/live/feed_calendar_test.exs
@@ -60,12 +60,14 @@ defmodule VutuvWeb.FeedCalendarTest do
 
   # A day with enough on it to take the heatmap's top step.
   defp busy_day(author, days_back) do
+    day = days_ago(days_back)
+
     for n <- 1..5 do
       post = PostsHelpers.create_post!(author, %{body: "busy day post #{n}"})
-      PostsHelpers.backdate_post!(post, days_back * @day + n * 60)
+      PostsHelpers.place_post_on_day!(post, day, n)
     end
 
-    days_ago(days_back)
+    day
   end
 
   describe "the calendar" do
@@ -110,7 +112,7 @@ defmodule VutuvWeb.FeedCalendarTest do
 
       for n <- 1..120 do
         post = PostsHelpers.create_post!(author, %{body: "day three post #{n}"})
-        PostsHelpers.backdate_post!(post, 3 * @day + n * 10)
+        PostsHelpers.place_post_on_day!(post, days_ago(3), n)
       end
 
       {:ok, view, _html} = live(conn, ~p"/feed")
@@ -218,10 +220,10 @@ defmodule VutuvWeb.FeedCalendarTest do
 
       day = days_ago(2)
       parent = PostsHelpers.create_post!(author, %{body: "thread root"})
-      PostsHelpers.backdate_post!(parent, 2 * @day + 300)
+      PostsHelpers.place_post_on_day!(parent, day, 300)
 
       reply = PostsHelpers.create_post!(author, %{body: "thread reply", parent_id: parent.id})
-      PostsHelpers.backdate_post!(reply, 2 * @day + 60)
+      PostsHelpers.place_post_on_day!(reply, day, 60)
 
       %{counts: counts} = Posts.feed_activity_by_day(user, day, day)
       counted = Map.get(counts, day, 0)
@@ -458,7 +460,7 @@ defmodule VutuvWeb.FeedCalendarTest do
 
       for n <- 1..12 do
         post = PostsHelpers.create_post!(author, %{body: "quiet day post #{n}"})
-        PostsHelpers.backdate_post!(post, 3 * @day + n * 60)
+        PostsHelpers.place_post_on_day!(post, days_ago(3), n)
       end
 
       {:ok, view, _html} = live(conn, ~p"/feed")
@@ -477,7 +479,7 @@ defmodule VutuvWeb.FeedCalendarTest do
 
       for n <- 1..120 do
         post = PostsHelpers.create_post!(author, %{body: "busy day post #{n}"})
-        PostsHelpers.backdate_post!(post, 3 * @day + n * 10)
+        PostsHelpers.place_post_on_day!(post, days_ago(3), n)
       end
 
       {:ok, view, _html} = live(conn, ~p"/feed")
@@ -498,7 +500,7 @@ defmodule VutuvWeb.FeedCalendarTest do
 
       for n <- 1..120 do
         post = PostsHelpers.create_post!(author, %{body: "busy day post #{n}"})
-        PostsHelpers.backdate_post!(post, 3 * @day + n * 10)
+        PostsHelpers.place_post_on_day!(post, days_ago(3), n)
       end
 
       {:ok, view, _html} = live(conn, ~p"/feed")
@@ -585,9 +587,9 @@ defmodule VutuvWeb.FeedCalendarTest do
       author = feed_with_history(user)
 
       mine = PostsHelpers.create_post!(user, %{body: "mine on that day"})
-      PostsHelpers.backdate_post!(mine, 3 * @day)
+      PostsHelpers.place_post_on_day!(mine, days_ago(3), 0)
       theirs = PostsHelpers.create_post!(author, %{body: "theirs on that day"})
-      PostsHelpers.backdate_post!(theirs, 3 * @day + 60)
+      PostsHelpers.place_post_on_day!(theirs, days_ago(3), 60)
 
       {:ok, view, _html} = live(conn, ~p"/feed")
       render_click(view, "cal-toggle")
@@ -883,7 +885,7 @@ defmodule VutuvWeb.FeedCalendarTest do
       # would prove nothing.
       for n <- 1..60 do
         post = PostsHelpers.create_post!(author, %{body: "quiet day post #{n}"})
-        PostsHelpers.backdate_post!(post, 3 * @day + n * 60)
+        PostsHelpers.place_post_on_day!(post, days_ago(3), n)
       end
 
       {:ok, view, _html} = live(conn, ~p"/feed?day=#{iso(days_ago(3))}")
@@ -995,7 +997,7 @@ defmodule VutuvWeb.FeedCalendarTest do
 
       for n <- 1..120 do
         post = PostsHelpers.create_post!(author, %{body: "busy day post #{n}"})
-        PostsHelpers.backdate_post!(post, 3 * @day + n * 10)
+        PostsHelpers.place_post_on_day!(post, days_ago(3), n)
       end
 
       conn = conn |> recycle() |> put_req_header("accept-language", "de-DE,de")


### PR DESCRIPTION
Eight tests in `VutuvWeb.FeedCalendarTest` go red in the first hour after local midnight. It is arithmetic, not flakiness: `backdate_post!(post, 3 * @day + n * 60)` places a post at `now - 3 days - n minutes`, and the `n * 60` comes off the current **time of day** — so a batch spreading sixty posts over an hour walks its tail into the day before, while the test opens `days_ago(3)`.

Not `Date.utc_today()`: the file builds its dates from `ViewerClock.today()`, which is right. The window is the first hour after the installation's midnight, not 22:00–24:00 UTC.

`PostsHelpers.place_post_on_day!/3` anchors a post at the **midday of the target day** instead of counting back from now, so placement no longer depends on the time of day at all. Measured in the window: 6 red at 00:06, all 59 green at 00:11, full `precommit` clean at 00:20.

Blocks nothing in production — `main`'s deploy is green; this only reddens PR runs opened in that hour.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_017X8HyDAzGmkMfKGZ1BvQYS
