### PR TITLE
Feed: stop shipping a megabyte the reader never uses

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -18,6 +18,7 @@ import { openPhotoCropper } from "./photo_crop"
 // reduced-motion) reused by every classic-page enhancement below.
 import {
   b64urlToBuf,
+  cancelIdle,
   csrfToken,
   localGet,
   localSet,
@@ -26,6 +27,8 @@ import {
   postJSON,
   request,
   reducedMotion,
+  savesData,
+  whenIdle,
 } from "./util"
 // The Milkdown WYSIWYG Markdown editor shared by the post + message composers
 // (VutuvWeb.UI.markdown_editor/1) is deliberately NOT imported here: it is a
@@ -328,9 +331,53 @@ function loadEditor(src) {
 // to cancel a boot that is still in flight, or the implementation would mount
 // itself onto an element LiveView has already removed.
 const MarkdownEditor = {
+  // The bundle is 512 kB of ProseMirror (137 kB over the wire), and it used to
+  // be fetched, parsed and run from `mounted()` on every page carrying a
+  // composer — including /feed, where the composer is collapsed. The panel
+  // stays mounted so a half-typed draft survives a re-render (#1148) and so
+  // morphdom never re-parents the editor mid-sentence (#1200), and LiveView
+  // mounts hooks on hidden elements all the same, so a feed visit ran the whole
+  // editor for a composer nobody had opened: measured at t=1.6s on an ordinary
+  // load (2026-08-31), competing with the first paint and the socket connect.
+  //
+  // So the boot asks one question, synchronously, at mount: **is this editor
+  // what the page is for?** A message thread, the organization form and the job
+  // form render it visible, and those boot exactly as they always did. The
+  // feed's collapsed composer is the only one that is not, and it waits for the
+  // browser to be idle — off the critical path, but still long before anybody
+  // presses "Write a post", so opening the composer is no slower than before.
+  //
+  // Deliberately NOT an IntersectionObserver, which is the obvious tool and the
+  // wrong one: it delivers nothing at all while a tab is in the background, so
+  // a feed opened in a background tab would sit on the plain textarea until the
+  // tab was focused (measured 2026-08-31). Idle callbacks have no such rule.
+  //
+  // On a metered connection nothing speculative runs and the first reach for
+  // the composer pays for it; the plain textarea underneath is a working
+  // composer until it lands.
   mounted() {
     const src = this.el.dataset.mdeSrc
     if (!src) return
+
+    // No client rects = `display: none` on it or on something above it.
+    if (this.el.getClientRects().length > 0) {
+      this.boot_(src)
+      return
+    }
+
+    this.onReach_ = () => this.boot_(src)
+    this.el.addEventListener("focusin", this.onReach_)
+    this.el.addEventListener("pointerdown", this.onReach_)
+
+    if (!savesData()) this.warm_ = whenIdle(() => this.boot_(src))
+  },
+
+  // Fetch, adopt and run the real hook. Idempotent: a reach and the idle
+  // warm-up can both arrive, and either may already have the module in hand.
+  boot_(src) {
+    if (this.booted_) return
+    this.booted_ = true
+    this.stopWaiting_()
 
     loadEditor(src)
       .then(({ MarkdownEditor: impl }) => {
@@ -360,7 +407,17 @@ const MarkdownEditor = {
 
   destroyed() {
     this.destroyed_ = true
+    this.stopWaiting_()
     this.impl_?.destroyed.call(this)
+  },
+
+  // Everything that was only there to notice the composer being reached.
+  stopWaiting_() {
+    cancelIdle(this.warm_)
+    if (!this.onReach_) return
+    this.el.removeEventListener("focusin", this.onReach_)
+    this.el.removeEventListener("pointerdown", this.onReach_)
+    this.onReach_ = null
   },
 }
 

--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -25,6 +25,40 @@ export function onReady(fn) {
   window.addEventListener("phx:page-loading-stop", fn)
 }
 
+// Run `fn` when the browser has nothing better to do, for speculative work that
+// must never compete with the page it is speculating about. Returns a handle for
+// cancelIdle(). Safari has no requestIdleCallback, so it falls back to a timeout
+// long enough to be clear of the first paint and the LiveView connect.
+export function whenIdle(fn, timeout = 3000) {
+  if (typeof requestIdleCallback === "function") {
+    return { idle: requestIdleCallback(fn, { timeout }) }
+  }
+
+  return { timer: setTimeout(fn, 1500) }
+}
+
+export function cancelIdle(handle) {
+  if (!handle) return
+  if (handle.idle !== undefined && typeof cancelIdleCallback === "function") {
+    cancelIdleCallback(handle.idle)
+  }
+  if (handle.timer !== undefined) clearTimeout(handle.timer)
+}
+
+// Whether the member has asked their browser to spend less data (iOS/Safari
+// report nothing, which reads as "no"). What it gates here is speculative
+// prefetching, never anything the member actually asked for: on a metered or
+// very slow link, work nobody requested is the first thing to drop.
+export function savesData() {
+  const connection = navigator.connection
+  if (!connection) return false
+
+  return (
+    connection.saveData === true ||
+    ["slow-2g", "2g"].includes(connection.effectiveType)
+  )
+}
+
 // "Wire this element exactly once" guard. Returns true the first time it sees
 // `el` under `key` (and marks it), false every time after, so a re-scan from
 // onReady() can't attach a duplicate listener.

--- a/lib/vutuv_web/components/ui.ex
+++ b/lib/vutuv_web/components/ui.ex
@@ -4488,6 +4488,58 @@ defmodule VutuvWeb.UI do
   end
 
   @doc """
+  The page's one copy of the glyphs a timeline repeats.
+
+  A feed card carries a like, a reply, a repost and a bookmark, so a page of
+  forty draws each of those four paths forty times: measured on production
+  (2026-08-31), 237 inline `<path d="…">` on one `/feed` document, **six**
+  distinct shapes, 41 KB of the 673 KB. Defined once here and referenced with
+  `<use>`, the same page spends under a kilobyte on them.
+
+  It is a **parse-and-memory** saving, not a download one — zstd compresses that
+  repetition away on the wire — which is why it is worth doing for the phone
+  that has to build the DOM and not worth doing for the connection.
+
+  Rendered once by the app layout, before anything that references it. `fill`,
+  `stroke`, `stroke-width`, `stroke-linecap` and `stroke-linejoin` are all
+  inherited properties, so each `<svg>` wrapper keeps styling its own glyph
+  through the shadow tree exactly as it did when the path was inline — which is
+  what lets `filled?` still switch the heart and the bookmark to solid.
+  """
+  def icon_sprite(assigns) do
+    ~H"""
+    <svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" aria-hidden="true" focusable="false">
+      <defs>
+        <path
+          id="glyph-repost"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M19.5 12c0-1.232-.046-2.453-.138-3.662a4.006 4.006 0 0 0-3.7-3.7 48.678 48.678 0 0 0-7.324 0 4.006 4.006 0 0 0-3.7 3.7c-.017.22-.032.441-.046.662M19.5 12l3-3m-3 3-3-3m-12 3c0 1.232.046 2.453.138 3.662a4.006 4.006 0 0 0 3.7 3.7 48.656 48.656 0 0 0 7.324 0 4.006 4.006 0 0 0 3.7-3.7c.017-.22.032-.441.046-.662M4.5 12l3 3m-3-3-3 3"
+        />
+        <path
+          id="glyph-reply"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3"
+        />
+        <path
+          id="glyph-bookmark"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M17.593 3.322c.1.128.157.288.157.456v16.444a.75.75 0 0 1-1.218.585L12 17.21l-4.532 3.597A.75.75 0 0 1 6.25 20.222V3.778c0-.168.057-.328.157-.456A2.25 2.25 0 0 1 8.25 2.5h7.5a2.25 2.25 0 0 1 1.843.822Z"
+        />
+        <path
+          id="glyph-heart"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z"
+        />
+      </defs>
+    </svg>
+    """
+  end
+
+  @doc """
   The outline repost-arrows icon (24×24 stroke), shared by the post card's
   "Reposted by" line and the action bar. Size it via `class`.
   """
@@ -4496,11 +4548,7 @@ defmodule VutuvWeb.UI do
   def icon_repost(assigns) do
     ~H"""
     <svg class={@class} fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24">
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        d="M19.5 12c0-1.232-.046-2.453-.138-3.662a4.006 4.006 0 0 0-3.7-3.7 48.678 48.678 0 0 0-7.324 0 4.006 4.006 0 0 0-3.7 3.7c-.017.22-.032.441-.046.662M19.5 12l3-3m-3 3-3-3m-12 3c0 1.232.046 2.453.138 3.662a4.006 4.006 0 0 0 3.7 3.7 48.656 48.656 0 0 0 7.324 0 4.006 4.006 0 0 0 3.7-3.7c.017-.22.032-.441.046-.662M4.5 12l3 3m-3-3-3 3"
-      />
+      <use href="#glyph-repost" />
     </svg>
     """
   end
@@ -4514,7 +4562,7 @@ defmodule VutuvWeb.UI do
   def icon_reply(assigns) do
     ~H"""
     <svg class={@class} fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24">
-      <path stroke-linecap="round" stroke-linejoin="round" d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3" />
+      <use href="#glyph-reply" />
     </svg>
     """
   end
@@ -4536,11 +4584,7 @@ defmodule VutuvWeb.UI do
       stroke-width="1.8"
       viewBox="0 0 24 24"
     >
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        d="M17.593 3.322c.1.128.157.288.157.456v16.444a.75.75 0 0 1-1.218.585L12 17.21l-4.532 3.597A.75.75 0 0 1 6.25 20.222V3.778c0-.168.057-.328.157-.456A2.25 2.25 0 0 1 8.25 2.5h7.5a2.25 2.25 0 0 1 1.843.822Z"
-      />
+      <use href="#glyph-bookmark" />
     </svg>
     """
   end
@@ -4562,11 +4606,7 @@ defmodule VutuvWeb.UI do
       stroke-width="1.8"
       viewBox="0 0 24 24"
     >
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z"
-      />
+      <use href="#glyph-heart" />
     </svg>
     """
   end

--- a/lib/vutuv_web/templates/layout/app.html.heex
+++ b/lib/vutuv_web/templates/layout/app.html.heex
@@ -3,6 +3,10 @@ classic controller pages and LiveViews. The shell (top bar + mobile bottom tab
 bar, with the live unread badges) is an embedded `ShellLive` so the badges stay
 live even on classic pages. `assigns[:conn]` is present on dead requests;
 LiveViews fall through to `@socket`. --%>
+<%!-- The glyphs a timeline repeats, defined once and referenced with `<use>`
+(see `<.icon_sprite>`). First, so every later `<use>` resolves. --%>
+<.icon_sprite />
+
 <%= if assigns[:conn] do %>
   {live_render(@conn, VutuvWeb.ShellLive, id: "app-shell-lv", session: shell_session(assigns))}
 <% else %>

--- a/test/vutuv_web/icon_sprite_test.exs
+++ b/test/vutuv_web/icon_sprite_test.exs
@@ -1,0 +1,67 @@
+defmodule VutuvWeb.IconSpriteTest do
+  @moduledoc """
+  The glyphs a timeline repeats are defined once and referenced with `<use>`.
+
+  Measured on production (2026-08-31), one `/feed` document carried 237 inline
+  `<path d="…">` for **six** distinct shapes — 41 KB of its 673 KB. It is a
+  parse-and-memory saving rather than a download one (zstd compresses that
+  repetition away on the wire), which is why it is worth doing for the phone
+  building the DOM.
+
+  A broken `<use>` shows **nothing** and raises nothing, so the two halves are
+  asserted together: the sprite has to be on the page, and the cards have to
+  point at it rather than carrying their own copy of the path.
+  """
+  use VutuvWeb.ConnCase
+
+  import Vutuv.PostsHelpers
+
+  @glyphs ~w(glyph-heart glyph-reply glyph-repost glyph-bookmark)
+
+  # The heart's own path data. If a card still carries this, the reference did
+  # not replace it and the page is paying for both.
+  @heart_path "M21 8.25c0-2.485-2.099-4.5-4.688-4.5"
+
+  describe "the page defines each repeated glyph once" do
+    test "the sprite ships with every glyph the action bar asks for", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      create_post!(user, %{body: "Etwas zu lesen."})
+
+      html = conn |> get(~p"/feed") |> html_response(200)
+
+      for glyph <- @glyphs do
+        assert html =~ ~s(id="#{glyph}"), "the sprite must define #{glyph}"
+        assert html =~ ~s(href="##{glyph}"), "something must reference #{glyph}"
+      end
+    end
+
+    test "a card references the heart rather than repeating its path", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      for i <- 1..3, do: create_post!(user, %{body: "Beitrag #{i}"})
+
+      html = conn |> get(~p"/feed") |> html_response(200)
+
+      # Once in the sprite, nowhere else — three cards would otherwise carry
+      # three more copies.
+      assert html |> String.split(@heart_path) |> length() == 2,
+             "the heart path belongs in the sprite only"
+
+      # …and every card still asks for it.
+      hearts = html |> String.split(~s(href="#glyph-heart")) |> length()
+      assert hearts >= 4, "each of the three cards must reference the heart, got #{hearts - 1}"
+    end
+  end
+
+  describe "the sprite is inert" do
+    test "it is hidden and announces nothing", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      html = conn |> get(~p"/feed") |> html_response(200)
+
+      [sprite | _] = String.split(html, ~s(id="glyph-repost"))
+      opening = sprite |> String.split("<svg") |> List.last()
+
+      assert opening =~ ~s(aria-hidden="true"), "a definitions block must not be announced"
+      assert opening =~ ~s(width="0"), "and must not take layout"
+    end
+  end
+end


### PR DESCRIPTION
Two things every `/feed` visit paid for and did not use. Both are browser-side weight, so neither shows up in TTFB.

**512 kB of ProseMirror.** The Milkdown bundle is already its own entry point, but its hook is on the feed's collapsed composer — and LiveView mounts hooks on hidden elements, so `mounted()` imported it on every visit: measured at t=1.6 s, competing with the first paint and the socket connect, and 1.92 s of download alone on a 50 kB/s link. The boot now asks once, synchronously, whether the editor is what the page is for: visible at mount (a message thread, the organization and job forms) starts as before, hidden waits for the browser to be idle, or for the first touch if that comes first. Deliberately not an `IntersectionObserver` — those deliver nothing in a background tab, which would leave the composer a plain textarea until focused.

**237 inline SVG paths for six shapes**, 41 kB of one feed document. Defined once, referenced with `<use>`.

Where: `assets/js/app.js`, `VutuvWeb.UI.icon_sprite/1`.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01CGaMzrCJ9VRejQZxoRU2md