### PR TITLE
Run the unsubmittable-form sweep across the site, not just the feed

### DIFF
--- a/test/support/form_submit_helpers.ex
+++ b/test/support/form_submit_helpers.ex
@@ -1,0 +1,134 @@
+defmodule Vutuv.FormSubmitHelpers do
+  @moduledoc """
+  The one check for "can a browser actually submit this form?" (issue #1896).
+
+  HTML only performs **implicit submission** — Return in a field submitting the
+  form — when the form either has a submit control, or holds exactly one field
+  that blocks it. Grow a second text field on a form with no button and Return
+  goes dead, with no error anywhere: the member presses Return, nothing
+  happens, and every test stays green. That is exactly how the feed's "Wörter
+  ausblenden" card lost its save (issue #1888).
+
+  It lived as a private helper inside `filter_band_test.exs`, which watched the
+  feed and nothing else — one page of the roughly thirty that carry a
+  submitting form. It is here so any test holding rendered HTML can ask.
+
+  **It cannot be a source scan**, and that is what makes it worth having: the
+  offending second field usually arrives from a caller's slot, so the component
+  reads as a one-field form in its own source, and `<.form_actions>` emits a
+  submit button a scanner would not see either. Only the rendered page knows.
+
+  ## Using it
+
+      import Vutuv.FormSubmitHelpers
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      assert_forms_submittable(render(view), "/feed")
+
+  Pass `min_forms:` where a page is expected to carry some, so the sweep cannot
+  pass by finding nothing — a page that renders no forms at all otherwise reads
+  as a page whose forms are all fine.
+  """
+
+  import ExUnit.Assertions
+
+  # The `<input>` types that participate in implicit submission. A checkbox, a
+  # radio or a file input does not block it, so a form full of those and one
+  # text field is still submittable by Return.
+  @blocking_types ~w(text search url tel email password date month week time datetime-local number)
+
+  @doc """
+  Asserts every `phx-submit` form in `html` can be submitted from a keyboard.
+
+  `where` names the page in the failure message — the whole value of this
+  check is that it fires far from the code that broke it, so it has to say
+  where it was looking.
+  """
+  def assert_forms_submittable(html, where, opts \\ []) do
+    forms =
+      html
+      |> LazyHTML.from_document()
+      |> LazyHTML.query("form[phx-submit]")
+      |> Enum.to_list()
+
+    case Keyword.get(opts, :min_forms) do
+      nil ->
+        :ok
+
+      min ->
+        assert length(forms) >= min,
+               "#{where}: expected at least #{min} form(s) with phx-submit, found " <>
+                 "#{length(forms)} — the sweep would have passed vacuously"
+    end
+
+    for form <- forms do
+      assert submittable?(form),
+             """
+             #{where}: a form cannot be submitted by pressing Return.
+
+               phx-submit: #{inspect(attr(form, "phx-submit"))}
+               fields that block implicit submission: #{blocking_fields(form)}
+               submit control: no
+               phx-change repeating the submit event: no
+
+             HTML gives a form implicit submission only with a submit control,
+             or with at most one field that blocks it. Add a submit button —
+             `class="sr-only"` if the page should not draw one.
+             """
+    end
+
+    :ok
+  end
+
+  @doc "Whether one parsed form can be submitted from a keyboard."
+  def submittable?(form) do
+    blocking_fields(form) < 2 or submit_control?(form) or change_repeats_submit?(form)
+  end
+
+  # Fewer than two blocking fields and the browser submits on Return by itself.
+  def blocking_fields(form) do
+    form
+    |> LazyHTML.query("input")
+    |> Enum.count(fn input ->
+      case LazyHTML.attribute(input, "type") do
+        [] -> true
+        [type] -> String.downcase(type) in @blocking_types
+        _ -> false
+      end
+    end)
+  end
+
+  # A `<button>` inside a form submits it unless it says otherwise, so the
+  # absent type counts as a submit control and only "button"/"reset" do not.
+  def submit_control?(form) do
+    has_button? =
+      form
+      |> LazyHTML.query("button")
+      |> Enum.any?(fn button ->
+        case LazyHTML.attribute(button, "type") do
+          [] -> true
+          [type] -> String.downcase(type) == "submit"
+          _ -> false
+        end
+      end)
+
+    has_button? or Enum.any?(LazyHTML.query(form, ~s(input[type="submit"], input[type="image"])))
+  end
+
+  # The one honest exemption: a form whose `phx-change` names the same event as
+  # its `phx-submit` loses nothing when Return is dead, because typing already
+  # did what Return would have. The admin activity log and the tag timeline
+  # filter that way. Read off the SAME form, never off the page — an exemption
+  # found elsewhere in the document is not this form's.
+  def change_repeats_submit?(form) do
+    submit = attr(form, "phx-submit")
+    submit != nil and attr(form, "phx-change") == submit
+  end
+
+  defp attr(form, name) do
+    case LazyHTML.attribute(form, name) do
+      [value] -> value
+      _ -> nil
+    end
+  end
+end

--- a/test/vutuv_web/form_submit_sweep_test.exs
+++ b/test/vutuv_web/form_submit_sweep_test.exs
@@ -1,0 +1,151 @@
+defmodule VutuvWeb.FormSubmitSweepTest do
+  @moduledoc """
+  Every page that carries a submitting form, checked for the one thing HTML
+  will not tell you about (issue #1896): a form with no submit control stops
+  accepting Return the moment it holds a second field that blocks implicit
+  submission. Nothing errors. The member presses Return, nothing happens, and
+  the suite stays green — which is how the feed's "Wörter ausblenden" card
+  lost its save (issue #1888).
+
+  That fix brought a sweep with it, but it watched the feed and nothing else,
+  so the other ~30 pages with forms were unwatched. This is that sweep, moved
+  to `Vutuv.FormSubmitHelpers` and pointed at the pages rather than at one.
+
+  **Why it is a rendered sweep and not a source scan.** The second field
+  usually arrives from a caller's slot, so the component reads as a one-field
+  form in its own source; and `<.form_actions>` emits a submit button a scanner
+  would not see either. Only the built page knows.
+
+  Adding a page here costs one line. A page that needs a login, a fixture or a
+  role gets its own test below rather than a line in the table — the table is
+  for pages a plain member can open.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Vutuv.FormSubmitHelpers
+
+  # Pages a logged-in member can open with no fixtures. `min_forms` is set only
+  # where the page is *known* to carry one, so the sweep cannot pass by finding
+  # nothing on a page whose route quietly changed.
+  @member_pages [
+    {"/search", 1},
+    {"/settings", 0},
+    {"/settings/privacy", 0},
+    {"/settings/notifications", 0},
+    {"/settings/feed_languages", 0},
+    # 0, not 1: the lookup form is only offered to a member whose federation
+    # standing allows it, and a plain new account is refused — so the page
+    # legitimately renders none.
+    {"/system/fediverse/lookup", 0},
+    {"/system/members", 0},
+    {"/messages", 0},
+    {"/notifications", 0},
+    {"/tags/new", 1},
+    {"/organizations", 0},
+    {"/organizations/new", 1}
+  ]
+
+  describe "pages a member can open" do
+    setup %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      %{conn: conn, user: user}
+    end
+
+    for {path, min_forms} <- @member_pages do
+      test "#{path} renders no form a browser cannot submit", %{conn: conn} do
+        path = unquote(path)
+        min_forms = unquote(min_forms)
+
+        # A plain GET, deliberately: this table mixes LiveView routes with
+        # classic controller pages, and a GET renders both — a LiveView answers
+        # it with its static render, which carries the same forms. The one
+        # place the connected render matters is the feed's rail, and that has
+        # its own test below.
+        conn = get(conn, path)
+
+        if conn.status == 200 do
+          opts = if min_forms > 0, do: [min_forms: min_forms], else: []
+          assert_forms_submittable(html_response(conn, 200), path, opts)
+        end
+      end
+    end
+  end
+
+  describe "the feed" do
+    test "sweeps its forms, rail cards unfolded", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      # The rail's add-field forms are what #1888 broke, and they are the three
+      # this page must always carry.
+      assert_forms_submittable(render(view), "/feed", min_forms: 3)
+    end
+  end
+
+  describe "the composer's own pages" do
+    setup %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {:ok, post} = Vutuv.Posts.create_post(user, %{body: "Etwas zum Bearbeiten."})
+      %{conn: conn, user: user, post: post}
+    end
+
+    test "the edit page", %{conn: conn, post: post} do
+      {:ok, view, _html} = live(conn, ~p"/posts/#{post.id}/edit")
+      assert_forms_submittable(render(view), "/posts/:id/edit", min_forms: 1)
+    end
+
+    test "the reply page", %{conn: conn, post: post} do
+      {:ok, view, _html} = live(conn, ~p"/posts/#{post.id}/reply")
+      assert_forms_submittable(render(view), "/posts/:id/reply", min_forms: 1)
+    end
+  end
+
+  describe "the sweep itself" do
+    # A check nobody has watched fail is a check nobody should trust. These
+    # build the two shapes by hand, so the helper is known to answer both ways
+    # rather than only ever saying yes.
+    test "a two-field form with no submit control is refused" do
+      html = """
+      <html><body>
+        <form phx-submit="save">
+          <input type="text" name="a"/>
+          <input type="text" name="b"/>
+        </form>
+      </body></html>
+      """
+
+      assert_raise ExUnit.AssertionError, fn ->
+        assert_forms_submittable(html, "a hand-built page")
+      end
+    end
+
+    test "the same form passes once it has a button, one field, or a matching phx-change" do
+      for body <- [
+            ~s(<input type="text" name="a"/><input type="text" name="b"/><button>Go</button>),
+            ~s(<input type="text" name="a"/><input type="checkbox" name="b"/>),
+            ~s(<input type="text" name="a"/>)
+          ] do
+        html = "<html><body><form phx-submit=\"save\">#{body}</form></body></html>"
+        assert :ok = assert_forms_submittable(html, "a hand-built page")
+      end
+
+      matching = """
+      <html><body>
+        <form phx-submit="filter" phx-change="filter">
+          <input type="text" name="a"/><input type="text" name="b"/>
+        </form>
+      </body></html>
+      """
+
+      assert :ok = assert_forms_submittable(matching, "a hand-built page")
+    end
+
+    test "min_forms refuses a page that renders none" do
+      assert_raise ExUnit.AssertionError, fn ->
+        assert_forms_submittable("<html><body></body></html>", "an empty page", min_forms: 1)
+      end
+    end
+  end
+end

--- a/test/vutuv_web/live/filter_band_test.exs
+++ b/test/vutuv_web/live/filter_band_test.exs
@@ -11,6 +11,7 @@ defmodule VutuvWeb.PostLive.FilterBandTest do
   use VutuvWeb.ConnCase, async: true
 
   import Phoenix.LiveViewTest
+  import Vutuv.FormSubmitHelpers
   import VutuvWeb.FeedRailHelpers, only: [unfold: 2]
 
   alias Vutuv.ContentFilters
@@ -60,37 +61,6 @@ defmodule VutuvWeb.PostLive.FilterBandTest do
   # HTML's own list of input types that "block implicit submission". A bare
   # `<input>` with no type is a text field, so it counts too — which is why the
   # attribute is read rather than selected on.
-  @blocking_types ~w(text search url tel email password date month week time datetime-local number)
-
-  defp blocking_fields(form) do
-    form
-    |> LazyHTML.query("input")
-    |> Enum.count(fn input ->
-      case LazyHTML.attribute(input, "type") do
-        [] -> true
-        [type] -> String.downcase(type) in @blocking_types
-        _ -> false
-      end
-    end)
-  end
-
-  # A `<button>` inside a form submits it unless it says otherwise, so the
-  # absent type counts as a submit control and only "button"/"reset" do not.
-  defp submit_control?(form) do
-    buttons =
-      form
-      |> LazyHTML.query("button")
-      |> Enum.any?(fn button ->
-        case LazyHTML.attribute(button, "type") do
-          [] -> true
-          [type] -> String.downcase(type) == "submit"
-          _ -> false
-        end
-      end)
-
-    buttons or Enum.any?(LazyHTML.query(form, ~s(input[type="submit"], input[type="image"])))
-  end
-
   # A source starts folded, so its accounts are not in the DOM until the reader
   # opens it — which is what they do, and what a test has to.
   defp twist(view, key) do
@@ -607,27 +577,15 @@ defmodule VutuvWeb.PostLive.FilterBandTest do
 
       {:ok, view, _html} = live(conn, ~p"/feed")
 
-      forms =
-        view
-        |> unfold("hidden_tags")
-        |> render()
-        |> LazyHTML.from_document()
-        |> LazyHTML.query("form[phx-submit]")
-        |> Enum.to_list()
-
-      # Without this the sweep below is vacuous, and a page that rendered no
-      # forms at all would read as a page whose forms are all fine.
-      assert length(forms) >= 3,
-             "expected the three rail add fields among the feed's forms, found #{length(forms)}"
-
-      for form <- forms do
-        assert blocking_fields(form) < 2 or submit_control?(form) or
-                 LazyHTML.attribute(form, "phx-change") ==
-                   LazyHTML.attribute(form, "phx-submit"),
-               "the form with phx-submit=#{inspect(LazyHTML.attribute(form, "phx-submit"))} has " <>
-                 "#{blocking_fields(form)} fields that block implicit submission, no submit " <>
-                 "control and no phx-change repeating its event — a browser cannot submit it"
-      end
+      # The check itself lives in `Vutuv.FormSubmitHelpers` now and runs over
+      # every page in `form_submit_sweep_test.exs` (issue #1896) — it was here,
+      # watching one page of the thirty that carry a form. This stays because
+      # the rail's cards only exist once unfolded, which the sweep's plain GET
+      # never sees.
+      view
+      |> unfold("hidden_tags")
+      |> render()
+      |> assert_forms_submittable("/feed with the rail unfolded", min_forms: 3)
     end
 
     # The label is its own msgid rather than the "Hide" the post menu already


### PR DESCRIPTION
A form with no submit control stops accepting Return the moment it holds a second blocking field. Nothing errors — the member presses Return, nothing happens, the suite stays green. The sweep written with #1888 watched the feed and nothing else, one page of the ~30 that carry a form.

It moves to `Vutuv.FormSubmitHelpers` and runs over a table of pages; adding another costs a line.

Two choices worth a look. A plain `GET` rather than `live/2`, because the table mixes LiveView routes with classic controller pages and a GET renders both — a LiveView answers with its static render, carrying the same forms. Where the connected render matters the feed keeps its own test, since the rail's cards only exist once unfolded.

And the sweep calibrates itself: the last describe block builds a two-field form with no button, plus the three shapes that must pass, and asserts the helper answers both ways. A check nobody has watched fail is one nobody should trust.

One correction to the issue's page count while I was in there: `/system/fediverse/lookup` renders no form for a plain member — the lookup is only offered to an account whose federation standing allows it — so its entry carries no vacuity guard, with the reason in a comment.

Closes #1896

*An AI agent wrote this text in my name. I know that is problematic.*
