### PR TITLE
Follow a searched Fediverse account with one click

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -794,8 +794,10 @@ It **follows nothing**. The arrival is a `GET` from another site, so acting on
 it would let any page on the web make a signed-in member send a signed `Follow`
 to a server of its choosing simply by linking here. The resolved address is
 handed to the follow box on `/settings/fediverse/following` instead — the same
-`?address=` prefill the search page uses, for the same reason it prefills rather
-than acts. A signed-out visitor is bounced through `/login` with the
+`?address=` prefill a post lookup uses when what was pasted turns out to name an
+account. A follow the member themselves asked for is *sent* by the page that
+owns the click (the search page's address card); this arrival is somebody
+else's link. A signed-out visitor is bounced through `/login` with the
 `:login_return_to` marker the OAuth consent screen uses, so the PIN round trip
 lands them back on this URL. The installation switch is checked first: an
 endpoint this vutuv does not run 404s instead of first asking anyone to sign in.

--- a/docs/architecture/search.md
+++ b/docs/architecture/search.md
@@ -78,8 +78,14 @@ both render as a card **above** the results, because they are the answer to what
 was pasted:
 
 * an **account address** (`@name@server`, or a profile URL, issue #1160):
-  `#search-remote-address` names it and hands it to the follow box at
-  `/settings/fediverse/following?address=`.
+  `#search-remote-address` names it, and its button **sends the follow from
+  here** — `Fediverse.follow_remote/2` on the click, then `push_navigate` to
+  `/settings/fediverse/following`, where the member finds the flash and the new
+  row. It used to carry the address there as `?address=` for a second press of
+  "Follow", which was the same click twice; the click stays on this page
+  because arriving on that one is a `GET`. A refusal stays on the card, and a
+  member the gate refuses (`Fediverse.follow_refusal/1`) gets the explanation
+  instead of the button — both exactly as the post card below does it.
 * the address of a **single post** out there (issue #1211):
   `#search-remote-post` offers the fetch that used to live only at
   `/system/fediverse/lookup` — a page under `/system/` that nobody finds, while

--- a/lib/vutuv_web/components/fediverse_components.ex
+++ b/lib/vutuv_web/components/fediverse_components.ex
@@ -1,15 +1,17 @@
 defmodule VutuvWeb.FediverseComponents do
   @moduledoc """
-  What the two pages that offer a follow out there have in common: the
-  address box, the panel that explains a refusal, the wording of every
-  `{:error, reason}` the context can answer with, and the follow-state pill.
+  What every page that offers a follow out there has in common: the address
+  box, the panel that explains a refusal, the wording of every `{:error,
+  reason}` the context can answer with, the sentence a follow that went through
+  gets, and the follow-state pill.
 
-  `VutuvWeb.FediverseFollowingLive` (`/settings/fediverse/following`) and
+  `VutuvWeb.FediverseFollowingLive` (`/settings/fediverse/following`),
   `VutuvWeb.FediverseAccountLive` (`/system/fediverse/account/:id`, issue #1162)
-  arrive at the same act from opposite ends — one starts from an address, the
-  other from an account already in front of the reader — but from the moment
-  the member presses Follow they are the same flow against the same context
-  function, so they must not describe it differently.
+  and the search page's address card (`VutuvWeb.SearchLive`, issue #1160)
+  arrive at the same act from different ends — an address typed, an account
+  already in front of the reader, an address that was typed as a search — but
+  from the moment the member presses Follow they are the same flow against the
+  same context function, so they must not describe it differently.
 
   `Vutuv.Fediverse.follow_refusal/1` is the data half of that (which of the four
   situations the member is in); this is the half that says it in words. Keeping
@@ -42,6 +44,7 @@ defmodule VutuvWeb.FediverseComponents do
 
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.RemoteAccount
 
   attr(:id, :string,
     required: true,
@@ -378,6 +381,35 @@ defmodule VutuvWeb.FediverseComponents do
       true -> gettext("Cancel request")
     end
   end
+
+  @doc """
+  The sentence for one `{:ok, …}` from `Vutuv.Fediverse.follow_remote/2`.
+
+  Beside `refusal_message/1` and for the same reason: four surfaces start a
+  follow — the address box on the following page, the account page, a looked-up
+  post's card and the search page's address card (issue #1160) — and the member
+  has to read the same thing about the same outcome. Two of the three shapes are
+  the ones that did something *other* than what was asked, so the sentence has
+  to say what really happened: neither the vutuv follow nor the tag subscription
+  will show up in the remote-follow table the member is looking at.
+  """
+  def follow_message({:local_follow, member}),
+    do:
+      gettext("@%{handle} is on this vutuv, so you now follow them here.",
+        handle: member.username
+      )
+
+  # It names the tag page, because the table below will not list this either —
+  # and because a subscription is silent, so the link is the only way to check.
+  def follow_message({:local_tag_follow, tag}),
+    do:
+      gettext("#%{tag} is a topic on this vutuv, so you now follow the tag here.", tag: tag.slug)
+
+  # A Follow is a request, so the confirmation says what really happened rather
+  # than "Following" — and names the account, since the row it just added may be
+  # on page four of a filtered table.
+  def follow_message(%Follow{remote_account: %RemoteAccount{} = account}),
+    do: gettext("Follow request sent to %{account}.", account: RemoteAccount.label(account))
 
   @doc """
   The sentence for one `{:error, reason}` from `Vutuv.Fediverse`.

--- a/lib/vutuv_web/live/fediverse_account_live.ex
+++ b/lib/vutuv_web/live/fediverse_account_live.ex
@@ -116,10 +116,7 @@ defmodule VutuvWeb.FediverseAccountLive do
         # nothing to reload.
         {:noreply,
          socket
-         |> put_flash(
-           :info,
-           gettext("Follow request sent to %{account}.", account: RemoteAccount.label(account))
-         )
+         |> put_flash(:info, follow_message(follow))
          |> assign(:follow, follow)}
 
       {:error, reason} ->

--- a/lib/vutuv_web/live/fediverse_following_live.ex
+++ b/lib/vutuv_web/live/fediverse_following_live.ex
@@ -76,10 +76,14 @@ defmodule VutuvWeb.FediverseFollowingLive do
      |> load_page(params)}
   end
 
-  # `?address=` arrives from the search page (issue #1160), which offers a full
-  # `@name@server` query as something to follow. Prefilled rather than followed
-  # on arrival: a GET must not send a signed request to a stranger's server,
-  # and the member should see what they are about to do.
+  # `?address=` arrives from the remote-follow hand-off
+  # (`/authorize_interaction`) and from a post lookup that turned out to name an
+  # account rather than a post (`VutuvWeb.SearchLive`, `VutuvWeb.FediverseLookupLive`).
+  # Prefilled, never followed on arrival: the hand-off is a GET from another
+  # site, and a GET must not send a signed request to a stranger's server on a
+  # link the member did not write; the lookup asked for a post, not a follow.
+  # A member who *did* ask to follow has had it sent before they got here —
+  # `SearchLive.follow_pasted_address/1` owns that click.
   defp prefill(socket, address) when is_binary(address), do: assign(socket, :address, address)
   defp prefill(socket, _address), do: socket
 
@@ -129,28 +133,20 @@ defmodule VutuvWeb.FediverseFollowingLive do
   @impl true
   def handle_event("follow", %{"address" => address}, socket) do
     case Fediverse.follow_remote(socket.assigns.user, address) do
-      # The address turned out to live here, so the member got a plain vutuv
-      # follow instead of a Fediverse request — say so, since the table below
-      # (remote follows only) will not show it.
-      {:ok, {:local_follow, member}} ->
+      # The address turned out to live here, so `follow_remote/2` did the local
+      # thing it names instead of sending a Fediverse request: a plain vutuv
+      # follow, or a tag subscription (issue #1330). The flash carries it,
+      # because the table below (remote follows only) shows neither, and the
+      # totals cannot have moved.
+      {:ok, {_kind, _subject} = local} ->
         {:noreply,
          socket
          |> assign(:address, "")
          |> assign_error(nil)
-         |> put_flash(:info, local_follow_message(member))
+         |> put_flash(:info, follow_message(local))
          |> patch_browse(%{}, &browse_path/1)}
 
-      # Same again for a topic on our own tag host (issue #1330): what the
-      # member asked for is a tag subscription, and that is what they got.
-      {:ok, {:local_tag_follow, tag}} ->
-        {:noreply,
-         socket
-         |> assign(:address, "")
-         |> assign_error(nil)
-         |> put_flash(:info, local_tag_follow_message(tag))
-         |> patch_browse(%{}, &browse_path/1)}
-
-      {:ok, follow} ->
+      {:ok, %Follow{} = follow} ->
         # Patch rather than reload in place: it keeps any active filter and
         # drops the `?address=` the search page may have arrived with, so a
         # later sort does not put the followed address back in the box.
@@ -159,7 +155,7 @@ defmodule VutuvWeb.FediverseFollowingLive do
          |> assign(:address, "")
          |> assign_error(nil)
          |> assign_totals()
-         |> put_flash(:info, follow_sent_message(follow))
+         |> put_flash(:info, follow_message(follow))
          |> patch_browse(%{}, &browse_path/1)}
 
       {:error, reason} ->
@@ -233,29 +229,6 @@ defmodule VutuvWeb.FediverseFollowingLive do
   def handle_info(_other, socket), do: {:noreply, socket}
 
   # ── Wording ───────────────────────────────────────────────────────────────
-
-  # The vutuv follow that answered a Fediverse address (the auto-follow): named
-  # by handle, because the address the member typed was one.
-  defp local_follow_message(member) do
-    gettext("@%{handle} is on this vutuv, so you now follow them here.",
-      handle: member.username
-    )
-  end
-
-  # The tag twin: the address named a topic of this installation, so the member
-  # got the subscription rather than a request that could never be sent. It
-  # names the tag page, because the table below will not list this either — and
-  # because a subscription is silent, so the link is the only way to check.
-  defp local_tag_follow_message(tag) do
-    gettext("#%{tag} is a topic on this vutuv, so you now follow the tag here.", tag: tag.slug)
-  end
-
-  # A Follow is a request, so the confirmation says what really happened rather
-  # than "Following" — and names the account, since the row it just added may be
-  # on page four of a filtered table.
-  defp follow_sent_message(%Follow{remote_account: %RemoteAccount{} = account}) do
-    gettext("Follow request sent to %{account}.", account: RemoteAccount.label(account))
-  end
 
   # The confirmation that goes with `end_follow_label/1`. This page knows the
   # account behind the row (the table preloads it), so it names it.

--- a/lib/vutuv_web/live/fediverse_lookup_live.ex
+++ b/lib/vutuv_web/live/fediverse_lookup_live.ex
@@ -142,10 +142,7 @@ defmodule VutuvWeb.FediverseLookupLive do
       {:ok, follow} ->
         {:noreply,
          socket
-         |> put_flash(
-           :info,
-           gettext("Follow request sent to %{account}.", account: RemoteAccount.label(account))
-         )
+         |> put_flash(:info, follow_message(follow))
          |> assign(:follow, follow)}
 
       {:error, reason} ->

--- a/lib/vutuv_web/live/search_live.ex
+++ b/lib/vutuv_web/live/search_live.ex
@@ -17,18 +17,29 @@ defmodule VutuvWeb.SearchLive do
   keystroke for two seconds), so typing "meier" stores one query, not five.
 
   Two things people paste in here are not queries at all, and both get named
-  and answered instead of searched: an `@name@server` address (the follow
-  hand-off, issue #1160) and the address of a **post** on another network, which
-  is offered the lookup that used to live at `/system/fediverse/lookup` alone
-  (issue #1211). Recognising either is pure string work, so a keystroke never
-  becomes an outbound request; the fetch behind the post address is a signed
-  request in the member's name against their hourly budget, so it happens on
-  their explicit submit or click and never while they type.
+  and answered instead of searched: an `@name@server` address, which is offered
+  the follow (issue #1160), and the address of a **post** on another network,
+  which is offered the lookup that used to live at `/system/fediverse/lookup`
+  alone (issue #1211). Recognising either is pure string work, so a keystroke
+  never becomes an outbound request; both acts behind them are signed requests
+  in the member's name against their hourly budget, so each happens on an
+  explicit submit or click and never while they type, and neither button is
+  offered to a member the gate would refuse. The follow is *sent from here* and
+  lands the member on `/settings/fediverse/following` with it done — carrying
+  the address over for them to press "Follow" a second time was the same click
+  twice.
   """
   use VutuvWeb, :live_view
 
   import VutuvWeb.FediverseComponents,
-    only: [lookup_refusal_link: 1, lookup_refusal_message: 1, lookup_refusal_text: 1]
+    only: [
+      follow_message: 1,
+      follow_refusal_panel: 1,
+      lookup_refusal_link: 1,
+      lookup_refusal_message: 1,
+      lookup_refusal_text: 1,
+      refusal_message: 1
+    ]
 
   import VutuvWeb.SavedSearchComponents
 
@@ -54,7 +65,13 @@ defmodule VutuvWeb.SearchLive do
      # than per keystroke: it reads their federation state, and the answer is
      # the same for every query they type. `look_up_post/2` asks again at the
      # click, so participation ending in another tab is still refused.
-     |> assign(:lookup_refusal, current_user && Fediverse.lookup_refusal(current_user))}
+     |> assign(:lookup_refusal, current_user && Fediverse.lookup_refusal(current_user))
+     # The follow's twin of the same question (`follow_refusal/1` tells the four
+     # situations apart where `federated?/1` collapses them). Without it the
+     # card would offer a live button to somebody who cannot sign a Follow at
+     # all, and answer their click with a page change instead of a sentence.
+     |> assign(:follow_refusal, current_user && Fediverse.follow_refusal(current_user))
+     |> assign(:remote_follow_error, nil)}
   end
 
   @impl true
@@ -63,6 +80,7 @@ defmodule VutuvWeb.SearchLive do
     scope = parse_scope(params["scope"])
     exact = params["exact"] == "1"
     results = Search.instant(q, scope: scope, exact: exact, viewer: socket.assigns[:current_user])
+    address = remote_address(q)
     post_url = remote_post_url(q)
 
     {:noreply,
@@ -79,8 +97,11 @@ defmodule VutuvWeb.SearchLive do
      |> assign(:effective_scope, (results && results.parsed.scope) || scope)
      |> assign(:scope_pinned?, (results && results.parsed.scope_pinned?) || false)
      |> assign(:results, results)
-     |> assign(:remote_address, remote_address(q))
+     |> assign(:remote_address, address)
      |> assign(:remote_post_url, post_url)
+     # Both refusals belong to what they were about and die with it, so the card
+     # is never still shouting about an address the member has since corrected.
+     |> assign(:remote_follow_error, kept_follow_error(socket, address))
      # A refusal belongs to the address it was about: it survives the patch the
      # debounced keystroke sends after a submit, and dies the moment the pasted
      # address changes, so the card is never still shouting about a URL the
@@ -93,6 +114,11 @@ defmodule VutuvWeb.SearchLive do
   defp kept_post_error(socket, post_url) do
     if post_url && post_url == socket.assigns[:remote_post_url],
       do: socket.assigns[:remote_post_error]
+  end
+
+  defp kept_follow_error(socket, address) do
+    if address && address == socket.assigns[:remote_address],
+      do: socket.assigns[:remote_follow_error]
   end
 
   # A full `@name@server` typed into the search box is not a vutuv query at all
@@ -184,6 +210,12 @@ defmodule VutuvWeb.SearchLive do
       else: {:noreply, socket}
   end
 
+  def handle_event("follow-remote-address", _params, socket) do
+    if follow_offered?(socket),
+      do: {:noreply, follow_pasted_address(socket)},
+      else: {:noreply, socket}
+  end
+
   def handle_event("toggle_save_search", _params, socket),
     do: {:noreply, update(socket, :show_save?, &(not &1))}
 
@@ -202,6 +234,13 @@ defmodule VutuvWeb.SearchLive do
   defp lookup_offered?(socket) do
     socket.assigns.remote_post_url != nil and socket.assigns.current_user != nil and
       socket.assigns.lookup_refusal == nil
+  end
+
+  # The same three questions for the follow: an address, a member, and nothing
+  # standing in the way of signing the request in their name.
+  defp follow_offered?(socket) do
+    socket.assigns.remote_address != nil and socket.assigns.current_user != nil and
+      socket.assigns.follow_refusal == nil
   end
 
   # The one outbound request this page can make, and only ever on an act of the
@@ -224,6 +263,30 @@ defmodule VutuvWeb.SearchLive do
 
       {:error, reason} ->
         assign(socket, :remote_post_error, reason)
+    end
+  end
+
+  # The other outbound request this page can make, and the twin of the one
+  # above in every respect: the member's own click, their hourly budget, their
+  # signature. It is sent from *here* rather than handed to
+  # `/settings/fediverse/following` as a prefilled box — the member asked for
+  # the follow once, and arriving on that page is a `GET`, which may not put a
+  # signed request on a stranger's server on the strength of a link somebody
+  # else wrote.
+  #
+  # A follow that goes through lands on that page, because the row, its state
+  # and the way to take it back are all there. A refusal stays on this card,
+  # like the pasted post's: the correction happens in the box above it, and the
+  # settings page has nothing to add to "that server did not answer".
+  defp follow_pasted_address(socket) do
+    case Fediverse.follow_remote(socket.assigns.current_user, socket.assigns.remote_address) do
+      {:ok, result} ->
+        socket
+        |> put_flash(:info, follow_message(result))
+        |> push_navigate(to: ~p"/settings/fediverse/following")
+
+      {:error, reason} ->
+        assign(socket, :remote_follow_error, reason)
     end
   end
 
@@ -441,10 +504,12 @@ defmodule VutuvWeb.SearchLive do
 
   attr(:address, :string, default: nil)
   attr(:signed_in?, :boolean, default: false)
+  attr(:refusal, :atom, default: nil)
+  attr(:error, :any, default: nil)
 
   # The result row for an address on another network. It sits above the vutuv
   # results because it is the *answer* to what was typed, and it renders for a
-  # signed-out visitor too — with the sign-in link instead of the follow one,
+  # signed-out visitor too — with the sign-in link instead of the follow button,
   # since the request has to be signed by a member's own key.
   defp remote_address_result(%{address: nil} = assigns) do
     ~H""
@@ -462,15 +527,29 @@ defmodule VutuvWeb.SearchLive do
           "That is an address on Mastodon or one of the other networks, so nobody here carries it. You can follow it from vutuv."
         )}
       </p>
-      <p class="mt-3">
-        <.link
+      <%!-- Somebody who cannot sign a Follow at all reads why here, rather than
+            pressing a button that was never going to work. Same shape as the
+            post card below, and the same panel the following page shows. --%>
+      <.follow_refusal_panel
+        :if={@signed_in? and @refusal}
+        id="search-remote-follow-refusal"
+        reason={@refusal}
+        class="mt-3"
+      />
+
+      <p :if={!@signed_in? or is_nil(@refusal)} class="mt-3">
+        <%!-- Full width on a phone, like the other card's: it is this card's
+              single call to action, and the standard pill is a small target for
+              a thumb. --%>
+        <.button
           :if={@signed_in?}
-          navigate={~p"/settings/fediverse/following?#{[address: @address]}"}
           id="search-remote-follow"
-          class="text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+          phx-click="follow-remote-address"
+          phx-disable-with={gettext("Following…")}
+          class="w-full sm:w-auto"
         >
-          {gettext("Follow this account")} ›
-        </.link>
+          {gettext("Follow this account")}
+        </.button>
         <.link
           :if={!@signed_in?}
           navigate={~p"/login"}
@@ -479,6 +558,15 @@ defmodule VutuvWeb.SearchLive do
         >
           {gettext("Sign in to follow this account")} ›
         </.link>
+      </p>
+
+      <p
+        :if={@error}
+        id="search-remote-follow-error"
+        role="alert"
+        class="mt-2 text-sm font-medium text-red-700 dark:text-red-300"
+      >
+        {refusal_message(@error)}
       </p>
     </.card>
     """
@@ -617,7 +705,12 @@ defmodule VutuvWeb.SearchLive do
         {gettext("Results appear once you have typed at least three letters.")}
       </p>
 
-      <.remote_address_result address={@remote_address} signed_in?={@current_user_id != nil} />
+      <.remote_address_result
+        address={@remote_address}
+        signed_in?={@current_user_id != nil}
+        refusal={@follow_refusal}
+        error={@remote_follow_error}
+      />
 
       <.remote_post_result
         url={@remote_post_url}

--- a/test/vutuv_web/live/fediverse_following_live_test.exs
+++ b/test/vutuv_web/live/fediverse_following_live_test.exs
@@ -230,7 +230,7 @@ defmodule VutuvWeb.FediverseFollowingLiveTest do
       assert_patched(view, ~p"/settings/fediverse/following?sort=account")
     end
 
-    test "an address handed over from the search page is prefilled, never followed", %{
+    test "an address handed over by a link is prefilled, never followed", %{
       conn: conn,
       user: user
     } do
@@ -310,12 +310,23 @@ defmodule VutuvWeb.FediverseFollowingLiveTest do
 
   describe "the search page's offer" do
     test "a full address offers the follow flow", %{conn: conn} do
-      {conn, _user} = create_and_login_user(conn)
+      {conn, _user} = federating(conn)
 
       {:ok, view, _html} = live(conn, ~p"/search?#{[q: "@them@social.example"]}")
 
       assert has_element?(view, "#search-remote-address")
       assert has_element?(view, "#search-remote-follow")
+    end
+
+    test "a member who does not federate reads why, instead of a dead button", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      {:ok, view, _html} = live(conn, ~p"/search?#{[q: "@them@social.example"]}")
+
+      assert has_element?(view, "#search-remote-address")
+      refute has_element?(view, "#search-remote-follow")
+      assert has_element?(view, "#search-remote-follow-refusal")
+      assert has_element?(view, "#enable-fediverse-link")
     end
 
     test "an ordinary query offers nothing of the sort", %{conn: conn} do
@@ -331,6 +342,43 @@ defmodule VutuvWeb.FediverseFollowingLiveTest do
 
       assert has_element?(view, "#search-remote-login")
       refute has_element?(view, "#search-remote-follow")
+    end
+
+    test "the click sends the follow and lands on the list", %{conn: conn} do
+      stub_account()
+      {conn, user} = federating(conn)
+
+      {:ok, view, _html} = live(conn, ~p"/search?#{[q: "@them@social.example"]}")
+      view |> element("#search-remote-follow") |> render_click()
+
+      # The whole point: one click, and the request is already out.
+      assert [%Follow{state: "requested"}] =
+               Repo.all(from(f in Follow, where: f.user_id == ^user.id))
+
+      flash = assert_redirect(view, ~p"/settings/fediverse/following")
+      assert flash["info"] =~ "Them"
+    end
+
+    test "a refusal stays on the card, with the search still there", %{conn: conn} do
+      # That server answers nothing, so the follow comes back refused. The
+      # member keeps their results and can correct the address in the box above.
+      Application.put_env(:vutuv, :fediverse_req_options,
+        plug: fn conn -> Plug.Conn.send_resp(conn, 404, "") end
+      )
+
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_req_options) end)
+      {conn, user} = federating(conn)
+
+      {:ok, view, _html} = live(conn, ~p"/search?#{[q: "@them@social.example"]}")
+      view |> element("#search-remote-follow") |> render_click()
+
+      assert has_element?(view, "#search-remote-follow-error")
+      assert has_element?(view, "#search-remote-address")
+      assert Repo.all(from(f in Follow, where: f.user_id == ^user.id)) == []
+
+      # Typing on takes the refusal with it.
+      view |> element("#search-form") |> render_change(%{"q" => "@them@social.exampl"})
+      refute has_element?(view, "#search-remote-follow-error")
     end
   end
 end


### PR DESCRIPTION
On `/search`, typing a Fediverse address offers "Follow this account". The
button only carried the address to `/settings/fediverse/following?address=`,
where it sat prefilled in the box waiting for a second press of "Follow".

Now the click sends the follow (`Fediverse.follow_remote/2` in
`VutuvWeb.SearchLive`) and lands the member on that page with the flash and the
new row. It has to be sent from the search page: arriving on the settings page
is a `GET`, and the same URL receives the remote-follow hand-off from
`/authorize_interaction`, which keeps its confirming click. A refusal now stays
on the card, and a member who cannot follow at all reads the explanation
instead of pressing a button that was never going to work — both the way the
pasted-post card beside it already behaves.

The "Follow request sent to X." sentence stood in four places; it is now
`FediverseComponents.follow_message/1`.

Hot deploy: no migrations, no config or dependency changes.

*An AI agent wrote this text in my name. I know that is problematic.*
