### PR TITLE
Give the editor's two suggestion lists one shared behaviour

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -2353,7 +2353,7 @@ div.footnotes li:target {
   cursor: pointer;
 }
 .mde__slash-item:hover,
-.mde__slash-item.is-current { background: #eff6ff; color: #1e40af; }
+.mde__slash-item.is-active { background: #eff6ff; color: #1e40af; }
 .mde__slash-glyph {
   flex: none;
   width: 1.35rem;
@@ -2363,7 +2363,7 @@ div.footnotes li:target {
   color: #64748b;
 }
 .mde__slash-item:hover .mde__slash-glyph,
-.mde__slash-item.is-current .mde__slash-glyph { color: inherit; }
+.mde__slash-item.is-active .mde__slash-glyph { color: inherit; }
 .mde__slash-empty { padding: 0.4rem 0.5rem; font-size: 0.8125rem; color: #475569; }
 
 /* --- the footer row (issue #1886) ---
@@ -2733,7 +2733,11 @@ body.mde-fullscreen-lock { overflow: hidden; }
 .mention-picker__list[hidden] { display: none; }
 /* Rows are pointed at with the caret still in the prose, so `.is-active`
    (arrow keys, hover) is the only "where am I" there is — no :focus ever lands
-   here. It has to read as clearly as a focus ring would. */
+   here. It has to read as clearly as a focus ring would. **`.is-active` is the
+   editor's one name for that** (`ACTIVE_CLASS` in assets/js/suggest_list.js):
+   the slash menu spells it the same way, so the two lists the same editor
+   opens cannot drift into disagreeing about what "highlighted" looks like —
+   which they had, as `.is-current` against `.is-active`. */
 .mention-picker__row {
   display: flex;
   align-items: center;
@@ -3414,7 +3418,7 @@ html.lightbox-open { overflow: hidden; }
   }
   .mde__slash-item { color: #e2e8f0; }
   .mde__slash-item:hover,
-  .mde__slash-item.is-current { background: #1e3a8a; color: #dbeafe; }
+  .mde__slash-item.is-active { background: #1e3a8a; color: #dbeafe; }
   .mde__slash-glyph { color: #94a3b8; }
   .mde__slash-empty { color: #94a3b8; }
   .mde__views { background: #1e293b; }

--- a/assets/js/markdown_editor.js
+++ b/assets/js/markdown_editor.js
@@ -58,6 +58,7 @@ import {
   NodeSelection,
   TextSelection,
 } from "@milkdown/kit/prose/state"
+import { ACTIVE_CLASS, markActiveRow, stepIndex, suggestKey } from "./suggest_list"
 import { Decoration, DecorationSet } from "@milkdown/kit/prose/view"
 import { inputRules, InputRule } from "@milkdown/kit/prose/inputrules"
 import { emojiForShortcode, SHORTCODE_AT_CARET } from "./emoji_data.js"
@@ -600,7 +601,7 @@ export const MarkdownEditor = {
     this.wireFoot()
     this.wireSubmitShortcut()
     this.wireSourceEmoji()
-    this.wireMentionKeys()
+    this.wireSuggestKeys()
   },
 
   // Last look at the DOM before morphdom patches it: a manual resize lives in
@@ -1145,20 +1146,29 @@ export const MarkdownEditor = {
     this.mentionRun = null
   },
 
-  // The keys the picker owns, taken in the CAPTURE phase on the way down to the
-  // prose. ProseMirror decides a keystroke by asking its plugins in order, and
-  // the base keymap — which owns Enter and Tab — is registered long before a
-  // plugin added at the end of the stack, so a `handleKeyDown` prop here would
-  // never see the Enter that is meant to take a suggestion. Catching it above
-  // the editable and stopping it there is what makes the list's Enter beat the
-  // paragraph split, and it keeps the two concerns in one place.
-  wireMentionKeys() {
+  // ONE keydown listener for everything the editor's pop-up surfaces claim,
+  // taken in the CAPTURE phase on the way down to the prose (issue #1891).
+  //
+  // Capture, because ProseMirror decides a keystroke by asking its plugins in
+  // order, and the base keymap — which owns Enter and Tab — is registered long
+  // before a plugin added at the end of the stack, so a `handleKeyDown` prop
+  // here would never see the Enter that is meant to take a suggestion.
+  //
+  // One listener, because two on the same element cannot be ordered by
+  // anything a reader can see: `stopPropagation` does not stop a sibling on
+  // the same node, so which of them owned Enter came down to the order of two
+  // lines in `mounted()`. The order is now declared here, in the only place it
+  // can be read — and because the two lists are mutually exclusive by
+  // construction (a run starts with `@` or with `/`, never both), the sequence
+  // below is a statement of intent rather than a tie-break.
+  wireSuggestKeys() {
     this.mountEl.addEventListener(
       "keydown",
       (event) => {
-        const handled = mentionsOpenFor(this.root)
-          ? this.handleMentionKey(event)
-          : event.key === "Backspace" && this.deleteMentionAtCaret()
+        const handled =
+          this.handleSlashKey(event) ||
+          (mentionsOpenFor(this.root) && this.handleMentionKey(event)) ||
+          (event.key === "Backspace" && this.deleteMentionAtCaret())
 
         if (!handled) return
         event.preventDefault()
@@ -1182,23 +1192,18 @@ export const MarkdownEditor = {
   // The keys the open list owns. Everything else falls through to the editor,
   // so typing never stops while it is up.
   handleMentionKey(event) {
-    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
-      moveMention(event.key === "ArrowDown" ? 1 : -1)
-      return true
-    }
-
-    if (event.key === "Enter" || event.key === "Tab") return acceptMention()
-
-    if (event.key === "Escape") {
-      // The editor's full-page mode listens for Escape on `document`, and
-      // dismissing a list is not a request to leave the page you are writing on.
-      event.stopPropagation()
-      this.mentionRun = null
-      closeMentions()
-      return true
-    }
-
-    return false
+    return suggestKey(event, {
+      move: (delta) => moveMention(delta),
+      accept: () => acceptMention(),
+      dismiss: () => {
+        // The editor's full-page mode listens for Escape on `document`, and
+        // dismissing a list is not a request to leave the page you are writing
+        // on. (The caller's own stopPropagation covers the rest.)
+        event.stopPropagation()
+        this.mentionRun = null
+        closeMentions()
+      },
+    })
   },
 
   // Only a CONFIRMED mention is atomic: a handle still being typed has to stay
@@ -1207,7 +1212,7 @@ export const MarkdownEditor = {
   // "the mention the caret is at the end of", so the run the picker offers for
   // and the run Backspace takes can never mean two different things.
   //
-  // Reachable only while the list is CLOSED (see the branch in `wireMentionKeys`),
+  // Reachable only while the list is CLOSED (see the branch in `wireSuggestKeys`),
   // which is the right split rather than an oversight: with suggestions up you
   // are still composing that handle, so Backspace shortens it and narrows the
   // list. Move past the mention — or dismiss the list — and it becomes one
@@ -1580,29 +1585,20 @@ export const MarkdownEditor = {
 
   // The highlighted row is a field, not a class read back out of the DOM: the
   // DOM copy needed clearing in two places and answered "which one" with
-  // whichever came first once a filter had hidden a marked row.
+  // whichever came first once a filter had hidden a marked row. The marking
+  // itself is `markActiveRow`, shared with the mention picker (issue #1891) —
+  // including the `aria-activedescendant` the slash menu shipped without.
   markSlashCurrent(index) {
-    const items = this.slashVisible()
+    // Rows the filter has hidden must lose the mark too, or a widened filter
+    // leaves two rows claiming to be active.
     for (const item of this.slashItems) {
-      item.el.classList.remove("is-current")
+      item.el.classList.remove(ACTIVE_CLASS)
       item.el.setAttribute("aria-selected", "false")
     }
 
-    if (items.length === 0) {
-      this.slashAt = 0
-      this.mountEl.removeAttribute("aria-activedescendant")
-      return
-    }
-
-    this.slashAt = ((index % items.length) + items.length) % items.length
-    const el = items[this.slashAt].el
-    el.classList.add("is-current")
-    el.setAttribute("aria-selected", "true")
-    el.scrollIntoView({ block: "nearest" })
-    // How a screen reader follows a list whose user is not focused on it —
-    // the caret stays in the prose, the same arrangement mention_picker.js
-    // makes for its own rows.
-    this.mountEl.setAttribute("aria-activedescendant", el.id)
+    const items = this.slashVisible()
+    this.slashAt = stepIndex(index, 0, items.length)
+    markActiveRow(items.map((i) => i.el), this.slashAt, this.mountEl)
   },
 
   // Take the "/query" back out before running the block command, or the
@@ -1643,50 +1639,29 @@ export const MarkdownEditor = {
       this.runSlashBlock(item.dataset.mdeBlock)
     })
 
-    // Capture phase, and only while the menu is open. Three rules here are
-    // each a bug that was caught in review:
-    //
-    //   * A MODIFIED key is never ours. Cmd/Ctrl+Enter submits the form
-    //     (issue #1196) from a listener on this same element, in the bubble
-    //     phase — and a capture-phase stopPropagation on an ancestor kills
-    //     it before the event ever reaches the target. Typing "/" and
-    //     pressing Cmd+Enter inserted a heading instead of posting.
-    //   * `stopImmediatePropagation`, not `stopPropagation`: the mention
-    //     picker owns a second capture-phase listener on this very element,
-    //     and stopPropagation does not stop a sibling on the same node. Which
-    //     of the two won was decided by the order of two lines in mounted().
-    //   * Escape must be remembered, not just obeyed — see slashDismissed.
-    this.mountEl.addEventListener(
-      "keydown",
-      (e) => {
-        if (!this.slash || this.slash.hidden) return
-        if (e.metaKey || e.ctrlKey || e.altKey) return
+  },
 
-        const take = () => {
-          e.preventDefault()
-          e.stopImmediatePropagation()
-        }
-        const items = this.slashVisible()
+  // The keys the open slash menu owns, in `suggestKey`'s shape so it answers
+  // them identically to the mention picker. Returns whether it took the event.
+  handleSlashKey(event) {
+    if (!this.slash || this.slash.hidden) return false
 
-        if (e.key === "Escape") {
-          take()
-          this.slashDismissed = this.slashRun && this.slashRun.start
-          return this.closeSlash()
-        }
-        if (e.key === "ArrowDown" || e.key === "ArrowUp") {
-          if (items.length === 0) return
-          take()
-          return this.markSlashCurrent(this.slashAt + (e.key === "ArrowDown" ? 1 : -1))
-        }
-        if (e.key === "Enter" || e.key === "Tab") {
-          const item = items[this.slashAt]
-          if (!item) return
-          take()
-          this.runSlashBlock(item.el.dataset.mdeBlock)
-        }
+    return suggestKey(event, {
+      move: (delta) => this.markSlashCurrent(this.slashAt + delta),
+      accept: () => {
+        const item = this.slashVisible()[this.slashAt]
+        if (!item) return false
+        this.runSlashBlock(item.el.dataset.mdeBlock)
+        return true
       },
-      true
-    )
+      dismiss: () => {
+        // Remembered, not merely obeyed: without this the next transaction
+        // re-derives the predicate and the menu comes straight back, so a line
+        // that is legitimately a path could never be written.
+        this.slashDismissed = this.slashRun && this.slashRun.start
+        this.closeSlash()
+      },
+    })
   },
 
   // Everything that hangs off a position in the prose, shut at once. Three

--- a/assets/js/mention_picker.js
+++ b/assets/js/mention_picker.js
@@ -16,6 +16,8 @@
 // It carries no copy of its own: the labels come from the data-mention-*
 // attributes the server rendered on the editor, because the server is the only
 // side that knows the reader's language.
+import { markActiveRow, stepIndex } from "./suggest_list"
+
 const ROW_ID = (index) => `mention-opt-${index}`
 
 let panel = null
@@ -93,14 +95,7 @@ const pick = (index) => {
 }
 
 const markActive = () => {
-  const rows = [...panel.list.children]
-  rows.forEach((row, index) => {
-    const active = index === session.active
-    row.setAttribute("aria-selected", String(active))
-    row.classList.toggle("is-active", active)
-    if (active) row.scrollIntoView({ block: "nearest" })
-  })
-  session.anchorEl?.setAttribute("aria-activedescendant", rows.length ? ROW_ID(session.active) : "")
+  markActiveRow([...panel.list.children], session.active, session.anchorEl)
 }
 
 const renderRow = (item, index) => {
@@ -238,8 +233,7 @@ export const mentionsOpenFor = (root) => mentionsOpen() && root?.contains(sessio
 // reach backwards than to walk down to.
 export const moveMention = (delta) => {
   if (!mentionsOpen() || session.items.length === 0) return
-  const count = session.items.length
-  session.active = (session.active + delta + count) % count
+  session.active = stepIndex(session.active, delta, session.items.length)
   markActive()
 }
 

--- a/assets/js/suggest_list.js
+++ b/assets/js/suggest_list.js
@@ -1,0 +1,69 @@
+// What the editor's two suggestion lists share (issue #1891).
+//
+// Two of them pop up while you write: the accounts offered after an `@`
+// (mention_picker.js) and the blocks offered after a `/` (the slash menu in
+// markdown_editor.js). They differ in everything that is theirs — where the
+// rows come from, where the panel hangs, what a pick does — and agreed on
+// nothing that is shared, so each grew its own copy of "which row is
+// highlighted", its own wrap arithmetic and its own key handling. The slash
+// menu, written second, shipped without the `aria-activedescendant` half and
+// with three defects the older one had already fixed.
+//
+// So: the *behaviour* lives here, the *rows* stay with whoever renders them.
+// Neither list owns a panel, a fetch or a placement in this file.
+
+// One class for both lists, so the stylesheet describes an active row once.
+export const ACTIVE_CLASS = "is-active"
+
+// Step an index with wrap at both ends — a short list is faster to reach
+// backwards than to walk down to.
+export const stepIndex = (index, delta, count) =>
+  count === 0 ? 0 : (index + delta + count) % count
+
+// Mark one row as the active one and tell the ANCHOR which it is.
+//
+// The anchor is the element that actually holds focus — the contenteditable,
+// or an input — because in both lists the caret never leaves the text being
+// written. `aria-activedescendant` is the whole of how a screen reader follows
+// a listbox its user is not focused on, which is why every row needs an `id`
+// and why an empty list must clear the attribute rather than point at a row
+// that is no longer there.
+export const markActiveRow = (rows, index, anchorEl) => {
+  rows.forEach((row, i) => {
+    const active = i === index
+    row.setAttribute("aria-selected", String(active))
+    row.classList.toggle(ACTIVE_CLASS, active)
+    if (active) row.scrollIntoView({ block: "nearest" })
+  })
+
+  if (!anchorEl) return
+  const active = rows[index]
+  if (active && active.id) anchorEl.setAttribute("aria-activedescendant", active.id)
+  else anchorEl.removeAttribute("aria-activedescendant")
+}
+
+// The keys an open suggestion list owns, in one place so both lists answer
+// them the same way. Returns whether the event was taken — the caller swallows
+// it only then, so ordinary typing never stops while a list is up.
+//
+// A MODIFIED key is never a list key. Cmd/Ctrl+Enter submits the composer
+// (issue #1196) from a listener on the same element, and a list that ate it
+// would turn a post into a heading — which is exactly what the slash menu did
+// before this was written down in one place.
+export const suggestKey = (event, { move, accept, dismiss }) => {
+  if (event.metaKey || event.ctrlKey || event.altKey) return false
+
+  if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+    move(event.key === "ArrowDown" ? 1 : -1)
+    return true
+  }
+
+  if (event.key === "Enter" || event.key === "Tab") return accept()
+
+  if (event.key === "Escape") {
+    dismiss()
+    return true
+  }
+
+  return false
+}

--- a/test/vutuv_web/suggest_list_test.exs
+++ b/test/vutuv_web/suggest_list_test.exs
@@ -1,0 +1,104 @@
+defmodule VutuvWeb.SuggestListTest do
+  @moduledoc """
+  The editor opens two suggestion lists — the accounts offered after an `@`
+  (`assets/js/mention_picker.js`) and the blocks offered after a `/` (the slash
+  menu in `assets/js/markdown_editor.js`). Issue #1891 made them share their
+  behaviour (`assets/js/suggest_list.js`) after the second one shipped with
+  three defects the first had already fixed, and without the
+  `aria-activedescendant` that is the whole of how a screen reader follows a
+  listbox its user is not focused on.
+
+  These are drift guards, not behaviour tests: the behaviour is client-side and
+  `mix test` cannot run it. What they can pin is that the shared module stays
+  the only definition — a second private copy of the wrap arithmetic, the
+  active-row marking or the key table is exactly how the two grew apart the
+  first time, and it is invisible until somebody fixes a bug in one of them.
+  """
+  use ExUnit.Case, async: true
+
+  defp shared, do: File.read!("assets/js/suggest_list.js")
+  defp picker, do: File.read!("assets/js/mention_picker.js")
+  defp editor, do: File.read!("assets/js/markdown_editor.js")
+
+  test "both lists import the shared behaviour" do
+    assert picker() =~ ~s(from "./suggest_list")
+    assert editor() =~ ~s(from "./suggest_list")
+  end
+
+  test "the wrap arithmetic is defined once" do
+    # `(i + delta + count) % count` is the shape both lists had their own copy
+    # of. It belongs to `stepIndex` now; a second one anywhere means the two
+    # can disagree at the ends of a list again.
+    assert shared() =~ "stepIndex"
+
+    for {name, source} <- [{"mention_picker.js", picker()}, {"markdown_editor.js", editor()}] do
+      refute source =~ ~r/\+\s*count\)\s*%\s*count/,
+             "#{name} has its own wrap arithmetic; call stepIndex/3 instead"
+    end
+  end
+
+  test "aria-activedescendant is written in one place" do
+    # Both lists leave the caret in the prose, so this attribute is the only
+    # thing that tells a screen-reader user which row Enter would take. The
+    # slash menu shipped without it precisely because it was a second copy of
+    # code that was never shared.
+    assert shared() =~ "aria-activedescendant"
+
+    for {name, source} <- [{"mention_picker.js", picker()}, {"markdown_editor.js", editor()}] do
+      refute source =~ ~s(setAttribute("aria-activedescendant"),
+             "#{name} sets aria-activedescendant itself; call markActiveRow/3 instead"
+    end
+  end
+
+  test "one class means \"this row is highlighted\"" do
+    # `.is-current` against `.is-active` was the drift: two lists in one editor
+    # describing the same state with different words, so the stylesheet
+    # described it twice and only one of them was ever updated.
+    assert shared() =~ ~s(ACTIVE_CLASS = "is-active")
+
+    css = File.read!("assets/css/components.css")
+    # A SELECTOR, not the bare word: the rule above the mention rows explains
+    # the rename in prose, and a refute on the word alone fails on its own
+    # explanation.
+    refute css =~ ~r/\.[\w-]+\.is-current/,
+           "the stylesheet still styles an .is-current row somewhere"
+
+    assert css =~ ".mention-picker__row.is-active"
+    assert css =~ ".mde__slash-item.is-active"
+  end
+
+  test "a modified key is never a list key (issue #1196 vs #1886)" do
+    # Cmd/Ctrl+Enter submits the composer from a listener on the same element.
+    # A list that swallowed it turned a post into a heading — which is what the
+    # slash menu did before this guard moved into the shared key table.
+    assert shared() =~ "metaKey"
+    assert shared() =~ "ctrlKey"
+  end
+
+  test "the editor keeps ONE keydown listener for its pop-up surfaces" do
+    # Two capture-phase listeners on the same element cannot be ordered by
+    # anything a reader can see: `stopPropagation` does not stop a sibling on
+    # the same node, so priority came down to the order of two lines in
+    # `mounted()`. There is one dispatcher now, and the order is written in it.
+    source = editor()
+
+    assert source =~ "wireSuggestKeys()"
+    # The DEFINITION, not any mention of the name: a comment may still point at
+    # the old one while explaining the change.
+    refute source =~ ~r/^\s{2}wireMentionKeys\(\)\s*\{/m,
+           "the second keydown listener is back"
+
+    # Counting every keydown listener would be the wrong measure — the two
+    # submit shortcuts and the full-screen Escape are all legitimate, and two
+    # of those share `mountEl` quite safely because they are in different
+    # phases. What must stay single is the DISPATCH: each surface's key handler
+    # called from exactly one place, so the order between them is written down
+    # rather than emerging from registration order.
+    for handler <- ~w(handleSlashKey handleMentionKey) do
+      calls = source |> String.split("this.#{handler}(event)") |> length() |> Kernel.-(1)
+
+      assert calls == 1,
+             "#{handler} is dispatched from #{calls} places; it must be exactly one"
+    end
+  end
+end


### PR DESCRIPTION
The editor pops up two lists while you write — accounts after an `@`, blocks after a `/` — and each had its own copy of the same behaviour. The second one was the weaker for it: no `aria-activedescendant`, so arrow keys through the slash menu were announced to nobody, and a different class name for the same highlighted state.

Behaviour moves to `assets/js/suggest_list.js`; the rows stay with whoever renders them. Both now say `.is-active`, so the stylesheet describes a highlighted row once.

The part worth reviewing is the keydown: there was one capture-phase listener per list, on the same element. `stopPropagation` does not stop a sibling on the same node, so which list owned `Enter` came down to the order of two lines in `mounted()`. There is one dispatcher now and the order is written in it.

Verified in a browser, both lists: filter, arrow, take, and `Cmd+Enter` still submitting instead of inserting a heading. The new tests are drift guards — the behaviour is client-side — and are calibrated: bypassing the shared function turns the aria guard red.

Closes #1891

*An AI agent wrote this text in my name. I know that is problematic.*
