### PR TITLE
docs: point the push comments at the module that holds the code

### DIFF
--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -711,7 +711,8 @@ url means here. A client following it attaches a photo that has already cleared
 the scan. The window above belongs to clients that post immediately with a
 freshly uploaded id.
 
-**Push** is RFC 8291/8292 Web Push, implemented in `Vutuv.MastodonApi.WebPush`
+**Push** is RFC 8291/8292 Web Push, implemented in `Vutuv.WebPush` (the
+adapter's own `Vutuv.MastodonApi.WebPush` adds nothing but its on/off gate)
 with **no dependency**: the obvious hex package requires `httpoison ~> 1.0`,
 which this project bans, and has not shipped since 2021 — everything needed is
 in OTP's `:crypto`, and delivery goes through `Req` like every other outbound

--- a/lib/vutuv_web/controllers/mastodon_api/push_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/push_controller.ex
@@ -5,14 +5,14 @@ defmodule VutuvWeb.MastodonApi.PushController do
 
   Keyed on the access token, so one device is one subscription and revoking the
   app takes it with it. `subscription[standard]` rides along and decides which
-  content encoding the pushes to this device use; `Vutuv.MastodonApi.WebPush`
-  owns what that means and why leaving it out is the useful default.
+  content encoding the pushes to this device use; `Vutuv.WebPush` owns what
+  that means and why leaving it out is the useful default.
 
   The `server_key` a client needs to build the browser subscription is this
-  installation's VAPID public key, which every installation has (`WebPush`
-  derives one where the operator pinned none). Only an installation that
-  switched push off answers 403, rather than accepting a subscription that could
-  never be delivered to.
+  installation's VAPID public key, which every installation has
+  (`Vutuv.WebPush` derives one where the operator pinned none). Only an
+  installation that switched push off answers 403, rather than accepting a
+  subscription that could never be delivered to.
   """
 
   use VutuvWeb, :controller
@@ -103,7 +103,7 @@ defmodule VutuvWeb.MastodonApi.PushController do
        # Written on every create and never left over from the row this one
        # replaces: the same device can be resubscribed by a client that has
        # since learned the standard encoding, or by an older build that has
-       # not. Absent reads as false — see `Vutuv.MastodonApi.WebPush`.
+       # not. Absent reads as false — see `Vutuv.WebPush`.
        "standard" => subscription["standard"]
      }}
   end


### PR DESCRIPTION
**Symptom:** two comments in `VutuvWeb.MastodonApi.PushController` send the reader to `Vutuv.MastodonApi.WebPush` to learn what the two content encodings mean and why the default is what it is. That module is a 37-line delegator (`enabled?`, `public_key`, `send`, `push`, each forwarding one line). `content_encoding/1`, both `encode_body/4` branches and `encrypt_aesgcm/5` live in `Vutuv.WebPush`.

**Change:** name `Vutuv.WebPush` in those two comments and in the VAPID sentence beside them. `docs/architecture/mastodon-api.md` made the same claim about where push is implemented, so it is corrected too, keeping the delegator named for what it actually does.

Comment and documentation text only, no code. Follow-up to #1771.

*An AI agent wrote this text in my name. I know that is problematic.*
