### PR TITLE
Make the composer's photo tiles the gallery they are arranging

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1646,6 +1646,12 @@ const Hooks = {
       // author already sees.
       const HOLD_MS = 220
       const LIFT_CLASSES = ["opacity-60", "z-10", "scale-[1.03]", "shadow-xl"]
+      // What the tile under the pointer wears while it is the one that would
+      // be traded with.
+      const OVER_CLASSES = ["ring-2", "ring-brand-500", "z-10"]
+      // A grid container means fixed cells: the same hook drives the composer's
+      // mosaic and the plain overflow row, and only the shape tells them apart.
+      const mosaic = strip.classList.contains("grid")
       let drag = null
 
       const lift = () => {
@@ -1666,6 +1672,7 @@ const Hooks = {
         if (!drag) return
         clearTimeout(drag.timer)
         drag.tile.classList.remove(...LIFT_CLASSES)
+        if (!fromPointerUp) drag.over?.classList.remove(...OVER_CLASSES)
         if (drag.lifted) {
           // A lifted drop must not also open the photo panel: swallow the
           // click the release generates (only on a real pointerup — a
@@ -1681,9 +1688,23 @@ const Hooks = {
               { capture: true, once: true }
             )
           }
-          this.pushEventTo(this.el, "photo-reorder", {
-            order: tiles().map((tile) => tile.dataset.photoTile),
-          })
+          if (mosaic) {
+            // The server swaps the pair; the re-render settles the cells. The
+            // tiles were never moved in the DOM here, so nothing has to be put
+            // back if the drop landed nowhere.
+            const over = drag.over
+            drag.over?.classList.remove(...OVER_CLASSES)
+            if (over && over !== drag.tile) {
+              this.pushEventTo(this.el, "photo-swap", {
+                from: drag.tile.dataset.photoTile,
+                to: over.dataset.photoTile,
+              })
+            }
+          } else {
+            this.pushEventTo(this.el, "photo-reorder", {
+              order: tiles().map((tile) => tile.dataset.photoTile),
+            })
+          }
         }
         drag = null
       }
@@ -1701,6 +1722,8 @@ const Hooks = {
           y: e.clientY,
           touch: e.pointerType !== "mouse",
           lifted: false,
+          // The tile a mosaic drop would trade with, or null.
+          over: null,
           timer: null,
         }
         if (drag.touch) drag.timer = setTimeout(lift, HOLD_MS)
@@ -1721,8 +1744,23 @@ const Hooks = {
           if (moved <= 6) return
           lift()
         }
+        // In a MOSAIC the cells are fixed and a tile cannot be slid between
+        // two others — dropping one onto another trades their places, which is
+        // also the only gesture that means anything on a 2x2 arrangement
+        // (issue #1892). A plain strip keeps sliding: the row has an order,
+        // not a set of seats.
         const { tile, before } = nearest(e.clientX, e.clientY)
         if (!tile) return
+
+        if (mosaic) {
+          if (drag.over !== tile) {
+            drag.over?.classList.remove(...OVER_CLASSES)
+            tile.classList.add(...OVER_CLASSES)
+            drag.over = tile
+          }
+          return
+        }
+
         if (before) strip.insertBefore(drag.tile, tile)
         else strip.insertBefore(drag.tile, tile.nextSibling)
       })

--- a/lib/vutuv_web/live/post_live/composer.ex
+++ b/lib/vutuv_web/live/post_live/composer.ex
@@ -160,10 +160,10 @@ defmodule VutuvWeb.PostLive.Composer do
     # page seeds a Markdown blockquote when the reader marked part of the post
     # before pressing Reply (issue #1114). An edited post's own body wins.
     |> assign(:body, (post && post.body) || socket.assigns[:initial_body] || "")
-    # Whether the folded licence/download row is opened. Starts folded even on
-    # edit — the fold names the answers in force, and a reconnect that resets
-    # the flag hides no data (the values live in assigns and the draft).
-    |> assign(:photo_details_open?, false)
+    # Whether the gallery sheet is open — the one place the arrangement, the
+    # fit and the two rights questions live (issue #1892). Closed on mount and
+    # after a reconnect: it holds no data of its own, only a view of assigns.
+    |> assign(:gallery_open?, false)
     |> assign(:tags_value, tags_value(post))
     |> assign(:images, images)
     # The per-photo settings the composer is editing (issue #1104), keyed by
@@ -182,7 +182,6 @@ defmodule VutuvWeb.PostLive.Composer do
     # photo tapped first, highlighted until its partner (or the same photo
     # again, to cancel) is tapped. Event-driven on purpose — tap-tap needs no
     # drag, so it works the same on a phone and a desktop.
-    |> assign(:swap_photo, nil)
     |> assign(:license, initial_license(post, socket.assigns.current_user))
     |> assign(:language, initial_language(post))
     |> assign(:preset, preset)
@@ -419,11 +418,47 @@ defmodule VutuvWeb.PostLive.Composer do
     }
   end
 
+  # The mosaic's own tiles, and the ones it has no room for (issue #1892).
+  # `mosaic_layout/2` caps at five, which is what the post will show — but the
+  # composer holds up to ten, and every one of them has to stay reachable or a
+  # sixth photo could never be removed again.
+  # `@bento` is `false` rather than nil when there is nothing to arrange (the
+  # render builds it with `length(images) > 1 && …`), so both of these match on
+  # the map instead of on the absence — a `nil` clause alone let a
+  # single-photo composer through to `bento.cells` and raised BadMapError.
+  defp gallery_tiles(_images, %{cells: cells}), do: Enum.map(cells, & &1.image)
+  defp gallery_tiles(images, _bento), do: images
+
+  defp overflow_photos(images, %{cells: cells}) do
+    shown = MapSet.new(cells, & &1.image.id)
+    Enum.reject(images, &MapSet.member?(shown, &1.id))
+  end
+
+  defp overflow_photos(_images, _bento), do: []
+
+  # The 12×6 grid the arrangements are written on, and the frame aspect the
+  # hero's orientation picked. Both come straight from `mosaic_layout/2`, so
+  # the composer's mosaic and the published one cannot disagree.
+  defp bento_grid_style(bento) do
+    "aspect-ratio: #{bento.aspect}; " <>
+      "grid-template-columns: repeat(12, 1fr); grid-template-rows: repeat(6, 1fr); " <>
+      "max-height: 32rem"
+  end
+
+  defp bento_cell_style(bento, index) do
+    case Enum.at(bento.cells, index) do
+      %{area: area} -> "grid-area: #{area}"
+      _ -> nil
+    end
+  end
+
   defp photo_settings(photos, %PostImage{} = image),
     do: Map.get(photos, image.id) || photo_defaults(image)
 
-  defp photo_setting(photos, %PostImage{} = image, key),
-    do: photos |> photo_settings(image) |> Map.fetch!(key)
+  # (`photo_setting/3` read one key for the inline caption input and camera
+  # switch under each tile. Issue #1892 moved both into the photo's sheet,
+  # which takes the whole settings map, so the single-key reader has no
+  # callers left.)
 
   # Whether the photo has an accessible name: an alt, or the caption that
   # `PostComponents.photo_alt/1` falls back to. The amber ALT nudge shows
@@ -683,9 +718,29 @@ defmodule VutuvWeb.PostLive.Composer do
 
   # The folded licence/download row (the two rights questions) opens on
   # request and stays open; the fold itself names the answers in force.
-  def handle_event("toggle-photo-details", _params, socket) do
-    {:noreply, assign(socket, :photo_details_open?, not socket.assigns.photo_details_open?)}
+  # The one control for everything that belongs to the SET rather than to a
+  # single photo (issue #1892): the arrangement, the fit, and the two rights
+  # questions that used to sit in a folded row of their own.
+  def handle_event("gallery-open", _params, socket) do
+    {:noreply, socket |> assign(:gallery_open?, true) |> assign(:open_photo, nil)}
   end
+
+  def handle_event("gallery-close", _params, socket) do
+    {:noreply, assign(socket, :gallery_open?, false)}
+  end
+
+  # A drag dropped one tile onto another. The tap-tap swap this replaces needed
+  # a "which photo is marked" mode; a drag says both ends in one gesture, so
+  # the mode is gone with it.
+  def handle_event("photo-swap", %{"from" => from, "to" => to}, socket)
+      when is_binary(from) and is_binary(to) and from != to do
+    {:noreply,
+     socket
+     |> assign(:images, swap_images(socket.assigns.images, from, to))
+     |> schedule_draft_save()}
+  end
+
+  def handle_event("photo-swap", _params, socket), do: {:noreply, socket}
 
   def handle_event("photo-open", %{"id" => id}, socket) do
     # Tapping the open photo's ⚙ again closes it — the same button, so nobody
@@ -764,26 +819,10 @@ defmodule VutuvWeb.PostLive.Composer do
     {:noreply, socket |> assign(:images, reordered ++ missing) |> schedule_draft_save()}
   end
 
-  # The bento preview's tap-tap swap: the first tap marks a photo, the second
-  # trades the two places (tapping the marked photo again unmarks it). Chosen
-  # over drag because it needs no pointer gymnastics on a phone and stays a
-  # plain pair of clicks in a test.
-  def handle_event("mosaic-swap", %{"id" => id}, socket) do
-    case socket.assigns.swap_photo do
-      nil ->
-        {:noreply, assign(socket, :swap_photo, id)}
-
-      ^id ->
-        {:noreply, assign(socket, :swap_photo, nil)}
-
-      other_id ->
-        {:noreply,
-         socket
-         |> assign(:images, swap_images(socket.assigns.images, other_id, id))
-         |> assign(:swap_photo, nil)
-         |> schedule_draft_save()}
-    end
-  end
+  # (`mosaic-swap` was the preview's tap-tap swap — first tap marks a photo,
+  # second trades the places. It needed a "which photo is marked" mode and a
+  # preview to tap in; issue #1892 put the tiles themselves in the mosaic, so a
+  # drag now says both ends in one gesture and `photo-swap` above replaced it.)
 
   # The bento pattern chips ("Muster"). "" is the Auto chip; an unknown name
   # (a stale chip after photos were removed) falls back to auto the same way.
@@ -836,7 +875,6 @@ defmodule VutuvWeb.PostLive.Composer do
            :open_photo,
            if(socket.assigns.open_photo == id, do: nil, else: socket.assigns.open_photo)
          )
-         |> update(:swap_photo, &if(&1 == id, do: nil, else: &1))
          |> schedule_draft_save()}
     end
   end
@@ -1077,8 +1115,7 @@ defmodule VutuvWeb.PostLive.Composer do
     |> assign(:open_photo, nil)
     |> assign(:layout, nil)
     |> assign(:fill?, false)
-    |> assign(:swap_photo, nil)
-    |> assign(:photo_details_open?, false)
+    |> assign(:gallery_open?, false)
     |> assign(:error, nil)
   end
 
@@ -1420,28 +1457,31 @@ defmodule VutuvWeb.PostLive.Composer do
           first, whether or not pictures join it below. --%>
           <.body_editor id={@id} body={@body} post={@post} seed={@editor_seed} />
 
-          <%!-- The photo grid, whenever photos are attached: they come large
-          in their own aspect ratio, with their caption and camera switch in
-          plain sight under every tile — nothing to hunt for behind ⚙, which
-          keeps only the rarer refinements (alt text, download override).
-          Adding more is a tile of its own, the way every photo tool does it.
-          Tiles reorder by pointer drag everywhere — the PhotoStrip hook
-          lifts a tile after a short hold on touch (so ordinary scrolling
-          over the photos keeps working) and on the first movement with a
-          mouse; the first tile leads the mosaic. Each tile carries a DOM id
-          so morphdom keys it: a drag has already moved the node when the
-          server's re-render arrives, and the patch then just settles it. --%>
-          <%!-- No phx-drop-target of its own: the whole form is the drop
-          zone now, and nesting a second one would steal the active state
-          from the overlay. The data-crop-* attributes carry the crop
-          dialog's translated copy (assets/js/photo_crop.js), server-worded
-          like the lightbox labels. --%>
+          <%!-- **The photos ARE the gallery** (issue #1892). They used to be a
+          plain grid with a small live preview of the arrangement further down,
+          so the author tuned a mosaic by looking at a copy of it. Now the
+          tiles are laid out in the very mosaic the feed will draw — the same
+          `mosaic_layout/2` the post card renders from — and dragging one onto
+          another swaps them in it.
+
+          Decisions about one photo used to live in four places (a caption
+          field under the tile, the ⚙ panel, that workshop, and a folded
+          licence row). They live in two now: the photo's own sheet, opened by
+          tapping it, and one **Galerie** control for the choices that belong
+          to the set. What stays on the tile is only what acts directly on the
+          picture — remove and crop.
+
+          No phx-drop-target of its own: the whole form is the drop zone, and
+          nesting a second one would steal the active state from the overlay.
+          The data-crop-* attributes carry the crop dialog's translated copy
+          (assets/js/photo_crop.js), server-worded like the lightbox labels. --%>
           <div
             :if={@images != []}
             id={"#{@id}-images"}
             phx-hook="PhotoStrip"
             phx-target={@myself}
-            class="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-3"
+            class={["mt-3", @bento && "grid gap-1 overflow-hidden rounded-xl"]}
+            style={@bento && bento_grid_style(@bento)}
             data-crop-title={gettext("Crop photo")}
             data-crop-hint={
               gettext("Pick a shape, then drag and zoom. The framed part is what the post shows.")
@@ -1451,237 +1491,97 @@ defmodule VutuvWeb.PostLive.Composer do
             data-crop-reset={gettext("Whole photo")}
             data-crop-zoom={gettext("Zoom")}
           >
+            <%!-- Each tile carries a DOM id so morphdom keys it: a drag has
+            already moved the node when the server's re-render arrives, and the
+            patch then just settles it. --%>
             <div
-              :for={{image, index} <- Enum.with_index(@images)}
+              :for={{image, index} <- Enum.with_index(gallery_tiles(@images, @bento))}
               id={"#{@id}-photo-#{image.id}"}
               data-photo-tile={image.id}
-              class="min-w-0"
+              style={@bento && bento_cell_style(@bento, index)}
+              class="relative min-w-0"
             >
               <.photo_frame
                 image={image}
                 index={index}
                 count={length(@images)}
+                bento?={!!@bento}
+                fill?={@fill?}
                 open?={@open_photo == image.id}
                 alt_missing?={photo_described?(@photos, image) == false}
                 myself={@myself}
               />
+            </div>
+          </div>
 
-              <div class="mt-1.5 space-y-1.5">
-                <%!-- One visible text per photo: the caption. It doubles as
-                the accessible name when no alt is written (photo_alt/1), so
-                the alt input can stay an opt-in refinement in the panel
-                instead of a second required-looking field. Full input size
-                on purpose: a shrunken input is a shrunken touch target. --%>
-                <input
-                  type="text"
-                  name={"photo[#{image.id}][caption]"}
-                  value={photo_setting(@photos, image, :caption)}
-                  phx-debounce="300"
-                  placeholder={gettext("Caption (optional)")}
-                  class={input_class()}
+          <%!-- Photos past the mosaic's five tiles. The post will not show
+          them, and saying so is better than hiding them behind a "+3" the
+          author cannot open: they stay tappable and removable, and dragging
+          one into the mosaic is how it gets seen. --%>
+          <div :if={overflow_photos(@images, @bento) != []} class="mt-2">
+            <p class="mb-1.5 text-xs text-slate-600 dark:text-slate-400">
+              {gettext("Not shown in the gallery — drag one into it to swap.")}
+            </p>
+            <div
+              id={"#{@id}-overflow"}
+              phx-hook="PhotoStrip"
+              phx-target={@myself}
+              class="flex flex-wrap gap-2"
+            >
+              <div
+                :for={image <- overflow_photos(@images, @bento)}
+                id={"#{@id}-photo-#{image.id}"}
+                data-photo-tile={image.id}
+                class="relative w-20"
+              >
+                <.photo_frame
+                  image={image}
+                  index={-1}
+                  count={length(@images)}
+                  bento?={false}
+                  fill?={@fill?}
+                  open?={@open_photo == image.id}
+                  alt_missing?={photo_described?(@photos, image) == false}
+                  myself={@myself}
                 />
-
-                <%!-- The photographer's marquee switch, right where the photo
-                is — behind the tile's ⚙ nobody found it. Only rendered when
-                the file actually carries camera facts, and it shows the very
-                line visitors would see. --%>
-                <label
-                  :if={PostImage.camera_info?(image)}
-                  data-photo-camera-inline={image.id}
-                  class="flex items-start gap-2 py-1 text-sm text-slate-700 dark:text-slate-200"
-                >
-                  <input
-                    type="checkbox"
-                    checked={photo_setting(@photos, image, :show_camera_info)}
-                    phx-click="photo-toggle"
-                    phx-value-id={image.id}
-                    phx-value-field="show_camera_info"
-                    phx-target={@myself}
-                    class={checkbox_class()}
-                  />
-                  <span class="min-w-0">
-                    <span class="font-semibold">{gettext("Show camera settings")}</span>
-                    <span class="mt-0.5 block text-xs text-slate-600 dark:text-slate-400">
-                      {PostComponents.camera_line(image)}
-                    </span>
-                  </span>
-                </label>
               </div>
             </div>
+          </div>
 
-            <%!-- Adding more photos is a tile among tiles. It shares its id
-            with the bottom row's picker (exactly one of the two renders, so
-            the upload input exists exactly once), which is how the feed's
-            camera button always finds a target to click. --%>
+          <%!-- One row under the pictures: the way to add more, and the one
+          control for everything that belongs to the set rather than to a
+          single photo. The chip names what is in force, so the arrangement is
+          readable without opening it. --%>
+          <div :if={@images != []} class="mt-2 flex flex-wrap items-center gap-2">
             <label
               id={"#{@id}-add-photos"}
-              data-photo-add-tile
-              class="flex aspect-square cursor-pointer flex-col items-center justify-center gap-1.5 rounded-lg border-2 border-dashed border-slate-300 text-slate-600 hover:border-brand-400 hover:bg-brand-50/50 hover:text-brand-700 dark:border-slate-700 dark:text-slate-400 dark:hover:border-brand-500 dark:hover:bg-brand-900/20 dark:hover:text-brand-200"
+              class="inline-flex h-9 mb-0 shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-lg bg-slate-100 px-3 text-sm font-semibold text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
             >
-              <.camera_icon class="h-6 w-6" />
-              <span class="px-2 text-center text-xs font-semibold">{gettext("Add photos")}</span>
+              📷 {gettext("Add photos")}
               <.live_file_input upload={@uploads.images} class="sr-only" />
             </label>
-          </div>
 
-          <p
-            :if={length(@images) > 1}
-            class="mt-1.5 text-xs text-slate-600 dark:text-slate-400"
-          >
-            {gettext("Drag to reorder. The first photo leads the gallery.")}
-          </p>
-
-          <%!-- The bento workshop (only with something to arrange): the very
-          mosaic the feed will show, live. Tap two tiles to swap the photos;
-          the chips switch the arrangement ("Muster") — each chip is that
-          arrangement's real geometry in miniature, drawn from the same
-          catalog the mosaic renders from. "Auto" keeps the orientation-aware
-          choice and stays the default. --%>
-          <div :if={@bento} class="mt-4" data-bento-editor>
-            <div class="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
-              <span class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                {gettext("Gallery preview")}
-              </span>
-              <span class="text-xs text-slate-600 dark:text-slate-400">
-                {gettext("Tap two photos to swap them.")}
-              </span>
-            </div>
-
-            <div class="mt-2 flex flex-wrap items-center gap-2">
-              <button
-                type="button"
-                phx-click="mosaic-pattern"
-                phx-value-name=""
-                phx-target={@myself}
-                aria-pressed={to_string(is_nil(@layout))}
-                data-bento-pattern="auto"
-                class={[
-                  "h-10 shrink-0 rounded-lg px-3 text-sm font-semibold ring-1",
-                  (is_nil(@layout) &&
-                     "bg-brand-50 text-brand-700 ring-2 ring-brand-500 dark:bg-brand-900/40 dark:text-brand-100") ||
-                    "text-slate-700 ring-slate-300 hover:bg-slate-100 dark:text-slate-200 dark:ring-slate-700 dark:hover:bg-slate-800"
-                ]}
-              >
-                {gettext("Auto")}
-              </button>
-
-              <button
-                :for={variant <- GalleryLayout.variants(min(length(@images), 5))}
-                type="button"
-                phx-click="mosaic-pattern"
-                phx-value-name={variant.name}
-                phx-target={@myself}
-                aria-pressed={to_string(@layout == variant.name)}
-                aria-label={layout_label(variant.name)}
-                title={layout_label(variant.name)}
-                data-bento-pattern={variant.name}
-                class={[
-                  "h-10 w-14 shrink-0 rounded-lg p-1.5",
-                  (@layout == variant.name &&
-                     "bg-brand-50 ring-2 ring-brand-500 dark:bg-brand-900/40") ||
-                    "ring-1 ring-slate-300 hover:bg-slate-100 dark:ring-slate-700 dark:hover:bg-slate-800"
-                ]}
-              >
-                <span
-                  class="grid h-full w-full gap-0.5"
-                  style="grid-template-columns: repeat(12, 1fr); grid-template-rows: repeat(6, 1fr)"
-                >
-                  <span
-                    :for={area <- variant.areas}
-                    style={"grid-area: #{area}"}
-                    class={[
-                      "rounded-[2px]",
-                      (@layout == variant.name && "bg-brand-500") ||
-                        "bg-slate-400 dark:bg-slate-500"
-                    ]}
-                  />
-                </span>
-              </button>
-            </div>
-
-            <%!-- The fit pair: whole photos (default) or tiles filled by
-            their photos, which crops them. Whole is the default on purpose —
-            nobody's picture loses its edges unless the author asks. --%>
-            <div class="mt-2 flex flex-wrap items-center gap-2">
-              <button
-                type="button"
-                phx-click="mosaic-fit"
-                phx-value-fill="false"
-                phx-target={@myself}
-                aria-pressed={to_string(not @fill?)}
-                data-bento-fit="whole"
-                class={[
-                  "h-10 shrink-0 rounded-lg px-3 text-sm font-semibold",
-                  (!@fill? &&
-                     "bg-brand-50 text-brand-700 ring-2 ring-brand-500 dark:bg-brand-900/40 dark:text-brand-100") ||
-                    "text-slate-700 ring-1 ring-slate-300 hover:bg-slate-100 dark:text-slate-200 dark:ring-slate-700 dark:hover:bg-slate-800"
-                ]}
-              >
-                {gettext("Whole photos")}
-              </button>
-              <button
-                type="button"
-                phx-click="mosaic-fit"
-                phx-value-fill="true"
-                phx-target={@myself}
-                aria-pressed={to_string(@fill?)}
-                data-bento-fit="fill"
-                class={[
-                  "h-10 shrink-0 rounded-lg px-3 text-sm font-semibold",
-                  (@fill? &&
-                     "bg-brand-50 text-brand-700 ring-2 ring-brand-500 dark:bg-brand-900/40 dark:text-brand-100") ||
-                    "text-slate-700 ring-1 ring-slate-300 hover:bg-slate-100 dark:text-slate-200 dark:ring-slate-700 dark:hover:bg-slate-800"
-                ]}
-              >
-                {gettext("Fill the tiles")}
-              </button>
-              <span class="text-xs text-slate-600 dark:text-slate-400">
-                {if @fill?,
-                  do: gettext("Each photo covers its tile and is cropped by it."),
-                  else: gettext("Each photo shows whole inside its tile.")}
-              </span>
-            </div>
-
-            <div
-              class="mt-2 grid gap-1 overflow-hidden rounded-lg"
-              style={"aspect-ratio: #{@bento.aspect}; grid-template-columns: repeat(12, 1fr); grid-template-rows: repeat(6, 1fr); max-height: 44rem"}
-              data-bento-preview
+            <button
+              type="button"
+              id={"#{@id}-gallery-open"}
+              phx-click="gallery-open"
+              phx-target={@myself}
+              data-gallery-open
+              class="inline-flex h-9 items-center gap-2 rounded-lg border border-slate-200 px-3 text-sm font-semibold text-slate-700 hover:border-brand-400 hover:text-brand-700 dark:border-slate-700 dark:text-slate-200 dark:hover:border-brand-500 dark:hover:text-brand-200"
             >
-              <button
-                :for={cell <- @bento.cells}
-                type="button"
-                phx-click="mosaic-swap"
-                phx-value-id={cell.image.id}
-                phx-target={@myself}
-                style={"grid-area: #{cell.area}"}
-                aria-pressed={to_string(@swap_photo == cell.image.id)}
-                aria-label={gettext("Swap this photo with another")}
-                title={gettext("Swap this photo with another")}
-                data-bento-tile={cell.image.id}
-                class="relative cursor-pointer overflow-hidden bg-slate-100 ring-1 ring-slate-200 focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-brand-500 dark:bg-slate-800 dark:ring-slate-800"
-              >
-                <img
-                  src={PostImage.url(cell.image, "feed")}
-                  alt=""
-                  class={["h-full w-full", (@fill? && "object-cover") || "object-contain"]}
-                />
-                <span
-                  :if={@swap_photo == cell.image.id}
-                  class="absolute inset-0 flex items-center justify-center bg-brand-600/50 text-3xl font-semibold text-white"
-                  data-bento-swap-marked
-                >
-                  ⇄
-                </span>
-                <span
-                  :if={cell.more > 0}
-                  class="pointer-events-none absolute inset-0 flex items-center justify-center bg-slate-900/55 text-2xl font-semibold text-white"
-                >
-                  +{compact_count(cell.more)}
-                </span>
-              </button>
-            </div>
-          </div>
+              <%!-- Named for what it holds. With one photo there is no
+              arrangement to speak of, and calling that "Gallery" would promise
+              a choice the sheet does not offer — but the licence and the
+              download answer still have to be reachable, which is exactly what
+              the folded row this replaces was for. --%>
+              {(@bento && "#{gettext("Gallery")} · #{layout_label(@layout) || gettext("Automatic")}") ||
+                "#{gettext("Photo details")} · #{PhotoLicense.label(@license)}"}
+            </button>
 
+            <p :if={@bento} class="text-xs text-slate-600 dark:text-slate-400">
+              {gettext("Drag one photo onto another to swap them.")}
+            </p>
+          </div>
           <%!-- In-flight uploads --%>
           <div :for={entry <- @uploads.images.entries} class="mt-2 flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
             <span class="truncate">{entry.client_name}</span>
@@ -1700,6 +1600,18 @@ defmodule VutuvWeb.PostLive.Composer do
             </p>
           </div>
 
+          <.gallery_sheet
+            :if={@gallery_open? and @images != []}
+            bento={@bento}
+            images={@images}
+            layout={@layout}
+            fill?={@fill?}
+            license={@license}
+            download_choice={@download_choice}
+            id={"#{@id}-gallery"}
+            myself={@myself}
+          />
+
           <.photo_panel
             :if={open_photo(@images, @open_photo)}
             image={open_photo(@images, @open_photo)}
@@ -1708,119 +1620,6 @@ defmodule VutuvWeb.PostLive.Composer do
             id={"#{@id}-photo-panel"}
             myself={@myself}
           />
-
-          <%!-- The two questions about the pictures themselves — who may reuse
-          them, and what a visitor can actually save — behind one collapsed
-          row that appears with the first photo. Someone stapling a screenshot
-          to a text is not publishing a picture, so they are never made to
-          rule on reuse rights and original files as the price of an ordinary
-          post (the spirit of issue #1157): the fold names the answers in
-          force and can simply be ignored, while a photographer is one tap
-          away. The selects render only while open, so a save with the row
-          folded falls back to the stored value and cannot reset it. --%>
-          <div :if={@images != []} class="mt-3">
-            <button
-              type="button"
-              id={"#{@id}-photo-details-toggle"}
-              data-photo-details-toggle
-              phx-click="toggle-photo-details"
-              phx-target={@myself}
-              aria-expanded={to_string(@photo_details_open?)}
-              aria-controls={"#{@id}-photo-details"}
-              class="-ml-2 inline-flex min-h-9 flex-wrap items-center gap-x-1.5 gap-y-0.5 rounded-lg px-2 py-1.5 text-left text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100"
-            >
-              <span aria-hidden="true" class="text-xs">
-                {if @photo_details_open?, do: "▾", else: "▸"}
-              </span>
-              {gettext("Photo details")}
-              <span class="font-normal text-slate-500 dark:text-slate-400">
-                · {PhotoLicense.label(@license)} · {download_label(@download_choice)}
-              </span>
-            </button>
-
-            <div :if={@photo_details_open?} id={"#{@id}-photo-details"} class="mt-2 space-y-2">
-              <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
-                <label
-                  for={"#{@id}-license"}
-                  class="text-sm font-medium text-slate-600 dark:text-slate-400"
-                >
-                  {gettext("Licence")}
-                </label>
-                <select
-                  name="post[license]"
-                  id={"#{@id}-license"}
-                  title={gettext("Who may reuse these photos")}
-                  class={compact_select_class()}
-                >
-                  <option
-                    :for={license <- PhotoLicense.values()}
-                    value={license}
-                    selected={@license == license}
-                  >
-                    {PhotoLicense.label(license)}
-                  </option>
-                </select>
-              </div>
-
-              <%!-- What a visitor gets is the licence's practical half, and
-              it is one answer for the whole set. The panel keeps the
-              per-photo override, so a post whose photos disagree reads
-              "Different per photo" rather than pretending the set agrees. --%>
-              <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
-                <label
-                  for={"#{@id}-download"}
-                  class="text-sm font-medium text-slate-600 dark:text-slate-400"
-                >
-                  {gettext("Download")}
-                </label>
-                <select
-                  name="post[download]"
-                  id={"#{@id}-download"}
-                  phx-change="download-choice"
-                  phx-target={@myself}
-                  title={gettext("What a visitor can save")}
-                  class={compact_select_class()}
-                >
-                  <option value="none" selected={@download_choice == "none"}>
-                    {download_label("none")}
-                  </option>
-                  <option value="clean" selected={@download_choice == "clean"}>
-                    {download_label("clean")}
-                  </option>
-                  <option value="exact" selected={@download_choice == "exact"}>
-                    {download_label("exact")}
-                  </option>
-                  <option :if={@download_choice == "mixed"} value="mixed" selected>
-                    {download_label("mixed")}
-                  </option>
-                </select>
-              </div>
-
-              <%!-- The two things that make the choice an informed one, each
-              shown at the moment it applies rather than as a standing notice
-              nobody reads. --%>
-              <p
-                :if={@download_choice == "exact" and located_photos(@images) > 0}
-                class="rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-800 ring-1 ring-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:ring-amber-800"
-                data-download-gps-warning
-              >
-                {ngettext(
-                  "This photo carries the location it was taken at, and the exact file hands it over.",
-                  "Some of these photos carry the location they were taken at, and the exact file hands it over.",
-                  located_photos(@images)
-                )}
-              </p>
-              <p
-                :if={@download_choice == "clean" and uncleanable?(@images)}
-                class="rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-800 ring-1 ring-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:ring-amber-800"
-                data-download-clean-notice
-              >
-                {gettext(
-                  "A file whose format cannot be cleaned is handed out exactly as uploaded."
-                )}
-              </p>
-            </div>
-          </div>
 
           <%!-- Tags get their own full-width row. --%>
           <.tag_input
@@ -2139,18 +1938,31 @@ defmodule VutuvWeb.PostLive.Composer do
   attr(:count, :integer, required: true)
   attr(:open?, :boolean, required: true)
   attr(:alt_missing?, :boolean, required: true)
+  attr(:bento?, :boolean, default: false)
+  attr(:fill?, :boolean, default: false)
   attr(:myself, :any, required: true)
 
   defp photo_frame(assigns) do
-    assigns = assign(assigns, :ratio_style, natural_ratio(assigns.image))
+    # Inside the mosaic the cell decides the shape — that IS the arrangement —
+    # so the tile fills it and the picture is fitted by `@fill?`, exactly as
+    # the published gallery does it. Outside it (one photo, or one the mosaic
+    # has no room for) the photo's own ratio decides, as before.
+    assigns =
+      assign(
+        assigns,
+        :ratio_style,
+        if(assigns.bento?, do: nil, else: natural_ratio(assigns.image))
+      )
 
     ~H"""
     <div
       data-photo-drag={@image.id}
       style={@ratio_style}
       class={[
-        "group relative overflow-hidden rounded-lg ring-1",
-        !@ratio_style && "aspect-square",
+        "group relative overflow-hidden ring-1",
+        @bento? && "h-full w-full",
+        !@bento? && "rounded-lg",
+        !@bento? && !@ratio_style && "aspect-square",
         (@open? && "ring-2 ring-brand-500") || "ring-slate-200 dark:ring-slate-800"
       ]}
     >
@@ -2177,7 +1989,7 @@ defmodule VutuvWeb.PostLive.Composer do
           src={PostImage.url(@image, "feed")}
           alt=""
           draggable="false"
-          class="h-full w-full object-cover"
+          class={["h-full w-full", (@bento? && !@fill? && "object-contain") || "object-cover"]}
         />
       </button>
 
@@ -2329,6 +2141,213 @@ defmodule VutuvWeb.PostLive.Composer do
   end
 
   @doc """
+  Everything that belongs to the SET of photos rather than to one of them
+  (issue #1892): the arrangement, how the pictures sit in it, and the two
+  rights questions.
+
+  It exists because those three used to be three separate places — a bento
+  workshop with its own live preview, a folded "Photo details" row, and the
+  post-wide download select inside it — stacked down the composer under a grid
+  that was itself a fourth. The tiles are the mosaic now, so the workshop had
+  nothing left to preview; what remains is a set of choices, and a set of
+  choices is a sheet you open when you want it.
+
+  The licence and download selects render only while it is open, so a save with
+  the sheet closed falls back to the stored value and cannot reset them — the
+  same guarantee the folded row gave.
+  """
+  attr(:bento, :any, required: true)
+  attr(:images, :list, required: true)
+  attr(:layout, :any, required: true)
+  attr(:fill?, :boolean, required: true)
+  attr(:license, :string, required: true)
+  attr(:download_choice, :string, required: true)
+  attr(:id, :string, required: true)
+  attr(:myself, :any, required: true)
+
+  def gallery_sheet(assigns) do
+    ~H"""
+    <div
+      id={@id}
+      data-gallery-sheet
+      class="mt-3 rounded-xl bg-slate-50 p-4 ring-1 ring-slate-200 dark:bg-slate-800/50 dark:ring-slate-700"
+    >
+      <div class="flex items-start justify-between gap-3">
+        <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          {(@bento && gettext("Gallery")) || gettext("Photo details")}
+        </h3>
+        <button
+          type="button"
+          phx-click="gallery-close"
+          phx-target={@myself}
+          aria-label={gettext("Close")}
+          class="-mt-1 shrink-0 rounded-lg px-2 py-1 text-sm font-semibold text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800"
+        >
+          ✕
+        </button>
+      </div>
+
+      <%!-- Each chip is that arrangement's real geometry in miniature, drawn
+      from the same catalog the mosaic renders from — so the choice is made by
+      looking at the shape rather than by reading a name for it. Only with
+      something to arrange: one photo has no arrangement, and the two rights
+      questions below are then the whole sheet. --%>
+      <div :if={@bento} class="mt-3 flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          phx-click="mosaic-pattern"
+          phx-value-name=""
+          phx-target={@myself}
+          aria-pressed={to_string(is_nil(@layout))}
+          data-bento-pattern="auto"
+          class={[
+            "h-10 shrink-0 rounded-lg px-3 text-sm font-semibold ring-1",
+            (is_nil(@layout) &&
+               "bg-brand-50 text-brand-700 ring-2 ring-brand-500 dark:bg-brand-900/40 dark:text-brand-100") ||
+              "text-slate-700 ring-slate-300 hover:bg-slate-100 dark:text-slate-200 dark:ring-slate-700 dark:hover:bg-slate-800"
+          ]}
+        >
+          {gettext("Automatic")}
+        </button>
+
+        <button
+          :for={variant <- GalleryLayout.variants(min(length(@images), 5))}
+          type="button"
+          phx-click="mosaic-pattern"
+          phx-value-name={variant.name}
+          phx-target={@myself}
+          aria-pressed={to_string(@layout == variant.name)}
+          aria-label={layout_label(variant.name)}
+          title={layout_label(variant.name)}
+          data-bento-pattern={variant.name}
+          class={[
+            "h-10 w-14 shrink-0 rounded-lg p-1.5",
+            (@layout == variant.name &&
+               "bg-brand-50 ring-2 ring-brand-500 dark:bg-brand-900/40") ||
+              "ring-1 ring-slate-300 hover:bg-slate-100 dark:ring-slate-700 dark:hover:bg-slate-800"
+          ]}
+        >
+          <span
+            class="grid h-full w-full gap-0.5"
+            style="grid-template-columns: repeat(12, 1fr); grid-template-rows: repeat(6, 1fr)"
+          >
+            <span
+              :for={area <- variant.areas}
+              style={"grid-area: #{area}"}
+              class={[
+                "rounded-[2px]",
+                (@layout == variant.name && "bg-brand-500") || "bg-slate-400 dark:bg-slate-500"
+              ]}
+            />
+          </span>
+        </button>
+      </div>
+
+      <%!-- Whole photos (default) or tiles filled by their photos, which crops
+      them. Whole is the default on purpose — nobody's picture loses its edges
+      unless the author asks. --%>
+      <div :if={@bento} class="mt-3 flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          phx-click="mosaic-fit"
+          phx-value-fill="false"
+          phx-target={@myself}
+          aria-pressed={to_string(not @fill?)}
+          data-bento-fit="whole"
+          class={[
+            "h-10 shrink-0 rounded-lg px-3 text-sm font-semibold",
+            (!@fill? &&
+               "bg-brand-50 text-brand-700 ring-2 ring-brand-500 dark:bg-brand-900/40 dark:text-brand-100") ||
+              "text-slate-700 ring-1 ring-slate-300 hover:bg-slate-100 dark:text-slate-200 dark:ring-slate-700 dark:hover:bg-slate-800"
+          ]}
+        >
+          {gettext("Whole photos")}
+        </button>
+        <button
+          type="button"
+          phx-click="mosaic-fit"
+          phx-value-fill="true"
+          phx-target={@myself}
+          aria-pressed={to_string(@fill?)}
+          data-bento-fit="fill"
+          class={[
+            "h-10 shrink-0 rounded-lg px-3 text-sm font-semibold",
+            (@fill? &&
+               "bg-brand-50 text-brand-700 ring-2 ring-brand-500 dark:bg-brand-900/40 dark:text-brand-100") ||
+              "text-slate-700 ring-1 ring-slate-300 hover:bg-slate-100 dark:text-slate-200 dark:ring-slate-700 dark:hover:bg-slate-800"
+          ]}
+        >
+          {gettext("Fill the tiles")}
+        </button>
+      </div>
+
+      <div class={[
+        "mt-4 space-y-2",
+        @bento && "border-t border-slate-200 pt-3 dark:border-slate-700"
+      ]}>
+        <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <label for={"#{@id}-license"} class="text-sm font-medium text-slate-600 dark:text-slate-400">
+            {gettext("Licence")}
+          </label>
+          <select
+            name="post[license]"
+            id={"#{@id}-license"}
+            title={gettext("Who may reuse these photos")}
+            class={compact_select_class()}
+          >
+            <option :for={license <- PhotoLicense.values()} value={license} selected={@license == license}>
+              {PhotoLicense.label(license)}
+            </option>
+          </select>
+        </div>
+
+        <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <label for={"#{@id}-download"} class="text-sm font-medium text-slate-600 dark:text-slate-400">
+            {gettext("Download")}
+          </label>
+          <select
+            name="post[download]"
+            id={"#{@id}-download"}
+            phx-change="download-choice"
+            phx-target={@myself}
+            title={gettext("What a visitor can save")}
+            class={compact_select_class()}
+          >
+            <option value="none" selected={@download_choice == "none"}>{download_label("none")}</option>
+            <option value="clean" selected={@download_choice == "clean"}>{download_label("clean")}</option>
+            <option value="exact" selected={@download_choice == "exact"}>{download_label("exact")}</option>
+            <option :if={@download_choice == "mixed"} value="mixed" selected>
+              {download_label("mixed")}
+            </option>
+          </select>
+        </div>
+
+        <%!-- The two things that make the choice an informed one, each shown at
+        the moment it applies rather than as a standing notice nobody reads. --%>
+        <p
+          :if={@download_choice == "exact" and located_photos(@images) > 0}
+          class="rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-800 ring-1 ring-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:ring-amber-800"
+          data-download-gps-warning
+        >
+          {ngettext(
+            "This photo carries the location it was taken at, and the exact file hands it over.",
+            "Some of these photos carry the location they were taken at, and the exact file hands it over.",
+            located_photos(@images)
+          )}
+        </p>
+        <p
+          :if={@download_choice == "clean" and uncleanable?(@images)}
+          class="rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-800 ring-1 ring-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:ring-amber-800"
+          data-download-clean-notice
+        >
+          {gettext("A file whose format cannot be cleaned is handed out exactly as uploaded.")}
+        </p>
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
   The per-photo panel: the two texts and the two opt-ins for one photo
   (issue #1104).
 
@@ -2378,6 +2397,20 @@ defmodule VutuvWeb.PostLive.Composer do
           class="h-16 w-16 shrink-0 rounded-lg object-cover ring-1 ring-slate-200 dark:ring-slate-800"
         />
         <div class="min-w-0 flex-1 space-y-2">
+          <%!-- The caption and the camera switch moved in here with issue
+          #1892: they used to sit inline under the tile, which is what made a
+          single photo's settings live in two places at once. There is exactly
+          one input of each name now, which is what keeps the submit honest. --%>
+          <input
+            type="text"
+            name={"photo[#{@image.id}][caption]"}
+            value={@settings.caption}
+            phx-debounce="300"
+            placeholder={gettext("Caption (optional)")}
+            class={input_class()}
+            data-photo-caption={@image.id}
+          />
+
           <input
             type="text"
             name={"photo[#{@image.id}][alt]"}
@@ -2386,6 +2419,28 @@ defmodule VutuvWeb.PostLive.Composer do
             placeholder={gettext("Describe the photo for people who can't see it")}
             class={input_class()}
           />
+
+          <label
+            :if={PostImage.camera_info?(@image)}
+            data-photo-camera-inline={@image.id}
+            class="flex items-start gap-2 py-1 text-sm text-slate-700 dark:text-slate-200"
+          >
+            <input
+              type="checkbox"
+              checked={@settings.show_camera_info}
+              phx-click="photo-toggle"
+              phx-value-id={@image.id}
+              phx-value-field="show_camera_info"
+              phx-target={@myself}
+              class={checkbox_class()}
+            />
+            <span class="min-w-0">
+              <span class="font-semibold">{gettext("Show camera settings")}</span>
+              <span class="mt-0.5 block text-xs text-slate-600 dark:text-slate-400">
+                {PostComponents.camera_line(@image)}
+              </span>
+            </span>
+          </label>
         </div>
         <button
           type="button"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -117,7 +117,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/live/job_posting_live/form.ex:811
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/organization_live/new.ex:231
-#: lib/vutuv_web/live/post_live/composer.ex:1450
+#: lib/vutuv_web/live/post_live/composer.ex:1490
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -203,7 +203,7 @@ msgid "Disable"
 msgstr "Inaktivieren"
 
 #: lib/vutuv_web/live/cv_live.ex:438
-#: lib/vutuv_web/live/post_live/composer.ex:1774
+#: lib/vutuv_web/live/post_live/composer.ex:2302
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
@@ -601,7 +601,7 @@ msgstr "Profile von "
 msgid "Provider"
 msgstr "Provider"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1910
+#: lib/vutuv_web/live/post_live/composer.ex:1709
 #: lib/vutuv_web/live/section_reorder_live.ex:270
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -613,7 +613,7 @@ msgstr "Öffentlich"
 
 #: lib/vutuv_web/components/ui.ex:4115
 #: lib/vutuv_web/live/organization_live/edit.ex:370
-#: lib/vutuv_web/live/post_live/composer.ex:1925
+#: lib/vutuv_web/live/post_live/composer.ex:1724
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -1647,9 +1647,10 @@ msgstr "Schauen Sie in Ihr Postfach"
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:480
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1411
-#: lib/vutuv_web/live/post_live/composer.ex:1412
-#: lib/vutuv_web/live/post_live/composer.ex:2394
+#: lib/vutuv_web/live/post_live/composer.ex:1448
+#: lib/vutuv_web/live/post_live/composer.ex:1449
+#: lib/vutuv_web/live/post_live/composer.ex:2179
+#: lib/vutuv_web/live/post_live/composer.ex:2445
 #: lib/vutuv_web/templates/layout/app.html.heex:188
 #: lib/vutuv_web/templates/layout/app.html.heex:194
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:20
@@ -2124,7 +2125,7 @@ msgstr "Markdown wird unterstützt: Fett, Kursiv, Links und Listen."
 msgid "Add images"
 msgstr "Bilder hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2036
+#: lib/vutuv_web/live/post_live/composer.ex:1835
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und Suchmaschinen den Beitrag nicht mehr."
@@ -2135,7 +2136,7 @@ msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und
 msgid "Back to the post"
 msgstr "Zurück zum Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1694
+#: lib/vutuv_web/live/post_live/composer.ex:1594
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Upload abbrechen"
@@ -2180,12 +2181,12 @@ msgstr "Folgen Sie %{name}, um ihn zu lesen."
 msgid "Hidden from:"
 msgstr "Verborgen vor:"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2012
+#: lib/vutuv_web/live/post_live/composer.ex:1811
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr "Vor einer bestimmten Person verbergen…"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1940
+#: lib/vutuv_web/live/post_live/composer.ex:1739
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
@@ -2196,13 +2197,13 @@ msgstr "Diesen Beitrag verbergen vor…"
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1982
+#: lib/vutuv_web/live/post_live/composer.ex:1781
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr "Nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1137
-#: lib/vutuv_web/live/post_live/composer.ex:1185
+#: lib/vutuv_web/live/post_live/composer.ex:1174
+#: lib/vutuv_web/live/post_live/composer.ex:1222
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
@@ -2214,23 +2215,23 @@ msgstr ""
 "Hier ist noch nichts. Folgen Sie anderen, um Ihren Feed zu füllen, oder "
 "schreiben Sie Ihren ersten Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1103
+#: lib/vutuv_web/live/post_live/composer.ex:1140
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr "Eines der Bilder konnte nicht angehängt werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1972
+#: lib/vutuv_web/live/post_live/composer.ex:1771
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr "Personen, denen ich nicht folge"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1962
+#: lib/vutuv_web/live/post_live/composer.ex:1761
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr "Personen, die mir nicht folgen"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:416
-#: lib/vutuv_web/live/post_live/composer.ex:1927
+#: lib/vutuv_web/live/post_live/composer.ex:1726
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2280,7 +2281,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/organization_live/domains.ex:246
 #: lib/vutuv_web/live/organization_live/edit.ex:402
 #: lib/vutuv_web/live/organization_live/roles.ex:247
-#: lib/vutuv_web/live/post_live/composer.ex:1998
+#: lib/vutuv_web/live/post_live/composer.ex:1797
 #: lib/vutuv_web/live/post_live/filter_band.ex:455
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
@@ -2297,7 +2298,7 @@ msgstr ""
 "Eingeschränkte Beiträge sind auch für nicht eingeloggte Besucher und "
 "Suchmaschinen unsichtbar."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1917
+#: lib/vutuv_web/live/post_live/composer.ex:1716
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr "Wird gespeichert…"
@@ -2314,12 +2315,12 @@ msgstr[1] "%{formatted} neue Beiträge anzeigen"
 msgid "Sorry, that page could not be found."
 msgstr "Diese Seite konnte leider nicht gefunden werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1211
+#: lib/vutuv_web/live/post_live/composer.ex:1248
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Diese Datei konnte nicht verarbeitet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1085
+#: lib/vutuv_web/live/post_live/composer.ex:1122
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr "Die Sichtbarkeitsauswahl ist ungültig."
@@ -2329,12 +2330,12 @@ msgstr "Die Sichtbarkeitsauswahl ist ungültig."
 msgid "This post is for followers of %{name}"
 msgstr "Dieser Beitrag ist für Follower von %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2543
+#: lib/vutuv_web/live/post_live/composer.ex:2594
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2544
+#: lib/vutuv_web/live/post_live/composer.ex:2595
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
@@ -2348,12 +2349,12 @@ msgstr "Upload fehlgeschlagen."
 msgid "View profile"
 msgstr "Profil ansehen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2111
+#: lib/vutuv_web/live/post_live/composer.ex:1910
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr "Was gibt's Neues?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2112
+#: lib/vutuv_web/live/post_live/composer.ex:1911
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
@@ -2389,17 +2390,17 @@ msgstr "Personen, denen Sie nicht folgen"
 msgid "unknown"
 msgstr "unbekannt"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1831
+#: lib/vutuv_web/live/post_live/composer.ex:1630
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr "Tags, durch Komma getrennt (max. %{max})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2534
+#: lib/vutuv_web/live/post_live/composer.ex:2585
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr "Die Datei ist größer als %{mb} MB."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2538
+#: lib/vutuv_web/live/post_live/composer.ex:2589
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
@@ -2556,13 +2557,13 @@ msgstr "Antworten"
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1088
-#: lib/vutuv_web/live/post_live/composer.ex:1905
+#: lib/vutuv_web/live/post_live/composer.ex:1125
+#: lib/vutuv_web/live/post_live/composer.ex:1704
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr "Solange es geteilte Beiträge oder Antworten gibt, lässt sich der Empfängerkreis nicht einschränken."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2043
+#: lib/vutuv_web/live/post_live/composer.ex:1842
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beiträge oder Antworten gibt, bleibt er öffentlich; löschen können Sie ihn weiterhin."
@@ -2866,7 +2867,7 @@ msgstr "Noch keine Vernetzungen."
 msgid "Other formats"
 msgstr "Andere Formate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1952
+#: lib/vutuv_web/live/post_live/composer.ex:1751
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr "Personen, mit denen ich nicht vernetzt bin"
@@ -5529,7 +5530,7 @@ msgstr ""
 "dauerhaft. Wir senden Ihnen zur Bestätigung eine PIN per E-Mail. Es kann "
 "nicht rückgängig gemacht werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1106
+#: lib/vutuv_web/live/post_live/composer.ex:1143
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
@@ -6371,7 +6372,7 @@ msgstr "Foto positionieren"
 msgid "Use photo"
 msgstr "Foto verwenden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1452
+#: lib/vutuv_web/live/post_live/composer.ex:1492
 #: lib/vutuv_web/templates/user/edit.html.heex:54
 #: lib/vutuv_web/templates/user/edit.html.heex:139
 #, elixir-autogen, elixir-format
@@ -11221,6 +11222,8 @@ msgid "Failed"
 msgstr "Fehlgeschlagen"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
+#: lib/vutuv_web/live/post_live/composer.ex:1577
+#: lib/vutuv_web/live/post_live/composer.ex:2173
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr "Galerie"
@@ -14014,7 +14017,7 @@ msgstr "Volle Breite"
 msgid "Insert image"
 msgstr "Bild einfügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2513
+#: lib/vutuv_web/live/post_live/composer.ex:2564
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr "In den Text einfügen"
@@ -14699,13 +14702,13 @@ msgstr "Erwähnung"
 msgid "mentioned you in a post."
 msgstr "hat Sie in einem Beitrag erwähnt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1093
+#: lib/vutuv_web/live/post_live/composer.ex:1130
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr "Dieser Beitrag lässt sich nicht mehr bearbeiten: jemand hat ihn geliked, geteilt oder beantwortet."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1096
+#: lib/vutuv_web/live/post_live/composer.ex:1133
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -16847,7 +16850,7 @@ msgstr ""
 "in eckigen Klammern, wie eine Lautschrift geschrieben wird; die Klammern "
 "ergänzen wir für Sie. Bleibt das Feld leer, wird nichts angezeigt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2526
+#: lib/vutuv_web/live/post_live/composer.ex:2577
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr "Diese Einstellungen für alle Fotos übernehmen"
@@ -16877,12 +16880,12 @@ msgstr "CC BY-SA 4.0 (Namensnennung, gleiche Bedingungen)"
 msgid "CC0 1.0 (no rights reserved)"
 msgstr "CC0 1.0 (keine Rechte vorbehalten)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2193
+#: lib/vutuv_web/live/post_live/composer.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Titelbild"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2386
+#: lib/vutuv_web/live/post_live/composer.ex:2415
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
@@ -16894,27 +16897,22 @@ msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 msgid "Download the original"
 msgstr "Original herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1531
-#, elixir-autogen, elixir-format
-msgid "Drag to reorder. The first photo leads the gallery."
-msgstr "Zum Umsortieren ziehen. Das erste Foto führt die Galerie an."
-
-#: lib/vutuv_web/live/post_live/composer.ex:2463
+#: lib/vutuv_web/live/post_live/composer.ex:2514
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr "Alle Metadaten bleiben erhalten, auch alles, was Ihre Kamera hineingeschrieben hat."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2419
+#: lib/vutuv_web/live/post_live/composer.ex:2470
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr "Alle dürfen dieses Foto herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2421
+#: lib/vutuv_web/live/post_live/composer.ex:2472
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr "Volle Auflösung, direkt aus dem Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2440
+#: lib/vutuv_web/live/post_live/composer.ex:2491
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr "Nur das Bild"
@@ -16924,7 +16922,7 @@ msgstr "Nur das Bild"
 msgid "Next photo"
 msgstr "Nächstes Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2212
+#: lib/vutuv_web/live/post_live/composer.ex:2020
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
@@ -16944,8 +16942,8 @@ msgstr "Foto %{n} von %{total}"
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2165
-#: lib/vutuv_web/live/post_live/composer.ex:2166
+#: lib/vutuv_web/live/post_live/composer.ex:1973
+#: lib/vutuv_web/live/post_live/composer.ex:1974
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr "Foto-Einstellungen"
@@ -16962,18 +16960,18 @@ msgstr "Fotos:"
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2225
-#: lib/vutuv_web/live/post_live/composer.ex:2226
+#: lib/vutuv_web/live/post_live/composer.ex:2033
+#: lib/vutuv_web/live/post_live/composer.ex:2034
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr "Foto entfernen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2442
+#: lib/vutuv_web/live/post_live/composer.ex:2493
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qualität unverändert."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1503
+#: lib/vutuv_web/live/post_live/composer.ex:2434
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
@@ -16983,17 +16981,17 @@ msgstr "Kameradaten anzeigen"
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2461
+#: lib/vutuv_web/live/post_live/composer.ex:2512
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr "Die Datei genau so, wie ich sie hochgeladen habe"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2497
+#: lib/vutuv_web/live/post_live/composer.ex:2548
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen Sie das Foto, wenn Sie das nicht möchten."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2489
+#: lib/vutuv_web/live/post_live/composer.ex:2540
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
@@ -17018,12 +17016,12 @@ msgstr "Diese Seite nimmt nicht am Fediverse teil."
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1752
+#: lib/vutuv_web/live/post_live/composer.ex:2291
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr "Wer diese Fotos weiterverwenden darf"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1120
+#: lib/vutuv_web/live/post_live/composer.ex:1157
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
@@ -17033,7 +17031,7 @@ msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke gesc
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1134
+#: lib/vutuv_web/live/post_live/composer.ex:1171
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
@@ -17048,70 +17046,70 @@ msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fedive
 msgid "© All rights reserved"
 msgstr "© Alle Rechte vorbehalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1522
-#: lib/vutuv_web/live/post_live/composer.ex:1868
+#: lib/vutuv_web/live/post_live/composer.ex:1560
+#: lib/vutuv_web/live/post_live/composer.ex:1667
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr "Fotos hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1747
+#: lib/vutuv_web/live/post_live/composer.ex:2286
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1480
+#: lib/vutuv_web/live/post_live/composer.ex:2405
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr "Bildunterschrift (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1348
-#: lib/vutuv_web/live/post_live/composer.ex:1406
+#: lib/vutuv_web/live/post_live/composer.ex:1385
+#: lib/vutuv_web/live/post_live/composer.ex:1443
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr "Entwurf verwerfen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1345
-#: lib/vutuv_web/live/post_live/composer.ex:1403
+#: lib/vutuv_web/live/post_live/composer.ex:1382
+#: lib/vutuv_web/live/post_live/composer.ex:1440
 #, elixir-autogen, elixir-format
 msgid "Discard the photos and text of this draft?"
 msgstr "Fotos und Text dieses Entwurfs verwerfen?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1340
+#: lib/vutuv_web/live/post_live/composer.ex:1377
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr "Weiter, wo Sie aufgehört haben."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1818
+#: lib/vutuv_web/live/post_live/composer.ex:2339
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr "Eine Datei, deren Format sich nicht säubern lässt, wird exakt so weitergegeben, wie sie hochgeladen wurde."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2092
+#: lib/vutuv_web/live/post_live/composer.ex:1891
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr "Pro Foto verschieden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2091
+#: lib/vutuv_web/live/post_live/composer.ex:1890
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr "Original, exakt wie hochgeladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2090
+#: lib/vutuv_web/live/post_live/composer.ex:1889
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr "Original, ohne Metadaten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2095
+#: lib/vutuv_web/live/post_live/composer.ex:1894
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr "Nur Web-Versionen (%{format})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1781
+#: lib/vutuv_web/live/post_live/composer.ex:2309
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr "Was Besucher speichern können"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1807
+#: lib/vutuv_web/live/post_live/composer.ex:2328
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -17230,7 +17228,8 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr "Rücknahme"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1735
+#: lib/vutuv_web/live/post_live/composer.ex:1578
+#: lib/vutuv_web/live/post_live/composer.ex:2173
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr "Fotodetails"
@@ -18111,135 +18110,104 @@ msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, desh
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr "Einen nachgeschlagenen Beitrag bewahrt vutuv genauso sechs Monate lang auf wie jeden anderen Beitrag aus einem anderen Netzwerk. Der Server der verfassenden Person wird sonst nichts gefragt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1449
+#: lib/vutuv_web/live/post_live/composer.ex:1489
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr "Zuschnitt übernehmen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1565
-#, elixir-autogen, elixir-format
-msgid "Auto"
-msgstr "Automatisch"
-
-#: lib/vutuv_web/live/post_live/composer.ex:2271
+#: lib/vutuv_web/live/post_live/composer.ex:2079
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr "Großes Foto links"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2272
+#: lib/vutuv_web/live/post_live/composer.ex:2080
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr "Großes Foto rechts"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2277
+#: lib/vutuv_web/live/post_live/composer.ex:2085
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr "Spalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2274
+#: lib/vutuv_web/live/post_live/composer.ex:2082
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr "Titelbild links"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2275
+#: lib/vutuv_web/live/post_live/composer.ex:2083
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr "Titelbild oben"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2276
+#: lib/vutuv_web/live/post_live/composer.ex:2084
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr "Titelbild rechts"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1445
-#: lib/vutuv_web/live/post_live/composer.ex:2242
-#: lib/vutuv_web/live/post_live/composer.ex:2243
+#: lib/vutuv_web/live/post_live/composer.ex:1485
+#: lib/vutuv_web/live/post_live/composer.ex:2050
+#: lib/vutuv_web/live/post_live/composer.ex:2051
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr "Foto zuschneiden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2201
+#: lib/vutuv_web/live/post_live/composer.ex:2009
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr "Zugeschnitten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1376
+#: lib/vutuv_web/live/post_live/composer.ex:1413
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr "Fotos hier ablegen, um sie hinzuzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1543
-#, elixir-autogen, elixir-format
-msgid "Gallery preview"
-msgstr "Galerie-Vorschau"
-
-#: lib/vutuv_web/live/post_live/composer.ex:2278
+#: lib/vutuv_web/live/post_live/composer.ex:2086
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr "Raster"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2279
+#: lib/vutuv_web/live/post_live/composer.ex:2087
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr "Mosaik"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1447
+#: lib/vutuv_web/live/post_live/composer.ex:1487
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr "Wählen Sie ein Format, dann verschieben und zoomen Sie. Der gerahmte Ausschnitt ist das, was der Beitrag zeigt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2270
+#: lib/vutuv_web/live/post_live/composer.ex:2078
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr "Nebeneinander"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2273
+#: lib/vutuv_web/live/post_live/composer.ex:2081
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr "Übereinander"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1658
-#: lib/vutuv_web/live/post_live/composer.ex:1659
-#, elixir-autogen, elixir-format
-msgid "Swap this photo with another"
-msgstr "Dieses Foto mit einem anderen tauschen"
-
-#: lib/vutuv_web/live/post_live/composer.ex:1546
-#, elixir-autogen, elixir-format
-msgid "Tap two photos to swap them."
-msgstr "Tippen Sie zwei Fotos an, um sie zu tauschen."
-
-#: lib/vutuv_web/live/post_live/composer.ex:450
+#: lib/vutuv_web/live/post_live/composer.ex:485
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr "Das Foto konnte nicht zugeschnitten werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2476
+#: lib/vutuv_web/live/post_live/composer.ex:2527
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr "Dieses Foto ist zugeschnitten: Downloads geben das zugeschnittene Bild heraus, die unveränderte Originaldatei bleibt privat."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1451
+#: lib/vutuv_web/live/post_live/composer.ex:1491
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr "Ganzes Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1640
-#, elixir-autogen, elixir-format
-msgid "Each photo covers its tile and is cropped by it."
-msgstr "Jedes Foto füllt seine Kachel und wird von ihr beschnitten."
-
-#: lib/vutuv_web/live/post_live/composer.ex:1641
-#, elixir-autogen, elixir-format
-msgid "Each photo shows whole inside its tile."
-msgstr "Jedes Foto ist ganz in seiner Kachel zu sehen."
-
-#: lib/vutuv_web/live/post_live/composer.ex:1636
+#: lib/vutuv_web/live/post_live/composer.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr "Kacheln füllen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1620
+#: lib/vutuv_web/live/post_live/composer.ex:2260
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr "Ganze Fotos"
@@ -20552,17 +20520,17 @@ msgstr "Der Besitzer vergibt die Rollen der anderen Mitglieder auf der Seite und
 msgid "Nothing published yet."
 msgstr "Noch nichts veröffentlicht."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1926
+#: lib/vutuv_web/live/post_live/composer.ex:1725
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr "Als %{name} veröffentlichen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1113
+#: lib/vutuv_web/live/post_live/composer.ex:1150
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1903
+#: lib/vutuv_web/live/post_live/composer.ex:1702
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr "Ein Beitrag im Namen einer Organisation ist immer öffentlich."
@@ -21362,17 +21330,17 @@ msgstr "Sie haben %{used} von %{max} Tags."
 msgid "{n} of {max} free slots selected."
 msgstr "{n} von {max} freien Plätzen ausgewählt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1888
+#: lib/vutuv_web/live/post_live/composer.ex:1687
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr "Weitere Sprachen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1881
+#: lib/vutuv_web/live/post_live/composer.ex:1680
 #, elixir-autogen, elixir-format
 msgid "Post language"
 msgstr "Sprache des Beitrags"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1882
+#: lib/vutuv_web/live/post_live/composer.ex:1681
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr "Die Sprache, in der dieser Beitrag geschrieben ist"
@@ -23171,3 +23139,19 @@ msgstr "Block einfügen"
 #, elixir-autogen, elixir-format
 msgid "Nothing matches."
 msgstr "Nichts gefunden."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1577
+#: lib/vutuv_web/live/post_live/composer.ex:2206
+#, elixir-autogen, elixir-format
+msgid "Automatic"
+msgstr "Automatisch"
+
+#: lib/vutuv_web/live/post_live/composer.ex:1582
+#, elixir-autogen, elixir-format
+msgid "Drag one photo onto another to swap them."
+msgstr "Ein Foto auf ein anderes ziehen, um sie zu tauschen."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1523
+#, elixir-autogen, elixir-format
+msgid "Not shown in the gallery — drag one into it to swap."
+msgstr "Nicht in der Galerie zu sehen — eines hineinziehen, um zu tauschen."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -119,7 +119,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_posting_live/form.ex:811
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/organization_live/new.ex:231
-#: lib/vutuv_web/live/post_live/composer.ex:1450
+#: lib/vutuv_web/live/post_live/composer.ex:1490
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -203,7 +203,7 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:438
-#: lib/vutuv_web/live/post_live/composer.ex:1774
+#: lib/vutuv_web/live/post_live/composer.ex:2302
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
@@ -601,7 +601,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1910
+#: lib/vutuv_web/live/post_live/composer.ex:1709
 #: lib/vutuv_web/live/section_reorder_live.ex:270
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -613,7 +613,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4115
 #: lib/vutuv_web/live/organization_live/edit.ex:370
-#: lib/vutuv_web/live/post_live/composer.ex:1925
+#: lib/vutuv_web/live/post_live/composer.ex:1724
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -1617,9 +1617,10 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:480
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1411
-#: lib/vutuv_web/live/post_live/composer.ex:1412
-#: lib/vutuv_web/live/post_live/composer.ex:2394
+#: lib/vutuv_web/live/post_live/composer.ex:1448
+#: lib/vutuv_web/live/post_live/composer.ex:1449
+#: lib/vutuv_web/live/post_live/composer.ex:2179
+#: lib/vutuv_web/live/post_live/composer.ex:2445
 #: lib/vutuv_web/templates/layout/app.html.heex:188
 #: lib/vutuv_web/templates/layout/app.html.heex:194
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:20
@@ -2083,7 +2084,7 @@ msgstr ""
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2036
+#: lib/vutuv_web/live/post_live/composer.ex:1835
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2094,7 +2095,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1694
+#: lib/vutuv_web/live/post_live/composer.ex:1594
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2139,12 +2140,12 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2012
+#: lib/vutuv_web/live/post_live/composer.ex:1811
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1940
+#: lib/vutuv_web/live/post_live/composer.ex:1739
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
@@ -2155,13 +2156,13 @@ msgstr ""
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1982
+#: lib/vutuv_web/live/post_live/composer.ex:1781
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1137
-#: lib/vutuv_web/live/post_live/composer.ex:1185
+#: lib/vutuv_web/live/post_live/composer.ex:1174
+#: lib/vutuv_web/live/post_live/composer.ex:1222
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
@@ -2171,23 +2172,23 @@ msgstr ""
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1103
+#: lib/vutuv_web/live/post_live/composer.ex:1140
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1972
+#: lib/vutuv_web/live/post_live/composer.ex:1771
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1962
+#: lib/vutuv_web/live/post_live/composer.ex:1761
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:416
-#: lib/vutuv_web/live/post_live/composer.ex:1927
+#: lib/vutuv_web/live/post_live/composer.ex:1726
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2237,7 +2238,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:246
 #: lib/vutuv_web/live/organization_live/edit.ex:402
 #: lib/vutuv_web/live/organization_live/roles.ex:247
-#: lib/vutuv_web/live/post_live/composer.ex:1998
+#: lib/vutuv_web/live/post_live/composer.ex:1797
 #: lib/vutuv_web/live/post_live/filter_band.ex:455
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
@@ -2252,7 +2253,7 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1917
+#: lib/vutuv_web/live/post_live/composer.ex:1716
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
@@ -2269,12 +2270,12 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1211
+#: lib/vutuv_web/live/post_live/composer.ex:1248
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1085
+#: lib/vutuv_web/live/post_live/composer.ex:1122
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2284,12 +2285,12 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2543
+#: lib/vutuv_web/live/post_live/composer.ex:2594
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2544
+#: lib/vutuv_web/live/post_live/composer.ex:2595
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -2303,12 +2304,12 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2111
+#: lib/vutuv_web/live/post_live/composer.ex:1910
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2112
+#: lib/vutuv_web/live/post_live/composer.ex:1911
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
@@ -2344,17 +2345,17 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1831
+#: lib/vutuv_web/live/post_live/composer.ex:1630
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2534
+#: lib/vutuv_web/live/post_live/composer.ex:2585
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2538
+#: lib/vutuv_web/live/post_live/composer.ex:2589
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2511,13 +2512,13 @@ msgstr ""
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1088
-#: lib/vutuv_web/live/post_live/composer.ex:1905
+#: lib/vutuv_web/live/post_live/composer.ex:1125
+#: lib/vutuv_web/live/post_live/composer.ex:1704
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2043
+#: lib/vutuv_web/live/post_live/composer.ex:1842
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2819,7 +2820,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1952
+#: lib/vutuv_web/live/post_live/composer.ex:1751
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -5308,7 +5309,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1106
+#: lib/vutuv_web/live/post_live/composer.ex:1143
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -6129,7 +6130,7 @@ msgstr ""
 msgid "Use photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1452
+#: lib/vutuv_web/live/post_live/composer.ex:1492
 #: lib/vutuv_web/templates/user/edit.html.heex:54
 #: lib/vutuv_web/templates/user/edit.html.heex:139
 #, elixir-autogen, elixir-format
@@ -10655,6 +10656,8 @@ msgid "Failed"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
+#: lib/vutuv_web/live/post_live/composer.ex:1577
+#: lib/vutuv_web/live/post_live/composer.ex:2173
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr ""
@@ -13359,7 +13362,7 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2513
+#: lib/vutuv_web/live/post_live/composer.ex:2564
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -14022,13 +14025,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1093
+#: lib/vutuv_web/live/post_live/composer.ex:1130
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1096
+#: lib/vutuv_web/live/post_live/composer.ex:1133
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -16137,7 +16140,7 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2526
+#: lib/vutuv_web/live/post_live/composer.ex:2577
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16167,12 +16170,12 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2193
+#: lib/vutuv_web/live/post_live/composer.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2386
+#: lib/vutuv_web/live/post_live/composer.ex:2415
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
@@ -16184,27 +16187,22 @@ msgstr ""
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1531
-#, elixir-autogen, elixir-format
-msgid "Drag to reorder. The first photo leads the gallery."
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:2463
+#: lib/vutuv_web/live/post_live/composer.ex:2514
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2419
+#: lib/vutuv_web/live/post_live/composer.ex:2470
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2421
+#: lib/vutuv_web/live/post_live/composer.ex:2472
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2440
+#: lib/vutuv_web/live/post_live/composer.ex:2491
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
@@ -16214,7 +16212,7 @@ msgstr ""
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2212
+#: lib/vutuv_web/live/post_live/composer.ex:2020
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
@@ -16234,8 +16232,8 @@ msgstr ""
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2165
-#: lib/vutuv_web/live/post_live/composer.ex:2166
+#: lib/vutuv_web/live/post_live/composer.ex:1973
+#: lib/vutuv_web/live/post_live/composer.ex:1974
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
@@ -16252,18 +16250,18 @@ msgstr ""
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2225
-#: lib/vutuv_web/live/post_live/composer.ex:2226
+#: lib/vutuv_web/live/post_live/composer.ex:2033
+#: lib/vutuv_web/live/post_live/composer.ex:2034
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2442
+#: lib/vutuv_web/live/post_live/composer.ex:2493
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1503
+#: lib/vutuv_web/live/post_live/composer.ex:2434
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr ""
@@ -16273,17 +16271,17 @@ msgstr ""
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2461
+#: lib/vutuv_web/live/post_live/composer.ex:2512
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2497
+#: lib/vutuv_web/live/post_live/composer.ex:2548
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2489
+#: lib/vutuv_web/live/post_live/composer.ex:2540
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
@@ -16308,12 +16306,12 @@ msgstr ""
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1752
+#: lib/vutuv_web/live/post_live/composer.ex:2291
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1120
+#: lib/vutuv_web/live/post_live/composer.ex:1157
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -16323,7 +16321,7 @@ msgstr ""
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1134
+#: lib/vutuv_web/live/post_live/composer.ex:1171
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -16338,70 +16336,70 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1522
-#: lib/vutuv_web/live/post_live/composer.ex:1868
+#: lib/vutuv_web/live/post_live/composer.ex:1560
+#: lib/vutuv_web/live/post_live/composer.ex:1667
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1747
+#: lib/vutuv_web/live/post_live/composer.ex:2286
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1480
+#: lib/vutuv_web/live/post_live/composer.ex:2405
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1348
-#: lib/vutuv_web/live/post_live/composer.ex:1406
+#: lib/vutuv_web/live/post_live/composer.ex:1385
+#: lib/vutuv_web/live/post_live/composer.ex:1443
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1345
-#: lib/vutuv_web/live/post_live/composer.ex:1403
+#: lib/vutuv_web/live/post_live/composer.ex:1382
+#: lib/vutuv_web/live/post_live/composer.ex:1440
 #, elixir-autogen, elixir-format
 msgid "Discard the photos and text of this draft?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1340
+#: lib/vutuv_web/live/post_live/composer.ex:1377
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1818
+#: lib/vutuv_web/live/post_live/composer.ex:2339
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2092
+#: lib/vutuv_web/live/post_live/composer.ex:1891
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2091
+#: lib/vutuv_web/live/post_live/composer.ex:1890
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2090
+#: lib/vutuv_web/live/post_live/composer.ex:1889
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2095
+#: lib/vutuv_web/live/post_live/composer.ex:1894
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1781
+#: lib/vutuv_web/live/post_live/composer.ex:2309
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1807
+#: lib/vutuv_web/live/post_live/composer.ex:2328
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -16511,7 +16509,8 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1735
+#: lib/vutuv_web/live/post_live/composer.ex:1578
+#: lib/vutuv_web/live/post_live/composer.ex:2173
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr ""
@@ -17379,135 +17378,104 @@ msgstr ""
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1449
+#: lib/vutuv_web/live/post_live/composer.ex:1489
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1565
-#, elixir-autogen, elixir-format
-msgid "Auto"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:2271
+#: lib/vutuv_web/live/post_live/composer.ex:2079
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2272
+#: lib/vutuv_web/live/post_live/composer.ex:2080
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2277
+#: lib/vutuv_web/live/post_live/composer.ex:2085
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2274
+#: lib/vutuv_web/live/post_live/composer.ex:2082
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2275
+#: lib/vutuv_web/live/post_live/composer.ex:2083
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2276
+#: lib/vutuv_web/live/post_live/composer.ex:2084
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1445
-#: lib/vutuv_web/live/post_live/composer.ex:2242
-#: lib/vutuv_web/live/post_live/composer.ex:2243
+#: lib/vutuv_web/live/post_live/composer.ex:1485
+#: lib/vutuv_web/live/post_live/composer.ex:2050
+#: lib/vutuv_web/live/post_live/composer.ex:2051
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2201
+#: lib/vutuv_web/live/post_live/composer.ex:2009
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1376
+#: lib/vutuv_web/live/post_live/composer.ex:1413
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1543
-#, elixir-autogen, elixir-format
-msgid "Gallery preview"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:2278
+#: lib/vutuv_web/live/post_live/composer.ex:2086
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2279
+#: lib/vutuv_web/live/post_live/composer.ex:2087
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1447
+#: lib/vutuv_web/live/post_live/composer.ex:1487
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2270
+#: lib/vutuv_web/live/post_live/composer.ex:2078
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2273
+#: lib/vutuv_web/live/post_live/composer.ex:2081
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1658
-#: lib/vutuv_web/live/post_live/composer.ex:1659
-#, elixir-autogen, elixir-format
-msgid "Swap this photo with another"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1546
-#, elixir-autogen, elixir-format
-msgid "Tap two photos to swap them."
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:450
+#: lib/vutuv_web/live/post_live/composer.ex:485
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2476
+#: lib/vutuv_web/live/post_live/composer.ex:2527
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1451
+#: lib/vutuv_web/live/post_live/composer.ex:1491
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1640
-#, elixir-autogen, elixir-format
-msgid "Each photo covers its tile and is cropped by it."
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1641
-#, elixir-autogen, elixir-format
-msgid "Each photo shows whole inside its tile."
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1636
+#: lib/vutuv_web/live/post_live/composer.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1620
+#: lib/vutuv_web/live/post_live/composer.ex:2260
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr ""
@@ -19797,17 +19765,17 @@ msgstr ""
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1926
+#: lib/vutuv_web/live/post_live/composer.ex:1725
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1113
+#: lib/vutuv_web/live/post_live/composer.ex:1150
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1903
+#: lib/vutuv_web/live/post_live/composer.ex:1702
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr ""
@@ -20588,17 +20556,17 @@ msgstr ""
 msgid "{n} of {max} free slots selected."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1888
+#: lib/vutuv_web/live/post_live/composer.ex:1687
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1881
+#: lib/vutuv_web/live/post_live/composer.ex:1680
 #, elixir-autogen, elixir-format
 msgid "Post language"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1882
+#: lib/vutuv_web/live/post_live/composer.ex:1681
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr ""
@@ -22366,4 +22334,20 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:433
 #, elixir-autogen, elixir-format
 msgid "Nothing matches."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1577
+#: lib/vutuv_web/live/post_live/composer.ex:2206
+#, elixir-autogen, elixir-format
+msgid "Automatic"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1582
+#, elixir-autogen, elixir-format
+msgid "Drag one photo onto another to swap them."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1523
+#, elixir-autogen, elixir-format
+msgid "Not shown in the gallery — drag one into it to swap."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -117,7 +117,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_posting_live/form.ex:811
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/organization_live/new.ex:231
-#: lib/vutuv_web/live/post_live/composer.ex:1450
+#: lib/vutuv_web/live/post_live/composer.ex:1490
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -201,7 +201,7 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:438
-#: lib/vutuv_web/live/post_live/composer.ex:1774
+#: lib/vutuv_web/live/post_live/composer.ex:2302
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1910
+#: lib/vutuv_web/live/post_live/composer.ex:1709
 #: lib/vutuv_web/live/section_reorder_live.ex:270
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -611,7 +611,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4115
 #: lib/vutuv_web/live/organization_live/edit.ex:370
-#: lib/vutuv_web/live/post_live/composer.ex:1925
+#: lib/vutuv_web/live/post_live/composer.ex:1724
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -1615,9 +1615,10 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:480
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1411
-#: lib/vutuv_web/live/post_live/composer.ex:1412
-#: lib/vutuv_web/live/post_live/composer.ex:2394
+#: lib/vutuv_web/live/post_live/composer.ex:1448
+#: lib/vutuv_web/live/post_live/composer.ex:1449
+#: lib/vutuv_web/live/post_live/composer.ex:2179
+#: lib/vutuv_web/live/post_live/composer.ex:2445
 #: lib/vutuv_web/templates/layout/app.html.heex:188
 #: lib/vutuv_web/templates/layout/app.html.heex:194
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:20
@@ -2081,7 +2082,7 @@ msgstr ""
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2036
+#: lib/vutuv_web/live/post_live/composer.ex:1835
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2092,7 +2093,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1694
+#: lib/vutuv_web/live/post_live/composer.ex:1594
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2137,12 +2138,12 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2012
+#: lib/vutuv_web/live/post_live/composer.ex:1811
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1940
+#: lib/vutuv_web/live/post_live/composer.ex:1739
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
@@ -2153,13 +2154,13 @@ msgstr ""
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1982
+#: lib/vutuv_web/live/post_live/composer.ex:1781
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1137
-#: lib/vutuv_web/live/post_live/composer.ex:1185
+#: lib/vutuv_web/live/post_live/composer.ex:1174
+#: lib/vutuv_web/live/post_live/composer.ex:1222
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
@@ -2169,23 +2170,23 @@ msgstr ""
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1103
+#: lib/vutuv_web/live/post_live/composer.ex:1140
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1972
+#: lib/vutuv_web/live/post_live/composer.ex:1771
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1962
+#: lib/vutuv_web/live/post_live/composer.ex:1761
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:416
-#: lib/vutuv_web/live/post_live/composer.ex:1927
+#: lib/vutuv_web/live/post_live/composer.ex:1726
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2235,7 +2236,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:246
 #: lib/vutuv_web/live/organization_live/edit.ex:402
 #: lib/vutuv_web/live/organization_live/roles.ex:247
-#: lib/vutuv_web/live/post_live/composer.ex:1998
+#: lib/vutuv_web/live/post_live/composer.ex:1797
 #: lib/vutuv_web/live/post_live/filter_band.ex:455
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
@@ -2250,7 +2251,7 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1917
+#: lib/vutuv_web/live/post_live/composer.ex:1716
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
@@ -2267,12 +2268,12 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1211
+#: lib/vutuv_web/live/post_live/composer.ex:1248
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1085
+#: lib/vutuv_web/live/post_live/composer.ex:1122
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2282,12 +2283,12 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2543
+#: lib/vutuv_web/live/post_live/composer.ex:2594
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2544
+#: lib/vutuv_web/live/post_live/composer.ex:2595
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -2301,12 +2302,12 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2111
+#: lib/vutuv_web/live/post_live/composer.ex:1910
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2112
+#: lib/vutuv_web/live/post_live/composer.ex:1911
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
@@ -2342,17 +2343,17 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1831
+#: lib/vutuv_web/live/post_live/composer.ex:1630
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2534
+#: lib/vutuv_web/live/post_live/composer.ex:2585
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2538
+#: lib/vutuv_web/live/post_live/composer.ex:2589
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2509,13 +2510,13 @@ msgstr ""
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1088
-#: lib/vutuv_web/live/post_live/composer.ex:1905
+#: lib/vutuv_web/live/post_live/composer.ex:1125
+#: lib/vutuv_web/live/post_live/composer.ex:1704
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2043
+#: lib/vutuv_web/live/post_live/composer.ex:1842
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2817,7 +2818,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1952
+#: lib/vutuv_web/live/post_live/composer.ex:1751
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -5306,7 +5307,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1106
+#: lib/vutuv_web/live/post_live/composer.ex:1143
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -6127,7 +6128,7 @@ msgstr ""
 msgid "Use photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1452
+#: lib/vutuv_web/live/post_live/composer.ex:1492
 #: lib/vutuv_web/templates/user/edit.html.heex:54
 #: lib/vutuv_web/templates/user/edit.html.heex:139
 #, elixir-autogen, elixir-format
@@ -10653,6 +10654,8 @@ msgid "Failed"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
+#: lib/vutuv_web/live/post_live/composer.ex:1577
+#: lib/vutuv_web/live/post_live/composer.ex:2173
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr ""
@@ -13357,7 +13360,7 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2513
+#: lib/vutuv_web/live/post_live/composer.ex:2564
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -14020,13 +14023,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1093
+#: lib/vutuv_web/live/post_live/composer.ex:1130
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1096
+#: lib/vutuv_web/live/post_live/composer.ex:1133
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -16135,7 +16138,7 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2526
+#: lib/vutuv_web/live/post_live/composer.ex:2577
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16165,12 +16168,12 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2193
+#: lib/vutuv_web/live/post_live/composer.ex:2001
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2386
+#: lib/vutuv_web/live/post_live/composer.ex:2415
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
@@ -16182,27 +16185,22 @@ msgstr ""
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1531
-#, elixir-autogen, elixir-format
-msgid "Drag to reorder. The first photo leads the gallery."
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:2463
+#: lib/vutuv_web/live/post_live/composer.ex:2514
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2419
+#: lib/vutuv_web/live/post_live/composer.ex:2470
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2421
+#: lib/vutuv_web/live/post_live/composer.ex:2472
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2440
+#: lib/vutuv_web/live/post_live/composer.ex:2491
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
@@ -16212,7 +16210,7 @@ msgstr ""
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2212
+#: lib/vutuv_web/live/post_live/composer.ex:2020
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
@@ -16232,8 +16230,8 @@ msgstr ""
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2165
-#: lib/vutuv_web/live/post_live/composer.ex:2166
+#: lib/vutuv_web/live/post_live/composer.ex:1973
+#: lib/vutuv_web/live/post_live/composer.ex:1974
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
@@ -16250,18 +16248,18 @@ msgstr ""
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2225
-#: lib/vutuv_web/live/post_live/composer.ex:2226
+#: lib/vutuv_web/live/post_live/composer.ex:2033
+#: lib/vutuv_web/live/post_live/composer.ex:2034
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2442
+#: lib/vutuv_web/live/post_live/composer.ex:2493
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1503
+#: lib/vutuv_web/live/post_live/composer.ex:2434
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Show camera settings"
 msgstr ""
@@ -16271,17 +16269,17 @@ msgstr ""
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2461
+#: lib/vutuv_web/live/post_live/composer.ex:2512
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2497
+#: lib/vutuv_web/live/post_live/composer.ex:2548
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2489
+#: lib/vutuv_web/live/post_live/composer.ex:2540
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
@@ -16306,12 +16304,12 @@ msgstr ""
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1752
+#: lib/vutuv_web/live/post_live/composer.ex:2291
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1120
+#: lib/vutuv_web/live/post_live/composer.ex:1157
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -16321,7 +16319,7 @@ msgstr ""
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1134
+#: lib/vutuv_web/live/post_live/composer.ex:1171
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -16336,70 +16334,70 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1522
-#: lib/vutuv_web/live/post_live/composer.ex:1868
+#: lib/vutuv_web/live/post_live/composer.ex:1560
+#: lib/vutuv_web/live/post_live/composer.ex:1667
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1747
+#: lib/vutuv_web/live/post_live/composer.ex:2286
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1480
+#: lib/vutuv_web/live/post_live/composer.ex:2405
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1348
-#: lib/vutuv_web/live/post_live/composer.ex:1406
+#: lib/vutuv_web/live/post_live/composer.ex:1385
+#: lib/vutuv_web/live/post_live/composer.ex:1443
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1345
-#: lib/vutuv_web/live/post_live/composer.ex:1403
+#: lib/vutuv_web/live/post_live/composer.ex:1382
+#: lib/vutuv_web/live/post_live/composer.ex:1440
 #, elixir-autogen, elixir-format
 msgid "Discard the photos and text of this draft?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1340
+#: lib/vutuv_web/live/post_live/composer.ex:1377
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1818
+#: lib/vutuv_web/live/post_live/composer.ex:2339
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2092
+#: lib/vutuv_web/live/post_live/composer.ex:1891
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2091
+#: lib/vutuv_web/live/post_live/composer.ex:1890
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2090
+#: lib/vutuv_web/live/post_live/composer.ex:1889
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2095
+#: lib/vutuv_web/live/post_live/composer.ex:1894
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1781
+#: lib/vutuv_web/live/post_live/composer.ex:2309
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1807
+#: lib/vutuv_web/live/post_live/composer.ex:2328
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -16509,7 +16507,8 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1735
+#: lib/vutuv_web/live/post_live/composer.ex:1578
+#: lib/vutuv_web/live/post_live/composer.ex:2173
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr ""
@@ -17377,135 +17376,104 @@ msgstr ""
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1449
+#: lib/vutuv_web/live/post_live/composer.ex:1489
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1565
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Auto"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:2271
+#: lib/vutuv_web/live/post_live/composer.ex:2079
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2272
+#: lib/vutuv_web/live/post_live/composer.ex:2080
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2277
+#: lib/vutuv_web/live/post_live/composer.ex:2085
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2274
+#: lib/vutuv_web/live/post_live/composer.ex:2082
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2275
+#: lib/vutuv_web/live/post_live/composer.ex:2083
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover on top"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2276
+#: lib/vutuv_web/live/post_live/composer.ex:2084
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1445
-#: lib/vutuv_web/live/post_live/composer.ex:2242
-#: lib/vutuv_web/live/post_live/composer.ex:2243
+#: lib/vutuv_web/live/post_live/composer.ex:1485
+#: lib/vutuv_web/live/post_live/composer.ex:2050
+#: lib/vutuv_web/live/post_live/composer.ex:2051
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Crop photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2201
+#: lib/vutuv_web/live/post_live/composer.ex:2009
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cropped"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1376
+#: lib/vutuv_web/live/post_live/composer.ex:1413
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1543
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Gallery preview"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:2278
+#: lib/vutuv_web/live/post_live/composer.ex:2086
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2279
+#: lib/vutuv_web/live/post_live/composer.ex:2087
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1447
+#: lib/vutuv_web/live/post_live/composer.ex:1487
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2270
+#: lib/vutuv_web/live/post_live/composer.ex:2078
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2273
+#: lib/vutuv_web/live/post_live/composer.ex:2081
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1658
-#: lib/vutuv_web/live/post_live/composer.ex:1659
-#, elixir-autogen, elixir-format
-msgid "Swap this photo with another"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1546
-#, elixir-autogen, elixir-format
-msgid "Tap two photos to swap them."
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:450
+#: lib/vutuv_web/live/post_live/composer.ex:485
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2476
+#: lib/vutuv_web/live/post_live/composer.ex:2527
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1451
+#: lib/vutuv_web/live/post_live/composer.ex:1491
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Whole photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1640
-#, elixir-autogen, elixir-format
-msgid "Each photo covers its tile and is cropped by it."
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1641
-#, elixir-autogen, elixir-format
-msgid "Each photo shows whole inside its tile."
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1636
+#: lib/vutuv_web/live/post_live/composer.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1620
+#: lib/vutuv_web/live/post_live/composer.ex:2260
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Whole photos"
 msgstr ""
@@ -19795,17 +19763,17 @@ msgstr ""
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1926
+#: lib/vutuv_web/live/post_live/composer.ex:1725
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1113
+#: lib/vutuv_web/live/post_live/composer.ex:1150
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1903
+#: lib/vutuv_web/live/post_live/composer.ex:1702
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr ""
@@ -20586,17 +20554,17 @@ msgstr ""
 msgid "{n} of {max} free slots selected."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1888
+#: lib/vutuv_web/live/post_live/composer.ex:1687
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1881
+#: lib/vutuv_web/live/post_live/composer.ex:1680
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post language"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1882
+#: lib/vutuv_web/live/post_live/composer.ex:1681
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr ""
@@ -22364,4 +22332,20 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:433
 #, elixir-autogen, elixir-format
 msgid "Nothing matches."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1577
+#: lib/vutuv_web/live/post_live/composer.ex:2206
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Automatic"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1582
+#, elixir-autogen, elixir-format
+msgid "Drag one photo onto another to swap them."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1523
+#, elixir-autogen, elixir-format
+msgid "Not shown in the gallery — drag one into it to swap."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -119,7 +119,7 @@ msgstr "Compleanno"
 #: lib/vutuv_web/live/job_posting_live/form.ex:811
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/organization_live/new.ex:231
-#: lib/vutuv_web/live/post_live/composer.ex:1450
+#: lib/vutuv_web/live/post_live/composer.ex:1490
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -203,7 +203,7 @@ msgid "Disable"
 msgstr "Disattiva"
 
 #: lib/vutuv_web/live/cv_live.ex:438
-#: lib/vutuv_web/live/post_live/composer.ex:1774
+#: lib/vutuv_web/live/post_live/composer.ex:2302
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
@@ -603,7 +603,7 @@ msgstr "Profili di "
 msgid "Provider"
 msgstr "Piattaforma"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1910
+#: lib/vutuv_web/live/post_live/composer.ex:1709
 #: lib/vutuv_web/live/section_reorder_live.ex:270
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -615,7 +615,7 @@ msgstr "Pubblico"
 
 #: lib/vutuv_web/components/ui.ex:4115
 #: lib/vutuv_web/live/organization_live/edit.ex:370
-#: lib/vutuv_web/live/post_live/composer.ex:1925
+#: lib/vutuv_web/live/post_live/composer.ex:1724
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -1648,9 +1648,10 @@ msgstr "Controlli la Sua casella di posta"
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:480
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1411
-#: lib/vutuv_web/live/post_live/composer.ex:1412
-#: lib/vutuv_web/live/post_live/composer.ex:2394
+#: lib/vutuv_web/live/post_live/composer.ex:1448
+#: lib/vutuv_web/live/post_live/composer.ex:1449
+#: lib/vutuv_web/live/post_live/composer.ex:2179
+#: lib/vutuv_web/live/post_live/composer.ex:2445
 #: lib/vutuv_web/templates/layout/app.html.heex:188
 #: lib/vutuv_web/templates/layout/app.html.heex:194
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:20
@@ -2124,7 +2125,7 @@ msgstr "Markdown è supportato: grassetto, corsivo, link ed elenchi."
 msgid "Add images"
 msgstr "Aggiungi immagini"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2036
+#: lib/vutuv_web/live/post_live/composer.ex:1835
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2137,7 +2138,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr "Torna al post"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1694
+#: lib/vutuv_web/live/post_live/composer.ex:1594
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Annulla il caricamento"
@@ -2182,12 +2183,12 @@ msgstr "Segua %{name} per leggerlo."
 msgid "Hidden from:"
 msgstr "Nascosto a:"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2012
+#: lib/vutuv_web/live/post_live/composer.ex:1811
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr "Nascondi a una persona specifica…"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1940
+#: lib/vutuv_web/live/post_live/composer.ex:1739
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr "Nascondi questo post a…"
@@ -2198,13 +2199,13 @@ msgstr "Nascondi questo post a…"
 msgid "Limited audience"
 msgstr "Pubblico limitato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1982
+#: lib/vutuv_web/live/post_live/composer.ex:1781
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr "Visitatori non connessi"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1137
-#: lib/vutuv_web/live/post_live/composer.ex:1185
+#: lib/vutuv_web/live/post_live/composer.ex:1174
+#: lib/vutuv_web/live/post_live/composer.ex:1222
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
@@ -2216,23 +2217,23 @@ msgstr ""
 "Qui non c'è ancora nulla. Segua altre persone per riempire il Suo feed, "
 "oppure scriva il Suo primo post."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1103
+#: lib/vutuv_web/live/post_live/composer.ex:1140
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr "Non è stato possibile allegare una delle immagini."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1972
+#: lib/vutuv_web/live/post_live/composer.ex:1771
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr "Persone che non seguo"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1962
+#: lib/vutuv_web/live/post_live/composer.ex:1761
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr "Persone che non mi seguono"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:416
-#: lib/vutuv_web/live/post_live/composer.ex:1927
+#: lib/vutuv_web/live/post_live/composer.ex:1726
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2282,7 +2283,7 @@ msgstr "Mostra meno"
 #: lib/vutuv_web/live/organization_live/domains.ex:246
 #: lib/vutuv_web/live/organization_live/edit.ex:402
 #: lib/vutuv_web/live/organization_live/roles.ex:247
-#: lib/vutuv_web/live/post_live/composer.ex:1998
+#: lib/vutuv_web/live/post_live/composer.ex:1797
 #: lib/vutuv_web/live/post_live/filter_band.ex:455
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
@@ -2299,7 +2300,7 @@ msgstr ""
 "I post con pubblico limitato sono nascosti anche ai visitatori non connessi "
 "e ai motori di ricerca."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1917
+#: lib/vutuv_web/live/post_live/composer.ex:1716
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr "Salvataggio…"
@@ -2316,12 +2317,12 @@ msgstr[1] "Mostra %{formatted} nuovi post"
 msgid "Sorry, that page could not be found."
 msgstr "Spiacenti, la pagina non è stata trovata."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1211
+#: lib/vutuv_web/live/post_live/composer.ex:1248
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Non è stato possibile elaborare il file."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1085
+#: lib/vutuv_web/live/post_live/composer.ex:1122
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr "La selezione del pubblico non è valida."
@@ -2331,12 +2332,12 @@ msgstr "La selezione del pubblico non è valida."
 msgid "This post is for followers of %{name}"
 msgstr "Questo post è per i follower di %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2543
+#: lib/vutuv_web/live/post_live/composer.ex:2594
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Troppi file."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2544
+#: lib/vutuv_web/live/post_live/composer.ex:2595
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Caricamento non riuscito."
@@ -2350,12 +2351,12 @@ msgstr "Caricamento non riuscito."
 msgid "View profile"
 msgstr "Vedi il profilo"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2111
+#: lib/vutuv_web/live/post_live/composer.ex:1910
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr "Che c'è di nuovo?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2112
+#: lib/vutuv_web/live/post_live/composer.ex:1911
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr "Che c'è di nuovo? Markdown è supportato."
@@ -2391,17 +2392,17 @@ msgstr "persone che non segue"
 msgid "unknown"
 msgstr "sconosciuto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1831
+#: lib/vutuv_web/live/post_live/composer.ex:1630
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr "Tag separati da virgole (max. %{max})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2534
+#: lib/vutuv_web/live/post_live/composer.ex:2585
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr "Il file supera %{mb} MB."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2538
+#: lib/vutuv_web/live/post_live/composer.ex:2589
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr "Tipo di file non supportato (ammessi: %{types})."
@@ -2558,15 +2559,15 @@ msgstr "Rispondi"
 msgid "Reply to a deleted post"
 msgstr "Risposta a un post eliminato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1088
-#: lib/vutuv_web/live/post_live/composer.ex:1905
+#: lib/vutuv_web/live/post_live/composer.ex:1125
+#: lib/vutuv_web/live/post_live/composer.ex:1704
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 "Il pubblico non può essere limitato finché esistono ripubblicazioni o "
 "risposte."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2043
+#: lib/vutuv_web/live/post_live/composer.ex:1842
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2873,7 +2874,7 @@ msgstr "Ancora nessun collegamento."
 msgid "Other formats"
 msgstr "Altri formati"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1952
+#: lib/vutuv_web/live/post_live/composer.ex:1751
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr "Persone che non sono miei collegamenti"
@@ -5526,7 +5527,7 @@ msgstr ""
 "Questo elimina definitivamente il Suo profilo, i post, i messaggi e tutto il"
 " resto. Le inviamo un PIN per e-mail per confermare. Non si può annullare."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1106
+#: lib/vutuv_web/live/post_live/composer.ex:1143
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr "Non può più rispondere a questo post."
@@ -6361,7 +6362,7 @@ msgstr "Posizioni la Sua foto"
 msgid "Use photo"
 msgstr "Usa questa foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1452
+#: lib/vutuv_web/live/post_live/composer.ex:1492
 #: lib/vutuv_web/templates/user/edit.html.heex:54
 #: lib/vutuv_web/templates/user/edit.html.heex:139
 #, elixir-autogen, elixir-format
@@ -11190,6 +11191,8 @@ msgid "Failed"
 msgstr "Non riuscito"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
+#: lib/vutuv_web/live/post_live/composer.ex:1577
+#: lib/vutuv_web/live/post_live/composer.ex:2173
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr "Galleria"
@@ -14091,7 +14094,7 @@ msgstr "A tutta larghezza"
 msgid "Insert image"
 msgstr "Inserisci un'immagine"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2513
+#: lib/vutuv_web/live/post_live/composer.ex:2564
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr "Inserisci nel testo"
@@ -14788,7 +14791,7 @@ msgstr "Menzione"
 msgid "mentioned you in a post."
 msgstr "L'ha menzionata in un post."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1093
+#: lib/vutuv_web/live/post_live/composer.ex:1130
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
@@ -14796,7 +14799,7 @@ msgstr ""
 "Questo post non può più essere modificato: qualcuno gli ha messo Mi piace, "
 "lo ha ripubblicato o gli ha risposto."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1096
+#: lib/vutuv_web/live/post_live/composer.ex:1133
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -17089,7 +17092,7 @@ msgstr ""
 "profilo, come si scrive una trascrizione, e le parentesi le aggiungiamo noi."
 " Se lo lascia vuoto non viene mostrato nulla."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2526
+#: lib/vutuv_web/live/post_live/composer.ex:2577
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr "Applica queste impostazioni a tutte le foto"
@@ -17119,12 +17122,12 @@ msgstr "CC BY-SA 4.0 (attribuzione, stessa licenza)"
 msgid "CC0 1.0 (no rights reserved)"
 msgstr "CC0 1.0 (nessun diritto riservato)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2193
+#: lib/vutuv_web/live/post_live/composer.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Copertina"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2386
+#: lib/vutuv_web/live/post_live/composer.ex:2415
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr "Descriva la foto per chi non può vederla"
@@ -17136,29 +17139,24 @@ msgstr "Descriva la foto per chi non può vederla"
 msgid "Download the original"
 msgstr "Scarica l'originale"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1531
-#, elixir-autogen, elixir-format
-msgid "Drag to reorder. The first photo leads the gallery."
-msgstr "Trascini per riordinare. La prima foto apre la galleria."
-
-#: lib/vutuv_web/live/post_live/composer.ex:2463
+#: lib/vutuv_web/live/post_live/composer.ex:2514
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 "Tutti i campi di metadati conservati, compreso ciò che ha scritto la Sua "
 "fotocamera."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2419
+#: lib/vutuv_web/live/post_live/composer.ex:2470
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr "Chiunque può scaricare questa foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2421
+#: lib/vutuv_web/live/post_live/composer.ex:2472
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr "Risoluzione piena, direttamente dal post."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2440
+#: lib/vutuv_web/live/post_live/composer.ex:2491
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr "Solo l'immagine"
@@ -17168,7 +17166,7 @@ msgstr "Solo l'immagine"
 msgid "Next photo"
 msgstr "Foto successiva"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2212
+#: lib/vutuv_web/live/post_live/composer.ex:2020
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr "Ancora nessuna descrizione dell'immagine"
@@ -17188,8 +17186,8 @@ msgstr "Foto %{n} di %{total}"
 msgid "Photo is being checked"
 msgstr "La foto è in fase di controllo"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2165
-#: lib/vutuv_web/live/post_live/composer.ex:2166
+#: lib/vutuv_web/live/post_live/composer.ex:1973
+#: lib/vutuv_web/live/post_live/composer.ex:1974
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr "Opzioni della foto"
@@ -17206,20 +17204,20 @@ msgstr "Foto:"
 msgid "Previous photo"
 msgstr "Foto precedente"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2225
-#: lib/vutuv_web/live/post_live/composer.ex:2226
+#: lib/vutuv_web/live/post_live/composer.ex:2033
+#: lib/vutuv_web/live/post_live/composer.ex:2034
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr "Rimuovi la foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2442
+#: lib/vutuv_web/live/post_live/composer.ex:2493
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 "Gli stessi pixel e nient'altro: posizione e numeri di serie rimossi, qualità"
 " intatta."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1503
+#: lib/vutuv_web/live/post_live/composer.ex:2434
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr "Mostra le impostazioni della fotocamera"
@@ -17231,19 +17229,19 @@ msgstr ""
 "Quel server è bloccato su questo sito, quindi non gli si può inviare alcuna "
 "risposta."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2461
+#: lib/vutuv_web/live/post_live/composer.ex:2512
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr "Il file esattamente come l'ho caricato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2497
+#: lib/vutuv_web/live/post_live/composer.ex:2548
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 "Questo formato di file può essere consegnato solo così com'è. Rimuova la "
 "foto se non è ciò che desidera."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2489
+#: lib/vutuv_web/live/post_live/composer.ex:2540
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
@@ -17275,12 +17273,12 @@ msgstr "Questo sito non partecipa al Fediverso."
 msgid "Turn on Fediverse participation to answer"
 msgstr "Attivi la partecipazione al Fediverso per rispondere"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1752
+#: lib/vutuv_web/live/post_live/composer.ex:2291
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr "Chi può riutilizzare queste foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1120
+#: lib/vutuv_web/live/post_live/composer.ex:1157
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -17293,7 +17291,7 @@ msgstr ""
 "Ha spostato il Suo account del Fediverso su un altro server, quindi da qui "
 "non vengono più inviate risposte."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1134
+#: lib/vutuv_web/live/post_live/composer.ex:1171
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -17312,72 +17310,72 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr "© Tutti i diritti riservati"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1522
-#: lib/vutuv_web/live/post_live/composer.ex:1868
+#: lib/vutuv_web/live/post_live/composer.ex:1560
+#: lib/vutuv_web/live/post_live/composer.ex:1667
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr "Aggiungi foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1747
+#: lib/vutuv_web/live/post_live/composer.ex:2286
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr "Licenza"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1480
+#: lib/vutuv_web/live/post_live/composer.ex:2405
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr "Didascalia (facoltativa)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1348
-#: lib/vutuv_web/live/post_live/composer.ex:1406
+#: lib/vutuv_web/live/post_live/composer.ex:1385
+#: lib/vutuv_web/live/post_live/composer.ex:1443
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr "Scarta la bozza"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1345
-#: lib/vutuv_web/live/post_live/composer.ex:1403
+#: lib/vutuv_web/live/post_live/composer.ex:1382
+#: lib/vutuv_web/live/post_live/composer.ex:1440
 #, elixir-autogen, elixir-format
 msgid "Discard the photos and text of this draft?"
 msgstr "Scartare le foto e il testo di questa bozza?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1340
+#: lib/vutuv_web/live/post_live/composer.ex:1377
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr "Ripreso da dove aveva lasciato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1818
+#: lib/vutuv_web/live/post_live/composer.ex:2339
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 "Un file il cui formato non può essere ripulito viene consegnato esattamente "
 "come caricato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2092
+#: lib/vutuv_web/live/post_live/composer.ex:1891
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr "Diverso per ogni foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2091
+#: lib/vutuv_web/live/post_live/composer.ex:1890
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr "Originale, esattamente come caricato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2090
+#: lib/vutuv_web/live/post_live/composer.ex:1889
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr "Originale, senza metadati"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2095
+#: lib/vutuv_web/live/post_live/composer.ex:1894
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr "Solo versioni per il web (%{format})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1781
+#: lib/vutuv_web/live/post_live/composer.ex:2309
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr "Cosa può salvare un visitatore"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1807
+#: lib/vutuv_web/live/post_live/composer.ex:2328
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -17500,7 +17498,8 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr "Richiesta di ritiro"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1735
+#: lib/vutuv_web/live/post_live/composer.ex:1578
+#: lib/vutuv_web/live/post_live/composer.ex:2173
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr "Dettagli della foto"
@@ -18494,139 +18493,108 @@ msgstr ""
 "previsti per ogni altro post da un'altra rete, e al server del suo autore "
 "non viene chiesto nient'altro."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1449
+#: lib/vutuv_web/live/post_live/composer.ex:1489
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr "Applica il ritaglio"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1565
-#, elixir-autogen, elixir-format
-msgid "Auto"
-msgstr "Automatico"
-
-#: lib/vutuv_web/live/post_live/composer.ex:2271
+#: lib/vutuv_web/live/post_live/composer.ex:2079
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr "Foto grande a sinistra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2272
+#: lib/vutuv_web/live/post_live/composer.ex:2080
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr "Foto grande a destra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2277
+#: lib/vutuv_web/live/post_live/composer.ex:2085
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr "Colonne"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2274
+#: lib/vutuv_web/live/post_live/composer.ex:2082
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr "Copertina a sinistra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2275
+#: lib/vutuv_web/live/post_live/composer.ex:2083
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr "Copertina in alto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2276
+#: lib/vutuv_web/live/post_live/composer.ex:2084
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr "Copertina a destra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1445
-#: lib/vutuv_web/live/post_live/composer.ex:2242
-#: lib/vutuv_web/live/post_live/composer.ex:2243
+#: lib/vutuv_web/live/post_live/composer.ex:1485
+#: lib/vutuv_web/live/post_live/composer.ex:2050
+#: lib/vutuv_web/live/post_live/composer.ex:2051
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr "Ritaglia la foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2201
+#: lib/vutuv_web/live/post_live/composer.ex:2009
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr "Ritagliata"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1376
+#: lib/vutuv_web/live/post_live/composer.ex:1413
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr "Trascini qui le foto per aggiungerle"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1543
-#, elixir-autogen, elixir-format
-msgid "Gallery preview"
-msgstr "Anteprima della galleria"
-
-#: lib/vutuv_web/live/post_live/composer.ex:2278
+#: lib/vutuv_web/live/post_live/composer.ex:2086
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr "Griglia"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2279
+#: lib/vutuv_web/live/post_live/composer.ex:2087
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr "Mosaico"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1447
+#: lib/vutuv_web/live/post_live/composer.ex:1487
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 "Scelga una forma, poi trascini e ingrandisca. La parte nel riquadro è quella"
 " che il post mostra."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2270
+#: lib/vutuv_web/live/post_live/composer.ex:2078
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr "Affiancate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2273
+#: lib/vutuv_web/live/post_live/composer.ex:2081
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr "Impilate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1658
-#: lib/vutuv_web/live/post_live/composer.ex:1659
-#, elixir-autogen, elixir-format
-msgid "Swap this photo with another"
-msgstr "Scambia questa foto con un'altra"
-
-#: lib/vutuv_web/live/post_live/composer.ex:1546
-#, elixir-autogen, elixir-format
-msgid "Tap two photos to swap them."
-msgstr "Prema due foto per scambiarle."
-
-#: lib/vutuv_web/live/post_live/composer.ex:450
+#: lib/vutuv_web/live/post_live/composer.ex:485
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr "Non è stato possibile ritagliare la foto."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2476
+#: lib/vutuv_web/live/post_live/composer.ex:2527
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 "Questa foto è ritagliata: i download consegnano l'immagine ritagliata, e il "
 "caricamento intatto resta privato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1451
+#: lib/vutuv_web/live/post_live/composer.ex:1491
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr "Foto intera"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1640
-#, elixir-autogen, elixir-format
-msgid "Each photo covers its tile and is cropped by it."
-msgstr "Ogni foto riempie la propria casella e viene ritagliata da essa."
-
-#: lib/vutuv_web/live/post_live/composer.ex:1641
-#, elixir-autogen, elixir-format
-msgid "Each photo shows whole inside its tile."
-msgstr "Ogni foto si vede per intero dentro la propria casella."
-
-#: lib/vutuv_web/live/post_live/composer.ex:1636
+#: lib/vutuv_web/live/post_live/composer.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr "Riempi le caselle"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1620
+#: lib/vutuv_web/live/post_live/composer.ex:2260
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr "Foto intere"
@@ -21202,17 +21170,17 @@ msgstr ""
 msgid "Nothing published yet."
 msgstr "Ancora nulla di pubblicato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1926
+#: lib/vutuv_web/live/post_live/composer.ex:1725
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr "Pubblica come %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1113
+#: lib/vutuv_web/live/post_live/composer.ex:1150
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr "Non può più scrivere a nome di questa organizzazione."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1903
+#: lib/vutuv_web/live/post_live/composer.ex:1702
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr "Un post a nome di un'organizzazione è sempre pubblico."
@@ -22078,17 +22046,17 @@ msgstr "Ha %{used} tag su %{max}."
 msgid "{n} of {max} free slots selected."
 msgstr "Selezionati {n} posti liberi su {max}."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1888
+#: lib/vutuv_web/live/post_live/composer.ex:1687
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr "Altre lingue"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1881
+#: lib/vutuv_web/live/post_live/composer.ex:1680
 #, elixir-autogen, elixir-format
 msgid "Post language"
 msgstr "Lingua del post"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1882
+#: lib/vutuv_web/live/post_live/composer.ex:1681
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr "La lingua in cui è scritto questo post"
@@ -23958,16 +23926,32 @@ msgstr[0] "lo ha condiviso."
 msgstr[1] "lo hanno condiviso."
 
 #: lib/vutuv_web/components/ui.ex:468
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Editor view"
-msgstr "Modifica profilo"
+msgstr "Vista"
 
 #: lib/vutuv_web/components/ui.ex:421
 #, elixir-autogen, elixir-format
 msgid "Insert a block"
-msgstr ""
+msgstr "Inserisci un blocco"
 
 #: lib/vutuv_web/components/ui.ex:433
 #, elixir-autogen, elixir-format
 msgid "Nothing matches."
-msgstr ""
+msgstr "Nessun risultato."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1577
+#: lib/vutuv_web/live/post_live/composer.ex:2206
+#, elixir-autogen, elixir-format
+msgid "Automatic"
+msgstr "Automatico"
+
+#: lib/vutuv_web/live/post_live/composer.ex:1582
+#, elixir-autogen, elixir-format
+msgid "Drag one photo onto another to swap them."
+msgstr "Trascina una foto su un'altra per scambiarle."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1523
+#, elixir-autogen, elixir-format
+msgid "Not shown in the gallery — drag one into it to swap."
+msgstr "Non nella galleria — trascinane una dentro per scambiarla."

--- a/test/vutuv_web/live/photo_composer_test.exs
+++ b/test/vutuv_web/live/photo_composer_test.exs
@@ -71,8 +71,11 @@ defmodule VutuvWeb.PhotoComposerTest do
     live
   end
 
+  # The licence and download answers moved from a folded row into the gallery
+  # sheet (issue #1892), which is also where the arrangement lives now — one
+  # control for everything that belongs to the set rather than to one photo.
   defp open_details(live) do
-    live |> element("#composer-photo-details-toggle") |> render_click()
+    live |> element("#composer-gallery-open") |> render_click()
   end
 
   # A pending row minted outside any composer — the shape a reconnected
@@ -135,7 +138,7 @@ defmodule VutuvWeb.PhotoComposerTest do
   # so a test drives it through the element rather than through `form/3`.
   defp choose_download(live, choice) do
     live
-    |> element("#composer-download")
+    |> element("#composer-gallery-download")
     |> render_change(%{"post" => %{"download" => choice}})
   end
 
@@ -160,9 +163,9 @@ defmodule VutuvWeb.PhotoComposerTest do
       refute render(live) =~ "data-photo-tile"
       # The two rights questions are about photos; without one they would be
       # controls about nothing.
-      refute has_element?(live, "[data-photo-details-toggle]")
-      refute has_element?(live, "#composer-license")
-      refute has_element?(live, "#composer-download")
+      refute has_element?(live, "[data-gallery-open]")
+      refute has_element?(live, "#composer-gallery-license")
+      refute has_element?(live, "#composer-gallery-download")
     end
   end
 
@@ -206,12 +209,18 @@ defmodule VutuvWeb.PhotoComposerTest do
 
       assert has_element?(live, ~s([data-photo-tile="#{image.id}"] img[src$="/feed.avif"]))
 
-      # One visible text per photo, right under the tile.
+      # The caption is one tap in, in the photo's own sheet — it used to sit
+      # inline under the tile, which is what made one photo's settings live in
+      # two places at once (issue #1892).
+      refute has_element?(live, ~s(input[name="photo[#{image.id}][caption]"]))
+      open_panel(live, image)
       assert has_element?(live, ~s(input[name="photo[#{image.id}][caption]"]))
 
-      # Adding more photos is now a tile among tiles; the same id, so the
-      # feed's camera button always finds its target.
-      assert has_element?(live, "[data-photo-add-tile]")
+      # Adding more photos sits in the row under the pictures, not as a tile
+      # among them: the mosaic's cells are the arrangement, and a "+" occupying
+      # one of them would be a seat the gallery does not have (issue #1892).
+      # The id is unchanged, so the feed's camera button still finds its target.
+      refute has_element?(live, "[data-photo-add-tile]")
       assert has_element?(live, "#composer-add-photos")
     end
 
@@ -238,7 +247,7 @@ defmodule VutuvWeb.PhotoComposerTest do
              end)
     end
 
-    test "a photo carrying camera facts offers the publish switch right under its tile", %{
+    test "a photo carrying camera facts offers the publish switch in its sheet", %{
       conn: conn,
       user: user
     } do
@@ -255,6 +264,12 @@ defmodule VutuvWeb.PhotoComposerTest do
             {"exif-ifd2-ISOSpeedRatings", "400"}
           ]
         )
+
+      # In the photo's sheet, beside its caption and description — the switch
+      # is about this picture, so it lives where everything about this picture
+      # lives (issue #1892).
+      refute has_element?(live, ~s([data-photo-camera-inline="#{image.id}"]))
+      open_panel(live, image)
 
       assert has_element?(live, ~s([data-photo-camera-inline="#{image.id}"]))
       assert render(live) =~ "Canon EOS R6 · 50 mm · f/1.8 · 1/200 s · ISO 400"
@@ -302,7 +317,10 @@ defmodule VutuvWeb.PhotoComposerTest do
       assert has_element?(live, ~s([data-photo-alt-missing="#{image.id}"]))
 
       # A caption gives the photo its accessible name (photo_alt/1 falls back
-      # to it), so the nudge is satisfied without the panel.
+      # to it), so the nudge is satisfied by either field — which is the point
+      # of writing them side by side in the photo's own sheet.
+      open_panel(live, image)
+
       live
       |> form("#composer-form", %{
         "photo" => %{image.id => %{"caption" => "Zugfenster"}}
@@ -355,6 +373,9 @@ defmodule VutuvWeb.PhotoComposerTest do
       live = open_composer(conn)
       image = upload_photo!(live, user)
 
+      # The caption field only exists while the photo's sheet is open.
+      open_panel(live, image)
+
       live
       |> form("#composer-form", %{
         "photo" => %{image.id => %{"caption" => "Gleich weg"}}
@@ -393,7 +414,7 @@ defmodule VutuvWeb.PhotoComposerTest do
       {:ok, live, _html} = live(conn, ~p"/posts/#{post.id}/edit")
 
       assert has_element?(live, ~s([data-photo-tile="#{image.id}"]))
-      assert has_element?(live, "#composer-photo-details-toggle")
+      assert has_element?(live, "#composer-gallery-open")
       assert has_element?(live, ~s(#composer-form textarea[name="post[body]"]))
     end
   end
@@ -640,21 +661,21 @@ defmodule VutuvWeb.PhotoComposerTest do
     } do
       live = open_composer(conn)
 
-      refute has_element?(live, "#composer-photo-details-toggle")
+      refute has_element?(live, "#composer-gallery-open")
 
       upload_photo!(live, user)
 
       # The row is there, its answers are named on the fold, but the selects
       # stay away until the author opens it.
-      assert has_element?(live, "#composer-photo-details-toggle")
+      assert has_element?(live, "#composer-gallery-open")
       assert render(live) =~ "All rights reserved"
-      refute has_element?(live, "#composer-license")
-      refute has_element?(live, "#composer-download")
+      refute has_element?(live, "#composer-gallery-license")
+      refute has_element?(live, "#composer-gallery-download")
 
       open_details(live)
 
-      assert has_element?(live, "#composer-license")
-      assert has_element?(live, "#composer-download")
+      assert has_element?(live, "#composer-gallery-license")
+      assert has_element?(live, "#composer-gallery-download")
     end
 
     test "left untouched, a post keeps the defaults silently", %{conn: conn, user: user} do
@@ -704,8 +725,8 @@ defmodule VutuvWeb.PhotoComposerTest do
 
       {:ok, live, _html} = live(conn, ~p"/posts/#{post.id}/edit")
 
-      assert has_element?(live, "#composer-photo-details-toggle")
-      refute has_element?(live, "#composer-license")
+      assert has_element?(live, "#composer-gallery-open")
+      refute has_element?(live, "#composer-gallery-license")
 
       live |> form("#composer-form", %{"post" => %{"body" => "Andere Worte."}}) |> render_submit()
 
@@ -720,7 +741,7 @@ defmodule VutuvWeb.PhotoComposerTest do
       image = upload_photo!(live, user)
       open_details(live)
 
-      assert has_element?(live, ~s(#composer-download option[value="none"][selected]))
+      assert has_element?(live, ~s(#composer-gallery-download option[value="none"][selected]))
 
       live |> form("#composer-form") |> render_submit()
 
@@ -794,7 +815,7 @@ defmodule VutuvWeb.PhotoComposerTest do
 
       # The set now disagrees, and the select says so rather than claiming an
       # answer nobody gave.
-      assert has_element?(live, ~s(#composer-download option[value="mixed"][selected]))
+      assert has_element?(live, ~s(#composer-gallery-download option[value="mixed"][selected]))
 
       # A validate carrying the select's stale value (every keystroke does)
       # must not push that value back onto the photos.
@@ -854,56 +875,85 @@ defmodule VutuvWeb.PhotoComposerTest do
     end
   end
 
-  describe "the bento workshop" do
+  describe "the gallery sheet" do
     setup %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       %{conn: conn, live: open_composer(conn), user: user}
     end
 
-    test "appears with the second photo: live preview, pattern chips, swap hint", %{
+    test "the tiles ARE the mosaic; the sheet holds what belongs to the set", %{
       live: live,
       user: user
     } do
       upload_photo!(live, user)
-      refute has_element?(live, "[data-bento-editor]")
+      # One photo is no arrangement, so the control names the two rights
+      # questions instead — they are the whole of what the sheet then holds,
+      # and they have to stay reachable for a single photo.
+      assert has_element?(live, "[data-gallery-open]")
+      assert render(live) =~ "Photo details"
+      refute render(live) =~ "grid-template-columns: repeat(12, 1fr)"
 
       upload_photo!(live, user)
-      assert has_element?(live, "[data-bento-editor]")
-      assert has_element?(live, "[data-bento-preview]")
-      # The Auto chip leads and is the state in force…
+
+      # The tiles themselves are laid out on the mosaic's 12x6 grid — there is
+      # no separate preview to compare them against any more (issue #1892).
+      assert render(live) =~ "grid-template-columns: repeat(12, 1fr)"
+      refute has_element?(live, "[data-bento-preview]")
+      refute has_element?(live, "[data-bento-editor]")
+
+      # The set's choices are one control away, and the chip names what is in
+      # force so the arrangement reads without opening it.
+      assert has_element?(live, "[data-gallery-open]")
+      refute has_element?(live, "[data-gallery-sheet]")
+
+      live |> element("[data-gallery-open]") |> render_click()
+      assert has_element?(live, "[data-gallery-sheet]")
       assert has_element?(live, ~s([data-bento-pattern="auto"][aria-pressed="true"]))
-      # …beside the two-photo arrangements from the catalog.
+
       for variant <- GalleryLayout.variants(2) do
         assert has_element?(live, ~s([data-bento-pattern="#{variant.name}"]))
       end
     end
 
-    test "tap-tap swaps two photos, and the swapped order is what saves", %{
+    test "dragging one photo onto another swaps them, and that order saves", %{
       live: live,
       user: user
     } do
       first = upload_photo!(live, user)
       second = upload_photo!(live, user)
 
-      live |> element(~s([data-bento-tile="#{first.id}"])) |> render_click()
-      assert has_element?(live, ~s([data-bento-tile="#{first.id}"] [data-bento-swap-marked]))
-
-      live |> element(~s([data-bento-tile="#{second.id}"])) |> render_click()
-      refute has_element?(live, "[data-bento-swap-marked]")
+      # The drop the PhotoStrip hook reports. It names both ends in one event —
+      # the tap-tap swap it replaces needed a "which one is marked" mode, and a
+      # preview to tap in.
+      live
+      |> element("#composer-images")
+      |> render_hook("photo-swap", %{"from" => first.id, "to" => second.id})
 
       live |> form("#composer-form", %{"post" => %{"body" => "Swapped."}}) |> render_submit()
       post = only_post(user)
+
       assert Enum.map(post.images, & &1.id) == [second.id, first.id]
     end
 
-    test "tapping the marked photo again unmarks it", %{live: live, user: user} do
+    test "a swap onto itself, or onto a photo that is gone, changes nothing", %{
+      live: live,
+      user: user
+    } do
       first = upload_photo!(live, user)
-      _second = upload_photo!(live, user)
+      second = upload_photo!(live, user)
 
-      live |> element(~s([data-bento-tile="#{first.id}"])) |> render_click()
-      live |> element(~s([data-bento-tile="#{first.id}"])) |> render_click()
+      for params <- [
+            %{"from" => first.id, "to" => first.id},
+            %{"from" => first.id, "to" => "not-a-real-id"},
+            %{"from" => "gone", "to" => second.id}
+          ] do
+        live |> element("#composer-images") |> render_hook("photo-swap", params)
+      end
 
-      refute has_element?(live, "[data-bento-swap-marked]")
+      live |> form("#composer-form", %{"post" => %{"body" => "Unmoved."}}) |> render_submit()
+      post = only_post(user)
+
+      assert Enum.map(post.images, & &1.id) == [first.id, second.id]
     end
 
     test "a pattern chip sets the arrangement and the save stores it", %{
@@ -912,21 +962,14 @@ defmodule VutuvWeb.PhotoComposerTest do
     } do
       upload_photo!(live, user)
       upload_photo!(live, user)
+      live |> element("[data-gallery-open]") |> render_click()
 
       live |> element(~s([data-bento-pattern="stack"])) |> render_click()
       assert has_element?(live, ~s([data-bento-pattern="stack"][aria-pressed="true"]))
       refute has_element?(live, ~s([data-bento-pattern="auto"][aria-pressed="true"]))
 
-      live |> form("#composer-form", %{"post" => %{"body" => "Arranged."}}) |> render_submit()
+      live |> form("#composer-form", %{"post" => %{"body" => "Stacked."}}) |> render_submit()
       assert only_post(user).gallery_layout == "stack"
-    end
-
-    test "Auto stays the default and stores no arrangement", %{live: live, user: user} do
-      upload_photo!(live, user)
-      upload_photo!(live, user)
-
-      live |> form("#composer-form", %{"post" => %{"body" => "Auto."}}) |> render_submit()
-      assert only_post(user).gallery_layout == nil
     end
 
     test "whole photos are the default fit; filling the tiles is the explicit choice", %{
@@ -935,62 +978,55 @@ defmodule VutuvWeb.PhotoComposerTest do
     } do
       upload_photo!(live, user)
       upload_photo!(live, user)
+      live |> element("[data-gallery-open]") |> render_click()
 
-      # The pair renders, "whole" in force, and the preview shows whole photos.
       assert has_element?(live, ~s([data-bento-fit="whole"][aria-pressed="true"]))
       assert has_element?(live, ~s([data-bento-fit="fill"][aria-pressed="false"]))
-      assert has_element?(live, "[data-bento-preview] img.object-contain")
-
-      live |> form("#composer-form", %{"post" => %{"body" => "Whole."}}) |> render_submit()
-      assert only_post(user).gallery_fill? == false
-    end
-
-    test "switching to filled tiles crops the preview and the save stores it", %{
-      live: live,
-      user: user
-    } do
-      upload_photo!(live, user)
-      upload_photo!(live, user)
+      # The fit is read off the TILES now, because the tiles are the gallery.
+      assert has_element?(live, "#composer-images img.object-contain")
 
       live |> element(~s([data-bento-fit="fill"])) |> render_click()
       assert has_element?(live, ~s([data-bento-fit="fill"][aria-pressed="true"]))
-      assert has_element?(live, "[data-bento-preview] img.object-cover")
-
-      live |> form("#composer-form", %{"post" => %{"body" => "Filled."}}) |> render_submit()
-      assert only_post(user).gallery_fill? == true
+      assert has_element?(live, "#composer-images img.object-cover")
     end
 
-    test "the fit rides the draft and comes back on reload", %{
+    test "the arrangement and the fit survive a reconnect", %{
       conn: conn,
       live: live,
       user: user
     } do
       upload_photo!(live, user)
       upload_photo!(live, user)
+      live |> element("[data-gallery-open]") |> render_click()
 
       live |> element(~s([data-bento-fit="fill"])) |> render_click()
-      assert %Posts.PostDraft{fill?: true} = Posts.get_draft(user)
+      live |> element(~s([data-bento-pattern="stack"])) |> render_click()
 
-      {:ok, reopened, _html} = live(conn, ~p"/feed")
+      reopened = open_composer(conn)
+      # The sheet itself is a view, not data: it comes back closed, and what it
+      # was showing is still in force underneath.
+      refute has_element?(reopened, "[data-gallery-sheet]")
+
+      reopened |> element("[data-gallery-open]") |> render_click()
       assert has_element?(reopened, ~s([data-bento-fit="fill"][aria-pressed="true"]))
+      assert has_element?(reopened, ~s([data-bento-pattern="stack"][aria-pressed="true"]))
     end
 
-    test "the chosen arrangement rides the draft and comes back on reload", %{
-      conn: conn,
-      live: live,
-      user: user
-    } do
-      upload_photo!(live, user)
-      upload_photo!(live, user)
+    test "a photo past the mosaic's five tiles stays reachable", %{live: live, user: user} do
+      images = for _ <- 1..6, do: upload_photo!(live, user)
+      sixth = List.last(images)
 
-      live |> element(~s([data-bento-pattern="stack"])) |> render_click()
-      assert %Posts.PostDraft{layout: "stack"} = Posts.get_draft(user)
+      # The post shows five; the composer holds ten. Hiding the sixth behind a
+      # "+1" the author cannot open would make it impossible to remove.
+      assert has_element?(live, ~s(#composer-overflow [data-photo-tile="#{sixth.id}"]))
 
-      # A reload rebuilds the composer from the stored draft (issue #1148);
-      # the arrangement must come back with the photos. The feed re-opens the
-      # composer over a held draft by itself, so there is no pill to click.
-      {:ok, reopened, _html} = live(conn, ~p"/feed")
-      assert has_element?(reopened, ~s([data-bento-pattern="stack"][aria-pressed="true"]))
+      live
+      |> element(
+        ~s(#composer-overflow [data-photo-tile="#{sixth.id}"] [phx-click="remove-image"])
+      )
+      |> render_click()
+
+      refute has_element?(live, ~s([data-photo-tile="#{sixth.id}"]))
     end
   end
 
@@ -1121,15 +1157,20 @@ defmodule VutuvWeb.PhotoComposerTest do
       upload_photo!(live, user)
       upload_photo!(live, user)
 
+      # What the tiles themselves say, before anything is opened.
       html = render(live)
-      assert html =~ "Automatisch"
-      assert html =~ "Galerie-Vorschau"
-      assert html =~ "Tippen Sie zwei Fotos an, um sie zu tauschen."
+      assert html =~ "Galerie"
+      assert html =~ "Ein Foto auf ein anderes ziehen, um sie zu tauschen."
       assert html =~ "Foto zuschneiden"
-      assert html =~ "Nebeneinander"
       assert html =~ "Fotos hier ablegen, um sie hinzuzufügen"
+
+      # …and what the sheet says once it is.
+      html = open_details(live)
+      assert html =~ "Automatisch"
+      assert html =~ "Nebeneinander"
       assert html =~ "Ganze Fotos"
       assert html =~ "Kacheln füllen"
+      assert html =~ "Lizenz"
     end
   end
 end


### PR DESCRIPTION
Attaching photos meant tuning a mosaic by looking at a small copy of it: a plain grid of tiles, and a live preview of the arrangement further down. The tiles are now laid out in the mosaic itself — the same `mosaic_layout/2` the post card renders from — and dragging one photo onto another swaps them.

Decisions about one photo lived in four places (caption under the tile, the ⚙ panel, that workshop, a folded licence row). Two now: the photo's own sheet, and one **Galerie** control for what belongs to the set. The tile keeps only what acts on the picture — remove and crop.

Two calls worth a look. The control appears with the **first** photo, named "Fotodetails" then, because licence and download apply to one photo and their folded row is gone. And photos past the mosaic's five tiles get a labelled row saying the post will not show them — hiding a sixth behind a "+1" would make it unremovable.

Try it at `/feed`: attach three photos, drag one onto another, open Galerie.

Also fixes an Italian catalog entry #1886 left fuzzy ("Editor view" → "Modifica profilo"); I had only checked German.

Closes #1892

*An AI agent wrote this text in my name. I know that is problematic.*
