### PR TITLE
One card per post for everything the fediverse sends back

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -5004,19 +5004,41 @@ defmodule Vutuv.Posts do
     |> Enum.group_by(& &1.user_id)
   end
 
-  # The lead photo of each teased post, as `%{post_id => %PostImage{}}`. Only
-  # images the AI scan has released can be shown: the proxy 404s on the rest,
-  # so a held photo must leave the rail thumbnail-less rather than broken.
-  defp teaser_images([]), do: %{}
-
+  # The lead photo of each teased post, as `%{post_id => %PostImage{}}`.
   defp teaser_images(post_ids) do
-    from(i in PostImage,
-      where: i.post_id in ^post_ids,
-      order_by: [asc: i.position, asc: i.id]
-    )
-    |> Repo.all()
-    |> Enum.filter(&ImageScans.released?(&1.moderation))
-    |> Enum.reduce(%{}, fn image, acc -> Map.put_new(acc, image.post_id, image) end)
+    post_ids
+    |> released_images_by_ids()
+    |> Map.new(fn {post_id, [lead | _rest]} -> {post_id, lead} end)
+  end
+
+  @doc """
+  The photos of `post_ids` a viewer may actually be shown, as
+  `%{post_id => [%PostImage{}]}` in gallery order (position, then id).
+
+  Only images the AI scan has released are in it: the image proxy 404s on the
+  rest, so a held photo has to leave a thumbnail slot empty rather than draw a
+  broken picture. A post whose images are all held is absent from the map, as
+  is one with no images at all — callers pattern-match on the list being there,
+  never on its length.
+
+  Batched on purpose: the surfaces that want it (the feed's "Who to follow"
+  rail, the notifications page's post cards) each hold a page of posts, and one
+  query per post is what this replaces.
+  """
+  def released_images_by_ids(post_ids) do
+    post_ids = post_ids |> Enum.filter(&is_binary/1) |> Enum.uniq()
+
+    if post_ids == [] do
+      %{}
+    else
+      from(i in PostImage,
+        where: i.post_id in ^post_ids,
+        order_by: [asc: i.position, asc: i.id]
+      )
+      |> Repo.all()
+      |> released_images()
+      |> Enum.group_by(& &1.post_id)
+    end
   end
 
   @doc """

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -4479,9 +4479,18 @@ defmodule VutuvWeb.PostComponents do
   # caption: the caption is at least *about* the picture, which beats an empty
   # string a screen reader announces as an unlabelled image. An alt the author
   # wrote always wins.
-  defp photo_alt(%PostImage{alt: alt}) when is_binary(alt) and alt != "", do: alt
-  defp photo_alt(%PostImage{caption: caption}) when is_binary(caption), do: caption
-  defp photo_alt(%PostImage{}), do: ""
+  @doc """
+  What a screen reader is told a photo shows: the author's alt text, else its
+  caption, else nothing (a decorative `alt=""`).
+
+  Public because every surface that draws a post's photo owes the same answer —
+  the post card, the mosaic, the lightbox and the notifications page's post
+  cards — and a thumbnail that answers it for itself is a thumbnail that
+  announces nothing the day somebody writes a caption instead of an alt text.
+  """
+  def photo_alt(%PostImage{alt: alt}) when is_binary(alt) and alt != "", do: alt
+  def photo_alt(%PostImage{caption: caption}) when is_binary(caption), do: caption
+  def photo_alt(%PostImage{}), do: ""
 
   defp present?(value), do: is_binary(value) and String.trim(value) != ""
 

--- a/lib/vutuv_web/live/notification_live/groups.ex
+++ b/lib/vutuv_web/live/notification_live/groups.ex
@@ -14,8 +14,12 @@ defmodule VutuvWeb.NotificationLive.Groups do
     * one endorser's **endorsements** - "endorsed you for Elixir and Phoenix."
     * **thread** events of the same thread - "Anna and Ben replied in a
       thread you posted in."
-    * **reactions from other networks** to the same post, per kind -
-      "@anna@chaos.social and @ben@social.example shared your post."
+    * everything **another network** sent back about the same post - favourites,
+      re-shares and replies together - as one **post card** (`kind:
+      "fediverse_post"`), headed by the post itself and carrying an `:events`
+      list of one line per verb. The three used to be three rows that named the
+      senders and the verb but never the post, so a reader with more than one
+      post that day could not tell which of them anybody meant.
 
   Direct replies, mentions and every rarer kind (moderation, CV updates,
   handle changes, ...) stay one row per event - each carries its own content.
@@ -31,6 +35,14 @@ defmodule VutuvWeb.NotificationLive.Groups do
   @named_actors 2
 
   def named_actors, do: @named_actors
+
+  # The kinds that answer a post from another network. They share one card per
+  # post; `Vutuv.Activity` keeps them as separate kinds, and the filter tabs
+  # still speak in those.
+  @post_card_kinds ~w(fediverse_reaction fediverse_reply)
+
+  @doc "The event kinds a post card merges (`kind: \"fediverse_post\"`)."
+  def post_card_kinds, do: @post_card_kinds
 
   @doc """
   Group `items` into `[%{day: Date, groups: [group]}]`, newest day first.
@@ -71,9 +83,19 @@ defmodule VutuvWeb.NotificationLive.Groups do
         item.kind == "follower" and MapSet.member?(connected, actor_key(item))
       end)
 
+    day_items
+    |> bucket(&group_key/1)
+    |> Enum.map(fn {key, members} -> build_group(key, day, members, read_marker) end)
+  end
+
+  # Bucket `items` by `key_fun` into `[{key, members}]`, both the buckets and
+  # the members in the newest-first order they arrived in (`Enum.group_by`
+  # keeps neither). Used twice: once to cut a day into rows, once more to cut a
+  # post card into one line per verb.
+  defp bucket(items, key_fun) do
     {keys, members} =
-      Enum.reduce(day_items, {[], %{}}, fn item, {keys, members} ->
-        key = group_key(item)
+      Enum.reduce(items, {[], %{}}, fn item, {keys, members} ->
+        key = key_fun.(item)
 
         case members do
           %{^key => list} -> {keys, Map.put(members, key, [item | list])}
@@ -83,9 +105,7 @@ defmodule VutuvWeb.NotificationLive.Groups do
 
     keys
     |> Enum.reverse()
-    |> Enum.map(fn key ->
-      build_group(key, day, Enum.reverse(members[key]), read_marker)
-    end)
+    |> Enum.map(&{&1, Enum.reverse(members[&1])})
   end
 
   # What merges: same-day likes per post, same-day followers/connections as
@@ -97,19 +117,54 @@ defmodule VutuvWeb.NotificationLive.Groups do
   defp group_key(%{kind: "thread", root_post_id: root_id}) when is_binary(root_id),
     do: {:thread, root_id}
 
-  # Reactions from other networks merge per post *and per kind*: a favourite and
-  # a re-share are different news, and one row can only carry one verb.
-  defp group_key(%{kind: "fediverse_reaction", post_id: post_id, reaction_kind: reaction_kind})
-       when is_binary(post_id) and is_binary(reaction_kind),
-       do: {:fediverse_reaction, post_id, reaction_kind}
+  # Everything one post collected from the other networks — favourites,
+  # re-shares and replies alike — merges into a single card headed by that post
+  # (`event_key/1` splits it back into one line per verb below). Before this the
+  # three arrived as three separate rows that named the senders and the verb but
+  # never the post, so a reader with more than one post that day could not tell
+  # which of them anybody meant.
+  defp group_key(%{kind: kind, post_id: post_id})
+       when kind in @post_card_kinds and is_binary(post_id),
+       do: {:fediverse_post, post_id}
 
   defp group_key(%{kind: "follower"}), do: :follower
   defp group_key(%{kind: "connection"}), do: :connection
   defp group_key(%{kind: "endorsement"} = item), do: {:endorsement, actor_key(item)}
   defp group_key(item), do: {:single, item.id}
 
+  # A post card is a group of groups: the head names the post, and each of its
+  # `:events` is an ordinary group built by the very same function one level
+  # down. Its own `actors` are empty on purpose — every actor belongs to one of
+  # the event lines, and the card has no sentence of its own for them to be the
+  # subject of.
+  defp build_group({:fediverse_post, post_id} = key, day, members, read_marker) do
+    events =
+      members
+      |> bucket(&event_key(post_id, &1))
+      |> Enum.map(fn {key, event_members} ->
+        build_group(key, day, event_members, read_marker)
+      end)
+
+    key
+    |> base_group(day, members, read_marker)
+    |> Map.merge(%{kind: "fediverse_post", actors: [], actor_count: 0, events: events})
+  end
+
+  defp build_group(key, day, members, read_marker),
+    do: base_group(key, day, members, read_marker)
+
+  # One line per verb inside a card: the favourites merge into one, the
+  # re-shares into another, and every reply keeps its own line, because each
+  # carries its own words. The keys are the same ones a row would use, so the
+  # ids stay what they were before the card existed.
+  defp event_key(post_id, %{kind: "fediverse_reaction", reaction_kind: reaction_kind})
+       when is_binary(reaction_kind),
+       do: {:fediverse_reaction, post_id, reaction_kind}
+
+  defp event_key(_post_id, item), do: {:single, item.id}
+
   # `members` arrive newest-first.
-  defp build_group(key, day, members, read_marker) do
+  defp base_group(key, day, members, read_marker) do
     newest = hd(members)
     actors = distinct_actors(members)
 
@@ -128,6 +183,9 @@ defmodule VutuvWeb.NotificationLive.Groups do
   defp group_id({:single, id}, _day, _newest), do: id
   defp group_id({:like, post_id}, day, _newest), do: "like-#{post_id}-#{day_key(day)}"
   defp group_id({:thread, root_id}, day, _newest), do: "thread-#{root_id}-#{day_key(day)}"
+
+  defp group_id({:fediverse_post, post_id}, day, _newest),
+    do: "fediverse-post-#{post_id}-#{day_key(day)}"
 
   defp group_id({:fediverse_reaction, post_id, reaction_kind}, day, _newest),
     do: "fediverse-reaction-#{reaction_kind}-#{post_id}-#{day_key(day)}"

--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -80,17 +80,23 @@ defmodule VutuvWeb.NotificationLive.Index do
   alias Vutuv.Pages
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
+  alias Vutuv.Posts.PostImage
   alias Vutuv.Social
   alias Vutuv.ViewerClock
   alias VutuvWeb.Live.MountHandoff
   alias VutuvWeb.Markdown
   alias VutuvWeb.NotificationLive.Groups
+  alias VutuvWeb.PostComponents
   alias VutuvWeb.PostTeaser
   alias VutuvWeb.UserHelpers
 
   @page_size 50
   @summary_days 30
   @follow_back_limit 5
+
+  # The kinds `Groups` folds into a post card, read from it at compile time so
+  # the list has one home and a guard can still use it.
+  @post_card_kinds Groups.post_card_kinds()
 
   # The filter tabs: each maps to the event kinds `notifications_page`'s
   # `kinds:` option keeps. "all" passes nil (every source).
@@ -211,13 +217,16 @@ defmodule VutuvWeb.NotificationLive.Index do
         {:noreply, update(socket, :total, &(&1 + 1))}
 
       true ->
-        [item] = with_post_previews([item], socket.assigns.current_user)
+        {[item], posts} = with_post_previews([item], socket.assigns.current_user)
 
         {:noreply,
          socket
          |> update(:items, fn items ->
            [item | Enum.reject(items, &(&1.id == item.id))] |> Enum.take(@page_size)
          end)
+         # The page already holds a card for every post it shows, so only the
+         # first event about a *new* post builds one here.
+         |> update(:post_cards, &Map.merge(&1, post_cards([item], posts, &1)))
          |> update(:total, &(&1 + 1))
          |> assign_sections()}
     end
@@ -275,14 +284,12 @@ defmodule VutuvWeb.NotificationLive.Index do
 
     feed = Activity.notifications_page(user.id, limit: @page_size, kinds: kinds, page: page)
 
-    %{
-      page: page,
-      total: total,
-      items:
-        feed.entries
-        |> with_seen_flags(user, socket.assigns.dismissed)
-        |> with_post_previews(user)
-    }
+    {items, posts} =
+      feed.entries
+      |> with_seen_flags(user, socket.assigns.dismissed)
+      |> with_post_previews(user)
+
+    %{page: page, total: total, items: items, post_cards: post_cards(items, posts)}
   end
 
   defp apply_page(socket, payload) do
@@ -419,6 +426,7 @@ defmodule VutuvWeb.NotificationLive.Index do
                   group={group}
                   current_user={@current_user}
                   quote_lines={@quote_lines}
+                  post_cards={@post_cards}
                   thread_hint={group.kind == "thread" and group.id == first_thread_id}
                 />
               </div>
@@ -498,22 +506,63 @@ defmodule VutuvWeb.NotificationLive.Index do
   attr(:group, :map, required: true)
   attr(:current_user, :any, required: true)
   attr(:quote_lines, :integer, required: true)
+  attr(:post_cards, :map, default: %{})
   attr(:thread_hint, :boolean, default: false)
+
+  defp notification_row(%{group: %{kind: "fediverse_post"}} = assigns) do
+    assigns = assign(assigns, :card, Map.get(assigns.post_cards, assigns.group.item[:post_id]))
+
+    ~H"""
+    <.notification_article group={@group}>
+      <.post_card_head card={@card} counts={event_counts(@group.events)} />
+
+      <%!-- One line per verb, on the same quote rail the row quotes wear: the
+      card head already said which post, so each line only has to say who and
+      what. --%>
+      <ul class="mt-2.5 space-y-1 border-l-2 border-slate-200 pl-3 dark:border-slate-700">
+        <li
+          :for={event <- @group.events}
+          data-notification-event
+          data-event-kind={event.kind}
+          data-unread={event.unread? && "true"}
+        >
+          <div class="flex items-baseline gap-2 text-sm leading-relaxed text-slate-800 dark:text-slate-100">
+            <span class="shrink-0 text-xs" aria-hidden="true">{kind_glyph(event.kind)}</span>
+            <p class="mb-0 min-w-0 flex-1">
+              <span class="sr-only">{kind_label(event.kind)}:</span>
+              <.actor_links group={event} current_user={@current_user} />
+              <.link
+                href={card_event_target(event, @current_user)}
+                class="hover:text-brand-700 hover:underline dark:hover:text-brand-300"
+              >
+                {card_event_text(event)}
+              </.link>
+            </p>
+            <.row_time at={event.at} />
+            <.unread_dot :if={event.unread?} class="mt-1.5 shrink-0" />
+          </div>
+
+          <%!-- A reply brings words of its own, so it keeps the quote (and the
+          private-reply warning) it had as its own row — the reader has to know
+          a reply is private before they answer it. --%>
+          <.remote_reply
+            :if={event.kind == "fediverse_reply" and event.item[:note_text]}
+            id={"quote-remote-#{event.id}"}
+            n={event.item}
+            current_user={@current_user}
+            quote_lines={@quote_lines}
+          />
+        </li>
+      </ul>
+    </.notification_article>
+    """
+  end
 
   defp notification_row(assigns) do
     assigns = assign(assigns, :n, assigns.group.item)
 
     ~H"""
-    <article
-      id={"notification-#{@group.id}"}
-      data-notification-row
-      data-kind={@group.kind}
-      data-unread={@group.unread? && "true"}
-      class={[
-        "flex gap-3 px-4 py-3 sm:px-5",
-        @group.unread? && "bg-brand-50/60 dark:bg-brand-900/15"
-      ]}
-    >
+    <.notification_article group={@group} class="flex gap-3">
       <.row_visual group={@group} />
       <div class="min-w-0 flex-1">
         <p class="mb-0 text-sm leading-relaxed text-slate-800 dark:text-slate-100">
@@ -588,55 +637,13 @@ defmodule VutuvWeb.NotificationLive.Index do
         least of all @mention links into local profiles. A private reply
         (issue #1071) says so, since the member has to know that before they
         answer. --%>
-        <div :if={@group.kind == "fediverse_reply" and @n[:note_text]} class="mt-1.5 space-y-1">
-          <p
-            :if={@n[:note_audience] && @n.note_audience != "public"}
-            data-remote-private
-            class="mb-0 text-xs font-medium text-slate-600 dark:text-slate-400"
-          >
-            <span aria-hidden="true">🔒</span> {gettext("Sent to you only, visible to nobody else")}
-          </p>
-          <%!-- The same solid quote rail the local reply quotes wear — the row's
-          wording already says it came from another network, so the quote needs
-          no dashed variant of its own. Marked for the clamp measurement like
-          those quotes too, so a remote reply that runs past the reader's line
-          budget also ends in a "…".
-
-          And it is a link, on the same stretched-overlay arrangement as
-          <.quoted_post>: a readable block of somebody's words is what the reader
-          reaches for, so a quote that does nothing on tap reads as a broken row,
-          whichever network the words came from. It goes where the row's own
-          sentence already goes (`primary_target/2` — the reader's post, not the
-          stranger's server, which the card over there links to) and carries the
-          note's anchor, so a post that collected several replies opens on this
-          one. No `[&_a]:relative` escape hatch is needed inside: unlike a local
-          quote's Markdown, this text is deliberately never linkified, so there
-          is no inner link for the overlay to swallow. --%>
-          <div
-            id={"quote-remote-#{@group.id}"}
-            phx-hook="PostPreviewClamp"
-            data-post-preview
-            data-remote-reply-preview="true"
-            class={[
-              "relative border-l-2 border-slate-200 pl-2.5 transition-colors hover:border-brand-400",
-              "dark:border-slate-700 dark:hover:border-brand-500"
-            ]}
-          >
-            <.link
-              href={remote_reply_target(@n, @current_user)}
-              aria-label={gettext("View the conversation")}
-              class="absolute inset-0 z-10"
-            >
-            </.link>
-            <%!-- No `text-*` / `leading-*` here: `.notif-clamp` owns the type
-            size and line height, since its box height is counted in them. --%>
-            <p
-              data-clamp-body
-              class="notif-clamp mb-0 whitespace-pre-line text-slate-600 dark:text-slate-400"
-              {clamp_attrs(@quote_lines)}
-            >{@n.note_text}</p>
-          </div>
-        </div>
+        <.remote_reply
+          :if={@group.kind == "fediverse_reply" and @n[:note_text]}
+          id={"quote-remote-#{@group.id}"}
+          n={@n}
+          current_user={@current_user}
+          quote_lines={@quote_lines}
+        />
 
         <%!-- The day's first thread row says why it is here and links to the
         switch that stops it (issue #1025), once per day so it stays a hint and
@@ -695,11 +702,45 @@ defmodule VutuvWeb.NotificationLive.Index do
       </div>
       <div class="flex shrink-0 flex-col items-end gap-1.5 pt-0.5">
         <.row_time at={@group.at} />
-        <span :if={@group.unread?} class="h-2 w-2 rounded-full bg-accent">
-          <span class="sr-only">{gettext("New")}</span>
-        </span>
+        <.unread_dot :if={@group.unread?} />
       </div>
+    </.notification_article>
+    """
+  end
+
+  # The shell every row wears, whatever it holds: the id and the markers the
+  # tests and the CSS key on (`assets/css/components.css` reads
+  # `[data-notification-row][data-unread]` to paint the quote clamp's fade on
+  # the row's own tint, so the tint cannot live in only one of the clauses).
+  attr(:group, :map, required: true)
+  attr(:class, :string, default: nil)
+  slot(:inner_block, required: true)
+
+  defp notification_article(assigns) do
+    ~H"""
+    <article
+      id={"notification-#{@group.id}"}
+      data-notification-row
+      data-kind={@group.kind}
+      data-unread={@group.unread? && "true"}
+      class={[
+        "px-4 py-3 sm:px-5",
+        @class,
+        @group.unread? && "bg-brand-50/60 dark:bg-brand-900/15"
+      ]}
+    >
+      {render_slot(@inner_block)}
     </article>
+    """
+  end
+
+  attr(:class, :string, default: nil)
+
+  defp unread_dot(assigns) do
+    ~H"""
+    <span class={["h-2 w-2 rounded-full bg-accent", @class]}>
+      <span class="sr-only">{gettext("New")}</span>
+    </span>
     """
   end
 
@@ -750,6 +791,147 @@ defmodule VutuvWeb.NotificationLive.Index do
         {clamp_attrs(@quote_lines)}
       >
         {@html}
+      </div>
+    </div>
+    """
+  end
+
+  # ── The post card ──
+
+  # The head of a post card: what the post says on the left, its first photos on
+  # the right, and under the text a line counting what came back.
+  #
+  # The text starts at the same edge whether the post carries a photo or not —
+  # the photos hang off the right — so a column of cards reads as one column
+  # rather than as two indents. The card is one link to the post: the reader's
+  # question is "which post was that", and the answer is one tap away.
+  attr(:card, :any, required: true)
+  attr(:counts, :list, required: true)
+
+  defp post_card_head(assigns) do
+    ~H"""
+    <div :if={@card} class="flex items-start gap-3">
+      <.link
+        href={Posts.path(@card.post)}
+        data-post-card
+        class="min-w-0 flex-1 text-sm font-medium text-slate-900 hover:text-brand-700 dark:text-white dark:hover:text-brand-300"
+      >
+        <%!-- A photo post has no text to name it with (`PostTeaser` skips an
+        image-only line), so the card says so rather than opening on a blank
+        line the reader has to interpret. --%>
+        <span
+          :if={@card.text == ""}
+          data-post-card-textless
+          class="italic font-normal text-slate-500 dark:text-slate-400"
+        >
+          {gettext("Post without text")}
+        </span>
+        <span :if={@card.text != ""} class="line-clamp-2 whitespace-pre-line">{@card.text}</span>
+        <span class="mt-0.5 block text-xs font-normal text-slate-500 dark:text-slate-400">
+          {Enum.join(@counts, " · ")}
+        </span>
+      </.link>
+
+      <.post_card_images card={@card} big={@card.text == ""} />
+    </div>
+    """
+  end
+
+  # Up to two photos, then the rest as a count on the second one. Two, because
+  # the card's right edge has to sit in the same place whether the post carries
+  # two pictures or twenty — a strip that grows with the picture count would
+  # make the text column a different width on every card.
+  #
+  # On a post with no text the photo *is* what names it, so it takes the space
+  # the missing text left and is rendered a size larger.
+  attr(:card, :map, required: true)
+  attr(:big, :boolean, default: false)
+
+  defp post_card_images(assigns) do
+    ~H"""
+    <.link
+      :if={@card.images != []}
+      href={Posts.path(@card.post)}
+      data-post-card-images
+      class="flex shrink-0 gap-1"
+    >
+      <span :for={{image, index} <- Enum.with_index(@card.images)} class="relative block">
+        <img
+          src={PostImage.url(image, "thumb")}
+          alt={PostComponents.photo_alt(image)}
+          loading="lazy"
+          class={["rounded-lg object-cover", if(@big, do: "h-16 w-16", else: "h-12 w-12")]}
+        />
+        <span
+          :if={@card.more_images > 0 and index == length(@card.images) - 1}
+          data-images-more={@card.more_images}
+          class="absolute bottom-0.5 right-0.5 rounded-md bg-slate-900/70 px-1 text-[11px] font-semibold leading-tight text-white"
+        >
+          +{compact_count(@card.more_images)}
+        </span>
+      </span>
+    </.link>
+    """
+  end
+
+  # A reply written on another network (issue #1069). Plain text, clamped like
+  # the other quotes and deliberately NOT run through the Markdown renderer: a
+  # stranger's words must not be able to mint links, least of all @mention links
+  # into local profiles. A private reply (issue #1071) says so, since the member
+  # has to know that before they answer.
+  #
+  # The same solid quote rail the local reply quotes wear — the line above it
+  # already says it came from another network, so the quote needs no dashed
+  # variant of its own. Marked for the clamp measurement like those quotes too,
+  # so a remote reply that runs past the reader's line budget also ends in a "…".
+  #
+  # And it is a link, on the same stretched-overlay arrangement as
+  # <.quoted_post>: a readable block of somebody's words is what the reader
+  # reaches for, so a quote that does nothing on tap reads as a broken row,
+  # whichever network the words came from. It goes where the row's own sentence
+  # already goes (the reader's post, not the stranger's server, which the card
+  # over there links to) and carries the note's anchor, so a post that collected
+  # several replies opens on this one. No `[&_a]:relative` escape hatch is needed
+  # inside: unlike a local quote's Markdown, this text is deliberately never
+  # linkified, so there is no inner link for the overlay to swallow.
+  attr(:id, :string, required: true)
+  attr(:n, :map, required: true)
+  attr(:current_user, :any, required: true)
+  attr(:quote_lines, :integer, required: true)
+
+  defp remote_reply(assigns) do
+    ~H"""
+    <div class="mt-1.5 space-y-1">
+      <p
+        :if={@n[:note_audience] && @n.note_audience != "public"}
+        data-remote-private
+        class="mb-0 text-xs font-medium text-slate-600 dark:text-slate-400"
+      >
+        <span aria-hidden="true">🔒</span> {gettext("Sent to you only, visible to nobody else")}
+      </p>
+      <div
+        id={@id}
+        phx-hook="PostPreviewClamp"
+        data-post-preview
+        data-remote-reply-preview="true"
+        class={[
+          "relative border-l-2 border-slate-200 pl-2.5 transition-colors hover:border-brand-400",
+          "dark:border-slate-700 dark:hover:border-brand-500"
+        ]}
+      >
+        <.link
+          href={remote_reply_target(@n, @current_user)}
+          aria-label={gettext("View the conversation")}
+          class="absolute inset-0 z-10"
+        >
+        </.link>
+        <%!-- No `text-*` / `leading-*` here: `.notif-clamp` owns the type size
+        and line height, since its box height is counted in them. --%>
+        <p
+          data-clamp-body
+          class="notif-clamp mb-0 whitespace-pre-line text-slate-600 dark:text-slate-400"
+          {clamp_attrs(@quote_lines)}
+        >{@n.note_text}</p>
       </div>
     </div>
     """
@@ -1127,6 +1309,65 @@ defmodule VutuvWeb.NotificationLive.Index do
 
   defp group_text(%{item: item}), do: notification_text(item)
 
+  # ── A post card's lines ──
+
+  # The sentence on one line inside a post card. It says only what was done:
+  # the card's head already named the post, so the row's "your post in another
+  # network" would be repeating the heading in every line under it.
+  defp card_event_text(%{kind: "fediverse_reply"}), do: gettext("replied.")
+
+  defp card_event_text(%{kind: "fediverse_reaction", actor_count: count, item: item}),
+    do: card_reaction_text(item[:reaction_kind], count)
+
+  # German conjugates the verb across the count where English conjugates it the
+  # other way round ("likes this" is the singular), so both are count-branched
+  # msgids rather than one string with a number in it.
+  defp card_reaction_text("like", count),
+    do: ngettext("likes this.", "like this.", count)
+
+  defp card_reaction_text("announce", count),
+    do: ngettext("shared this.", "shared this.", count)
+
+  defp card_reaction_text(_kind, count),
+    do: ngettext("reacted to this.", "reacted to this.", count)
+
+  # Where a card line leads: a reply to the reader's own post anchored at that
+  # reply, a favourite or re-share to the post itself.
+  defp card_event_target(%{kind: "fediverse_reply", item: item}, viewer),
+    do: remote_reply_target(item, viewer)
+
+  defp card_event_target(%{item: item}, viewer), do: notification_target(item, viewer)
+
+  # What the card's head counts: the reactions folded into its lines, one
+  # fragment per verb. Each fragment is its own complete translatable phrase —
+  # the line is a list of facts, not a sentence assembled from pieces.
+  defp event_counts(events) do
+    likes = reaction_count(events, "like")
+    shares = reaction_count(events, "announce")
+    replies = Enum.count(events, &(&1.kind == "fediverse_reply"))
+
+    [
+      count_label(likes, &ngettext("%{formatted} like", "%{formatted} likes", &1, &2)),
+      count_label(shares, &ngettext("%{formatted} share", "%{formatted} shares", &1, &2)),
+      count_label(replies, &ngettext("%{formatted} reply", "%{formatted} replies", &1, &2))
+    ]
+    |> Enum.reject(&is_nil/1)
+  end
+
+  # `ngettext/3` binds `%{count}` to the raw integer and a `count:` binding does
+  # not override it, so the formatted number rides a placeholder of its own.
+  defp count_label(0, _phrase), do: nil
+  defp count_label(count, phrase), do: phrase.(count, formatted: compact_count(count))
+
+  defp reaction_count(events, reaction_kind) do
+    events
+    |> Enum.filter(
+      &(&1.kind == "fediverse_reaction" and &1.item[:reaction_kind] == reaction_kind)
+    )
+    |> Enum.map(& &1.actor_count)
+    |> Enum.sum()
+  end
+
   # "Elixir, Phoenix and Rails" - all but the last joined by commas, the last
   # by the localized joining word.
   defp join_names([single]), do: single
@@ -1171,6 +1412,8 @@ defmodule VutuvWeb.NotificationLive.Index do
   # as `:post_preview` / `:reply_preview`. Other kinds carry no ids, a post with
   # no text (a photo-only one) yields no preview, and a reply hidden from the
   # viewer is absent from `posts`, so all pass through unchanged.
+  # Returns `{entries, posts}` — the looked-up posts come back out so the post
+  # cards can be built from the same batch instead of asking for them again.
   defp with_post_previews(entries, viewer) do
     posts =
       entries
@@ -1179,12 +1422,71 @@ defmodule VutuvWeb.NotificationLive.Index do
 
     lines = User.notification_post_lines(viewer)
 
-    Enum.map(entries, fn entry ->
-      entry
-      |> put_preview(:post_preview, entry[:post_id], posts, lines, quoted_form(entry))
-      |> put_preview(:reply_preview, entry[:reply_post_id], posts, lines, :html)
-      |> put_change_previews(posts, lines)
-    end)
+    entries =
+      Enum.map(entries, fn entry ->
+        entry
+        |> put_preview(:post_preview, entry[:post_id], posts, lines, quoted_form(entry))
+        |> put_preview(:reply_preview, entry[:reply_post_id], posts, lines, :html)
+        |> put_change_previews(posts, lines)
+      end)
+
+    {entries, posts}
+  end
+
+  # ── The head of a post card ──
+
+  # How many of a post's photos ride its card before the rest become a count.
+  # Two, so the card says "there are pictures, and here are the first of them"
+  # without letting its right edge move with the picture count.
+  @card_images 2
+
+  # The card head clamps its teaser to two lines, so it asks `char_budget/1`
+  # for two lines' worth of characters rather than keeping a second constant.
+  @card_teaser_lines 2
+
+  # The card heads for one page, as `%{post_id => card}`: the post itself, its
+  # one-line teaser and its released photos.
+  #
+  # One entry per *post*, not per event — a post that collected a favourite, a
+  # re-share and a reply is one card, and hanging that card off each raw item
+  # instead would copy it as many times as there were reactions. That is not
+  # free even though the copies share a reference in the process: the page
+  # payload crosses `MountHandoff`'s ETS table, and ETS does not preserve
+  # sharing (measured: 30 entries sharing one card cost 15 KB in-process and
+  # 437 KB after an ETS round trip).
+  #
+  # `known` are the cards the page already holds, so a live push only looks up
+  # a post that is not on the page yet.
+  #
+  # The teaser is `PostTeaser`, the app's shared one line, so the card skips a
+  # quote post's `RE: <url>` opener and an image-only line exactly as the feed's
+  # ticker does — which is also what leaves a photo post's head text-less, the
+  # case `post_card_head/1` names in words.
+  defp post_cards(entries, posts, known \\ %{}) do
+    # Only ids the viewer may actually see reach the image query: `posts` is
+    # already visibility-scoped, so a hidden or deleted post costs nothing here.
+    ids =
+      for entry <- entries,
+          entry[:kind] in @post_card_kinds,
+          is_map_key(posts, entry[:post_id]),
+          not is_map_key(known, entry[:post_id]),
+          uniq: true,
+          do: entry[:post_id]
+
+    images = Posts.released_images_by_ids(ids)
+
+    for id <- ids, into: %{} do
+      post = Map.fetch!(posts, id)
+      photos = Map.get(images, id, [])
+
+      {id,
+       %{
+         post: post,
+         text: PostTeaser.plain_line(post, length: char_budget(@card_teaser_lines)),
+         images: Enum.take(photos, @card_images),
+         more_images: max(length(photos) - @card_images, 0)
+       }}
+    end
   end
 
   # A reply row shows the recipient's own post only as the one-line breadcrumb
@@ -1193,6 +1495,12 @@ defmodule VutuvWeb.NotificationLive.Index do
   # both forms) keeps a page of 50 rows off the Markdown renderer's DB lookups
   # for bodies nothing will show formatted.
   defp quoted_form(%{kind: "reply"}), do: :text
+
+  # A post card renders the post's *head*, never a formatted quote of it, so
+  # rendering one would be a full Markdown pass (Earmark + sanitizer +
+  # highlighter, ~0.2 ms) per event, thrown away — and it is per event, so 50
+  # reactions to one post paid for it 50 times on the blocking first paint.
+  defp quoted_form(%{kind: kind}) when kind in @post_card_kinds, do: :none
   defp quoted_form(_entry), do: :html
 
   # A handle-change entry links the recipient's own posts that were rewritten:
@@ -1243,6 +1551,8 @@ defmodule VutuvWeb.NotificationLive.Index do
   # feed's ticker and the RSS description do; the reader's line budget only
   # decides how many characters may ride the row. The formatted multi-line
   # quote below it is this page's own, and stays here.
+  defp quoted_excerpt(_post, _lines, :none), do: nil
+
   defp quoted_excerpt(post, lines, :text) do
     case PostTeaser.plain_line(post, length: char_budget(lines)) do
       "" -> nil

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -315,7 +315,7 @@ msgstr "Vorname"
 #: lib/vutuv_web/agent_docs/text.ex:595
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
-#: lib/vutuv_web/live/notification_live/index.ex:1020
+#: lib/vutuv_web/live/notification_live/index.ex:1202
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:27
@@ -454,7 +454,7 @@ msgstr "Einloggen"
 msgid "Middle Name"
 msgstr "Zweiter Vorname"
 
-#: lib/vutuv_web/live/notification_live/index.ex:945
+#: lib/vutuv_web/live/notification_live/index.ex:1127
 #, elixir-autogen
 msgid "More"
 msgstr "Mehr"
@@ -472,7 +472,7 @@ msgid "Name"
 msgstr "Name"
 
 #: lib/vutuv_web/components/post_components.ex:714
-#: lib/vutuv_web/live/notification_live/index.ex:699
+#: lib/vutuv_web/live/notification_live/index.ex:742
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
@@ -793,7 +793,7 @@ msgstr "User wurde verifiziert."
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
 #: lib/vutuv_web/live/directory_search_live.ex:134
-#: lib/vutuv_web/live/notification_live/index.ex:1099
+#: lib/vutuv_web/live/notification_live/index.ex:1281
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -1795,7 +1795,7 @@ msgstr "Netzwerk"
 msgid "Nothing here yet."
 msgstr "Hier gibt es noch nichts."
 
-#: lib/vutuv_web/live/notification_live/index.ex:428
+#: lib/vutuv_web/live/notification_live/index.ex:436
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr "Noch nichts Neues."
@@ -1803,8 +1803,8 @@ msgstr "Noch nichts Neues."
 #: lib/vutuv/api_auth/scopes.ex:85
 #: lib/vutuv_web/components/ui.ex:4648
 #: lib/vutuv_web/controllers/page_controller.ex:228
-#: lib/vutuv_web/live/notification_live/index.ex:140
-#: lib/vutuv_web/live/notification_live/index.ex:377
+#: lib/vutuv_web/live/notification_live/index.ex:146
+#: lib/vutuv_web/live/notification_live/index.ex:384
 #: lib/vutuv_web/live/shell_live.ex:1247
 #: lib/vutuv_web/templates/layout/app.html.heex:153
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
@@ -2247,7 +2247,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/gettext_extraction_anchors.ex:103
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:396
-#: lib/vutuv_web/live/notification_live/index.ex:943
+#: lib/vutuv_web/live/notification_live/index.ex:1125
 #: lib/vutuv_web/live/organization_live/show.ex:700
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:345
@@ -2362,22 +2362,22 @@ msgstr "Was gibt's Neues? Markdown wird unterstützt."
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:5401
+#: lib/vutuv_web/components/post_components.ex:5410
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:5405
+#: lib/vutuv_web/components/post_components.ex:5414
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:5403
+#: lib/vutuv_web/components/post_components.ex:5412
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:5404
+#: lib/vutuv_web/components/post_components.ex:5413
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2419,7 +2419,7 @@ msgid "All posts"
 msgstr "Alle Beiträge"
 
 #: lib/vutuv_web/components/post_components.ex:2019
-#: lib/vutuv_web/components/post_components.ex:5497
+#: lib/vutuv_web/components/post_components.ex:5506
 #: lib/vutuv_web/components/ui.ex:3684
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
@@ -2438,17 +2438,17 @@ msgid "Bookmarks"
 msgstr "Lesezeichen"
 
 #: lib/vutuv_web/components/post_components.ex:1972
-#: lib/vutuv_web/components/post_components.ex:5733
+#: lib/vutuv_web/components/post_components.ex:5742
 #: lib/vutuv_web/components/ui.ex:3670
-#: lib/vutuv_web/live/notification_live/index.ex:1089
+#: lib/vutuv_web/live/notification_live/index.ex:1271
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1144
-#: lib/vutuv_web/components/post_components.ex:5743
-#: lib/vutuv_web/live/notification_live/index.ex:1022
+#: lib/vutuv_web/components/post_components.ex:5752
+#: lib/vutuv_web/live/notification_live/index.ex:1204
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
 #: lib/vutuv_web/live/shell_live.ex:1298
@@ -2469,13 +2469,13 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:5485
+#: lib/vutuv_web/components/post_components.ex:5494
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
 #: lib/vutuv_web/components/post_components.ex:2018
-#: lib/vutuv_web/components/post_components.ex:5496
+#: lib/vutuv_web/components/post_components.ex:5505
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
@@ -2483,26 +2483,26 @@ msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
 #: lib/vutuv_web/components/post_components.ex:2000
-#: lib/vutuv_web/components/post_components.ex:5482
+#: lib/vutuv_web/components/post_components.ex:5491
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
 #: lib/vutuv_web/components/post_components.ex:2265
-#: lib/vutuv_web/components/post_components.ex:4577
+#: lib/vutuv_web/components/post_components.ex:4586
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
 #: lib/vutuv_web/components/post_components.ex:1999
-#: lib/vutuv_web/components/post_components.ex:5481
+#: lib/vutuv_web/components/post_components.ex:5490
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
 #: lib/vutuv_web/components/post_components.ex:1971
-#: lib/vutuv_web/components/post_components.ex:5732
+#: lib/vutuv_web/components/post_components.ex:5741
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
@@ -2530,21 +2530,21 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:5787
+#: lib/vutuv_web/components/post_components.ex:5796
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
 #: lib/vutuv_web/components/post_components.ex:408
-#: lib/vutuv_web/live/notification_live/index.ex:1023
+#: lib/vutuv_web/live/notification_live/index.ex:1205
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
 
 #: lib/vutuv_web/components/post_components.ex:1985
-#: lib/vutuv_web/components/post_components.ex:5770
-#: lib/vutuv_web/components/post_components.ex:5771
-#: lib/vutuv_web/live/notification_live/index.ex:1086
+#: lib/vutuv_web/components/post_components.ex:5779
+#: lib/vutuv_web/components/post_components.ex:5780
+#: lib/vutuv_web/live/notification_live/index.ex:1268
 #: lib/vutuv_web/live/post_live/reply.ex:46
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2844,7 +2844,7 @@ msgstr[1] "+%{formatted} weitere Tags"
 #: lib/vutuv_web/agent_docs/markdown.ex:633
 #: lib/vutuv_web/agent_docs/text.ex:597
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:1021
+#: lib/vutuv_web/live/notification_live/index.ex:1203
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2888,7 +2888,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:5402
+#: lib/vutuv_web/components/post_components.ex:5411
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -2899,23 +2899,23 @@ msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
 
 #: lib/vutuv_web/components/organization_components.ex:259
-#: lib/vutuv_web/live/notification_live/index.ex:1101
+#: lib/vutuv_web/live/notification_live/index.ex:1283
 #: lib/vutuv_web/live/organization_live/activity.ex:104
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr "Aktivität"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1092
+#: lib/vutuv_web/live/notification_live/index.ex:1274
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr "Vernetzung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1085
+#: lib/vutuv_web/live/notification_live/index.ex:1267
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr "Empfehlung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1084
+#: lib/vutuv_web/live/notification_live/index.ex:1266
 #: lib/vutuv_web/templates/user/show.html.heex:957
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -3080,7 +3080,7 @@ msgstr "Familienfreundlich bleiben"
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1093
+#: lib/vutuv_web/live/notification_live/index.ex:1275
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3777,7 +3777,7 @@ msgstr "Besitzer hat den Inhalt bearbeitet"
 msgid "Report filed"
 msgstr "Meldung eingegangen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1095
+#: lib/vutuv_web/live/notification_live/index.ex:1277
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr "Schutz nach Meldung"
@@ -4774,7 +4774,7 @@ msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 #: lib/vutuv_web/agent_docs/text.ex:463
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:589
-#: lib/vutuv_web/live/notification_live/index.ex:944
+#: lib/vutuv_web/live/notification_live/index.ex:1126
 #: lib/vutuv_web/live/organization_live/show.ex:787
 #: lib/vutuv_web/live/post_live/saved.ex:523
 #: lib/vutuv_web/live/search_live.ex:343
@@ -4800,7 +4800,7 @@ msgstr "Ähnliche Namen"
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
-#: lib/vutuv_web/live/notification_live/index.ex:942
+#: lib/vutuv_web/live/notification_live/index.ex:1124
 #: lib/vutuv_web/live/search_live.ex:342
 #: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
@@ -5648,7 +5648,7 @@ msgstr "Fußzeilen-Navigation"
 #: lib/vutuv_web/components/post_components.ex:3643
 #: lib/vutuv_web/components/post_components.ex:3698
 #: lib/vutuv_web/components/post_components.ex:4106
-#: lib/vutuv_web/live/notification_live/index.ex:743
+#: lib/vutuv_web/live/notification_live/index.ex:784
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5776,7 +5776,7 @@ msgstr "Ansehen"
 msgid "Your name"
 msgstr "Ihr Name"
 
-#: lib/vutuv_web/live/notification_live/index.ex:572
+#: lib/vutuv_web/live/notification_live/index.ex:621
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr "Ihr Beitrag"
@@ -5871,7 +5871,7 @@ msgid "Apps & API"
 msgstr "Apps & API-Zugang"
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:1024
+#: lib/vutuv_web/live/notification_live/index.ex:1206
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -6567,10 +6567,10 @@ msgid "No endorsements yet."
 msgstr "Noch keine Empfehlungen."
 
 #: lib/vutuv_web/components/ui.ex:2420
-#: lib/vutuv_web/live/notification_live/index.ex:677
-#: lib/vutuv_web/live/notification_live/index.ex:692
-#: lib/vutuv_web/live/notification_live/index.ex:830
-#: lib/vutuv_web/live/notification_live/index.ex:832
+#: lib/vutuv_web/live/notification_live/index.ex:684
+#: lib/vutuv_web/live/notification_live/index.ex:699
+#: lib/vutuv_web/live/notification_live/index.ex:1012
+#: lib/vutuv_web/live/notification_live/index.ex:1014
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
@@ -7626,7 +7626,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5643
+#: lib/vutuv_web/components/post_components.ex:5652
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8041,13 +8041,13 @@ msgstr "Neue Mitglieder"
 #: lib/vutuv_web/components/job_components.ex:219
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:468
-#: lib/vutuv_web/live/notification_live/index.ex:971
+#: lib/vutuv_web/live/notification_live/index.ex:1153
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Heute"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:291
-#: lib/vutuv_web/live/notification_live/index.ex:974
+#: lib/vutuv_web/live/notification_live/index.ex:1156
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr "Gestern"
@@ -9190,7 +9190,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:4580
+#: lib/vutuv_web/components/post_components.ex:4589
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -12386,7 +12386,7 @@ msgstr "Organisationsseite"
 msgid "Organization pages"
 msgstr "Organisationsseiten"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1096
+#: lib/vutuv_web/live/notification_live/index.ex:1278
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr "Organisationsrolle"
@@ -13910,7 +13910,7 @@ msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 T
 msgid "Image awaiting review, visible only to you"
 msgstr "Bild wird geprüft, nur für Sie sichtbar"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1094
+#: lib/vutuv_web/live/notification_live/index.ex:1276
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13997,7 +13997,7 @@ msgstr[1] "%{formatted} Beiträge erwähnen aktuell %{handle} und werden beim Um
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr "Beim Ändern werden alle Erwähnungen Ihres alten Handles in Beiträgen automatisch auf den neuen umgeschrieben und die Verfasser dieser Beiträge benachrichtigt. Ihre alte Profiladresse funktioniert dann nicht mehr."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1097
+#: lib/vutuv_web/live/notification_live/index.ex:1279
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr "Handle-Änderung"
@@ -14218,7 +14218,7 @@ msgstr[1] "Meine %{formatted} Follower darüber informieren"
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1098
+#: lib/vutuv_web/live/notification_live/index.ex:1280
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr "Lebenslauf-Update"
@@ -14263,34 +14263,34 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:5251
+#: lib/vutuv_web/components/post_components.ex:5260
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1233
-#: lib/vutuv_web/components/post_components.ex:5208
+#: lib/vutuv_web/components/post_components.ex:5217
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:5252
+#: lib/vutuv_web/components/post_components.ex:5261
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:5254
+#: lib/vutuv_web/components/post_components.ex:5263
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:5250
+#: lib/vutuv_web/components/post_components.ex:5259
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1233
-#: lib/vutuv_web/components/post_components.ex:5207
+#: lib/vutuv_web/components/post_components.ex:5216
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14301,12 +14301,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:5249
+#: lib/vutuv_web/components/post_components.ex:5258
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:5253
+#: lib/vutuv_web/components/post_components.ex:5262
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14326,7 +14326,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:5290
+#: lib/vutuv_web/components/post_components.ex:5299
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14334,27 +14334,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:5320
+#: lib/vutuv_web/components/post_components.ex:5329
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:5321
+#: lib/vutuv_web/components/post_components.ex:5330
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:5319
+#: lib/vutuv_web/components/post_components.ex:5328
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:5279
+#: lib/vutuv_web/components/post_components.ex:5288
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:5326
+#: lib/vutuv_web/components/post_components.ex:5335
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14384,55 +14384,55 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5093
+#: lib/vutuv_web/components/post_components.ex:5102
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
 
-#: lib/vutuv_web/live/notification_live/index.ex:963
+#: lib/vutuv_web/live/notification_live/index.ex:1145
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] "%{formatted} neue Mitteilung"
 msgstr[1] "%{formatted} neue Mitteilungen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:977
+#: lib/vutuv_web/live/notification_live/index.ex:1159
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr "%{day}. %{month} %{year}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:445
+#: lib/vutuv_web/live/notification_live/index.ex:453
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr "Zurückfolgen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:460
+#: lib/vutuv_web/live/notification_live/index.ex:468
 #, elixir-autogen, elixir-format
 msgid "Last 30 days"
 msgstr "Letzte 30 Tage"
 
-#: lib/vutuv_web/live/notification_live/index.ex:929
-#: lib/vutuv_web/live/notification_live/index.ex:1136
+#: lib/vutuv_web/live/notification_live/index.ex:1111
+#: lib/vutuv_web/live/notification_live/index.ex:1377
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "und"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1115
+#: lib/vutuv_web/live/notification_live/index.ex:1297
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr "sind jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1112
+#: lib/vutuv_web/live/notification_live/index.ex:1294
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr "folgen Ihnen jetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1121
+#: lib/vutuv_web/live/notification_live/index.ex:1303
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:5084
+#: lib/vutuv_web/components/post_components.ex:5093
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -14686,7 +14686,7 @@ msgstr ""
 "familienfreundlich genug für ein Arbeitsumfeld. Sie kann sich irren, "
 "antworten Sie in dem Fall einfach auf unsere E-Mail."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1087
+#: lib/vutuv_web/live/notification_live/index.ex:1269
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr "Thread-Antwort"
@@ -14714,7 +14714,7 @@ msgstr "Unterhaltung"
 msgid "Only part of this long conversation is shown."
 msgstr "Von dieser langen Unterhaltung wird nur ein Teil angezeigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1088
+#: lib/vutuv_web/live/notification_live/index.ex:1270
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr "Erwähnung"
@@ -14860,7 +14860,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:5742
+#: lib/vutuv_web/components/post_components.ex:5751
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -15067,7 +15067,7 @@ msgstr "Diese Ausbildung wird jetzt oben in Ihrem Profil angezeigt."
 msgid "Thread replies"
 msgstr "Thread-Antworten"
 
-#: lib/vutuv_web/live/notification_live/index.ex:655
+#: lib/vutuv_web/live/notification_live/index.ex:662
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr "Thread-Benachrichtigungen abschalten"
@@ -15118,7 +15118,7 @@ msgstr "Sie haben noch nichts stummgeschaltet."
 msgid "You have reached the maximum of %{count} filters."
 msgstr "Sie haben das Maximum von %{count} Filtern erreicht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:650
+#: lib/vutuv_web/live/notification_live/index.ex:657
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr "Sie haben in diesem Thread geschrieben."
@@ -16019,21 +16019,23 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:5688
+#: lib/vutuv_web/components/post_components.ex:5697
+#: lib/vutuv_web/live/notification_live/index.ex:1352
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:5692
+#: lib/vutuv_web/components/post_components.ex:5701
+#: lib/vutuv_web/live/notification_live/index.ex:1350
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:5696
+#: lib/vutuv_web/components/post_components.ex:5705
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16041,7 +16043,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1182
-#: lib/vutuv_web/components/post_components.ex:5647
+#: lib/vutuv_web/components/post_components.ex:5656
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16083,7 +16085,7 @@ msgstr "Vom Mitglied entfernt"
 msgid "Replies from other networks"
 msgstr "Antworten aus anderen Netzwerken"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1090
+#: lib/vutuv_web/live/notification_live/index.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr "Antwort aus einem anderen Netzwerk"
@@ -16104,7 +16106,7 @@ msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
 #: lib/vutuv_web/components/post_components.ex:1374
-#: lib/vutuv_web/live/notification_live/index.ex:597
+#: lib/vutuv_web/live/notification_live/index.ex:910
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr "Nur an Sie gesendet, für niemanden sonst sichtbar"
@@ -17141,13 +17143,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1200
-#: lib/vutuv_web/components/post_components.ex:5685
+#: lib/vutuv_web/components/post_components.ex:5694
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1198
-#: lib/vutuv_web/components/post_components.ex:5682
+#: lib/vutuv_web/components/post_components.ex:5691
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17157,12 +17159,12 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:5574
+#: lib/vutuv_web/components/post_components.ex:5583
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1091
+#: lib/vutuv_web/live/notification_live/index.ex:1273
 #, elixir-autogen, elixir-format
 msgid "Reaction from another network"
 msgstr "Reaktion aus einem anderen Netzwerk"
@@ -18534,7 +18536,7 @@ msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
 "Noch nichts von vutuv. Folgen Sie Menschen hier, um diesen Tab zu füllen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:627
+#: lib/vutuv_web/live/notification_live/index.ex:924
 #, elixir-autogen, elixir-format
 msgid "View the conversation"
 msgstr "Unterhaltung ansehen"
@@ -18874,19 +18876,19 @@ msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:4750
+#: lib/vutuv_web/components/post_components.ex:4759
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4752
+#: lib/vutuv_web/components/post_components.ex:4761
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:4763
+#: lib/vutuv_web/components/post_components.ex:4772
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
@@ -19410,7 +19412,7 @@ msgstr "Arbeitszeugnis geändert"
 msgid "Employment reference deleted"
 msgstr "Arbeitszeugnis gelöscht"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1100
+#: lib/vutuv_web/live/notification_live/index.ex:1282
 #, elixir-autogen, elixir-format
 msgid "Employment reference review"
 msgstr "Zeugnisprüfung"
@@ -19844,7 +19846,7 @@ msgstr ""
 msgid "Cancel registration"
 msgstr "Registrierung abbrechen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:896
+#: lib/vutuv_web/live/notification_live/index.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -21447,27 +21449,27 @@ msgstr "Sprache des Beitrags"
 msgid "The language this post is written in"
 msgstr "Die Sprache, in der dieser Beitrag geschrieben ist"
 
-#: lib/vutuv_web/components/post_components.ex:4644
+#: lib/vutuv_web/components/post_components.ex:4653
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Original anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:4680
+#: lib/vutuv_web/components/post_components.ex:4689
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Übersetzen"
 
-#: lib/vutuv_web/components/post_components.ex:4689
+#: lib/vutuv_web/components/post_components.ex:4698
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Übersetzt"
 
-#: lib/vutuv_web/components/post_components.ex:4692
+#: lib/vutuv_web/components/post_components.ex:4701
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Übersetzt aus %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:4669
+#: lib/vutuv_web/components/post_components.ex:4678
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Wird übersetzt …"
@@ -21477,7 +21479,7 @@ msgstr "Wird übersetzt …"
 msgid "Feed language settings reset to the site defaults."
 msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
 
-#: lib/vutuv_web/components/post_components.ex:4659
+#: lib/vutuv_web/components/post_components.ex:4668
 #: lib/vutuv_web/components/ui.ex:4663
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -23188,3 +23190,41 @@ msgstr "nur %{account}"
 msgctxt "filter rule"
 msgid "Hide"
 msgstr "Ausblenden"
+
+#: lib/vutuv_web/live/notification_live/index.ex:1351
+#, elixir-autogen, elixir-format
+msgid "%{formatted} share"
+msgid_plural "%{formatted} shares"
+msgstr[0] "%{formatted} Mal geteilt"
+msgstr[1] "%{formatted} Mal geteilt"
+
+#: lib/vutuv_web/live/notification_live/index.ex:827
+#, elixir-autogen, elixir-format
+msgid "Post without text"
+msgstr "Beitrag ohne Text"
+
+#: lib/vutuv_web/live/notification_live/index.ex:1326
+#, elixir-autogen, elixir-format
+msgid "likes this."
+msgid_plural "like this."
+msgstr[0] "gefällt das."
+msgstr[1] "gefällt das."
+
+#: lib/vutuv_web/live/notification_live/index.ex:1332
+#, elixir-autogen, elixir-format
+msgid "reacted to this."
+msgid_plural "reacted to this."
+msgstr[0] "hat darauf reagiert."
+msgstr[1] "haben darauf reagiert."
+
+#: lib/vutuv_web/live/notification_live/index.ex:1317
+#, elixir-autogen, elixir-format
+msgid "replied."
+msgstr "hat geantwortet."
+
+#: lib/vutuv_web/live/notification_live/index.ex:1329
+#, elixir-autogen, elixir-format
+msgid "shared this."
+msgid_plural "shared this."
+msgstr[0] "hat das geteilt."
+msgstr[1] "haben das geteilt."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -315,7 +315,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:595
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
-#: lib/vutuv_web/live/notification_live/index.ex:1020
+#: lib/vutuv_web/live/notification_live/index.ex:1202
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:27
@@ -454,7 +454,7 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:945
+#: lib/vutuv_web/live/notification_live/index.ex:1127
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -472,7 +472,7 @@ msgid "Name"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:714
-#: lib/vutuv_web/live/notification_live/index.ex:699
+#: lib/vutuv_web/live/notification_live/index.ex:742
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
@@ -791,7 +791,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
 #: lib/vutuv_web/live/directory_search_live.ex:134
-#: lib/vutuv_web/live/notification_live/index.ex:1099
+#: lib/vutuv_web/live/notification_live/index.ex:1281
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -1762,7 +1762,7 @@ msgstr ""
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:428
+#: lib/vutuv_web/live/notification_live/index.ex:436
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr ""
@@ -1770,8 +1770,8 @@ msgstr ""
 #: lib/vutuv/api_auth/scopes.ex:85
 #: lib/vutuv_web/components/ui.ex:4648
 #: lib/vutuv_web/controllers/page_controller.ex:228
-#: lib/vutuv_web/live/notification_live/index.ex:140
-#: lib/vutuv_web/live/notification_live/index.ex:377
+#: lib/vutuv_web/live/notification_live/index.ex:146
+#: lib/vutuv_web/live/notification_live/index.ex:384
 #: lib/vutuv_web/live/shell_live.ex:1247
 #: lib/vutuv_web/templates/layout/app.html.heex:153
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
@@ -2204,7 +2204,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:103
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:396
-#: lib/vutuv_web/live/notification_live/index.ex:943
+#: lib/vutuv_web/live/notification_live/index.ex:1125
 #: lib/vutuv_web/live/organization_live/show.ex:700
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:345
@@ -2317,22 +2317,22 @@ msgstr ""
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5401
+#: lib/vutuv_web/components/post_components.ex:5410
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5405
+#: lib/vutuv_web/components/post_components.ex:5414
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5403
+#: lib/vutuv_web/components/post_components.ex:5412
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5404
+#: lib/vutuv_web/components/post_components.ex:5413
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2374,7 +2374,7 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2019
-#: lib/vutuv_web/components/post_components.ex:5497
+#: lib/vutuv_web/components/post_components.ex:5506
 #: lib/vutuv_web/components/ui.ex:3684
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
@@ -2393,17 +2393,17 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1972
-#: lib/vutuv_web/components/post_components.ex:5733
+#: lib/vutuv_web/components/post_components.ex:5742
 #: lib/vutuv_web/components/ui.ex:3670
-#: lib/vutuv_web/live/notification_live/index.ex:1089
+#: lib/vutuv_web/live/notification_live/index.ex:1271
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1144
-#: lib/vutuv_web/components/post_components.ex:5743
-#: lib/vutuv_web/live/notification_live/index.ex:1022
+#: lib/vutuv_web/components/post_components.ex:5752
+#: lib/vutuv_web/live/notification_live/index.ex:1204
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
 #: lib/vutuv_web/live/shell_live.ex:1298
@@ -2424,13 +2424,13 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5485
+#: lib/vutuv_web/components/post_components.ex:5494
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2018
-#: lib/vutuv_web/components/post_components.ex:5496
+#: lib/vutuv_web/components/post_components.ex:5505
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
@@ -2438,26 +2438,26 @@ msgid "Remove bookmark"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2000
-#: lib/vutuv_web/components/post_components.ex:5482
+#: lib/vutuv_web/components/post_components.ex:5491
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2265
-#: lib/vutuv_web/components/post_components.ex:4577
+#: lib/vutuv_web/components/post_components.ex:4586
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1999
-#: lib/vutuv_web/components/post_components.ex:5481
+#: lib/vutuv_web/components/post_components.ex:5490
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1971
-#: lib/vutuv_web/components/post_components.ex:5732
+#: lib/vutuv_web/components/post_components.ex:5741
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
@@ -2485,21 +2485,21 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5787
+#: lib/vutuv_web/components/post_components.ex:5796
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:408
-#: lib/vutuv_web/live/notification_live/index.ex:1023
+#: lib/vutuv_web/live/notification_live/index.ex:1205
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1985
-#: lib/vutuv_web/components/post_components.ex:5770
-#: lib/vutuv_web/components/post_components.ex:5771
-#: lib/vutuv_web/live/notification_live/index.ex:1086
+#: lib/vutuv_web/components/post_components.ex:5779
+#: lib/vutuv_web/components/post_components.ex:5780
+#: lib/vutuv_web/live/notification_live/index.ex:1268
 #: lib/vutuv_web/live/post_live/reply.ex:46
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2797,7 +2797,7 @@ msgstr[1] ""
 #: lib/vutuv_web/agent_docs/markdown.ex:633
 #: lib/vutuv_web/agent_docs/text.ex:597
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:1021
+#: lib/vutuv_web/live/notification_live/index.ex:1203
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2841,7 +2841,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5402
+#: lib/vutuv_web/components/post_components.ex:5411
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2852,23 +2852,23 @@ msgid "Open someone's profile to message them."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:259
-#: lib/vutuv_web/live/notification_live/index.ex:1101
+#: lib/vutuv_web/live/notification_live/index.ex:1283
 #: lib/vutuv_web/live/organization_live/activity.ex:104
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1092
+#: lib/vutuv_web/live/notification_live/index.ex:1274
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1085
+#: lib/vutuv_web/live/notification_live/index.ex:1267
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1084
+#: lib/vutuv_web/live/notification_live/index.ex:1266
 #: lib/vutuv_web/templates/user/show.html.heex:957
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -3024,7 +3024,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1093
+#: lib/vutuv_web/live/notification_live/index.ex:1275
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3672,7 +3672,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1095
+#: lib/vutuv_web/live/notification_live/index.ex:1277
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -4605,7 +4605,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:463
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:589
-#: lib/vutuv_web/live/notification_live/index.ex:944
+#: lib/vutuv_web/live/notification_live/index.ex:1126
 #: lib/vutuv_web/live/organization_live/show.ex:787
 #: lib/vutuv_web/live/post_live/saved.ex:523
 #: lib/vutuv_web/live/search_live.ex:343
@@ -4629,7 +4629,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
-#: lib/vutuv_web/live/notification_live/index.ex:942
+#: lib/vutuv_web/live/notification_live/index.ex:1124
 #: lib/vutuv_web/live/search_live.ex:342
 #: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
@@ -5427,7 +5427,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:3643
 #: lib/vutuv_web/components/post_components.ex:3698
 #: lib/vutuv_web/components/post_components.ex:4106
-#: lib/vutuv_web/live/notification_live/index.ex:743
+#: lib/vutuv_web/live/notification_live/index.ex:784
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5554,7 +5554,7 @@ msgstr ""
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:572
+#: lib/vutuv_web/live/notification_live/index.ex:621
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
@@ -5647,7 +5647,7 @@ msgid "Apps & API"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:1024
+#: lib/vutuv_web/live/notification_live/index.ex:1206
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -6317,10 +6317,10 @@ msgid "No endorsements yet."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2420
-#: lib/vutuv_web/live/notification_live/index.ex:677
-#: lib/vutuv_web/live/notification_live/index.ex:692
-#: lib/vutuv_web/live/notification_live/index.ex:830
-#: lib/vutuv_web/live/notification_live/index.ex:832
+#: lib/vutuv_web/live/notification_live/index.ex:684
+#: lib/vutuv_web/live/notification_live/index.ex:699
+#: lib/vutuv_web/live/notification_live/index.ex:1012
+#: lib/vutuv_web/live/notification_live/index.ex:1014
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
@@ -7326,7 +7326,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5643
+#: lib/vutuv_web/components/post_components.ex:5652
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7711,13 +7711,13 @@ msgstr ""
 #: lib/vutuv_web/components/job_components.ex:219
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:468
-#: lib/vutuv_web/live/notification_live/index.ex:971
+#: lib/vutuv_web/live/notification_live/index.ex:1153
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:291
-#: lib/vutuv_web/live/notification_live/index.ex:974
+#: lib/vutuv_web/live/notification_live/index.ex:1156
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -8764,7 +8764,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4580
+#: lib/vutuv_web/components/post_components.ex:4589
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -11758,7 +11758,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1096
+#: lib/vutuv_web/live/notification_live/index.ex:1278
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -13255,7 +13255,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1094
+#: lib/vutuv_web/live/notification_live/index.ex:1276
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13342,7 +13342,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1097
+#: lib/vutuv_web/live/notification_live/index.ex:1279
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13556,7 +13556,7 @@ msgstr[1] ""
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1098
+#: lib/vutuv_web/live/notification_live/index.ex:1280
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
@@ -13601,34 +13601,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5251
+#: lib/vutuv_web/components/post_components.ex:5260
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1233
-#: lib/vutuv_web/components/post_components.ex:5208
+#: lib/vutuv_web/components/post_components.ex:5217
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5252
+#: lib/vutuv_web/components/post_components.ex:5261
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5254
+#: lib/vutuv_web/components/post_components.ex:5263
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5250
+#: lib/vutuv_web/components/post_components.ex:5259
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1233
-#: lib/vutuv_web/components/post_components.ex:5207
+#: lib/vutuv_web/components/post_components.ex:5216
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13639,12 +13639,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5249
+#: lib/vutuv_web/components/post_components.ex:5258
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5253
+#: lib/vutuv_web/components/post_components.ex:5262
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13664,7 +13664,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5290
+#: lib/vutuv_web/components/post_components.ex:5299
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13672,27 +13672,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5320
+#: lib/vutuv_web/components/post_components.ex:5329
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5321
+#: lib/vutuv_web/components/post_components.ex:5330
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5319
+#: lib/vutuv_web/components/post_components.ex:5328
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5279
+#: lib/vutuv_web/components/post_components.ex:5288
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5326
+#: lib/vutuv_web/components/post_components.ex:5335
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13722,55 +13722,55 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5093
+#: lib/vutuv_web/components/post_components.ex:5102
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:963
+#: lib/vutuv_web/live/notification_live/index.ex:1145
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:977
+#: lib/vutuv_web/live/notification_live/index.ex:1159
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:445
+#: lib/vutuv_web/live/notification_live/index.ex:453
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:460
+#: lib/vutuv_web/live/notification_live/index.ex:468
 #, elixir-autogen, elixir-format
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:929
-#: lib/vutuv_web/live/notification_live/index.ex:1136
+#: lib/vutuv_web/live/notification_live/index.ex:1111
+#: lib/vutuv_web/live/notification_live/index.ex:1377
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1115
+#: lib/vutuv_web/live/notification_live/index.ex:1297
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1112
+#: lib/vutuv_web/live/notification_live/index.ex:1294
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1121
+#: lib/vutuv_web/live/notification_live/index.ex:1303
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5084
+#: lib/vutuv_web/components/post_components.ex:5093
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14009,7 +14009,7 @@ msgstr ""
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1087
+#: lib/vutuv_web/live/notification_live/index.ex:1269
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
@@ -14037,7 +14037,7 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1088
+#: lib/vutuv_web/live/notification_live/index.ex:1270
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
@@ -14176,7 +14176,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5742
+#: lib/vutuv_web/components/post_components.ex:5751
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14381,7 +14381,7 @@ msgstr ""
 msgid "Thread replies"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:655
+#: lib/vutuv_web/live/notification_live/index.ex:662
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr ""
@@ -14432,7 +14432,7 @@ msgstr ""
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:650
+#: lib/vutuv_web/live/notification_live/index.ex:657
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr ""
@@ -15319,21 +15319,23 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5688
+#: lib/vutuv_web/components/post_components.ex:5697
+#: lib/vutuv_web/live/notification_live/index.ex:1352
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5692
+#: lib/vutuv_web/components/post_components.ex:5701
+#: lib/vutuv_web/live/notification_live/index.ex:1350
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5696
+#: lib/vutuv_web/components/post_components.ex:5705
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15341,7 +15343,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1182
-#: lib/vutuv_web/components/post_components.ex:5647
+#: lib/vutuv_web/components/post_components.ex:5656
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15383,7 +15385,7 @@ msgstr ""
 msgid "Replies from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1090
+#: lib/vutuv_web/live/notification_live/index.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr ""
@@ -15404,7 +15406,7 @@ msgid "Reported as not appropriate"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1374
-#: lib/vutuv_web/live/notification_live/index.ex:597
+#: lib/vutuv_web/live/notification_live/index.ex:910
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr ""
@@ -16431,13 +16433,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1200
-#: lib/vutuv_web/components/post_components.ex:5685
+#: lib/vutuv_web/components/post_components.ex:5694
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1198
-#: lib/vutuv_web/components/post_components.ex:5682
+#: lib/vutuv_web/components/post_components.ex:5691
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16447,12 +16449,12 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5574
+#: lib/vutuv_web/components/post_components.ex:5583
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1091
+#: lib/vutuv_web/live/notification_live/index.ex:1273
 #, elixir-autogen, elixir-format
 msgid "Reaction from another network"
 msgstr ""
@@ -17799,7 +17801,7 @@ msgstr ""
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:627
+#: lib/vutuv_web/live/notification_live/index.ex:924
 #, elixir-autogen, elixir-format
 msgid "View the conversation"
 msgstr ""
@@ -18139,19 +18141,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4750
+#: lib/vutuv_web/components/post_components.ex:4759
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4752
+#: lib/vutuv_web/components/post_components.ex:4761
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4763
+#: lib/vutuv_web/components/post_components.ex:4772
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18673,7 +18675,7 @@ msgstr ""
 msgid "Employment reference deleted"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1100
+#: lib/vutuv_web/live/notification_live/index.ex:1282
 #, elixir-autogen, elixir-format
 msgid "Employment reference review"
 msgstr ""
@@ -19096,7 +19098,7 @@ msgstr ""
 msgid "Cancel registration"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:896
+#: lib/vutuv_web/live/notification_live/index.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -20673,27 +20675,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4644
+#: lib/vutuv_web/components/post_components.ex:4653
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4680
+#: lib/vutuv_web/components/post_components.ex:4689
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4689
+#: lib/vutuv_web/components/post_components.ex:4698
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4692
+#: lib/vutuv_web/components/post_components.ex:4701
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4669
+#: lib/vutuv_web/components/post_components.ex:4678
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20703,7 +20705,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4659
+#: lib/vutuv_web/components/post_components.ex:4668
 #: lib/vutuv_web/components/ui.ex:4663
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -22384,3 +22386,41 @@ msgstr ""
 msgctxt "filter rule"
 msgid "Hide"
 msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1351
+#, elixir-autogen, elixir-format
+msgid "%{formatted} share"
+msgid_plural "%{formatted} shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:827
+#, elixir-autogen, elixir-format
+msgid "Post without text"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1326
+#, elixir-autogen, elixir-format
+msgid "likes this."
+msgid_plural "like this."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1332
+#, elixir-autogen, elixir-format
+msgid "reacted to this."
+msgid_plural "reacted to this."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1317
+#, elixir-autogen, elixir-format
+msgid "replied."
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1329
+#, elixir-autogen, elixir-format
+msgid "shared this."
+msgid_plural "shared this."
+msgstr[0] ""
+msgstr[1] ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -313,7 +313,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:595
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
-#: lib/vutuv_web/live/notification_live/index.ex:1020
+#: lib/vutuv_web/live/notification_live/index.ex:1202
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:27
@@ -452,7 +452,7 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:945
+#: lib/vutuv_web/live/notification_live/index.ex:1127
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -470,7 +470,7 @@ msgid "Name"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:714
-#: lib/vutuv_web/live/notification_live/index.ex:699
+#: lib/vutuv_web/live/notification_live/index.ex:742
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
@@ -789,7 +789,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
 #: lib/vutuv_web/live/directory_search_live.ex:134
-#: lib/vutuv_web/live/notification_live/index.ex:1099
+#: lib/vutuv_web/live/notification_live/index.ex:1281
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -1760,7 +1760,7 @@ msgstr ""
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:428
+#: lib/vutuv_web/live/notification_live/index.ex:436
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr ""
@@ -1768,8 +1768,8 @@ msgstr ""
 #: lib/vutuv/api_auth/scopes.ex:85
 #: lib/vutuv_web/components/ui.ex:4648
 #: lib/vutuv_web/controllers/page_controller.ex:228
-#: lib/vutuv_web/live/notification_live/index.ex:140
-#: lib/vutuv_web/live/notification_live/index.ex:377
+#: lib/vutuv_web/live/notification_live/index.ex:146
+#: lib/vutuv_web/live/notification_live/index.ex:384
 #: lib/vutuv_web/live/shell_live.ex:1247
 #: lib/vutuv_web/templates/layout/app.html.heex:153
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
@@ -2202,7 +2202,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:103
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:396
-#: lib/vutuv_web/live/notification_live/index.ex:943
+#: lib/vutuv_web/live/notification_live/index.ex:1125
 #: lib/vutuv_web/live/organization_live/show.ex:700
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:345
@@ -2315,22 +2315,22 @@ msgstr ""
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5401
+#: lib/vutuv_web/components/post_components.ex:5410
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5405
+#: lib/vutuv_web/components/post_components.ex:5414
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5403
+#: lib/vutuv_web/components/post_components.ex:5412
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5404
+#: lib/vutuv_web/components/post_components.ex:5413
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2372,7 +2372,7 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2019
-#: lib/vutuv_web/components/post_components.ex:5497
+#: lib/vutuv_web/components/post_components.ex:5506
 #: lib/vutuv_web/components/ui.ex:3684
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
@@ -2391,17 +2391,17 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1972
-#: lib/vutuv_web/components/post_components.ex:5733
+#: lib/vutuv_web/components/post_components.ex:5742
 #: lib/vutuv_web/components/ui.ex:3670
-#: lib/vutuv_web/live/notification_live/index.ex:1089
+#: lib/vutuv_web/live/notification_live/index.ex:1271
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1144
-#: lib/vutuv_web/components/post_components.ex:5743
-#: lib/vutuv_web/live/notification_live/index.ex:1022
+#: lib/vutuv_web/components/post_components.ex:5752
+#: lib/vutuv_web/live/notification_live/index.ex:1204
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
 #: lib/vutuv_web/live/shell_live.ex:1298
@@ -2422,13 +2422,13 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5485
+#: lib/vutuv_web/components/post_components.ex:5494
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2018
-#: lib/vutuv_web/components/post_components.ex:5496
+#: lib/vutuv_web/components/post_components.ex:5505
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
@@ -2436,26 +2436,26 @@ msgid "Remove bookmark"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2000
-#: lib/vutuv_web/components/post_components.ex:5482
+#: lib/vutuv_web/components/post_components.ex:5491
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2265
-#: lib/vutuv_web/components/post_components.ex:4577
+#: lib/vutuv_web/components/post_components.ex:4586
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1999
-#: lib/vutuv_web/components/post_components.ex:5481
+#: lib/vutuv_web/components/post_components.ex:5490
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1971
-#: lib/vutuv_web/components/post_components.ex:5732
+#: lib/vutuv_web/components/post_components.ex:5741
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
@@ -2483,21 +2483,21 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5787
+#: lib/vutuv_web/components/post_components.ex:5796
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:408
-#: lib/vutuv_web/live/notification_live/index.ex:1023
+#: lib/vutuv_web/live/notification_live/index.ex:1205
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1985
-#: lib/vutuv_web/components/post_components.ex:5770
-#: lib/vutuv_web/components/post_components.ex:5771
-#: lib/vutuv_web/live/notification_live/index.ex:1086
+#: lib/vutuv_web/components/post_components.ex:5779
+#: lib/vutuv_web/components/post_components.ex:5780
+#: lib/vutuv_web/live/notification_live/index.ex:1268
 #: lib/vutuv_web/live/post_live/reply.ex:46
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2795,7 +2795,7 @@ msgstr[1] ""
 #: lib/vutuv_web/agent_docs/markdown.ex:633
 #: lib/vutuv_web/agent_docs/text.ex:597
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:1021
+#: lib/vutuv_web/live/notification_live/index.ex:1203
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2839,7 +2839,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5402
+#: lib/vutuv_web/components/post_components.ex:5411
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2850,23 +2850,23 @@ msgid "Open someone's profile to message them."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:259
-#: lib/vutuv_web/live/notification_live/index.ex:1101
+#: lib/vutuv_web/live/notification_live/index.ex:1283
 #: lib/vutuv_web/live/organization_live/activity.ex:104
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1092
+#: lib/vutuv_web/live/notification_live/index.ex:1274
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1085
+#: lib/vutuv_web/live/notification_live/index.ex:1267
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1084
+#: lib/vutuv_web/live/notification_live/index.ex:1266
 #: lib/vutuv_web/templates/user/show.html.heex:957
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -3022,7 +3022,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1093
+#: lib/vutuv_web/live/notification_live/index.ex:1275
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3670,7 +3670,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1095
+#: lib/vutuv_web/live/notification_live/index.ex:1277
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -4603,7 +4603,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:463
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:589
-#: lib/vutuv_web/live/notification_live/index.ex:944
+#: lib/vutuv_web/live/notification_live/index.ex:1126
 #: lib/vutuv_web/live/organization_live/show.ex:787
 #: lib/vutuv_web/live/post_live/saved.ex:523
 #: lib/vutuv_web/live/search_live.ex:343
@@ -4627,7 +4627,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
-#: lib/vutuv_web/live/notification_live/index.ex:942
+#: lib/vutuv_web/live/notification_live/index.ex:1124
 #: lib/vutuv_web/live/search_live.ex:342
 #: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
@@ -5425,7 +5425,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:3643
 #: lib/vutuv_web/components/post_components.ex:3698
 #: lib/vutuv_web/components/post_components.ex:4106
-#: lib/vutuv_web/live/notification_live/index.ex:743
+#: lib/vutuv_web/live/notification_live/index.ex:784
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5552,7 +5552,7 @@ msgstr ""
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:572
+#: lib/vutuv_web/live/notification_live/index.ex:621
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
@@ -5645,7 +5645,7 @@ msgid "Apps & API"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:1024
+#: lib/vutuv_web/live/notification_live/index.ex:1206
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -6315,10 +6315,10 @@ msgid "No endorsements yet."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2420
-#: lib/vutuv_web/live/notification_live/index.ex:677
-#: lib/vutuv_web/live/notification_live/index.ex:692
-#: lib/vutuv_web/live/notification_live/index.ex:830
-#: lib/vutuv_web/live/notification_live/index.ex:832
+#: lib/vutuv_web/live/notification_live/index.ex:684
+#: lib/vutuv_web/live/notification_live/index.ex:699
+#: lib/vutuv_web/live/notification_live/index.ex:1012
+#: lib/vutuv_web/live/notification_live/index.ex:1014
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
@@ -7324,7 +7324,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5643
+#: lib/vutuv_web/components/post_components.ex:5652
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7709,13 +7709,13 @@ msgstr ""
 #: lib/vutuv_web/components/job_components.ex:219
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:468
-#: lib/vutuv_web/live/notification_live/index.ex:971
+#: lib/vutuv_web/live/notification_live/index.ex:1153
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:291
-#: lib/vutuv_web/live/notification_live/index.ex:974
+#: lib/vutuv_web/live/notification_live/index.ex:1156
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -8762,7 +8762,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4580
+#: lib/vutuv_web/components/post_components.ex:4589
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -11756,7 +11756,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1096
+#: lib/vutuv_web/live/notification_live/index.ex:1278
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -13253,7 +13253,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1094
+#: lib/vutuv_web/live/notification_live/index.ex:1276
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13340,7 +13340,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1097
+#: lib/vutuv_web/live/notification_live/index.ex:1279
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13554,7 +13554,7 @@ msgstr[1] ""
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1098
+#: lib/vutuv_web/live/notification_live/index.ex:1280
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
@@ -13599,34 +13599,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5251
+#: lib/vutuv_web/components/post_components.ex:5260
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1233
-#: lib/vutuv_web/components/post_components.ex:5208
+#: lib/vutuv_web/components/post_components.ex:5217
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5252
+#: lib/vutuv_web/components/post_components.ex:5261
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5254
+#: lib/vutuv_web/components/post_components.ex:5263
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5250
+#: lib/vutuv_web/components/post_components.ex:5259
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1233
-#: lib/vutuv_web/components/post_components.ex:5207
+#: lib/vutuv_web/components/post_components.ex:5216
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13637,12 +13637,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5249
+#: lib/vutuv_web/components/post_components.ex:5258
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5253
+#: lib/vutuv_web/components/post_components.ex:5262
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13662,7 +13662,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5290
+#: lib/vutuv_web/components/post_components.ex:5299
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13670,27 +13670,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5320
+#: lib/vutuv_web/components/post_components.ex:5329
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5321
+#: lib/vutuv_web/components/post_components.ex:5330
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5319
+#: lib/vutuv_web/components/post_components.ex:5328
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5279
+#: lib/vutuv_web/components/post_components.ex:5288
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5326
+#: lib/vutuv_web/components/post_components.ex:5335
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13720,55 +13720,55 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5093
+#: lib/vutuv_web/components/post_components.ex:5102
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:963
+#: lib/vutuv_web/live/notification_live/index.ex:1145
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:977
+#: lib/vutuv_web/live/notification_live/index.ex:1159
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:445
+#: lib/vutuv_web/live/notification_live/index.ex:453
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:460
+#: lib/vutuv_web/live/notification_live/index.ex:468
 #, elixir-autogen, elixir-format
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:929
-#: lib/vutuv_web/live/notification_live/index.ex:1136
+#: lib/vutuv_web/live/notification_live/index.ex:1111
+#: lib/vutuv_web/live/notification_live/index.ex:1377
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1115
+#: lib/vutuv_web/live/notification_live/index.ex:1297
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1112
+#: lib/vutuv_web/live/notification_live/index.ex:1294
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1121
+#: lib/vutuv_web/live/notification_live/index.ex:1303
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5084
+#: lib/vutuv_web/components/post_components.ex:5093
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14007,7 +14007,7 @@ msgstr ""
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1087
+#: lib/vutuv_web/live/notification_live/index.ex:1269
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
@@ -14035,7 +14035,7 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1088
+#: lib/vutuv_web/live/notification_live/index.ex:1270
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
@@ -14174,7 +14174,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5742
+#: lib/vutuv_web/components/post_components.ex:5751
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14379,7 +14379,7 @@ msgstr ""
 msgid "Thread replies"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:655
+#: lib/vutuv_web/live/notification_live/index.ex:662
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr ""
@@ -14430,7 +14430,7 @@ msgstr ""
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:650
+#: lib/vutuv_web/live/notification_live/index.ex:657
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr ""
@@ -15317,21 +15317,23 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5688
+#: lib/vutuv_web/components/post_components.ex:5697
+#: lib/vutuv_web/live/notification_live/index.ex:1352
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5692
+#: lib/vutuv_web/components/post_components.ex:5701
+#: lib/vutuv_web/live/notification_live/index.ex:1350
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5696
+#: lib/vutuv_web/components/post_components.ex:5705
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15339,7 +15341,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1182
-#: lib/vutuv_web/components/post_components.ex:5647
+#: lib/vutuv_web/components/post_components.ex:5656
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15381,7 +15383,7 @@ msgstr ""
 msgid "Replies from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1090
+#: lib/vutuv_web/live/notification_live/index.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr ""
@@ -15402,7 +15404,7 @@ msgid "Reported as not appropriate"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1374
-#: lib/vutuv_web/live/notification_live/index.ex:597
+#: lib/vutuv_web/live/notification_live/index.ex:910
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr ""
@@ -16429,13 +16431,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1200
-#: lib/vutuv_web/components/post_components.ex:5685
+#: lib/vutuv_web/components/post_components.ex:5694
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1198
-#: lib/vutuv_web/components/post_components.ex:5682
+#: lib/vutuv_web/components/post_components.ex:5691
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16445,12 +16447,12 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5574
+#: lib/vutuv_web/components/post_components.ex:5583
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1091
+#: lib/vutuv_web/live/notification_live/index.ex:1273
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reaction from another network"
 msgstr ""
@@ -17797,7 +17799,7 @@ msgstr ""
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:627
+#: lib/vutuv_web/live/notification_live/index.ex:924
 #, elixir-autogen, elixir-format
 msgid "View the conversation"
 msgstr ""
@@ -18137,19 +18139,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4750
+#: lib/vutuv_web/components/post_components.ex:4759
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4752
+#: lib/vutuv_web/components/post_components.ex:4761
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4763
+#: lib/vutuv_web/components/post_components.ex:4772
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18671,7 +18673,7 @@ msgstr ""
 msgid "Employment reference deleted"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1100
+#: lib/vutuv_web/live/notification_live/index.ex:1282
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employment reference review"
 msgstr ""
@@ -19094,7 +19096,7 @@ msgstr ""
 msgid "Cancel registration"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:896
+#: lib/vutuv_web/live/notification_live/index.ex:1078
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -20671,27 +20673,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4644
+#: lib/vutuv_web/components/post_components.ex:4653
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4680
+#: lib/vutuv_web/components/post_components.ex:4689
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4689
+#: lib/vutuv_web/components/post_components.ex:4698
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4692
+#: lib/vutuv_web/components/post_components.ex:4701
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4669
+#: lib/vutuv_web/components/post_components.ex:4678
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20701,7 +20703,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4659
+#: lib/vutuv_web/components/post_components.ex:4668
 #: lib/vutuv_web/components/ui.ex:4663
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -22382,3 +22384,41 @@ msgstr ""
 msgctxt "filter rule"
 msgid "Hide"
 msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1351
+#, elixir-autogen, elixir-format, fuzzy
+msgid "%{formatted} share"
+msgid_plural "%{formatted} shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:827
+#, elixir-autogen, elixir-format
+msgid "Post without text"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1326
+#, elixir-autogen, elixir-format
+msgid "likes this."
+msgid_plural "like this."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1332
+#, elixir-autogen, elixir-format
+msgid "reacted to this."
+msgid_plural "reacted to this."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1317
+#, elixir-autogen, elixir-format
+msgid "replied."
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1329
+#, elixir-autogen, elixir-format
+msgid "shared this."
+msgid_plural "shared this."
+msgstr[0] ""
+msgstr[1] ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -315,7 +315,7 @@ msgstr "Nome"
 #: lib/vutuv_web/agent_docs/text.ex:595
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
-#: lib/vutuv_web/live/notification_live/index.ex:1020
+#: lib/vutuv_web/live/notification_live/index.ex:1202
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:27
@@ -456,7 +456,7 @@ msgstr "Accedi"
 msgid "Middle Name"
 msgstr "Secondo nome"
 
-#: lib/vutuv_web/live/notification_live/index.ex:945
+#: lib/vutuv_web/live/notification_live/index.ex:1127
 #, elixir-autogen
 msgid "More"
 msgstr "Altro"
@@ -474,7 +474,7 @@ msgid "Name"
 msgstr "Nome"
 
 #: lib/vutuv_web/components/post_components.ex:714
-#: lib/vutuv_web/live/notification_live/index.ex:699
+#: lib/vutuv_web/live/notification_live/index.ex:742
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
@@ -793,7 +793,7 @@ msgstr "Utente verificato."
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
 #: lib/vutuv_web/live/directory_search_live.ex:134
-#: lib/vutuv_web/live/notification_live/index.ex:1099
+#: lib/vutuv_web/live/notification_live/index.ex:1281
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -1795,7 +1795,7 @@ msgstr "Rete"
 msgid "Nothing here yet."
 msgstr "Qui non c'è ancora nulla."
 
-#: lib/vutuv_web/live/notification_live/index.ex:428
+#: lib/vutuv_web/live/notification_live/index.ex:436
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr "Ancora nessuna novità."
@@ -1803,8 +1803,8 @@ msgstr "Ancora nessuna novità."
 #: lib/vutuv/api_auth/scopes.ex:85
 #: lib/vutuv_web/components/ui.ex:4648
 #: lib/vutuv_web/controllers/page_controller.ex:228
-#: lib/vutuv_web/live/notification_live/index.ex:140
-#: lib/vutuv_web/live/notification_live/index.ex:377
+#: lib/vutuv_web/live/notification_live/index.ex:146
+#: lib/vutuv_web/live/notification_live/index.ex:384
 #: lib/vutuv_web/live/shell_live.ex:1247
 #: lib/vutuv_web/templates/layout/app.html.heex:153
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
@@ -2249,7 +2249,7 @@ msgstr "Post eliminato."
 #: lib/vutuv_web/gettext_extraction_anchors.ex:103
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:396
-#: lib/vutuv_web/live/notification_live/index.ex:943
+#: lib/vutuv_web/live/notification_live/index.ex:1125
 #: lib/vutuv_web/live/organization_live/show.ex:700
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:345
@@ -2364,22 +2364,22 @@ msgstr "Che c'è di nuovo? Markdown è supportato."
 msgid "edited"
 msgstr "modificato"
 
-#: lib/vutuv_web/components/post_components.ex:5401
+#: lib/vutuv_web/components/post_components.ex:5410
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "tutti gli altri"
 
-#: lib/vutuv_web/components/post_components.ex:5405
+#: lib/vutuv_web/components/post_components.ex:5414
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "visitatori non connessi"
 
-#: lib/vutuv_web/components/post_components.ex:5403
+#: lib/vutuv_web/components/post_components.ex:5412
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "persone che non La seguono"
 
-#: lib/vutuv_web/components/post_components.ex:5404
+#: lib/vutuv_web/components/post_components.ex:5413
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "persone che non segue"
@@ -2421,7 +2421,7 @@ msgid "All posts"
 msgstr "Tutti i post"
 
 #: lib/vutuv_web/components/post_components.ex:2019
-#: lib/vutuv_web/components/post_components.ex:5497
+#: lib/vutuv_web/components/post_components.ex:5506
 #: lib/vutuv_web/components/ui.ex:3684
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
@@ -2440,17 +2440,17 @@ msgid "Bookmarks"
 msgstr "Salvati"
 
 #: lib/vutuv_web/components/post_components.ex:1972
-#: lib/vutuv_web/components/post_components.ex:5733
+#: lib/vutuv_web/components/post_components.ex:5742
 #: lib/vutuv_web/components/ui.ex:3670
-#: lib/vutuv_web/live/notification_live/index.ex:1089
+#: lib/vutuv_web/live/notification_live/index.ex:1271
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr "Mi piace"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1144
-#: lib/vutuv_web/components/post_components.ex:5743
-#: lib/vutuv_web/live/notification_live/index.ex:1022
+#: lib/vutuv_web/components/post_components.ex:5752
+#: lib/vutuv_web/live/notification_live/index.ex:1204
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
 #: lib/vutuv_web/live/shell_live.ex:1298
@@ -2471,13 +2471,13 @@ msgstr "Qui non c'è ancora nulla. I post che salva compaiono qui."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Qui non c'è ancora nulla. I post a cui mette Mi piace compaiono qui."
 
-#: lib/vutuv_web/components/post_components.ex:5485
+#: lib/vutuv_web/components/post_components.ex:5494
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Solo i post pubblici possono essere ripubblicati."
 
 #: lib/vutuv_web/components/post_components.ex:2018
-#: lib/vutuv_web/components/post_components.ex:5496
+#: lib/vutuv_web/components/post_components.ex:5505
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
@@ -2485,26 +2485,26 @@ msgid "Remove bookmark"
 msgstr "Rimuovi dai salvati"
 
 #: lib/vutuv_web/components/post_components.ex:2000
-#: lib/vutuv_web/components/post_components.ex:5482
+#: lib/vutuv_web/components/post_components.ex:5491
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Ripubblica"
 
 #: lib/vutuv_web/components/post_components.ex:2265
-#: lib/vutuv_web/components/post_components.ex:4577
+#: lib/vutuv_web/components/post_components.ex:4586
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Ripubblicato da %{name}"
 
 #: lib/vutuv_web/components/post_components.ex:1999
-#: lib/vutuv_web/components/post_components.ex:5481
+#: lib/vutuv_web/components/post_components.ex:5490
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Annulla la ripubblicazione"
 
 #: lib/vutuv_web/components/post_components.ex:1971
-#: lib/vutuv_web/components/post_components.ex:5732
+#: lib/vutuv_web/components/post_components.ex:5741
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
@@ -2532,21 +2532,21 @@ msgstr "Non seguire più"
 msgid "Welcome to vutuv!"
 msgstr "Benvenuto su vutuv."
 
-#: lib/vutuv_web/components/post_components.ex:5787
+#: lib/vutuv_web/components/post_components.ex:5796
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Solo ai post pubblici si può rispondere."
 
 #: lib/vutuv_web/components/post_components.ex:408
-#: lib/vutuv_web/live/notification_live/index.ex:1023
+#: lib/vutuv_web/live/notification_live/index.ex:1205
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Risposte"
 
 #: lib/vutuv_web/components/post_components.ex:1985
-#: lib/vutuv_web/components/post_components.ex:5770
-#: lib/vutuv_web/components/post_components.ex:5771
-#: lib/vutuv_web/live/notification_live/index.ex:1086
+#: lib/vutuv_web/components/post_components.ex:5779
+#: lib/vutuv_web/components/post_components.ex:5780
+#: lib/vutuv_web/live/notification_live/index.ex:1268
 #: lib/vutuv_web/live/post_live/reply.ex:46
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2851,7 +2851,7 @@ msgstr[1] "+%{formatted} altri tag"
 #: lib/vutuv_web/agent_docs/markdown.ex:633
 #: lib/vutuv_web/agent_docs/text.ex:597
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:1021
+#: lib/vutuv_web/live/notification_live/index.ex:1203
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2895,7 +2895,7 @@ msgid_plural "connections"
 msgstr[0] "collegamento"
 msgstr[1] "collegamenti"
 
-#: lib/vutuv_web/components/post_components.ex:5402
+#: lib/vutuv_web/components/post_components.ex:5411
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "persone che non sono Suoi collegamenti"
@@ -2906,23 +2906,23 @@ msgid "Open someone's profile to message them."
 msgstr "Apra il profilo di una persona per scriverle."
 
 #: lib/vutuv_web/components/organization_components.ex:259
-#: lib/vutuv_web/live/notification_live/index.ex:1101
+#: lib/vutuv_web/live/notification_live/index.ex:1283
 #: lib/vutuv_web/live/organization_live/activity.ex:104
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr "Attività"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1092
+#: lib/vutuv_web/live/notification_live/index.ex:1274
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr "Collegamento"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1085
+#: lib/vutuv_web/live/notification_live/index.ex:1267
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr "Conferma"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1084
+#: lib/vutuv_web/live/notification_live/index.ex:1266
 #: lib/vutuv_web/templates/user/show.html.heex:957
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -3092,7 +3092,7 @@ msgstr "Contenuti adatti a tutti"
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1093
+#: lib/vutuv_web/live/notification_live/index.ex:1275
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3784,7 +3784,7 @@ msgstr "Il proprietario ha modificato il contenuto"
 msgid "Report filed"
 msgstr "Segnalazione inviata"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1095
+#: lib/vutuv_web/live/notification_live/index.ex:1277
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr "Protezione dopo la segnalazione"
@@ -4783,7 +4783,7 @@ msgstr "Non è una corrispondenza esatta, ma somiglia alla Sua ricerca."
 #: lib/vutuv_web/agent_docs/text.ex:463
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:589
-#: lib/vutuv_web/live/notification_live/index.ex:944
+#: lib/vutuv_web/live/notification_live/index.ex:1126
 #: lib/vutuv_web/live/organization_live/show.ex:787
 #: lib/vutuv_web/live/post_live/saved.ex:523
 #: lib/vutuv_web/live/search_live.ex:343
@@ -4807,7 +4807,7 @@ msgstr "Nomi simili"
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
-#: lib/vutuv_web/live/notification_live/index.ex:942
+#: lib/vutuv_web/live/notification_live/index.ex:1124
 #: lib/vutuv_web/live/search_live.ex:342
 #: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
@@ -5645,7 +5645,7 @@ msgstr "Navigazione a piè di pagina"
 #: lib/vutuv_web/components/post_components.ex:3643
 #: lib/vutuv_web/components/post_components.ex:3698
 #: lib/vutuv_web/components/post_components.ex:4106
-#: lib/vutuv_web/live/notification_live/index.ex:743
+#: lib/vutuv_web/live/notification_live/index.ex:784
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5772,7 +5772,7 @@ msgstr "Vedi"
 msgid "Your name"
 msgstr "Il Suo nome"
 
-#: lib/vutuv_web/live/notification_live/index.ex:572
+#: lib/vutuv_web/live/notification_live/index.ex:621
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr "Il Suo post"
@@ -5867,7 +5867,7 @@ msgid "Apps & API"
 msgstr "App e API"
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:1024
+#: lib/vutuv_web/live/notification_live/index.ex:1206
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -6557,10 +6557,10 @@ msgid "No endorsements yet."
 msgstr "Ancora nessuna conferma."
 
 #: lib/vutuv_web/components/ui.ex:2420
-#: lib/vutuv_web/live/notification_live/index.ex:677
-#: lib/vutuv_web/live/notification_live/index.ex:692
-#: lib/vutuv_web/live/notification_live/index.ex:830
-#: lib/vutuv_web/live/notification_live/index.ex:832
+#: lib/vutuv_web/live/notification_live/index.ex:684
+#: lib/vutuv_web/live/notification_live/index.ex:699
+#: lib/vutuv_web/live/notification_live/index.ex:1012
+#: lib/vutuv_web/live/notification_live/index.ex:1014
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr "e altri %{count}"
@@ -7617,7 +7617,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "vale per l'intero elenco, non solo per questa pagina"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5643
+#: lib/vutuv_web/components/post_components.ex:5652
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8029,13 +8029,13 @@ msgstr "Nuovi membri"
 #: lib/vutuv_web/components/job_components.ex:219
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:468
-#: lib/vutuv_web/live/notification_live/index.ex:971
+#: lib/vutuv_web/live/notification_live/index.ex:1153
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Oggi"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:291
-#: lib/vutuv_web/live/notification_live/index.ex:974
+#: lib/vutuv_web/live/notification_live/index.ex:1156
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr "Ieri"
@@ -9164,7 +9164,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Download del CV"
 
-#: lib/vutuv_web/components/post_components.ex:4580
+#: lib/vutuv_web/components/post_components.ex:4589
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -12370,7 +12370,7 @@ msgstr "Pagina dell'organizzazione"
 msgid "Organization pages"
 msgstr "Pagine delle organizzazioni"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1096
+#: lib/vutuv_web/live/notification_live/index.ex:1278
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr "Ruolo nell'organizzazione"
@@ -13968,7 +13968,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr "Immagine in attesa di esame, visibile solo a Lei"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1094
+#: lib/vutuv_web/live/notification_live/index.ex:1276
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -14070,7 +14070,7 @@ msgstr ""
 "con quello nuovo e gli autori di quei post vengono avvisati. Il Suo vecchio "
 "indirizzo di profilo smette di funzionare."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1097
+#: lib/vutuv_web/live/notification_live/index.ex:1279
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr "Cambio di handle"
@@ -14300,7 +14300,7 @@ msgstr ""
 "Vedono una notifica che rimanda a questa voce. Non viene inviata alcuna "
 "e-mail, e accade solo per una voce nuova."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1098
+#: lib/vutuv_web/live/notification_live/index.ex:1280
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr "Aggiornamento del CV"
@@ -14348,34 +14348,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr "ha aggiunto %{count} nuove voci al proprio CV:"
 
-#: lib/vutuv_web/components/post_components.ex:5251
+#: lib/vutuv_web/components/post_components.ex:5260
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Audiolibro"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1233
-#: lib/vutuv_web/components/post_components.ex:5208
+#: lib/vutuv_web/components/post_components.ex:5217
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Recensione di un libro"
 
-#: lib/vutuv_web/components/post_components.ex:5252
+#: lib/vutuv_web/components/post_components.ex:5261
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Cinema"
 
-#: lib/vutuv_web/components/post_components.ex:5254
+#: lib/vutuv_web/components/post_components.ex:5263
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:5250
+#: lib/vutuv_web/components/post_components.ex:5259
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1233
-#: lib/vutuv_web/components/post_components.ex:5207
+#: lib/vutuv_web/components/post_components.ex:5216
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Recensione di un film"
@@ -14386,12 +14386,12 @@ msgstr "Recensione di un film"
 msgid "Look up"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:5249
+#: lib/vutuv_web/components/post_components.ex:5258
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Libro cartaceo"
 
-#: lib/vutuv_web/components/post_components.ex:5253
+#: lib/vutuv_web/components/post_components.ex:5262
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14411,7 +14411,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Anno"
 
-#: lib/vutuv_web/components/post_components.ex:5290
+#: lib/vutuv_web/components/post_components.ex:5299
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14419,27 +14419,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} pagina"
 msgstr[1] "%{formatted} pagine"
 
-#: lib/vutuv_web/components/post_components.ex:5320
+#: lib/vutuv_web/components/post_components.ex:5329
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} h"
 
-#: lib/vutuv_web/components/post_components.ex:5321
+#: lib/vutuv_web/components/post_components.ex:5330
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} h %{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:5319
+#: lib/vutuv_web/components/post_components.ex:5328
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:5279
+#: lib/vutuv_web/components/post_components.ex:5288
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(edizione cartacea)"
 
-#: lib/vutuv_web/components/post_components.ex:5326
+#: lib/vutuv_web/components/post_components.ex:5335
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "circa %{duration}"
@@ -14471,55 +14471,55 @@ msgstr "Con certificazione:"
 msgid "With qualification: %{name}"
 msgstr "Con certificazione: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5093
+#: lib/vutuv_web/components/post_components.ex:5102
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Editore:"
 
-#: lib/vutuv_web/live/notification_live/index.ex:963
+#: lib/vutuv_web/live/notification_live/index.ex:1145
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] "%{formatted} nuova notifica"
 msgstr[1] "%{formatted} nuove notifiche"
 
-#: lib/vutuv_web/live/notification_live/index.ex:977
+#: lib/vutuv_web/live/notification_live/index.ex:1159
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr "%{day} %{month} %{year}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:445
+#: lib/vutuv_web/live/notification_live/index.ex:453
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr "Segui anche tu"
 
-#: lib/vutuv_web/live/notification_live/index.ex:460
+#: lib/vutuv_web/live/notification_live/index.ex:468
 #, elixir-autogen, elixir-format
 msgid "Last 30 days"
 msgstr "Ultimi 30 giorni"
 
-#: lib/vutuv_web/live/notification_live/index.ex:929
-#: lib/vutuv_web/live/notification_live/index.ex:1136
+#: lib/vutuv_web/live/notification_live/index.ex:1111
+#: lib/vutuv_web/live/notification_live/index.ex:1377
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "e"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1115
+#: lib/vutuv_web/live/notification_live/index.ex:1297
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr "ora sono collegati con Lei."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1112
+#: lib/vutuv_web/live/notification_live/index.ex:1294
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr "ora La seguono."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1121
+#: lib/vutuv_web/live/notification_live/index.ex:1303
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr "L'ha confermata per %{tags}."
 
-#: lib/vutuv_web/components/post_components.ex:5084
+#: lib/vutuv_web/components/post_components.ex:5093
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "di:"
@@ -14775,7 +14775,7 @@ msgstr ""
 "non abbastanza adatta a un ambiente di lavoro. Può sbagliare, quindi "
 "risponda alla nostra e-mail se non è d'accordo."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1087
+#: lib/vutuv_web/live/notification_live/index.ex:1269
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr "Risposta in una discussione"
@@ -14803,7 +14803,7 @@ msgstr "Conversazione"
 msgid "Only part of this long conversation is shown."
 msgstr "Di questa lunga conversazione è mostrata solo una parte."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1088
+#: lib/vutuv_web/live/notification_live/index.ex:1270
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr "Menzione"
@@ -14962,7 +14962,7 @@ msgstr ""
 "Digiti un nome, un @handle o un indirizzo e-mail per trovare un account da "
 "bloccare."
 
-#: lib/vutuv_web/components/post_components.ex:5742
+#: lib/vutuv_web/components/post_components.ex:5751
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Non può mettere Mi piace al Suo stesso post."
@@ -15190,7 +15190,7 @@ msgstr "Questa formazione ora compare in cima al Suo profilo."
 msgid "Thread replies"
 msgstr "Risposte nelle discussioni"
 
-#: lib/vutuv_web/live/notification_live/index.ex:655
+#: lib/vutuv_web/live/notification_live/index.ex:662
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr "Disattiva le notifiche delle discussioni"
@@ -15248,7 +15248,7 @@ msgstr "Non ha ancora silenziato nulla."
 msgid "You have reached the maximum of %{count} filters."
 msgstr "Ha raggiunto il massimo di %{count} filtri."
 
-#: lib/vutuv_web/live/notification_live/index.ex:650
+#: lib/vutuv_web/live/notification_live/index.ex:657
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr "Ha scritto in questa discussione."
@@ -16226,21 +16226,23 @@ msgstr ""
 " vedere dove va a finire. Modificare o eliminare un post su vutuv è solo una"
 " richiesta rivolta a quei server, e non tutti la rispettano."
 
-#: lib/vutuv_web/components/post_components.ex:5688
+#: lib/vutuv_web/components/post_components.ex:5697
+#: lib/vutuv_web/live/notification_live/index.ex:1352
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} risposta"
 msgstr[1] "%{formatted} risposte"
 
-#: lib/vutuv_web/components/post_components.ex:5692
+#: lib/vutuv_web/components/post_components.ex:5701
+#: lib/vutuv_web/live/notification_live/index.ex:1350
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Mi piace"
 msgstr[1] "%{formatted} Mi piace"
 
-#: lib/vutuv_web/components/post_components.ex:5696
+#: lib/vutuv_web/components/post_components.ex:5705
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16248,7 +16250,7 @@ msgstr[0] "%{formatted} ripubblicazione"
 msgstr[1] "%{formatted} ripubblicazioni"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1182
-#: lib/vutuv_web/components/post_components.ex:5647
+#: lib/vutuv_web/components/post_components.ex:5656
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Già conteggiate nei numeri qui sopra."
@@ -16295,7 +16297,7 @@ msgstr "Rimossa dal membro"
 msgid "Replies from other networks"
 msgstr "Risposte da altre reti"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1090
+#: lib/vutuv_web/live/notification_live/index.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr "Risposta da un'altra rete"
@@ -16317,7 +16319,7 @@ msgid "Reported as not appropriate"
 msgstr "Segnalata come non appropriata"
 
 #: lib/vutuv_web/components/post_components.ex:1374
-#: lib/vutuv_web/live/notification_live/index.ex:597
+#: lib/vutuv_web/live/notification_live/index.ex:910
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr "Inviata solo a Lei, non visibile a nessun altro"
@@ -17411,13 +17413,13 @@ msgstr[1] ""
 "il file esatto lo rivela."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1200
-#: lib/vutuv_web/components/post_components.ex:5685
+#: lib/vutuv_web/components/post_components.ex:5694
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "A %{handle} è piaciuto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1198
-#: lib/vutuv_web/components/post_components.ex:5682
+#: lib/vutuv_web/components/post_components.ex:5691
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} lo ha condiviso"
@@ -17427,12 +17429,12 @@ msgstr "%{handle} lo ha condiviso"
 msgid "Fediverse reactions"
 msgstr "Reazioni dal Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:5574
+#: lib/vutuv_web/components/post_components.ex:5583
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Da altre reti"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1091
+#: lib/vutuv_web/live/notification_live/index.ex:1273
 #, elixir-autogen, elixir-format
 msgid "Reaction from another network"
 msgstr "Reazione da un'altra rete"
@@ -18942,7 +18944,7 @@ msgstr ""
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr "Ancora nulla da vutuv. Segua persone qui per riempire questa scheda."
 
-#: lib/vutuv_web/live/notification_live/index.ex:627
+#: lib/vutuv_web/live/notification_live/index.ex:924
 #, elixir-autogen, elixir-format
 msgid "View the conversation"
 msgstr "Vedi la conversazione"
@@ -19358,19 +19360,19 @@ msgstr ""
 msgid "Liked by"
 msgstr "Piace a"
 
-#: lib/vutuv_web/components/post_components.ex:4750
+#: lib/vutuv_web/components/post_components.ex:4759
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Piace a %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4752
+#: lib/vutuv_web/components/post_components.ex:4761
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Piace a %{name} e a %{formatted} altro"
 msgstr[1] "Piace a %{name} e ad altri %{formatted}"
 
-#: lib/vutuv_web/components/post_components.ex:4763
+#: lib/vutuv_web/components/post_components.ex:4772
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -19928,7 +19930,7 @@ msgstr "Attestato di lavoro modificato"
 msgid "Employment reference deleted"
 msgstr "Attestato di lavoro eliminato"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1100
+#: lib/vutuv_web/live/notification_live/index.ex:1282
 #, elixir-autogen, elixir-format
 msgid "Employment reference review"
 msgstr "Analisi dell'attestato di lavoro"
@@ -20414,7 +20416,7 @@ msgstr ""
 msgid "Cancel registration"
 msgstr "Annulla la registrazione"
 
-#: lib/vutuv_web/live/notification_live/index.ex:896
+#: lib/vutuv_web/live/notification_live/index.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -22163,27 +22165,27 @@ msgstr "Lingua del post"
 msgid "The language this post is written in"
 msgstr "La lingua in cui è scritto questo post"
 
-#: lib/vutuv_web/components/post_components.ex:4644
+#: lib/vutuv_web/components/post_components.ex:4653
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Mostra l'originale"
 
-#: lib/vutuv_web/components/post_components.ex:4680
+#: lib/vutuv_web/components/post_components.ex:4689
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Traduci"
 
-#: lib/vutuv_web/components/post_components.ex:4689
+#: lib/vutuv_web/components/post_components.ex:4698
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Tradotto"
 
-#: lib/vutuv_web/components/post_components.ex:4692
+#: lib/vutuv_web/components/post_components.ex:4701
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Tradotto da %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:4669
+#: lib/vutuv_web/components/post_components.ex:4678
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Traduzione in corso…"
@@ -22194,7 +22196,7 @@ msgid "Feed language settings reset to the site defaults."
 msgstr ""
 "Impostazioni delle lingue del feed riportate ai valori predefiniti del sito."
 
-#: lib/vutuv_web/components/post_components.ex:4659
+#: lib/vutuv_web/components/post_components.ex:4668
 #: lib/vutuv_web/components/ui.ex:4663
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -23988,3 +23990,41 @@ msgstr "solo %{account}"
 msgctxt "filter rule"
 msgid "Hide"
 msgstr "Nascondi"
+
+#: lib/vutuv_web/live/notification_live/index.ex:1351
+#, elixir-autogen, elixir-format
+msgid "%{formatted} share"
+msgid_plural "%{formatted} shares"
+msgstr[0] "%{formatted} condivisione"
+msgstr[1] "%{formatted} condivisioni"
+
+#: lib/vutuv_web/live/notification_live/index.ex:827
+#, elixir-autogen, elixir-format
+msgid "Post without text"
+msgstr "Post senza testo"
+
+#: lib/vutuv_web/live/notification_live/index.ex:1326
+#, elixir-autogen, elixir-format
+msgid "likes this."
+msgid_plural "like this."
+msgstr[0] "ha messo Mi piace."
+msgstr[1] "hanno messo Mi piace."
+
+#: lib/vutuv_web/live/notification_live/index.ex:1332
+#, elixir-autogen, elixir-format
+msgid "reacted to this."
+msgid_plural "reacted to this."
+msgstr[0] "ha reagito."
+msgstr[1] "hanno reagito."
+
+#: lib/vutuv_web/live/notification_live/index.ex:1317
+#, elixir-autogen, elixir-format
+msgid "replied."
+msgstr "ha risposto."
+
+#: lib/vutuv_web/live/notification_live/index.ex:1329
+#, elixir-autogen, elixir-format
+msgid "shared this."
+msgid_plural "shared this."
+msgstr[0] "lo ha condiviso."
+msgstr[1] "lo hanno condiviso."

--- a/test/vutuv_web/live/notification_live_test.exs
+++ b/test/vutuv_web/live/notification_live_test.exs
@@ -979,37 +979,23 @@ defmodule VutuvWeb.NotificationLiveTest do
       {:ok, live, _html} = live(conn, ~p"/notifications")
       html = render(live)
 
-      assert length(row_ids(html, "fediverse_reaction")) == 1
+      assert length(row_ids(html, "fediverse_post")) == 1
       assert html =~ "@alice@social.example"
-      assert html =~ "shared your post on another network."
+      assert html =~ "shared this."
       # It opens the reader's own post, where the line naming them sits — not
       # the remote copy, which they can still reach from the chip there.
       assert has_element?(live, ~s(a[href="/#{user.username}/posts/#{post.id}"]))
     end
 
-    test "a favourite and a boost of one post stay two rows", %{conn: conn} do
-      {conn, user} = create_and_login_user(conn)
-      post = create_post!(user, %{body: "two kinds of answer"})
-      remote_reaction!(post, "alice", "announce")
-      remote_reaction!(post, "bob", "like")
-
-      html = render_the_page(conn)
-
-      # Same post, same day, but a re-share and a favourite are different news,
-      # so they must not merge into one sentence.
-      assert length(row_ids(html, "fediverse_reaction")) == 2
-      assert html =~ "shared your post on another network."
-      assert html =~ "liked your post on another network."
-    end
-
-    test "same-day boosts of one post merge into a single row", %{conn: conn} do
+    test "same-day boosts of one post merge into a single line", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       post = create_post!(user, %{body: "much shared"})
       for name <- ~w(alice bob carol), do: remote_reaction!(post, name, "announce")
 
       html = render_the_page(conn)
 
-      assert length(row_ids(html, "fediverse_reaction")) == 1
+      assert length(row_ids(html, "fediverse_post")) == 1
+      assert event_kinds(html) == ["fediverse_reaction"]
       assert html =~ "and 1 more"
     end
 
@@ -1019,12 +1005,191 @@ defmodule VutuvWeb.NotificationLiveTest do
 
       {:ok, live, _html} = live(conn, ~p"/notifications?filter=posts")
 
-      assert length(row_ids(render(live), "fediverse_reaction")) == 1
+      assert length(row_ids(render(live), "fediverse_post")) == 1
     end
 
     defp render_the_page(conn) do
       {:ok, live, _html} = live(conn, ~p"/notifications")
       render(live)
+    end
+  end
+
+  describe "one card per post, for everything the fediverse sends back" do
+    alias Vutuv.Posts.PostImage
+
+    test "a favourite, a boost and a reply to one post share one card", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = create_post!(user, %{body: "two kinds of answer"})
+      remote_reaction!(post, "alice", "announce")
+      remote_reaction!(post, "bob", "like")
+      remote_note!(post, "carol", "the delays come down to two factors")
+
+      html = render_the_page(conn)
+
+      # One post, one card — the three verbs are three lines inside it, not
+      # three cards asking the reader which post each one meant.
+      assert length(row_ids(html, "fediverse_post")) == 1
+
+      assert Enum.sort(event_kinds(html)) ==
+               ~w(fediverse_reaction fediverse_reaction fediverse_reply)
+
+      assert html =~ "likes this."
+      assert html =~ "shared this."
+      assert html =~ "replied."
+      assert html =~ "the delays come down to two factors"
+    end
+
+    test "reactions to two posts stay two cards", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      remote_reaction!(create_post!(user, %{body: "the first one"}), "alice", "like")
+      remote_reaction!(create_post!(user, %{body: "the second one"}), "bob", "like")
+
+      html = render_the_page(conn)
+
+      assert length(row_ids(html, "fediverse_post")) == 2
+      assert html =~ "the first one"
+      assert html =~ "the second one"
+    end
+
+    test "the card names the post and opens it", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = create_post!(user, %{body: "warum sind die Züge zu spät"})
+      remote_reaction!(post, "alice", "like")
+
+      {:ok, live, _html} = live(conn, ~p"/notifications")
+
+      assert has_element?(live, "[data-post-card]", "warum sind die Züge zu spät")
+
+      assert has_element?(
+               live,
+               ~s([data-post-card][href="/#{user.username}/posts/#{post.id}"])
+             )
+    end
+
+    test "two images ride the card and the rest are counted", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = create_post!(user, %{body: "fünf Bilder"})
+
+      [first, second, third] =
+        for position <- 0..2,
+            do: insert(:post_image, post: post, user: user, position: position)
+
+      remote_reaction!(post, "alice", "like")
+
+      html = render_the_page(conn)
+
+      # Two thumbnails, then a count: the card's right edge has to sit in the
+      # same place whether a post carries two pictures or twenty.
+      assert html =~ PostImage.url(first, "thumb")
+      assert html =~ PostImage.url(second, "thumb")
+      refute html =~ PostImage.url(third, "thumb")
+      assert html =~ ~s(data-images-more="1")
+    end
+
+    test "a single image rides alone, with no count", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = create_post!(user, %{body: "ein Bild"})
+      image = insert(:post_image, post: post, user: user)
+      remote_reaction!(post, "alice", "like")
+
+      html = render_the_page(conn)
+
+      assert html =~ PostImage.url(image, "thumb")
+      refute html =~ "data-images-more"
+    end
+
+    test "an image the scan still holds never reaches the card", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = create_post!(user, %{body: "noch in Prüfung"})
+      insert(:post_image, post: post, user: user, moderation: "pending")
+      remote_reaction!(post, "alice", "like")
+
+      # The image proxy 404s on an unreleased picture, so a card that linked to
+      # one would draw a broken thumbnail on the reader's own notifications.
+      refute render_the_page(conn) =~ "/post_images/"
+    end
+
+    test "a post with no text says so instead of showing an empty line", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = insert(:post, user: user, body: "")
+      insert(:post_image, post: post, user: user)
+      remote_reaction!(post, "alice", "like")
+
+      html = render_the_page(conn)
+
+      assert html =~ ~s(data-post-card-textless)
+      assert html =~ "Post without text"
+    end
+
+    test "the German is written, not fuzzy-filled from something else", %{conn: conn} do
+      # A brand-new msgid comes out of `gettext.extract --merge` fuzzy-filled
+      # with the translation of whatever looked similar, and nothing fails the
+      # build. vutuv is a German site, so the German is asserted by name.
+      {conn, user} = create_and_login_user(conn)
+      post = create_post!(user, %{body: "die Züge sind zu spät"})
+      remote_reaction!(post, "alice", "like")
+      remote_reaction!(post, "bob", "announce")
+      remote_note!(post, "carol", "das liegt an zwei Faktoren")
+
+      bodyless = insert(:post, user: user, body: "")
+      remote_reaction!(bodyless, "dora", "like")
+
+      {:ok, live, _html} =
+        conn
+        |> recycle()
+        |> put_req_header("accept-language", "de-DE,de;q=0.9")
+        |> live(~p"/notifications")
+
+      html = render(live)
+
+      assert html =~ "gefällt das."
+      assert html =~ "hat das geteilt."
+      assert html =~ "hat geantwortet."
+      assert html =~ "Beitrag ohne Text"
+      assert html =~ "1 Like"
+      assert html =~ "1 Antwort"
+      assert html =~ "1 Mal geteilt"
+    end
+
+    test "the card counts what it holds", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = create_post!(user, %{body: "gut gelaufen"})
+      for name <- ~w(alice bob carol), do: remote_reaction!(post, name, "like")
+      remote_note!(post, "dora", "schöner Beitrag")
+
+      html = render_the_page(conn)
+
+      assert html =~ "3 likes"
+      assert html =~ "1 reply"
+    end
+
+    test "a private reply keeps its warning inside the card", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = create_post!(user, %{body: "why are the trains late"})
+
+      post
+      |> remote_note!("ba_eh", "just between us")
+      |> Ecto.Changeset.change(audience: "direct")
+      |> Vutuv.Repo.update!()
+
+      {:ok, live, _html} = live(conn, ~p"/notifications")
+
+      # The member has to know the reply is private *before* they answer it, so
+      # the notice cannot be a casualty of moving the row into a card.
+      assert has_element?(live, "[data-remote-private]")
+    end
+
+    test "unread reactions keep their own marker per line", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      # A minute back, not "now": the marker and the reaction would otherwise
+      # land in the same second, and `unread?` compares with `:gt`.
+      set_read_marker(user, NaiveDateTime.add(NaiveDateTime.utc_now(:second), -60))
+      post = create_post!(user, %{body: "frisch"})
+      remote_reaction!(post, "alice", "like")
+
+      html = render_the_page(conn)
+
+      assert html =~ ~s(data-unread="true")
     end
   end
 
@@ -1271,6 +1436,13 @@ defmodule VutuvWeb.NotificationLiveTest do
   # Grouped rows carry `id="notification-<kind>-..."` plus a data-kind marker.
   defp row_ids(html, kind) do
     Regex.scan(~r/data-kind="#{kind}"/, html)
+  end
+
+  # The lines inside a post card, one per merged event.
+  defp event_kinds(html) do
+    ~r/data-event-kind="([a-z_]+)"/
+    |> Regex.scan(html)
+    |> Enum.map(fn [_, kind] -> kind end)
   end
 
   defp backdate_follow(%Vutuv.Social.Follow{id: id}, at) do


### PR DESCRIPTION
A like, a boost and a reply from another network arrived as three separate rows on `/notifications`. Each named the senders and the verb but never the post, so a member who had posted more than once that day had to click every row to find out which post anybody meant.

They now sit under one card headed by the post: teaser left, up to two thumbnails right, a `+N` badge from the third picture on so the right edge stays put whatever the picture count. A post with no text puts the picture where the teaser would be, one size larger.

The text preview was already being built and thrown away; the only new query is the batched `Posts.released_images_by_ids/1`, which reuses the moderation filter the feed's rail tiles use. Cards hang off the page rather than off each event — `MountHandoff`'s ETS table does not preserve sharing, measured 15 KB against 437 KB for 30 reactions to one post.

Where: `VutuvWeb.NotificationLive.Groups` (new `"fediverse_post"` group with an `:events` list) and `notification_row/1` in `NotificationLive.Index`.

Local likes and replies keep their own rows for now — worth deciding separately whether they should join the card.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01RLi5x8ZQuf2JmAsqvQjdK3