### PR TITLE
Apply the new-version bar by itself while the tab is in the background

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -29,6 +29,8 @@ import {
   request,
   reducedMotion,
   savesData,
+  sessionGet,
+  sessionSet,
   whenIdle,
 } from "./util"
 // The Milkdown WYSIWYG Markdown editor shared by the post + message composers
@@ -565,6 +567,13 @@ document.addEventListener("click", async (event) => {
   // followed the link and this handler is addressing a page that is leaving.
   event.preventDefault()
 
+  await applyUpdate()
+})
+
+// Carrying the update out, shared by the press and by the automatic path below
+// so the two cannot drift into applying it differently - the press promoting
+// the waiting worker while the quiet one leaves the old one serving the tab.
+async function applyUpdate() {
   // `reload()` rather than the href, which is the path without its query: once
   // we are in JS the current URL is the better target.
   const reload = () => window.location.reload()
@@ -589,7 +598,165 @@ document.addEventListener("click", async (event) => {
     { once: true }
   )
   waiting.postMessage({ type: "skip-waiting" })
-})
+}
+
+// The same bar, applied without being asked. "A new version is ready" is news
+// and not a problem — the page keeps working on the bundle it downloaded — so
+// it must not interrupt anybody, which is why it is a hairline strip and not a
+// dialog. But the one reader the strip exists for is the tab that sits open for
+// hours and never navigates (everybody else picks up the new release on their
+// next click), and a strip is easy to miss for exactly as long as that tab
+// stays open.
+//
+// So the page reloads itself at the one moment nobody is looking: while the tab
+// is in the background. The reader comes back to the new release having seen no
+// flash, lost no scroll position and answered no question, and the strip stays
+// for whoever wants it sooner.
+//
+// Like the click handler above, this ships one release before it can ever run:
+// the document that carries the bar is running the PREVIOUS release's
+// JavaScript, so what auto-reloads a tab is the code the deploy BEFORE this one
+// put there.
+const AUTO_RELOAD_KEY = "vutuv:auto-reloaded-for"
+
+let autoReloadTimer = null
+
+// Whether the reader has written anything into this document. The answer never
+// goes back to "no", which is deliberate rather than sloppy: a tab somebody has
+// typed in keeps its manual Reload and simply never applies an update by
+// itself, and the next navigation is a fresh document with a fresh answer. So
+// the listeners take themselves off the moment they have their answer.
+//
+// Two details are load-bearing. `input` alone would not do - a file chosen in a
+// picker raises only `change`, and choosing one is as deliberate as typing. And
+// **only a trusted event counts**: this app dispatches `input` at itself in
+// several places (the Milkdown hook mirroring the editor into its textarea, the
+// tag box mirroring its pills into the hidden field), and some of those fire
+// while a composer is still booting - so without the check a page carrying a
+// composer would answer "somebody is writing" before anybody had touched it,
+// which is /feed, the very tab this feature exists for.
+const TYPING_EVENTS = ["input", "change"]
+let readerTyped = false
+
+function markReaderTyped(event) {
+  if (!event.isTrusted) return
+
+  readerTyped = true
+  for (const kind of TYPING_EVENTS) document.removeEventListener(kind, markReaderTyped, true)
+}
+
+for (const kind of TYPING_EVENTS) {
+  document.addEventListener(kind, markReaderTyped, { capture: true, passive: true })
+}
+
+// ShellLive pushes this on the mount that decides to show the bar, and it is
+// the whole signal: the browser cannot see the bar arrive on its own, and a tab
+// that was ALREADY in the background when the deploy landed hears its socket
+// reconnect without a single `visibilitychange` ever firing. `once` because a
+// later reconnect pushing it again must not restart the wait below.
+window.addEventListener(
+  "phx:version:ready",
+  () => {
+    // Asked here rather than at reload time because it is a fact about the
+    // document and cannot change without a navigation - and a navigation
+    // replaces this whole context. So a page that must never be re-requested
+    // arms no listener and sets no timer for the rest of its life.
+    if (document.querySelector("[data-no-auto-reload]")) return
+
+    document.addEventListener("visibilitychange", onVisibilityForReload)
+    onVisibilityForReload()
+  },
+  { once: true }
+)
+
+// Coming back cancels a pending reload, which is the point of the wait: a tab
+// glanced away from and returned to a minute later is a tab somebody is
+// reading. Going away (re)starts it.
+function onVisibilityForReload() {
+  clearTimeout(autoReloadTimer)
+
+  // Spread over minutes, not seconds, and the number is about the SERVER rather
+  // than about the reader. It reads as an over-long wait for something nobody
+  // is watching, and that is exactly why it costs nothing: what synchronises
+  // these tabs is not a laptop lid, it is the deploy itself - every socket
+  // reconnects within a few hundred milliseconds of the switch, so every hidden
+  // tab learns of the release at once, and each reload is a full page render
+  // plus this shell's badge counts aimed at a slot that came up seconds ago.
+  // A wide window turns that spike into a trickle.
+  autoReloadTimer = document.hidden ? setTimeout(autoReload, 5000 + Math.random() * 115_000) : null
+}
+
+function autoReload() {
+  // Re-asked rather than assumed: the reader can have come back during the
+  // wait, which means "not now" and not "never" - the listener above is still
+  // armed for the next trip to the background.
+  if (!document.hidden) return
+
+  // Once per release per tab. `static_changed?/1` compares what the browser
+  // reports against the current manifest, so the document this reload fetches
+  // answers "current" and the question does not come back - but one that
+  // somehow kept answering "stale" would otherwise reload this tab on every
+  // trip to the background, unseen and forever. Keyed on the bundle rather than
+  // on a clock, because the bundle is what the answer is ABOUT: a second deploy
+  // ten minutes or ten seconds later is a different release and gets its turn,
+  // while a document repeating itself is refused for good. The strip still
+  // carries the manual reload throughout.
+  const bundle = document.querySelector("script[phx-track-static]")?.src || ""
+  if (bundle && sessionGet(AUTO_RELOAD_KEY) === bundle) return
+
+  if (hasUnsavedInput()) return
+
+  sessionSet(AUTO_RELOAD_KEY, bundle)
+  applyUpdate()
+}
+
+// Whether this page is holding work its author has not handed in yet. The
+// composer would survive (it autosaves into post_drafts and restores on mount),
+// but nothing else does - a half-written message, a settings form, a job
+// posting - and a reload is not worth guessing about, so anything a person has
+// touched and not submitted stops it.
+//
+// **Both halves are needed, because each is blind where the other sees.** On a
+// classic page the DOM is the whole truth, so a field differing from its
+// DEFAULT is what unsaved work looks like - against the default and not against
+// emptiness, or a settings form arriving full of the member's stored values
+// would count as work in progress and this would never fire on half the app.
+// But a LiveView form with `phx-change` has already sent every keystroke and
+// the server echoes it back into the `value` attribute, so the default catches
+// up with the text and a half-written job posting reads as clean. `readerTyped`
+// is what covers that one, and it is why the sweep does not ask a Milkdown
+// editor about its own text: the hook mirrors every change into the plain
+// textarea beside it, which the default comparison already reads, and treating
+// any text at all as unsaved would strand a restored draft forever.
+function hasUnsavedInput() {
+  if (readerTyped) return true
+
+  for (const el of document.querySelectorAll("input, textarea, select")) {
+    if (el.tagName === "SELECT") {
+      for (const option of el.options) if (option.selected !== option.defaultSelected) return true
+      continue
+    }
+
+    switch (el.type) {
+      // The CSRF token every form carries, and nothing a person types.
+      case "hidden":
+        break
+      // A chosen file has no `defaultValue` to differ from, and choosing one is
+      // as deliberate as typing.
+      case "file":
+        if (el.files.length > 0) return true
+        break
+      case "checkbox":
+      case "radio":
+        if (el.checked !== el.defaultChecked) return true
+        break
+      default:
+        if (el.value !== el.defaultValue) return true
+    }
+  }
+
+  return false
+}
 
 async function currentPushSubscription() {
   const registration = await serviceWorker()

--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -119,26 +119,37 @@ export function bufToB64url(buf) {
   return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
 }
 
-// localStorage, wrapped. A private window, or a browser set to block site data,
-// throws on plain access — so every read answers null and every write is a
-// no-op rather than taking an unrelated feature down with it. That failure mode
-// is reasoned about once, here, instead of in each `try {}` at a call site.
-export function localGet(key) {
+// Browser storage, wrapped. A private window, or a browser set to block site
+// data, throws on plain access — so every read answers null and every write is
+// a no-op rather than taking an unrelated feature down with it. That failure
+// mode is reasoned about once, here, instead of in each `try {}` at a call
+// site; the two stores differ only in scope, so they share the wrapper too.
+// A null (or undefined) value forgets the key, which is what every caller here
+// means by "no longer true".
+function storeGet(store, key) {
   try {
-    return window.localStorage.getItem(key)
+    return window[store].getItem(key)
   } catch (_e) {
     return null
   }
 }
 
-// A null (or undefined) value forgets the key, which is what every caller here
-// means by "no longer true".
-export function localSet(key, value) {
+function storeSet(store, key, value) {
   try {
-    if (value == null) window.localStorage.removeItem(key)
-    else window.localStorage.setItem(key, value)
+    if (value == null) window[store].removeItem(key)
+    else window[store].setItem(key, value)
   } catch (_e) {}
 }
+
+// localStorage: this browser, all its tabs, across sittings.
+export const localGet = (key) => storeGet("localStorage", key)
+export const localSet = (key, value) => storeSet("localStorage", key, value)
+
+// sessionStorage: this tab, and it dies with it — which is what a fact about
+// "this window, in this sitting" needs. The same fact in localStorage would
+// speak for every other tab of the same browser too.
+export const sessionGet = (key) => storeGet("sessionStorage", key)
+export const sessionSet = (key, value) => storeSet("sessionStorage", key, value)
 
 // Copy to the clipboard, with the fallback the modern API needs. `writeText`
 // wants a secure context (https or localhost — every place vutuv runs itself),

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -126,6 +126,53 @@ on it for as long as the tab stays open. The worker's remaining job is carrying
 the reload out — Reload posts `skip-waiting` to a waiting worker, or plainly
 reloads when there is none.
 
+**The page also applies that bar by itself, while the tab is in the
+background.** The strip is deliberately quiet, because nothing is broken — a
+dialog for news would spend on every asset deploy the attention the next real
+one needs — and the one reader it is for is the tab nobody has clicked in for
+hours, who is therefore the one least likely to notice it. So `app.js` reloads
+at the moment that costs nothing: the tab is hidden, the reader sees no flash,
+loses no scroll position and is asked nothing. `ShellLive` pushes
+`"version:ready"` alongside the bar, because the browser cannot see it arrive —
+a tab that was *already* in the background when the deploy landed hears its
+socket reconnect and no `visibilitychange` ever fires. The push is what the
+client listens for rather than a hook on the bar, for the reason everything
+about this bar comes back to: the markup lands in a document running the
+previous release's JavaScript, where an unknown hook name is an error and an
+unknown window event is nothing at all. Which also means the release that
+introduces this cannot use it — what auto-reloads a tab is always the code the
+deploy *before* put there.
+
+The reader coming back cancels the pending reload, and the wait before it is
+minutes rather than seconds — deliberately long for something nobody is
+watching, because what synchronises these tabs is the deploy itself: every
+socket reconnects within a few hundred milliseconds of the switch, so a narrow
+window would aim every hidden tab's full page render at a slot that came up
+seconds earlier. It reloads **once per release per tab**, keyed on the tracked
+bundle rather than on a clock, so a second deploy ten minutes or ten seconds
+later gets its turn while a document that kept answering "stale" is refused for
+good.
+
+Anything the reader has written holds it, and that takes two questions because
+each is blind where the other sees. On a classic page a field differing from
+its own **default** is what unsaved work looks like — against the default and
+not against emptiness, or a settings form full of stored values would read as
+work in progress. But a LiveView form with `phx-change` has already sent every
+keystroke and the server echoes it back into the `value` attribute, so the
+default catches up and a half-written job posting reads as clean; a document
+that has seen one **trusted** `input` or `change` covers that one. Trusted
+matters: the app dispatches `input` at itself while a composer boots, and
+counting that would strand /feed, the tab this is for.
+
+And a document that must not be re-requested at all carries
+**`data-no-auto-reload`**. It names the effect rather than a cause, because
+there are two: `root.html.heex` stamps it from `conn.method` for a page
+rendered in answer to a form submission (reloading raises the browser's
+"resubmit?" dialog in a tab nobody is watching), and `<.secret_once>` stamps it
+on itself, although its page is an ordinary GET after a redirect — the token it
+shows exists nowhere else, only its hash is stored, and the flash carrying it
+is spent by that render. A method check could never have seen the second one.
+
 **Which means a worker from the previous release keeps running, and nothing
 bounds how long.** This is the one asset that deliberately outlives a deploy,
 so it is worth being exact about. A new worker appears only when `/sw.js`

--- a/lib/vutuv_web/components/ui.ex
+++ b/lib/vutuv_web/components/ui.ex
@@ -3266,6 +3266,14 @@ defmodule VutuvWeb.UI do
   freshly minted secret (access tokens, client secrets, webhook signing
   secrets). `label` is the "copy it now" sentence; `class` adds margin
   utilities at the call site.
+
+  It also carries **`data-no-auto-reload`**, which is not decoration: the value
+  shown here exists nowhere else — only its hash is stored — and a flash is
+  spent by the render that shows it, so re-requesting this URL loses the secret
+  for good (a webhook signing secret cannot even be minted again; the
+  subscription has to be deleted and rebuilt). Every call site is reached by a
+  redirect, so the document is an ordinary GET and nothing else about it says
+  it must stay. See the auto-reload block in `app.js`.
   """
   attr(:flash, :map, required: true)
   attr(:key, :atom, required: true)
@@ -3283,6 +3291,7 @@ defmodule VutuvWeb.UI do
         @class
       ]}
       data-secret-once={@key}
+      data-no-auto-reload
     >
       <p class="text-sm font-semibold text-brand-800 dark:text-brand-100">{@label}</p>
       <code class="mt-2 block select-all break-all rounded bg-white px-3 py-2 text-sm text-slate-800 dark:bg-slate-900 dark:text-slate-100">{@secret}</code>

--- a/lib/vutuv_web/live/shell_live.ex
+++ b/lib/vutuv_web/live/shell_live.ex
@@ -223,6 +223,7 @@ defmodule VutuvWeb.ShellLive do
     # raises rather than answering. Only the `and` short-circuit keeps it from
     # being called there. Dropping it 500s every classic page in the app.
     |> assign(:update_ready?, connected?(socket) and static_changed?(socket))
+    |> announce_update()
     |> assign(:self_online?, false)
     # Whether this member asked for browser notifications (issue #1249). False
     # for the anonymous shell and for the throwaway dead render, which raises
@@ -263,6 +264,22 @@ defmodule VutuvWeb.ShellLive do
     # the number sliding in.
     |> assign(:people_count_ticked?, false)
   end
+
+  # Tells app.js the same thing the bar tells the reader, because the browser
+  # cannot see the bar arrive. app.js reloads the page by itself once the tab
+  # goes into the background (nobody is looking, so nothing is interrupted), and
+  # the tab this is for is very often ALREADY hidden when the deploy lands: its
+  # socket reconnects, the bar appears, and no `visibilitychange` ever fires —
+  # the same blind spot `TabBadge` has to work around.
+  #
+  # A pushed event rather than a `phx-hook` on the bar, for the reason the bar's
+  # own comment gives: this markup is patched into a document running the
+  # PREVIOUS release's JavaScript, where a hook name that release does not know
+  # is a client-side error. A window event nobody listens for is a no-op.
+  defp announce_update(%{assigns: %{update_ready?: true}} = socket),
+    do: push_event(socket, "version:ready", %{})
+
+  defp announce_update(socket), do: socket
 
   # Site-wide online presence. The shell is the one component on every page, so
   # it is where the current member is tracked online. Tracking (broadcasting my

--- a/lib/vutuv_web/templates/layout/root.html.heex
+++ b/lib/vutuv_web/templates/layout/root.html.heex
@@ -98,7 +98,21 @@
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
     <script defer phx-track-static src={~p"/assets/app.js"}></script>
   </head>
-  <body class={assigns[:conn] && @conn.assigns[:body_class]}>
+  <%!-- "This document must not be re-requested", the marker app.js reads before
+  reloading a backgrounded tab onto a new release. It names the **effect**
+  rather than one of its causes, so anything else that knows it holds something
+  a second GET would destroy can say so too — `<.secret_once>` does, for a
+  freshly minted token that exists nowhere else.
+
+  The cause here is a non-GET render: a `create`/`update` action that
+  re-renders its form instead of redirecting. Reloading such a page asks the
+  browser to resubmit the form, and re-fetching the URL throws away the input
+  it is showing back to its author. Absent on every LiveView page, which has no
+  conn here and is a GET either way. --%>
+  <body
+    class={assigns[:conn] && @conn.assigns[:body_class]}
+    data-no-auto-reload={assigns[:conn] && @conn.method != "GET" && "true"}
+  >
     {@inner_content}
   </body>
 </html>

--- a/test/vutuv_web/live/shell_live_update_bar_test.exs
+++ b/test/vutuv_web/live/shell_live_update_bar_test.exs
@@ -32,12 +32,17 @@ defmodule VutuvWeb.ShellLiveUpdateBarTest do
   end
 
   defp mount_shell(conn, connect_params, session \\ %{}) do
-    {:ok, _view, html} =
+    {_view, html} = mount_shell_view(conn, connect_params, session)
+    html
+  end
+
+  defp mount_shell_view(conn, connect_params, session \\ %{}) do
+    {:ok, view, html} =
       conn
       |> put_connect_params(connect_params)
       |> live_isolated(VutuvWeb.ShellLive, session: session)
 
-    html
+    {view, html}
   end
 
   describe "who gets offered the reload" do
@@ -83,6 +88,70 @@ defmodule VutuvWeb.ShellLiveUpdateBarTest do
       html = mount_shell(conn, %{})
 
       refute html =~ ~s(id="sw-update")
+    end
+  end
+
+  # The bar is also what app.js reloads on by itself once the tab goes into the
+  # background, and the browser cannot see it arrive. A tab that was ALREADY
+  # hidden when the deploy landed hears its socket reconnect and the bar appear
+  # without a single `visibilitychange` firing (the same blind spot the TabBadge
+  # hook has), so the server has to say so.
+  #
+  # It says so with a pushed event and not with a `phx-hook` on the bar, for the
+  # reason every other note in this file circles: the bar renders ONLY into a
+  # document running the previous release's JavaScript, and a hook name that
+  # release does not know is a client-side error there. An unknown window event
+  # is a no-op in every release that predates it.
+  describe "the announcement app.js reloads on" do
+    test "a stale browser is told a new version is ready", %{conn: conn} do
+      {view, _html} = mount_shell_view(conn, %{"_track_static" => @stale})
+
+      assert_push_event(view, "version:ready", %{})
+    end
+
+    test "a browser already on the current release is told nothing", %{conn: conn} do
+      {view, _html} = mount_shell_view(conn, %{"_track_static" => @current})
+
+      refute_push_event(view, "version:ready", %{})
+    end
+  end
+
+  # What app.js must NOT reload on its own. The marker names the effect — this
+  # document may not be re-requested — rather than any one cause, so the two
+  # sources that know it can both say so, and a third can be added without app.js
+  # learning a second selector.
+  #
+  # The root layout's cause is a non-GET render: a `create`/`update` action that
+  # re-renders its form instead of redirecting leaves the reader on a document
+  # born of a POST, and reloading that raises the browser's "resubmit this form?"
+  # dialog in a tab nobody is watching. `<.secret_once>`'s cause is the opposite
+  # shape — an ordinary GET after a redirect — which is exactly why the method
+  # alone could not answer for it: the freshly minted token it shows exists
+  # nowhere else (only its hash is stored) and the flash carrying it is spent by
+  # this render, so a second GET of the same URL loses it for good.
+  describe "the marker on a document that must not be re-requested" do
+    test "the PIN screen a login POST renders carries it", %{conn: conn} do
+      html =
+        conn
+        |> post(~p"/login", %{"session" => %{"email" => "nobody@example.com"}})
+        |> html_response(200)
+
+      assert html =~ ~s(data-no-auto-reload="true")
+    end
+
+    test "an ordinary page does not", %{conn: conn} do
+      refute conn |> get(~p"/") |> html_response(200) =~ "data-no-auto-reload"
+    end
+
+    test "a show-once secret carries it although its page is a plain GET" do
+      html =
+        render_component(&VutuvWeb.UI.secret_once/1,
+          flash: %{"new_token" => "vtv_plaintext_only_shown_once"},
+          key: :new_token,
+          label: "Copy it now"
+        )
+
+      assert html =~ "data-no-auto-reload"
     end
   end
 


### PR DESCRIPTION
The "A new version is ready" strip (`#sw-update` in `VutuvWeb.ShellLive`) is
deliberately quiet, so the one reader it exists for misses it: the tab nobody
has clicked in for hours. That tab now applies the update itself while it is in
the background, with no flash and nothing to answer.

`ShellLive` pushes `version:ready` beside the bar (a hidden tab never fires
`visibilitychange` on its own), and `app.js` reloads through the same
`applyUpdate()` the manual Reload uses, once per release per tab. Three things
stop it: the reader coming back, anything typed and not handed in, and
`data-no-auto-reload` on a document that must not be re-requested. That marker
names the effect, so `<.secret_once>` sets it too, for a token that exists
nowhere else.

Driven in a browser: it reloads when hidden and holds on each of the three.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_017xK9CfSVcvpcGoV93GWcGE
