### PR TITLE
A feed row is a conversation, and every presenter owes the whole of it

### DIFF
--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -140,6 +140,20 @@ API profile responses carry the member's `noindex?`/`noai?` consent flags
 in-band (the public `.json`/`.md` siblings signal the same via
 `Content-Signal`/`X-Robots-Tag` headers)
 
+**A feed row is a conversation, and every presenter owes the whole of it.**
+`Posts.collapse_threads/1` folds every post of one thread that reached the page
+into a single entry and hangs the rest off `:ancestors`, so a presenter that
+reads `entry.post` shows the answer and drops what it answers — and the cursor
+has already walked past that post's own row, so no later page brings it back.
+The HTML feed stacked the conversation; `/feed.md|txt|json|xml` and
+`/api/2.0/feed` each showed one post of two, silently, until issue #1880. Both
+now carry it as a `thread` array (oldest first, `[]` for a standalone row), and
+`/organizations/:slug/feed` renders the same `<.post_thread_entry>` the member
+feed does rather than a flat card. `Posts.feed_subjects/1` is the contract —
+what it returns for a row has to appear in what the presenter renders — and
+`feed_presenter_coverage_test.exs` walks one fixture per source through all of
+them, so a tenth source fails the build instead of quietly losing a post.
+
 **A feed row is not always a vutuv post, and `GET /feed` says so per entry.**
 Four of the timeline's nine sources carry something from another network — a
 cached post, a reply somebody here reshared, a boost — and none of them holds a

--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -140,6 +140,23 @@ API profile responses carry the member's `noindex?`/`noai?` consent flags
 in-band (the public `.json`/`.md` siblings signal the same via
 `Content-Signal`/`X-Robots-Tag` headers)
 
+**A feed row is not always a vutuv post, and `GET /feed` says so per entry.**
+Four of the timeline's nine sources carry something from another network — a
+cached post, a reply somebody here reshared, a boost — and none of them holds a
+`%Post{}`, so `/api/2.0/feed` answered a 500 to any member who follows one
+account out there, from the day the source shipped until issue #1880. Such a row
+is marked `"network": "fediverse"` and names the origin URL, the remote account
+(`%{name:, handle:, url:}`, since the `Vutuv.Identity` protocol is about vutuv
+identities and deliberately raises for anything else) and a plain `body_text`
+rather than `body_markdown` — a remote body was reduced to text at the inbox,
+and a client rendering it as Markdown would eat a leading `1.` into a list
+marker. The facts come from the same owners the HTML card reads
+(`Vutuv.Fediverse.subject_origin/1` and `subject_author_ref/1`,
+`Vutuv.Posts.text/1` and `written_at/1`), so the API cannot drift from the page.
+The agent-format siblings (`/feed.md|.txt|.json|.xml`,
+`VutuvWeb.AgentDocs.PostDoc.timeline_entry/1`) had the cached-post half and were
+missing the reshared reply, which 500ed all four the same way.
+
 
 ## The Mastodon-compatible surface is elsewhere
 

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -6900,6 +6900,47 @@ defmodule Vutuv.Fediverse do
   """
   def subject_key(subject), do: {subject_kind(subject), subject.id}
 
+  @doc """
+  Where a thing from another network really lives — the address a reader is sent
+  to, since this installation serves no page of its own for it.
+
+  For a caller that does not know which kind it holds — a feed row is either
+  (`VutuvWeb.ApiV2.PostController`, `VutuvWeb.AgentDocs.PostDoc`). A caller
+  inside a clause that already matched one keeps calling `RemotePost.origin/1`
+  or `Note.origin/1` directly; there is nothing to dispatch there. Same family
+  as `Vutuv.Posts.path/1` and `text/1`, one world over.
+  """
+  def subject_origin(%RemotePost{} = post), do: RemotePost.origin(post)
+  def subject_origin(%Note{} = note), do: Note.origin(note)
+
+  @doc """
+  Who wrote it, as `%{name:, handle:, url:}` — the remote twin of
+  `Vutuv.Identity.ref/1`, for the surfaces that describe an author to a machine
+  (`/api/2.0/feed`) and cannot use the protocol: an account out there is not a
+  vutuv identity and has no page here.
+
+  A cached post is keyed to a stored account, a reply carries its author's
+  handle and name on its own row, and `url` is the actor's own address on their
+  server in both cases. Requires `:remote_account` to be preloaded on a cached
+  post — the head deliberately does not say so, because a clause matching the
+  association reads as a type check and behaves as a preload check, and the
+  answer here belongs to the kind of thing, not to what somebody remembered to
+  load.
+  """
+  def subject_author_ref(%RemotePost{} = post) do
+    account = post.remote_account
+
+    %{
+      name: RemoteAccount.label(account),
+      handle: RemoteAccount.display_handle(account),
+      url: account.actor_uri
+    }
+  end
+
+  def subject_author_ref(%Note{} = note) do
+    %{name: Note.label(note), handle: Note.display_handle(note), url: note.actor_uri}
+  end
+
   defp subject_schema(%RemotePost{}), do: RemotePost
   defp subject_schema(%Note{}), do: Note
 

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2767,6 +2767,17 @@ defmodule Vutuv.Posts do
   the feed timestamp (publication or repost time). Posts are preloaded for
   rendering.
 
+  **`:post` is nil on the rows from another network, and a presenter that reads
+  it without asking is a 500.** Four of the nine sources produce such a row:
+  `:remote_post` holds a cached post (a followed account's, a member's reshare,
+  a boost), `:note` a reply somebody here passed on — and a note row carries no
+  `:remote_post` key at all, so even a nil check on that one is not enough.
+  `remote_feed_entry?/1` and `remote_reply_entry?/1` are the questions to ask;
+  `text/1`, `written_at/1` and `Vutuv.Fediverse.subject_origin/1` /
+  `subject_author_ref/1` answer for every kind, so a presenter need not know
+  which it holds. This was not written down, and both `/api/2.0/feed` and all
+  four `/feed.<ext>` siblings 500ed on it (issue #1880).
+
   A post appears **once per page**, at its newest event: several followed
   members reposting the same post collapse into one entry, and a repost of a
   post the viewer also follows directly replaces the standalone original

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -3608,6 +3608,28 @@ defmodule Vutuv.Posts do
   def thread_posts(_entry), do: []
 
   @doc """
+  Every record a feed row puts on the page, **in reading order** — the folded
+  conversation oldest-first, or the one thing from another network.
+
+  `thread_posts/1` answers the same question as a *set*, for the membership
+  checks (a content filter, an id list); this answers it as the *list a
+  presenter renders*, which is why the order matters and why the remote kinds
+  are in it.
+
+  **It is the contract every feed presenter owes.** Whatever this returns has to
+  appear in what the caller renders — the HTML card, the agent doc, the API
+  entry, the Mastodon status alike. Reading `entry.post` instead silently drops
+  the posts `collapse_threads/1` folded into the row, and silently is the word:
+  `/feed.md|txt|json|xml` and `/api/2.0/feed` each showed a reply while the post
+  it answered was on no page at all, beside an HTML feed that drew the whole
+  conversation (issue #1880). `feed_presenter_coverage_test.exs` walks this list
+  through every presenter, so a tenth source or a fourth row shape fails the
+  build instead of quietly losing a post.
+  """
+  def feed_subjects(%{post: %Post{} = post} = entry), do: (entry[:ancestors] || []) ++ [post]
+  def feed_subjects(entry), do: [remote_subject(entry)]
+
+  @doc """
   The records from **another network** a feed entry draws a card for: the cached
   post an answer answers (`:remote_parents`) and the replies woven into its
   thread (`:remote_replies`).

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -1006,8 +1006,24 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   end
 
   defp post_line(post) do
-    "- #{post.published_on}#{pin_suffix(post)}#{repost_suffix(post)}: " <>
-      "[#{md_text(entry_label(post))}](#{post.url})#{quote_suffix(post)}"
+    line =
+      "- #{post.published_on}#{pin_suffix(post)}#{repost_suffix(post)}: " <>
+        "[#{md_text(entry_label(post))}](#{post.url})#{quote_suffix(post)}"
+
+    Enum.join([line | Enum.map(thread_context(post), &thread_context_line/1)], "\n")
+  end
+
+  @doc false
+  # The posts a feed row answers (issue #1880), oldest first. Absent on an
+  # archive entry and on a row from another network, so the shared reader
+  # answers `[]` rather than each call site guarding.
+  def thread_context(post), do: Map.get(post, :thread) || []
+
+  # Indented under the entry it belongs to, and naming its author — which is
+  # what tells it apart from an entry line, since those carry no author.
+  defp thread_context_line(post) do
+    "  - #{post.published_on} [#{md_text(post.author)}](#{post.url}): " <>
+      md_text(entry_label(post))
   end
 
   @doc false

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -283,36 +283,31 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
   `reposted_by` stays the newest for callers that want just the one name.
   """
   def timeline_entry(%{remote_post: %RemotePost{} = remote} = entry) do
-    account = remote.remote_account
-
-    %{
-      id: remote.id,
-      # The origin, not a vutuv URL: the post lives on its own server and we
-      # serve no page for it.
-      url: RemotePost.origin(remote),
-      author: RemoteAccount.label(account),
-      published_on: DateTime.to_date(remote.published_at),
-      excerpt: PostTeaser.line(remote),
+    entry
+    |> remote_timeline_entry(remote)
+    |> Map.merge(%{
       # How many pictures the entry carries (issue #1163). A post from another
       # network can be a photograph and nothing else, and its stored body is
       # then genuinely empty — so without this an agent would read a wordless
       # photo post as an entry with no content at all. The renderers turn the
       # count into a phrase in the reader's own language.
       pictures: Enum.count(entry[:images] || [], &RemoteImage.released?/1),
-      quote: quoted_entry(remote),
-      reposted_by: nil,
-      reposters: [],
-      # What the HTML card says in its footer, as a fact rather than a skin: an
-      # agent reading this timeline has to be able to tell a member's own post
-      # from somebody else's, published elsewhere and cached here.
-      network: "fediverse",
-      account: RemoteAccount.display_handle(account)
-    }
+      quote: quoted_entry(remote)
+    })
   end
 
-  def timeline_entry(%{post: post} = entry) do
-    reposters = entry[:reposters] || List.wrap(entry[:reposted_by])
+  # The **second** remote row shape (issue #1275): a reply from out there that
+  # somebody here reshared. It carries a `note` and no `remote_post` at all, so
+  # without this clause it fell through to the `%{post: post}` one below with a
+  # nil post, and every agent-format sibling of the feed — `.md`, `.txt`,
+  # `.json`, `.xml` — 500ed the moment one landed (issue #1880).
+  #
+  # A note is a reply and nothing more: no cached pictures of its own and
+  # nothing it quotes, so it takes the shared shape unchanged.
+  def timeline_entry(%{note: %Note{} = note} = entry),
+    do: remote_timeline_entry(entry, note)
 
+  def timeline_entry(%{post: post} = entry) do
     %{
       id: post.id,
       url: AgentDocs.abs_url(Posts.path(post)),
@@ -328,9 +323,58 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       # rendered the photos and every agent format showed an entry with no
       # content at all. Only released images count, exactly as on the page.
       pictures: picture_count(post),
-      reposted_by: entry[:reposted_by] && UserHelpers.author_name(entry[:reposted_by]),
-      reposters: Enum.map(reposters, &UserHelpers.author_name/1)
+      reposted_by: reposted_name(entry),
+      reposters: reposter_names(entry)
     }
+  end
+
+  # The nine keys a row from another network answers whichever kind it is —
+  # each read through the owner of that fact (`Vutuv.Fediverse.subject_origin/1`
+  # and `subject_author_ref/1`, `Vutuv.Posts.written_at/1`), so a third kind
+  # arrives here already handled and a tenth key cannot be remembered in one
+  # clause and forgotten in the other. That is not hypothetical: the note shape
+  # was the one forgotten, and it 500ed all four formats until issue #1880.
+  defp remote_timeline_entry(entry, subject) do
+    author = Fediverse.subject_author_ref(subject)
+
+    %{
+      id: subject.id,
+      # The origin, not a vutuv URL: the thing lives on its own server and we
+      # serve no page for it.
+      url: Fediverse.subject_origin(subject),
+      author: author.name,
+      published_on: subject |> Posts.written_at() |> DateTime.to_date(),
+      excerpt: PostTeaser.line(subject),
+      pictures: 0,
+      quote: nil,
+      # Who **here** passed it on — the reshare line the card wears (issue
+      # #1166), and for a reader who follows nobody out there the answer to "why
+      # is a stranger's post in my feed". It was hardcoded nil until issue
+      # #1880, so that half of the timeline read as unexplained. The other half
+      # still does: a row carried by a boost names its account in `boosted_by`,
+      # which no agent format reads yet — `Vutuv.MastodonApi.Presenter.resharer/1`
+      # is the one place that treats the two as one question.
+      reposted_by: reposted_name(entry),
+      reposters: reposter_names(entry),
+      # What the HTML card says in its footer, as a fact rather than a skin: an
+      # agent reading this timeline has to be able to tell a member's own post
+      # from somebody else's, published elsewhere and cached here.
+      network: "fediverse",
+      account: author.handle
+    }
+  end
+
+  # Who put this row in the reader's feed, for all three row shapes at once —
+  # `reposted_by` the newest resharer alone, `reposters` the whole follow-scoped
+  # roster the feed carries behind it (the archive carries a single one). Only
+  # the local rows ever get a roster attached, so the other two fall back to the
+  # one name they have.
+  defp reposted_name(entry),
+    do: entry[:reposted_by] && UserHelpers.author_name(entry[:reposted_by])
+
+  defp reposter_names(entry) do
+    reposters = entry[:reposters] || List.wrap(entry[:reposted_by])
+    Enum.map(reposters, &UserHelpers.author_name/1)
   end
 
   # An unloaded association answers 0 rather than raising: not every caller of

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -324,7 +324,14 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       # content at all. Only released images count, exactly as on the page.
       pictures: picture_count(post),
       reposted_by: reposted_name(entry),
-      reposters: reposter_names(entry)
+      reposters: reposter_names(entry),
+      # The posts this row answers, oldest first (issue #1880). A feed entry is
+      # a conversation, not a post — `Posts.collapse_threads/1` folds every post
+      # of one thread that reached the page into a single row, and the HTML card
+      # stacks them above the answer. This document drew the answer alone, so
+      # the post it replied to was on no page of the feed at all and never came
+      # back: the cursor had already walked past it.
+      thread: thread_context(entry)
     }
   end
 
@@ -360,8 +367,26 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       # agent reading this timeline has to be able to tell a member's own post
       # from somebody else's, published elsewhere and cached here.
       network: "fediverse",
-      account: author.handle
+      account: author.handle,
+      # A row from another network is one record; nothing is folded into it.
+      # The key is here rather than absent so a client reads one entry shape.
+      thread: []
     }
+  end
+
+  # The conversation folded into a local row, oldest first — each post as the
+  # same four facts the entry line carries, so a reader meets one shape twice
+  # rather than two. `Posts.feed_subjects/1` is what says this must exist.
+  defp thread_context(entry) do
+    Enum.map(entry[:ancestors] || [], fn post ->
+      %{
+        id: post.id,
+        url: AgentDocs.abs_url(Posts.path(post)),
+        author: UserHelpers.author_name(post),
+        published_on: post.published_on,
+        excerpt: PostTeaser.line(post)
+      }
+    end)
   end
 
   # Who put this row in the reader's feed, for all three row shapes at once —

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -733,8 +733,17 @@ defmodule VutuvWeb.AgentDocs.Text do
   defp verified_suffix(_link), do: ""
 
   defp post_lines(post) do
-    "* #{post.published_on}#{Markdown.pin_suffix(post)}#{Markdown.repost_suffix(post)}: " <>
-      "#{Markdown.entry_label(post)}#{Markdown.quote_suffix(post)}\n  #{post.url}"
+    line =
+      "* #{post.published_on}#{Markdown.pin_suffix(post)}#{Markdown.repost_suffix(post)}: " <>
+        "#{Markdown.entry_label(post)}#{Markdown.quote_suffix(post)}\n  #{post.url}"
+
+    Enum.join([line | Enum.map(Markdown.thread_context(post), &thread_context_lines/1)], "\n")
+  end
+
+  # The posts a feed row answers (issue #1880), oldest first — indented one
+  # level under it, the same shape the entry above carries.
+  defp thread_context_lines(post) do
+    "  * #{post.published_on} #{post.author}: #{Markdown.entry_label(post)}\n    #{post.url}"
   end
 
   defp person_line(person, prefix \\ "* ") do

--- a/lib/vutuv_web/controllers/api_v2/post_controller.ex
+++ b/lib/vutuv_web/controllers/api_v2/post_controller.ex
@@ -218,8 +218,26 @@ defmodule VutuvWeb.ApiV2.PostController do
       # `reposted_by` stays the newest reposter (unchanged shape); `reposters`
       # adds the whole follow-scoped roster behind the entry, newest first.
       reposted_by: entry[:reposted_by] && Vutuv.Identity.ref(entry[:reposted_by]),
-      reposters: Enum.map(reposters, &Vutuv.Identity.ref/1)
+      reposters: Enum.map(reposters, &Vutuv.Identity.ref/1),
+      # The posts this entry answers, oldest first (issue #1880). A feed row is
+      # a conversation: `Posts.collapse_threads/1` folds every post of one
+      # thread that reached the page into a single row, and reading `post`
+      # alone dropped the rest — a client saw the answer and no page of the
+      # feed ever carried the post it answered.
+      thread: thread_entries(entry)
     }
+  end
+
+  defp thread_entries(entry) do
+    Enum.map(entry[:ancestors] || [], fn post ->
+      %{
+        id: post.id,
+        url: VutuvWeb.AgentDocs.abs_url(Posts.path(post)),
+        author: Vutuv.Identity.ref(Posts.author(post)),
+        published_on: post.published_on,
+        body_markdown: post.body
+      }
+    end)
   end
 
   # Both remote row shapes answer the same eight keys — only where each fact is
@@ -238,7 +256,10 @@ defmodule VutuvWeb.ApiV2.PostController do
       body_text: Posts.text(subject),
       network: "fediverse",
       reposted_by: resharer,
-      reposters: List.wrap(resharer)
+      reposters: List.wrap(resharer),
+      # One record, nothing folded into it — the key is present so a client
+      # reads one entry shape rather than two.
+      thread: []
     }
   end
 

--- a/lib/vutuv_web/controllers/api_v2/post_controller.ex
+++ b/lib/vutuv_web/controllers/api_v2/post_controller.ex
@@ -19,6 +19,9 @@ defmodule VutuvWeb.ApiV2.PostController do
 
   use VutuvWeb, :controller
 
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Note
+  alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias VutuvWeb.AgentDocs.PostDoc
@@ -181,6 +184,25 @@ defmodule VutuvWeb.ApiV2.PostController do
     |> Map.put(:post_id, post.id)
   end
 
+  # A feed row from another network — the two shapes `Posts.feed_page/2`
+  # documents, neither carrying a `%Post{}`, so the clause below read `post.id`
+  # off a nil and 500ed this endpoint for any member who follows one account
+  # out there (issue #1880).
+  #
+  # Two shape decisions, since the row cannot borrow the local one. `author` is
+  # a `%{name:, handle:, url:}` ref rather than `Vutuv.Identity.ref/1`: that
+  # protocol is about vutuv identities and raises for anything else, on purpose.
+  # And `body_text`, not `body_markdown` — a remote body arrived as HTML and was
+  # reduced to plain text at the inbox (`Vutuv.RemoteHtml.to_text/3`), so a
+  # client that ran it through a Markdown renderer would shorten a URL the
+  # author never wrote as a link and eat a leading `1.` into a list marker.
+  # `network` is what a client branches on, spelled as the agent formats spell
+  # it (`VutuvWeb.AgentDocs.PostDoc.timeline_entry/1`).
+  defp feed_entry(%{remote_post: %RemotePost{} = cached} = entry),
+    do: remote_feed_entry(entry, cached)
+
+  defp feed_entry(%{note: %Note{} = note} = entry), do: remote_feed_entry(entry, note)
+
   defp feed_entry(%{post: post} = entry) do
     reposters = entry[:reposters] || List.wrap(entry[:reposted_by])
 
@@ -197,6 +219,26 @@ defmodule VutuvWeb.ApiV2.PostController do
       # adds the whole follow-scoped roster behind the entry, newest first.
       reposted_by: entry[:reposted_by] && Vutuv.Identity.ref(entry[:reposted_by]),
       reposters: Enum.map(reposters, &Vutuv.Identity.ref/1)
+    }
+  end
+
+  # Both remote row shapes answer the same eight keys — only where each fact is
+  # kept differs, and `Vutuv.Fediverse` owns that (`subject_origin/1`,
+  # `subject_author_ref/1`) beside `Vutuv.Posts.text/1` and `written_at/1`.
+  # There is no roster to attach out there, so `reposters` is the one name the
+  # row carries, if any.
+  defp remote_feed_entry(entry, subject) do
+    resharer = entry[:reposted_by] && Vutuv.Identity.ref(entry[:reposted_by])
+
+    %{
+      id: subject.id,
+      url: Fediverse.subject_origin(subject),
+      author: Fediverse.subject_author_ref(subject),
+      published_on: subject |> Posts.written_at() |> DateTime.to_date(),
+      body_text: Posts.text(subject),
+      network: "fediverse",
+      reposted_by: resharer,
+      reposters: List.wrap(resharer)
     }
   end
 

--- a/lib/vutuv_web/live/organization_live/feed.ex
+++ b/lib/vutuv_web/live/organization_live/feed.ex
@@ -23,6 +23,17 @@ defmodule VutuvWeb.OrganizationLive.Feed do
   existed (issue #1482) — the same split `VutuvWeb.PostLive.Feed` and the tag
   timeline make.
 
+  **A row is a conversation, and it is drawn as one** (issue #1880). Several
+  posts of one thread reaching the same page arrive as a single entry with the
+  rest on `:ancestors`; this view drew the carrier alone, so a post a followed
+  member had answered simply left the feed — the cursor had already walked past
+  its own row, so no later page brought it back. It renders the same
+  `<.post_thread_entry>` the member feed does, which was the way out the note
+  above `Posts.collapse_threads/1` named. What it still does not pay for is
+  `threads: true`: no thread root is fetched and no reply from another network
+  is woven in, so a row whose parent never reached this page keeps its plain
+  "Replying to" banner.
+
   Embedded via `live_render` from `VutuvWeb.OrganizationController`, which gates
   it before this ever mounts.
   """
@@ -30,7 +41,7 @@ defmodule VutuvWeb.OrganizationLive.Feed do
   use VutuvWeb, :live_view
 
   import VutuvWeb.OrganizationComponents, only: [manage_header: 1]
-  import VutuvWeb.PostComponents, only: [post_card: 1, remote_post_card: 1]
+  import VutuvWeb.PostComponents, only: [post_thread_entry: 1, remote_post_card: 1]
 
   alias Vutuv.Fediverse
   alias Vutuv.Organizations
@@ -77,13 +88,18 @@ defmodule VutuvWeb.OrganizationLive.Feed do
   end
 
   # One engagement read for the whole page instead of one per card: without a
-  # handed-in map every `<.post_card>`'s action bar falls back to its own
+  # handed-in map every card's action bar falls back to its own
   # `Posts.post_engagement/2`, which is twenty extra round trips at the default
-  # feed limit. Remote entries carry no vutuv post, so they are skipped.
+  # feed limit.
+  #
+  # Read through `Posts.thread_posts/1`, which answers the carrier **and** the
+  # posts folded under it — every one of those draws a card with its own bar, so
+  # a list of carriers alone left each nested card to load its own. It answers
+  # `[]` for a row from another network, which carries no vutuv post at all.
   defp engagement_map(entries, viewer) do
     entries
-    |> Enum.reject(&Posts.remote_feed_entry?/1)
-    |> Enum.map(& &1.post.id)
+    |> Enum.flat_map(&Posts.thread_posts/1)
+    |> Enum.map(& &1.id)
     |> Posts.post_engagement_map(viewer)
   end
 
@@ -167,13 +183,23 @@ defmodule VutuvWeb.OrganizationLive.Feed do
               />
             </.card>
           <% else %>
-            <.post_card
+            <%!-- A row is a **conversation**, not a post (issue #1880).
+            `Posts.collapse_threads/1` folds every post of one thread that
+            reached this page into a single entry and hangs the rest off
+            `:ancestors`; the flat `<.post_card>` here drew only the carrier, so
+            a post a followed member had answered left this feed for good — the
+            cursor had already walked past its own row. The same component the
+            member feed uses stacks them, so a page reads a thread the way its
+            publishers read theirs. --%>
+            <.post_thread_entry
               entry_id={entry.id}
               post={entry.post}
+              ancestors={entry[:ancestors]}
               engagement={@engagement[entry.post.id]}
+              ancestor_engagement={@engagement}
               viewer={@current_user}
               conn_or_socket={@socket}
-              mode={:preview}
+              surface={:card}
             />
           <% end %>
         <% end %>

--- a/priv/dev_docs/reference.md
+++ b/priv/dev_docs/reference.md
@@ -238,6 +238,24 @@ auth "$API/feed?cursor=NEXT_CURSOR_FROM_LAST_PAGE"
 }
 ```
 
+A feed also carries posts and replies from **other networks** — from accounts
+the member follows out there, from things somebody here reshared, and from what
+a followed account boosted. Such an entry is marked `"network": "fediverse"` and
+describes itself differently, because it lives on its own server and vutuv
+serves no page for it: `url` is the origin address, `author` names the remote
+account (`name`, `handle`, `url`) instead of a vutuv identity, and the text is
+plain — `body_text`, never Markdown. `reposted_by` and `reposters` still name
+whoever here put it in this feed. Branch on `network`; an entry without it is a
+vutuv post.
+
+```json
+{"id": "0190…", "url": "https://social.example/@them/1",
+ "author": {"name": "Thea Remote", "handle": "@them@social.example",
+            "url": "https://social.example/users/them"},
+ "published_on": "2026-06-12", "body_text": "…", "network": "fediverse",
+ "reposted_by": null, "reposters": []}
+```
+
 ### POST /posts
 
 Scope: `posts:write`. Fields: `body` (Markdown, required unless images),

--- a/priv/dev_docs/reference.md
+++ b/priv/dev_docs/reference.md
@@ -238,6 +238,19 @@ auth "$API/feed?cursor=NEXT_CURSOR_FROM_LAST_PAGE"
 }
 ```
 
+A feed row is a **conversation, not a post**: when several posts of one thread
+reach the same page they arrive as one entry, and `thread` carries the ones it
+answers, oldest first (`[]` for a standalone post). Read it, or you will show a
+reply and never show the post it replied to — no other page of the feed carries
+it.
+
+```json
+{"id": "0190…", "excerpt": "…", "thread": [
+  {"id": "018f…", "url": "…", "author": {"name": "…", "username": "…"},
+   "published_on": "2026-06-11", "body_markdown": "…"}
+]}
+```
+
 A feed also carries posts and replies from **other networks** — from accounts
 the member follows out there, from things somebody here reshared, and from what
 a followed account boosted. Such an entry is marked `"network": "fediverse"` and

--- a/test/support/mastodon_helpers.ex
+++ b/test/support/mastodon_helpers.ex
@@ -169,6 +169,7 @@ defmodule Vutuv.MastodonHelpers do
     Repo.insert!(%RemotePost{
       remote_account_id: account.id,
       object_uri: attrs[:object_uri] || "https://social.example/p/#{unique_suffix()}",
+      origin_url: attrs[:origin_url],
       in_reply_to_uri: attrs[:in_reply_to_uri],
       content_text: attrs[:content_text] || "Von woanders.",
       audience: attrs[:audience] || "public",

--- a/test/vutuv_web/controllers/api_v2/posts_api_test.exs
+++ b/test/vutuv_web/controllers/api_v2/posts_api_test.exs
@@ -1,8 +1,12 @@
 defmodule VutuvWeb.ApiV2.PostsApiTest do
   use VutuvWeb.ConnCase
 
+  import Vutuv.MastodonHelpers, only: [remote_account: 1, cached_post: 2]
+
   alias Vutuv.ApiAuth
+  alias Vutuv.Fediverse
   alias Vutuv.Posts
+  alias Vutuv.Repo
 
   setup %{conn: conn} do
     Vutuv.RateLimiter.reset()
@@ -159,6 +163,69 @@ defmodule VutuvWeb.ApiV2.PostsApiTest do
       assert [entry] = entries
       assert Enum.map(entry["reposters"], & &1["name"]) == ["Bruno Booster", "Renate Repost"]
       assert entry["reposted_by"]["name"] == "Bruno Booster"
+    end
+
+    # Issue #1880. Four of the feed's nine sources carry no `%Post{}` at all, so
+    # the entry builder read `post.id` off a nil and this endpoint 500ed for
+    # anybody who follows one account out there — which the HTML feed has shown
+    # since #1161. Both remote row shapes are here because they are separately
+    # fatal: the cached post and the reply somebody here passed on, which does
+    # not even carry a `remote_post` key.
+    test "a post and a reply from another network describe themselves", %{
+      conn: conn,
+      me: me,
+      token: token
+    } do
+      account = remote_account(name: "Thea Remote")
+
+      Repo.insert!(%Fediverse.Follow{
+        user_id: me.id,
+        remote_account_id: account.id,
+        state: "accepted",
+        follow_activity_id: "https://vutuv.test/#{me.id}/actor#follows/1"
+      })
+
+      cached =
+        cached_post(account,
+          content_text: "Was da draussen steht.",
+          origin_url: "https://social.example/@them/1"
+        )
+
+      sharer = insert_activated_user(first_name: "Sina", last_name: "Share")
+      follow!(me, sharer)
+      {:ok, mine} = Posts.create_post(me, %{body: "Eine Frage in die Runde."})
+
+      note =
+        insert(:note,
+          post: mine,
+          actor_uri: account.actor_uri,
+          handle: account.handle,
+          content_text: "Die weitergereichte Antwort."
+        )
+
+      Repo.insert!(%Fediverse.NoteRepost{user_id: sharer.id, note_id: note.id})
+
+      body = json_response(get(authed(conn, token), "/api/2.0/feed"), 200)
+      by_id = Map.new(body["posts"], &{&1["id"], &1})
+
+      # The cached post: where it really lives, who wrote it out there, its
+      # text, and the marker that says how to read all three.
+      post_entry = by_id[cached.id]
+      assert post_entry["url"] == "https://social.example/@them/1"
+      assert post_entry["network"] == "fediverse"
+      assert post_entry["author"]["name"] == "Thea Remote"
+      assert post_entry["author"]["handle"] == "@#{account.handle}@social.example"
+      assert post_entry["author"]["url"] == account.actor_uri
+      assert post_entry["body_text"] == "Was da draussen steht."
+      assert post_entry["reposted_by"] == nil
+
+      # The reshared reply: same keys, and `reposted_by` naming the member here
+      # who put it in this feed — without them the row is unexplainable.
+      note_entry = by_id[note.id]
+      assert note_entry["network"] == "fediverse"
+      assert note_entry["body_text"] == "Die weitergereichte Antwort."
+      assert note_entry["reposted_by"]["name"] == "Sina Share"
+      assert Enum.map(note_entry["reposters"], & &1["name"]) == ["Sina Share"]
     end
   end
 

--- a/test/vutuv_web/controllers/newsfeed_controller_test.exs
+++ b/test/vutuv_web/controllers/newsfeed_controller_test.exs
@@ -8,7 +8,9 @@ defmodule VutuvWeb.NewsfeedControllerTest do
   """
   use VutuvWeb.ConnCase
 
+  alias Vutuv.Fediverse.NoteRepost
   alias Vutuv.Posts
+  alias Vutuv.Repo
 
   defp fresh_conn, do: Phoenix.ConnTest.build_conn() |> Plug.Test.init_test_session(%{})
 
@@ -95,6 +97,43 @@ defmodule VutuvWeb.NewsfeedControllerTest do
       entry = Enum.find(json["posts"], &(&1["id"] == post.id))
       assert entry["reposters"] == ["Bruno Booster", "Renate Repost"]
       assert entry["reposted_by"] == "Bruno Booster"
+    end
+
+    # The second remote row shape (issue #1275): a reply from another network
+    # that a member here passed on. It carries a `note` and no `remote_post`, so
+    # it fell through to the local clause with a nil post and every one of these
+    # four formats 500ed the moment one reached the reader (issue #1880) — while
+    # the HTML feed drew it fine.
+    test "a reshared reply from another network is a line like any other", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      sharer = insert(:user, email_confirmed?: true, first_name: "Sina", last_name: "Share")
+      insert(:follow, follower: user, followee: sharer)
+
+      {:ok, post} = Posts.create_post(user, %{body: "eine Frage in die Runde"})
+
+      note =
+        insert(:note,
+          post: post,
+          actor_uri: "https://social.example/users/them",
+          origin_url: "https://social.example/@them/1",
+          handle: "them",
+          content_text: "die weitergereichte Antwort"
+        )
+
+      Repo.insert!(%NoteRepost{user_id: sharer.id, note_id: note.id})
+
+      json = Jason.decode!(get(conn, "/feed.json").resp_body)
+      entry = Enum.find(json["posts"], &(&1["id"] == note.id))
+
+      assert entry["network"] == "fediverse"
+      assert entry["account"] == "@them@social.example"
+      assert entry["url"] == "https://social.example/@them/1"
+      assert entry["excerpt"] == "die weitergereichte Antwort"
+      # Why it is in this feed at all — the reshare line the HTML card wears.
+      assert entry["reposted_by"] == "Sina Share"
+
+      assert recycle(conn) |> get("/feed.md") |> Map.get(:resp_body) =~
+               "die weitergereichte Antwort"
     end
 
     test "?lang=de renders the German labels", %{conn: conn} do

--- a/test/vutuv_web/feed_presenter_coverage_test.exs
+++ b/test/vutuv_web/feed_presenter_coverage_test.exs
@@ -1,0 +1,187 @@
+defmodule VutuvWeb.FeedPresenterCoverageTest do
+  @moduledoc """
+  Every presenter of a feed row must show everything the row carries, for every
+  shape `Vutuv.Posts.feed_sources/3` can produce — issue #1880, where two
+  different halves of that sentence were false at once.
+
+  The row shapes are what broke it. Four of the nine sources hand over a map
+  with no `%Post{}` (a cached post, a boost, a member's reshare of either, and a
+  reply from out there that carries no `:remote_post` key at all), and both
+  machine presenters read `post.id` off it: `/api/2.0/feed` and all four
+  `/feed.<ext>` siblings answered 500 to any member who follows one account out
+  there. Underneath that, a feed row is a **conversation** — `collapse_threads/1`
+  folds every post of one thread that reached the page into a single entry — and
+  every flat presenter drew the carrier alone, so the post an answer answered was
+  on no page of the feed at all while the HTML page beside it drew the whole
+  exchange.
+
+  So this asks the one question both bugs failed: `Vutuv.Posts.feed_subjects/1`
+  says what a row is about, and each presenter's output has to name all of it.
+  The oracle is deliberately the context function rather than a list written
+  here — a tenth source, or a fourth row shape, joins the fixture below and is
+  then checked everywhere at once instead of in whichever presenter somebody
+  remembered.
+
+  `async: false` because the last case holds the global
+  `:verify_organization_domains` flag down for the module's lifetime, and the
+  DNS-resolver stub beside it.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Vutuv.MastodonHelpers, only: [remote_account: 1, cached_post: 2]
+
+  alias Vutuv.ApiAuth
+  alias Vutuv.Fediverse
+  alias Vutuv.Posts
+  alias Vutuv.Repo
+
+  # One row of every shape a member's feed can hold, each carrying a sentence
+  # nothing else on the page says, so "is this row's content present" is a
+  # substring question rather than a structural one.
+  defp seed_every_shape(me) do
+    author = insert_activated_user(first_name: "Anna", last_name: "Autor")
+    sharer = insert_activated_user(first_name: "Sina", last_name: "Share")
+    follow!(me, author)
+    follow!(me, sharer)
+
+    # A plain post by a followed member, and — the folded case — a post of that
+    # member's that somebody answers, so the row is a conversation of two.
+    {:ok, _plain} = Posts.create_post(author, %{body: "EIN EINZELNER BEITRAG"})
+    {:ok, parent} = Posts.create_post(author, %{body: "DER BEANTWORTETE BEITRAG"})
+    {:ok, _reply} = Posts.create_reply(author, parent, %{body: "DIE ANTWORT DARAUF"})
+
+    # A member here reshares somebody's post.
+    {:ok, reposted} = Posts.create_post(insert_activated_user(), %{body: "DER GETEILTE BEITRAG"})
+    :ok = Posts.repost_post(sharer, reposted)
+
+    # A post by an account the member follows on another network.
+    followed = remote_account(handle: "thea", name: "Thea Remote")
+    accept_follow!(me, followed)
+    cached_post(followed, content_text: "EIN BEITRAG VON DRUEBEN")
+
+    # ...one that account boosted, by somebody nobody here follows.
+    stranger = remote_account(handle: "fremd", name: "Fremde Person")
+    boosted = cached_post(stranger, content_text: "EIN GEBOOSTETER BEITRAG")
+    boost!(followed, boosted)
+
+    # ...one a member **here** reshared, which is how it reaches a reader who
+    # follows nobody out there.
+    passed_on = cached_post(stranger, content_text: "EIN WEITERGEREICHTER BEITRAG")
+    Repo.insert!(%Fediverse.PostRepost{user_id: sharer.id, remote_post_id: passed_on.id})
+
+    # ...and a **reply** from out there that a member here passed on — the shape
+    # that carries no `:remote_post` key at all.
+    {:ok, mine} = Posts.create_post(me, %{body: "MEINE FRAGE"})
+
+    note =
+      insert(:note,
+        post: mine,
+        actor_uri: stranger.actor_uri,
+        handle: stranger.handle,
+        content_text: "EINE WEITERGEREICHTE ANTWORT"
+      )
+
+    Repo.insert!(%Fediverse.NoteRepost{user_id: sharer.id, note_id: note.id})
+  end
+
+  defp accept_follow!(user, account) do
+    Repo.insert!(%Fediverse.Follow{
+      user_id: user.id,
+      remote_account_id: account.id,
+      state: "accepted",
+      follow_activity_id: "https://vutuv.test/#{user.id}/actor#follows/#{account.id}"
+    })
+  end
+
+  defp boost!(booster, %Fediverse.RemotePost{} = post) do
+    Repo.insert!(%Fediverse.PostBoost{
+      remote_account_id: booster.id,
+      remote_post_id: post.id,
+      activity_id: "https://social.example/announce/#{post.id}",
+      announced_at: DateTime.utc_now(:second)
+    })
+  end
+
+  # What every presenter owes the reader, straight from the context: the text of
+  # each record the rows carry. `Posts.text/1` answers for all three post kinds,
+  # so a fourth arrives here already handled.
+  defp texts_owed(viewer) do
+    viewer
+    |> Posts.feed_page(limit: 50)
+    |> Map.fetch!(:entries)
+    |> Enum.flat_map(&Posts.feed_subjects/1)
+    |> Enum.map(&Posts.text/1)
+    |> Enum.reject(&(&1 in [nil, ""]))
+  end
+
+  defp missing(body, texts), do: Enum.reject(texts, &String.contains?(body, &1))
+
+  setup %{conn: conn} do
+    Vutuv.RateLimiter.reset()
+
+    # The organization helpers below flip this global flag and the DNS stub
+    # beside it; the module is `async: false` for that too.
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    {conn, me} = create_and_login_user(conn)
+    seed_every_shape(me)
+
+    texts = texts_owed(me)
+
+    # The fixture is only worth what it covers: nine sentences means every shape
+    # above really reached the page. A silently empty feed would make every
+    # assertion below vacuously true.
+    assert length(texts) == 9, "the fixture stopped covering every row shape: #{inspect(texts)}"
+
+    {:ok, conn: conn, me: me, texts: texts}
+  end
+
+  test "the agent formats name every record their rows carry", %{conn: conn, texts: texts} do
+    for ext <- ~w(md txt json xml) do
+      body = recycle(conn) |> get("/feed.#{ext}") |> response(200)
+      assert missing(body, texts) == [], "/feed.#{ext} lost: #{inspect(missing(body, texts))}"
+    end
+  end
+
+  test "the API names every record its rows carry", %{me: me, texts: texts} do
+    {:ok, token, _} = ApiAuth.create_pat(me, %{"name" => "t", "scopes" => ["posts:read"]})
+
+    body = get(authed(build_conn(), token), "/api/2.0/feed?limit=50").resp_body
+    assert missing(body, texts) == [], "/api/2.0/feed lost: #{inspect(missing(body, texts))}"
+  end
+
+  # The reference the three above are measured against: this page was always
+  # right, which is what made the others' silence so hard to see — the same
+  # conversation read whole here and came back one post short everywhere else.
+  test "the HTML feed names every record its rows carry", %{conn: conn, texts: texts} do
+    html = conn |> get(~p"/feed") |> html_response(200)
+    assert missing(html, texts) == [], "/feed lost: #{inspect(missing(html, texts))}"
+  end
+
+  # A page's feed folds a conversation the same way and drew the carrier alone,
+  # so a post a followed member had answered left it for good — the cursor had
+  # already walked past its own row, so no later page brought it back.
+  test "a page's feed shows the post an answer answers" do
+    {conn, owner} =
+      build_conn() |> Plug.Test.init_test_session(%{}) |> create_and_login_user()
+
+    page = Vutuv.OrganizationsHelpers.active_organization_for(owner)
+    {:ok, _} = Vutuv.Organizations.add_role(page, owner, "publisher", owner)
+
+    author = insert_activated_user(first_name: "Anna", last_name: "Autor")
+    {:ok, _} = Vutuv.Social.follow_as_organization(page, author)
+
+    {:ok, parent} = Posts.create_post(author, %{body: "DER BEANTWORTETE BEITRAG"})
+    {:ok, _reply} = Posts.create_reply(author, parent, %{body: "DIE ANTWORT DARAUF"})
+
+    html = conn |> get(~p"/organizations/#{page.slug}/feed") |> html_response(200)
+
+    assert html =~ "DIE ANTWORT DARAUF"
+    assert html =~ "DER BEANTWORTETE BEITRAG"
+  end
+end


### PR DESCRIPTION
Two silent failures on the same rows, both against `Vutuv.Posts.feed_page/2`.

**It crashed.** Four of the feed's nine sources hand over a row with no `%Post{}` — a cached post, a boost, a reshare of either, and a reply from out there that carries no `remote_post` key at all. Both presenters read `post.id` off it, so `GET /api/2.0/feed` answered 500 to any member who follows one account out there, and `/feed.md|.txt|.json|.xml` did the same for a reshared reply.

**It lost posts.** `collapse_threads/1` folds every post of one thread that reached the page into a single row. The HTML feed stacks the conversation; the machine formats and the page feed drew the carrier alone — so a reply showed and the post it answered was on no page at all, and the cursor had already walked past its own row. `/organizations/:slug/feed` now renders the same `<.post_thread_entry>` the member feed does, which is what the note above `collapse_threads/1` said the way out was.

Your call on the entry shape, which #1880 left open: `network: "fediverse"` with the origin URL, an author ref of name + handle + address (the `Vutuv.Identity` protocol is deliberately vutuv-only), `body_text` rather than `body_markdown` (a remote body is plain text after the inbox), and a `thread` array of the posts a row answers.

`Posts.feed_subjects/1` is the contract; `feed_presenter_coverage_test.exs` walks one row of every source through every presenter and measures against it. Calibrated: without the fix `.md`, the API and the page feed each lose the same post while the HTML feed stays green as the reference.

Smoke-tested at `/organizations/acme-gmbh/feed` in Chrome. Docs: `docs/architecture/api.md`, `priv/dev_docs/reference.md`.

Closes #1880

An AI agent wrote this text in my name. I know that is problematic.

https://claude.ai/code/session_01H3dKxEvGaV9oKRAo47GYLw