### PR TITLE
Tag chips from a remote post's closing line survive a glued-on word

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -352,7 +352,18 @@ every activity of a member it finds no key for, silently.
     — one we do not carry stays a plain chip rather than being dropped. Only a
     **closing** run is taken (blank lines between hashtag lines go with it); a
     hashtag inside a sentence, or a hashtag line the author wrote in the middle
-    of a post, stays exactly where they put it and still links inline. The
+    of a post, stays exactly where they put it and still links inline. A token
+    only has to **begin** with a hashtag, because a tag row is typed by hand
+    and glues things to its tags (tagesschau closes on
+    `#FlughafenLeipzig/Halle`), and demanding the whole token be one hashtag
+    left the whole line in the body as a run of blue words. **Lifting is a
+    move, never a delete**, so the chip shows the tag as it was typed and links
+    the tag that text names — `FlughafenLeipzig/Halle` on the pill,
+    `/tags/flughafenleipzig` behind it — and tags run together in one token
+    (`#Nepal#Rockfall#FlashFlood`) become one chip each. A token carrying a URL
+    or an address disqualifies its line instead: authors write their closing
+    link straight onto the last tag (`#linuxhttps://flathub.org/apps/…`), and
+    that line is better left where they put it than folded into a pill. The
     grammar is Unicode-wide (`#München` is an ordinary German hashtag), and a
     warned post keeps its chips **inside** the content-warning lid: the tags of
     a post its author covered up are part of what they covered. Only the two

--- a/lib/vutuv/fediverse/remote_post_tag.ex
+++ b/lib/vutuv/fediverse/remote_post_tag.ex
@@ -5,10 +5,11 @@ defmodule Vutuv.Fediverse.RemotePostTag do
 
   The row is written from the post's hashtags — the ActivityPub `tag` array's
   `Hashtag` objects and, for servers that send none, the `#hashtags` left in the
-  text — and it names a tag that **already exists here**. Ingestion mints no tag
-  from a stranger's hashtag: our tag namespace is what members chose to call
-  things, and a table a remote server can extend is a table a remote server can
-  flood with pages on our own domain.
+  text. A hashtag naming a topic nobody here has written about yet **mints** it
+  (`Vutuv.Fediverse.Hashtags`, which explains what changed and what still holds
+  the line): nothing reaches that module unless a member here follows the
+  account that sent it, so the names arriving are the topics our own members
+  chose to read about rather than a table a stranger can flood.
 
   There is deliberately no changeset. Nothing here is user-supplied: both ids
   come from records `Vutuv.Fediverse.Hashtags` already resolved, and the write

--- a/lib/vutuv/mentions.ex
+++ b/lib/vutuv/mentions.ex
@@ -163,20 +163,27 @@ defmodule Vutuv.Mentions do
   @doc "The canonical entity regex, so the renderer shares this module's grammar."
   def entity_regex, do: @entity
 
-  # One whole `#hashtag` and nothing else, in the same alphabet `@entity` reads.
-  # Split out so `VutuvWeb.Markdown.split_trailing_hashtags/1` — which asks of a
-  # *token* what `@entity` asks of a body — cannot answer it with a second,
-  # slightly different class. The two had already drifted (`\p{N}` against
-  # `\p{Nd}\p{M}`), which decided differently on a decomposed `#Thüringen`.
-  @hashtag_token ~r"\A#([\p{L}\p{M}\p{Nd}_]+)\z"u
+  # A token that **opens** with a whole `#hashtag`, in the same alphabet
+  # `@entity` reads. Split out so `VutuvWeb.Markdown.split_trailing_hashtags/1`
+  # — which asks of a *token* what `@entity` asks of a body — cannot answer it
+  # with a second, slightly different class. The two had already drifted
+  # (`\p{N}` against `\p{Nd}\p{M}`), which decided differently on a decomposed
+  # `#Thüringen`.
+  #
+  # Unanchored at the end, because a closing tag line is written by hand and
+  # routinely glues something to a tag: `#Berlin,` in a list, `#Wahl2026.` at
+  # the end of a sentence, `#FlughafenLeipzig/Halle` where the tag names half
+  # of a double name. The hashtag still has to come first, which is what keeps
+  # a sentence a sentence.
+  @hashtag_prefix ~r"\A#([\p{L}\p{M}\p{Nd}_]+)"u
 
   @doc """
-  Matches a single token that is one whole hashtag, capturing the name.
+  Matches a token that begins with one whole hashtag, capturing its name.
 
   The token twin of `entity_regex/0`, for a caller deciding whether a *line*
-  is nothing but hashtags rather than finding them inside prose.
+  is a row of hashtags rather than finding them inside prose.
   """
-  def hashtag_token_regex, do: @hashtag_token
+  def hashtag_prefix_regex, do: @hashtag_prefix
 
   @doc "How many distinct local accounts one post may mention."
   def max_post_mentions, do: @max_post_mentions

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -1868,16 +1868,22 @@ defmodule VutuvWeb.PostComponents do
   # A tag we do not carry still gets its chip, as a plain span: dropping it
   # would silently swallow part of what the author wrote, and rendering it
   # differently would say something about the tag that is really about us.
+  #
+  # The chip shows `text` (the tag as its author typed it, `/Halle` and all)
+  # and is looked up by `name` (the tag that text names) — see
+  # `Markdown.split_trailing_hashtags/1`. The two differ exactly where a tag
+  # row glues something to a tag, and showing `name` there would delete the
+  # difference from the card.
   defp remote_tag_chips([]), do: []
 
   defp remote_tag_chips(hashtags) do
-    linkable = Tags.linkable_slugs(hashtags)
+    linkable = hashtags |> Enum.map(& &1.name) |> Tags.linkable_slugs()
 
-    Enum.map(hashtags, fn hashtag ->
+    Enum.map(hashtags, fn %{name: name, text: text} ->
       # The slug we link is the one the gate hands back, which is the canonical
       # tag's when the remote server wrote an alternative name (issue #1338).
-      slug = Map.get(linkable, String.downcase(hashtag))
-      %{name: hashtag, path: slug && ~p"/tags/#{slug}"}
+      slug = Map.get(linkable, String.downcase(name))
+      %{name: text, path: slug && ~p"/tags/#{slug}"}
     end)
   end
 

--- a/lib/vutuv_web/markdown.ex
+++ b/lib/vutuv_web/markdown.ex
@@ -369,14 +369,31 @@ defmodule VutuvWeb.Markdown do
   thing a member's own post does with its tags.
 
   Only a **closing** run is taken: walking the text back to front, every line
-  that consists solely of hashtags is lifted (blank lines between them go
-  too), and the walk stops at the first line carrying anything else. A hashtag
-  inside a sentence, or a hashtag line the author wrote in the *middle* of a
-  post, therefore stays exactly where it was and still links through
-  `render_remote/1`. Hashtags come back in reading order, in the case the
-  author typed, with repeats dropped case-insensitively.
+  that is a row of tags is lifted (blank lines between them go too), and the
+  walk stops at the first line carrying anything else. A hashtag inside a
+  sentence, or a hashtag line the author wrote in the *middle* of a post,
+  therefore stays exactly where it was and still links through
+  `render_remote/1`.
 
-  The grammar is `Vutuv.Mentions.hashtag_token_regex/0`, so a line splits on
+  Each tag comes back as `%{name: _, text: _}`: `text` is what the chip shows
+  and `name` is the tag it links. **Lifting a line is a move, never a delete**,
+  so `text` is the tag exactly as it was typed, whatever is glued to it
+  included — a tag row is written by hand and routinely carries more than the
+  tag. `#FlughafenLeipzig/Halle` shows as `FlughafenLeipzig/Halle` and links
+  `flughafenleipzig`, which is the tag the post was filed under and the one
+  Mastodon named in the `tag` array it sent. Tags run together in one token
+  (`#Nepal#Rockfall#FlashFlood`) become one chip each, because three tags in
+  one pill is three tags nobody can click. Order is reading order, repeats drop
+  case-insensitively on the name.
+
+  A token carrying a **URL or an address** disqualifies its line instead. Both
+  are things to read rather than tags, and authors glue their closing link
+  straight onto the last tag (`#linuxhttps://flathub.org/apps/org.kde.kweather`
+  — 7 posts of 5,398 in the cache did this against 8 that the glue rule fixes);
+  moving that into a chip row would fold a whole URL into a pill. The line
+  stays in the body, where it read the way its author wrote it all along.
+
+  The grammar is `Vutuv.Mentions.hashtag_prefix_regex/0`, so a line splits on
   exactly what the body's own `#hashtag` linking reads — `#München` is an
   ordinary German hashtag and a line holding one must split like any other.
   (It used to carry its own wider class, because the shared grammar was
@@ -392,7 +409,7 @@ defmodule VutuvWeb.Markdown do
         text |> String.split("\n") |> Enum.reverse() |> take_trailing_hashtag_lines([])
 
       {kept |> Enum.join("\n") |> String.trim_trailing(),
-       Enum.uniq_by(hashtags, &String.downcase/1)}
+       Enum.uniq_by(hashtags, &String.downcase(&1.name))}
     else
       {text, []}
     end
@@ -408,30 +425,71 @@ defmodule VutuvWeb.Markdown do
   defp take_trailing_hashtag_lines([], hashtags), do: {[], hashtags}
 
   defp take_trailing_hashtag_lines([line | above], hashtags) do
+    if String.trim(line) == "" do
+      take_trailing_hashtag_lines(above, hashtags)
+    else
+      case tag_row(line) do
+        [] -> {Enum.reverse([line | above]), hashtags}
+        row -> take_trailing_hashtag_lines(above, row ++ hashtags)
+      end
+    end
+  end
+
+  # `Vutuv.Mentions` owns what a hashtag is; this asks it of a token that has to
+  # **begin** with one, rather than of a token that is nothing else. A tag row
+  # is typed by hand and glues things to its tags — tagesschau closes on
+  # `#FlughafenLeipzig/Halle` — and demanding the whole token be one hashtag
+  # left the entire line in the body as a run of blue words, chips and all.
+  @hashtag_prefix Mentions.hashtag_prefix_regex()
+
+  # Where one tag ends and the next begins inside a single token. Authors run
+  # them together (`#Nepal#Rockfall#FlashFlood`, `#oksh#mekofestival#…`), and
+  # three tags in one pill is three tags nobody can click. Zero-width, so the
+  # `#` stays with the tag it opens.
+  @glued_tags ~r/(?=#[\p{L}\p{M}\p{Nd}_])/u
+
+  # The tags a line carries, in reading order, or `[]` when the line is not a
+  # tag row at all — one answer, so the two questions cannot be asked with two
+  # slightly different rules and the caller cannot ask them in the wrong order.
+  defp tag_row(line) do
+    line |> String.split(~r/\s+/u, trim: true) |> collect_tags([])
+  end
+
+  defp collect_tags([], acc), do: Enum.reverse(acc)
+
+  # One token that is not a tag ends the whole row, which is what keeps a
+  # sentence a sentence: "Mehr dazu: #Berlin." fails on "Mehr" long before the
+  # full stop is reached.
+  defp collect_tags([token | rest], acc) do
+    case tags_in(token) do
+      [] -> []
+      tags -> collect_tags(rest, Enum.reverse(tags) ++ acc)
+    end
+  end
+
+  # A URL or an address disqualifies the line rather than riding into a chip:
+  # authors glue their closing link onto the last tag
+  # (`#linuxhttps://flathub.org/apps/org.kde.kweather`), and lifting that line
+  # would fold the URL into a pill — or, if the chip only kept the tag, delete
+  # it from the card outright. Seven posts of 5,398 in the cache write that,
+  # against eight the glue rule fixes; both are better served by leaving those
+  # lines where their author put them.
+  defp tags_in(token) do
     cond do
-      String.trim(line) == "" -> take_trailing_hashtag_lines(above, hashtags)
-      hashtag_line?(line) -> take_trailing_hashtag_lines(above, hashtags_in(line) ++ hashtags)
-      true -> {Enum.reverse([line | above]), hashtags}
+      not Regex.match?(@hashtag_prefix, token) -> []
+      String.contains?(token, "://") or String.contains?(token, "@") -> []
+      true -> @glued_tags |> Regex.split(token, trim: true) |> Enum.flat_map(&tag_of/1)
     end
   end
 
-  # `Vutuv.Mentions` owns what a hashtag is; this asks it of a whole token.
-  # Punctuation is not part of a hashtag, so a line like "Mehr dazu: #Berlin."
-  # keeps its full stop and is therefore not a hashtag line — which is right,
-  # it is a sentence.
-  @hashtag_token Mentions.hashtag_token_regex()
-
-  defp hashtag_line?(line) do
-    case String.split(line, ~r/\s+/u, trim: true) do
-      [] -> false
-      tokens -> Enum.all?(tokens, &Regex.match?(@hashtag_token, &1))
+  # `text` is the tag as it was typed, glue included, so lifting the line moves
+  # it and never deletes part of it; `name` is the tag that text names, which is
+  # what the chip links and what the post was filed under.
+  defp tag_of(segment) do
+    case Regex.run(@hashtag_prefix, segment, capture: :all_but_first) do
+      [name] -> [%{name: name, text: String.trim_leading(segment, "#")}]
+      nil -> []
     end
-  end
-
-  defp hashtags_in(line) do
-    line
-    |> String.split(~r/\s+/u, trim: true)
-    |> Enum.map(&String.trim_leading(&1, "#"))
   end
 
   @doc """

--- a/test/vutuv_web/live/feed_remote_posts_test.exs
+++ b/test/vutuv_web/live/feed_remote_posts_test.exs
@@ -743,6 +743,48 @@ defmodule VutuvWeb.FeedRemotePostsTest do
       assert render(view) =~ "Kamen die Gespräche zu spät?"
     end
 
+    test "a tag with a name glued to its end leaves the prose whole", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      tag = linkable_tag()
+
+      # tagesschau closes on `#FlughafenLeipzig/Halle`, and one such token used
+      # to keep the whole line in the body as a run of blue words.
+      post =
+        cached_post(user, %{content_text: "Kommentar zu Sanktionen\n\n##{tag.name}/Halle"})
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      card = "[data-remote-post='#{post.id}']"
+
+      # The chip reads as the author typed it and links the tag it names, so
+      # lifting the line moved the "/Halle" rather than deleting it.
+      assert has_element?(
+               view,
+               "#{card} a[data-remote-tag='#{tag.name}/Halle'][href='/tags/#{tag.slug}']"
+             )
+
+      assert render(view) =~ "Kommentar zu Sanktionen"
+    end
+
+    test "a closing URL glued to the last tag stays in the body", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      tag = linkable_tag()
+
+      # Authors write their closing link straight onto the last tag; folding
+      # that line into pills would put a whole URL in one.
+      post =
+        cached_post(user, %{
+          content_text: "Neu im Store\n\n#flathub ##{tag.name}https://flathub.org/apps/kweather"
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      card = "[data-remote-post='#{post.id}']"
+
+      refute has_element?(view, "#{card} [data-remote-tags]")
+      assert render(view) =~ "flathub.org/apps/kweather"
+    end
+
     test "a hashtag inside a sentence stays in the sentence", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       tag = linkable_tag()

--- a/test/vutuv_web/markdown_remote_test.exs
+++ b/test/vutuv_web/markdown_remote_test.exs
@@ -78,48 +78,87 @@ defmodule VutuvWeb.MarkdownRemoteTest do
   end
 
   describe "split_trailing_hashtags/1" do
+    # The chips a text comes back with, as `{name, text}` pairs.
+    defp tags(text) do
+      {body, tags} = Markdown.split_trailing_hashtags(text)
+      {body, Enum.map(tags, &{&1.name, &1.text})}
+    end
+
     test "lifts a closing hashtag line off the body" do
-      assert Markdown.split_trailing_hashtags(
-               "Fall Abdul B.\n\nDer Anwalt sagt Report Mainz.\n\n#CSD #Anschlag #Berlin"
-             ) ==
-               {"Fall Abdul B.\n\nDer Anwalt sagt Report Mainz.", ["CSD", "Anschlag", "Berlin"]}
+      assert tags("Fall Abdul B.\n\nDer Anwalt sagt Report Mainz.\n\n#CSD #Anschlag #Berlin") ==
+               {"Fall Abdul B.\n\nDer Anwalt sagt Report Mainz.",
+                [{"CSD", "CSD"}, {"Anschlag", "Anschlag"}, {"Berlin", "Berlin"}]}
     end
 
     test "takes every consecutive closing hashtag line, blank lines and all" do
-      assert Markdown.split_trailing_hashtags("Ein Text\n\n#eins #zwei\n\n#drei\n") ==
-               {"Ein Text", ["eins", "zwei", "drei"]}
+      assert tags("Ein Text\n\n#eins #zwei\n\n#drei\n") ==
+               {"Ein Text", [{"eins", "eins"}, {"zwei", "zwei"}, {"drei", "drei"}]}
     end
 
     test "a hashtag line in the middle of the text stays where the author put it" do
       text = "Oben\n\n#mitten drin\n\nUnten"
 
-      assert Markdown.split_trailing_hashtags(text) == {text, []}
+      assert tags(text) == {text, []}
     end
 
     test "a closing line that is more than hashtags is left alone" do
       text = "Ein Text\n\nMehr zu #Berlin gibt es hier"
 
-      assert Markdown.split_trailing_hashtags(text) == {text, []}
+      assert tags(text) == {text, []}
     end
 
     test "a post that is nothing but hashtags becomes pills and an empty body" do
-      assert Markdown.split_trailing_hashtags("#Crochet #Botanik") ==
-               {"", ["Crochet", "Botanik"]}
+      assert tags("#Crochet #Botanik") ==
+               {"", [{"Crochet", "Crochet"}, {"Botanik", "Botanik"}]}
     end
 
     test "the typed case is kept and a repeat is dropped" do
-      assert Markdown.split_trailing_hashtags("Text\n\n#Berlin #berlin #BERLIN") ==
-               {"Text", ["Berlin"]}
+      assert tags("Text\n\n#Berlin #berlin #BERLIN") == {"Text", [{"Berlin", "Berlin"}]}
     end
 
     test "text without a closing hashtag line comes back unchanged" do
-      assert Markdown.split_trailing_hashtags("Nur ein Satz.") == {"Nur ein Satz.", []}
-      assert Markdown.split_trailing_hashtags("") == {"", []}
+      assert tags("Nur ein Satz.") == {"Nur ein Satz.", []}
+      assert tags("") == {"", []}
     end
 
     test "a non-ASCII hashtag counts, so a German closing line splits too" do
-      assert Markdown.split_trailing_hashtags("Text\n\n#München #Grünflächen") ==
-               {"Text", ["München", "Grünflächen"]}
+      assert tags("Text\n\n#München #Grünflächen") ==
+               {"Text", [{"München", "München"}, {"Grünflächen", "Grünflächen"}]}
+    end
+
+    test "a tag with something glued to its end closes the line and keeps the glue" do
+      assert tags("Kommentar\n\n#Kommentar #Russland #Drohnen #FlughafenLeipzig/Halle") ==
+               {"Kommentar",
+                [
+                  {"Kommentar", "Kommentar"},
+                  {"Russland", "Russland"},
+                  {"Drohnen", "Drohnen"},
+                  {"FlughafenLeipzig", "FlughafenLeipzig/Halle"}
+                ]}
+    end
+
+    test "tags run together in one token become one chip each" do
+      assert tags("Text\n\n#Nepal#Rockfall#FlashFlood") ==
+               {"Text",
+                [{"Nepal", "Nepal"}, {"Rockfall", "Rockfall"}, {"FlashFlood", "FlashFlood"}]}
+    end
+
+    test "a closing URL glued to the last tag keeps the whole line in the body" do
+      text = "Text\n\n#comic #humor #wortspielhttps://rainking.de/2026/08/16/wok/"
+
+      assert tags(text) == {text, []}
+    end
+
+    test "an address glued to a tag keeps the line too" do
+      text = "Text\n\n#aborto #Italia #islam@politica@salute"
+
+      assert tags(text) == {text, []}
+    end
+
+    test "a token that only carries a hashtag later in it is still prose" do
+      text = "Text\n\nFlughafen#Leipzig #Halle"
+
+      assert tags(text) == {text, []}
     end
   end
 end


### PR DESCRIPTION
A tagesschau post closing on `#Kommentar #Russland #Drohnen #FlughafenLeipzig/Halle` showed that line as blue words in its body and no tag chips, on `/system/fediverse/post/:id` and every other remote card. The tags were filed correctly; only the display split failed, demanding every token be one whole hashtag and nothing else.

A token now only has to **begin** with one. The chip shows the tag as typed (`FlughafenLeipzig/Halle`) and links the tag that text names — lifting a line is a move, not a delete. Run-together tags become one chip each; a token carrying a URL or an address disqualifies its line, so a closing link glued to the last tag stays readable.

That last rule is the measured part: against the 5,398 cached remote posts the plain widening fixed 8 and made 12 worse. This one lifts 18 and loses nothing.

`split_trailing_hashtags/1` now returns `%{name:, text:}`; `Mentions.hashtag_token_regex/0` became `hashtag_prefix_regex/0`. Driven in a browser on both cases.

An AI agent wrote this text in my name. I know that is problematic.

https://claude.ai/code/session_01CHCmiFDbTA4mdPdMLQyocQ
