### PR TITLE
Feed: a reshared fediverse post keeps its text, and the calendar keeps its numbers

### DIFF
--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -1798,14 +1798,20 @@ defmodule VutuvWeb.PostLive.Feed do
       |> with_engagement(user)
       |> mark_filtered(socket.assigns.content_filters, user.id)
 
+    month = if day, do: FeedTimeTravel.month_of(day), else: socket.assigns.cal_month
+
     socket
     |> assign(:cal_day, day)
     # Opening a day from another month moves the calendar to it, or the reader
     # is looking at a highlighted day that is not on the grid in front of them.
-    |> assign(
-      :cal_month,
-      if(day, do: FeedTimeTravel.month_of(day), else: socket.assigns.cal_month)
-    )
+    |> assign(:cal_month, month)
+    # …and the shading has to travel with the grid. Every cell is a button, and
+    # a grid draws whole weeks, so its first row holds days of the month before
+    # — clicking one moved the month and kept the counts of the month left
+    # behind, which shaded the new grid by the old month's numbers and left the
+    # day the reader had just opened reading as empty. "Load the whole day" went
+    # with it, since it asks those counts how big the day is.
+    |> then(&if(month != socket.assigns.cal_month, do: defer_calendar_counts(&1), else: &1))
     |> replace_timeline(entries, page)
   end
 

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -1491,12 +1491,12 @@ defmodule VutuvWeb.PostLive.Feed do
     # can't see the ones already on screen. The higher card already carries the
     # complete follow-scoped roster, so dropping the older duplicate loses
     # nothing. Filter before the engagement batch so it queries only survivors.
-    shown = shown_post_ids(socket.assigns.entries)
+    shown =
+      socket.assigns.entries
+      |> shown_post_ids()
+      |> MapSet.union(shown_remote_keys(socket.assigns.entries))
 
-    fresh =
-      Enum.reject(page.entries, fn entry ->
-        not Posts.remote_feed_entry?(entry) and MapSet.member?(shown, entry.post.id)
-      end)
+    fresh = Enum.reject(page.entries, &MapSet.member?(shown, dedupe_key(&1)))
 
     entries =
       fresh
@@ -2739,6 +2739,37 @@ defmodule VutuvWeb.PostLive.Feed do
         post <- [entry.post | entry[:ancestors] || []],
         into: MapSet.new(),
         do: post.id
+  end
+
+  # The same rule one world over, and it is not about repetition. A cached post
+  # reaches the feed from two sources — the reader follows its author, and
+  # somebody here reshared it — and `dedupe_remote/1` collapses them within one
+  # `feed_page/2` call. Across two calls neither sees the other, so both cards
+  # render, and they carry the **same** body id and the same action-bar
+  # LiveComponent: the browser's patch moves each into whichever card was
+  # rendered last and leaves the other a header with nothing under it. That is
+  # not exotic since the arrival itself is two calls (ten cards, then the fill),
+  # so an entry stamped with a reshare and its own entry stamped with the
+  # publication land on opposite sides of the boundary — which is exactly how a
+  # reshared post read as an empty card on 2026-09-01.
+  #
+  # Keyed by `subject_key/1`, the identity the DOM ids are built from, so the
+  # two cannot drift, and read through `entry_record/1`, which answers for a
+  # cached post and a remote reply alike.
+  defp shown_remote_keys(entries) do
+    for entry <- entries,
+        Posts.remote_feed_entry?(entry),
+        into: MapSet.new(),
+        do: remote_key(entry)
+  end
+
+  defp remote_key(entry), do: Fediverse.subject_key(entry_record(entry))
+
+  # What identifies an arriving entry against the two sets above — a remote card
+  # by its subject, a member's post by its id. Spelled once, so what goes into
+  # those sets and what is looked up in them cannot drift apart.
+  defp dedupe_key(entry) do
+    if Posts.remote_feed_entry?(entry), do: remote_key(entry), else: entry.post.id
   end
 
   # Fold a new reposter into an on-screen card's avatar stack, in place: keep

--- a/test/vutuv_web/live/feed_calendar_test.exs
+++ b/test/vutuv_web/live/feed_calendar_test.exs
@@ -49,6 +49,33 @@ defmodule VutuvWeb.FeedCalendarTest do
   defp iso(date), do: Date.to_iso8601(date)
   defp days_ago(n), do: Date.add(ViewerClock.today(), -n)
 
+  # Unfolds the rail **at the month `day` sits in**, which is not the month it
+  # opens at for the first days of a new one. The grid draws whole weeks from
+  # the Monday on or before the 1st, so it reaches at most six days back: on
+  # 2026-09-01 it began on 31 August and a day two or three back was simply not
+  # a cell — and the counts the rail holds are that month's, which is where the
+  # "load the whole day" button reads a day's size from. Five tests in this file
+  # went red that morning, every 1st and 2nd of a month, for that alone.
+  #
+  # Paging is what a reader does here too, so the tests reach those days the way
+  # they would rather than by pinning the clock. Only the tests that read the
+  # grid or its counts need it: clicking a day re-anchors the month by itself
+  # (`load_day/3`), so a test that only asks what the timeline then holds can
+  # keep unfolding and clicking.
+  # It asserts it arrived: a backward step is refused once the feed stops
+  # reaching past the shown month (`cal_earlier?`), and a helper that silently
+  # did nothing would fail two lines later on the cell instead of here.
+  defp open_calendar(view, day) do
+    today = ViewerClock.today()
+    months = (today.year - day.year) * 12 + (today.month - day.month)
+
+    render_click(view, "cal-toggle")
+    if months > 0, do: render_click(view, "cal-month", %{"n" => to_string(-months)})
+
+    assert has_element?(view, ~s(#feed-calendar-rail [phx-value-date="#{iso(day)}"])),
+           "the rail did not page to #{iso(day)}"
+  end
+
   # Every day cell in `html` the heatmap has put a shade on. Read out of the
   # parsed document rather than by matching a class anywhere on the page:
   # `bg-brand-*` is a colour half the feed's controls wear.
@@ -213,11 +240,36 @@ defmodule VutuvWeb.FeedCalendarTest do
       busy = busy_day(author, 2)
 
       {:ok, view, _html} = live(conn, ~p"/feed")
-      render_click(view, "cal-toggle")
+      open_calendar(view, busy)
 
       # The busiest day of the month gets the top step; an empty day gets none.
+      # Yesterday is the empty one: nothing is placed there, and it is on the
+      # same grid as `busy` whichever month that grid is showing — a day twenty
+      # back is off it for most of any month.
       assert has_element?(view, ~s([phx-value-date="#{iso(busy)}"].bg-brand-700))
-      assert has_element?(view, ~s([phx-value-date="#{iso(days_ago(20))}"].bg-slate-100))
+      assert has_element?(view, ~s([phx-value-date="#{iso(days_ago(1))}"].bg-slate-100))
+    end
+
+    test "a day from a neighbouring month brings the shading with it", %{conn: conn} do
+      # A grid draws whole weeks, so its first row holds days of the month
+      # before — as ordinary buttons, not decoration. Opening one moves the grid
+      # to that month (`load_day/3`) and used to leave the counts behind on the
+      # month the reader came from: the day they had just opened drew unshaded,
+      # every other cell wore a shade belonging to a different month, and
+      # "load the whole day" never appeared, because it reads the day's size
+      # from those same counts.
+      {conn, user} = create_and_login_user(conn)
+      author = feed_with_history(user)
+
+      # Five weeks back is a cell of another month whatever today's date is.
+      elsewhere = busy_day(author, 35)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-toggle")
+      render_click(view, "cal-day", %{"date" => iso(elsewhere)})
+
+      assert has_element?(view, ~s([phx-value-date="#{iso(elsewhere)}"].bg-brand-700)),
+             "the opened day is shaded by the month it belongs to, not the one behind it"
     end
 
     test "the heatmap counts arrivals, which is never fewer than the cards",
@@ -260,7 +312,7 @@ defmodule VutuvWeb.FeedCalendarTest do
       PostsHelpers.backdate_post!(theirs, 2 * @day)
 
       {:ok, view, _html} = live(conn, ~p"/feed")
-      render_click(view, "cal-toggle")
+      open_calendar(view, quiet)
 
       assert has_element?(view, ~s([phx-value-date="#{iso(quiet)}"].bg-brand-700))
 
@@ -504,8 +556,9 @@ defmodule VutuvWeb.FeedCalendarTest do
 
       {:ok, view, _html} = live(conn, ~p"/feed")
       # Unfold first, as a reader must: the grid is what a day is clicked from,
-      # and unfolding is what computes the counts the button names.
-      render_click(view, "cal-toggle")
+      # and unfolding is what computes the counts the button names — that day's
+      # month, hence `open_calendar/2`.
+      open_calendar(view, days_ago(3))
       render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
 
       assert has_element?(view, "#load-more")
@@ -760,7 +813,11 @@ defmodule VutuvWeb.FeedCalendarTest do
       author = feed_with_history(user)
       busy = busy_day(author, 2)
 
-      html = conn |> get(~p"/feed?cal=1") |> html_response(200)
+      # A dead render has no rail to page, so the URL names the day instead —
+      # the grid then opens at ITS month, whatever today's date is. `?cal=1`
+      # opens at the current month, where a day two back is not a cell during
+      # the first days of a new one.
+      html = conn |> get(~p"/feed?day=#{iso(busy)}") |> html_response(200)
 
       assert html =~ ~s(phx-value-date="#{iso(busy)}")
 
@@ -772,7 +829,7 @@ defmodule VutuvWeb.FeedCalendarTest do
       assert elements(html, ~s([aria-busy="true"])) == []
 
       # And the socket, which does get a second render, ends up shaded.
-      {:ok, view, _html} = live(conn, ~p"/feed?cal=1")
+      {:ok, view, _html} = live(conn, ~p"/feed?day=#{iso(busy)}")
       assert has_element?(view, ~s([phx-value-date="#{iso(busy)}"].bg-brand-700))
     end
 
@@ -1041,7 +1098,7 @@ defmodule VutuvWeb.FeedCalendarTest do
 
       conn = conn |> recycle() |> put_req_header("accept-language", "de-DE,de")
       {:ok, view, _html} = live(conn, ~p"/feed")
-      render_click(view, "cal-toggle")
+      open_calendar(view, days_ago(3))
       render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
 
       assert render(view) =~ "Ganzen Tag laden"

--- a/test/vutuv_web/live/feed_duplicate_cards_test.exs
+++ b/test/vutuv_web/live/feed_duplicate_cards_test.exs
@@ -22,14 +22,23 @@ defmodule VutuvWeb.FeedDuplicateCardsTest do
   `Vutuv.Fediverse.subject_key/1` — the same identity the DOM id is built from,
   so the two cannot drift.
 
+  **And per feed, not per page.** An arrival is two `feed_page/2` calls (ten
+  cards in the document, the rest appended when the socket connects), so a
+  subject can hold a card in each without either call seeing the other. Two
+  renders raise nothing — they degrade, and a member's reshare read as an empty
+  card that way on 2026-09-01. `VutuvWeb.PostLive.Feed`'s `shown_remote_keys/1`
+  is where that rule lives and why.
+
   Not async: answering a note claims from `Vutuv.RateLimiter`, a shared ETS
   table the SQL sandbox does not roll back.
   """
   use VutuvWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
+  import Vutuv.PostsHelpers
 
   alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Follow
   alias Vutuv.Fediverse.Note
   alias Vutuv.Fediverse.NoteRepost
   alias Vutuv.Fediverse.RemoteAccount
@@ -69,8 +78,11 @@ defmodule VutuvWeb.FeedDuplicateCardsTest do
     })
   end
 
-  defp cached_post(body) do
+  # `age` backdates the publication, which is what the feed stamps a direct
+  # entry with — the only way to put one below a reshare of the same post.
+  defp cached_post(body, age \\ 0) do
     now = DateTime.utc_now(:second)
+    published = DateTime.add(now, -age)
     unique = System.unique_integer([:positive])
 
     Repo.insert!(%RemotePost{
@@ -80,8 +92,8 @@ defmodule VutuvWeb.FeedDuplicateCardsTest do
       content_text: body,
       audience: "public",
       kind: "note",
-      published_at: now,
-      received_at: now,
+      published_at: published,
+      received_at: published,
       expires_at: DateTime.add(now, 86_400)
     })
     |> Repo.preload(:remote_account)
@@ -215,5 +227,42 @@ defmodule VutuvWeb.FeedDuplicateCardsTest do
     assert html =~ "zweite Antwort"
     assert html =~ "die Antwort von draussen"
     assert html =~ "mein Nachsatz"
+  end
+
+  test "a reshared post does not come back as its own row in the arrival's fill",
+       %{conn: conn} do
+    {conn, user} = reader(conn)
+
+    # Published two hours ago, so the reader's own follow puts its direct
+    # entry at the bottom of the arrival — while the reshare of it is stamped
+    # now and sits at the top. The twelve posts between them are what pushes
+    # the two into different `feed_page/2` calls, which is the whole shape:
+    # each call dedupes itself and neither knows about the other.
+    remote = cached_post("was da draussen steht", 7_200)
+
+    Repo.insert!(%Follow{
+      user_id: user.id,
+      remote_account_id: remote.remote_account_id,
+      state: "accepted",
+      follow_activity_id: "https://vutuv.test/#{user.id}/actor#follows/1"
+    })
+
+    author = insert(:activated_user)
+    follow!(user, author)
+
+    for i <- 1..12 do
+      author |> create_post!(%{body: "Beitrag Nummer #{i}"}) |> backdate_post!(60 + i)
+    end
+
+    {:ok, :reposted} = Fediverse.repost_remote_post(answerer(user), remote)
+
+    {:ok, view, html} = live(conn, ~p"/feed")
+
+    # The reshare is the newest thing here, so the document's ten cards hold
+    # it and the post's own entry is still below them.
+    assert cards_for(html, remote) == 1
+
+    assert cards_for(render(view), remote) == 1,
+           "the fill must not draw a second card for a post already on screen"
   end
 end


### PR DESCRIPTION
**A post you reshare shows up in your feed as a header with no text under it.** The same cached post reaches the feed twice — once as the reshare, once as the direct entry from your follow of its author — and `Posts.dedupe_remote/1` only collapses that pair inside one `feed_page/2` call. An arrival has been two calls since #1862, so the two land on opposite sides of that boundary almost every time. Both cards carry the same body id and the same action-bar LiveComponent, so the DOM patch moves both into whichever card rendered last. Measured on vutuv.de/feed: the reshare card's body was empty, the duplicate 26 rows below held all 411 characters.

`VutuvWeb.PostLive.Feed.append_older_page/2` skipped remote entries in its cross-page filter; it now keys them on `Fediverse.subject_key/1`, the identity the DOM ids are built from.

**Second, the feed calendar.** Every grid cell is a button and a grid draws whole weeks, so its first row belongs to the month before. Clicking one moved the grid to that month and left the counts behind: the day just opened drew unshaded and "load the whole day" never appeared. Same PR because it is what the five red `FeedCalendarTest` tests were standing on — they expected a day two or three back on a grid that reaches six days back, so they failed every 1st and 2nd of a month.

Not covered: a remote card nested inside a local entry (a reply's parent, a thread note) can still collide across pages. That wants the seen-set threaded into `feed_page/2` — say the word and I will.