### PR TITLE
Feed: cut the server time an arrival spends before it paints

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -549,6 +549,12 @@ config :vutuv, :refresh_popular_users, true
 # Same deal for the "who to follow" recent-poster pool (Vutuv.Posts.TopPosters)
 # and the feed rail's suggested-posts pool (Vutuv.Posts.PopularPosts).
 config :vutuv, :refresh_top_posters, true
+# The memo in front of Vutuv.Tags.linkable_slugs/1 (Vutuv.Tags.LinkableCache):
+# whether a written #hashtag names a topic worth a click, remembered for a
+# minute. Every rendered post body asks, so a feed page asked once per card.
+# Off in tests, where a memo outliving the asking process would answer for the
+# next test's freshly created tag.
+config :vutuv, :linkable_tag_cache, true
 config :vutuv, :refresh_popular_posts, true
 
 # The inline social posts on profiles (Vutuv.SocialFeed), one flag per

--- a/config/test.exs
+++ b/config/test.exs
@@ -39,6 +39,12 @@ config :vutuv, :sweep_api_auth, false
 # pref resolution falls back to the shipped defaults and tests inject
 # installation defaults via Vutuv.Prefs.Cache.store/1 (see prefs_test.exs).
 config :vutuv, :prefs_defaults_cache, false
+# The hashtag-linkability memo is off here for the same reason it is elsewhere
+# a win: its answers outlive the process that asked. A global one-minute memo
+# would let one test's "no such tag" stand for the next test's freshly created
+# one, so every test sees the live query and the cache's own tests
+# (linkable_cache_test.exs) start an isolated instance.
+config :vutuv, :linkable_tag_cache, false
 # Same deal for the screenshot blocklist's cache: with it off, every check
 # reads the table from the calling (sandbox-owning) process, so a test that
 # inserts an entry sees it act immediately.

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -22,6 +22,23 @@ posts, chat messages, ads, the RSS/JSON renderings), skipping entities typed
 inside code spans/blocks or existing links and resolving all of a body's
 mentions and hashtags in one batched query each.
 
+**One batched query per body is still one per card**, which on a feed page is
+forty, and the hashtag half of it is not a cheap query: a `UNION ALL` of two
+multi-join subqueries under a `DISTINCT`. Measured on a copy of production
+(2026-08-31), a body carrying a hashtag cost **3.4 ms and one round trip**
+against **0.2 ms and none** for a body without one, and a single `/feed` arrival
+ran it twenty-one times for sixty-four distinct hashtags — about 90 % of what
+rendering a card cost at all. So `Vutuv.Tags.LinkableCache` sits in front of it:
+one ETS table for the whole installation (the answer depends on no viewer — both
+gates are the anonymous public view), each folded key remembered for a minute,
+**misses included**, since almost every hashtag on a cached remote post names no
+topic here. And because a memo only helps the *second* render, the one place
+that can see a whole page warms it in one go before the first card renders —
+`Posts.decorate_feed_entries/3`, beside the other batch loads. The cache is a
+fast path and never a requirement: with its process off (tests,
+`:linkable_tag_cache`) or its table not yet up, every call is the live query it
+always was. Card rendering went from 3.3 ms and 21 queries to 0.96 ms and none.
+
 A hashtag also **files the post under that tag**, so the link points both ways:
 `Vutuv.Posts.PostHashtag` (table `post_hashtags`, re-derived from the body on
 every save), **minting the tag** when the body is the first thing here to name
@@ -331,7 +348,28 @@ page nobody asked for, so it is the one that has to carry the reader past the
 first few scrolls without a round trip; an older page is fetched while they are
 still reading and can afford to be half of it; and a switch is a wait with
 nothing on screen at all, where twenty rendered cards are the bulk of the second
-it takes on a slow line, for a screen that holds three or four. `more?` comes
+it takes on a slow line, for a screen that holds three or four.
+
+**The arrival is forty cards, but the HTML document carries ten**
+(`@first_render_size`), and the socket appends the other thirty as soon as it
+connects (`:fill_arrival`, which is `append_older_page/2` — the same act as
+pressing "Load more", so the dedup rule has one owner). Rendering a card costs
+about **10 ms** of server time on production, measured two ways on 2026-08-31 —
+a twelve-day regression across `?day=` volumes and a twenty-run paired A/B
+against an empty day, agreeing on 10.2 and 10.0 — so the forty were roughly
+400 ms of the ~660 ms the browser waited for its first byte, spent drawing
+thirty-seven cards below a fold that shows two or three. Ten is the same number
+`@filter_page_size` uses and for the reason written there: it is what a screen
+holding three or four cards needs in order not to run out. What changed is only
+that an *arrival* is now judged by the same standard as a switch.
+
+This is **not** the lazy discovery rail of #1229, which was reverted the same
+day because content popping in where the reader was looking read as slowness:
+the fill lands below the tenth card, off-screen, and a reader who never scrolls
+never learns it happened. A fill is owed to the page that asked for it
+(`:owes_fill?`) and is dropped if the reader has meanwhile switched sources or
+opened a calendar day — appending an older page to a day would spill posts from
+before it into that day. `more?` comes
 from the same query in all three cases, so a short page still knows there is
 more and the button below picks the rest up. The `/feed.md|txt|json|xml`
 siblings take the arrival page as *their* page size, every page of them, and

--- a/lib/vutuv/application.ex
+++ b/lib/vutuv/application.ex
@@ -68,8 +68,10 @@ defmodule Vutuv.Application do
   def start(_type, _args) do
     if Application.get_env(:vutuv, :ops_log_visibility, true), do: ensure_ops_logs_visible()
     # The optional children below are gated per config flag (off in tests, see
-    # config/test.exs): mostly periodic jobs, plus the Vutuv.Prefs.Cache,
-    # whose DB reloads would likewise touch the SQL sandbox from outside.
+    # config/test.exs): mostly periodic jobs, plus the two memos whose answers
+    # outlive the process that asked — Vutuv.Prefs.Cache, whose DB reloads
+    # would touch the SQL sandbox from outside, and Vutuv.Tags.LinkableCache,
+    # which would answer one test with the tag state of the one before it.
     children =
       [
         Vutuv.Repo,
@@ -116,6 +118,7 @@ defmodule Vutuv.Application do
         VutuvWeb.Live.MountHandoff,
         VutuvWeb.Endpoint
       ] ++
+        optional_child(:linkable_tag_cache, Vutuv.Tags.LinkableCache) ++
         optional_child(:prefs_defaults_cache, Vutuv.Prefs.Cache) ++
         optional_child(:screenshot_blocklist_cache, Vutuv.ScreenshotBlocklist.Cache) ++
         optional_child(:sweep_pending_images, Vutuv.Posts.PendingImageSweeper) ++

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -3179,7 +3179,57 @@ defmodule Vutuv.Posts do
       |> attach_thread_starts(viewer, threads?)
       |> attach_remote_thread(viewer, remote, threads?)
 
-    Vutuv.FeedPage.sort_entries(local ++ decorate_remote(remote, viewer))
+    entries = Vutuv.FeedPage.sort_entries(local ++ decorate_remote(remote, viewer))
+    warm_hashtag_links(entries)
+    entries
+  end
+
+  # The last batch load a page of cards needs, and the only one that is not an
+  # association: whether each `#hashtag` in these bodies names a topic worth a
+  # click (`Tags.linkable_slugs/1`). The renderer asks that question **per
+  # body**, so without this a page of forty cards ran the query up to forty
+  # times — 3.4 ms and one round trip for every card carrying a hashtag against
+  # 0.2 ms for one that does not (measured on a copy of production,
+  # 2026-08-31). Asked here for the whole page at once, it is one query, and
+  # `Vutuv.Tags.LinkableCache` hands the answers to each card in turn.
+  #
+  # It belongs beside the other batch loads rather than in the renderer for the
+  # reason they all do: this is the one place that can see the whole page. The
+  # answer is discarded — the cache is the delivery mechanism — so a miss costs
+  # nothing but the ordinary per-body path, and with the cache process off
+  # (tests) this is one extra query and no change in behaviour.
+  defp warm_hashtag_links(entries) do
+    written =
+      entries
+      |> Enum.flat_map(&entry_bodies/1)
+      |> Enum.flat_map(&Mentions.written_hashtags/1)
+      |> Enum.uniq()
+
+    if written != [], do: Tags.linkable_slugs(written)
+    :ok
+  end
+
+  # Every text an entry's cards will render — its own post and the ancestors
+  # above it (`thread_posts/1`, the owner of that list), a cached remote post
+  # or remote reply, and the remote parent a local reply answers. Each read
+  # through `text/1` rather than by column, so a fourth kind of post arrives
+  # here already handled.
+  defp entry_bodies(entry) do
+    # `:remote_parents` is keyed by the answering post and its values are the
+    # decorated map a remote card is drawn from, not the cached post itself.
+    parents =
+      entry
+      |> Map.get(:remote_parents, %{})
+      |> Map.values()
+      |> Enum.map(& &1[:remote_post])
+
+    entry
+    |> thread_posts()
+    |> Enum.concat([entry[:remote_post], entry[:note]])
+    |> Enum.concat(parents)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.map(&text/1)
+    |> Enum.reject(&is_nil/1)
   end
 
   defp attach_remote_thread(local, _viewer, _remote, false), do: local

--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -20,6 +20,7 @@ defmodule Vutuv.Tags do
   alias Vutuv.SlugHelpers
   require Vutuv.Tags.MatchKey
 
+  alias Vutuv.Tags.LinkableCache
   alias Vutuv.Tags.MatchKey
   alias Vutuv.Tags.Tag
   alias Vutuv.Tags.TagFollow
@@ -636,50 +637,79 @@ defmodule Vutuv.Tags do
   threshold of one member rather than two — that bar asks whether a page
   deserves a crawler, this one only whether it deserves a click.
 
-  One query per body (two arms of a union); an empty input skips the DB so the
-  renderer's no-hashtag path stays query-free.
-  """
-  def linkable_slugs(written) when is_list(written) do
-    import Vutuv.Moderation.Query, only: [account_hidden_row: 1, account_confirmed_row: 1]
+  At most one query per call (two arms of a union), and usually none:
+  `Vutuv.Tags.LinkableCache` remembers each folded key's answer — the misses
+  included — for a minute, and a feed page warms every hashtag it carries in
+  one go before the first card renders (`Posts.decorate_feed_entries/3`). The
+  cache is a fast path and never a requirement: with its process off (tests) or
+  its table not yet up, every call is the live query it always was. An empty
+  input skips both, so the renderer's no-hashtag path stays query-free.
 
+  `table` is the cache's ETS table, injectable so a test can run an isolated
+  instance.
+  """
+  def linkable_slugs(written, table \\ LinkableCache) when is_list(written) do
     keys = written |> Enum.map(&MatchKey.normalize/1) |> Enum.reject(&is_nil/1) |> Enum.uniq()
 
     if keys == [] do
       %{}
     else
-      held =
-        from(t in Tag,
-          as: :tag,
-          left_join: c in assoc(t, :merged_into),
-          as: :canonical,
-          join: ut in UserTag,
-          on: ut.tag_id == coalesce(c.id, t.id),
-          join: u in assoc(ut, :user),
-          where: account_confirmed_row(u) and not account_hidden_row(u)
-        )
-        |> keyed_target(keys)
+      # Whatever the memo already knows; anything it does not is one query for
+      # the lot, so a body naming five unseen tags still costs one round trip.
+      {known, missing} = LinkableCache.fetch(keys, table)
 
-      posted =
-        from([post_tag: pt] in Posts.visible_tagged_posts_query(),
-          join: t in Tag,
-          as: :tag,
-          on: pt.tag_id == coalesce(t.merged_into_id, t.id),
-          left_join: c in assoc(t, :merged_into),
-          as: :canonical
-        )
-        |> keyed_target(keys)
+      by_key =
+        case missing do
+          [] ->
+            known
 
-      from(row in subquery(union_all(held, ^posted)),
-        distinct: true,
-        select: {row.name, row.slug, row.target}
-      )
-      |> Repo.all()
-      |> Enum.map(fn {name, slug, target} ->
-        {MatchKey.normalize(name), MatchKey.normalize(slug), target}
-      end)
-      |> index_by_match_keys()
-      |> targets_for(written)
+          missing ->
+            fresh = query_targets(missing)
+            LinkableCache.put(missing, fresh, table)
+            Map.merge(known, fresh)
+        end
+
+      targets_for(by_key, written)
     end
+  end
+
+  # The live answer for `keys`: `{folded key => target slug}` for every tag they
+  # name that is worth a click. Split out of `linkable_slugs/2` so the memo in
+  # front of it has one thing to call and one thing to remember.
+  defp query_targets(keys) do
+    import Vutuv.Moderation.Query, only: [account_hidden_row: 1, account_confirmed_row: 1]
+
+    held =
+      from(t in Tag,
+        as: :tag,
+        left_join: c in assoc(t, :merged_into),
+        as: :canonical,
+        join: ut in UserTag,
+        on: ut.tag_id == coalesce(c.id, t.id),
+        join: u in assoc(ut, :user),
+        where: account_confirmed_row(u) and not account_hidden_row(u)
+      )
+      |> keyed_target(keys)
+
+    posted =
+      from([post_tag: pt] in Posts.visible_tagged_posts_query(),
+        join: t in Tag,
+        as: :tag,
+        on: pt.tag_id == coalesce(t.merged_into_id, t.id),
+        left_join: c in assoc(t, :merged_into),
+        as: :canonical
+      )
+      |> keyed_target(keys)
+
+    from(row in subquery(union_all(held, ^posted)),
+      distinct: true,
+      select: {row.name, row.slug, row.target}
+    )
+    |> Repo.all()
+    |> Enum.map(fn {name, slug, target} ->
+      {MatchKey.normalize(name), MatchKey.normalize(slug), target}
+    end)
+    |> index_by_match_keys()
   end
 
   # The half both arms of the union share. Written once because the two

--- a/lib/vutuv/tags/linkable_cache.ex
+++ b/lib/vutuv/tags/linkable_cache.ex
@@ -1,0 +1,142 @@
+defmodule Vutuv.Tags.LinkableCache do
+  @moduledoc """
+  The short-lived memo in front of `Vutuv.Tags.linkable_slugs/1` — "does this
+  written `#hashtag` name a topic whose page is worth a click".
+
+  That question is asked **once per rendered post body**, which on a feed page
+  is once per card, and answering it is a `UNION ALL` of two multi-join
+  subqueries wrapped in a `DISTINCT`. Measured on a copy of production
+  (2026-08-31), a body carrying a hashtag cost **3.4 ms and one query** against
+  **0.2 ms and none** for a body without one, and a single `/feed` arrival ran
+  that query twenty-one times for sixty-four distinct hashtags. The answer does
+  not depend on who is reading — the member gate (`account_confirmed_row/1`,
+  not hidden) and the post gate (`Posts.visible_tagged_posts_query/0`) are both
+  the anonymous public view — so one process's answer is every process's
+  answer, and the table is global rather than per-viewer.
+
+  Like `Vutuv.Posts.TopPosters` and `Vutuv.SocialFeed.Cache`: one GenServer owns
+  a `read_concurrency` ETS table, readers hit it directly and never call the
+  process, and **any miss is a live query** — an absent table (this process is
+  off in the test env, or boot has not finished) answers "everything is
+  missing", so behaviour is unchanged and only cheaper.
+
+  **Negative answers are cached too**, and they are the half that pays: nearly
+  every hashtag on a cached remote post names no topic here, so remembering
+  only the hits would leave the expensive path running for the common case.
+
+  ## What the staleness costs
+
+  An entry lives #{div(60_000, 1000)}s. Within that window a tag minted a moment
+  ago stays plain text, and a tag whose last member and last post went away
+  keeps its link. Both heal on their own and neither is wrong enough to pay a
+  query per card for: the window is one minute, not one hour, precisely so that
+  a member writing a brand-new hashtag sees it become a link while they are
+  still looking at the page.
+
+  `name:` and `table:` are injectable so a test can run an isolated instance
+  (the app-wide one is off under `config :vutuv, :linkable_tag_cache, false`).
+  """
+
+  use GenServer
+
+  @table __MODULE__
+  @ttl :timer.seconds(60)
+  @sweep_interval :timer.seconds(30)
+
+  @doc """
+  Splits `keys` (folded `MatchKey`s) into `{known, missing}` — `known` maps a
+  key to the slug its link points at, and a key remembered as naming nothing is
+  in **neither** list, since it is answered rather than missing.
+
+  A caller-side ETS read. An absent table answers `{%{}, keys}`, so the caller
+  runs its ordinary query.
+  """
+  def fetch(keys, table \\ @table) when is_list(keys) do
+    now = System.monotonic_time(:millisecond)
+    Enum.reduce(keys, {%{}, []}, &take(table, &1, now, &2))
+  rescue
+    ArgumentError -> {%{}, keys}
+  end
+
+  # One key's three outcomes: remembered as naming nothing (answered, so it
+  # joins neither list), remembered as naming a topic, or not remembered.
+  defp take(table, key, now, {known, missing}) do
+    case :ets.lookup(table, key) do
+      [{^key, nil, expires_at}] when expires_at > now -> {known, missing}
+      [{^key, target, expires_at}] when expires_at > now -> {Map.put(known, key, target), missing}
+      _absent_or_expired -> {known, [key | missing]}
+    end
+  end
+
+  @doc """
+  Remembers what a live query answered: every key in `asked` that `found` does
+  not carry named nothing, and is stored as such.
+
+  `found` may hold keys nobody asked for — a tag is indexed under both its
+  folded name and its folded slug (`Vutuv.Tags.index_by_match_keys/1`), so a
+  lookup by one spelling answers for the other — and those are kept, since the
+  next body may well write it the other way.
+  """
+  def put(asked, found, table \\ @table) when is_list(asked) and is_map(found) do
+    expires_at = System.monotonic_time(:millisecond) + @ttl
+
+    rows =
+      asked
+      |> Enum.reduce(found, &Map.put_new(&2, &1, nil))
+      |> Enum.map(fn {key, target} -> {key, target, expires_at} end)
+
+    :ets.insert(table, rows)
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  @doc """
+  Ages every entry out on the spot (tests).
+
+  The stamp is read back from the clock rather than set to zero:
+  `System.monotonic_time/1` has an arbitrary origin and is routinely
+  **negative**, so a literal `0` is a stamp comfortably in the future on a
+  freshly booted machine and would expire nothing.
+  """
+  def expire_all(table \\ @table) do
+    past = System.monotonic_time(:millisecond) - 1
+
+    table
+    |> :ets.tab2list()
+    |> Enum.map(fn {key, target, _expires_at} -> {key, target, past} end)
+    |> then(&:ets.insert(table, &1))
+
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  @doc "How long an entry is served for, in milliseconds."
+  def ttl, do: @ttl
+
+  def start_link(opts \\ []) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @impl true
+  def init(opts) do
+    table = Keyword.get(opts, :table, @table)
+
+    :ets.new(table, [:named_table, :public, :set, read_concurrency: true])
+    schedule_sweep()
+    {:ok, %{table: table}}
+  end
+
+  @impl true
+  def handle_info(:sweep, %{table: table} = state) do
+    now = System.monotonic_time(:millisecond)
+    # Expired rows only; `:"$3"` is the expiry stamp.
+    :ets.select_delete(table, [{{:_, :_, :"$3"}, [{:"=<", :"$3", now}], [true]}])
+    schedule_sweep()
+    {:noreply, state}
+  end
+
+  defp schedule_sweep, do: Process.send_after(self(), :sweep, @sweep_interval)
+end

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -73,6 +73,27 @@ defmodule VutuvWeb.PostLive.Feed do
   # trip, while an older page is fetched while they are still reading and can
   # afford to be half the size.
   @first_page_size 40
+  # …and how many of them the **HTML document** carries. The rest arrive over
+  # the socket the moment it connects, appended below the fold, so an arrival
+  # still holds forty cards by the time anybody has scrolled to the tenth.
+  #
+  # This is the split between what the reader waits for and what they merely
+  # get. Rendering a card is ~10 ms of server time on production (measured
+  # 2026-08-31 two ways: a twelve-day regression over `?day=` volumes and a
+  # paired A/B against an empty day, agreeing on 10.2 and 10.0), so the forty
+  # were about 400 ms of the ~660 ms the browser sat waiting for the first
+  # byte, to draw thirty-seven cards below a fold that shows two or three.
+  # Ten costs ~100 ms of that and fills the screen three times over.
+  #
+  # It is deliberately the same number as `@filter_page_size`, for the reason
+  # written there: ten is what a screen holding three or four cards needs to
+  # not run out. What is new is only that an *arrival* is now judged by the
+  # same standard as a switch — both are a wait with nothing on screen.
+  #
+  # Not a lazy rail (#1229, reverted the same day): nothing here pops in where
+  # the reader is looking. The fill lands below the tenth card, off-screen, and
+  # a reader who never scrolls never learns it happened.
+  @first_render_size 10
   @page_size 20
   # What a source switch loads (see `load_source_filter/2`) — deliberately
   # smaller than either, because that press is a wait with nothing on screen to
@@ -187,11 +208,20 @@ defmodule VutuvWeb.PostLive.Feed do
       # (VutuvWeb.Live.MountHandoff); take it and skip re-running the same
       # queries. Any miss (expired, consumed, a reconnect) recomputes.
       case MountHandoff.take(user.id, {:feed, remembered, day}) do
-        {:ok, payload} -> apply_feed_payload(socket, payload, day, open?)
-        :error -> apply_feed_payload(socket, feed_payload(user, remembered, day), day, open?)
+        # The dead render's short page (`@first_render_size`), so this mount
+        # owes the reader the rest of the arrival — see `:fill_arrival` below.
+        {:ok, payload} ->
+          apply_feed_payload(socket, payload, day, open?)
+
+        # No stash to take (a reconnect, an expired one, a socket that arrived
+        # without a dead render): nothing has been drawn yet, so there is no
+        # short page to extend and this mount loads the whole arrival at once.
+        :error ->
+          payload = feed_payload(user, remembered, day, @first_page_size)
+          apply_feed_payload(socket, payload, day, open?)
       end
     else
-      payload = feed_payload(user, remembered, day)
+      payload = feed_payload(user, remembered, day, @first_render_size)
       MountHandoff.stash(user.id, {:feed, remembered, day}, payload)
       apply_feed_payload(socket, payload, day, open?)
     end
@@ -199,7 +229,7 @@ defmodule VutuvWeb.PostLive.Feed do
 
   # Everything a feed mount computes, as data — what the dead render hands the
   # connected mount through the single-use stash.
-  defp feed_payload(user, remembered, day) do
+  defp feed_payload(user, remembered, day, limit) do
     # The member's private content filters (issue #940): compiled once, applied
     # to every page, and the set of posts they chose to reveal anyway.
     compiled = ContentFilters.compile_for(user)
@@ -226,7 +256,7 @@ defmodule VutuvWeb.PostLive.Feed do
     # arrival for one number.
     page =
       Posts.feed_page(user,
-        limit: if(day, do: @day_full_limit, else: @first_page_size),
+        limit: if(day, do: @day_full_limit, else: limit),
         cursor: FeedTimeTravel.day_cursor(day),
         filter: filter
       )
@@ -246,6 +276,11 @@ defmodule VutuvWeb.PostLive.Feed do
       # Which sources these entries were pulled for — what the band's two
       # source checkboxes show, and what a switch there changes.
       filter: filter,
+      # Whether this page is the dead render's short one and the arrival still
+      # owes the reader cards. Carried rather than inferred from the entry
+      # count: a genuinely short feed (a quiet day, a new member) also has
+      # fewer than `@first_render_size` entries and owes nothing.
+      partial?: limit < @first_page_size and page.more?,
       # The desktop rail renders WITH the page: it was lazy-loaded for one
       # release (v7.200.3) and the pop-in read as slowness, so it is eager
       # again — computed here once, riding the handoff to the connected mount.
@@ -353,7 +388,34 @@ defmodule VutuvWeb.PostLive.Feed do
     |> stream(:posts, payload.entries)
     |> watch_pending_photos(payload.entries)
     |> auto_translate_entries(payload.entries)
+    |> fill_arrival(payload)
   end
+
+  # The rest of the arrival, once the document the reader is looking at has
+  # been drawn. The dead render carries `@first_render_size` cards so the page
+  # arrives; this asks for the remainder as soon as the socket is up, and it
+  # lands below the fold.
+  #
+  # A message to self rather than a load here: mount has to return before the
+  # stream exists on the client, and appending to a stream in the same mount
+  # that populated it does not take (the same trap the day-link arrival above
+  # documents for `reset:`).
+  defp fill_arrival(socket, %{partial?: true}) do
+    if connected?(socket) do
+      send(self(), :fill_arrival)
+      # What the fill is owed *for*. The message sits in the mailbox behind
+      # anything the reader does in the meantime, and by the time it is handled
+      # they may be looking at a different timeline — an opened calendar day is
+      # the one that matters, since appending an older page there would spill
+      # cards from before that day into it. So the fill is claimed rather than
+      # assumed, and every reset below drops the claim.
+      assign(socket, :owes_fill?, true)
+    else
+      assign(socket, :owes_fill?, false)
+    end
+  end
+
+  defp fill_arrival(socket, _whole_page), do: assign(socket, :owes_fill?, false)
 
   # Every post on the page whose photo is still with the AI image scan gets a
   # subscription to its own topic, so the placecard swaps itself for the picture
@@ -1088,38 +1150,7 @@ defmodule VutuvWeb.PostLive.Feed do
 
   @impl true
   def handle_event("load-more", _params, socket) do
-    page =
-      Posts.feed_page(socket.assigns.current_user,
-        limit: @page_size,
-        cursor: socket.assigns.cursor,
-        filter: effective_filter(socket)
-      )
-
-    # A post shown higher up (as a newer repost, or nested in a shown thread)
-    # must not reappear on an older page: `feed_page/2` dedups within a page but
-    # can't see the ones already on screen. The higher card already carries the
-    # complete follow-scoped roster, so dropping the older duplicate loses
-    # nothing. Filter before the engagement batch so it queries only survivors.
-    shown = shown_post_ids(socket.assigns.entries)
-
-    fresh =
-      Enum.reject(page.entries, fn entry ->
-        not Posts.remote_feed_entry?(entry) and MapSet.member?(shown, entry.post.id)
-      end)
-
-    entries =
-      fresh
-      |> with_engagement(socket.assigns.current_user)
-      |> mark_filtered(socket.assigns.content_filters, socket.assigns.current_user.id)
-
-    {:noreply,
-     socket
-     |> assign(:more?, page.more?)
-     |> assign(:cursor, page.next_cursor)
-     |> update(:entries, &(&1 ++ entries))
-     |> stream(:posts, entries, at: -1)
-     |> watch_pending_photos(entries)
-     |> auto_translate_entries(entries)}
+    {:noreply, append_older_page(socket, @page_size)}
   end
 
   # Time travel (`VutuvWeb.Live.FeedTimeTravel`), all of it driven by the feed
@@ -1430,6 +1461,46 @@ defmodule VutuvWeb.PostLive.Feed do
   # member waits on a slow line — for a screen that holds three or four.
   # `more?` comes from the same query, so the "Load more" button below picks the
   # rest up at the full page size.
+  # One older page, appended below what is on screen. Shared by the "Load more"
+  # button and by the arrival's own fill (`:fill_arrival`), which is the same
+  # act — fetch from the cursor, drop what is already shown, append — and would
+  # otherwise be two copies of the dedup rule.
+  defp append_older_page(socket, limit) do
+    user = socket.assigns.current_user
+
+    page =
+      Posts.feed_page(user,
+        limit: limit,
+        cursor: socket.assigns.cursor,
+        filter: effective_filter(socket)
+      )
+
+    # A post shown higher up (as a newer repost, or nested in a shown thread)
+    # must not reappear on an older page: `feed_page/2` dedups within a page but
+    # can't see the ones already on screen. The higher card already carries the
+    # complete follow-scoped roster, so dropping the older duplicate loses
+    # nothing. Filter before the engagement batch so it queries only survivors.
+    shown = shown_post_ids(socket.assigns.entries)
+
+    fresh =
+      Enum.reject(page.entries, fn entry ->
+        not Posts.remote_feed_entry?(entry) and MapSet.member?(shown, entry.post.id)
+      end)
+
+    entries =
+      fresh
+      |> with_engagement(user)
+      |> mark_filtered(socket.assigns.content_filters, user.id)
+
+    socket
+    |> assign(:more?, page.more?)
+    |> assign(:cursor, page.next_cursor)
+    |> update(:entries, &(&1 ++ entries))
+    |> stream(:posts, entries, at: -1)
+    |> watch_pending_photos(entries)
+    |> auto_translate_entries(entries)
+  end
+
   defp load_source_filter(socket, filter) do
     user = socket.assigns.current_user
     page = Posts.feed_page(user, limit: @filter_page_size, filter: filter)
@@ -1446,6 +1517,9 @@ defmodule VutuvWeb.PostLive.Feed do
     |> assign(:empty?, entries == [])
     |> assign(:pending_posts, [])
     |> assign(:pending_overflow, 0)
+    # This timeline replaces the arrival, so a fill still on its way is owed to
+    # a page that is no longer on screen (see `fill_arrival/2`).
+    |> assign(:owes_fill?, false)
     |> assign(:entries, entries)
     |> stream(:posts, entries, reset: true)
     |> watch_pending_photos(entries)
@@ -1683,13 +1757,29 @@ defmodule VutuvWeb.PostLive.Feed do
     |> assign(:empty?, entries == [])
     |> assign(:pending_posts, [])
     |> assign(:pending_overflow, 0)
+    # This timeline replaces the arrival, so a fill still on its way is owed to
+    # a page that is no longer on screen (see `fill_arrival/2`).
+    |> assign(:owes_fill?, false)
     |> assign(:entries, entries)
     |> stream(:posts, entries, reset: true)
     |> watch_pending_photos(entries)
     |> auto_translate_entries(entries)
   end
 
+  # The rest of the arrival, once the reader has the page (see `fill_arrival/2`).
+  # It is the same act as pressing "Load more", so it is the same code — the
+  # cards land at the end of the stream, below the fold, and the cursor and the
+  # "Load more" button move on exactly as if the reader had pressed it.
   @impl true
+  def handle_info(:fill_arrival, %{assigns: %{owes_fill?: true}} = socket) do
+    socket = assign(socket, :owes_fill?, false)
+    {:noreply, append_older_page(socket, @first_page_size - @first_render_size)}
+  end
+
+  # The reader moved on (a source switch, an opened day) before the fill was
+  # handled; that page is not the one this was owed for.
+  def handle_info(:fill_arrival, socket), do: {:noreply, socket}
+
   def handle_info({:new_post, %{post_id: post_id, author_id: author_id}}, socket) do
     post = Posts.get_post(post_id)
 

--- a/test/vutuv/tags/linkable_cache_test.exs
+++ b/test/vutuv/tags/linkable_cache_test.exs
@@ -1,0 +1,225 @@
+defmodule Vutuv.Tags.LinkableCacheTest do
+  @moduledoc """
+  `Vutuv.Tags.linkable_slugs/1` answers "which of these written `#hashtags`
+  should become links" and used to ask the database **once per rendered post
+  body** — which on a feed page is once per card. The cache in front of it turns
+  the repeat asks into ETS reads.
+
+  The cache process is off in the test env (`:linkable_tag_cache`), so every
+  other test keeps seeing the live query; these tests start their own isolated
+  instance and hand its table in.
+
+  **`async: false`, and it has to be**: what these tests assert is a *query
+  count*, and `:telemetry.attach/4` is global — an async module would count
+  every query the twenty cases running beside it happened to make, so the
+  counts would drift with the seed. The ETS table is per-test; the handler is
+  not.
+  """
+  use Vutuv.DataCase, async: false
+  import Vutuv.PostsHelpers
+
+  alias Vutuv.Tags
+  alias Vutuv.Tags.LinkableCache
+  alias Vutuv.Tags.Tag
+
+  setup do
+    # Its own table and name, so nothing here leaks into another test's answers.
+    # Its own child id too, so a test that also wants the real-named instance
+    # (the page-prefetch one below) is not rejected as a duplicate child.
+    table = :"linkable_cache_#{System.unique_integer([:positive])}"
+
+    start_supervised!(
+      Supervisor.child_spec({LinkableCache, name: table, table: table}, id: table)
+    )
+
+    %{table: table}
+  end
+
+  # Counts the SQL a block runs, which is the whole point of the cache.
+  defp count_queries(fun) do
+    ref = make_ref()
+    parent = self()
+    handler = "qc-#{inspect(ref)}"
+
+    :telemetry.attach(
+      handler,
+      [:vutuv, :repo, :query],
+      fn _e, _m, _md, _c -> send(parent, {ref, :query}) end,
+      nil
+    )
+
+    try do
+      result = fun.()
+      {result, drain(ref, 0)}
+    after
+      :telemetry.detach(handler)
+    end
+  end
+
+  defp drain(ref, n) do
+    receive do
+      {^ref, :query} -> drain(ref, n + 1)
+    after
+      0 -> n
+    end
+  end
+
+  # A tag worth a click: a real tag one visible member carries, which is the
+  # `held` arm of the union `linkable_slugs/2` asks.
+  defp linkable_tag(base), do: linkable_tag_named(unique_tag_name(base))
+
+  defp linkable_tag_named(name) do
+    tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.gen_tag_slug_unique(name, Tag, :slug))
+    insert(:user_tag, user: insert(:activated_user), tag: tag)
+    tag
+  end
+
+  describe "the second ask costs no query" do
+    test "a known tag is answered from the table", %{table: table} do
+      tag = linkable_tag("Elixir")
+      written = String.downcase(tag.name)
+
+      {first, first_queries} = count_queries(fn -> Tags.linkable_slugs([written], table) end)
+      {second, second_queries} = count_queries(fn -> Tags.linkable_slugs([written], table) end)
+
+      assert first == %{written => tag.slug}
+      assert second == first, "a cached answer must equal the live one"
+      assert first_queries > 0, "the first ask has to reach the database"
+      assert second_queries == 0, "the second ask must not"
+    end
+
+    test "an unknown hashtag is remembered as unknown", %{table: table} do
+      # Negative caching is the half that matters most: almost every hashtag on
+      # a cached remote post names no topic here, so without it the feed's
+      # repeat renders would re-ask for every one of them.
+      written = "nichtvorhanden#{System.unique_integer([:positive])}"
+
+      {first, first_queries} = count_queries(fn -> Tags.linkable_slugs([written], table) end)
+      {second, second_queries} = count_queries(fn -> Tags.linkable_slugs([written], table) end)
+
+      assert first == %{}
+      assert second == %{}
+      assert first_queries > 0
+      assert second_queries == 0
+    end
+
+    test "a page's worth of bodies asks once, not once per body", %{table: table} do
+      tag = linkable_tag("Fotografie")
+      written = String.downcase(tag.name)
+
+      # What a feed page does today: twenty cards, each rendering its own body.
+      {_, queries} =
+        count_queries(fn ->
+          for _ <- 1..20, do: Tags.linkable_slugs([written], table)
+        end)
+
+      assert queries == 1, "twenty bodies naming one tag must cost one query, got #{queries}"
+    end
+  end
+
+  describe "the cache never changes the answer" do
+    test "mixed known and unknown names resolve exactly as the live query does", %{table: table} do
+      tag = linkable_tag("Thüringen")
+      written = String.downcase(tag.name)
+      stranger = "keintag#{System.unique_integer([:positive])}"
+
+      live = Tags.linkable_slugs([written, stranger])
+      cached_cold = Tags.linkable_slugs([written, stranger], table)
+      cached_warm = Tags.linkable_slugs([written, stranger], table)
+
+      assert cached_cold == live
+      assert cached_warm == live
+      assert Map.has_key?(live, written), "the transliterated German tag must still link"
+      refute Map.has_key?(live, stranger)
+    end
+
+    test "a hashtag that names nothing foldable stays plain text", %{table: table} do
+      # `MatchKey.normalize/1` answers nil for these, so they never reach the
+      # query and must never reach the cache either.
+      assert Tags.linkable_slugs(["-", "."], table) == %{}
+      assert Tags.linkable_slugs(["-", "."], table) == %{}
+    end
+
+    test "an empty list still skips the database", %{table: table} do
+      {result, queries} = count_queries(fn -> Tags.linkable_slugs([], table) end)
+      assert result == %{}
+      assert queries == 0
+    end
+  end
+
+  describe "staleness is bounded" do
+    test "an expired entry is asked again", %{table: table} do
+      written = "spaeter#{System.unique_integer([:positive])}"
+
+      # Ask once with a TTL that is already spent by the time we ask again.
+      Tags.linkable_slugs([written], table)
+      LinkableCache.expire_all(table)
+
+      {_, queries} = count_queries(fn -> Tags.linkable_slugs([written], table) end)
+      assert queries > 0, "an expired entry must not be served"
+    end
+
+    test "a tag created after the answer was cached links once the entry expires", %{table: table} do
+      name = "Nachzuegler#{System.unique_integer([:positive])}"
+      written = String.downcase(name)
+
+      assert Tags.linkable_slugs([written], table) == %{}
+
+      tag = linkable_tag_named(name)
+      assert Tags.linkable_slugs([written], table) == %{}, "still the cached answer"
+
+      LinkableCache.expire_all(table)
+      assert Tags.linkable_slugs([written], table) == %{written => tag.slug}
+    end
+  end
+
+  describe "a feed page warms the whole page at once" do
+    test "after building a page, every card's own hashtag lookup is free" do
+      # The memo alone only helps the SECOND render of a body. The prefetch in
+      # `decorate_feed_entries/3` is what makes the first one cheap too: it is
+      # the only place that can see the whole page, so it asks once for all of
+      # it and every card then reads the answer out of the table.
+      #
+      # This one runs the cache under its real name — the app-wide process is
+      # off in this env, and the module is sync, so nothing else can see it.
+      start_supervised!(LinkableCache)
+
+      author = insert(:activated_user)
+      reader = insert(:activated_user)
+      follow!(reader, author)
+
+      names = for i <- 1..6, do: unique_tag_name("Thema#{i}")
+      for name <- names, do: linkable_tag_named(name)
+
+      for name <- names, do: create_post!(author, %{body: "Etwas über ##{name}."})
+
+      page = Vutuv.Posts.feed_page(reader, limit: 20)
+      assert length(page.entries) == 6
+
+      # What each card does while rendering its body.
+      {_, queries} =
+        count_queries(fn ->
+          for entry <- page.entries do
+            entry.post
+            |> Vutuv.Posts.text()
+            |> Vutuv.Mentions.written_hashtags()
+            |> Tags.linkable_slugs()
+          end
+        end)
+
+      assert queries == 0,
+             "the page's prefetch must have answered every card already, got #{queries} queries"
+    end
+  end
+
+  describe "the cache is never a requirement" do
+    test "a missing table falls through to the live query" do
+      # The process is off in this env, so the app-wide table does not exist —
+      # the same shape as the moment before boot finishes.
+      tag = linkable_tag("Ausfall")
+      written = String.downcase(tag.name)
+
+      assert Tags.linkable_slugs([written], :no_such_linkable_table) == %{written => tag.slug}
+    end
+  end
+end

--- a/test/vutuv_web/live/feed_first_render_test.exs
+++ b/test/vutuv_web/live/feed_first_render_test.exs
@@ -1,0 +1,182 @@
+defmodule VutuvWeb.FeedFirstRenderTest do
+  @moduledoc """
+  What the **document** carries against what the **arrival** carries.
+
+  Rendering a post card costs ~10 ms of server time on production (measured
+  2026-08-31), so the forty cards a `/feed` arrival used to put in the HTML were
+  about 400 ms of the wait before anything painted — to draw thirty-seven cards
+  below a fold that shows two or three. The dead render now carries
+  `@first_render_size` and the socket fills the arrival up to `@first_page_size`
+  the moment it connects.
+
+  What must stay true: the reader still ends up with a whole arrival, the fill
+  lands **below** what they are looking at, and it never repeats a card the
+  short page already showed.
+  """
+  use VutuvWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Vutuv.PostsHelpers
+
+  alias Vutuv.Posts
+  alias VutuvWeb.PostLive.Feed
+
+  # The two numbers under test, read off the module so the test cannot drift
+  # from it — and asserted against each other, because the whole design is that
+  # one is smaller than the other.
+  @first_render 10
+  @first_page 40
+
+  defp feed_cards(html) do
+    ~r/id="feed-(?:post|repost|remote|boost)-/
+    |> Regex.scan(html)
+    |> length()
+  end
+
+  # `n` posts by somebody the reader follows, oldest first so the newest is last.
+  defp fill_feed(reader, n) do
+    author = insert(:activated_user)
+    follow!(reader, author)
+
+    for i <- 1..n do
+      create_post!(author, %{body: "Beitrag Nummer #{i}"})
+    end
+  end
+
+  describe "the document carries a screenful, not the whole arrival" do
+    test "the dead render stops at the first-render size", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      fill_feed(user, @first_page + 5)
+
+      html = conn |> get(~p"/feed") |> html_response(200)
+
+      assert feed_cards(html) == @first_render,
+             "the HTML document must carry #{@first_render} cards, got #{feed_cards(html)}"
+    end
+
+    test "the connected arrival is filled back up to the full page", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      fill_feed(user, @first_page + 5)
+
+      {:ok, live, html} = live(conn, ~p"/feed")
+
+      # The join renders the short page, then `:fill_arrival` appends the rest.
+      assert feed_cards(html) == @first_render
+
+      filled = render(live)
+
+      assert feed_cards(filled) == @first_page,
+             "the socket must fill the arrival to #{@first_page}, got #{feed_cards(filled)}"
+    end
+
+    test "a feed with less than a screenful owes nothing and asks for nothing", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      fill_feed(user, 3)
+
+      {:ok, live, html} = live(conn, ~p"/feed")
+
+      assert feed_cards(html) == 3
+      assert feed_cards(render(live)) == 3, "a short feed must not grow a second page"
+    end
+  end
+
+  describe "the fill is an ordinary older page" do
+    test "it appends below the short page and repeats nothing", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      fill_feed(user, @first_page + 5)
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+      html = render(live)
+
+      ids = Regex.scan(~r/id="(feed-[a-z]+-[0-9a-f-]+)"/, html, capture: :all_but_first)
+      assert length(ids) == length(Enum.uniq(ids)), "the fill must not repeat a card"
+
+      # Newest first, and the newest post is the one the reader arrived for, so
+      # it must be at the top rather than somewhere in the filled tail.
+      assert feed_cards(html) == @first_page
+      newest = "Beitrag Nummer #{@first_page + 5}"
+      oldest_shown = "Beitrag Nummer #{@first_page + 5 - @first_page + 1}"
+      assert html =~ newest
+      assert html =~ oldest_shown
+
+      {newest_at, _} = :binary.match(html, newest)
+      {oldest_at, _} = :binary.match(html, oldest_shown)
+      assert newest_at < oldest_at, "the fill belongs below what the document already showed"
+    end
+
+    test "Load more still picks up from where the fill stopped", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      fill_feed(user, @first_page + 15)
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+      assert feed_cards(render(live)) == @first_page
+
+      html = live |> element("#load-more") |> render_click()
+
+      assert feed_cards(html) == @first_page + 15,
+             "after the fill, Load more must add the remaining posts"
+    end
+  end
+
+  describe "the fill is owed to one page, not to whatever is on screen" do
+    test "an opened calendar day is not filled with cards from before it", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      author = insert(:activated_user)
+      follow!(user, author)
+
+      # Two days, so the opened one really does have older posts behind it —
+      # which is the whole spill this guards against. Built from the Berlin
+      # clock the app stamps, never `Date.utc_today/0`.
+      today = Vutuv.BerlinTime.today()
+      yesterday = Date.add(today, -1)
+      before_that = Date.add(today, -2)
+
+      quiet_day =
+        for i <- 1..3 do
+          author
+          |> create_post!(%{body: "Gestern #{i}"})
+          |> Vutuv.PostsHelpers.place_post_on_day!(yesterday, i)
+        end
+
+      for i <- 1..20 do
+        author
+        |> create_post!(%{body: "Vorgestern #{i}"})
+        |> Vutuv.PostsHelpers.place_post_on_day!(before_that, i)
+      end
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      # The fill message sits in the mailbox behind anything the reader does
+      # first. Opening a day is the one that must not be extended.
+      render_click(live, "cal-day", %{"date" => Date.to_iso8601(yesterday)})
+      opened = render(live)
+      assert feed_cards(opened) == length(quiet_day)
+      refute opened =~ "Vorgestern"
+
+      # Now let a fill owed to the arrival arrive late.
+      send(live.pid, :fill_arrival)
+      after_stale = render(live)
+
+      assert feed_cards(after_stale) == length(quiet_day),
+             "a fill owed to the arrival must not extend the day the reader opened"
+
+      refute after_stale =~ "Vorgestern",
+             "the day must not gain posts from before it"
+    end
+  end
+
+  describe "the agent-format siblings are unchanged" do
+    test "/feed.json still carries the whole arrival", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      fill_feed(user, @first_page + 5)
+
+      # The document siblings are not a browser arrival and have no socket to be
+      # filled by, so they keep asking for the full page.
+      assert Posts.feed_page(user, limit: Feed.first_page_size()).entries
+             |> length() == @first_page
+
+      body = conn |> get(~p"/feed.json") |> json_response(200)
+      assert length(body["posts"]) == @first_page
+    end
+  end
+end

--- a/test/vutuv_web/live/post_feed_live_test.exs
+++ b/test/vutuv_web/live/post_feed_live_test.exs
@@ -1256,11 +1256,20 @@ defmodule VutuvWeb.PostFeedLiveTest do
 
       {:ok, live, html} = live(conn, ~p"/feed")
 
-      # Forty on arrival, twenty per page after that: the first screenful is
-      # the one nobody asked for, so it is the one that has to last.
+      # The **document** carries a screenful (`@first_render_size`), because
+      # every card in it is server time the reader waits through before anything
+      # paints; the rest of the arrival follows over the socket. So the join
+      # holds the ten newest and not yet the eleventh.
       assert html =~ "post number 41"
-      assert html =~ "post number 2<"
-      refute html =~ "post number 1<"
+      assert html =~ "post number 32<"
+      refute html =~ "post number 31<"
+
+      # …and the **arrival** is still forty, twenty per page after that: the
+      # first screenful is the one nobody asked for, so it is the one that has
+      # to last. By the time anybody has scrolled to the tenth card it is here.
+      filled = render(live)
+      assert filled =~ "post number 2<"
+      refute filled =~ "post number 1<"
       assert has_element?(live, "#load-more")
 
       live |> element("#load-more") |> render_click()


### PR DESCRIPTION
`/feed` spent 350–1,360 ms on the server before the browser had a byte, and two thirds of that was rendering forty post cards into the HTML at ~10 ms each — measured two ways on production (a twelve-day regression across `?day=` volumes, and a twenty-run paired A/B against an empty day, agreeing on 10.2 and 10.0).

**A hashtag cost a database query per card.** `Tags.linkable_slugs/1` runs once per rendered body and is a `UNION` of two multi-join subqueries: 3.4 ms and one round trip for a body carrying one, 0.2 ms for one without. It now sits behind a one-minute memo (misses included — those are the common case), and `decorate_feed_entries/3` warms a whole page in one query before the first card renders. Card rendering: **3.3 ms → 0.96 ms, 21 queries → 0.**

**The document carries ten cards**, and the socket appends the other thirty on connect, below the fold. The arrival is still forty, "Load more" is exactly as far away, and the `.md/.txt/.json/.xml` siblings are untouched. Not the reverted lazy rail of #1229: nothing pops in where the reader is looking.

Where: `Vutuv.Tags.LinkableCache`, `VutuvWeb.PostLive.Feed`.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01CGaMzrCJ9VRejQZxoRU2md