### PR TITLE
Let an embedded LiveView reach the toast tray, and make three selects fit their content

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1687,12 +1687,17 @@ const TOAST_DISMISS_MS = 3000
 function wireToast(el) {
   if (!once(el, "toast")) return
 
+  // Both ways out go through the close button, because on a LiveView page its
+  // phx-click="lv:clear-flash" also clears the server-side flash — without that
+  // a later patch resurrects the dismissed toast, and the very same sentence
+  // never draws a toast a second time. Which is why the detach waits for the
+  // NEXT tick: LiveView listens for phx-click on the window, so it sees the ×
+  // only while the toast is still in the document.
   const closeBtn = el.querySelector("[data-toast-close]")
-  if (closeBtn) closeBtn.addEventListener("click", () => el.remove())
+  if (closeBtn) {
+    closeBtn.addEventListener("click", () => setTimeout(() => el.remove()))
+  }
 
-  // Click the close button instead of removing the node directly: on LiveView
-  // pages the button's phx-click="lv:clear-flash" clears the server-side flash
-  // too, so a later LiveView patch can't resurrect the dismissed toast.
   setTimeout(() => (closeBtn ? closeBtn.click() : el.remove()), TOAST_DISMISS_MS)
 }
 
@@ -1702,16 +1707,19 @@ function setupToasts() {
 
   tray.querySelectorAll(".toast").forEach(wireToast)
 
+  // `subtree`, not just the tray's own children: an embedded LiveView reaches
+  // the tray through `<.portal>` (LayoutHTML.embedded_flash), which lands its
+  // toasts one wrapper deep.
   if (once(tray, "toastObserver")) {
     new MutationObserver((mutations) => {
       mutations.forEach((m) =>
         m.addedNodes.forEach((node) => {
-          if (node.nodeType === 1 && node.classList.contains("toast")) {
-            wireToast(node)
-          }
+          if (node.nodeType !== 1) return
+          if (node.classList.contains("toast")) wireToast(node)
+          node.querySelectorAll(".toast").forEach(wireToast)
         })
       )
-    }).observe(tray, { childList: true })
+    }).observe(tray, { childList: true, subtree: true })
   }
 }
 

--- a/lib/vutuv_web/components/saved_search_components.ex
+++ b/lib/vutuv_web/components/saved_search_components.ex
@@ -93,7 +93,11 @@ defmodule VutuvWeb.SavedSearchComponents do
         <span class="text-sm font-medium text-slate-700 dark:text-slate-200">
           {gettext("Email me")}:
         </span>
-        <select name="notify" class={[input_class(), "w-auto py-1.5 text-sm"]} aria-label={gettext("Alert frequency")}>
+        <select
+          name="notify"
+          class={[narrow_input_class(), "py-1.5 text-sm"]}
+          aria-label={gettext("Alert frequency")}
+        >
           <option :for={{label, value} <- cadence_options()} value={value}>{label}</option>
         </select>
         <button

--- a/lib/vutuv_web/components/ui.ex
+++ b/lib/vutuv_web/components/ui.ex
@@ -81,11 +81,30 @@ defmodule VutuvWeb.UI do
   input recipe (full width, rounded, slate border, brand focus ring, dark-aware).
   The single source for the post composer, the auth pages and any green-field
   form, so the field look stays consistent. Compose with utilities via a list,
-  e.g. `class={[input_class(), "resize-y"]}`.
+  e.g. `class={[input_class(), "resize-y"]}`. A control that should be only as
+  wide as its content takes `narrow_input_class/0` — appending `w-auto` here
+  does not work, and that function says why.
   """
   def input_class do
     "w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-3 focus:ring-brand-500/40 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
   end
+
+  @doc """
+  `input_class/0` for a control that should be as wide as the word it holds —
+  a two-option select, a unit picker — rather than the whole line.
+
+  A function and not two utilities at the call site, because the pair is not
+  guessable. `input_class/0` opens with `w-full`, and Tailwind emits `.w-auto`
+  *before* `.w-full`, so a plain appended `w-auto` loses to the very class it
+  was appended to no matter which order the call site writes them in: the
+  control silently draws the full width of its container. The `!` is what wins
+  (a variant like `sm:w-auto` wins on its own, its rules coming after the bare
+  ones), and `max-w-full` keeps a long option from then pushing past a narrow
+  column. Three forms asked the losing way for months.
+
+  Compose further utilities the same way: `[narrow_input_class(), "text-sm"]`.
+  """
+  def narrow_input_class, do: [input_class(), "w-auto! max-w-full"]
 
   @doc """
   Like `input_class/0`, but aware of a specific field's validation state: once
@@ -1650,11 +1669,13 @@ defmodule VutuvWeb.UI do
           >
             <.card_menu_item_body item={item} />
           </button>
+          <%!-- `|| "get"` for the same reason `button/1` defaults it so; a
+          slot attribute cannot carry a `:default`, so it is normalised here. --%>
           <.link
             :if={!item[:click]}
             id={item[:id]}
             href={item[:href]}
-            method={item[:method]}
+            method={item[:method] || "get"}
             target={item[:target]}
             rel={item[:rel]}
             data-confirm={item[:confirm]}
@@ -2459,7 +2480,11 @@ defmodule VutuvWeb.UI do
   attr(:navigate, :string, default: nil)
   attr(:patch, :string, default: nil)
   attr(:href, :string, default: nil)
-  attr(:method, :string, default: nil)
+  # `"get"`, not nil: `<.link>` reads any other method as a CSRF form post, so a
+  # nil made every plain `<.button href=…>` carry a `data-csrf` and a `data-to`
+  # it never uses — and made that token generation raise wherever the render
+  # happens off the request process.
+  attr(:method, :string, default: "get")
   attr(:type, :string, default: nil)
   attr(:class, :string, default: nil)
 

--- a/lib/vutuv_web/live/organization_live/domains.ex
+++ b/lib/vutuv_web/live/organization_live/domains.ex
@@ -261,7 +261,7 @@ defmodule VutuvWeb.OrganizationLive.Domains do
             class={input_class()}
           />
           <div class="flex flex-wrap items-center gap-3">
-            <select name="method" class={[input_class(), "w-auto"]}>
+            <select name="method" class={narrow_input_class()}>
               <option value="dns" selected={@new_method == "dns"}>{gettext("DNS TXT record")}</option>
               <option value="well_known" selected={@new_method == "well_known"}>{gettext("Website file")}</option>
             </select>

--- a/lib/vutuv_web/live/organization_live/edit.ex
+++ b/lib/vutuv_web/live/organization_live/edit.ex
@@ -413,7 +413,7 @@ defmodule VutuvWeb.OrganizationLive.Edit do
             placeholder={gettext("Alternative name")}
             class={[input_class(), "flex-1"]}
           />
-          <select name="kind" class={[input_class(), "w-auto"]}>
+          <select name="kind" class={narrow_input_class()}>
             <option value="alias" selected={@alias_kind == "alias"}>{gettext("Alias")}</option>
             <option value="brand" selected={@alias_kind == "brand"}>{gettext("Brand")}</option>
             <option value="abbreviation" selected={@alias_kind == "abbreviation"}>{gettext("Abbreviation")}</option>

--- a/lib/vutuv_web/live/organization_live/show.ex
+++ b/lib/vutuv_web/live/organization_live/show.ex
@@ -418,9 +418,10 @@ defmodule VutuvWeb.OrganizationLive.Show do
   # a publisher who had pressed "Load more" to page one. The offset moves with
   # the list so the next "Load more" does not hand back the row above it.
   #
-  # No flash: this page is embedded with `live_render` and the flash container
-  # lives in the controller's layout, so a `put_flash/3` here renders nowhere.
-  # The post arriving at the head of the list is the confirmation anyway.
+  # No flash, by choice rather than by constraint: this page IS the LiveView the
+  # controller renders (`ControllerHelpers.render_live/3`), so it brings the app
+  # layout and its toast tray itself and a `put_flash/3` here would show. The
+  # post arriving at the head of the list is the better confirmation.
   def handle_info({:composer_published, post}, socket) do
     viewer = socket.assigns.current_user
 

--- a/lib/vutuv_web/live/post_live/composer.ex
+++ b/lib/vutuv_web/live/post_live/composer.ex
@@ -2077,18 +2077,12 @@ defmodule VutuvWeb.PostLive.Composer do
   end
 
   # The composer's three small selects — licence, download, language — all want
-  # the same thing: a control the width of its own content, 36px high to sit
-  # level with the Post button, on the shared input recipe.
-  #
-  # `w-auto!` and not `w-auto`, which is the whole reason this is a function.
-  # `input_class/0` opens with `w-full`, and Tailwind emits `.w-auto` BEFORE
-  # `.w-full`, so the plain utility loses to the very class it is appended to no
-  # matter which order the call site writes them in. Two of these three selects
-  # had been asking for `w-auto` and silently rendering full-width since they
-  # were written; the language one drew 260px to hold the word "DE", which is
-  # what left the bottom row nothing to wrap into on a narrow column.
-  defp compact_select_class,
-    do: [input_class(), "h-9 w-auto! max-w-full py-0 text-sm"]
+  # the same thing: a control the width of its own content
+  # (`narrow_input_class/0`, which explains why that takes a `!`), 36px high so
+  # it sits level with the Post button. The language one used to draw 260px to
+  # hold the word "DE", which left the bottom row nothing to wrap into on a
+  # narrow column.
+  defp compact_select_class, do: [narrow_input_class(), "h-9 py-0 text-sm"]
 
   # What the folded details row says a visitor may save — the same wording
   # the download select's options use, so the fold and the open control can

--- a/lib/vutuv_web/live/post_live/remote_actions_component.ex
+++ b/lib/vutuv_web/live/post_live/remote_actions_component.ex
@@ -34,10 +34,10 @@ defmodule VutuvWeb.PostLive.RemoteActionsComponent do
   by one on the same path (`Vutuv.Fediverse`), which is why the change survives a
   reload rather than living in this socket.
 
-  A refusal is explained **here**, inline under the bar, rather than as a flash.
-  Two of the hosts are embedded LiveViews whose flash never reaches the toast
-  tray in the dead layout, so a `put_flash/3` would be swallowed on exactly the
-  page where the reply card lives.
+  A refusal is explained **here**, inline under the bar, rather than as a flash:
+  it is about this one card, and the reader's eye is on it. (An embedded host
+  *can* toast — `VutuvWeb.LayoutHTML.embedded_flash/1` portals its flash into the
+  layout's tray — so this is a placement choice, not a constraint.)
   """
   use VutuvWeb, :live_component
 

--- a/lib/vutuv_web/live/post_live/thread.ex
+++ b/lib/vutuv_web/live/post_live/thread.ex
@@ -329,8 +329,9 @@ defmodule VutuvWeb.PostLive.Thread do
   end
 
   # The outcome is shown as an inline notice above the conversation, not as a
-  # toast: this is an **embedded** LiveView and the toast tray lives in the dead
-  # app layout, so a `put_flash/3` here would never reach the screen.
+  # toast: a refusal belongs next to the reply it is about. (An embedded
+  # LiveView *can* toast — `LayoutHTML.embedded_flash/1` portals its flash into
+  # the layout's tray — so this is a placement choice, not a constraint.)
   #
   # A successful takedown says so by the card vanishing, which is why it clears
   # the notice rather than setting one.

--- a/lib/vutuv_web/live/tag_live/timeline.ex
+++ b/lib/vutuv_web/live/tag_live/timeline.ex
@@ -46,6 +46,7 @@ defmodule VutuvWeb.TagLive.Timeline do
   alias Vutuv.Repo
   alias Vutuv.Tags.Tag
   alias Vutuv.Tags.Timeline
+  alias VutuvWeb.LayoutHTML
   alias VutuvWeb.Live.InitAssigns
   alias VutuvWeb.Live.RemoteImages
   alias VutuvWeb.Live.RemotePostActions
@@ -243,6 +244,10 @@ defmodule VutuvWeb.TagLive.Timeline do
     one container, so a press dims the list it is about while the answer is on
     its way (the rule lives in `assets/css/app.css`). --%>
     <section id="tag-timeline" data-filter-scope class="mt-6">
+      <%!-- Reporting a cached post answers here (`RemotePostActions`), and this
+      LiveView is embedded in a page the controller already wrapped in the app
+      layout, so its flash needs the portal to reach the one toast tray. --%>
+      <LayoutHTML.embedded_flash id="tag-timeline-flash" flash={@flash} />
       <div class="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
         <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
           {gettext("Posts with this tag")}

--- a/lib/vutuv_web/templates/layout/app.html.heex
+++ b/lib/vutuv_web/templates/layout/app.html.heex
@@ -11,40 +11,15 @@ LiveViews fall through to `@socket`. --%>
 
 <%!-- Flash as top-right toasts. Every toast auto-dismisses after a few seconds
 (one knob, app.js `TOAST_DISMISS_MS`) and the × closes it early; on LiveView
-pages `phx-click="lv:clear-flash"` also clears the server-side flash. --%>
+pages `phx-click="lv:clear-flash"` also clears the server-side flash. This is
+the app's ONE tray — `<.embedded_flash>` is how a LiveView that renders no
+layout of its own reaches it. --%>
 <div
   id="toast-tray"
   class="pointer-events-none fixed right-[max(1rem,env(safe-area-inset-right))] top-20 z-50 flex w-80 max-w-[90vw] flex-col gap-2"
   aria-live="polite"
 >
-  <%= if msg = Phoenix.Flash.get(@flash, :info) do %>
-    <.toast
-      kind="info"
-      msg={msg}
-      role="status"
-      class="toast pointer-events-auto flex items-start gap-3 rounded-xl bg-white p-4 shadow-lg ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700"
-      badge_class="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-emerald-600"
-    >
-      <:icon>
-        <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
-        </svg>
-      </:icon>
-    </.toast>
-  <% end %>
-  <%= if msg = Phoenix.Flash.get(@flash, :error) do %>
-    <.toast
-      kind="error"
-      msg={msg}
-      role="alert"
-      class="toast toast--error pointer-events-auto flex items-start gap-3 rounded-xl bg-white p-4 shadow-lg ring-1 ring-red-200 dark:bg-slate-800 dark:ring-red-900/60"
-      badge_class="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-red-100 font-bold text-red-600"
-    >
-      <:icon>
-        !
-      </:icon>
-    </.toast>
-  <% end %>
+  <.flash_toasts flash={@flash} />
 </div>
 
 <%!-- The daily text ad (or the house ad selling the slot), between the

--- a/lib/vutuv_web/views/layout_html.ex
+++ b/lib/vutuv_web/views/layout_html.ex
@@ -24,6 +24,89 @@ defmodule VutuvWeb.LayoutHTML do
   end
 
   @doc """
+  The whole content of the `#toast-tray` in `app.html.heex`: the info toast, the
+  error toast, or nothing. Shared with `embedded_flash/1`, which fills the same
+  tray from a LiveView that never renders the layout.
+  """
+  attr(:flash, :map, required: true)
+
+  def flash_toasts(assigns) do
+    ~H"""
+    <%= if msg = Phoenix.Flash.get(@flash, :info) do %>
+      <.toast
+        kind="info"
+        msg={msg}
+        role="status"
+        class="toast pointer-events-auto flex items-start gap-3 rounded-xl bg-white p-4 shadow-lg ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700"
+        badge_class="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-emerald-600"
+      >
+        <:icon>
+          <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+          </svg>
+        </:icon>
+      </.toast>
+    <% end %>
+    <%= if msg = Phoenix.Flash.get(@flash, :error) do %>
+      <.toast
+        kind="error"
+        msg={msg}
+        role="alert"
+        class="toast toast--error pointer-events-auto flex items-start gap-3 rounded-xl bg-white p-4 shadow-lg ring-1 ring-red-200 dark:bg-slate-800 dark:ring-red-900/60"
+        badge_class="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-red-100 font-bold text-red-600"
+      >
+        <:icon>
+          !
+        </:icon>
+      </.toast>
+    <% end %>
+    """
+  end
+
+  @doc """
+  How a LiveView that renders **no layout of its own** says what just happened.
+
+  An embedded child (`live_render`ed into a page the controller already wrapped
+  in `app.html.heex` — the tag timeline, the permalink conversation, a card's
+  action bar) reaches its own `render/1` and nothing else, so the `#toast-tray`
+  up in the layout belongs to whoever rendered that layout, and a `put_flash/3`
+  down here lands in a flash map nobody prints. This teleports the child's own
+  toasts into that one tray (LiveView's `<.portal>`), so the confirmation reads
+  exactly like the same act on a page that is a LiveView. Give it an id nothing
+  else on the page uses and render it anywhere in the child's tree:
+
+      <LayoutHTML.embedded_flash id="tag-timeline-flash" flash={@flash} />
+
+  The × still carries `phx-click="lv:clear-flash"` and still reaches **this**
+  child: a teleported element keeps belonging to the view that rendered it.
+
+  A page that is a LiveView (`ControllerHelpers.render_live/3`, or a routed
+  `live/4`) needs none of this — those bring `app.html.heex` and its tray
+  themselves, and their flash has always worked.
+  """
+  attr(:id, :string, required: true)
+  attr(:flash, :map, required: true)
+
+  def embedded_flash(assigns) do
+    ~H"""
+    <%!-- Only while there is something to say. A portal costs the client work on
+    every patch it survives — LiveView re-queries the target and morphs the
+    teleported node — and a host like the tag timeline patches on every
+    keystroke; removing the template takes the teleported node down with it.
+
+    `class="contents"`: the portal wraps what it teleports in one element, and
+    the tray is a flex column, so without this the toasts would stack inside
+    that wrapper instead of being rows of the tray. --%>
+    <.portal :if={flashing?(@flash)} id={@id} target="#toast-tray" class="contents">
+      <.flash_toasts flash={@flash} />
+    </.portal>
+    """
+  end
+
+  defp flashing?(flash),
+    do: Phoenix.Flash.get(flash, :info) != nil or Phoenix.Flash.get(flash, :error) != nil
+
+  @doc """
   One flash toast (the `#toast-tray` entry in `app.html.heex`). The info and
   error toasts are the same shell differing only in the outer ring colour, the
   ARIA role, the icon-badge tint and the icon glyph, so they share this

--- a/test/vutuv_web/live/embedded_flash_test.exs
+++ b/test/vutuv_web/live/embedded_flash_test.exs
@@ -1,0 +1,87 @@
+defmodule VutuvWeb.EmbeddedFlashTest do
+  @moduledoc """
+  A LiveView that declares no layout — bare `use Phoenix.LiveView`, the shape
+  every `live_render`ed child here uses — renders its own tree and nothing else.
+  The app's one `#toast-tray` sits in `app.html.heex`, around a page some
+  controller rendered, so a `put_flash/3` in such a child lands in a flash map
+  nobody prints: the act succeeds and says nothing. That is how the tag
+  timeline thanked people for a report they never saw acknowledged.
+
+  `VutuvWeb.LayoutHTML.embedded_flash/1` is the way in — a `<.portal>` that
+  teleports the child's own toasts into that tray. These fail the build when a
+  layoutless LiveView gains a flash without it.
+
+  A page that IS a LiveView (`ControllerHelpers.render_live/3` or a routed
+  `live/4`) is not covered and needs nothing: it brings the app layout itself,
+  and its flash has always shown.
+  """
+  use ExUnit.Case, async: true
+
+  # Helpers that put a flash into the socket they are handed, so a LiveView
+  # reaches one without spelling `put_flash` itself. Two lists because the
+  # distinction is a judgement: a flash on the way to a `redirect/2` is printed
+  # by the NEXT page's layout and needs no portal. The second test fails if a
+  # third such helper appears, so neither list can go quietly stale.
+  @flashing_helpers [VutuvWeb.Live.RemotePostActions]
+  @redirecting_helpers [VutuvWeb.Live.InitAssigns]
+
+  test "a layoutless LiveView that can flash reaches the layout's tray" do
+    for module <- layoutless_liveviews(),
+        source = File.read!(source_path(module)),
+        flashes?(source) do
+      assert source =~ "embedded_flash", """
+      #{inspect(module)} renders no layout of its own, so its flash never
+      reaches the #toast-tray in app.html.heex — the act succeeds silently.
+
+      Either render `<LayoutHTML.embedded_flash id="..." flash={@flash} />`
+      somewhere in it, or say what happened another way (an inline notice next
+      to the thing, or the thing itself visibly changing).
+      """
+    end
+  end
+
+  test "every helper that flashes on a LiveView's behalf is accounted for" do
+    found =
+      Enum.filter(app_modules(), fn module ->
+        path = source_path(module)
+
+        String.starts_with?(path, "lib/vutuv_web/live/") and
+          not function_exported?(module, :__live__, 0) and
+          String.contains?(File.read!(path), "put_flash(")
+      end)
+
+    assert Enum.sort(found) == Enum.sort(@flashing_helpers ++ @redirecting_helpers), """
+    A module under lib/vutuv_web/live puts a flash into a socket it is handed,
+    and this test does not know whether that flash stays on the page (list it in
+    @flashing_helpers, and every layoutless caller then needs an
+    `embedded_flash`) or rides a redirect (@redirecting_helpers).
+    """
+  end
+
+  # Only this app's web modules, and loaded — `function_exported?/3` answers
+  # false for a module nobody has touched yet, and loading all ~790 of them to
+  # find seven views costs more than the rest of the file put together.
+  defp app_modules do
+    :vutuv
+    |> Application.spec(:modules)
+    |> Enum.filter(
+      &(String.starts_with?(Atom.to_string(&1), "Elixir.VutuvWeb.") and Code.ensure_loaded?(&1))
+    )
+  end
+
+  defp layoutless_liveviews do
+    Enum.filter(app_modules(), fn module ->
+      function_exported?(module, :__live__, 0) and module.__live__()[:kind] == :view and
+        !module.__live__()[:layout]
+    end)
+  end
+
+  defp flashes?(source) do
+    String.contains?(source, "put_flash(") or
+      Enum.any?(@flashing_helpers, &String.contains?(source, inspect(&1)))
+  end
+
+  defp source_path(module) do
+    module.module_info(:compile)[:source] |> to_string() |> Path.relative_to_cwd()
+  end
+end

--- a/test/vutuv_web/live/tag_timeline_live_test.exs
+++ b/test/vutuv_web/live/tag_timeline_live_test.exs
@@ -282,4 +282,30 @@ defmodule VutuvWeb.TagTimelineLiveTest do
       assert html =~ "1 aktiv"
     end
   end
+
+  describe "reporting a cached post" do
+    test "says so in the layout's toast tray, which this LiveView never renders",
+         %{conn: conn} do
+      {tag, _post} = tag_with_post("Ein Beitrag")
+      remote = remote_post(tag, "Etwas aus einem anderen Netz")
+
+      view = timeline(conn, tag, shell_session(insert_activated_user()))
+
+      # Nothing to say yet, so no portal at all.
+      refute has_element?(view, "#tag-timeline-flash")
+
+      view
+      |> element(~s(button[phx-click="report-remote-post"][phx-value-id="#{remote.id}"]))
+      |> render_click()
+
+      # The tray lives in `app.html.heex`, which the controller rendered and this
+      # embedded LiveView has no part of, so the confirmation travels by portal.
+      # Its contents are a `<template>`, which `element/3` cannot look inside —
+      # render the portal itself and read the string.
+      portal = view |> element("#tag-timeline-flash") |> render()
+
+      assert portal =~ ~s(data-phx-portal="#toast-tray")
+      assert portal =~ "Thank you. Our copy was deleted right away."
+    end
+  end
 end

--- a/test/vutuv_web/narrow_input_class_test.exs
+++ b/test/vutuv_web/narrow_input_class_test.exs
@@ -1,0 +1,42 @@
+defmodule VutuvWeb.NarrowInputClassTest do
+  @moduledoc """
+  A control that should be as wide as the word it holds takes
+  `VutuvWeb.UI.narrow_input_class/0`. Appending a plain `w-auto` to
+  `input_class/0` does not work — that string opens with `w-full` and Tailwind
+  emits `.w-auto` before `.w-full`, so the shorter one loses whichever order the
+  call site writes them in, and the select silently draws the full width of its
+  container. Three forms asked the losing way for months: the saved-search
+  cadence, an organization's kind, its domain verification method.
+
+  A variant (`sm:w-auto`) wins on its own, its rules coming after the bare ones,
+  so this only refuses the bare utility.
+  """
+  use ExUnit.Case, async: true
+
+  # Whitespace-collapsed, because whether the composed class list fits on one
+  # source line is `mix format`'s decision, not the author's — a per-line scan
+  # reports clean on exactly the regression it exists for the moment a
+  # `class={[…]}` grows long enough to be broken across lines.
+  @composed ~r/input_class\(\)[^\]]{0,200}?(?<![:\w-])w-auto(?![!\w-])/
+
+  test "no field composes input_class/0 with a plain w-auto" do
+    offenders =
+      "lib/vutuv_web/**/*.{ex,heex}"
+      |> Path.wildcard()
+      |> Enum.filter(fn path ->
+        source = File.read!(path)
+
+        String.contains?(source, "input_class(") and
+          Regex.match?(@composed, String.replace(source, ~r/\s+/, " "))
+      end)
+
+    assert offenders == [], """
+    These compose input_class/0 with a bare `w-auto`, which never wins:
+
+    #{Enum.join(offenders, "\n")}
+
+    Call `narrow_input_class/0` instead — it carries the `w-auto!` that does,
+    and the `max-w-full` that keeps a long option inside a narrow column.
+    """
+  end
+end


### PR DESCRIPTION
**#1855.** Reporting a post from another network on a tag page thanked you in a flash nobody saw. `VutuvWeb.TagLive.Timeline` renders no layout, so the app's one `#toast-tray` belongs to the controller. `LayoutHTML.embedded_flash/1` teleports such a LiveView's flash into that tray with `<.portal>`.

The issue named the profile, an organization's domain check and a Fediverse mute as silent too — measured in a browser, all three already toast: those pages go through `ControllerHelpers.render_live/3` and bring the layout themselves. The timeline is the only layoutless LiveView that reaches a `put_flash`. Two code comments recorded the wrong reason and are corrected.

Two pre-existing bugs on the way. The auto-dismiss removed the toast inside the click handler, so LiveView's window listener saw a detached button and dropped `lv:clear-flash` — the same sentence never drew a toast twice. And `card_menu` handed `<.link>` a nil `method`, which it reads as a CSRF post; `UI.button/1` had the same default.

**#1856.** The three selects take `narrow_input_class/0` instead of a `w-auto` that cannot beat `input_class/0`'s `w-full`. Measured on `/organizations/:slug/edit`: 117px, against the 526px container.

Guard tests for both, each calibrated red against the unfixed code.

Closes #1855
Closes #1856

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_011GqojNoKnqEg4kUY2r14Co