### PR TITLE
Strip Earmark's layout whitespace from federated and API status HTML

### DIFF
--- a/lib/vutuv/mastodon_api/presenter.ex
+++ b/lib/vutuv/mastodon_api/presenter.ex
@@ -977,6 +977,10 @@ defmodule Vutuv.MastodonApi.Presenter do
   # `NotLoaded`, fail its `is_list` guard and silently render a status with no
   # text at all (`Vutuv.Search` does not preload, and the search endpoint duly
   # served blank posts once).
+  #
+  # `compact_html/1` for the reason the federated Note runs it: a client renders
+  # status HTML as preformatted text, so Earmark's layout newlines are drawn as
+  # blank lines and stray indents. See its docstring.
   defp content_html(post, photo_viewer) do
     post.body
     |> Markdown.render_post(Posts.released_images(post),
@@ -984,6 +988,7 @@ defmodule Vutuv.MastodonApi.Presenter do
     )
     |> safe_html()
     |> Markdown.absolutize_html(main_base())
+    |> Markdown.compact_html()
   end
 
   # The same for a cached post or reply. It carries no picture of ours, but

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -967,6 +967,9 @@ defmodule VutuvWeb.Fediverse.Docs do
   # sidecar is rendered INTO the content: the Note is one more rendering of
   # the post (like the agent docs), so a Mastodon reader gets the reviewed
   # work's facts even though remote software knows nothing of review cards.
+  #
+  # `compact_html/1` last, because a Note is read as preformatted text: see its
+  # docstring for what Mastodon does with Earmark's indentation.
   defp content_html(post, remote, hashtags) do
     body_html =
       post.body
@@ -976,6 +979,7 @@ defmodule VutuvWeb.Fediverse.Docs do
     (mention_html(remote) <>
        body_html <> PostComponents.review_content_html(post) <> hashtag_line(hashtags))
     |> absolutize()
+    |> VutuvWeb.Markdown.compact_html()
   end
 
   # The chips as a closing line of `#hashtags`, added **here, on the wire, only**

--- a/lib/vutuv_web/markdown.ex
+++ b/lib/vutuv_web/markdown.ex
@@ -973,6 +973,52 @@ defmodule VutuvWeb.Markdown do
   defp pattern(["href"]), do: @href_only
   defp pattern(attrs), do: ~r{(#{Enum.join(attrs, "|")})="/(?!/)}
 
+  # No capture group, so the split interleaves whole `<pre>` blocks between the
+  # segments around them and nothing else.
+  @preformatted ~r{<pre\b[^>]*>.*?</pre>}s
+
+  @block_tags "p|div|ul|ol|li|blockquote|h[1-6]|table|thead|tbody|tfoot|tr|td|th|br|hr|figure|figcaption|dl|dt|dd|pre|section|article"
+  @block_tag "(?:<(?:#{@block_tags})\\b[^>]*>|</(?:#{@block_tags})>)"
+
+  @soft_newline ~r/[ \t]*\r?\n[ \t]*/
+  @after_block ~r{(#{@block_tag})\s+}
+  @before_block ~r{\s+(#{@block_tag})}
+
+  @doc """
+  Strips the layout whitespace out of rendered HTML, for a reader that renders
+  it as **preformatted text**.
+
+  Earmark lays its output out to be read in a source file: a newline after every
+  opening `<p>`, indented list items, trailing spaces before a closing tag. A
+  browser collapses all of it, which is why the page is right and why this pass
+  changes nothing on any surface of ours. Mastodon's `.status__content p`
+  carries `white-space: pre-wrap`, so it **draws** every one of those newlines:
+  each paragraph opens with a blank line and each `<li>`'s text lands on the
+  line below its own bullet. The Mastodon client API renders the same way, so
+  both wire surfaces run this.
+
+  What is left is the whitespace a browser would show too: a soft newline inside
+  a paragraph becomes the single space it renders as (posts are rendered with
+  `breaks: false`, so those two source lines are one flowing line on our page
+  as well, and a hard break is a `<br>` long before this), while the whitespace
+  around a block tag goes. Content inside `<pre>` is the author's own and is
+  handed through untouched, since Mastodon renders `pre` preformatted on purpose.
+  """
+  def compact_html(html) when is_binary(html) do
+    @preformatted
+    |> Regex.split(html, include_captures: true)
+    |> Enum.map_join(&compact_segment/1)
+  end
+
+  defp compact_segment("<pre" <> _ = preformatted), do: preformatted
+
+  defp compact_segment(text) do
+    text
+    |> String.replace(@soft_newline, " ")
+    |> String.replace(@after_block, "\\1")
+    |> String.replace(@before_block, "\\1")
+  end
+
   ## @handle / fediverse mentions and #hashtags
 
   # Turns every `@handle` of an existing member into a same-tab link to their

--- a/test/vutuv/mastodon_api/status_content_test.exs
+++ b/test/vutuv/mastodon_api/status_content_test.exs
@@ -1,0 +1,29 @@
+defmodule Vutuv.MastodonApi.StatusContentTest do
+  # A Mastodon client renders a status body the way Mastodon's own web UI does,
+  # with the paragraphs preformatted (`white-space: pre-wrap`), so the layout
+  # newlines Earmark writes for readability are drawn as blank lines and stray
+  # indents. The federated Note and this API are the two wire surfaces that have
+  # to answer for it; see `VutuvWeb.Markdown.compact_html/1`.
+  use Vutuv.DataCase, async: true
+
+  alias Vutuv.MastodonApi.Presenter
+
+  defp content(body) do
+    user = insert(:activated_user)
+    post = insert(:post, user: user, body: body)
+
+    post |> Presenter.one_status(user) |> Map.fetch!(:content)
+  end
+
+  test "a status carries no layout whitespace" do
+    content = content("# Titel\n\nEin Satz.\n\n* eins\n* zwei")
+
+    assert content =~ "<h1>Titel</h1>"
+    assert content =~ "<li>eins</li><li>zwei</li>"
+    refute content =~ "\n"
+  end
+
+  test "a status keeps the newlines inside a code block" do
+    assert content("```elixir\ndef a do\n  :ok\nend\n```") =~ "do</span>\n  <span"
+  end
+end

--- a/test/vutuv_web/fediverse/docs_test.exs
+++ b/test/vutuv_web/fediverse/docs_test.exs
@@ -161,6 +161,35 @@ defmodule VutuvWeb.Fediverse.DocsTest do
       assert note["content"] =~ ~s(href="//evil.com")
       refute note["content"] =~ ~s(href="#{base()}//evil.com")
     end
+
+    # Mastodon renders `.status__content p` with `white-space: pre-wrap`, so
+    # Earmark's layout newlines are DRAWN: a blank line opening every paragraph
+    # and each bullet's text pushed onto the line below its own marker. Nothing
+    # about that is visible on our own page, where the browser collapses it.
+    test "the content carries no layout whitespace, which the other side draws" do
+      user = insert(:activated_user)
+
+      post =
+        insert(:post,
+          user: user,
+          body: "# Titel\n\nEin Satz.\n\n* eins\n* zwei"
+        )
+
+      content = Docs.create_activity(post, user)["object"]["content"]
+
+      assert content =~ "<h1>Titel</h1>"
+      assert content =~ "<li>eins</li><li>zwei</li>"
+      refute content =~ "\n"
+    end
+
+    test "the content keeps the newlines inside a code block" do
+      user = insert(:activated_user)
+      post = insert(:post, user: user, body: "```elixir\ndef a do\n  :ok\nend\n```")
+
+      content = Docs.create_activity(post, user)["object"]["content"]
+
+      assert content =~ "do</span>\n  <span"
+    end
   end
 
   describe "hashtags on an outgoing note (#1421)" do

--- a/test/vutuv_web/markdown_test.exs
+++ b/test/vutuv_web/markdown_test.exs
@@ -507,4 +507,68 @@ defmodule VutuvWeb.MarkdownTest do
       assert html =~ "mastodon.social/@hostsharing"
     end
   end
+
+  describe "compact_html/1" do
+    # Mastodon renders a status paragraph with `white-space: pre-wrap`, so
+    # every newline and indent Earmark lays out for readability is *drawn*.
+    defp wire_html(body), do: body |> post_html() |> Markdown.compact_html()
+
+    test "a paragraph no longer opens with a blank line" do
+      assert wire_html("Ein Satz.") == "<p>Ein Satz.</p>"
+    end
+
+    test "a list item carries its text on the marker's own line" do
+      html = wire_html("* eins\n* zwei")
+
+      assert html == "<ul><li>eins</li><li>zwei</li></ul>"
+    end
+
+    test "a loose list keeps its paragraphs but loses the padding" do
+      html = wire_html("* eins\n\n* zwei")
+
+      assert html == "<ul><li><p>eins</p></li><li><p>zwei</p></li></ul>"
+    end
+
+    test "a heading and the paragraph under it do not run together" do
+      html = wire_html("# Titel\n\nEin Satz.")
+
+      assert html == "<h1>Titel</h1><p>Ein Satz.</p>"
+    end
+
+    test "a soft line break reads as the space it renders as on vutuv" do
+      # `breaks: false` means the two source lines are one flowing line on the
+      # page; without this they arrive as two lines on Mastodon.
+      html = wire_html("erste Zeile\nzweite Zeile")
+
+      assert html == "<p>erste Zeile zweite Zeile</p>"
+    end
+
+    test "a hard break survives as the <br> it already is" do
+      html = wire_html("erste Zeile\\\nzweite Zeile")
+
+      assert html == "<p>erste Zeile<br />zweite Zeile</p>"
+    end
+
+    test "the words around inline markup keep the spaces between them" do
+      html = wire_html("ganz **fett** und `code` dazwischen")
+
+      assert html ==
+               "<p>ganz <strong>fett</strong> und <code class=\"inline\">code</code> dazwischen</p>"
+    end
+
+    test "a code block keeps every line and every indent" do
+      # Highlighting wraps the keywords in spans, so read the newlines and the
+      # indent rather than the source text: those are what the pass must not eat.
+      html = wire_html("```elixir\ndef a do\n  :ok\nend\n```")
+
+      assert html =~ "do</span>\n  <span"
+      assert html =~ ":ok</span>\n<span"
+    end
+
+    test "a blockquote's own text is not glued to the paragraph after it" do
+      html = wire_html("> zitiert\n\ndanach")
+
+      assert html == "<blockquote><p>zitiert</p></blockquote><p>danach</p>"
+    end
+  end
 end


### PR DESCRIPTION
A post federated to Mastodon opens every paragraph with a blank line, and each bullet's text sits on the line below its own marker. Reported on https://genomic.social/@abuuba@vutuv.de/117188808796404549.

Mastodon renders status paragraphs as preformatted text (`.status__content p { white-space: pre-wrap }`), so the newlines and indentation Earmark writes for readability are drawn. A browser collapses them, which is why vutuv.de itself looks right.

New `VutuvWeb.Markdown.compact_html/1`, applied by `Fediverse.Docs.content_html/3` and `MastodonApi.Presenter.content_html/2` — the client API has the same defect and every app on it renders the same way. A soft newline inside a paragraph becomes the space it renders as here (posts use `breaks: false`), whitespace around block tags goes, and `<pre>` is handed through untouched.

Hot deploy: no migrations, no config or supervision changes.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01URnNZBLv2d8rr6xkw9RZqv
