### PR TITLE
Make the slash menu follow the text it hangs off

### DIFF
--- a/assets/js/markdown_editor.js
+++ b/assets/js/markdown_editor.js
@@ -58,7 +58,7 @@ import {
   NodeSelection,
   TextSelection,
 } from "@milkdown/kit/prose/state"
-import { ACTIVE_CLASS, markActiveRow, stepIndex, suggestKey } from "./suggest_list"
+import { ACTIVE_CLASS, followsCaret, markActiveRow, stepIndex, suggestKey } from "./suggest_list"
 import { Decoration, DecorationSet } from "@milkdown/kit/prose/view"
 import { inputRules, InputRule } from "@milkdown/kit/prose/inputrules"
 import { emojiForShortcode, SHORTCODE_AT_CARET } from "./emoji_data.js"
@@ -685,9 +685,12 @@ export const MarkdownEditor = {
   destroyed() {
     this.editor?.destroy()
     closeMentionsFor(this.root)
-    // The one listener this hook puts outside its own subtree; everything
-    // else dies with the editor's DOM.
+    // The listeners this hook puts outside its own subtree; everything else
+    // dies with the editor's DOM. `followsCaret` holds two on `window`, which
+    // outlives every editor on the page — the messages page tears one down per
+    // closed conversation, so leaking these would pile up a handler per chat.
     if (this._away) document.removeEventListener("mousedown", this._away)
+    if (this._unfollow) this._unfollow()
     // A pending suggest/check timer would fire into a destroyed editor —
     // retaining it (and its document) until it does, then dispatching onto a
     // dead view. The messages page tears an editor down per closed conversation.
@@ -1559,18 +1562,48 @@ export const MarkdownEditor = {
     const opening = this.slash.hidden
     this.slash.hidden = false
 
-    // Place it once, on the way open. It hangs off the "/" itself, not the
+    // Placed on the way open only. It hangs off the "/" itself, not the
     // caret, precisely so it stays put while the rest of the word is typed —
     // re-measuring every keystroke would cost two forced layouts to arrive at
-    // the same two numbers.
-    if (opening) {
-      const at = view.coordsAtPos(this.slashRun.start)
-      const frame = this.frame.getBoundingClientRect()
-      this.slash.style.top = `${at.bottom - frame.top + 6}px`
-      this.slash.style.left = `${Math.max(0, at.left - frame.left)}px`
-    }
+    // the same two numbers. A SCROLL is the other story: then the "/" really
+    // has moved, and `replaceOverlays` re-places it.
+    if (opening) this.placeSlash(view)
 
     this.markSlashCurrent(0)
+  },
+
+  // Pin the menu under the "/" that opened it — and close it when that "/" has
+  // scrolled out of the prose box. Somebody who scrolls away from the word
+  // they were typing is done with the menu, and the alternative is a panel
+  // clamped to an edge, pointing at whatever they scrolled to. The mention
+  // picker makes the same judgement about the window.
+  placeSlash(view) {
+    if (!this.slashRun) return
+
+    const at = view.coordsAtPos(this.slashRun.start)
+    const mount = this.mountEl.getBoundingClientRect()
+
+    if (at.bottom < mount.top || at.top > mount.bottom) return this.closeSlash()
+
+    const frame = this.frame.getBoundingClientRect()
+    this.slash.style.top = `${at.bottom - frame.top + 6}px`
+    this.slash.style.left = `${Math.max(0, at.left - frame.left)}px`
+  },
+
+  // Both overlays, re-pinned after the page moved under them. Only whichever
+  // is actually showing: this runs on every scroll of a page that is mostly
+  // not composing anything, so the resting cost has to be two hidden checks.
+  replaceOverlays() {
+    if (!this.editor) return
+    const bubbleUp = this.bubble && !this.bubble.hidden
+    const slashUp = this.slash && !this.slash.hidden
+    if (!bubbleUp && !slashUp) return
+
+    this.editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx)
+      if (bubbleUp) this.syncBubble(view)
+      if (slashUp) this.placeSlash(view)
+    })
   },
 
   closeSlash() {
@@ -1689,13 +1722,11 @@ export const MarkdownEditor = {
     }
     document.addEventListener("mousedown", this._away)
 
-    // The prose is its own scroll container (.mde__mount caps at 24rem), and
-    // the bubble is positioned against the frame outside it, so a scroll
-    // leaves it behind. Only while it is showing — this must not cost
-    // anything on an ordinary scroll.
-    this.mountEl.addEventListener("scroll", () => {
-      if (this.bubble && !this.bubble.hidden) this.editor?.action((ctx) => this.syncBubble(ctx.get(editorViewCtx)))
-    })
+    // Both overlays hang off a position in the prose, and the prose is its own
+    // scroll container once it passes 24rem — so a scroll leaves them behind
+    // and nothing tells them (issue #1898). The bubble had this; the slash
+    // menu did not, and was placed once on the way open and then abandoned.
+    this._unfollow = followsCaret(() => this.replaceOverlays())
     this.bubble.addEventListener("mousedown", (e) => {
       // The whole point of the bubble is that a selection exists; letting the
       // press move focus would collapse it before the command runs.

--- a/assets/js/mention_picker.js
+++ b/assets/js/mention_picker.js
@@ -16,7 +16,7 @@
 // It carries no copy of its own: the labels come from the data-mention-*
 // attributes the server rendered on the editor, because the server is the only
 // side that knows the reader's language.
-import { markActiveRow, stepIndex } from "./suggest_list"
+import { followsCaret, markActiveRow, stepIndex } from "./suggest_list"
 
 const ROW_ID = (index) => `mention-opt-${index}`
 
@@ -82,8 +82,11 @@ const wire = () => {
     closeMentions()
   })
 
-  window.addEventListener("resize", () => place())
-  window.addEventListener("scroll", () => place(), { passive: true, capture: true })
+  // The same rule the slash menu follows (issue #1898), from the one place it
+  // is written. `wire()` runs once for the page's single panel, so the detach
+  // it hands back has nobody to hand it to — that is why this reads as a bare
+  // call and the editor's does not.
+  followsCaret(() => place())
 }
 
 const pick = (index) => {

--- a/assets/js/suggest_list.js
+++ b/assets/js/suggest_list.js
@@ -42,6 +42,36 @@ export const markActiveRow = (rows, index, anchorEl) => {
   else anchorEl.removeAttribute("aria-activedescendant")
 }
 
+// A panel pinned to a caret is wrong the moment the page moves under it, and
+// nothing tells it so: the editor only re-asks on a ProseMirror transaction,
+// and scrolling dispatches none (issue #1898). The prose is its own scroll
+// container once it passes ~24rem, so this is not only about the window.
+//
+// The TRIGGER is shared; the arithmetic is not, and deliberately stays with
+// each caller — the mention picker places a <body>-level panel against the
+// viewport, the slash menu places a frame-relative one, and folding those into
+// one function would be a coincidence dressed as an abstraction.
+//
+// `capture: true` is what makes one window listener enough: a scroll event on
+// an element does NOT bubble, but it does travel down the capture phase, so
+// this sees the prose box scrolling as well as the page. The mention picker
+// proved that arrangement before there was anywhere to share it from.
+//
+// Returns the detach function. A caller that dies while the page lives — the
+// messages page tears an editor down per closed conversation — must hold it
+// and call it, or it leaks a handler on `window` per editor.
+export const followsCaret = (onMove) => {
+  const handler = () => onMove()
+
+  window.addEventListener("scroll", handler, { passive: true, capture: true })
+  window.addEventListener("resize", handler)
+
+  return () => {
+    window.removeEventListener("scroll", handler, { capture: true })
+    window.removeEventListener("resize", handler)
+  }
+}
+
 // The keys an open suggestion list owns, in one place so both lists answer
 // them the same way. Returns whether the event was taken — the caller swallows
 // it only then, so ordinary typing never stops while a list is up.

--- a/test/vutuv_web/suggest_list_test.exs
+++ b/test/vutuv_web/suggest_list_test.exs
@@ -67,6 +67,35 @@ defmodule VutuvWeb.SuggestListTest do
     assert css =~ ".mde__slash-item.is-active"
   end
 
+  test "\"follow the caret when the page moves\" is written once (issue #1898)" do
+    # A panel pinned to a caret is wrong the moment the page moves under it,
+    # and the editor only re-asks on a ProseMirror transaction — scrolling
+    # dispatches none. The slash menu shipped without this and was placed once
+    # on the way open, then abandoned; the bubble had an ad-hoc copy.
+    assert shared() =~ "followsCaret"
+    assert picker() =~ "followsCaret("
+    assert editor() =~ "followsCaret("
+
+    # `capture: true` on window is the whole trick — a scroll on an element
+    # does not bubble but does travel down the capture phase, so one listener
+    # sees the prose box scrolling as well as the page. A second copy of that
+    # subtlety is how the two drifted apart in the first place.
+    for {name, source} <- [{"mention_picker.js", picker()}, {"markdown_editor.js", editor()}] do
+      refute source =~ ~r/addEventListener\(\s*"scroll"/,
+             "#{name} wires its own scroll listener; call followsCaret/1 instead"
+    end
+  end
+
+  test "the editor detaches its window listeners when it dies" do
+    # `followsCaret` puts two handlers on `window`, which outlives every editor
+    # on the page — and the messages page tears one down per closed
+    # conversation, so an editor that never detaches leaks a handler per chat.
+    source = editor()
+
+    assert source =~ "this._unfollow = followsCaret("
+    assert source =~ "if (this._unfollow) this._unfollow()"
+  end
+
   test "a modified key is never a list key (issue #1196 vs #1886)" do
     # Cmd/Ctrl+Enter submits the composer from a listener on the same element.
     # A list that swallowed it turned a post into a heading — which is what the


### PR DESCRIPTION
The editor only re-asks where things are on a ProseMirror transaction, and scrolling dispatches none. The slash menu was placed once on the way open and then left there, so once the prose scrolls — it becomes its own container past 24rem — it pointed at nothing. The bubble had its own line for this, the mention picker a second one.

The rule now lives once in `suggest_list.js` (`followsCaret/1`); the arithmetic deliberately stays with each caller, because the picker places a `<body>`-level panel against the viewport and the slash menu a frame-relative one. Folding those together would be a coincidence dressed as an abstraction.

One `window` listener with `capture: true` is enough: a scroll event on an element does not bubble but does travel down the capture phase. The mention picker proved that before there was anywhere to share it from.

The menu also **closes** when the `/` scrolls out of the prose — somebody who scrolls away from the word they typed is done with it, and the alternative is a panel clamped to an edge pointing at whatever they scrolled to. Same judgement the picker makes about the window.

Measured in a browser: a 100px scroll moves the menu exactly 100px and it stays open; a large one closes it.

Closes #1898

*An AI agent wrote this text in my name. I know that is problematic.*
