### PR TITLE
Open a card for a fediverse mention instead of leaving for that server

### DIFF
--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -302,6 +302,27 @@ LiveView can sit on either style.
   `.error-page__note` is the prominent brand-tinted callout inside that card
   (the `/username` placeholder helper uses it to own up to a broken newsletter
   link); it is the one non-muted line, distinct from the grey `.error-page__hint`.
+- **The mention card is a body-level panel, not a page element** (`.actor-card*`
+  in `components.css`, `assets/js/mention_card.js`). A `@user@host` mention keeps
+  its link to that server; a plain left click by a signed-in member opens a
+  small card under the word instead — who that account is, one Follow button,
+  their page here and the original out there. The markup arrives from the server
+  on every act (`VutuvWeb.RemoteActorCardController` +
+  `templates/remote_actor_card/card.html.heex`, **POST only**, since opening one
+  may resolve an address nobody here has seen), so every sentence in it is
+  translated where sentences belong and the JS only positions a box and swaps
+  HTML into it. **Nothing in that fragment may be a `<.link navigate>` or carry
+  a fixed `id`**: it lands outside every LiveView root, where a live-navigation
+  link does nothing, and it can be open over a page that already renders the
+  same element (which is why the card shows `follow_refusal_sentence/1` and not
+  the `follow_refusal_panel/1` the account page shows). Appended to `<body>`,
+  like the emoji picker; under 40rem it becomes a bottom sheet with a backdrop,
+  and only the sheet dims the page (a popover is read together with the sentence
+  it came from). The signed-in test is the shell's own `[data-account-menu]`,
+  the marker `keyboard_shortcuts.js` already reads — a logged-out click stays
+  the plain link, with no request to find that out. Its dark rules sit **with**
+  its light ones at the end of `components.css` rather than in that file's big
+  `prefers-color-scheme` block: one component, one place.
 
 ### CSS architecture (don't break it)
 

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -3647,6 +3647,109 @@ html.lightbox-open { overflow: hidden; }
   }
 }
 
+/* ---------- The card behind a `@user@host` mention (mention_card.js) ----------
+   A mention is a link to another server, and a plain click on it opens this
+   instead: who that account is, one Follow button, and the way onward. The why
+   is in `assets/js/mention_card.js`; what matters here is that the panel lives
+   on <body>, outside every LiveView root, and is filled with a fragment the
+   server renders.
+
+   Written as one block, its dark half nested rather than filed in this file's
+   big `prefers-color-scheme` section: this is a self-contained component whose
+   two halves are read together, and 400 lines between them is how a dark
+   variant gets forgotten. */
+.actor-card {
+  position: fixed;
+  /* The band the other body-level panels sit in (the emoji and @ pickers), not
+     the full-page editor's 60 — a card opened over that editor must be on top
+     of it, not under it. */
+  z-index: 70;
+  width: 20rem;
+  max-width: calc(100vw - 1rem);
+  padding: 0.875rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  background: #fff;
+  color: #0f172a;
+  box-shadow: 0 10px 25px -5px rgb(15 23 42 / 0.18), 0 8px 10px -6px rgb(15 23 42 / 0.1);
+}
+.actor-card[hidden] { display: none; }
+
+/* On a phone the box becomes a sheet at the bottom edge: a 20rem popover
+   anchored to a word in a paragraph has nowhere to go on a 360px screen, and
+   the buttons belong where the thumb already is. `env(safe-area-inset-bottom)`
+   keeps them clear of the home indicator. */
+.actor-card--sheet {
+  left: 0.5rem;
+  right: 0.5rem;
+  bottom: 0.5rem;
+  top: auto;
+  width: auto;
+  max-width: none;
+  border-radius: 1rem;
+  padding-bottom: calc(0.875rem + env(safe-area-inset-bottom));
+}
+
+/* Only the sheet dims the page behind it — a popover under a word is read
+   together with the sentence it came from, and dimming that sentence would
+   take away the context the card is about. */
+.actor-card__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 69;
+  background: rgb(15 23 42 / 0.35);
+}
+.actor-card__backdrop[hidden] { display: none; }
+
+.actor-card__close {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: 0;
+  border-radius: 0.5rem;
+  background: transparent;
+  color: #64748b;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+}
+.actor-card__close:hover { background: #f1f5f9; color: #0f172a; }
+@media (any-pointer: coarse) {
+  .actor-card__close { width: 2.5rem; height: 2.5rem; }
+}
+
+/* The wait: the same breathing outline every other not-yet-arrived thing here
+   wears (`.skeleton`), in the shape of the card that is coming. */
+.actor-card__skeleton { display: flex; gap: 0.75rem; align-items: flex-start; }
+.actor-card__skeleton-tile {
+  flex: 0 0 auto;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+}
+.actor-card__skeleton-lines { flex: 1 1 auto; display: flex; flex-direction: column; gap: 0.4rem; }
+.actor-card__skeleton-lines i { display: block; height: 0.7rem; }
+.actor-card__skeleton-lines i:nth-child(1) { width: 55%; }
+.actor-card__skeleton-lines i:nth-child(2) { width: 85%; }
+.actor-card__skeleton-lines i:nth-child(3) { width: 40%; }
+
+@media (prefers-color-scheme: dark) {
+  .actor-card {
+    border-color: #1e293b;
+    background: #0f172a;
+    color: #e2e8f0;
+    box-shadow: 0 10px 25px -5px rgb(0 0 0 / 0.6), 0 8px 10px -6px rgb(0 0 0 / 0.5);
+  }
+  .actor-card__backdrop { background: rgb(2 6 23 / 0.6); }
+  .actor-card__close { color: #94a3b8; }
+  .actor-card__close:hover { background: #1e293b; color: #f1f5f9; }
+}
+
 /* Changing this file (or app.css @theme / lib/vutuv_web/components/ui.ex) is a
    design-language change — a PostToolUse hook reminds you to update
    .claude/rules/design.md so the design rule stays in sync. */

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -45,6 +45,10 @@ import "./lightbox"
 // (self-contained; marks <html>, which is outside every LiveView root, so no
 // patch can drop the state. See scroll_top_tab.js).
 import "./scroll_top_tab"
+// The card behind a `@user@host` mention in a post: who that is, and a Follow
+// button, instead of leaving the site for their server (self-contained; its
+// panel lives on <body>, outside every LiveView root. See mention_card.js).
+import "./mention_card"
 
 // LiveSocket drives the incremental LiveView shell (live unread badges, the
 // notifications/messages pages, presence). The CSRF token is rendered into the

--- a/assets/js/mention_card.js
+++ b/assets/js/mention_card.js
@@ -1,0 +1,254 @@
+// The card behind a `@user@host` mention.
+//
+// The mention stays a link to that server (`VutuvWeb.Markdown`), and this
+// intercepts the plain left click on it to open a small card instead: who that
+// account is, one Follow button, and the two ways onward (their page here, the
+// original out there). Every other way of following the link is left alone —
+// a modified click, a middle click, "copy link address", a visitor who is not
+// signed in, and a page whose JavaScript never arrived all get today's
+// behaviour, because the `href` is still the whole truth of that anchor.
+//
+// It reaches every rendered `@user@host`, which is more than posts: a chat
+// message and a work-experience description run through the same renderer, and
+// the same reader wants the same thing there.
+//
+// The card's markup comes from the server on every act
+// (`VutuvWeb.RemoteActorCardController`), so no sentence about a follow, a
+// refusal or an hourly budget is written twice — this file positions a box and
+// swaps HTML into it, and knows nothing about what is inside.
+//
+// The panel is appended to `document.body`, deliberately outside every
+// LiveView root: a patch of the page underneath must not be able to take the
+// open card with it. That is also why the fragment carries no `phx-` link and
+// no fixed id (see the template).
+import { request } from "./util"
+
+const CARD_URL = "/system/fediverse/actor_card"
+
+// Below this the card is a sheet at the bottom of the screen rather than a box
+// under the word: a 20rem popover anchored to a word in a paragraph has
+// nowhere to go on a 360px phone, and a sheet puts its buttons where a thumb
+// already is. In `rem` like the other panels' breakpoint, so a reader who
+// enlarged their default font gets the sheet at the same point the CSS does.
+const SHEET = window.matchMedia("(width < 40rem)")
+
+// Room the card keeps from the window edge, and from the mention it belongs to.
+const EDGE = 8
+const GAP = 6
+
+// No words: the sentences are the server's to write, and an outline that says
+// nothing says it in every language. `.skeleton` is the breathing outline every
+// other not-yet-arrived thing here wears.
+const SKELETON = `<div class="actor-card__skeleton" aria-busy="true" aria-hidden="true">
+  <span class="skeleton actor-card__skeleton-tile"></span>
+  <span class="actor-card__skeleton-lines">
+    <i class="skeleton"></i><i class="skeleton"></i><i class="skeleton"></i>
+  </span>
+</div>`
+
+let panel = null
+let backdrop = null
+let anchor = null
+let queued = false
+
+const isOpen = () => anchor !== null
+
+function ensurePanel() {
+  if (panel) return
+
+  backdrop = document.createElement("div")
+  backdrop.className = "actor-card__backdrop"
+  backdrop.hidden = true
+  backdrop.addEventListener("click", close)
+
+  panel = document.createElement("div")
+  panel.className = "actor-card"
+  panel.setAttribute("role", "dialog")
+  panel.hidden = true
+
+  document.body.append(backdrop, panel)
+
+  // Only from here on: a page where no mention is ever clicked should not carry
+  // a capture-phase scroll listener, which every scrolling container on it
+  // would otherwise feed.
+  window.addEventListener("scroll", reposition, { passive: true, capture: true })
+  window.addEventListener("resize", reposition, { passive: true })
+}
+
+function close() {
+  if (!isOpen()) return
+  panel.hidden = true
+  panel.innerHTML = ""
+  backdrop.hidden = true
+  anchor.removeAttribute("aria-expanded")
+  // Only take the focus back when it is still inside the card — a reader who
+  // has clicked away has already said where they want to be.
+  if (panel.contains(document.activeElement)) anchor.focus()
+  anchor = null
+}
+
+// Scroll fires more than once per frame, and `place()` measures and then
+// writes; coalesce to one measure-and-write per paint (the shape
+// `scroll_top_tab.js` uses for the same reason).
+function reposition() {
+  if (queued || !isOpen() || SHEET.matches) return
+  queued = true
+  window.requestAnimationFrame(() => {
+    queued = false
+    place()
+  })
+}
+
+// Under the mention, and inside the window: flipped above the word when there
+// is no room below, and shifted sideways rather than hanging off an edge. The
+// anchor's rect is viewport-relative and so is `position: fixed`, so scrolling
+// only has to re-run this, not correct for it.
+function place() {
+  if (!isOpen()) return
+  if (!anchor.isConnected) return close()
+
+  if (SHEET.matches) {
+    panel.classList.add("actor-card--sheet")
+    panel.style.left = panel.style.top = ""
+    return
+  }
+
+  panel.classList.remove("actor-card--sheet")
+
+  const at = anchor.getBoundingClientRect()
+
+  // The mention scrolled out of the window: the card would point at nothing.
+  if (at.bottom < 0 || at.top > window.innerHeight) return close()
+
+  const box = panel.getBoundingClientRect()
+  const below = at.bottom + GAP
+  const top = below + box.height > window.innerHeight - EDGE ? at.top - box.height - GAP : below
+
+  panel.style.left = `${Math.max(EDGE, Math.min(at.left, window.innerWidth - box.width - EDGE))}px`
+  panel.style.top = `${Math.max(EDGE, top)}px`
+}
+
+// The reader asked for this box, so the keyboard follows them into it — and
+// keeps up when the card is replaced, since the button they just pressed is
+// gone with the old fragment and focus would otherwise fall back to the body.
+// The Follow button first, not whatever comes first in the markup: the × leads
+// the fragment (it belongs in the corner), and dropping a keyboard reader on
+// "Close" answers a question they did not ask.
+function takeFocus() {
+  const first = panel.querySelector("[data-actor-act]") || panel.querySelector("button, a")
+  if (first) first.focus({ preventScroll: true })
+}
+
+// One shape for the three calls (open, follow, unfollow): a form-encoded
+// address, and the whole card back as HTML.
+//
+// `innerHTML` with that answer is deliberate and safe: it is our own
+// same-origin endpoint rendering a HEEx template, so everything a remote server
+// supplied — a display name, a self-description — is escaped there, on the side
+// that knows what is markup and what is text. Building the card here instead
+// would mean writing its sentences twice, once in German.
+async function fetchCard(url, method) {
+  const resp = await request(url, {
+    method,
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: `address=${encodeURIComponent(anchor.dataset.remoteActor)}`,
+  })
+  if (!resp.ok) throw new Error(`actor card ${resp.status}`)
+  return resp.text()
+}
+
+// The mention's own link, taken as soon as the enhancement gives up: a session
+// that expired, a server that answered with something else. `window.open`
+// keeps the new tab the anchor asks for; a blocked popup falls back to this
+// tab, which is still where the reader wanted to go.
+function followTheLink(link) {
+  const href = link.getAttribute("href")
+  if (!href) return
+  if (!window.open(href, "_blank", "noopener,noreferrer")) window.location.assign(href)
+}
+
+async function open(link) {
+  ensurePanel()
+  anchor = link
+  link.setAttribute("aria-expanded", "true")
+
+  panel.innerHTML = SKELETON
+  panel.hidden = false
+  backdrop.hidden = !SHEET.matches
+  place()
+
+  try {
+    panel.innerHTML = await fetchCard(CARD_URL, "POST")
+    place()
+    takeFocus()
+  } catch (_e) {
+    close()
+    followTheLink(link)
+  }
+}
+
+// Follow / unfollow from inside the card. The answer is the whole card again,
+// so the button's next state, the status pill and any refusal all arrive
+// together and this side never has to guess what the act meant.
+async function act(button) {
+  button.disabled = true
+
+  const method = button.dataset.actorAct === "follow" ? "POST" : "DELETE"
+
+  try {
+    panel.innerHTML = await fetchCard(`${CARD_URL}/follow`, method)
+    place()
+    takeFocus()
+  } catch (_e) {
+    // Leave the card as it stands rather than inventing an outcome; the button
+    // comes back, so the reader can try again.
+    button.disabled = false
+  }
+}
+
+document.addEventListener("click", (e) => {
+  const link = e.target.closest("a[data-remote-actor]")
+
+  if (isOpen()) {
+    if (panel.contains(e.target)) {
+      if (e.target.closest("[data-actor-card-close]")) {
+        e.preventDefault()
+        return close()
+      }
+
+      const button = e.target.closest("[data-actor-act]")
+      if (button) {
+        e.preventDefault()
+        return act(button)
+      }
+
+      // A link inside the card (their page here, the original out there):
+      // that is a destination, not a control. Let it navigate.
+      return
+    }
+
+    // A click anywhere else closes it — and on the mention it belongs to, that
+    // is the whole gesture: pressing the word again puts the card away.
+    const sameMention = anchor === link
+    close()
+    if (sameMention) return e.preventDefault()
+  }
+
+  if (!link) return
+
+  // Everything that is not a plain left click means "take me to that server",
+  // and so does a click by anybody who is not signed in: the card is a follow
+  // surface, and asking the server whether they may have one would cost a
+  // request just to find out that they may not. The shell renders the account
+  // menu for a signed-in reader on every page, dead render included, which is
+  // the marker the keyboard shortcuts already read.
+  if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return
+  if (!document.querySelector("[data-account-menu]")) return
+
+  e.preventDefault()
+  open(link)
+})
+
+document.addEventListener("keydown", (e) => {
+  if (e.key === "Escape") close()
+})

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -1405,6 +1405,51 @@ defmodule Vutuv.Fediverse do
   def get_remote_account(id), do: UUIDv7.with_cast(id, &Repo.get(RemoteAccount, &1))
 
   @doc """
+  The stored account an address names, or nil — **without asking anybody**
+  (issue: the mention card).
+
+  A reader who taps `@user@host` in a post wants to know who that is, and this
+  is the half of that answer that costs nothing: most accounts a member meets in
+  a post are already here, because somebody follows them or something of theirs
+  was stored. Only a miss goes on to `resolve_remote_account/2`, which spends an
+  outbound request and a slot of the member's hourly budget.
+
+  The handle is matched case-insensitively, but on `lower(…)` equality rather
+  than the `ilike` the follow browser's search uses: `_` is a legal character in
+  a handle and a single-character wildcard in LIKE, so `@ada_b@host` would also
+  match `@adaXb@host` — tolerable when somebody is searching their own follow
+  list, not when it decides whose card a reader is shown.
+
+  The **host is compared as stored**, which keeps the query on the `host` index
+  (`lower(host) = …` is not sargable, and a seq scan over every remote account
+  is not what a click on a word in a paragraph should cost): the column is
+  always written through `BlockedInstance.normalize_host/1`, which downcases,
+  and `parse_address/1` downcases what it hands back.
+
+  The stored `host` comes from the **actor URI**, so an address whose WebFinger
+  points at a different host than it spells (`@you@example.com` living at
+  `mastodon.example.com`) misses here and is resolved instead — a slower right
+  answer, never a wrong one.
+  """
+  def remote_account_by_address(address) do
+    case RemoteFollow.parse_address(address) do
+      {:ok, {name, host}} ->
+        name = String.downcase(name)
+
+        Repo.one(
+          from(a in RemoteAccount,
+            where: a.host == ^host,
+            where: fragment("lower(?)", a.handle) == ^name,
+            limit: 1
+          )
+        )
+
+      _invalid ->
+        nil
+    end
+  end
+
+  @doc """
   The stored remote accounts these actor URIs name, keyed by URI — one query
   for a whole page. A URI nobody here stored is simply absent, so callers
   fall back per actor.

--- a/lib/vutuv/fediverse/handle.ex
+++ b/lib/vutuv/fediverse/handle.ex
@@ -106,6 +106,24 @@ defmodule Vutuv.Fediverse.Handle do
 
   def host(_uri), do: nil
 
+  @doc """
+  Where a `@user@host` address reads on the web: `https://host/@user`, the
+  Mastodon-web convention that geno.social and the vast majority of servers
+  follow.
+
+  A pure string mapping, no WebFinger — so it costs nothing, works on an
+  air-gapped installation, and leaks no reader's request to the remote host.
+  One owner because two callers must agree on it: the `href`
+  `VutuvWeb.Markdown` writes into a mention, and the "View the original" link on
+  the card that mention opens. A card that sent a reader somewhere the link
+  would not have is a card that lied about the link.
+
+  The host is lowercased (hostnames are case-insensitive); the typed user case
+  is kept, since a handle's case is the account's own.
+  """
+  def web_profile_url(user, host) when is_binary(user) and is_binary(host),
+    do: "https://#{String.downcase(host)}/@#{user}"
+
   # The last path segment, when it reads like a username. A leading "@" is part
   # of the URL style (`/@alice`), not part of the name.
   defp derive(uri) when is_binary(uri) do

--- a/lib/vutuv_web/components/fediverse_components.ex
+++ b/lib/vutuv_web/components/fediverse_components.ex
@@ -335,6 +335,54 @@ defmodule VutuvWeb.FediverseComponents do
       "font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
 
   @doc """
+  The one-sentence version of `follow_refusal_panel/1`, for a surface with no
+  room for a panel.
+
+  The mention card is that surface: a 20rem box on `<body>`, filled with a
+  fragment fetched over HTTP. The panel cannot go there, because its links are
+  `<.link navigate={…}>` — inert outside a LiveView root — and its ids are fixed
+  (`enable-fediverse-link` and friends), so a card opened over the account page
+  would put a second element of that id in the document. The sentences are the
+  same ones, and `refusal_message(:not_federating)` already ends with where to
+  go, so nothing is lost but the button.
+  """
+  def follow_refusal_sentence(:restricted),
+    do:
+      gettext(
+        "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
+      )
+
+  def follow_refusal_sentence(:disabled), do: refusal_message(:fediverse_disabled)
+  def follow_refusal_sentence(:moved), do: refusal_message(:moved)
+  def follow_refusal_sentence(_opted_out), do: refusal_message(:not_federating)
+
+  attr(:follow, :map, required: true, doc: "a `Vutuv.Fediverse.Follow`")
+  attr(:class, :string, default: nil)
+
+  @doc """
+  The follow's state as a pill: the word from `follow_state_label/1`, the
+  colours from `follow_state_class/1`, and `data-follow-state` for the tests.
+
+  Four surfaces show it — the account page, the following list, a looked-up
+  post's card and the mention card — and one member's follow must not read as
+  three different things depending on where they met it.
+  """
+  def follow_state_pill(assigns) do
+    ~H"""
+    <span
+      data-follow-state={@follow.state}
+      class={[
+        "inline-flex rounded-full px-2 py-0.5 text-xs font-semibold ring-1",
+        follow_state_class(@follow),
+        @class
+      ]}
+    >
+      {follow_state_label(@follow)}
+    </span>
+    """
+  end
+
+  @doc """
   A follow that has not been answered reads **"Requested"**, not "Following".
   An account that approves its followers by hand may take days or never answer,
   and showing it as settled would be a lie the member acts on.

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -2811,7 +2811,16 @@ defmodule VutuvWeb.PostComponents do
   # to the handle for the letters — `RemoteAccount.display_name/1` exists for
   # exactly that distinction, and the full card and the quoted card must draw
   # the same tile for the same account.
-  defp remote_initials(account),
+  @doc """
+  The monogram for a remote account: its display name's initials, and the bare
+  handle's when it has no display name.
+
+  Public because the mention card (`VutuvWeb.RemoteActorCardHTML`) draws the
+  same account and must draw the same letters. Deliberately not built from
+  `RemoteAccount.label/1`, whose fallback is the whole `@user@host` address —
+  `name_initials/1` would answer "@" for it.
+  """
+  def remote_initials(account),
     do: name_initials(RemoteAccount.display_name(account) || account.handle)
 
   # Where the fallback link goes, or nil when there is nothing to add: no quote

--- a/lib/vutuv_web/controllers/remote_actor_card_controller.ex
+++ b/lib/vutuv_web/controllers/remote_actor_card_controller.ex
@@ -1,0 +1,126 @@
+defmodule VutuvWeb.RemoteActorCardController do
+  @moduledoc """
+  The card behind a `@user@host` mention in a post.
+
+  A mention inside remote text was the one remote handle on the site that still
+  led straight off it: every other one (a reaction chip, a reply card, the
+  author line of a remote post) has landed on `/system/fediverse/account/:id`
+  since issue #1162, while a handle *in a sentence* sent the reader to that
+  server's own profile. Which is a fine answer to "who is that" and the wrong
+  one to "I want their posts here", and the second is what a reader means far
+  more often — following meant leaving vutuv, finding the account again, coming
+  back and pasting the address into a settings page.
+
+  So the mention keeps its `href` (a middle-click, a copied link and a page
+  whose JavaScript never arrived all still go there) and a plain click opens
+  this: name, address, self-description, one Follow button, and the two ways
+  onward — the account's page here and the original out there.
+
+  **Every action is a POST**, none a GET, and that is deliberate: `show` may
+  resolve an address this installation has never seen, which is an outbound
+  request to a host somebody else named. As a GET that would be an open-ended
+  "go and fetch this" surface reachable by a link, a prefetch or a crawler. The
+  account page made the same call for the same reason ("the lookup resolves the
+  address as an event and not as a GET"), and a POST behind CSRF and a login is
+  what keeps this a member's act rather than anybody's.
+
+  The gates, the hourly budget and every refusal sentence are
+  `Vutuv.Fediverse`'s and `VutuvWeb.FediverseComponents`': four surfaces start a
+  follow and the member must read the same thing about the same outcome.
+  """
+
+  use VutuvWeb, :controller
+
+  plug(VutuvWeb.Plug.RequireLoginOr404)
+
+  # BOTH layouts off. `put_layout` alone drops the chrome and leaves the
+  # `:browser` pipeline's root layout on, so every card came back as a whole
+  # HTML document — 22 meta tags, six stylesheet links and two scripts — which
+  # `innerHTML` happily unwraps into the panel, re-fetching the stylesheets on
+  # every open. A fragment endpoint has to say so twice.
+  plug(:put_root_layout, html: false)
+  plug(:put_layout, html: false)
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.RemoteAccount
+
+  @doc """
+  Who is `address`, and where do I stand with them.
+
+  Answered from the stored account whenever we hold it, which costs nothing and
+  is the common case — the accounts a member meets in a post are mostly here
+  already. Only an address nobody here has ever stored is resolved, which
+  spends one of the member's hourly lookups.
+  """
+  def show(conn, %{"address" => address}) when is_binary(address) do
+    case Fediverse.remote_account_by_address(address) do
+      %RemoteAccount{} = account ->
+        card(conn, address, account)
+
+      nil ->
+        case Fediverse.resolve_remote_account(conn.assigns[:current_user], address) do
+          {:ok, account} -> card(conn, address, account)
+          {:error, reason} -> card(conn, address, nil, reason)
+        end
+    end
+  end
+
+  @doc """
+  Follow the account this card is showing.
+
+  `follow_remote_account/2` rather than `follow_remote/2`: the card has the row
+  in front of it, so there is nothing to re-derive from the string — and a real
+  actor id is under no obligation to be shaped like an address (the reason that
+  split exists). An address we do not hold cannot be followed from here; the
+  card said so in the first place, and the member never saw a button.
+  """
+  def follow(conn, %{"address" => address}) when is_binary(address) do
+    case Fediverse.remote_account_by_address(address) do
+      %RemoteAccount{} = account ->
+        case Fediverse.follow_remote_account(conn.assigns[:current_user], account) do
+          {:ok, _follow} -> card(conn, address, account)
+          {:error, reason} -> card(conn, address, account, reason)
+        end
+
+      nil ->
+        card(conn, address, nil, :invalid_address)
+    end
+  end
+
+  @doc """
+  Take the follow back: an accepted one ends, a request nobody answered is
+  withdrawn. `unfollow_remote_account/2` is the same withdrawal named by the
+  account rather than by the follow row, which is what this card has in hand;
+  it answers `{:error, :not_found}` when a second tab got there first, and the
+  card that comes back then simply shows Follow again.
+
+  Deliberately **not** falling through to `show/2` when the address is one we do
+  not hold: that would re-enter the resolve path, and a DELETE has no business
+  spending a slot of the member's hourly budget on two outbound requests.
+  """
+  def unfollow(conn, %{"address" => address}) when is_binary(address) do
+    case Fediverse.remote_account_by_address(address) do
+      %RemoteAccount{} = account ->
+        Fediverse.unfollow_remote_account(conn.assigns[:current_user], account.id)
+        card(conn, address, account)
+
+      nil ->
+        card(conn, address, nil, :invalid_address)
+    end
+  end
+
+  # The one render. The follow is re-read from the database rather than taken
+  # from whatever the act returned, so what the card draws is what is true — a
+  # second tab that changed it is then not contradicted by this one.
+  defp card(conn, address, account, error \\ nil) do
+    viewer = conn.assigns[:current_user]
+
+    render(conn, :card,
+      address: address,
+      account: account,
+      follow: account && Fediverse.remote_follow_for(viewer, account),
+      blocked_reason: Fediverse.follow_refusal(viewer),
+      error: error
+    )
+  end
+end

--- a/lib/vutuv_web/live/fediverse_account_live.ex
+++ b/lib/vutuv_web/live/fediverse_account_live.ex
@@ -354,15 +354,7 @@ defmodule VutuvWeb.FediverseAccountLive do
                   word and colour and the button's label, and those come from
                   the sibling page, so "Requested" cannot mean two things. --%>
             <div :if={@follow} class="flex flex-wrap items-center gap-3">
-              <span
-                data-follow-state={@follow.state}
-                class={[
-                  "inline-flex rounded-full px-2 py-0.5 text-xs font-semibold ring-1",
-                  follow_state_class(@follow)
-                ]}
-              >
-                {follow_state_label(@follow)}
-              </span>
+              <.follow_state_pill follow={@follow} />
               <span
                 :if={@follow.muted}
                 data-follow-muted

--- a/lib/vutuv_web/live/fediverse_following_live.ex
+++ b/lib/vutuv_web/live/fediverse_following_live.ex
@@ -393,15 +393,7 @@ defmodule VutuvWeb.FediverseFollowingLive do
                     </td>
                     <td>
                       <div class="flex flex-wrap items-center justify-end gap-x-3 gap-y-1">
-                        <span
-                          data-follow-state={follow.state}
-                          class={[
-                            "inline-flex rounded-full px-2 py-0.5 text-xs font-semibold ring-1",
-                            follow_state_class(follow)
-                          ]}
-                        >
-                          {follow_state_label(follow)}
-                        </span>
+                        <.follow_state_pill follow={follow} />
                         <button
                           type="button"
                           phx-click="unfollow"

--- a/lib/vutuv_web/live/fediverse_lookup_live.ex
+++ b/lib/vutuv_web/live/fediverse_lookup_live.ex
@@ -305,16 +305,7 @@ defmodule VutuvWeb.FediverseLookupLive do
             </p>
           </div>
 
-          <span
-            :if={@follow}
-            data-follow-state={@follow.state}
-            class={[
-              "inline-flex rounded-full px-2 py-0.5 text-xs font-semibold ring-1",
-              follow_state_class(@follow)
-            ]}
-          >
-            {follow_state_label(@follow)}
-          </span>
+          <.follow_state_pill :if={@follow} follow={@follow} />
 
           <.button :if={is_nil(@follow)} id="follow-author" phx-click="follow">
             {gettext("Follow")}

--- a/lib/vutuv_web/markdown.ex
+++ b/lib/vutuv_web/markdown.ex
@@ -29,6 +29,7 @@ defmodule VutuvWeb.Markdown do
   use Gettext, backend: VutuvWeb.Gettext
 
   alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Handle
   alias Vutuv.Mentions
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
@@ -1178,7 +1179,7 @@ defmodule VutuvWeb.Markdown do
     cond do
       Fediverse.tag_host?(host) -> tag_actor_link(whole, user, tags)
       Fediverse.local_host?(host) -> local_address_link(whole, user, host, users, form)
-      true -> remote_actor_link(user, host)
+      true -> remote_actor_link(user, host, form)
     end
   end
 
@@ -1236,10 +1237,26 @@ defmodule VutuvWeb.Markdown do
   # case-insensitive); the typed user case is kept in both the URL and the
   # label. Opens in a new tab like other external links; both parts are a
   # validated charset (`[A-Za-z0-9_]` / `[A-Za-z0-9.-]`), so no escaping needed.
-  defp remote_actor_link(user, host) do
-    href = "https://#{String.downcase(host)}/@#{user}"
+  # `data-remote-actor` is what `assets/js/mention_card.js` binds the mention
+  # card to: a click opens a small card with the account and a Follow button
+  # instead of leaving the site, because "who is that" and "I want their posts
+  # here" is what a reader means far more often than "take me to their server".
+  # The `href` stays this link's whole truth, so a middle-click, a copied link,
+  # a logged-out visitor and a page whose JavaScript never arrived all keep
+  # today's behaviour.
+  #
+  # Only on the `:local` form, which is the on-site render. The `:address` form
+  # is what goes out — `Vutuv.Fediverse.Docs` builds the ActivityPub Note's
+  # `content` with it, and the RSS/Atom item bodies come through here too — and
+  # a hook for our own click handler has no business in a copy stored on
+  # somebody else's server, which sanitizes it away on arrival anyway. Per
+  # mention, per follower inbox.
+  defp remote_actor_link(user, host, form) do
+    href = Handle.web_profile_url(user, host)
+    hook = if form == :local, do: ~s( data-remote-actor="#{user}@#{host}"), else: ""
 
-    ~s(<a href="#{href}" target="_blank" rel="noopener noreferrer" class="mention">@#{user}@#{host}</a>)
+    ~s(<a href="#{href}" target="_blank" rel="noopener noreferrer" class="mention"#{hook}>) <>
+      ~s(@#{user}@#{host}</a>)
   end
 
   # A bare `@ada` is the everyday spelling here and the wrong one everywhere

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -823,6 +823,15 @@ defmodule VutuvWeb.Router do
     # `system` is already reserved (`Vutuv.Accounts.ReservedSlugs`).
     delete("/system/act_as", ActingAsController, :delete)
 
+    # The card behind a `@user@host` mention (`VutuvWeb.RemoteActorCardController`,
+    # which says why none of these is a GET). Login is the controller's
+    # `RequireLoginOr404`, not a pipeline redirect: a 404 is what tells the
+    # browser to fall back to the mention's own link, while a 302 to the login
+    # page would be fetched and shown *as* the card.
+    post("/system/fediverse/actor_card", RemoteActorCardController, :show)
+    post("/system/fediverse/actor_card/follow", RemoteActorCardController, :follow)
+    delete("/system/fediverse/actor_card/follow", RemoteActorCardController, :unfollow)
+
     get("/new_registration", PageController, :redirect_index)
     post("/new_registration", PageController, :new_registration)
 

--- a/lib/vutuv_web/templates/remote_actor_card/card.html.heex
+++ b/lib/vutuv_web/templates/remote_actor_card/card.html.heex
@@ -1,0 +1,110 @@
+<%!-- The whole card, re-rendered after every act on it: the follow state, the
+refusal and the buttons are one answer from the server, so the browser never
+has to work out what a click meant. mention_card.js swaps this fragment in
+place.
+
+Nothing in here may be a `<.link navigate>` or carry a fixed `id`: the fragment
+lands on a `<body>`-level node outside every LiveView root, where a live
+navigation link does nothing, and it can be open over a page that already
+renders the same element. --%>
+<% origin = origin_url(@account, @address) %>
+<div class="actor-card__content" data-actor-card-content>
+  <%!-- The way out lives in the fragment, not in the shell mention_card.js
+  builds, so its label is a translated string like every other word on the card.
+  Escape and a click outside close it too; this is the one a thumb can reach on
+  a phone, where the card is a sheet at the bottom of the screen. --%>
+  <button
+    type="button"
+    data-actor-card-close
+    class="actor-card__close"
+    aria-label={gettext("Close")}
+  >
+    <span aria-hidden="true">×</span>
+  </button>
+
+  <%!-- Before the name, like the account page's header: a reader has to know
+  which world they are looking at before they read who it is. It gets the full
+  width of the card (`pr-6` clears the ×) rather than the column beside the
+  avatar, where it wrapped to two lines and pushed the name down. --%>
+  <p class="mb-1.5 pr-6 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+    {gettext("Account on another network")}
+  </p>
+
+  <div class="flex items-start gap-3">
+    <.remote_avatar
+      initials={card_initials(@account, @address)}
+      src={@account && RemoteAccount.avatar_url(@account)}
+      size="sm"
+    />
+
+    <div class="min-w-0 flex-1">
+      <p class="mb-0 break-words font-bold leading-tight text-slate-900 dark:text-white">
+        {card_name(@account, @address)}
+      </p>
+      <%!-- `break-words`, not `break-all`: the address only breaks when it has
+      to, so `@name@social.bund.de` does not come apart mid-host on a card this
+      narrow. --%>
+      <a
+        href={origin}
+        target="_blank"
+        rel="nofollow noopener noreferrer"
+        class="break-words text-sm font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+      >
+        {card_handle(@account, @address)}
+      </a>
+    </div>
+  </div>
+
+  <%!-- A self-description can be 10,000 characters, and this card is 20rem
+  wide: three lines, and the account page carries the whole of it. --%>
+  <p
+    :if={@account && @account.summary}
+    class="mb-0 mt-3 line-clamp-3 whitespace-pre-line break-words text-sm leading-relaxed text-slate-700 dark:text-slate-300"
+  >
+    {@account.summary}
+  </p>
+
+  <%!-- Why nothing can be followed from here, in the vocabulary every other
+  follow surface speaks: the standing refusal (this member has no Fediverse
+  identity, is on hold, has moved) first, then whatever the last act answered.
+  Never a dead end — the links below stay, so a spent hourly budget still leaves
+  the reader one click from the account. --%>
+  <p
+    :if={@blocked_reason || @error}
+    data-actor-card-error
+    class="mb-0 mt-3 rounded-lg bg-slate-50 p-2.5 text-sm leading-relaxed text-slate-700 dark:bg-slate-800/60 dark:text-slate-300"
+  >
+    {(@blocked_reason && follow_refusal_sentence(@blocked_reason)) || refusal_message(@error)}
+  </p>
+
+  <div :if={is_nil(@blocked_reason) && @account} class="mt-3 flex flex-wrap items-center gap-2">
+    <%= if @follow do %>
+      <.follow_state_pill follow={@follow} />
+      <.button variant="secondary" type="button" data-actor-act="unfollow">
+        {end_follow_label(@follow)}
+      </.button>
+    <% else %>
+      <.button type="button" data-actor-act="follow">{gettext("Follow")}</.button>
+    <% end %>
+  </div>
+
+  <div class="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 border-t border-slate-100 pt-2.5 text-sm dark:border-slate-800">
+    <%!-- The page here first: it is the one that holds this account's cached
+    posts, the mute switch and the whole self-description. --%>
+    <.link
+      :if={@account}
+      href={~p"/system/fediverse/account/#{@account}"}
+      class="font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+    >
+      {gettext("Their account page here")}
+    </.link>
+    <a
+      href={origin}
+      target="_blank"
+      rel="nofollow noopener noreferrer"
+      class="font-medium text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200"
+    >
+      {gettext("View the original")}
+    </a>
+  </div>
+</div>

--- a/lib/vutuv_web/views/remote_actor_card_html.ex
+++ b/lib/vutuv_web/views/remote_actor_card_html.ex
@@ -1,0 +1,63 @@
+defmodule VutuvWeb.RemoteActorCardHTML do
+  @moduledoc false
+  use VutuvWeb, :html
+
+  import VutuvWeb.FediverseComponents
+  import VutuvWeb.PostComponents
+
+  alias Vutuv.Fediverse.Handle
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemoteFollow
+
+  embed_templates("../templates/remote_actor_card/*")
+
+  @doc """
+  What the card calls the account: its display name, else the address it wears
+  out there, else the address the reader tapped.
+
+  Deliberately not `RemoteAccount.label/1`, whose last resort is the bare
+  `actor_uri` — a card headed by a URL says nothing a reader was not already
+  looking at, and the address they clicked says more.
+  """
+  def card_name(nil, address), do: "@" <> address
+
+  def card_name(%RemoteAccount{} = account, address),
+    do:
+      RemoteAccount.display_name(account) || RemoteAccount.display_handle(account) ||
+        card_name(nil, address)
+
+  @doc "The `@user@host` line under the name, from the row where we have one."
+  def card_handle(nil, address), do: "@" <> address
+
+  def card_handle(%RemoteAccount{} = account, address),
+    do: RemoteAccount.display_handle(account) || card_handle(nil, address)
+
+  @doc """
+  The monogram, from the same source every other remote-account surface uses
+  (`remote_initials/1`) so one account is not "T" on its page and "@" here — the
+  account's label starts with the `@` of its address whenever it has no display
+  name, and `name_initials/1` would take that as the initial.
+
+  For an address that resolved to nobody there is no row, so the handle the
+  reader typed is all there is.
+  """
+  def card_initials(nil, address),
+    do: address |> String.split("@") |> List.first() |> name_initials()
+
+  def card_initials(%RemoteAccount{} = account, _address), do: remote_initials(account)
+
+  @doc """
+  Where "View the original" goes: the canonical actor id once we hold the row,
+  and otherwise the same `https://host/@user` the mention's own `href` carries
+  (`Vutuv.Fediverse.Handle.web_profile_url/2` owns that spelling), so the card
+  can never send a reader somewhere the link would not have.
+  """
+  def origin_url(%RemoteAccount{actor_uri: uri}, _address), do: uri
+
+  def origin_url(nil, address) do
+    case RemoteFollow.parse_address(address) do
+      {:ok, {user, host}} -> Handle.web_profile_url(user, host)
+      _unparsable -> nil
+    end
+  end
+end

--- a/test/vutuv_web/controllers/remote_actor_card_test.exs
+++ b/test/vutuv_web/controllers/remote_actor_card_test.exs
@@ -1,0 +1,215 @@
+defmodule VutuvWeb.RemoteActorCardTest do
+  @moduledoc """
+  The card behind a `@user@host` mention in a post: who may open it, what it
+  answers, and the follow round trip inside it
+  (`VutuvWeb.RemoteActorCardController`).
+  """
+  # `async: false`: every test here stubs the Fediverse HTTP client through
+  # `Application.put_env/3`, which is global and outlives no transaction.
+  use VutuvWeb.ConnCase, async: false
+
+  import Vutuv.FediverseHelpers
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.RemoteAccount
+
+  @actor "https://social.example/users/them"
+  @address "them@social.example"
+
+  defp account do
+    Repo.insert!(%RemoteAccount{
+      actor_uri: @actor,
+      host: "social.example",
+      handle: "them",
+      name: "Them Themself",
+      summary: "Schreibt über Züge.",
+      inbox_uri: @actor <> "/inbox"
+    })
+  end
+
+  defp federating(conn) do
+    {conn, user} = create_and_login_user(conn)
+    {:ok, user} = Vutuv.Accounts.update_user(user, %{"fediverse_followers?" => "true"})
+    {:ok, _actor} = Fediverse.ensure_actor(user)
+    {conn, user}
+  end
+
+  # A remote server that answers the actor document and nothing else. Any other
+  # request is a request this card should not be making.
+  defp serve_actor do
+    stub_remote(fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/activity+json")
+      |> Plug.Conn.send_resp(
+        200,
+        Jason.encode!(%{
+          "id" => @actor,
+          "type" => "Person",
+          "preferredUsername" => "them",
+          "name" => "Them Themself",
+          "inbox" => @actor <> "/inbox",
+          "publicKey" => %{"id" => @actor <> "#main-key", "publicKeyPem" => "PEM"}
+        })
+      )
+    end)
+  end
+
+  test "a visitor who is not signed in gets no card", %{conn: conn} do
+    account()
+
+    conn = post(conn, ~p"/system/fediverse/actor_card", address: @address)
+
+    assert conn.status == 404
+  end
+
+  # The card may resolve an address this installation has never seen, which is
+  # an outbound request to a host somebody else named in a post. As a GET that
+  # would be a link, and a link is followed by prefetches and crawlers.
+  test "there is no GET surface at all", %{conn: conn} do
+    {conn, _user} = federating(conn)
+
+    conn = get(conn, "/system/fediverse/actor_card?address=#{@address}")
+
+    assert conn.status == 404
+  end
+
+  test "it names the account, offers the follow and keeps both ways onward", %{conn: conn} do
+    {conn, _user} = federating(conn)
+    acc = account()
+
+    html = post(conn, ~p"/system/fediverse/actor_card", address: @address) |> html_response(200)
+
+    assert html =~ "Them Themself"
+    assert html =~ "@them@social.example"
+    assert html =~ "Schreibt über Züge."
+    assert html =~ ~s(data-actor-act="follow")
+    # Their page here, and the original out there: a reader who does not want to
+    # follow is never left in a box with one button.
+    assert html =~ ~p"/system/fediverse/account/#{acc.id}"
+    assert html =~ @actor
+  end
+
+  # The common case, and the reason the card is cheap: most accounts a member
+  # meets in a post are already stored, because somebody here follows them or
+  # something of theirs arrived. Calibrated by the stub, which fails the test if
+  # any request goes out at all.
+  test "an account we already hold costs no request", %{conn: conn} do
+    {conn, _user} = federating(conn)
+    account()
+
+    stub_remote(fn _conn -> raise "an account we already hold must not be fetched" end)
+
+    assert post(conn, ~p"/system/fediverse/actor_card", address: @address)
+           |> html_response(200) =~ "Them Themself"
+  end
+
+  test "the follow starts as requested and is taken back from the same card", %{conn: conn} do
+    {conn, _user} = federating(conn)
+    account()
+    serve_actor()
+
+    html =
+      post(conn, ~p"/system/fediverse/actor_card/follow", address: @address)
+      |> html_response(200)
+
+    # "Requested", not "Following": that server has not answered yet, and a card
+    # that said otherwise would be a lie the member acts on.
+    assert html =~ ~s(data-follow-state="requested")
+    assert html =~ ~s(data-actor-act="unfollow")
+    assert Repo.aggregate(Follow, :count) == 1
+
+    html =
+      conn
+      |> delete(~p"/system/fediverse/actor_card/follow", address: @address)
+      |> html_response(200)
+
+    assert html =~ ~s(data-actor-act="follow")
+    assert Repo.aggregate(Follow, :count) == 0
+  end
+
+  # Real visitors here send `Accept-Language: de`, and `Phoenix.ConnTest`
+  # defaults to English — so the German render is its own case. Every word on
+  # this card is an existing msgid rather than a new one (the same sentences the
+  # account page and a looked-up post's card already say), and this is what
+  # holds that: a new msgid would come back fuzzy-filled and read as confident
+  # nonsense in German while every English assertion above stayed green.
+  test "it reads German for a German reader", %{conn: conn} do
+    {conn, _user} = federating(conn)
+    account()
+
+    html =
+      conn
+      # The login already sent a response on this conn; a header goes on the
+      # recycled one.
+      |> recycle()
+      |> put_req_header("accept-language", "de-DE,de")
+      |> post(~p"/system/fediverse/actor_card", address: @address)
+      |> html_response(200)
+
+    assert html =~ "Konto in einem anderen Netzwerk"
+    assert html =~ "Folgen"
+    assert html =~ "Die Seite dieses Kontos hier"
+    assert html =~ "Original ansehen"
+  end
+
+  test "a member without a Fediverse identity is told why, not shown a dead button", %{conn: conn} do
+    {conn, _user} = create_and_login_user(conn)
+    account()
+
+    html = post(conn, ~p"/system/fediverse/actor_card", address: @address) |> html_response(200)
+
+    refute html =~ ~s(data-actor-act="follow")
+    assert html =~ ~s(data-actor-card-error)
+    assert html =~ "Fediverse"
+  end
+
+  # The fragment lands on a `<body>`-level node outside every LiveView root, so
+  # two things in it would be quietly broken: a `<.link navigate>` (LiveView
+  # binds those to an owning view, and there is none) and a fixed `id` (the card
+  # can be open over a page that already renders the same element — the account
+  # page renders the refusal panel this card deliberately does not). Hence
+  # `follow_refusal_sentence/1` instead of `follow_refusal_panel/1`, and hence
+  # this test, which is the only thing standing between the next author and a
+  # dead link nobody notices.
+  test "carries no live-navigation link and no id anybody else could own", %{conn: conn} do
+    {conn, _user} = create_and_login_user(conn)
+    account()
+
+    html = post(conn, ~p"/system/fediverse/actor_card", address: @address) |> html_response(200)
+
+    refute html =~ "data-phx-link"
+    refute html =~ ~s(id=)
+  end
+
+  # A fragment, not a page: both layouts are off. With only `put_layout` off the
+  # `:browser` pipeline's root layout still wrapped every card in a whole HTML
+  # document, and `innerHTML` unwraps that into the panel — 22 meta tags, six
+  # stylesheet links and two scripts, re-fetched on every open, none of which a
+  # substring assertion on the card's own words would ever notice.
+  test "the answer is a fragment, not a document", %{conn: conn} do
+    {conn, _user} = federating(conn)
+    account()
+
+    html = post(conn, ~p"/system/fediverse/actor_card", address: @address) |> html_response(200)
+
+    refute html =~ "<html"
+    refute html =~ "<meta"
+    refute html =~ "<script"
+    assert html =~ ~s(class="actor-card__content")
+  end
+
+  test "an address nobody can resolve still says why, and still leads out", %{conn: conn} do
+    {conn, _user} = federating(conn)
+
+    stub_remote(fn conn -> Plug.Conn.send_resp(conn, 404, "") end)
+
+    html =
+      post(conn, ~p"/system/fediverse/actor_card", address: "nobody@social.example")
+      |> html_response(200)
+
+    assert html =~ ~s(data-actor-card-error)
+    assert html =~ "https://social.example/@nobody"
+    refute html =~ ~s(data-actor-act="follow")
+  end
+end

--- a/test/vutuv_web/markdown_test.exs
+++ b/test/vutuv_web/markdown_test.exs
@@ -422,6 +422,17 @@ defmodule VutuvWeb.MarkdownTest do
       assert html =~ ">@hostsharing@geno.social</a>"
     end
 
+    test "marks the handle for the mention card without giving up its link" do
+      # `data-remote-actor` is what app.js opens the card on. The `href` is what
+      # everything else still uses — a middle-click, a copied link, a visitor
+      # who is not signed in — so the two have to travel together.
+      html = post_html("Follow @hostsharing@geno.social for hosting")
+
+      assert html =~ ~s(data-remote-actor="hostsharing@geno.social")
+      assert html =~ ~s(href="https://geno.social/@hostsharing")
+      assert html =~ ~s(target="_blank")
+    end
+
     test "links the same handle identically in a post (shared with messages)" do
       html = post_html("Follow @hostsharing@geno.social for hosting")
 


### PR DESCRIPTION
Clicking `@user@host` in a post left vutuv for the remote server. That answers "who is that" and not "I want their posts here", which is what a reader means more often — following meant leaving the site, finding the account again and pasting its address into a settings page.

A plain left click by a signed-in member now opens a small card under the word: name, address, self-description, one Follow button, their account page here, the original out there. The `href` is untouched, so a middle-click, a copied link, a logged-out visitor and a page without JavaScript keep today's behaviour.

Entry points: `VutuvWeb.Markdown.remote_actor_link/3` writes `data-remote-actor` (on-site renders only, so the attribute stays out of federated Notes and RSS), `assets/js/mention_card.js` positions the panel, `VutuvWeb.RemoteActorCardController` renders it. Every route is POST, never GET: opening a card may resolve an address nobody here has seen.

To decide: the card is the app's first HTML-over-fetch endpoint. The alternative is the tag-vote shape (JSON plus labels in data attributes), which would mean re-authoring four follow states and five refusal sentences in JavaScript.

Driven in a browser against a real fediverse post before opening.

*An AI agent wrote this text in my name. I know that is problematic.*