### PR TITLE
Feed: an answer and the post it answers are one row

### DIFF
--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -1278,11 +1278,41 @@ which the flat-card surfaces leave off), and `post_thread_entry/1` takes them:
   as the head of that branch in place of its "Replying to @user@host" line.
 
 **One card per thing per page** is the rule both obey, the one `dedupe_remote/1`
-and `collapse_reposts/1` already hold: a reply that is on the page as a reshared
-row of its own is not drawn a second time inside a thread (nor a cached post
-that has its own card), and within the threads the first claim wins. A second
-card is not merely repetition — the action bar is a LiveComponent keyed by the
-subject, so a duplicate id takes the render down.
+and `collapse_reposts/1` already hold, and within the threads the first claim
+wins. A second card is not merely repetition — the action bar is a LiveComponent
+keyed by the subject, so a duplicate id takes the render down.
+
+The two halves settle a tie in **opposite** directions, and each direction is a
+product decision rather than a dedup detail. A **note** that is on the page as a
+reshared row of its own keeps that row and is not woven into the thread as well:
+the row exists because somebody here passed it on, an act the woven copy does
+not carry. A **cached post** the other way round — the conversation wins, so a
+post that an answer on this page carries as its parent card gives up the row it
+would otherwise hold and the exchange is one row, the way a local thread is one
+row. Until 2026-09-01 the standalone row won there too, and the same exchange
+stood twice in the timeline a few cards apart, the answer under a bare "Replying
+to @handle" line. What that costs is the dropped row's reshare stamp; a parent
+card at the head of a branch deliberately wears no reshare line.
+
+**Across two pages neither call can see the other**, and the arrival is two of
+them (ten cards in the document, the rest on connect), so the rule is split.
+`VutuvWeb.PostLive.Feed`'s `shown_remote_keys/1` collects every subject already
+on screen — a remote entry's own, **and** the ones nested inside an entry
+(`:remote_parents`, `:remote_replies`) — and does two things with it: it drops an
+arriving row for a subject that is already up there, and it hands the set to the
+next `feed_page/2` as **`seen:`**, which is the only way the nested cards can be
+suppressed (they hang off an entry the page has every reason to keep). Without
+that second half the two cards render, no error is raised, and the browser's
+patch moves the shared body into whichever was rendered last — leaving the other
+a name with its hashtags and nothing under them.
+
+Both ties above are decided **within a page**; across the boundary it is simply
+first come, first served, since the earlier page was already sent. So a note
+whose reshare row lands on the second page loses it to the woven-in copy above
+(reshare stamp and all), which is the opposite of what the same pair does side
+by side. Two cards a page apart are not read as a repetition, so this is the
+cheap answer rather than a wrong one — but do not read either tie as an absolute
+rule about the two records.
 
 A surface that draws these cards **owes their events**: the ⋯ menu's
 `remove-remote-reply` / `report-remote-reply` (`VutuvWeb.Live.RemoteReplyActions`,

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2770,8 +2770,14 @@ defmodule Vutuv.Posts do
   A post appears **once per page**, at its newest event: several followed
   members reposting the same post collapse into one entry, and a repost of a
   post the viewer also follows directly replaces the standalone original
-  (`collapse_reposts/1`). Cross-page duplicates are the LiveView's job — the
-  cursor merge can't see previous pages.
+  (`collapse_reposts/1`). A post from another network that an answer on this
+  page carries as its parent card gives up its own row, so a conversation that
+  crossed the network boundary is one row like any other.
+
+  Cross-page duplicates are mostly the LiveView's job — the cursor merge can't
+  see previous pages — but a card nested **inside** an entry is not one it can
+  drop, so `seen:` takes the subject keys (`Vutuv.Fediverse.subject_key/1`)
+  already on screen and nothing on this page draws a card for one of them.
 
   Returns `%{entries:, more?:, next_cursor:}` — pass `cursor:` back for the
   next older page. The cursor (and the merge across the two sources) is the
@@ -2787,7 +2793,13 @@ defmodule Vutuv.Posts do
 
     page = Vutuv.FeedPage.paginate(feed_sources(viewer, filter), limit, cursor)
 
-    %{page | entries: decorate_feed_entries(page.entries, viewer, threads: true)}
+    decorated =
+      decorate_feed_entries(page.entries, viewer,
+        threads: true,
+        seen: Keyword.get(opts, :seen, [])
+      )
+
+    %{page | entries: decorated}
   end
 
   @doc """
@@ -3234,6 +3246,7 @@ defmodule Vutuv.Posts do
   defp decorate_feed_entries(entries, viewer, opts \\ []) do
     {remote, local} = Enum.split_with(entries, &remote_feed_entry?/1)
     threads? = Keyword.get(opts, :threads, false)
+    seen = opts |> Keyword.get(:seen, []) |> MapSet.new()
 
     local =
       local
@@ -3242,7 +3255,8 @@ defmodule Vutuv.Posts do
       |> collapse_reposts()
       |> attach_reposters(viewer)
       |> attach_thread_starts(viewer, threads?)
-      |> attach_remote_thread(viewer, remote, threads?)
+
+    {local, remote} = settle_remote_cards(local, viewer, remote, seen, threads?)
 
     entries = Vutuv.FeedPage.sort_entries(local ++ decorate_remote(remote, viewer))
     warm_hashtag_links(entries)
@@ -3297,12 +3311,61 @@ defmodule Vutuv.Posts do
     |> Enum.reject(&is_nil/1)
   end
 
-  defp attach_remote_thread(local, _viewer, _remote, false), do: local
+  # Which cards from the other network this page gets, and the **one** place
+  # that settles it — the threads pull in what they can draw, and the rows for
+  # subjects that are drawn anyway step aside. Both directions in one function
+  # because they are one decision; splitting them is how the page ended up
+  # drawing some subjects twice.
+  #
+  # `seen` is what already has a card **further up this feed**: an earlier
+  # `feed_page/2` call of the same timeline, which this one cannot see
+  # (`VutuvWeb.PostLive.Feed` keeps that set and hands it down). Nothing here
+  # draws a second card for one of those. Within a page a repeat is fatal — a
+  # repeated LiveComponent id raises in the static render — and across two it is
+  # merely silent, which is worse to find: the browser's patch moves the body
+  # into whichever card was rendered last and leaves the other one a name with
+  # its hashtags and nothing under them (reported 2026-09-01).
+  #
+  # The tie between a row and a card inside a conversation goes **opposite ways
+  # for the two kinds**, and each way is a product decision:
+  #
+  #   * a **cached post** loses its row — the conversation wins, so an exchange
+  #     that crossed the network boundary is one row like any other, at the
+  #     newest post of it. Until 2026-09-01 the row won and the answer wore a
+  #     bare "Replying to @handle" line, so the same exchange stood twice in the
+  #     timeline a few cards apart. What it costs is the dropped row's reshare
+  #     stamp; a parent card at the head of a branch deliberately wears no
+  #     reshare line, it says "this is what is being answered".
+  #   * a **note** keeps its row: that row exists because somebody **here
+  #     reshared it** (issue #1275), an act of its own that the woven-in copy
+  #     does not carry, so the thread does without it.
+  defp settle_remote_cards(local, _viewer, remote, seen, false),
+    do: {local, drop_drawn(remote, seen)}
 
-  defp attach_remote_thread(local, viewer, remote, true) do
-    local
-    |> attach_thread_notes(viewer, standalone_note_ids(remote))
-    |> attach_remote_parents(viewer, standalone_remote_post_ids(remote))
+  defp settle_remote_cards(local, viewer, remote, seen, true) do
+    notes_taken = MapSet.union(seen, MapSet.new(standalone_note_ids(remote)))
+
+    local =
+      local
+      |> attach_thread_notes(viewer, notes_taken)
+      |> attach_remote_parents(viewer, seen)
+
+    {local, drop_drawn(remote, parent_card_subjects(local, seen))}
+  end
+
+  # The subjects the page's conversations now draw a parent card for, on top of
+  # the ones already up the timeline. Read back off the entries rather than
+  # carried out of `attach_remote_parents/3`: they are on the entries either
+  # way, and one of the two spellings would eventually stop matching the other.
+  defp parent_card_subjects(local, seen) do
+    for entry <- local,
+        parent <- Map.values(entry[:remote_parents] || %{}),
+        into: seen,
+        do: Vutuv.Fediverse.subject_key(parent.remote_post)
+  end
+
+  defp drop_drawn(remote, drawn) do
+    Enum.reject(remote, &MapSet.member?(drawn, Vutuv.Fediverse.subject_key(remote_subject(&1))))
   end
 
   # The post that STARTED the conversation, for a row that would otherwise open
@@ -3392,10 +3455,10 @@ defmodule Vutuv.Posts do
   # (`post_preloads/0`), so this costs no lookup — only the same three batch
   # reads a remote card needs anywhere (its pictures, the reader's marks, the
   # reader's follow), run once for the page. `taken` keeps a post that already
-  # has a card of its own from getting a second one, exactly as for a reply.
+  # has a card **further up the feed** from getting a second one; a post whose
+  # own row is on *this* page is not in it — that row steps aside instead, see
+  # `settle_remote_cards/5`.
   defp attach_remote_parents(entries, viewer, taken) do
-    taken = MapSet.new(taken)
-
     parents =
       for entry <- entries,
           post <- thread_posts(entry),
@@ -3403,7 +3466,7 @@ defmodule Vutuv.Posts do
           Vutuv.Fediverse.subject_key(parent) not in taken,
           do: %{post_id: post.id, remote_post: parent}
 
-    case Enum.uniq_by(parents, &Vutuv.Fediverse.subject_key(&1.remote_post)) do
+    case Enum.uniq_by(parents, &parent_key/1) do
       [] ->
         entries
 
@@ -3439,6 +3502,8 @@ defmodule Vutuv.Posts do
     end
   end
 
+  defp parent_key(%{remote_post: post}), do: Vutuv.Fediverse.subject_key(post)
+
   defp claim_remote_parents(entry, by_post) do
     case Map.take(by_post, Enum.map(thread_posts(entry), & &1.id)) do
       mine when mine == %{} -> entry
@@ -3450,15 +3515,6 @@ defmodule Vutuv.Posts do
     do: p
 
   defp remote_parent(_post), do: nil
-
-  # The cached posts that already have a card of their own on this page.
-  defp standalone_remote_post_ids(remote),
-    do:
-      for(
-        entry <- remote,
-        entry[:remote_post],
-        do: Vutuv.Fediverse.subject_key(entry.remote_post)
-      )
 
   # The replies from other networks (issues #1069/#1071) that belong inside the
   # threads on this page, read once for the whole page and hung on the entries
@@ -3496,7 +3552,7 @@ defmodule Vutuv.Posts do
         marks = notes |> Map.values() |> List.flatten() |> Vutuv.Fediverse.mark_lookup(viewer)
 
         {entries, _seen} =
-          Enum.map_reduce(entries, MapSet.new(taken), &claim_thread_notes(&1, &2, notes, marks))
+          Enum.map_reduce(entries, taken, &claim_thread_notes(&1, &2, notes, marks))
 
         entries
     end
@@ -3539,6 +3595,28 @@ defmodule Vutuv.Posts do
   """
   def thread_posts(%{post: %Post{} = post} = entry), do: [post | entry[:ancestors] || []]
   def thread_posts(_entry), do: []
+
+  @doc """
+  The records from **another network** a feed entry draws a card for: the cached
+  post an answer answers (`:remote_parents`) and the replies woven into its
+  thread (`:remote_replies`).
+
+  The other half of `thread_posts/1`, and public for the same reason — a row
+  carries more than the post it is keyed on, and every question about "what is
+  on this row" that forgot these got a quietly wrong answer. Each of them is a
+  full card with the subject's own action bar, so it counts for the reader's
+  content filters, for auto-translation and for the one-card-per-subject rule
+  alike.
+
+  A remote entry's own subject is **not** in here — that is the entry itself
+  (`remote_feed_entry?/1`), not something nested inside it.
+  """
+  def remote_cards(entry) do
+    parents = entry[:remote_parents] || %{}
+    notes = entry[:remote_replies] || %{}
+
+    Enum.map(Map.values(parents), & &1.remote_post) ++ Enum.concat(Map.values(notes))
+  end
 
   # The remote reply this post answers (issue #1070), if it answers one at all.
   defp answered_note_ids(%Post{remote_reply_ref: %PostRemoteReply{note_id: id}})

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -473,13 +473,24 @@ defmodule VutuvWeb.PostLive.Feed do
     end
   end
 
-  # What a feed entry shows that could be translated: its own post (plus the
-  # nested ancestors of a reply), a cached remote post, or a remote reply.
+  # Everything a feed entry puts on the page: its own post (plus the nested
+  # ancestors of a reply), a cached remote post or a remote reply, and the cards
+  # a conversation pulls in from the other network (`Posts.remote_cards/1`) —
+  # the post an answer answers is as much on the row as the answer is, and a
+  # reader with auto-translate on was getting the answer in their language and
+  # the foreign post above it untouched.
+  #
+  # Two callers, both asking the same question of a row: what may be translated
+  # (`auto_translate_entries/2`) and what already holds a card
+  # (`shown_remote_keys/1`).
   defp entry_subjects(entry) do
-    case entry_record(entry) do
-      %Post{} = post -> [post | entry[:ancestors] || []]
-      remote -> [remote]
-    end
+    own =
+      case entry_record(entry) do
+        %Post{} = post -> [post | entry[:ancestors] || []]
+        remote -> [remote]
+      end
+
+    own ++ Posts.remote_cards(entry)
   end
 
   # The desktop "New here" rail: five of the newest members, drawn at random out
@@ -1478,12 +1489,16 @@ defmodule VutuvWeb.PostLive.Feed do
   # otherwise be two copies of the dedup rule.
   defp append_older_page(socket, limit) do
     user = socket.assigns.current_user
+    seen_remote = shown_remote_keys(socket.assigns.entries)
 
     page =
       Posts.feed_page(user,
         limit: limit,
         cursor: socket.assigns.cursor,
-        filter: effective_filter(socket)
+        filter: effective_filter(socket),
+        # What is on screen already, for the cards this page would nest inside
+        # its own entries — the half no filter out here can reach.
+        seen: seen_remote
       )
 
     # A post shown higher up (as a newer repost, or nested in a shown thread)
@@ -1494,7 +1509,7 @@ defmodule VutuvWeb.PostLive.Feed do
     shown =
       socket.assigns.entries
       |> shown_post_ids()
-      |> MapSet.union(shown_remote_keys(socket.assigns.entries))
+      |> MapSet.union(seen_remote)
 
     fresh = Enum.reject(page.entries, &MapSet.member?(shown, dedupe_key(&1)))
 
@@ -2759,14 +2774,22 @@ defmodule VutuvWeb.PostLive.Feed do
   # publication land on opposite sides of the boundary — which is exactly how a
   # reshared post read as an empty card on 2026-09-01.
   #
+  # A card **nested inside** an entry counts here too — the cached post an
+  # answer answers and the replies woven into a thread (`Posts.remote_cards/1`)
+  # each get a full card with the subject's own action bar. That is the half
+  # this set was missing on 2026-09-01: a member's answer carried the post above
+  # it, the same post came back as its own row in the fill, and the patch moved
+  # the body into the lower card.
+  #
   # Keyed by `subject_key/1`, the identity the DOM ids are built from, so the
   # two cannot drift, and read through `entry_record/1`, which answers for a
   # cached post and a remote reply alike.
   defp shown_remote_keys(entries) do
     for entry <- entries,
-        Posts.remote_feed_entry?(entry),
+        subject <- entry_subjects(entry),
+        not match?(%Post{}, subject),
         into: MapSet.new(),
-        do: remote_key(entry)
+        do: Fediverse.subject_key(subject)
   end
 
   defp remote_key(entry), do: Fediverse.subject_key(entry_record(entry))

--- a/lib/vutuv_web/post_teaser.ex
+++ b/lib/vutuv_web/post_teaser.ex
@@ -210,6 +210,12 @@ defmodule VutuvWeb.PostTeaser do
   (reported 2026-08-28). The reader's own posts keep their exemption **per
   post**: replying once to a muted conversation must not reopen it, and a word
   the reader wrote themselves must not fold the row either.
+
+  **The posts it draws from the other network count too** (`remote_cards/1`).
+  They always should have, and since the conversation started winning the tie
+  against a cached post's own row (2026-09-01) they have to: that row was the
+  copy this check could see, so without them a muted word answered by anybody
+  would be back on the page with nothing looking at it.
   """
   def filtered_pattern(entry, compiled, viewer_id) do
     case filtered_hit(entry, compiled, viewer_id) do
@@ -236,6 +242,7 @@ defmodule VutuvWeb.PostTeaser do
       entry
       |> Posts.thread_posts()
       |> Enum.reject(&(&1.user_id == viewer_id))
+      |> Enum.concat(Posts.remote_cards(entry))
       |> Enum.find_value(&hit(&1, ContentFilters.filtered(&1, compiled)))
     end
   end

--- a/test/vutuv_web/live/feed_duplicate_cards_test.exs
+++ b/test/vutuv_web/live/feed_duplicate_cards_test.exs
@@ -27,7 +27,9 @@ defmodule VutuvWeb.FeedDuplicateCardsTest do
   subject can hold a card in each without either call seeing the other. Two
   renders raise nothing — they degrade, and a member's reshare read as an empty
   card that way on 2026-09-01. `VutuvWeb.PostLive.Feed`'s `shown_remote_keys/1`
-  is where that rule lives and why.
+  is where that rule lives and why; a card nested inside an entry cannot be
+  dropped out here at all, so the same set rides back down as `feed_page/2`'s
+  `seen:`.
 
   Not async: answering a note claims from `Vutuv.RateLimiter`, a shared ETS
   table the SQL sandbox does not roll back.
@@ -119,6 +121,26 @@ defmodule VutuvWeb.FeedDuplicateCardsTest do
     })
   end
 
+  # The reader follows the account out there, and twelve posts sit between the
+  # two things under test — which is what pushes them into different
+  # `feed_page/2` calls (ten cards in the document, the rest in the fill), the
+  # whole point of every test that uses it.
+  defp two_pages!(user, remote) do
+    Repo.insert!(%Follow{
+      user_id: user.id,
+      remote_account_id: remote.remote_account_id,
+      state: "accepted",
+      follow_activity_id: "https://vutuv.test/#{user.id}/actor#follows/1"
+    })
+
+    author = insert(:activated_user)
+    follow!(user, author)
+
+    for i <- 1..12 do
+      author |> create_post!(%{body: "Beitrag Nummer #{i}"}) |> backdate_post!(60 + i)
+    end
+  end
+
   # How many cards a cached post got. `data-remote-post` rides every one of
   # them, so this counts the thing whose repeated LiveComponent id is fatal.
   defp cards_for(html, %RemotePost{id: id}),
@@ -177,20 +199,19 @@ defmodule VutuvWeb.FeedDuplicateCardsTest do
   end
 
   test "a cached post that is both a standalone row and a post's parent", %{conn: conn} do
-    # `standalone_remote_post_ids/1`'s case: the reader follows the account, so
-    # the cached post has a row of its own, and a member here answered it, which
-    # would draw it a second time above the answer.
+    # The conversation wins: the cached post has a row of its own (somebody
+    # reshared it) and a member here answered it, and what the reader gets is
+    # **one** row — the answer with the post it answers above it — not a row for
+    # each a few cards apart.
     {conn, user} = reader(conn)
     remote = cached_post("was da draussen steht")
 
-    # A member the reader follows reshares it, which gives it a row of its own;
-    # another answers it, which would draw it again above the answer. Reshared
-    # rather than followed-directly because following an account out there is a
-    # signed request to a server that does not exist in a test, while the
-    # reshare produces the same standalone row.
+    # Reshared rather than followed-directly because following an account out
+    # there is a signed request to a server that does not exist in a test, while
+    # the reshare produces the same standalone row.
     {:ok, :reposted} = Fediverse.repost_remote_post(answerer(user), remote)
 
-    {:ok, _post} =
+    {:ok, post} =
       Posts.create_remote_post_reply(answerer(user), remote, %{body: "meine Antwort darauf"})
 
     {:ok, view, _html} = live(conn, ~p"/feed")
@@ -198,6 +219,56 @@ defmodule VutuvWeb.FeedDuplicateCardsTest do
     html = render(view)
     assert html =~ "meine Antwort darauf"
     assert cards_for(html, remote) == 1
+
+    # And the one card is the answer's parent, inside the answer's own row.
+    assert has_element?(view, "#feed-post-#{post.id} [data-remote-post='#{remote.id}']")
+  end
+
+  test "an answer's parent card and the post's own row across two pages", %{conn: conn} do
+    # The reported shape (2026-09-01), and the one no `feed_page/2` call can see
+    # by itself: the answer is the newest thing here, so it and its parent card
+    # are in the document's ten, while the post's own row is old enough to land
+    # in the fill. Both cards carry the same body id and the same action-bar
+    # LiveComponent, so the second render moved the body into the lower card and
+    # left the upper one a name with three hashtags under it.
+    {conn, user} = reader(conn)
+    remote = cached_post("was da draussen steht", 7_200)
+
+    two_pages!(user, remote)
+
+    {:ok, _post} =
+      Posts.create_remote_post_reply(answerer(user), remote, %{body: "meine Antwort darauf"})
+
+    {:ok, view, html} = live(conn, ~p"/feed")
+
+    assert cards_for(html, remote) == 1
+
+    assert cards_for(render(view), remote) == 1,
+           "the fill must not draw a second card for a post already answered above"
+  end
+
+  test "a post's own row above and an answer to it on the next page", %{conn: conn} do
+    # The same pair the other way round, which the `seen:` half of the rule
+    # covers: the post's row is on screen and the answer arrives in the fill, so
+    # the answer keeps its "Replying to @handle" line rather than drawing the
+    # post a second card underneath it.
+    {conn, user} = reader(conn)
+    remote = cached_post("was da draussen steht")
+
+    two_pages!(user, remote)
+
+    {:ok, post} =
+      Posts.create_remote_post_reply(answerer(user), remote, %{body: "meine Antwort darauf"})
+
+    backdate_post!(post, 7_200)
+
+    {:ok, view, html} = live(conn, ~p"/feed")
+
+    assert cards_for(html, remote) == 1
+
+    html = render(view)
+    assert html =~ "meine Antwort darauf"
+    assert cards_for(html, remote) == 1, "the answer must not draw a card the page already has"
   end
 
   test "all four shapes on one page at once", %{conn: conn} do
@@ -240,19 +311,7 @@ defmodule VutuvWeb.FeedDuplicateCardsTest do
     # each call dedupes itself and neither knows about the other.
     remote = cached_post("was da draussen steht", 7_200)
 
-    Repo.insert!(%Follow{
-      user_id: user.id,
-      remote_account_id: remote.remote_account_id,
-      state: "accepted",
-      follow_activity_id: "https://vutuv.test/#{user.id}/actor#follows/1"
-    })
-
-    author = insert(:activated_user)
-    follow!(user, author)
-
-    for i <- 1..12 do
-      author |> create_post!(%{body: "Beitrag Nummer #{i}"}) |> backdate_post!(60 + i)
-    end
+    two_pages!(user, remote)
 
     {:ok, :reposted} = Fediverse.repost_remote_post(answerer(user), remote)
 

--- a/test/vutuv_web/live/feed_filtered_remote_parent_test.exs
+++ b/test/vutuv_web/live/feed_filtered_remote_parent_test.exs
@@ -1,0 +1,89 @@
+defmodule VutuvWeb.PostLive.FeedFilteredRemoteParentTest do
+  @moduledoc """
+  A word filter against the post from **another network** that a member's answer
+  carries above it.
+
+  The sibling of `FeedFilteredThreadTest`, one world over. The filter check
+  looked at the vutuv posts a row draws (`Posts.thread_posts/1`) and at a remote
+  entry standing on its own, and at nothing in between — so a cached post
+  carrying a muted word was never checked in the place it is actually drawn in
+  full, as the head of somebody's answer.
+
+  That was survivable while such a post also held a row of its own, which the
+  check *did* see and fold. Since the conversation started winning that tie
+  (2026-09-01) the checked copy is gone, so the row is the only copy and it has
+  to be checked here.
+
+  Not async: answering a post out there claims from `Vutuv.RateLimiter`, a
+  shared ETS table the SQL sandbox does not roll back.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.ContentFilters
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Posts
+  alias Vutuv.Social
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    :ok
+  end
+
+  defp cached_post(body) do
+    now = DateTime.utc_now(:second)
+    unique = System.unique_integer([:positive])
+
+    account =
+      Repo.insert!(%RemoteAccount{
+        actor_uri: "https://social.example/users/them#{unique}",
+        host: "social.example",
+        handle: "them#{unique}",
+        name: "Thea Remote",
+        inbox_uri: "https://social.example/users/them#{unique}/inbox"
+      })
+
+    Repo.insert!(%RemotePost{
+      remote_account_id: account.id,
+      object_uri: "https://social.example/p/#{unique}",
+      origin_url: "https://social.example/@them/#{unique}",
+      content_text: body,
+      audience: "public",
+      kind: "note",
+      published_at: now,
+      received_at: now,
+      expires_at: DateTime.add(now, 86_400)
+    })
+    |> Repo.preload(:remote_account)
+  end
+
+  test "a muted word in the answered post folds the row it arrived in", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+
+    answerer = insert(:activated_user, fediverse_followers?: true)
+    {:ok, _actor} = Fediverse.ensure_actor(answerer)
+    Social.follow(user, answerer.id)
+
+    remote = cached_post("Die Zeugnisanalyse funktioniert hervorragend.")
+
+    {:ok, _post} =
+      Posts.create_remote_post_reply(Repo.reload!(answerer), remote, %{
+        body: "Danke für Dein Feedback!"
+      })
+
+    {:ok, _} = ContentFilters.create_filter(user, %{kind: :keyword, pattern: "Zeugnis*"})
+
+    {:ok, live, _html} = live(conn, ~p"/feed")
+
+    refute render(live) =~ "Die Zeugnisanalyse funktioniert hervorragend."
+    assert has_element?(live, "#feed-posts [data-filtered-post]")
+
+    # And it opens, like every other folded row: the filter hides, it does not
+    # delete.
+    live |> element("#feed-posts [data-filtered-post] button") |> render_click()
+    assert render(live) =~ "Die Zeugnisanalyse funktioniert hervorragend."
+  end
+end

--- a/test/vutuv_web/live/remote_post_reply_test.exs
+++ b/test/vutuv_web/live/remote_post_reply_test.exs
@@ -115,7 +115,7 @@ defmodule VutuvWeb.RemotePostReplyTest do
       refute has_element?(view, "#composer [phx-click='close-composer']")
     end
 
-    test "sending creates a top-level post that wears the replying-to line", ctx do
+    test "sending creates a top-level post carrying the post it answers", ctx do
       {:ok, view, _html} = live(ctx.conn, ~p"/system/fediverse/reply/post/#{ctx.post.id}")
 
       view
@@ -126,11 +126,30 @@ defmodule VutuvWeb.RemotePostReplyTest do
       assert post.body == "Meine Antwort."
 
       {:ok, view, html} = live(ctx.conn, ~p"/feed")
+      assert html =~ "Meine Antwort."
+
+      # One row for the conversation: the answer carries the post it answers
+      # above it, and that post gives up the row its own author's follow would
+      # otherwise give it — so it is on the page exactly once.
+      assert has_element?(view, "#feed-post-#{post.id} [data-remote-post='#{ctx.post.id}']")
+    end
+
+    test "the replying-to line names the account here, not out there", ctx do
+      # The line is what a card without the answered post above it wears, and
+      # the profile is such a surface: it draws flat cards and pulls in no
+      # parent from another network.
+      {:ok, view, _html} = live(ctx.conn, ~p"/system/fediverse/reply/post/#{ctx.post.id}")
+
+      view
+      |> form("#composer form", post: %{body: "Meine Antwort."})
+      |> render_submit()
+
+      {:ok, view, html} = live(ctx.conn, ~p"/#{ctx.user}")
       assert html =~ "data-reply-banner=\"remote\""
       assert html =~ "@them@social.example"
 
-      # The line names who is being answered, so it links to that account's
-      # page here — not out to their server, and not to a compose form.
+      # It names who is being answered, so it links to that account's page
+      # here — not out to their server, and not to a compose form.
       assert has_element?(
                view,
                "[data-reply-banner='remote'] a[href='/system/fediverse/account/#{ctx.account.id}']"


### PR DESCRIPTION
A post from another network stood twice on `/feed`: once as the parent card above a member's answer, once as its own row a few cards down. Both cards carry the same DOM id, so the browser's patch moved the body into whichever was rendered last and left the other one a name with its hashtags and nothing under them — the open remainder of #1874, whose cross-page filter knew only standalone cards, not the ones nested inside an entry.

The conversation now wins that tie: the cached post gives up its own row when an answer on the page already shows it, the way a local thread has been one row since `collapse_threads/1`. `Vutuv.Posts.settle_remote_cards/5` decides both directions in one place, and `VutuvWeb.PostLive.Feed` hands the subjects already on screen down to the next `feed_page/2` as `seen:`, because a nested card cannot be dropped from outside.

That row was also the copy the content filters could see, so `Posts.remote_cards/1` now counts the nested cards for the filter, for auto-translation and for the one-card-per-subject rule alike.

Entry point: `/feed`, `Vutuv.Posts.settle_remote_cards/5`. Smoke-tested in a browser against a dev copy: one card, full text, the answer nested under it.

Two things I left alone and would like your call on: `/api/2.0/feed` raises for any member whose feed page holds a fediverse post (`feed_entry/1` matches `%{post: nil}`), and the organization feed appends pages with no dedup at all — both older than this change.