### PR TITLE
Feed: the boost source uses its index at every page size

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -3164,7 +3164,24 @@ defmodule Vutuv.Fediverse do
   # boosted vutuv post's author for the moderation check instead of re-fetching
   # the user per row, and asks the boosted remote post's `audience` column
   # whether it is still open.
+  # The boosters arrive as a **constant id list**, the same shape (and for the
+  # same reason) as `remote_posts_query/4` above. Joined to `fediverse_follows`,
+  # Postgres could not use `fediverse_post_boosts_recency_index` for anything
+  # but the smallest page: measured on the production copy (2026-08-31) it took
+  # the index at limit 11 and fell back to a full scan the moment the page grew
+  # — 3,039 buffers at the fill's limit of 31 and 3,708 at a calendar day's 100.
+  # Handed the ids, it walks the index at every limit: **156 and 448 buffers**,
+  # returning the same rows.
+  #
+  # So this is what makes that index earn its keep beyond the first ten cards.
   defp remote_boosts_query(%User{id: viewer_id} = viewer, fetch_n, cursor, opts) do
+    boosters =
+      from(f in Follow,
+        where: f.user_id == ^viewer_id and f.muted == false and f.state == "accepted",
+        select: f.remote_account_id
+      )
+      |> Repo.all()
+
     # The author's own follow is consulted too, not only the booster's: a
     # reader who muted an account out there muted *them*, and somebody else
     # passing their post on is exactly the back door that would undo it.
@@ -3178,8 +3195,6 @@ defmodule Vutuv.Fediverse do
       join: a in RemoteAccount,
       as: :remote_account,
       on: a.id == b.remote_account_id,
-      join: f in Follow,
-      on: f.remote_account_id == a.id,
       left_join: rp in RemotePost,
       as: :language_source,
       on: rp.id == b.remote_post_id,
@@ -3189,7 +3204,7 @@ defmodule Vutuv.Fediverse do
       left_join: author in RemoteAccount,
       as: :boosted_author,
       on: author.id == rp.remote_account_id,
-      where: f.user_id == ^viewer_id and f.muted == false and f.state == "accepted",
+      where: b.remote_account_id in ^boosters,
       where: is_nil(rp.id) or rp.remote_account_id not in subquery(muted_authors),
       order_by: [desc: b.announced_at, desc: b.id],
       limit: ^fetch_n,

--- a/test/vutuv/fediverse_boosts_source_test.exs
+++ b/test/vutuv/fediverse_boosts_source_test.exs
@@ -1,0 +1,137 @@
+defmodule Vutuv.FediverseBoostsSourceTest do
+  @moduledoc """
+  The feed's boost source across **several** boosting accounts at once.
+
+  It used to reach them through a join to `fediverse_follows`, which kept
+  Postgres off `fediverse_post_boosts_recency_index` for anything but the
+  smallest page: measured on the production copy (2026-08-31) it took the index
+  at limit 11 and fell back to a full scan the moment the page grew — 3,039
+  buffers at the fill's limit of 31, 3,708 at a calendar day's 100. The boosters
+  are now read first and handed over as a constant id list, so it walks the
+  index at every limit (156 and 448 buffers).
+
+  `fediverse_post_boosts_test.exs` pins what one booster may show whom. What is
+  new here is what the join did implicitly across **many**: no duplicates, one
+  merged order, and each follow's own state and mute honoured.
+  """
+  use Vutuv.DataCase, async: true
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.PostBoost
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Posts
+
+  defp member, do: insert(:activated_user, fediverse_followers?: true)
+
+  defp account(handle) do
+    Repo.insert!(%RemoteAccount{
+      actor_uri: "https://social.example/users/#{handle}",
+      host: "social.example",
+      handle: handle,
+      name: handle,
+      inbox_uri: "https://social.example/users/#{handle}/inbox"
+    })
+  end
+
+  defp follow(user, account, state \\ "accepted", muted \\ false) do
+    Repo.insert!(%Follow{
+      user_id: user.id,
+      remote_account_id: account.id,
+      state: state,
+      muted: muted,
+      follow_activity_id: "https://vutuv.test/#{user.id}/actor#f/#{account.id}"
+    })
+  end
+
+  # A vutuv member's post passed on by a remote account — the `post_id` half of
+  # a boost, which needs no third server to resolve.
+  defp boost(account, post, minutes_ago) do
+    Repo.insert!(%PostBoost{
+      remote_account_id: account.id,
+      post_id: post.id,
+      activity_id: "https://social.example/act/#{System.unique_integer([:positive])}",
+      announced_at: DateTime.utc_now(:second) |> DateTime.add(-minutes_ago * 60, :second)
+    })
+  end
+
+  defp author_post(body) do
+    author = insert(:activated_user, fediverse_followers?: true)
+    {:ok, _} = Fediverse.ensure_actor(author)
+    Vutuv.PostsHelpers.create_post!(Repo.reload!(author), %{body: body})
+  end
+
+  defp boosted_bodies(user) do
+    user
+    |> Posts.feed_page(limit: 20)
+    |> Map.fetch!(:entries)
+    |> Enum.filter(&(&1[:boosted_by] != nil))
+    |> Enum.map(& &1.post.body)
+  end
+
+  describe "several boosting accounts at once" do
+    test "the source merges them by announce time, not account by account" do
+      user = member()
+      a = account("alpha")
+      b = account("beta")
+      follow(user, a)
+      follow(user, b)
+
+      boost(a, author_post("oldest"), 30)
+      boost(b, author_post("middle"), 20)
+      boost(a, author_post("newest"), 10)
+
+      assert boosted_bodies(user) == ["newest", "middle", "oldest"]
+    end
+
+    test "a boost appears once, however many accounts the viewer follows" do
+      user = member()
+      accounts = for h <- ~w(one two three four), do: account(h)
+      for acc <- accounts, do: follow(user, acc)
+      for {acc, i} <- Enum.with_index(accounts), do: boost(acc, author_post("post #{i}"), i)
+
+      got = boosted_bodies(user)
+      assert length(got) == 4
+      assert got == Enum.uniq(got)
+    end
+  end
+
+  describe "each follow's own state governs its boosts" do
+    test "only an accepted follow carries them" do
+      user = member()
+      yes = account("accepted")
+      no = account("pending")
+      follow(user, yes, "accepted")
+      follow(user, no, "requested")
+
+      boost(yes, author_post("from the accepted one"), 10)
+      boost(no, author_post("from the pending one"), 9)
+
+      assert boosted_bodies(user) == ["from the accepted one"]
+    end
+
+    test "muting one booster leaves the others alone" do
+      user = member()
+      loud = account("loud")
+      quiet = account("quiet")
+      follow(user, loud, "accepted", true)
+      follow(user, quiet)
+
+      boost(loud, author_post("from the muted one"), 10)
+      boost(quiet, author_post("from the other one"), 9)
+
+      assert boosted_bodies(user) == ["from the other one"]
+    end
+
+    test "somebody else's follow carries nothing to this reader" do
+      user = member()
+      stranger = member()
+      acc = account("theirs")
+      follow(stranger, acc)
+
+      boost(acc, author_post("not for you"), 5)
+
+      assert boosted_bodies(user) == []
+    end
+  end
+end


### PR DESCRIPTION
The recency index from #1864 only ever helped the arrival. Through the join to `fediverse_follows`, Postgres could reach it at the smallest page and fell back to a full scan as soon as the page grew — measured on the production copy: **3,039 buffers at the fill's limit of 31, 3,708 at a calendar day's 100**, against 83 at the arrival's 11.

The boosting accounts are now read first and handed over as a constant id list, the same shape as #1865. The query then walks the index at every page size: **156 and 448 buffers**, returning identical rows at limits 11, 31 and 101.

On a whole page build the source has dropped off the flagged list entirely — the calendar day went **3,702 → 450 buffers**.

Together with #1865 that clears both fediverse sources from every feed path (arrival, fill, calendar day, source switch). What still stands out is the six local `posts` sources each re-running the viewer's `follows` / `blocks` / `past_follows` subqueries, which is a wider design question and deliberately left alone here.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01CGaMzrCJ9VRejQZxoRU2md