### PR TITLE
Give the search form a submit control so Return keeps working

### DIFF
--- a/lib/vutuv_web/live/search_live.ex
+++ b/lib/vutuv_web/live/search_live.ex
@@ -668,6 +668,20 @@ defmodule VutuvWeb.SearchLive do
           phx-debounce="250"
           class={[input_class(), "text-base"]}
         />
+        <%!-- Return in the search box submits, and this button is what keeps
+        that true (issue #1895). A browser submits a form with no submit
+        control only while it holds exactly ONE text field — so today it works
+        by luck, and the day somebody puts an author filter or a date range
+        beside the box, Return goes dead with nothing to say so. That is how
+        the feed's "Wörter ausblenden" card lost its save (#1888).
+
+        Hidden rather than drawn: the box already searches as you type, so a
+        visible "Search" would offer a second way to do what has just
+        happened, and the one thing Return does that typing cannot — fetching
+        a pasted post from another network — has its own button on the card
+        below. Hidden, not `disabled` or `hidden`: it stays in the tab order,
+        which is a keyboard path the form did not have at all before. --%>
+        <button type="submit" class="sr-only">{gettext("Search")}</button>
       </form>
 
       <div id="search-filters" class="mt-3 flex flex-wrap items-center gap-2">

--- a/test/vutuv_web/live/search_live_test.exs
+++ b/test/vutuv_web/live/search_live_test.exs
@@ -30,6 +30,25 @@ defmodule VutuvWeb.SearchLiveTest do
       assert html =~ "words in public posts"
     end
 
+    test "the form carries a submit control, so Return keeps working (issue #1895)", %{
+      conn: conn
+    } do
+      {:ok, view, _html} = live(conn, ~p"/search")
+
+      # A browser submits a form with no submit control only while it holds
+      # exactly one text field. The search box is that one field today, so
+      # Return works by luck — and the day an author filter or a date range
+      # joins it, Return would go dead with nothing to say so. This is the
+      # same shape that cost the feed's words card its save (#1888).
+      assert has_element?(view, ~s(#search-form button[type="submit"]))
+
+      # Hidden, because the box already searches as you type — but hidden the
+      # way that keeps it focusable, not `hidden`/`disabled`, which would take
+      # the keyboard path away again.
+      assert has_element?(view, ~s(#search-form button[type="submit"].sr-only))
+      refute has_element?(view, ~s(#search-form button[type="submit"][disabled]))
+    end
+
     test "shows a hint instead of results below three letters", %{conn: conn} do
       searchable_user("Maria", "Meier")
 


### PR DESCRIPTION
A browser submits a form with no submit control only while it holds exactly one text field. The search box is that one field, so Return works by luck — and the day an author filter or a date range joins it, Return goes dead with nothing to say so. That is how the feed's words card lost its save (#1888). This gives the form a submit button.

Hidden rather than drawn: the box already searches as you type, so a visible "Search" would offer a second way to do what has just happened. Hidden with `sr-only`, not `hidden` or `disabled`, so it stays in the tab order — the form had no keyboard path to submit at all before this.

One correction to the issue, since it shaped the reasoning: Return is **not** the only way to fetch a pasted post. `handle_params` sets `remote_post_url` from the live search too, so the "Fetch this post" button appears without pressing anything. Return is a shortcut for it. The fragility the issue names is real regardless.

Calibrated: removing the button turns the new test red.

Closes #1895

*An AI agent wrote this text in my name. I know that is problematic.*
