### PR TITLE
Give each git worktree its own dev/test database and dev port

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -37,9 +37,23 @@ config :phoenix_live_view,
   debug_heex_annotations: true,
   debug_attributes: true
 
+# Several sessions work this repository in parallel git worktrees, each with its
+# own dev server against the same Postgres. Each gets its own database and its
+# own port, derived from the checkout it runs in, so one session's `ecto.migrate`
+# or `ecto.reset` does not land in every other tree and two servers do not race
+# for 4000. The main checkout is unchanged: `vutuv1_dev` on 4000. `DEV_DATABASE`
+# and `PORT` still win. See `Vutuv.MixProject.worktree_name/1`.
+dev_database = System.get_env("DEV_DATABASE") || "vutuv1_dev#{Vutuv.MixProject.worktree_suffix()}"
+
+dev_port =
+  case System.get_env("PORT") do
+    nil -> Vutuv.MixProject.worktree_port()
+    port -> String.to_integer(port)
+  end
+
 config :vutuv, VutuvWeb.Endpoint,
-  http: [port: String.to_integer(System.get_env("PORT") || "4000")],
-  url: [host: "localhost", port: String.to_integer(System.get_env("PORT") || "4000")],
+  http: [port: dev_port],
+  url: [host: "localhost", port: dev_port],
   # Dev-only signing secret so `mix phx.server` boots without extra setup.
   # This is not a real secret: it only signs localhost dev sessions/cookies.
   # Production reads its secret_key_base from the environment in runtime.exs,
@@ -62,7 +76,7 @@ config :vutuv, VutuvWeb.Endpoint,
     # a correct one-shot build per change — see VutuvWeb.TailwindWatcher.
     tailwind: {VutuvWeb.TailwindWatcher, :watch, [:vutuv]}
   ],
-  public_url: "http://localhost:4000/",
+  public_url: "http://localhost:#{dev_port}/",
   live_reload: [
     patterns: [
       ~r{priv/static/(?!assets).*\.(js|css|png|jpeg|jpg|gif|svg)$},
@@ -81,9 +95,7 @@ config :vutuv, Vutuv.Repo,
   adapter: Ecto.Adapters.Postgres,
   username: "postgres",
   password: "postgres",
-  # Overridable so two checkouts (a git worktree working on a schema change,
-  # say) can each keep their own dev database instead of migrating one another's.
-  database: System.get_env("DEV_DATABASE", "vutuv1_dev"),
+  database: dev_database,
   hostname: "localhost",
   pool_size: 10,
   # Keep the dev log readable: don't echo every SQL query.

--- a/config/test.exs
+++ b/config/test.exs
@@ -224,7 +224,11 @@ config :vutuv, Vutuv.Repo,
   adapter: Ecto.Adapters.Postgres,
   username: "postgres",
   password: "postgres",
-  database: "vutuv1_test#{System.get_env("MIX_TEST_PARTITION")}",
+  # A worktree runs its own suite against the same Postgres, so it gets its own
+  # test database (`Vutuv.MixProject.worktree_name/1`, same reasoning as the dev
+  # one). `MIX_TEST_PARTITION` still isolates targeted runs inside one checkout.
+  database:
+    "vutuv1_test#{Vutuv.MixProject.worktree_suffix()}#{System.get_env("MIX_TEST_PARTITION")}",
   hostname: System.get_env("DATABASE_HOST", "localhost"),
   pool: Ecto.Adapters.SQL.Sandbox,
   # The suite runs ~20 async cases; the default pool (10) plus the default

--- a/docs/DEVELOPERS.md
+++ b/docs/DEVELOPERS.md
@@ -48,12 +48,48 @@ mix setup           # deps.get + npm ci + ecto.create/migrate/seeds + esbuild/ta
 mix phx.server
 ```
 
-Visit http://localhost:4000. (`mix setup` does everything except the
+Visit http://localhost:4000 — or the port of your checkout, if you are in a
+worktree (see below). (`mix setup` does everything except the
 `config/dev.secret.exs` step above.)
+
+### Working in a git worktree
+
+Several checkouts of this repository can be worked at once through `git
+worktree`, and they share one Postgres. Each linked worktree therefore gets its
+own dev database, its own test database and its own dev-server port, all derived
+from the checkout's directory name so that nothing has to be exported:
+
+| checkout | dev database | port |
+| --- | --- | --- |
+| the main one | `vutuv1_dev` | 4000 |
+| `…/worktrees/profile` | `vutuv1_dev_profile` | 4653 |
+
+Without the split, one checkout's `mix ecto.migrate` or `mix ecto.reset` lands
+in every other one, and two `mix phx.server` race for port 4000. `DEV_DATABASE`,
+`MIX_TEST_PARTITION` and `PORT` still win where you want them to;
+`Vutuv.MixProject.worktree_name/1` holds the derivation.
+
+Two things a `git worktree add` leaves behind, both because they are gitignored:
+
+- **The build artefacts.** `deps/`, `assets/node_modules/` and
+  `priv/static/assets/` are missing, so run `mix setup` in the new checkout.
+  Until you do, `/assets/app.js` 404s and every page renders with no JavaScript
+  at all — no LiveView, and `data-method` links degrade to a plain GET.
+- **The member uploads.** In dev `:uploads_dir_prefix` is empty, so every image
+  path resolves against the cwd of the running server, and the new checkout's
+  upload trees are empty. Symlink each of them to the main checkout's — all of
+  them, the list is `@upload_trees` in
+  `test/vutuv/uploads_gitignore_test.exs` — and never `ln -sfn` over a tree that
+  already holds files: move it aside first, those are member uploads.
+
+The new dev database starts empty: `mix ecto.setup` seeds it, or copy the one
+you already have with `pg_dump -Fc vutuv1_dev | pg_restore -d vutuv1_dev_<name>`
+(`createdb -T` refuses to run while any session is connected to the source, and
+a dev server always is).
 
 ### Email in development
 
-Emails are displayed in the browser via Swoosh's mailbox preview at http://localhost:4000/sent_emails.
+Emails are displayed in the browser via Swoosh's mailbox preview at `/sent_emails` (http://localhost:4000/sent_emails on the main checkout).
 
 The email architecture (the single `Emailer` chokepoint, the multipart
 text + HTML bodies, bounce handling) is described in

--- a/mix.exs
+++ b/mix.exs
@@ -49,6 +49,74 @@ defmodule Vutuv.MixProject do
   @doc false
   def calver(iso_date), do: Calendar.strftime(Date.from_iso8601!(iso_date), "%Y.%-m.%-d")
 
+  @doc """
+  The name of the git worktree this checkout is, or `nil` for the main checkout.
+
+  Several sessions work this repository in parallel worktrees, each running its
+  own `mix phx.server` and its own `mix test` against the same Postgres. Sharing
+  one dev database means one session's `ecto.migrate` or `ecto.reset` lands in
+  everybody else's tree, so `config/dev.exs` and `config/test.exs` suffix the
+  database name with `worktree_suffix/0` and the dev endpoint takes its port
+  from `worktree_port/1`. `DEV_DATABASE`, `MIX_TEST_PARTITION` and `PORT` still
+  win.
+
+  The name comes out of the `.git` **file** a linked worktree has in place of a
+  directory, which reads `gitdir: …/.git/worktrees/<name>`. That is git's own
+  name for the worktree, which `git worktree add` keeps unique — a directory
+  basename is neither unique nor conclusive, and a git **submodule** also has a
+  `.git` file (`gitdir: …/.git/modules/<name>`), so a vendored copy of vutuv
+  would otherwise be handed a worktree's treatment. Reading the file costs one
+  `File.read` per `mix` invocation and no shell-out to git.
+
+  What comes back is cut to what Postgres takes unquoted and to 20 characters,
+  so `vutuv1_test_<name><partition>` stays inside the 63-byte identifier limit.
+  (`Vutuv.SlugHelpers.handleize/1` does the same reduction and is the obvious
+  reuse, but it lives in `lib/`, which is not compiled yet when `config/*.exs`
+  is evaluated — that is also why these two functions are in `mix.exs`.)
+  """
+  def worktree_name(dir \\ __DIR__) do
+    with {:ok, "gitdir: " <> gitdir} <- File.read(Path.join(dir, ".git")),
+         ["worktrees", name] <- gitdir |> String.trim() |> Path.split() |> Enum.take(-2) do
+      name
+      |> String.downcase()
+      |> String.replace(~r/[^a-z0-9]+/, "_")
+      |> String.slice(0, 20)
+    else
+      _not_a_worktree -> nil
+    end
+  end
+
+  @doc """
+  What a worktree appends to a database name: `""` in the main checkout,
+  `"_profile"` in the worktree named `profile`. The one spelling of the naming
+  scheme, so `config/dev.exs` and `config/test.exs` cannot drift apart.
+  """
+  def worktree_suffix(dir \\ __DIR__) do
+    case worktree_name(dir) do
+      nil -> ""
+      name -> "_" <> name
+    end
+  end
+
+  @doc """
+  The dev-server port for a worktree: 4000 in the main checkout, else
+  4100..4899.
+
+  Two dev servers on port 4000 is the collision that makes somebody reach for a
+  `pkill -f "mix phx.server"` and take a parallel session's server down with
+  their own. The port is derived rather than assigned because nothing in a
+  worktree survives to hold an assignment: a rolling hash over the name's bytes
+  (`h = rem(h * 31 + byte, 800)`). 800 slots and no registry, so two names can
+  still land on one port — that fails loudly with `:eaddrinuse`, and `PORT`
+  overrides it.
+  """
+  def worktree_port(name \\ worktree_name())
+  def worktree_port(nil), do: 4000
+
+  def worktree_port(name) when is_binary(name) do
+    4100 + Enum.reduce(:binary.bin_to_list(name), 0, &rem(&2 * 31 + &1, 800))
+  end
+
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 

--- a/test/vutuv/worktree_test.exs
+++ b/test/vutuv/worktree_test.exs
@@ -1,0 +1,108 @@
+defmodule Vutuv.WorktreeTest do
+  @moduledoc """
+  The three helpers in `mix.exs` that keep parallel git worktrees off each
+  other's databases and ports. The reasoning lives in their `@doc`s.
+  """
+  use ExUnit.Case, async: true
+
+  alias Vutuv.MixProject
+
+  describe "worktree_name/1" do
+    @describetag :tmp_dir
+
+    test "the main checkout has none: its .git is a directory", %{tmp_dir: tmp} do
+      dir = Path.join(tmp, "vutuv")
+      File.mkdir_p!(Path.join(dir, ".git"))
+
+      assert MixProject.worktree_name(dir) == nil
+    end
+
+    test "a linked worktree is named the way git names it", %{tmp_dir: tmp} do
+      assert tmp |> checkout("profile") |> MixProject.worktree_name() == "profile"
+    end
+
+    test "the name is lowercased and reduced to database-safe characters", %{tmp_dir: tmp} do
+      assert tmp |> checkout("Fix-Feed.Rail") |> MixProject.worktree_name() == "fix_feed_rail"
+    end
+
+    test "a long name is cut so the database name stays inside Postgres' 63 bytes",
+         %{tmp_dir: tmp} do
+      name = tmp |> checkout(String.duplicate("a", 60)) |> MixProject.worktree_name()
+
+      assert byte_size("vutuv1_test_#{name}#{String.duplicate("p", 8)}") < 63
+    end
+
+    # A submodule's .git is a file too, and a third party vendoring vutuv would
+    # otherwise get a worktree's treatment: its own database, its own port.
+    test "a git submodule is not a worktree", %{tmp_dir: tmp} do
+      dir = Path.join(tmp, "vendored")
+      File.mkdir_p!(dir)
+      File.write!(Path.join(dir, ".git"), "gitdir: ../.git/modules/vutuv\n")
+
+      assert MixProject.worktree_name(dir) == nil
+    end
+
+    test "a checkout without any .git counts as the main one", %{tmp_dir: tmp} do
+      dir = Path.join(tmp, "export")
+      File.mkdir_p!(dir)
+
+      assert MixProject.worktree_name(dir) == nil
+    end
+  end
+
+  describe "worktree_suffix/1" do
+    @describetag :tmp_dir
+
+    test "the main checkout appends nothing", %{tmp_dir: tmp} do
+      dir = Path.join(tmp, "vutuv")
+      File.mkdir_p!(Path.join(dir, ".git"))
+
+      assert MixProject.worktree_suffix(dir) == ""
+    end
+
+    test "a worktree appends its own name", %{tmp_dir: tmp} do
+      assert tmp |> checkout("profile") |> MixProject.worktree_suffix() == "_profile"
+    end
+  end
+
+  describe "worktree_port/1" do
+    test "the main checkout keeps 4000" do
+      assert MixProject.worktree_port(nil) == 4000
+    end
+
+    test "every port lands in the range reserved for worktrees" do
+      for name <- ~w(a profile feed_rail x9 verylongworktreename) do
+        assert MixProject.worktree_port(name) in 4100..4899
+      end
+    end
+
+    # The `cw` shell function that creates these worktrees computes the port too,
+    # to print the URL — it lives in the author's shell, not in this repository,
+    # so nothing here can prove the two agree. These fixtures pin the formula, so
+    # at least a change on this side is visible rather than silent.
+    test "the fixtures pin the formula" do
+      assert MixProject.worktree_port("profile") == 4653
+      assert MixProject.worktree_port("vutuv") == 4346
+    end
+  end
+
+  describe "the config wiring" do
+    # This one only bites where it matters: in a worktree it fails the moment
+    # config/test.exs stops deriving the name (verified by reverting that line —
+    # "vutuv1_test" against "vutuv1_test_vutuv_wt_cal"). In the main checkout,
+    # CI included, both sides are "vutuv1_test" and it asserts nothing.
+    test "the suite runs on this checkout's own database" do
+      expected =
+        "vutuv1_test#{MixProject.worktree_suffix()}#{System.get_env("MIX_TEST_PARTITION")}"
+
+      assert Application.get_env(:vutuv, Vutuv.Repo)[:database] == expected
+    end
+  end
+
+  defp checkout(tmp, name) do
+    dir = Path.join(tmp, "checkout")
+    File.mkdir_p!(dir)
+    File.write!(Path.join(dir, ".git"), "gitdir: /elsewhere/.git/worktrees/#{name}\n")
+    dir
+  end
+end


### PR DESCRIPTION
Several sessions work this repo in parallel git worktrees against one Postgres,
and they all read `vutuv1_dev` and `vutuv1_test`. One checkout's `ecto.migrate`
or `ecto.reset` therefore lands in every other tree, and two `mix phx.server`
race for port 4000.

A checkout now derives its own: `vutuv1_dev_profile` on port 4653 for the
worktree `profile`; `vutuv1_dev` on 4000, unchanged, for the main checkout. The
name is the `gitdir:` line of a worktree's `.git` file, which is git's own
unique name, and a submodule is deliberately not a worktree. `DEV_DATABASE`,
`MIX_TEST_PARTITION` and `PORT` still win; CI, a plain clone and a tarball take
the main-checkout branch; `config/runtime.exs` is untouched.

Driven in a real worktree before this: server on the derived port, German page,
`app.js` and an avatar all served.

Where: `Vutuv.MixProject.worktree_name/1`, `config/dev.exs`, `config/test.exs`.

*An AI agent wrote this text in my name. I know that is problematic.*