### PR TITLE
Give the feed one place that decides what a freshly loaded timeline means

### DIFF
--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -270,7 +270,9 @@ defmodule VutuvWeb.PostLive.Feed do
     %{
       content_filters: compiled,
       more?: page.more?,
-      cursor: page.next_cursor,
+      # Spelled the way `Posts.feed_page/2` spells it, so this payload and a
+      # page are the same shape to `put_timeline/3`.
+      next_cursor: page.next_cursor,
       draft: draft,
       entries: entries,
       # Which sources these entries were pulled for — what the band's two
@@ -317,13 +319,6 @@ defmodule VutuvWeb.PostLive.Feed do
     # assign is the truth, and the stored column is not read again while the
     # page lives.
     |> assign(:feed_filter, payload.filter)
-    |> assign(:more?, payload.more?)
-    |> assign(:cursor, payload.cursor)
-    |> assign(:empty?, payload.entries == [])
-    |> assign(:pending_posts, [])
-    # How many arrivals the cap turned away. Nonzero means the timeline no longer
-    # holds a row for every waiting post, so the press has to load a page.
-    |> assign(:pending_overflow, 0)
     # The calendar's own state: whether it is unfolded, which month is on
     # screen, which reading its heatmap shades, and which day (if any) the
     # reader opened. `cal_day` is a Date rather than a moment because it names a
@@ -352,12 +347,6 @@ defmodule VutuvWeb.PostLive.Feed do
     # thrown away. Resolved here rather than announced by the composer so the
     # disconnected render already agrees and the panel never flickers open.
     |> assign(:composer_open?, payload.draft != nil)
-    # The set of entries currently on screen, kept so the midnight :day_changed
-    # tick can re-render each stamp in place (streams don't retain their data).
-    # Order/dupes don't matter: the refresh uses stream_insert update_only, which
-    # updates existing rows where they sit and ignores ones already gone.
-    |> assign(:entries, payload.entries)
-    |> rebase_seam(payload.entries)
     # The posts on screen we hold a photo-scan subscription for (below).
     |> assign(:photo_watch, MapSet.new())
     # How this member arranged the rail: the order of its cards, which are
@@ -385,10 +374,15 @@ defmodule VutuvWeb.PostLive.Feed do
         limit: 5
       )
     )
+    # Everything that is true of the list the reader has just been handed
+    # (`put_timeline/3`), the entries themselves included. It sits here rather
+    # than up with the other assigns because `watch_pending_photos/2` reads the
+    # `:photo_watch` set above. The mount is the one of the three moments that
+    # does not REPLACE a timeline: it seeds the stream itself, and owes its fill
+    # to `fill_arrival/2` rather than clearing it.
+    |> put_timeline(payload.entries, payload)
     |> stream_configure(:posts, dom_id: &"feed-#{&1.id}")
     |> stream(:posts, payload.entries)
-    |> watch_pending_photos(payload.entries)
-    |> auto_translate_entries(payload.entries)
     |> fill_arrival(payload)
   end
 
@@ -1509,6 +1503,59 @@ defmodule VutuvWeb.PostLive.Feed do
     |> auto_translate_entries(entries)
   end
 
+  # Everything that is true of a list of entries the feed has just put on
+  # screen. Three moments do that — the mount, a source-filter change and a
+  # travelled-to day — and they used to spell this out one by one, which cost
+  # nothing until a fact was added to two of them and forgotten in the third.
+  # That is not hypothetical: every one of them asked for the page's
+  # translations except the source switch, so a reader with auto-translate on
+  # who moved to the Fediverse sources — where the foreign-language posts are —
+  # got untranslated cards until they reloaded (issue #1870).
+  #
+  # `page` is anything carrying `more?` and `next_cursor` — the result of
+  # `Posts.feed_page/2` for the two loaders, the mount's own payload, which
+  # `feed_payload/4` builds with the same two keys.
+  #
+  # **Nothing added here may touch the `:posts` stream.** The mount is the only
+  # caller that has not configured it yet (`stream_configure/3` raises once a
+  # stream exists, and it runs on the line after this one), so a `stream_insert`
+  # dropped in here would take every feed mount down and neither loader would
+  # show it. Streaming is the callers' half: `replace_timeline/3` resets,
+  # the mount seeds.
+  #
+  # `append_older_page/2` deliberately does NOT come through here: it adds a
+  # page below the fold rather than replacing one, so it must not clear the
+  # waiting posts, must not re-base the seam, and cannot change `:empty?`.
+  defp put_timeline(socket, entries, page) do
+    socket
+    |> assign(:more?, page.more?)
+    |> assign(:cursor, page.next_cursor)
+    |> assign(:empty?, entries == [])
+    |> assign(:pending_posts, [])
+    # How many arrivals the cap turned away. Nonzero means the timeline no
+    # longer holds a row for every waiting post, so the press has to load a
+    # page.
+    |> assign(:pending_overflow, 0)
+    # The set of entries currently on screen, kept so the midnight :day_changed
+    # tick can re-render each stamp in place (streams don't retain their data).
+    # Order/dupes don't matter: the refresh uses stream_insert update_only,
+    # which updates existing rows where they sit and ignores ones already gone.
+    |> assign(:entries, entries)
+    |> rebase_seam(entries)
+    |> watch_pending_photos(entries)
+    |> auto_translate_entries(entries)
+  end
+
+  # The same, for the two moments that throw an existing timeline away: the
+  # stream is reset rather than seeded, and a fill still on its way is owed to
+  # a page that is no longer on screen (see `fill_arrival/2`).
+  defp replace_timeline(socket, entries, page) do
+    socket
+    |> put_timeline(entries, page)
+    |> assign(:owes_fill?, false)
+    |> stream(:posts, entries, reset: true)
+  end
+
   defp load_source_filter(socket, filter) do
     user = socket.assigns.current_user
     page = Posts.feed_page(user, limit: @filter_page_size, filter: filter)
@@ -1520,18 +1567,7 @@ defmodule VutuvWeb.PostLive.Feed do
 
     socket
     |> assign(:feed_filter, filter)
-    |> assign(:more?, page.more?)
-    |> assign(:cursor, page.next_cursor)
-    |> assign(:empty?, entries == [])
-    |> assign(:pending_posts, [])
-    |> assign(:pending_overflow, 0)
-    # This timeline replaces the arrival, so a fill still on its way is owed to
-    # a page that is no longer on screen (see `fill_arrival/2`).
-    |> assign(:owes_fill?, false)
-    |> assign(:entries, entries)
-    |> rebase_seam(entries)
-    |> stream(:posts, entries, reset: true)
-    |> watch_pending_photos(entries)
+    |> replace_timeline(entries, page)
   end
 
   # Whether the reader is looking at the live present. One way to leave it, the
@@ -1761,19 +1797,7 @@ defmodule VutuvWeb.PostLive.Feed do
       :cal_month,
       if(day, do: FeedTimeTravel.month_of(day), else: socket.assigns.cal_month)
     )
-    |> assign(:more?, page.more?)
-    |> assign(:cursor, page.next_cursor)
-    |> assign(:empty?, entries == [])
-    |> assign(:pending_posts, [])
-    |> assign(:pending_overflow, 0)
-    # This timeline replaces the arrival, so a fill still on its way is owed to
-    # a page that is no longer on screen (see `fill_arrival/2`).
-    |> assign(:owes_fill?, false)
-    |> assign(:entries, entries)
-    |> rebase_seam(entries)
-    |> stream(:posts, entries, reset: true)
-    |> watch_pending_photos(entries)
-    |> auto_translate_entries(entries)
+    |> replace_timeline(entries, page)
   end
 
   # The rest of the arrival, once the reader has the page (see `fill_arrival/2`).

--- a/test/vutuv_web/live/feed_timeline_reset_test.exs
+++ b/test/vutuv_web/live/feed_timeline_reset_test.exs
@@ -1,0 +1,125 @@
+defmodule VutuvWeb.FeedTimelineResetTest do
+  @moduledoc """
+  What must be true every time the feed throws its timeline away and loads
+  another one (issue #1870).
+
+  There are three such moments — the mount, a source-filter change, and
+  travelling to a day — and each used to spell the same ten assignments out by
+  hand. The cost was not the repetition: it was that a fact about "the list on
+  screen" could be added to two of them and forgotten in the third, with
+  nothing failing. That had already happened once when this was written. Every
+  path that puts entries on screen asks for their translations — the mount,
+  "Load more", the day traveller — **except** the source switch, so a reader
+  with auto-translate on who switched to the Fediverse sources (where the
+  foreign-language posts are) got a page of untranslated cards until they
+  reloaded.
+
+  So these tests are about the paths agreeing, not about any one of them. They
+  are the reason `replace_timeline/3` exists; if a fourth path is ever added,
+  add it here.
+  """
+  use VutuvWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Vutuv.PostsHelpers
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Posts
+  alias Vutuv.Social
+  alias Vutuv.Translations.TranslationJob
+  alias Vutuv.ViewerClock
+
+  defp followed_author(viewer) do
+    author = insert(:activated_user)
+    Social.follow(viewer, author.id)
+    author
+  end
+
+  # Switch the reader's sources the way the filter band does: write the column,
+  # then hand the feed the member it was written to (the shape
+  # `feed_source_tabs_test.exs` established).
+  defp switch(view, user, filter) do
+    :ok = Posts.remember_feed_filter(user, filter, Repo.get!(User, user.id).feed_source)
+    send(view.pid, {:filter_band, :changed, Repo.get!(User, user.id)})
+    render(view)
+  end
+
+  defp translate_mode!(user) do
+    user
+    |> Ecto.Changeset.change(%{feed_foreign_posts: "translate"})
+    |> Repo.update!()
+  end
+
+  describe "a source switch" do
+    test "asks for the translations of the page it loads", %{conn: conn} do
+      # The regression the chokepoint was built for. Calibrate it by taking
+      # `auto_translate_entries/2` back out of `replace_timeline/3`, and the
+      # last two assertions go red on their own.
+      {conn, user} = create_and_login_user(conn)
+      translate_mode!(user)
+      author = followed_author(user)
+      create_post!(author, %{body: "Already in the reader's language.", language: "en"})
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      assert Repo.all(TranslationJob) == []
+
+      # Written after the mount, so the socket's own `post_translations` map has
+      # never seen it — deleting queued rows instead would prove nothing, since
+      # that map remembers what it asked for and would not ask twice.
+      #
+      # The empty assertion below pins today's behaviour and is NOT an
+      # endorsement of it: `queue/1` streams an arriving row into the timeline
+      # and watches its photos without ever asking for its translation, so a
+      # foreign-language post that arrives live stays untranslated even after
+      # the reader presses the pill. That is the same gap one layer down, and it
+      # is its own issue — the moment to translate an arrival (on arrival, or
+      # when the reader reveals it) is a decision this refactor should not make.
+      foreign = create_post!(author, %{body: "Ein fremdsprachiger Beitrag.", language: "de"})
+      # `render/1` first, or this asserts against a LiveView that has not yet
+      # handled the arrival and would pass however the arrival path behaves.
+      render(view)
+      assert Repo.all(TranslationJob) == []
+
+      switch(view, user, :vutuv)
+
+      assert [job] = Repo.all(TranslationJob)
+      assert job.post_id == foreign.id
+    end
+
+    test "puts the visit boundary back on the list it just loaded", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      author = followed_author(user)
+      create_post!(author, %{body: "on the page at mount"})
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      create_post!(author, %{body: "arrived while reading"})
+      render_click(view, "show-new")
+      assert has_element?(view, "[data-feed-seam]")
+
+      # A different timeline: "what I did not have when I got here" is about to
+      # mean something else, so the line goes until something is revealed again.
+      switch(view, user, :vutuv)
+
+      refute has_element?(view, "[data-feed-seam]")
+    end
+  end
+
+  describe "travelling to a day" do
+    test "puts the visit boundary back on the list it just loaded", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      author = followed_author(user)
+      create_post!(author, %{body: "on the page at mount"})
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      create_post!(author, %{body: "arrived while reading"})
+      render_click(view, "show-new")
+      assert has_element?(view, "[data-feed-seam]")
+
+      render_click(view, "cal-day", %{"date" => Date.to_iso8601(ViewerClock.today())})
+
+      refute has_element?(view, "[data-feed-seam]")
+    end
+  end
+end


### PR DESCRIPTION
The feed threw its timeline away and built a new one in three places — the
mount, a source-filter change, a travelled-to day — each spelling out the same
ten assignments by hand. `put_timeline/3` now holds what is true of any freshly
loaded list; `replace_timeline/3` adds the stream reset for the two moments that
replace one.

It found what it was built for. Every path that puts entries on screen asks
for their translations except the source switch, so a reader with auto-translate
on who moved to the Fediverse sources, where the foreign-language posts are,
got untranslated cards until they reloaded. Fixed by the move, and the test is
calibrated against taking it back out.

Two more gaps of the same family turned up and are deliberately not in here.

Closes #1870. Where: `VutuvWeb.PostLive.Feed`.

*An AI agent wrote this text in my name. I know that is problematic.*
