### PR TITLE
A low-bandwidth composer that never downloads the editor

### DIFF
--- a/.claude/rules/liveview.md
+++ b/.claude/rules/liveview.md
@@ -107,6 +107,24 @@ pages — both render `PostComponents.post_actions/1` and share `PostLive.Action
   builds the page a careless dedup chokes on and lets LiveView do the asserting
   — that catches code paths nobody has written yet, which a rule cannot.
 
+- **A value a function component derives per render belongs in `Map.put/3`,
+  never `assign/3`, and never in a `{helper(assigns)}` spread.** Both spellings
+  are the tidier-looking ones and both switch change tracking off for every
+  attribute that reads the value, so the component re-sends them on every
+  keystroke — to the members who did *not* ask for the cheaper page.
+  `assign/3` marks the key changed each time (it is absent from the incoming
+  assigns, so any value counts as new), and handing `assigns` to a function is
+  a strong taint in `Phoenix.LiveView.Engine`, which collapses the separately
+  tracked dynamics into one it always recomputes. Measured on the composer with
+  a 200-byte body: 2,353 bytes per keystroke either way, against 422 written
+  correctly, which is also what the component cost before the feature existed.
+  The test to write asserts on `rendered.dynamic.(true)` (what a re-render
+  actually re-sends) against `rendered.dynamic.(false)`, picking a constant big
+  enough to notice as the canary — see the change-tracking test in
+  `markdown_editor_test.exs`. Reach for `Map.put/3` only where the value truly
+  cannot change without a new mount; anything that can change is a real assign
+  and belongs in `assign/3`.
+
 ## Phoenix LiveView guidelines
 
 - **Never** use the deprecated `live_redirect` and `live_patch` functions, instead **always** use the `<.link navigate={href}>` and  `<.link patch={href}>` in templates, and `push_navigate` and `push_patch` functions LiveViews

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -626,6 +626,18 @@ feed turns *Quote what arrives on the other tab* off at `/admin/preferences`,
 or shortens the window there; the dot is unaffected, and every member can set
 both for themselves.
 
+A fourth is about what the site costs to load: **low-bandwidth mode**. The
+composer is a WYSIWYG editor whose bundle is 155 kB gzipped, two and a half
+times the rest of vutuv's JavaScript together. A member with the mode on is
+never sent it: everywhere they write they get the plain Markdown field that has
+always been the no-JavaScript fallback, and what they publish is byte for byte
+what the editor would have produced. vutuv ships it off and asks every new
+account once, on the sign-up form. Where the line is the scarce resource (a
+rural co-op, a ship, mobile data), turn *Low-bandwidth mode* on at
+`/admin/preferences` and every member who has not decided for themselves gets
+the cheap composer. Walking past the sign-up box leaves the column empty, so
+this default reaches new accounts too.
+
 - **`/admin` → Preference defaults** (`/admin/preferences`): change the
   default for the whole installation at any time. It applies immediately to
   every member who has not set an own value — and to logged-out visitors.

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -804,17 +804,30 @@ first. `markdown_editor.js` is its own esbuild entry point (155 kB gzipped
 against 61 kB for all of `app.js`), fetched on demand by the hook, and a member
 with the `low_bandwidth?` preference on is never told where it lives.
 `VutuvWeb.UI.markdown_editor/1` takes a required `user=` and asks
-`Vutuv.Prefs.get/2` once. `editor_hook/1` then returns either every
-`data-mde-*` attribute and the `phx-hook`, or nothing at all, and the editor's
-frame (mount point, selection bubble, slash menu) is skipped with it. What is
-left is the plain `<textarea>` that `components.css` shows whenever
-`data-mde-ready` is absent: the same fallback a member with JavaScript off has
-always had, and a working Markdown composer. Withholding the URL rather than
-letting the hook decide is deliberate, because the decision is then the
-server's, made once for every composer on the site, and no failed fetch or
-client-side race can undo it. `user=` is required rather than defaulted so a
-new composer cannot silently ship the bundle to somebody who asked not to be
-sent it; `--warnings-as-errors` turns the omission into a build failure.
+`Vutuv.Prefs.low_bandwidth?/1` once; every `data-mde-*` attribute and the
+`phx-hook` itself are gated on the answer, and the editor's frame (mount point,
+selection bubble, slash menu) is skipped with them. What is left is the plain
+`<textarea>` that `components.css` shows whenever `data-mde-ready` is absent:
+the same fallback a member with JavaScript off has always had, and a working
+Markdown composer. Withholding the URL rather than letting the hook decide is
+deliberate, because the decision is then the server's, made once for every
+composer on the site, and no failed fetch or client-side race can undo it.
+`user=` is required rather than defaulted so a new composer cannot silently
+ship the bundle to somebody who asked not to be sent it;
+`--warnings-as-errors` turns the omission into a build failure.
+
+**Two tidier spellings of that gate each cost every OTHER member ~2 kB per
+keystroke**, so both are pinned by a test. Collecting the attributes into a
+`{editor_hook(assigns)}` spread hands `assigns` to a function, which is a
+strong taint in `Phoenix.LiveView.Engine`: fifteen independently-tracked
+dynamics collapse into one that is recomputed and re-sent on every render, the
+1.6 kB fence-language table included. Deriving the flag with `assign/3` rather
+than `Map.put/3` does the same by marking the key changed on every render (it
+is absent from the incoming assigns, so any value counts as new). Measured on a
+keystroke with a 200-byte body: 422 bytes either way when written as it is now,
+2,353 with either shape, against 422 for the component before this feature
+existed. The flag cannot change without a new mount, which is what makes it
+derived state rather than a tracked assign.
 
 Two consequences. An **unticked** sign-up box is dropped rather than stored
 (`PageController.drop_untouched_low_bandwidth/1`), because `Vutuv.Prefs` needs

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -799,6 +799,31 @@ opt-in the message composer passes, one handler in the hook); the shortcut
 respects a disabled submit button, so it cannot post past the photo-upload
 guard, and the "?" shortcuts overlay lists it.
 
+**Low-bandwidth mode** is the second composer, and it is the *absence* of the
+first. `markdown_editor.js` is its own esbuild entry point (155 kB gzipped
+against 61 kB for all of `app.js`), fetched on demand by the hook, and a member
+with the `low_bandwidth?` preference on is never told where it lives.
+`VutuvWeb.UI.markdown_editor/1` takes a required `user=` and asks
+`Vutuv.Prefs.get/2` once. `editor_hook/1` then returns either every
+`data-mde-*` attribute and the `phx-hook`, or nothing at all, and the editor's
+frame (mount point, selection bubble, slash menu) is skipped with it. What is
+left is the plain `<textarea>` that `components.css` shows whenever
+`data-mde-ready` is absent: the same fallback a member with JavaScript off has
+always had, and a working Markdown composer. Withholding the URL rather than
+letting the hook decide is deliberate, because the decision is then the
+server's, made once for every composer on the site, and no failed fetch or
+client-side race can undo it. `user=` is required rather than defaulted so a
+new composer cannot silently ship the bundle to somebody who asked not to be
+sent it; `--warnings-as-errors` turns the omission into a build failure.
+
+Two consequences. An **unticked** sign-up box is dropped rather than stored
+(`PageController.drop_untouched_low_bandwidth/1`), because `Vutuv.Prefs` needs
+NULL to mean "inherit the installation default" and a checkbox posts `"false"`
+for the box nobody touched. And the photo panel's *Insert into text* button has
+no editor to push into, so `Composer.append_image_reference/2` writes the
+`![](…)` reference to the end of the body instead: a button that silently did
+nothing would read as a failed upload.
+
 **Emoji** (issue #1197) are typed as a shortcode: `:tada:` becomes 🎉 on the
 closing colon, aliases included. The picker panel that used to sit behind a 🙂
 toolbar button is **gone** (issue #1886, with the toolbar). What a body stores

--- a/docs/architecture/settings-and-account.md
+++ b/docs/architecture/settings-and-account.md
@@ -144,7 +144,17 @@ people who liked it (issue #1233, see the "Who liked it" section in
 [posts-and-feed.md](posts-and-feed.md)). It is the one pref whose home is not
 `/settings/preferences` but the visibility page (`/settings/privacy`, reset via
 POST `/settings/privacy/reset`), because it is a privacy posture rather than a
-display detail. Every such knob is declared once in the
+display detail. The `:bandwidth` group holds one knob with a different shape
+again: `low_bandwidth?` decides whether this member's browser is ever told
+where the 155 kB WYSIWYG editor bundle lives (see "Low-bandwidth mode" in
+[posts-and-feed.md](posts-and-feed.md)). It is the only pref also asked at
+**sign-up**, and the only one whose form box is dropped rather than stored when
+it is left unticked — `Vutuv.Prefs` needs NULL to mean "inherit", and a
+checkbox posts `"false"` for the box nobody touched, which would cut every new
+account off from an installation default an operator later turns on. Unticking
+it on `/settings/preferences` is a real choice and is stored as one; the card's
+reset link (POST `/settings/low_bandwidth/reset`) is the way back to
+inheriting. Every such knob is declared once in the
 `Vutuv.Prefs.registry/0` (key, type, shipped default, constraints, group) and
 resolves in three layers: the member's **explicit value** (a non-nil `users`
 column; an explicit `0`/`false` is a choice) → the **installation default**

--- a/docs/architecture/settings-and-account.md
+++ b/docs/architecture/settings-and-account.md
@@ -149,9 +149,11 @@ again: `low_bandwidth?` decides whether this member's browser is ever told
 where the 155 kB WYSIWYG editor bundle lives (see "Low-bandwidth mode" in
 [posts-and-feed.md](posts-and-feed.md)). It is the only pref also asked at
 **sign-up**, and the only one whose form box is dropped rather than stored when
-it is left unticked — `Vutuv.Prefs` needs NULL to mean "inherit", and a
-checkbox posts `"false"` for the box nobody touched, which would cut every new
-account off from an installation default an operator later turns on. Unticking
+it is left unticked (`Prefs.drop_unchosen_booleans/1`, registry-driven so the
+next preference offered on a sign-up or onboarding form is covered too) —
+`Vutuv.Prefs` needs NULL to mean "inherit", and a checkbox posts `"false"` for
+the box nobody touched, which would cut every new account off from an
+installation default an operator later turns on. Unticking
 it on `/settings/preferences` is a real choice and is stored as one; the card's
 reset link (POST `/settings/low_bandwidth/reset`) is the way back to
 inheriting. Every such knob is declared once in the

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -318,6 +318,12 @@ defmodule Vutuv.Accounts.User do
     # the browser tab's title. nil = inherit the installation default; read
     # through `Vutuv.Prefs.get/2`, never straight off the struct.
     field(:browser_tab_teaser?, :boolean)
+    # Whether this member is spared the WYSIWYG editor bundle wherever they
+    # write prose (asked once at sign-up, changeable at /settings/preferences).
+    # nil = inherit the installation default; read through `Vutuv.Prefs.get/2`,
+    # never straight off the struct — and in the view through
+    # `VutuvWeb.UI.markdown_editor/1`, which owns the one decision it drives.
+    field(:low_bandwidth?, :boolean)
     # The feed's remembered source tab (issue #1499): "vutuv" / "fediverse",
     # nil = All. Not a form field — `Vutuv.Posts.remember_feed_filter/2` writes
     # it from the tab click and `remembered_feed_filter/1` reads it back at
@@ -539,7 +545,7 @@ defmodule Vutuv.Accounts.User do
   # :email_confirmed? is NOT here either: it flips only via the login-PIN path
   # (Accounts.activate_user/1, its own narrow cast) — castable, it would let a
   # registration self-activate without ever proving control of an email.
-  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? email_on_reference_check? newsletter_emails? saved_search_emails? cv_update_notifications? thread_notifications? browser_notifications? show_online_status? show_mastodon_feed? mastodon_clients? show_code_stats? fediverse_followers? fediverse_reactions? fediverse_replies? also_known_as_input map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines like_attribution? headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix name_pronunciation gender birthdate birthdate_visibility locale date_region time_zone tag_list auto_post_deletion? auto_post_deletion_after_days auto_post_deletion_keep_photos? auto_post_deletion_keep_answered? auto_post_deletion_keep_bookmarked? auto_post_deletion_delete_replies? auto_post_deletion_min_likes auto_post_deletion_min_bookmarks auto_post_deletion_min_reposts feed_foreign_posts feed_languages feed_tab_ticker? feed_tab_ticker_seconds browser_tab_teaser?)a
+  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? email_on_reference_check? newsletter_emails? saved_search_emails? cv_update_notifications? thread_notifications? browser_notifications? show_online_status? show_mastodon_feed? mastodon_clients? show_code_stats? fediverse_followers? fediverse_reactions? fediverse_replies? also_known_as_input map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines like_attribution? headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix name_pronunciation gender birthdate birthdate_visibility locale date_region time_zone tag_list auto_post_deletion? auto_post_deletion_after_days auto_post_deletion_keep_photos? auto_post_deletion_keep_answered? auto_post_deletion_keep_bookmarked? auto_post_deletion_delete_replies? auto_post_deletion_min_likes auto_post_deletion_min_bookmarks auto_post_deletion_min_reposts feed_foreign_posts feed_languages feed_tab_ticker? feed_tab_ticker_seconds browser_tab_teaser? low_bandwidth?)a
 
   # The ages the automatic post deletion offers (issue #1255), in days. A fixed
   # list rather than a free number field on purpose: this setting deletes

--- a/lib/vutuv/markdown_content.ex
+++ b/lib/vutuv/markdown_content.ex
@@ -23,6 +23,21 @@ defmodule Vutuv.MarkdownContent do
   @own_upload_src ~r{\A/post_images/[A-Za-z0-9_-]+/(thumb|feed|large)\.(avif|webp)(\?v=[A-Za-z0-9_-]+)?(#(left|right|center))?\z}
 
   @doc """
+  The Markdown for an embedded image, in the one shape `@image_markdown` above
+  can read back.
+
+  Lives here rather than at the call site because that regex is the definition
+  of "an image reference" for every stored body, and it takes no `]` inside the
+  label at all — escaped or not. So an alt text is stripped of brackets rather
+  than escaped: `![a\]b](…)` is invisible to `validate_own_images_only/2`
+  while Earmark renders it happily, which is a body whose pictures nothing
+  checked.
+  """
+  def image_markdown(url, alt) do
+    "![#{String.replace(alt || "", ["[", "]"], "")}](#{url})"
+  end
+
+  @doc """
   Reject a body that embeds an image. Code samples are exempt: `![](x)` inside a
   fenced or inline code span renders as literal text, not an image (the same
   distinction `VutuvWeb.Markdown` makes at render time), so it stays allowed.

--- a/lib/vutuv/prefs.ex
+++ b/lib/vutuv/prefs.ex
@@ -100,6 +100,20 @@ defmodule Vutuv.Prefs do
     # else's first line can end up in a screenshot, a recording or a window
     # switcher.
     %Pref{key: :browser_tab_teaser?, type: :boolean, default: true, group: :browser_tab},
+    # Whether this member's browser is spared the WYSIWYG editor bundle
+    # (155 kB gzipped, measured 2026-09-02 — two and a half times the whole
+    # rest of app.js). On, every place a member writes prose renders the plain
+    # Markdown textarea that already sits under Milkdown as the no-JS
+    # fallback, and `VutuvWeb.UI.markdown_editor/1` leaves out the bundle's
+    # URL entirely, so the browser cannot fetch what it is never told about.
+    #
+    # Off by default: the editor is what most members expect from a composer,
+    # and a switch that quietly takes it away would be a worse first
+    # impression than a slow one. The knob exists for the member on a metered
+    # or rural link, who is the one person able to judge that trade — and for
+    # the installation whose members are all on one (an intranet, a rural
+    # co-op), which flips the default once at /admin/preferences.
+    %Pref{key: :low_bandwidth?, type: :boolean, default: false, group: :bandwidth},
     # How a member's dates and times are written, and which clock they are
     # written on (issue #1502). Two knobs rather than one because they answer
     # different questions — a German-speaking member in Chicago wants German
@@ -174,6 +188,8 @@ defmodule Vutuv.Prefs do
   def label(:feed_foreign_posts),
     do: Gettext.gettext(VutuvWeb.Gettext, "Posts in other languages")
 
+  def label(:low_bandwidth?), do: Gettext.gettext(VutuvWeb.Gettext, "Low-bandwidth mode")
+
   def label(:browser_tab_teaser?),
     do: Gettext.gettext(VutuvWeb.Gettext, "Tease new posts in the browser tab")
 
@@ -191,6 +207,13 @@ defmodule Vutuv.Prefs do
       Gettext.gettext(
         VutuvWeb.Gettext,
         "What your feed does with posts outside your chosen languages: show them as they are, translate them for you, or hide them. Posts that declare no language always show."
+      )
+
+  def hint(:low_bandwidth?),
+    do:
+      Gettext.gettext(
+        VutuvWeb.Gettext,
+        "Writing a post or a message then uses a plain Markdown box instead of the formatting editor, which saves about 150 kB of download. Everything you write still looks the same to everyone who reads it."
       )
 
   def hint(:browser_tab_teaser?),
@@ -249,6 +272,7 @@ defmodule Vutuv.Prefs do
   def group_label(:post_display), do: Gettext.gettext(VutuvWeb.Gettext, "Posts")
   def group_label(:feed), do: Gettext.gettext(VutuvWeb.Gettext, "Feed")
   def group_label(:browser_tab), do: Gettext.gettext(VutuvWeb.Gettext, "Browser tab")
+  def group_label(:bandwidth), do: Gettext.gettext(VutuvWeb.Gettext, "Bandwidth")
   def group_label(:privacy), do: Gettext.gettext(VutuvWeb.Gettext, "Privacy")
   def group_label(:region), do: Gettext.gettext(VutuvWeb.Gettext, "Date & time")
   def group_label(:maps), do: Gettext.gettext(VutuvWeb.Gettext, "Maps")

--- a/lib/vutuv/prefs.ex
+++ b/lib/vutuv/prefs.ex
@@ -484,6 +484,50 @@ defmodule Vutuv.Prefs do
   end
 
   @doc """
+  Whether this member writes in the cheap composer: no WYSIWYG editor bundle,
+  the plain Markdown textarea instead (`VutuvWeb.UI.markdown_editor/1`).
+
+  A named predicate rather than `get(user, :low_bandwidth?)` spelled out at
+  each call site, because two modules now ask (the component and the post
+  composer's inline-image handler) and the key should be written down once.
+  """
+  def low_bandwidth?(user), do: get(user, :low_bandwidth?)
+
+  @doc """
+  Drop every boolean-pref param that is not ticked, so the column stays NULL.
+
+  For a form where an untouched box means *no opinion*: the sign-up form, where
+  a member is offered a preference in passing and most walk past it. A checkbox
+  posts `"false"` for the box nobody touched, and storing that would record a
+  choice nobody made and cut the member off from the installation default for
+  good — on exactly the kind of installation the switch exists for, where an
+  admin later turns it on for everybody at /admin/preferences.
+
+  Registry-driven rather than written per key, because the failure is silent
+  and permanent: the next preference offered on a sign-up or onboarding form
+  would need the same clause, and nothing breaks when it is forgotten.
+
+  **Not** for /settings, which is the opposite case: unticking there is a real
+  choice and is stored as one, with the card's reset link as the way back to
+  inheriting.
+  """
+  def drop_unchosen_booleans(params) when is_map(params) do
+    Enum.reduce(@registry, params, fn
+      %Pref{type: :boolean, key: key}, acc ->
+        param = Atom.to_string(key)
+
+        case Map.fetch(acc, param) do
+          {:ok, value} when value in [true, "true", "1", "on"] -> acc
+          {:ok, _unticked} -> Map.delete(acc, param)
+          :error -> acc
+        end
+
+      %Pref{}, acc ->
+        acc
+    end)
+  end
+
+  @doc """
   The member struct with every inherited (nil) pref field filled with its
   installation default — what the /settings forms render, so a member always
   sees the values that actually apply to them.

--- a/lib/vutuv_web/components/ui.ex
+++ b/lib/vutuv_web/components/ui.ex
@@ -296,8 +296,8 @@ defmodule VutuvWeb.UI do
   attr(:user, :any,
     required: true,
     doc:
-      "the signed-in member whose editor this is. Their `low_bandwidth?` " <>
-        "preference decides whether the WYSIWYG bundle is offered at all. " <>
+      "the signed-in member whose editor this is. `Vutuv.Prefs.low_bandwidth?/1` " <>
+        "decides from them whether the WYSIWYG bundle is offered at all. " <>
         "Required, not optional: a composer that forgot to pass it would " <>
         "silently send 155 kB to somebody who asked not to be sent it, and " <>
         "`--warnings-as-errors` is what stops that reaching a release"
@@ -351,10 +351,71 @@ defmodule VutuvWeb.UI do
   attr(:rest, :global)
 
   def markdown_editor(assigns) do
-    assigns = assign(assigns, :low_bandwidth?, Prefs.get(assigns.user, :low_bandwidth?))
+    # `Map.put/3`, deliberately, where `assign/3` is what you would reach for.
+    # This runs on every render, and `assign/3` would mark the key changed every
+    # time (the key is absent from the incoming assigns, so any value counts as
+    # new) — which re-sends every attribute below that is gated on it, the 1.6 kB
+    # language table included. The member's answer cannot change without a new
+    # mount, so it is derived state, not a tracked assign. Measured on a
+    # keystroke with a 200-byte body: 422 bytes re-sent this way, 2,353 with
+    # `assign/3`, against 422 for the component before this feature existed.
+    assigns = Map.put(assigns, :low_bandwidth?, Prefs.low_bandwidth?(assigns.user))
 
     ~H"""
-    <div id={@id} class={["mde", @compact && "mde--compact", @class]} {editor_hook(assigns)} {@rest}>
+    <%!-- Every attribute below exists to feed the MarkdownEditor hook, and a
+    member in low-bandwidth mode gets none of them: no `phx-hook`, so LiveView
+    builds no hook, and above all no `data-mde-src`, so nothing on the page
+    names the 155 kB bundle and the browser cannot fetch a URL it was never
+    given. What is left is the plain `<textarea>` below, which components.css
+    shows whenever `data-mde-ready` is absent - the same fallback that has
+    always served a member with JavaScript off, and a working Markdown composer
+    in its own right. Withholding the URL rather than letting the hook decide
+    is what makes the promise keepable: the decision is the server's, made once
+    here for every composer on the site, and no client-side race or failed
+    fetch can turn it back on.
+
+    Gated one by one, NOT collected into a `{editor_hook(assigns)}` spread,
+    however much better that reads. Handing `assigns` to a function is a strong
+    taint in `Phoenix.LiveView.Engine`, which collapses these fifteen
+    independently-tracked dynamics into one that is recomputed and re-sent on
+    every render. The composer re-renders on every keystroke, so that shape
+    measured at ~2.4 kB per keystroke against ~218 bytes here (~1 MB extra over
+    the socket per post composed) - paid by everyone who did NOT turn
+    low-bandwidth on. `@low_bandwidth?` never changes mid-session, so gated
+    this way the constants (the gettext strings, the routes, the 1.6 kB
+    language table) fall back into the bucket LiveView sends once and skips
+    forever. --%>
+    <div
+      id={@id}
+      phx-hook={not @low_bandwidth? && "MarkdownEditor"}
+      data-mde-src={not @low_bandwidth? && ~p"/assets/markdown_editor.js"}
+      data-mde-value={not @low_bandwidth? && @value}
+      data-mde-seed={not @low_bandwidth? && @seed}
+      data-mde-placeholder={not @low_bandwidth? && @placeholder}
+      data-mde-submit={not @low_bandwidth? && @submit_on}
+      data-mde-images={not @low_bandwidth? && @images && "1"}
+      data-mde-link-prompt={not @low_bandwidth? && gettext("Link URL")}
+      data-mention-url={not @low_bandwidth? && ~p"/system/mentions/suggest"}
+      data-mention-check-url={not @low_bandwidth? && ~p"/system/mentions/check"}
+      data-mention-label={not @low_bandwidth? && gettext("Mention an account")}
+      data-mention-empty={not @low_bandwidth? && gettext("No account found.")}
+      data-mention-max={not @low_bandwidth? && @mention_limit}
+      data-mention-budget={
+        not @low_bandwidth? && @mention_limit && gettext("{used} of {max} mentions")
+      }
+      data-mde-langs={not @low_bandwidth? && code_fence_labels()}
+      class={["mde", @compact && "mde--compact", @class]}
+      {@rest}
+    >
+      <%!-- Skipped in low-bandwidth mode for its BYTES, not for correctness:
+      components.css hides `.mde__frame` without `data-mde-ready` either way.
+      Roughly 4 kB of bubble, slash menu and mount point that no hook will ever
+      animate. The footer below is left standing by the same measure pointing
+      the other way - it is ~900 bytes, and its own CSS rule
+      (`.mde:not([data-mde-ready]) .mde__foot > :not(.mde__help)`) already
+      shows exactly the one control that still means something without JS, the
+      Markdown help link. Gating it here too would buy those bytes with a
+      second place to remember. --%>
       <div
         :if={not @low_bandwidth?}
         id={"#{@id}-frame"}
@@ -509,43 +570,6 @@ defmodule VutuvWeb.UI do
       </div>
     </div>
     """
-  end
-
-  # Everything the MarkdownEditor hook needs, or nothing at all.
-  #
-  # A member with `low_bandwidth?` on gets no `phx-hook`, so LiveView builds no
-  # hook; no `data-mde-src`, so nothing on the page names the 155 kB bundle and
-  # the browser cannot fetch a URL it was never given; and none of the words,
-  # endpoints and language labels that only ever existed to feed it. What is
-  # left is the plain `<textarea>` below, which components.css shows whenever
-  # `data-mde-ready` is absent — the same fallback that has always served a
-  # member with JavaScript switched off, and a working Markdown composer in its
-  # own right.
-  #
-  # Withholding the URL, rather than letting the hook decide, is what makes the
-  # promise keepable: the decision is the server's, it is made once here for
-  # every composer on the site, and no client-side race or failed fetch can
-  # turn it back on.
-  defp editor_hook(%{low_bandwidth?: true}), do: []
-
-  defp editor_hook(assigns) do
-    [
-      "phx-hook": "MarkdownEditor",
-      "data-mde-src": ~p"/assets/markdown_editor.js",
-      "data-mde-value": assigns.value,
-      "data-mde-seed": assigns.seed,
-      "data-mde-placeholder": assigns.placeholder,
-      "data-mde-submit": assigns.submit_on,
-      "data-mde-images": assigns.images && "1",
-      "data-mde-link-prompt": gettext("Link URL"),
-      "data-mention-url": ~p"/system/mentions/suggest",
-      "data-mention-check-url": ~p"/system/mentions/check",
-      "data-mention-label": gettext("Mention an account"),
-      "data-mention-empty": gettext("No account found."),
-      "data-mention-max": assigns.mention_limit,
-      "data-mention-budget": assigns.mention_limit && gettext("{used} of {max} mentions"),
-      "data-mde-langs": code_fence_labels()
-    ]
   end
 
   @doc """

--- a/lib/vutuv_web/components/ui.ex
+++ b/lib/vutuv_web/components/ui.ex
@@ -32,6 +32,7 @@ defmodule VutuvWeb.UI do
   alias Vutuv.Organizations.Organization
   alias Vutuv.Organizations.OrganizationImage
   alias Vutuv.Posts
+  alias Vutuv.Prefs
   alias Vutuv.Tags.UserTag
   alias Vutuv.Uploads.Spec
   alias Vutuv.ViewerClock
@@ -267,6 +268,12 @@ defmodule VutuvWeb.UI do
   a raw-Markdown source view for power users, and "⤢" expands to a near
   full-page editor. With JS off the plain textarea shows through as the fallback.
 
+  That fallback is also the whole of the **low-bandwidth composer**: a member
+  who turned on `low_bandwidth?` (at sign-up or on /settings/preferences) is
+  never told where the 155 kB editor bundle lives, so their browser never
+  fetches it and they write in the plain Markdown box instead. `@user` is
+  required for exactly that reason — see `editor_hook/1`.
+
   The offered features are exactly the subset `VutuvWeb.Markdown` renders: bold,
   italic, strikethrough (durchgestrichen), links, bullet / ordered / nested
   lists, headings, blockquote, inline + fenced code, tables and horizontal
@@ -285,6 +292,17 @@ defmodule VutuvWeb.UI do
   """
   attr(:id, :string, required: true)
   attr(:name, :string, required: true, doc: "the form field name, e.g. post[body]")
+
+  attr(:user, :any,
+    required: true,
+    doc:
+      "the signed-in member whose editor this is. Their `low_bandwidth?` " <>
+        "preference decides whether the WYSIWYG bundle is offered at all. " <>
+        "Required, not optional: a composer that forgot to pass it would " <>
+        "silently send 155 kB to somebody who asked not to be sent it, and " <>
+        "`--warnings-as-errors` is what stops that reaching a release"
+  )
+
   attr(:value, :string, default: "")
   attr(:label, :string, required: true, doc: "sr-only label for the field")
   attr(:placeholder, :string, default: "")
@@ -333,28 +351,17 @@ defmodule VutuvWeb.UI do
   attr(:rest, :global)
 
   def markdown_editor(assigns) do
+    assigns = assign(assigns, :low_bandwidth?, Prefs.get(assigns.user, :low_bandwidth?))
+
     ~H"""
-    <div
-      id={@id}
-      phx-hook="MarkdownEditor"
-      data-mde-src={~p"/assets/markdown_editor.js"}
-      data-mde-value={@value}
-      data-mde-seed={@seed}
-      data-mde-placeholder={@placeholder}
-      data-mde-submit={@submit_on}
-      data-mde-images={@images && "1"}
-      data-mde-link-prompt={gettext("Link URL")}
-      data-mention-url={~p"/system/mentions/suggest"}
-      data-mention-check-url={~p"/system/mentions/check"}
-      data-mention-label={gettext("Mention an account")}
-      data-mention-empty={gettext("No account found.")}
-      data-mention-max={@mention_limit}
-      data-mention-budget={@mention_limit && gettext("{used} of {max} mentions")}
-      data-mde-langs={code_fence_labels()}
-      class={["mde", @compact && "mde--compact", @class]}
-      {@rest}
-    >
-      <div id={"#{@id}-frame"} data-mde-frame phx-update="ignore" class="mde__frame">
+    <div id={@id} class={["mde", @compact && "mde--compact", @class]} {editor_hook(assigns)} {@rest}>
+      <div
+        :if={not @low_bandwidth?}
+        id={"#{@id}-frame"}
+        data-mde-frame
+        phx-update="ignore"
+        class="mde__frame"
+      >
         <%!-- The prose itself, and nothing above it. What used to be a
         permanent row of eighteen buttons is now two surfaces that appear
         when they mean something: the bubble over a selection, the slash
@@ -502,6 +509,43 @@ defmodule VutuvWeb.UI do
       </div>
     </div>
     """
+  end
+
+  # Everything the MarkdownEditor hook needs, or nothing at all.
+  #
+  # A member with `low_bandwidth?` on gets no `phx-hook`, so LiveView builds no
+  # hook; no `data-mde-src`, so nothing on the page names the 155 kB bundle and
+  # the browser cannot fetch a URL it was never given; and none of the words,
+  # endpoints and language labels that only ever existed to feed it. What is
+  # left is the plain `<textarea>` below, which components.css shows whenever
+  # `data-mde-ready` is absent — the same fallback that has always served a
+  # member with JavaScript switched off, and a working Markdown composer in its
+  # own right.
+  #
+  # Withholding the URL, rather than letting the hook decide, is what makes the
+  # promise keepable: the decision is the server's, it is made once here for
+  # every composer on the site, and no client-side race or failed fetch can
+  # turn it back on.
+  defp editor_hook(%{low_bandwidth?: true}), do: []
+
+  defp editor_hook(assigns) do
+    [
+      "phx-hook": "MarkdownEditor",
+      "data-mde-src": ~p"/assets/markdown_editor.js",
+      "data-mde-value": assigns.value,
+      "data-mde-seed": assigns.seed,
+      "data-mde-placeholder": assigns.placeholder,
+      "data-mde-submit": assigns.submit_on,
+      "data-mde-images": assigns.images && "1",
+      "data-mde-link-prompt": gettext("Link URL"),
+      "data-mention-url": ~p"/system/mentions/suggest",
+      "data-mention-check-url": ~p"/system/mentions/check",
+      "data-mention-label": gettext("Mention an account"),
+      "data-mention-empty": gettext("No account found."),
+      "data-mention-max": assigns.mention_limit,
+      "data-mention-budget": assigns.mention_limit && gettext("{used} of {max} mentions"),
+      "data-mde-langs": code_fence_labels()
+    ]
   end
 
   @doc """

--- a/lib/vutuv_web/controllers/page_controller.ex
+++ b/lib/vutuv_web/controllers/page_controller.ex
@@ -303,7 +303,10 @@ defmodule VutuvWeb.PageController do
   end
 
   def new_registration(conn, %{"user" => user_params}) do
-    user_params = expand_fediverse_choice(user_params)
+    user_params =
+      user_params
+      |> expand_fediverse_choice()
+      |> drop_untouched_low_bandwidth()
 
     # Extract defensively: a malformed "emails" param (not the nested
     # %{"0" => %{"value" => …}} the form produces) must reach register_user/2
@@ -359,6 +362,22 @@ defmodule VutuvWeb.PageController do
   end
 
   defp expand_fediverse_choice(params), do: params
+
+  # The low-bandwidth box is a `Vutuv.Prefs` knob, not a plain column, and the
+  # three layers only work while "never chose" stays distinguishable from
+  # "chose off". A checkbox posts "false" for the box nobody touched, which
+  # would write that indifference into the column as a decision and cut the
+  # member off from the installation default forever - on exactly the kind of
+  # installation this switch exists for, where an admin turns it on for
+  # everybody at /admin/preferences. So an unticked box is dropped: the column
+  # stays NULL and inherits. A ticked one is a real choice and is stored.
+  # (/settings/preferences is the other way round on purpose - unticking there
+  # IS a choice, and its reset link is the way back to inheriting.)
+  defp drop_untouched_low_bandwidth(%{"low_bandwidth?" => value} = params)
+       when value in [true, "true", "1", "on"],
+       do: params
+
+  defp drop_untouched_low_bandwidth(params), do: Map.delete(params, "low_bandwidth?")
 
   defp handle_post_registration_login(conn, email) do
     # The account was just created, so login_by_email/2 always mails the PIN

--- a/lib/vutuv_web/controllers/page_controller.ex
+++ b/lib/vutuv_web/controllers/page_controller.ex
@@ -6,6 +6,7 @@ defmodule VutuvWeb.PageController do
   alias Vutuv.Accounts.User
   alias Vutuv.Fediverse
   alias Vutuv.Languages
+  alias Vutuv.Prefs
   alias Vutuv.SourceRepo
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.AgentDocs.ListDocs
@@ -306,7 +307,7 @@ defmodule VutuvWeb.PageController do
     user_params =
       user_params
       |> expand_fediverse_choice()
-      |> drop_untouched_low_bandwidth()
+      |> Prefs.drop_unchosen_booleans()
 
     # Extract defensively: a malformed "emails" param (not the nested
     # %{"0" => %{"value" => …}} the form produces) must reach register_user/2
@@ -343,6 +344,11 @@ defmodule VutuvWeb.PageController do
     end
   end
 
+  # What a ticked checkbox posts, in the four spellings a form can send. A guard
+  # rather than a function so it can head a clause, and one place rather than
+  # one per box.
+  defguardp checked_box?(value) when value in [true, "true", "1", "on"]
+
   # The sign-up form asks about the Fediverse once; `/settings/fediverse` has
   # three switches. Ticking the box means the whole thing, so it sets all three:
   # taking part, the reactions that come back, and the replies people write out
@@ -357,27 +363,11 @@ defmodule VutuvWeb.PageController do
   # land on exactly the defaults that page argues for, rather than on a silent
   # echo of a box they unticked at sign-up.
   defp expand_fediverse_choice(%{"fediverse_followers?" => value} = params)
-       when value in [true, "true", "1", "on"] do
+       when checked_box?(value) do
     Map.merge(params, %{"fediverse_reactions?" => "true", "fediverse_replies?" => "true"})
   end
 
   defp expand_fediverse_choice(params), do: params
-
-  # The low-bandwidth box is a `Vutuv.Prefs` knob, not a plain column, and the
-  # three layers only work while "never chose" stays distinguishable from
-  # "chose off". A checkbox posts "false" for the box nobody touched, which
-  # would write that indifference into the column as a decision and cut the
-  # member off from the installation default forever - on exactly the kind of
-  # installation this switch exists for, where an admin turns it on for
-  # everybody at /admin/preferences. So an unticked box is dropped: the column
-  # stays NULL and inherits. A ticked one is a real choice and is stored.
-  # (/settings/preferences is the other way round on purpose - unticking there
-  # IS a choice, and its reset link is the way back to inheriting.)
-  defp drop_untouched_low_bandwidth(%{"low_bandwidth?" => value} = params)
-       when value in [true, "true", "1", "on"],
-       do: params
-
-  defp drop_untouched_low_bandwidth(params), do: Map.delete(params, "low_bandwidth?")
 
   defp handle_post_registration_login(conn, email) do
     # The account was just created, so login_by_email/2 always mails the PIN

--- a/lib/vutuv_web/controllers/settings_controller.ex
+++ b/lib/vutuv_web/controllers/settings_controller.ex
@@ -848,6 +848,26 @@ defmodule VutuvWeb.SettingsController do
     reset_prefs(conn, :browser_tab, gettext("Browser tab settings reset to the site defaults."))
   end
 
+  # Low-bandwidth mode: whether this member's composer fetches the WYSIWYG
+  # editor at all (`VutuvWeb.UI.markdown_editor/1`). Unticking here IS a
+  # choice and is stored as one - the reset link below is the way back to
+  # inheriting the installation default, which is also what an untouched
+  # sign-up keeps.
+  def update_low_bandwidth(conn, %{"user" => params}) do
+    save(
+      conn,
+      params,
+      "preferences.html",
+      ~p"/settings/preferences",
+      gettext("Bandwidth settings saved."),
+      event: "preferences_changed"
+    )
+  end
+
+  def reset_low_bandwidth(conn, _params) do
+    reset_prefs(conn, :bandwidth, gettext("Bandwidth settings reset to the site defaults."))
+  end
+
   # The like-attribution switch (issue #1233) lives on the visibility page
   # rather than under language & display, so its reset lands back there.
   def reset_privacy_prefs(conn, _params) do

--- a/lib/vutuv_web/gettext_extraction_anchors.ex
+++ b/lib/vutuv_web/gettext_extraction_anchors.ex
@@ -96,6 +96,12 @@ defmodule VutuvWeb.GettextExtractionAnchors do
       gettext(
         "Only while you are looking at another tab, and only for a few seconds. The tab title also shows up in screenshots, in your window switcher and in a screen share."
       ),
+      # Vutuv.Prefs - low-bandwidth mode. "Bandwidth" itself is anchored by the
+      # settings card and the sign-up legend, which both use the macro.
+      gettext("Low-bandwidth mode"),
+      gettext(
+        "Writing a post or a message then uses a plain Markdown box instead of the formatting editor, which saves about 150 kB of download. Everything you write still looks the same to everyone who reads it."
+      ),
       gettext("Between 4 and 20 seconds."),
       gettext("0 means posts are never shortened."),
       gettext("How much of a post a notification quotes before it is cut off."),

--- a/lib/vutuv_web/live/job_posting_live/form.ex
+++ b/lib/vutuv_web/live/job_posting_live/form.ex
@@ -687,6 +687,7 @@ defmodule VutuvWeb.JobPostingLive.Form do
           <.markdown_editor
             id="job-description"
             name="job_posting[description]"
+            user={@current_user}
             value={@form[:description].value || ""}
             label={gettext("Job description")}
             placeholder={gettext("Describe the role. Markdown is supported.")}

--- a/lib/vutuv_web/live/message_live/index.ex
+++ b/lib/vutuv_web/live/message_live/index.ex
@@ -895,6 +895,7 @@ defmodule VutuvWeb.MessageLive.Index do
           <.markdown_editor
             id="message-body"
             name="message[body]"
+            user={@current_user}
             value={@form[:body].value || ""}
             seed={@editor_seed}
             label={gettext("Write a message…")}

--- a/lib/vutuv_web/live/organization_live/edit.ex
+++ b/lib/vutuv_web/live/organization_live/edit.ex
@@ -309,6 +309,7 @@ defmodule VutuvWeb.OrganizationLive.Edit do
           <.markdown_editor
             id="organization-description"
             name="organization[description]"
+            user={@current_user}
             value={@form[:description].value || ""}
             label={gettext("Description")}
             placeholder={gettext("Describe the organization. Markdown is supported.")}

--- a/lib/vutuv_web/live/post_live/composer.ex
+++ b/lib/vutuv_web/live/post_live/composer.ex
@@ -70,6 +70,7 @@ defmodule VutuvWeb.PostLive.Composer do
   alias Vutuv.Fediverse.Note
   alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Languages
+  alias Vutuv.MarkdownContent
   alias Vutuv.Mentions
   alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
@@ -728,7 +729,7 @@ defmodule VutuvWeb.PostLive.Composer do
         # instead. Not "at the cursor": where the caret sits is the browser's
         # business and this side cannot ask, so the honest place is the end of
         # what the member has written, on a paragraph of its own.
-        if Prefs.get(socket.assigns.current_user, :low_bandwidth?) do
+        if Prefs.low_bandwidth?(socket.assigns.current_user) do
           {:noreply, append_image_reference(socket, image)}
         else
           {:noreply, push_event(socket, "mde-insert-image", editor_image_payload(socket, image))}
@@ -1371,15 +1372,14 @@ defmodule VutuvWeb.PostLive.Composer do
     end
   end
 
-  # The payload both editor-hook events share: which editor (the DOM id of
-  # this composer's markdown_editor), the served URL to embed and the alt.
-  # `![alt](/post_images/...)` appended to the body, escaped the way the
-  # editor's own serializer would: an alt text is member-written, and an
-  # unescaped `]` in it would end the label early and leave the rest of their
-  # caption standing in the post as stray characters.
+  # The picture written into the Markdown itself, for the low-bandwidth
+  # composer, which has no editor to place it in. Its own paragraph at the end
+  # of what the member has written: where the caret sits is the browser's
+  # business and this side cannot ask, so the end is the honest answer.
+  # `Vutuv.MarkdownContent` owns the reference's shape, because that module's
+  # regex is what has to read it back when the post is saved.
   defp append_image_reference(socket, image) do
-    alt = String.replace(image.alt || "", ["[", "]"], &("\\" <> &1))
-    reference = "![#{alt}](#{PostImage.url(image, "feed")})"
+    reference = MarkdownContent.image_markdown(PostImage.url(image, "feed"), image.alt)
 
     body =
       case String.trim_trailing(socket.assigns.body) do
@@ -1390,6 +1390,8 @@ defmodule VutuvWeb.PostLive.Composer do
     assign(socket, :body, body)
   end
 
+  # The payload both editor-hook events share: which editor (the DOM id of
+  # this composer's markdown_editor), the served URL to embed and the alt.
   defp editor_image_payload(socket, image) do
     %{
       editor: "#{socket.assigns.id}-body",

--- a/lib/vutuv_web/live/post_live/composer.ex
+++ b/lib/vutuv_web/live/post_live/composer.ex
@@ -78,6 +78,7 @@ defmodule VutuvWeb.PostLive.Composer do
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostDraft
   alias Vutuv.Posts.PostImage
+  alias Vutuv.Prefs
   alias Vutuv.Uploads.Spec
   alias VutuvWeb.ErrorHelpers
   alias VutuvWeb.PostComponents
@@ -721,7 +722,17 @@ defmodule VutuvWeb.PostLive.Composer do
         {:noreply, socket}
 
       image ->
-        {:noreply, push_event(socket, "mde-insert-image", editor_image_payload(socket, image))}
+        # A low-bandwidth composer has no editor to push the picture into, so
+        # the button would sit there doing nothing - which reads as a failed
+        # upload, not as a setting. Write the reference into the Markdown
+        # instead. Not "at the cursor": where the caret sits is the browser's
+        # business and this side cannot ask, so the honest place is the end of
+        # what the member has written, on a paragraph of its own.
+        if Prefs.get(socket.assigns.current_user, :low_bandwidth?) do
+          {:noreply, append_image_reference(socket, image)}
+        else
+          {:noreply, push_event(socket, "mde-insert-image", editor_image_payload(socket, image))}
+        end
     end
   end
 
@@ -1362,6 +1373,23 @@ defmodule VutuvWeb.PostLive.Composer do
 
   # The payload both editor-hook events share: which editor (the DOM id of
   # this composer's markdown_editor), the served URL to embed and the alt.
+  # `![alt](/post_images/...)` appended to the body, escaped the way the
+  # editor's own serializer would: an alt text is member-written, and an
+  # unescaped `]` in it would end the label early and leave the rest of their
+  # caption standing in the post as stray characters.
+  defp append_image_reference(socket, image) do
+    alt = String.replace(image.alt || "", ["[", "]"], &("\\" <> &1))
+    reference = "![#{alt}](#{PostImage.url(image, "feed")})"
+
+    body =
+      case String.trim_trailing(socket.assigns.body) do
+        "" -> reference
+        written -> written <> "\n\n" <> reference
+      end
+
+    assign(socket, :body, body)
+  end
+
   defp editor_image_payload(socket, image) do
     %{
       editor: "#{socket.assigns.id}-body",
@@ -1634,7 +1662,7 @@ defmodule VutuvWeb.PostLive.Composer do
 
           <%!-- The editor is always on screen: a post is one kind, words
           first, whether or not pictures join it below. --%>
-          <.body_editor id={@id} body={@body} post={@post} seed={@editor_seed} />
+          <.body_editor id={@id} body={@body} post={@post} seed={@editor_seed} user={@current_user} />
 
           <%!-- **The photos ARE the gallery** (issue #1892). They used to be a
           plain grid with a small live preview of the arrangement further down,
@@ -2137,6 +2165,7 @@ defmodule VutuvWeb.PostLive.Composer do
   attr(:body, :string, required: true)
   attr(:post, :any, required: true)
   attr(:seed, :integer, required: true)
+  attr(:user, :any, required: true)
 
   defp body_editor(assigns) do
     ~H"""
@@ -2144,6 +2173,7 @@ defmodule VutuvWeb.PostLive.Composer do
       <.markdown_editor
         id={"#{@id}-body"}
         name="post[body]"
+        user={@user}
         value={@body}
         seed={@seed}
         label={gettext("What's new?")}

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -1648,6 +1648,9 @@ defmodule VutuvWeb.Router do
     put("/browser_tab", SettingsController, :update_browser_tab)
     patch("/browser_tab", SettingsController, :update_browser_tab)
     post("/browser_tab/reset", SettingsController, :reset_browser_tab)
+    put("/low_bandwidth", SettingsController, :update_low_bandwidth)
+    patch("/low_bandwidth", SettingsController, :update_low_bandwidth)
+    post("/low_bandwidth/reset", SettingsController, :reset_low_bandwidth)
     # Clear a whole preference group back to nil = "inherit the installation
     # default" (Vutuv.Prefs) — the quiet reset links under the two cards.
     post("/post_display/reset", SettingsController, :reset_post_display)

--- a/lib/vutuv_web/templates/page/index.html.heex
+++ b/lib/vutuv_web/templates/page/index.html.heex
@@ -66,6 +66,11 @@
   <% email_type_options = Enum.map(Email.email_types(), &{email_type_label(&1), &1}) %>
   <% label_class = "mb-1.5 block text-sm font-semibold text-slate-700 dark:text-slate-300" %>
   <% check_label_class = "flex items-start gap-2 text-sm text-slate-600 dark:text-slate-300" %>
+  <%!-- The helper line under a box label. `font-normal` is not decoration:
+        components.css sets every <label> bold, which the box labels want and an
+        explanation does not - without it the helper shouts as loudly as the
+        choice it explains. --%>
+  <% hint_class = "mt-0.5 block text-xs font-normal text-slate-600 dark:text-slate-400" %>
 
   <.form
     :let={f}
@@ -232,10 +237,6 @@
             <%= checkbox f, :fediverse_followers?, class: checkbox_class() %>
             <span>
               {gettext("Take part in the Fediverse")}
-              <%!-- `font-normal` is not decoration: components.css sets every
-                    <label> bold, which the box labels want and this helper line
-                    does not - without it the explanation shouts as loudly as the
-                    choice it explains. --%>
               <%!-- "Mastodon" links out to the project's own site, because the
                     word is the one thing in this sentence a first-time visitor
                     may not know, and the tick is only informed consent if they
@@ -251,7 +252,7 @@
                   ),
                   "{mastodon}"
                 ) %>
-              <span class="mt-0.5 block text-xs font-normal text-slate-600 dark:text-slate-400">
+              <span class={hint_class}>
                 {mastodon_pre}<a
                   href="https://joinmastodon.org"
                   target="_blank"
@@ -288,9 +289,7 @@
         <%= checkbox f, :low_bandwidth?, class: checkbox_class() %>
         <span>
           {Vutuv.Prefs.label(:low_bandwidth?)}
-          <span class="mt-0.5 block text-xs font-normal text-slate-600 dark:text-slate-400">
-            {Vutuv.Prefs.hint(:low_bandwidth?)}
-          </span>
+          <span class={hint_class}>{Vutuv.Prefs.hint(:low_bandwidth?)}</span>
         </span>
         <%= error_tag f, :low_bandwidth? %>
       </label>

--- a/lib/vutuv_web/templates/page/index.html.heex
+++ b/lib/vutuv_web/templates/page/index.html.heex
@@ -266,6 +266,36 @@
       </fieldset>
     </.inputs_for>
 
+    <%!-- The one question on this form that is about the member's line rather
+          than about their data. Unticked by default, and deliberately the only
+          box here that leaves its column NULL when it is not ticked (see
+          PageController.drop_untouched_low_bandwidth/1), so a member who walks
+          past it keeps inheriting whatever this installation's default is - an
+          intranet or a rural co-op turns it on for everybody at
+          /admin/preferences and nobody has to find this box.
+
+          The label and the explanation are Vutuv.Prefs' own, the same two
+          sentences /settings/preferences shows, so the member recognizes the
+          switch they are looking for later. --%>
+    <fieldset id="signup-bandwidth">
+      <%!-- Not gettext("Connection"): that msgid is vutuv's social one and is
+            translated "Vernetzung" (being connected to another member), which
+            over a bandwidth box says something else entirely. A msgid is a
+            key, not a phrase. This is the same word the settings card wears,
+            so the member recognizes the switch when they go looking. --%>
+      <legend class={label_class}>{gettext("Bandwidth")}</legend>
+      <label class={check_label_class}>
+        <%= checkbox f, :low_bandwidth?, class: checkbox_class() %>
+        <span>
+          {Vutuv.Prefs.label(:low_bandwidth?)}
+          <span class="mt-0.5 block text-xs font-normal text-slate-600 dark:text-slate-400">
+            {Vutuv.Prefs.hint(:low_bandwidth?)}
+          </span>
+        </span>
+        <%= error_tag f, :low_bandwidth? %>
+      </label>
+    </fieldset>
+
     <.button type="submit" class="w-full">{gettext("Sign up for a free account")}</.button>
 
     <%!-- Consent / information notice by the button. Accepting the

--- a/lib/vutuv_web/templates/settings/preferences.html.heex
+++ b/lib/vutuv_web/templates/settings/preferences.html.heex
@@ -201,45 +201,34 @@ shortened and hyphenated. Each form posts its own subset and lands back here. --
           the composer stops fetching the WYSIWYG editor. Everything they write
           still reads the same to everybody else - this changes the writing
           surface, never the post. --%>
-    <.card>
-      <.section_title>{gettext("Bandwidth")}</.section_title>
-      <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
-        {gettext(
+    <.toggle_form_card
+      changeset={@changeset}
+      field={:low_bandwidth?}
+      form_id="low-bandwidth-form"
+      action={~p"/settings/low_bandwidth"}
+      title={gettext("Bandwidth")}
+      intro={
+        gettext(
           "If you are on a slow or metered connection, vutuv can leave out the parts of the page that cost the most to download."
-        )}
-      </p>
+        )
+      }
+      label={Vutuv.Prefs.label(:low_bandwidth?)}
+      hint={Vutuv.Prefs.hint(:low_bandwidth?)}
+    />
 
-      <.form :let={f} for={@changeset} action={~p"/settings/low_bandwidth"} class="mt-5 space-y-5">
-        <.form_error changeset={@changeset} />
-
-        <label class="flex items-center gap-3 text-sm text-slate-700 dark:text-slate-300">
-          <%= checkbox f, :low_bandwidth?, class: checkbox_class() %>
-          <span>{Vutuv.Prefs.label(:low_bandwidth?)}</span>
-        </label>
-        <p class="text-sm text-slate-600 dark:text-slate-400">
-          {Vutuv.Prefs.hint(:low_bandwidth?)}
-        </p>
-
-        <div class="pt-1">
-          <.button type="submit">{gettext("Save")}</.button>
-        </div>
-      </.form>
-
-      <%!-- Back to inheriting the installation default - see the maps card. --%>
-      <div
-        :if={Vutuv.Prefs.customized_in_group?(@user, :bandwidth)}
-        class="mt-5 border-t border-slate-100 pt-4 dark:border-slate-800"
+    <%!-- Back to inheriting the installation default (a nil field). Outside the
+          card and only once the member holds a value of their own, the same
+          shape the like-attribution switch on /settings/privacy uses. --%>
+    <div :if={Vutuv.Prefs.customized_in_group?(@user, :bandwidth)} class="-mt-3">
+      <.link
+        href={~p"/settings/low_bandwidth/reset"}
+        method="post"
+        id="reset-low-bandwidth"
+        class="text-sm font-semibold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200"
       >
-        <.link
-          href={~p"/settings/low_bandwidth/reset"}
-          method="post"
-          id="reset-low-bandwidth"
-          class="text-sm font-semibold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200"
-        >
-          {gettext("Reset to the site defaults")}
-        </.link>
-      </div>
-    </.card>
+        {gettext("Reset to the site defaults")}
+      </.link>
+    </div>
 
     <%!-- The browser tab's teaser (issue #1681): the same quote one surface
           further out, in the tab's own title while the member is looking at

--- a/lib/vutuv_web/templates/settings/preferences.html.heex
+++ b/lib/vutuv_web/templates/settings/preferences.html.heex
@@ -197,6 +197,50 @@ shortened and hyphenated. Each form posts its own subset and lands back here. --
       </ul>
     </.card>
 
+    <%!-- Bandwidth: the switch a member on a metered or slow line turns on so
+          the composer stops fetching the WYSIWYG editor. Everything they write
+          still reads the same to everybody else - this changes the writing
+          surface, never the post. --%>
+    <.card>
+      <.section_title>{gettext("Bandwidth")}</.section_title>
+      <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+        {gettext(
+          "If you are on a slow or metered connection, vutuv can leave out the parts of the page that cost the most to download."
+        )}
+      </p>
+
+      <.form :let={f} for={@changeset} action={~p"/settings/low_bandwidth"} class="mt-5 space-y-5">
+        <.form_error changeset={@changeset} />
+
+        <label class="flex items-center gap-3 text-sm text-slate-700 dark:text-slate-300">
+          <%= checkbox f, :low_bandwidth?, class: checkbox_class() %>
+          <span>{Vutuv.Prefs.label(:low_bandwidth?)}</span>
+        </label>
+        <p class="text-sm text-slate-600 dark:text-slate-400">
+          {Vutuv.Prefs.hint(:low_bandwidth?)}
+        </p>
+
+        <div class="pt-1">
+          <.button type="submit">{gettext("Save")}</.button>
+        </div>
+      </.form>
+
+      <%!-- Back to inheriting the installation default - see the maps card. --%>
+      <div
+        :if={Vutuv.Prefs.customized_in_group?(@user, :bandwidth)}
+        class="mt-5 border-t border-slate-100 pt-4 dark:border-slate-800"
+      >
+        <.link
+          href={~p"/settings/low_bandwidth/reset"}
+          method="post"
+          id="reset-low-bandwidth"
+          class="text-sm font-semibold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200"
+        >
+          {gettext("Reset to the site defaults")}
+        </.link>
+      </div>
+    </.card>
+
     <%!-- The browser tab's teaser (issue #1681): the same quote one surface
           further out, in the tab's own title while the member is looking at
           something else. The dot there is not in question — it stays either

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -15,12 +15,12 @@ msgstr "Language: de\n"
 msgid "About us"
 msgstr "Impressum"
 
-#: lib/vutuv_web/components/ui.ex:4370
-#: lib/vutuv_web/components/ui.ex:4375
+#: lib/vutuv_web/components/ui.ex:4414
+#: lib/vutuv_web/components/ui.ex:4419
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
 #: lib/vutuv_web/live/organization_live/domains.ex:272
-#: lib/vutuv_web/live/organization_live/edit.ex:430
+#: lib/vutuv_web/live/organization_live/edit.ex:431
 #: lib/vutuv_web/live/organization_live/roles.ex:214
 #, elixir-autogen
 msgid "Add"
@@ -62,7 +62,7 @@ msgstr "Eine Adresse wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/text.ex:71
-#: lib/vutuv_web/components/ui.ex:4668
+#: lib/vutuv_web/components/ui.ex:4712
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -75,14 +75,14 @@ msgstr "Eine Adresse wurde geändert."
 msgid "Addresses"
 msgstr "Adressen"
 
-#: lib/vutuv_web/components/ui.ex:1462
-#: lib/vutuv_web/templates/page/index.html.heex:290
+#: lib/vutuv_web/components/ui.ex:1506
+#: lib/vutuv_web/templates/page/index.html.heex:320
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr "Schon ein Mitglied? Einloggen."
 
-#: lib/vutuv_web/components/ui.ex:4165
-#: lib/vutuv_web/components/ui.ex:4259
+#: lib/vutuv_web/components/ui.ex:4209
+#: lib/vutuv_web/components/ui.ex:4303
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -110,14 +110,14 @@ msgid "Birthday"
 msgstr "Geburtstag"
 
 #: lib/vutuv_web/components/saved_search_components.ex:114
-#: lib/vutuv_web/components/ui.ex:4159
+#: lib/vutuv_web/components/ui.ex:4203
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
-#: lib/vutuv_web/live/job_posting_live/form.ex:811
-#: lib/vutuv_web/live/organization_live/edit.ex:381
+#: lib/vutuv_web/live/job_posting_live/form.ex:812
+#: lib/vutuv_web/live/organization_live/edit.ex:382
 #: lib/vutuv_web/live/organization_live/new.ex:231
-#: lib/vutuv_web/live/post_live/composer.ex:1669
+#: lib/vutuv_web/live/post_live/composer.ex:1697
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -163,7 +163,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
 #: lib/vutuv_web/components/post_components.ex:3586
-#: lib/vutuv_web/components/ui.ex:4262
+#: lib/vutuv_web/components/ui.ex:4306
 #: lib/vutuv_web/live/admin/job_live.ex:489
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -179,7 +179,7 @@ msgstr "Löschen"
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:686
 #: lib/vutuv_web/live/organization_live/edit.ex:301
-#: lib/vutuv_web/live/organization_live/edit.ex:313
+#: lib/vutuv_web/live/organization_live/edit.ex:314
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
 #: lib/vutuv_web/templates/address/form_en.html.heex:11
 #: lib/vutuv_web/templates/address/form_generic.html.heex:13
@@ -203,7 +203,7 @@ msgid "Disable"
 msgstr "Inaktivieren"
 
 #: lib/vutuv_web/live/cv_live.ex:438
-#: lib/vutuv_web/live/post_live/composer.ex:2579
+#: lib/vutuv_web/live/post_live/composer.ex:2609
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
@@ -211,7 +211,7 @@ msgid "Download"
 msgstr "Download"
 
 #: lib/vutuv_web/components/post_components.ex:3551
-#: lib/vutuv_web/components/ui.ex:4253
+#: lib/vutuv_web/components/ui.ex:4297
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -285,7 +285,7 @@ msgstr "E-Mail-Adresse eingeben"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:4632
+#: lib/vutuv_web/components/ui.ex:4676
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -326,8 +326,8 @@ msgstr "Follower"
 #: lib/vutuv_web/agent_docs/markdown.ex:632
 #: lib/vutuv_web/agent_docs/text.ex:596
 #: lib/vutuv_web/components/fediverse_components.ex:400
-#: lib/vutuv_web/components/ui.ex:2661
-#: lib/vutuv_web/components/ui.ex:2696
+#: lib/vutuv_web/components/ui.ex:2705
+#: lib/vutuv_web/components/ui.ex:2740
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:608
@@ -603,7 +603,7 @@ msgstr "Profile von "
 msgid "Provider"
 msgstr "Provider"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1881
+#: lib/vutuv_web/live/post_live/composer.ex:1909
 #: lib/vutuv_web/live/section_reorder_live.ex:270
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -613,9 +613,9 @@ msgstr "Provider"
 msgid "Public"
 msgstr "Öffentlich"
 
-#: lib/vutuv_web/components/ui.ex:4158
-#: lib/vutuv_web/live/organization_live/edit.ex:375
-#: lib/vutuv_web/live/post_live/composer.ex:1896
+#: lib/vutuv_web/components/ui.ex:4202
+#: lib/vutuv_web/live/organization_live/edit.ex:376
+#: lib/vutuv_web/live/post_live/composer.ex:1924
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -625,8 +625,9 @@ msgstr "Öffentlich"
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
 #: lib/vutuv_web/templates/settings/preferences.html.heex:157
-#: lib/vutuv_web/templates/settings/preferences.html.heex:229
-#: lib/vutuv_web/templates/settings/preferences.html.heex:362
+#: lib/vutuv_web/templates/settings/preferences.html.heex:224
+#: lib/vutuv_web/templates/settings/preferences.html.heex:273
+#: lib/vutuv_web/templates/settings/preferences.html.heex:406
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:462
@@ -665,7 +666,7 @@ msgstr "Suche"
 msgid "Show"
 msgstr "Anzeigen"
 
-#: lib/vutuv_web/templates/page/index.html.heex:269
+#: lib/vutuv_web/templates/page/index.html.heex:299
 #, elixir-autogen
 msgid "Sign up for a free account"
 msgstr "Gratis-Konto erstellen"
@@ -790,7 +791,7 @@ msgstr "Profil aktualisiert."
 msgid "User verified successfully."
 msgstr "User wurde verifiziert."
 
-#: lib/vutuv_web/components/ui.ex:4628
+#: lib/vutuv_web/components/ui.ex:4672
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -842,7 +843,7 @@ msgstr "Benutzername"
 msgid "Users"
 msgstr "Benutzer"
 
-#: lib/vutuv_web/components/ui.ex:1269
+#: lib/vutuv_web/components/ui.ex:1313
 #: lib/vutuv_web/views/user_html.ex:562
 #: lib/vutuv_web/views/user_html.ex:563
 #: lib/vutuv_web/views/user_html.ex:577
@@ -850,17 +851,17 @@ msgstr "Benutzer"
 msgid "vCard"
 msgstr "vCard"
 
-#: lib/vutuv_web/components/ui.ex:4323
+#: lib/vutuv_web/components/ui.ex:4367
 #: lib/vutuv_web/templates/user/show.html.heex:973
 #: lib/vutuv_web/templates/user/show.html.heex:996
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
 
-#: lib/vutuv_web/components/ui.ex:4736
+#: lib/vutuv_web/components/ui.ex:4780
 #: lib/vutuv_web/controllers/settings_controller.ex:171
-#: lib/vutuv_web/live/job_posting_live/form.ex:767
-#: lib/vutuv_web/live/organization_live/edit.ex:334
+#: lib/vutuv_web/live/job_posting_live/form.ex:768
+#: lib/vutuv_web/live/organization_live/edit.ex:335
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:295
@@ -874,7 +875,7 @@ msgstr "Sichtbarkeit"
 msgid "We can't find em' cap'n!"
 msgstr "Nichts zu finden, Käpt'n!"
 
-#: lib/vutuv_web/templates/page/index.html.heex:293
+#: lib/vutuv_web/templates/page/index.html.heex:323
 #, elixir-autogen
 msgid "We reserve the right to stop this service or delete your account anytime without warning."
 msgstr ""
@@ -960,7 +961,7 @@ msgstr "Eine E-Mail mit einem Löschlink wurde gerade an Sie verschickt."
 msgid "Allow others to view your email address"
 msgstr "Diese E-Mail-Adresse soll auf meinem Profil öffentlich sichtbar sein."
 
-#: lib/vutuv_web/templates/page/index.html.heex:279
+#: lib/vutuv_web/templates/page/index.html.heex:309
 #, elixir-autogen, elixir-format
 msgid "By creating an account you accept our {nutzungsbedingungen} and confirm that you have read our {datenschutz}."
 msgstr ""
@@ -1095,7 +1096,7 @@ msgstr "vutuv Login-PIN"
 msgid "Listings"
 msgstr "Listen"
 
-#: lib/vutuv_web/controllers/page_controller.ex:399
+#: lib/vutuv_web/controllers/page_controller.ex:418
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1400,7 +1401,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:522
 #: lib/vutuv_web/agent_docs/text.ex:768
-#: lib/vutuv_web/components/ui.ex:4653
+#: lib/vutuv_web/components/ui.ex:4697
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1411,7 +1412,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:444
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
-#: lib/vutuv_web/live/job_posting_live/form.ex:716
+#: lib/vutuv_web/live/job_posting_live/form.ex:717
 #: lib/vutuv_web/live/search_live.ex:344
 #: lib/vutuv_web/live/search_live.ex:822
 #: lib/vutuv_web/live/tag_new_live.ex:35
@@ -1593,7 +1594,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:776
 #: lib/vutuv_web/live/job_board_live.ex:360
 #: lib/vutuv_web/live/job_posting_live/form.ex:548
-#: lib/vutuv_web/live/organization_live/edit.ex:330
+#: lib/vutuv_web/live/organization_live/edit.ex:331
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
 #: lib/vutuv_web/templates/address/country_input.html.heex:5
@@ -1646,15 +1647,15 @@ msgstr "Zur Startseite"
 msgid "Check your inbox"
 msgstr "Schauen Sie in Ihr Postfach"
 
-#: lib/vutuv_web/components/ui.ex:2820
+#: lib/vutuv_web/components/ui.ex:2864
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:480
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1525
-#: lib/vutuv_web/live/post_live/composer.ex:1627
-#: lib/vutuv_web/live/post_live/composer.ex:1628
-#: lib/vutuv_web/live/post_live/composer.ex:2456
-#: lib/vutuv_web/live/post_live/composer.ex:2722
+#: lib/vutuv_web/live/post_live/composer.ex:1553
+#: lib/vutuv_web/live/post_live/composer.ex:1655
+#: lib/vutuv_web/live/post_live/composer.ex:1656
+#: lib/vutuv_web/live/post_live/composer.ex:2486
+#: lib/vutuv_web/live/post_live/composer.ex:2752
 #: lib/vutuv_web/templates/layout/app.html.heex:188
 #: lib/vutuv_web/templates/layout/app.html.heex:194
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
@@ -1677,7 +1678,7 @@ msgstr "Kontolöschung bestätigen"
 
 #: lib/vutuv_web/controllers/page_controller.ex:254
 #: lib/vutuv_web/templates/layout/app.html.heex:117
-#: lib/vutuv_web/templates/page/index.html.heex:286
+#: lib/vutuv_web/templates/page/index.html.heex:316
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
@@ -1685,7 +1686,7 @@ msgstr "Datenschutzerklärung"
 
 #: lib/vutuv_web/controllers/page_controller.ex:260
 #: lib/vutuv_web/templates/layout/app.html.heex:118
-#: lib/vutuv_web/templates/page/index.html.heex:286
+#: lib/vutuv_web/templates/page/index.html.heex:316
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Nutzungsbedingungen"
@@ -1703,20 +1704,20 @@ msgstr "Mein Konto löschen"
 msgid "Edit profile"
 msgstr "Profil bearbeiten"
 
-#: lib/vutuv_web/components/ui.ex:1981
-#: lib/vutuv_web/components/ui.ex:1990
-#: lib/vutuv_web/components/ui.ex:2468
+#: lib/vutuv_web/components/ui.ex:2025
+#: lib/vutuv_web/components/ui.ex:2034
+#: lib/vutuv_web/components/ui.ex:2512
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr "Empfehlen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:236
-#: lib/vutuv_web/components/ui.ex:2626
-#: lib/vutuv_web/components/ui.ex:2626
-#: lib/vutuv_web/components/ui.ex:2643
-#: lib/vutuv_web/components/ui.ex:2652
-#: lib/vutuv_web/components/ui.ex:2668
-#: lib/vutuv_web/components/ui.ex:2730
+#: lib/vutuv_web/components/ui.ex:2670
+#: lib/vutuv_web/components/ui.ex:2670
+#: lib/vutuv_web/components/ui.ex:2687
+#: lib/vutuv_web/components/ui.ex:2696
+#: lib/vutuv_web/components/ui.ex:2712
+#: lib/vutuv_web/components/ui.ex:2774
 #: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:311
@@ -1791,7 +1792,7 @@ msgid "Network"
 msgstr "Netzwerk"
 
 #: lib/vutuv_web/components/post_components.ex:450
-#: lib/vutuv_web/components/ui.ex:4372
+#: lib/vutuv_web/components/ui.ex:4416
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
@@ -1807,7 +1808,7 @@ msgid "Nothing new yet."
 msgstr "Noch nichts Neues."
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:4690
+#: lib/vutuv_web/components/ui.ex:4734
 #: lib/vutuv_web/controllers/page_controller.ex:228
 #: lib/vutuv_web/live/notification_live/index.ex:146
 #: lib/vutuv_web/live/notification_live/index.ex:384
@@ -1833,7 +1834,7 @@ msgid "Pardon us! Something went wrong."
 msgstr "Entschuldigung! Etwas ist schiefgelaufen."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:911
+#: lib/vutuv_web/live/message_live/index.ex:912
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
@@ -1913,8 +1914,8 @@ msgstr ""
 msgid "Who to follow"
 msgstr "Vorgeschlagene Profile"
 
-#: lib/vutuv_web/live/message_live/index.ex:900
 #: lib/vutuv_web/live/message_live/index.ex:901
+#: lib/vutuv_web/live/message_live/index.ex:902
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr "Nachricht schreiben…"
@@ -1959,15 +1960,15 @@ msgstr "ist jetzt mit Ihnen vernetzt."
 msgid "started following you."
 msgstr "folgt Ihnen jetzt."
 
-#: lib/vutuv_web/components/ui.ex:3651
-#: lib/vutuv_web/components/ui.ex:3804
+#: lib/vutuv_web/components/ui.ex:3695
+#: lib/vutuv_web/components/ui.ex:3848
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr "Seitennavigation"
 
-#: lib/vutuv_web/components/ui.ex:4397
+#: lib/vutuv_web/components/ui.ex:4441
 #: lib/vutuv_web/live/organization_live/activity.ex:151
 #: lib/vutuv_web/live/organization_live/feed.ex:210
 #: lib/vutuv_web/live/organization_live/show.ex:777
@@ -1982,13 +1983,13 @@ msgstr ""
 "Die Adresse selbst kann nicht geändert werden. Um eine andere zu verwenden, "
 "legen Sie sie als neue E-Mail-Adresse an und löschen Sie diese hier."
 
-#: lib/vutuv_web/components/ui.ex:4168
+#: lib/vutuv_web/components/ui.ex:4212
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Eintrag löschen"
 
-#: lib/vutuv_web/components/ui.ex:1662
-#: lib/vutuv_web/components/ui.ex:1672
+#: lib/vutuv_web/components/ui.ex:1706
+#: lib/vutuv_web/components/ui.ex:1716
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr "Optionen"
@@ -2027,12 +2028,12 @@ msgstr "Titelbild hinzufügen"
 msgid "Add cover photo"
 msgstr "Titelbild hinzufügen"
 
-#: lib/vutuv_web/components/ui.ex:3174
+#: lib/vutuv_web/components/ui.ex:3218
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr "April"
 
-#: lib/vutuv_web/components/ui.ex:3178
+#: lib/vutuv_web/components/ui.ex:3222
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr "August"
@@ -2057,37 +2058,37 @@ msgstr "Titelbild"
 msgid "Cover photo of %{name}"
 msgstr "Titelbild von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:3182
+#: lib/vutuv_web/components/ui.ex:3226
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr "Dezember"
 
-#: lib/vutuv_web/components/ui.ex:3172
+#: lib/vutuv_web/components/ui.ex:3216
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr "Februar"
 
-#: lib/vutuv_web/components/ui.ex:3171
+#: lib/vutuv_web/components/ui.ex:3215
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr "Januar"
 
-#: lib/vutuv_web/components/ui.ex:3177
+#: lib/vutuv_web/components/ui.ex:3221
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr "Juli"
 
-#: lib/vutuv_web/components/ui.ex:3176
+#: lib/vutuv_web/components/ui.ex:3220
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr "Juni"
 
-#: lib/vutuv_web/components/ui.ex:3173
+#: lib/vutuv_web/components/ui.ex:3217
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr "März"
 
-#: lib/vutuv_web/components/ui.ex:3175
+#: lib/vutuv_web/components/ui.ex:3219
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr "Mai"
@@ -2102,17 +2103,17 @@ msgstr "Mitglied seit %{month} %{year}"
 msgid "Member since %{year}"
 msgstr "Mitglied seit %{year}"
 
-#: lib/vutuv_web/components/ui.ex:3181
+#: lib/vutuv_web/components/ui.ex:3225
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr "November"
 
-#: lib/vutuv_web/components/ui.ex:3180
+#: lib/vutuv_web/components/ui.ex:3224
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr "Oktober"
 
-#: lib/vutuv_web/components/ui.ex:3179
+#: lib/vutuv_web/components/ui.ex:3223
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr "September"
@@ -2124,12 +2125,12 @@ msgstr "September"
 msgid "Markdown is supported: bold, italics, links and lists."
 msgstr "Markdown wird unterstützt: Fett, Kursiv, Links und Listen."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:709
+#: lib/vutuv_web/live/job_posting_live/form.ex:710
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr "Bilder hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2074
+#: lib/vutuv_web/live/post_live/composer.ex:2102
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und Suchmaschinen den Beitrag nicht mehr."
@@ -2140,7 +2141,7 @@ msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und
 msgid "Back to the post"
 msgstr "Zurück zum Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1767
+#: lib/vutuv_web/live/post_live/composer.ex:1795
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Upload abbrechen"
@@ -2185,12 +2186,12 @@ msgstr "Folgen Sie %{name}, um ihn zu lesen."
 msgid "Hidden from:"
 msgstr "Verborgen vor:"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2050
+#: lib/vutuv_web/live/post_live/composer.ex:2078
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr "Vor einer bestimmten Person verbergen…"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1978
+#: lib/vutuv_web/live/post_live/composer.ex:2006
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
@@ -2201,13 +2202,13 @@ msgstr "Diesen Beitrag verbergen vor…"
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2020
+#: lib/vutuv_web/live/post_live/composer.ex:2048
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr "Nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1284
-#: lib/vutuv_web/live/post_live/composer.ex:1332
+#: lib/vutuv_web/live/post_live/composer.ex:1295
+#: lib/vutuv_web/live/post_live/composer.ex:1343
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
@@ -2219,23 +2220,23 @@ msgstr ""
 "Hier ist noch nichts. Folgen Sie anderen, um Ihren Feed zu füllen, oder "
 "schreiben Sie Ihren ersten Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1250
+#: lib/vutuv_web/live/post_live/composer.ex:1261
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr "Eines der Bilder konnte nicht angehängt werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2010
+#: lib/vutuv_web/live/post_live/composer.ex:2038
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr "Personen, denen ich nicht folge"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2000
+#: lib/vutuv_web/live/post_live/composer.ex:2028
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr "Personen, die mir nicht folgen"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:416
-#: lib/vutuv_web/live/post_live/composer.ex:1898
+#: lib/vutuv_web/live/post_live/composer.ex:1926
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2250,7 +2251,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/controllers/post_controller.ex:62
 #: lib/vutuv_web/controllers/post_controller.ex:74
 #: lib/vutuv_web/controllers/user_controller.ex:76
-#: lib/vutuv_web/gettext_extraction_anchors.ex:103
+#: lib/vutuv_web/gettext_extraction_anchors.ex:109
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:388
 #: lib/vutuv_web/live/notification_live/index.ex:1125
@@ -2258,7 +2259,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:345
 #: lib/vutuv_web/live/search_live.ex:836
-#: lib/vutuv_web/templates/settings/preferences.html.heex:275
+#: lib/vutuv_web/templates/settings/preferences.html.heex:319
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
@@ -2283,9 +2284,9 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:246
-#: lib/vutuv_web/live/organization_live/edit.ex:407
+#: lib/vutuv_web/live/organization_live/edit.ex:408
 #: lib/vutuv_web/live/organization_live/roles.ex:247
-#: lib/vutuv_web/live/post_live/composer.ex:2036
+#: lib/vutuv_web/live/post_live/composer.ex:2064
 #: lib/vutuv_web/live/post_live/filter_band.ex:455
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
@@ -2302,7 +2303,7 @@ msgstr ""
 "Eingeschränkte Beiträge sind auch für nicht eingeloggte Besucher und "
 "Suchmaschinen unsichtbar."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1888
+#: lib/vutuv_web/live/post_live/composer.ex:1916
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr "Wird gespeichert…"
@@ -2319,12 +2320,12 @@ msgstr[1] "%{formatted} neue Beiträge anzeigen"
 msgid "Sorry, that page could not be found."
 msgstr "Diese Seite konnte leider nicht gefunden werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1358
+#: lib/vutuv_web/live/post_live/composer.ex:1369
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Diese Datei konnte nicht verarbeitet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1232
+#: lib/vutuv_web/live/post_live/composer.ex:1243
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr "Die Sichtbarkeitsauswahl ist ungültig."
@@ -2334,17 +2335,17 @@ msgstr "Die Sichtbarkeitsauswahl ist ungültig."
 msgid "This post is for followers of %{name}"
 msgstr "Dieser Beitrag ist für Follower von %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2871
+#: lib/vutuv_web/live/post_live/composer.ex:2901
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2872
+#: lib/vutuv_web/live/post_live/composer.ex:2902
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
-#: lib/vutuv_web/components/ui.ex:4990
+#: lib/vutuv_web/components/ui.ex:5034
 #: lib/vutuv_web/live/shell_live.ex:1307
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2353,12 +2354,12 @@ msgstr "Upload fehlgeschlagen."
 msgid "View profile"
 msgstr "Profil ansehen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2149
+#: lib/vutuv_web/live/post_live/composer.ex:2179
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr "Was gibt's Neues?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2150
+#: lib/vutuv_web/live/post_live/composer.ex:2180
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
@@ -2388,23 +2389,23 @@ msgstr "Personen, die Ihnen nicht folgen"
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
 
-#: lib/vutuv_web/components/ui.ex:3252
+#: lib/vutuv_web/components/ui.ex:3296
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr "unbekannt"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1803
+#: lib/vutuv_web/live/post_live/composer.ex:1831
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr "Tags, durch Komma getrennt (max. %{max})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2862
+#: lib/vutuv_web/live/post_live/composer.ex:2892
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr "Die Datei ist größer als %{mb} MB."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2866
+#: lib/vutuv_web/live/post_live/composer.ex:2896
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
@@ -2426,7 +2427,7 @@ msgstr "Alle Beiträge"
 
 #: lib/vutuv_web/components/post_components.ex:2033
 #: lib/vutuv_web/components/post_components.ex:5535
-#: lib/vutuv_web/components/ui.ex:3726
+#: lib/vutuv_web/components/ui.ex:3770
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2445,7 +2446,7 @@ msgstr "Lesezeichen"
 
 #: lib/vutuv_web/components/post_components.ex:1986
 #: lib/vutuv_web/components/post_components.ex:5771
-#: lib/vutuv_web/components/ui.ex:3712
+#: lib/vutuv_web/components/ui.ex:3756
 #: lib/vutuv_web/live/notification_live/index.ex:1271
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
@@ -2517,9 +2518,9 @@ msgstr "Gefällt mir entfernen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:430
 #: lib/vutuv_web/components/post_components.ex:2648
-#: lib/vutuv_web/components/ui.ex:2621
-#: lib/vutuv_web/components/ui.ex:2621
-#: lib/vutuv_web/components/ui.ex:2697
+#: lib/vutuv_web/components/ui.ex:2665
+#: lib/vutuv_web/components/ui.ex:2665
+#: lib/vutuv_web/components/ui.ex:2741
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:611
@@ -2561,13 +2562,13 @@ msgstr "Antworten"
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1235
-#: lib/vutuv_web/live/post_live/composer.ex:1876
+#: lib/vutuv_web/live/post_live/composer.ex:1246
+#: lib/vutuv_web/live/post_live/composer.ex:1904
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr "Solange es geteilte Beiträge oder Antworten gibt, lässt sich der Empfängerkreis nicht einschränken."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2081
+#: lib/vutuv_web/live/post_live/composer.ex:2109
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beiträge oder Antworten gibt, bleibt er öffentlich; löschen können Sie ihn weiterhin."
@@ -2607,7 +2608,7 @@ msgstr "%{names} schreiben…"
 msgid "%{name} is typing…"
 msgstr "%{name} schreibt…"
 
-#: lib/vutuv_web/live/message_live/index.ex:923
+#: lib/vutuv_web/live/message_live/index.ex:924
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr "@%{slug} hat Ihre Nachrichtenanfrage noch nicht angenommen."
@@ -2653,7 +2654,7 @@ msgstr "Mitglied nicht gefunden."
 msgid "No conversations yet."
 msgstr "Noch keine Unterhaltungen."
 
-#: lib/vutuv_web/components/ui.ex:2944
+#: lib/vutuv_web/components/ui.ex:2988
 #: lib/vutuv_web/live/message_live/index.ex:760
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2664,7 +2665,7 @@ msgstr "Online"
 msgid "Requests"
 msgstr "Anfragen"
 
-#: lib/vutuv_web/live/message_live/index.ex:932
+#: lib/vutuv_web/live/message_live/index.ex:933
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr "Wählen Sie eine Unterhaltung aus."
@@ -2742,7 +2743,7 @@ msgstr "Eine neue PIN ist unterwegs zu Ihrer E-Mail-Adresse."
 msgid "Okay, let's start over."
 msgstr "Alles klar, fangen wir neu an."
 
-#: lib/vutuv_web/components/ui.ex:771
+#: lib/vutuv_web/components/ui.ex:815
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr "PIN erneut senden"
@@ -2753,7 +2754,7 @@ msgstr "PIN erneut senden"
 msgid "Too many PIN requests. Please try again later."
 msgstr "Zu viele PIN-Anfragen. Bitte versuchen Sie es später erneut."
 
-#: lib/vutuv_web/components/ui.ex:792
+#: lib/vutuv_web/components/ui.ex:836
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr "Andere E-Mail-Adresse verwenden"
@@ -2803,8 +2804,8 @@ msgstr "Berufserfahrung hinzufügen"
 msgid "Write your first post"
 msgstr "Ersten Beitrag schreiben"
 
-#: lib/vutuv_web/components/ui.ex:3892
-#: lib/vutuv_web/components/ui.ex:4325
+#: lib/vutuv_web/components/ui.ex:3936
+#: lib/vutuv_web/components/ui.ex:4369
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:104
@@ -2856,7 +2857,7 @@ msgstr[1] "+%{formatted} weitere Tags"
 msgid "Connections"
 msgstr "Vernetzungen"
 
-#: lib/vutuv_web/components/ui.ex:1260
+#: lib/vutuv_web/components/ui.ex:1304
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr "Markdown"
@@ -2866,17 +2867,17 @@ msgstr "Markdown"
 msgid "No connections yet."
 msgstr "Noch keine Vernetzungen."
 
-#: lib/vutuv_web/components/ui.ex:1276
+#: lib/vutuv_web/components/ui.ex:1320
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr "Andere Formate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1990
+#: lib/vutuv_web/live/post_live/composer.ex:2018
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr "Personen, mit denen ich nicht vernetzt bin"
 
-#: lib/vutuv_web/components/ui.ex:1261
+#: lib/vutuv_web/components/ui.ex:1305
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr "Nur Text"
@@ -3228,7 +3229,7 @@ msgstr ""
 msgid "Private message"
 msgstr "Private Nachricht"
 
-#: lib/vutuv_web/components/ui.ex:4622
+#: lib/vutuv_web/components/ui.ex:4666
 #: lib/vutuv_web/live/shell_live.ex:1128
 #: lib/vutuv_web/live/shell_live.ex:1425
 #: lib/vutuv_web/templates/import/new.html.heex:16
@@ -3342,7 +3343,7 @@ msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 "Meldungen sind anonym; wir verraten nie, wer gemeldet hat. Unsere Regeln:"
 
-#: lib/vutuv_web/components/ui.ex:3601
+#: lib/vutuv_web/components/ui.ex:3645
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3999,7 +4000,7 @@ msgstr "Follower von %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:157
 #: lib/vutuv_web/agent_docs/text.ex:112
 #: lib/vutuv_web/agent_docs/text.ex:143
-#: lib/vutuv_web/live/job_posting_live/form.ex:699
+#: lib/vutuv_web/live/job_posting_live/form.ex:700
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr "Bilder"
@@ -4188,7 +4189,7 @@ msgstr "Für die Buchung ist ein vutuv-Login erforderlich."
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
 #: lib/vutuv_web/live/job_posting_live/form.ex:542
-#: lib/vutuv_web/live/organization_live/edit.ex:326
+#: lib/vutuv_web/live/organization_live/edit.ex:327
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
 #: lib/vutuv_web/templates/address/form_en.html.heex:33
@@ -4490,12 +4491,12 @@ msgstr "Buchbar bis einschließlich %{last}."
 msgid "Bookings are open through %{last}. Next available day: %{day}"
 msgstr "Buchbar bis einschließlich %{last}. Nächster freier Tag: %{day}"
 
-#: lib/vutuv_web/components/ui.ex:3204
+#: lib/vutuv_web/components/ui.ex:3248
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr "Fr"
 
-#: lib/vutuv_web/components/ui.ex:3200
+#: lib/vutuv_web/components/ui.ex:3244
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr "Mo"
@@ -4507,27 +4508,27 @@ msgstr ""
 "Eine Anzeige pro Kalendertag: Wählen Sie einen freien Tag im Kalender; "
 "durchgestrichene Tage sind bereits vergeben."
 
-#: lib/vutuv_web/components/ui.ex:3205
+#: lib/vutuv_web/components/ui.ex:3249
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr "Sa"
 
-#: lib/vutuv_web/components/ui.ex:3206
+#: lib/vutuv_web/components/ui.ex:3250
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr "So"
 
-#: lib/vutuv_web/components/ui.ex:3203
+#: lib/vutuv_web/components/ui.ex:3247
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr "Do"
 
-#: lib/vutuv_web/components/ui.ex:3201
+#: lib/vutuv_web/components/ui.ex:3245
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr "Di"
 
-#: lib/vutuv_web/components/ui.ex:3202
+#: lib/vutuv_web/components/ui.ex:3246
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr "Mi"
@@ -4671,7 +4672,7 @@ msgstr ""
 "beide Richtungen unterbunden. Eine Aufhebung der Blockierung stellt das "
 "Entfernte nicht wieder her."
 
-#: lib/vutuv_web/components/ui.ex:4740
+#: lib/vutuv_web/components/ui.ex:4784
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -5493,7 +5494,7 @@ msgstr "API-Token (%{date})"
 msgid "API documentation"
 msgstr "API-Dokumentation"
 
-#: lib/vutuv_web/components/ui.ex:4800
+#: lib/vutuv_web/components/ui.ex:4844
 #: lib/vutuv_web/controllers/settings_controller.ex:157
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5534,7 +5535,7 @@ msgstr ""
 "dauerhaft. Wir senden Ihnen zur Bestätigung eine PIN per E-Mail. Es kann "
 "nicht rückgängig gemacht werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1253
+#: lib/vutuv_web/live/post_live/composer.ex:1264
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
@@ -5577,10 +5578,10 @@ msgstr "Tastaturkürzel"
 msgid "Navigation"
 msgstr "Navigation"
 
-#: lib/vutuv_web/components/ui.ex:4897
-#: lib/vutuv_web/components/ui.ex:4902
-#: lib/vutuv_web/components/ui.ex:4981
-#: lib/vutuv_web/components/ui.ex:5045
+#: lib/vutuv_web/components/ui.ex:4941
+#: lib/vutuv_web/components/ui.ex:4946
+#: lib/vutuv_web/components/ui.ex:5025
+#: lib/vutuv_web/components/ui.ex:5089
 #: lib/vutuv_web/controllers/settings_controller.ex:64
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5698,7 +5699,7 @@ msgstr "Art der E-Mail-Adresse"
 msgid "About you"
 msgstr "Über Sie"
 
-#: lib/vutuv_web/components/ui.ex:4760
+#: lib/vutuv_web/components/ui.ex:4804
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5709,7 +5710,7 @@ msgstr "Über Sie"
 msgid "Account"
 msgstr "Konto"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:481
+#: lib/vutuv_web/live/organization_live/edit.ex:482
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr "Ändern"
@@ -5720,7 +5721,7 @@ msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 "Laden Sie alles herunter, was vutuv über Sie speichert, als eine Datei."
 
-#: lib/vutuv_web/components/ui.ex:4660
+#: lib/vutuv_web/components/ui.ex:4704
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5749,13 +5750,13 @@ msgstr "Personen, die nicht mit Ihnen interagieren können."
 msgid "Personal tokens for the vutuv API."
 msgstr "Persönliche Tokens für die vutuv-API."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2192
+#: lib/vutuv_web/live/post_live/composer.ex:2222
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
 msgstr "Fotos"
 
-#: lib/vutuv_web/components/ui.ex:4734
+#: lib/vutuv_web/components/ui.ex:4778
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/templates/page/index.html.heex:191
 #, elixir-autogen, elixir-format
@@ -5870,7 +5871,7 @@ msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/vutuv_web/components/ui.ex:4793
+#: lib/vutuv_web/components/ui.ex:4837
 #: lib/vutuv_web/controllers/settings_controller.ex:181
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -6079,28 +6080,28 @@ msgid "Sort"
 msgstr "Sortieren"
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3261
+#: lib/vutuv_web/components/ui.ex:3305
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "vor %{count} Tag"
 msgstr[1] "vor %{count} Tagen"
 
-#: lib/vutuv_web/components/ui.ex:3260
+#: lib/vutuv_web/components/ui.ex:3304
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "vor %{count} Stunde"
 msgstr[1] "vor %{count} Stunden"
 
-#: lib/vutuv_web/components/ui.ex:3259
+#: lib/vutuv_web/components/ui.ex:3303
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] "vor %{count} Minute"
 msgstr[1] "vor %{count} Minuten"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:923
+#: lib/vutuv_web/controllers/settings_controller.ex:943
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr "Alle anderen Geräte wurden abgemeldet."
@@ -6140,7 +6141,7 @@ msgstr "Neue Anmeldung bei Ihrem vutuv-Konto"
 msgid "Signed-in devices"
 msgstr "Angemeldete Geräte"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:910
+#: lib/vutuv_web/controllers/settings_controller.ex:930
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr "Dieses Gerät wurde abgemeldet."
@@ -6162,7 +6163,7 @@ msgstr ""
 "Das ist die erste Anmeldung, die wir von diesem Gerät oder Browser gesehen "
 "haben."
 
-#: lib/vutuv_web/components/ui.ex:3258
+#: lib/vutuv_web/components/ui.ex:3302
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "gerade eben"
@@ -6314,7 +6315,7 @@ msgstr "Kurzbeschreibung hinzufügen"
 msgid "Tagline"
 msgstr "Kurzbeschreibung"
 
-#: lib/vutuv_web/components/ui.ex:389
+#: lib/vutuv_web/components/ui.ex:396
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:907
@@ -6377,7 +6378,7 @@ msgstr "Foto positionieren"
 msgid "Use photo"
 msgstr "Foto verwenden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1671
+#: lib/vutuv_web/live/post_live/composer.ex:1699
 #: lib/vutuv_web/templates/user/edit.html.heex:54
 #: lib/vutuv_web/templates/user/edit.html.heex:139
 #, elixir-autogen, elixir-format
@@ -6505,9 +6506,9 @@ msgstr "Nach unten"
 msgid "Move up"
 msgstr "Nach oben"
 
-#: lib/vutuv_web/components/ui.ex:1981
-#: lib/vutuv_web/components/ui.ex:1990
-#: lib/vutuv_web/components/ui.ex:2469
+#: lib/vutuv_web/components/ui.ex:2025
+#: lib/vutuv_web/components/ui.ex:2034
+#: lib/vutuv_web/components/ui.ex:2513
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr "Empfehlung zurücknehmen"
@@ -6528,7 +6529,7 @@ msgstr "Karteneinstellungen gespeichert."
 msgid "Map services to show"
 msgstr "Anzuzeigende Kartendienste"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:104
+#: lib/vutuv_web/gettext_extraction_anchors.ex:110
 #: lib/vutuv_web/templates/settings/preferences.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Maps"
@@ -6541,7 +6542,7 @@ msgstr "Karten"
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:102
+#: lib/vutuv_web/gettext_extraction_anchors.ex:108
 #: lib/vutuv_web/templates/settings/preferences.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Opens first, as the main button. The others appear as alternatives."
@@ -6572,7 +6573,7 @@ msgstr "Mitglieder, die %{name} für %{tag} empfohlen haben"
 msgid "No endorsements yet."
 msgstr "Noch keine Empfehlungen."
 
-#: lib/vutuv_web/components/ui.ex:2422
+#: lib/vutuv_web/components/ui.ex:2466
 #: lib/vutuv_web/live/notification_live/index.ex:684
 #: lib/vutuv_web/live/notification_live/index.ex:699
 #: lib/vutuv_web/live/notification_live/index.ex:1012
@@ -6894,7 +6895,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2628
 #: lib/vutuv_web/components/post_components.ex:3603
-#: lib/vutuv_web/components/ui.ex:2769
+#: lib/vutuv_web/components/ui.ex:2813
 #: lib/vutuv_web/live/fediverse_account_live.ex:375
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
@@ -6922,7 +6923,7 @@ msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
 #: lib/vutuv_web/components/post_components.ex:3603
-#: lib/vutuv_web/components/ui.ex:2768
+#: lib/vutuv_web/components/ui.ex:2812
 #: lib/vutuv_web/live/fediverse_account_live.ex:373
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
@@ -7316,7 +7317,7 @@ msgstr "Zurücksetzen"
 msgid "Save audience"
 msgstr "Zielgruppe speichern"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:808
+#: lib/vutuv_web/live/job_posting_live/form.ex:809
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:16
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:11
 #, elixir-autogen, elixir-format
@@ -7545,13 +7546,13 @@ msgstr "Ihre Mitglieder werden zu dieser hinzugefügt (Vereinigung)."
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr "Seite %{page} von %{pages}, %{total} gesamt"
 
-#: lib/vutuv_web/components/ui.ex:3664
+#: lib/vutuv_web/components/ui.ex:3708
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Zurück"
 
-#: lib/vutuv_web/components/ui.ex:3680
+#: lib/vutuv_web/components/ui.ex:3724
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7588,7 +7589,7 @@ msgid "Removed:"
 msgstr "Entfernt:"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:979
-#: lib/vutuv_web/live/post_live/composer.ex:1519
+#: lib/vutuv_web/live/post_live/composer.ex:1547
 #: lib/vutuv_web/live/post_live/filter_band.ex:532
 #, elixir-autogen, elixir-format
 msgid "Undo"
@@ -8354,7 +8355,7 @@ msgstr "PIN abgelaufen"
 msgid "PIN registered"
 msgstr "PIN-registriert"
 
-#: lib/vutuv_web/components/ui.ex:3667
+#: lib/vutuv_web/components/ui.ex:3711
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr "Seite %{page} von %{pages}"
@@ -8493,7 +8494,7 @@ msgstr "Abschluss"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:4636
+#: lib/vutuv_web/components/ui.ex:4680
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8553,7 +8554,7 @@ msgstr ""
 " was Sie nicht übernehmen möchten. Einträge, die bereits in Ihrem Profil "
 "stehen, sind für Sie abgewählt."
 
-#: lib/vutuv_web/components/ui.ex:4781
+#: lib/vutuv_web/components/ui.ex:4825
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
@@ -8582,7 +8583,7 @@ msgstr "%{items} importiert."
 msgid "Nothing new to import."
 msgstr "Nichts Neues zu importieren."
 
-#: lib/vutuv_web/components/ui.ex:4664
+#: lib/vutuv_web/components/ui.ex:4708
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8679,7 +8680,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 
-#: lib/vutuv_web/components/ui.ex:3944
+#: lib/vutuv_web/components/ui.ex:3988
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8773,13 +8774,13 @@ msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 "Ziehen Sie Ihre ZIP-Datei hierher oder klicken Sie, um eine auszuwählen."
 
-#: lib/vutuv_web/components/ui.ex:4624
+#: lib/vutuv_web/components/ui.ex:4668
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr "Basisdaten & Fotos"
 
-#: lib/vutuv_web/components/ui.ex:4771
+#: lib/vutuv_web/components/ui.ex:4815
 #: lib/vutuv_web/controllers/settings_controller.ex:125
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8791,7 +8792,7 @@ msgstr "Sprache & Anzeige"
 msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
 
-#: lib/vutuv_web/components/ui.ex:4762
+#: lib/vutuv_web/components/ui.ex:4806
 #: lib/vutuv_web/controllers/settings_controller.ex:108
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8801,7 +8802,7 @@ msgstr "Weitere Profil-Bereiche"
 msgid "Sign-in & security"
 msgstr "Anmeldung & Sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:4785
+#: lib/vutuv_web/components/ui.ex:4829
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8923,7 +8924,7 @@ msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 "Die Seite %{letter} des Mitgliederverzeichnisses, sortiert nach Nachnamen."
 
-#: lib/vutuv_web/components/ui.ex:1278
+#: lib/vutuv_web/components/ui.ex:1322
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -9031,8 +9032,8 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/agent_docs/text.ex:586
 #: lib/vutuv_web/agent_docs/text.ex:590
 #: lib/vutuv_web/components/organization_components.ex:276
-#: lib/vutuv_web/components/ui.ex:1479
-#: lib/vutuv_web/components/ui.ex:4752
+#: lib/vutuv_web/components/ui.ex:1523
+#: lib/vutuv_web/components/ui.ex:4796
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:357
 #: lib/vutuv_web/controllers/settings_controller.ex:424
@@ -9194,7 +9195,7 @@ msgstr ""
 "Ihres Browsers (Strg+P oder Cmd+P) und wählen Sie \"Als PDF speichern\", um "
 "eine PDF-Datei zu erhalten."
 
-#: lib/vutuv_web/components/ui.ex:1568
+#: lib/vutuv_web/components/ui.ex:1612
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr "Lebenslauf-Download"
@@ -9232,7 +9233,7 @@ msgstr "Jeder Download enthält genau die ausgewählten Teile."
 msgid "Header"
 msgstr "Kopfzeile"
 
-#: lib/vutuv_web/components/ui.ex:1578
+#: lib/vutuv_web/components/ui.ex:1622
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -9270,7 +9271,7 @@ msgstr ""
 "Besuchers enthält nur, was er dort ohnehin sehen kann, und private E-Mail-"
 "Adressen erscheinen nur in Ihrem eigenen."
 
-#: lib/vutuv_web/components/ui.ex:1570
+#: lib/vutuv_web/components/ui.ex:1614
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -9445,8 +9446,8 @@ msgstr "Dieses Tag kann nur von einem Admin entfernt werden."
 msgid "Yes"
 msgstr "Ja"
 
-#: lib/vutuv_web/components/ui.ex:2025
-#: lib/vutuv_web/components/ui.ex:2026
+#: lib/vutuv_web/components/ui.ex:2069
+#: lib/vutuv_web/components/ui.ex:2070
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9889,7 +9890,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
-#: lib/vutuv/accounts/user.ex:1187
+#: lib/vutuv/accounts/user.ex:1193
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9900,7 +9901,7 @@ msgstr "Auf Jobsuche"
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
-#: lib/vutuv/accounts/user.ex:1184
+#: lib/vutuv/accounts/user.ex:1190
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10026,7 +10027,7 @@ msgstr "Zertifikate"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:4640
+#: lib/vutuv_web/components/ui.ex:4684
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -10229,13 +10230,13 @@ msgstr "Dauerhafter Profillink"
 msgid "Dismiss"
 msgstr "Schließen"
 
-#: lib/vutuv_web/components/ui.ex:3374
+#: lib/vutuv_web/components/ui.ex:3418
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Kopiert"
 
-#: lib/vutuv_web/components/ui.ex:3373
-#: lib/vutuv_web/components/ui.ex:3381
+#: lib/vutuv_web/components/ui.ex:3417
+#: lib/vutuv_web/components/ui.ex:3425
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Kopieren"
@@ -10429,17 +10430,17 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr "Authenticator-App ausgeschaltet."
 
-#: lib/vutuv_web/components/ui.ex:377
+#: lib/vutuv_web/components/ui.ex:384
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr "Fett"
 
-#: lib/vutuv_web/components/ui.ex:429
+#: lib/vutuv_web/components/ui.ex:436
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr "Aufzählung"
 
-#: lib/vutuv_web/components/ui.ex:432
+#: lib/vutuv_web/components/ui.ex:439
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr "Codeblock"
@@ -10455,13 +10456,13 @@ msgid "Delete your code list? All its codes stop working immediately."
 msgstr ""
 "Kennwortliste löschen? Alle Codes darauf funktionieren sofort nicht mehr."
 
-#: lib/vutuv_web/components/ui.ex:373
+#: lib/vutuv_web/components/ui.ex:380
 #, elixir-autogen, elixir-format
 msgid "Formatting"
 msgstr "Formatierung"
 
-#: lib/vutuv_web/components/ui.ex:496
-#: lib/vutuv_web/components/ui.ex:497
+#: lib/vutuv_web/components/ui.ex:503
+#: lib/vutuv_web/components/ui.ex:504
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr "Vollbild"
@@ -10476,27 +10477,27 @@ msgstr "Neue Liste erstellen"
 msgid "Generate code list"
 msgstr "Kennwortliste erstellen"
 
-#: lib/vutuv_web/components/ui.ex:427
+#: lib/vutuv_web/components/ui.ex:434
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr "Überschrift 1"
 
-#: lib/vutuv_web/components/ui.ex:428
+#: lib/vutuv_web/components/ui.ex:435
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr "Überschrift 2"
 
-#: lib/vutuv_web/components/ui.ex:386
+#: lib/vutuv_web/components/ui.ex:393
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr "Inline-Code"
 
-#: lib/vutuv_web/components/ui.ex:380
+#: lib/vutuv_web/components/ui.ex:387
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr "Kursiv"
 
-#: lib/vutuv_web/components/ui.ex:346
+#: lib/vutuv_web/components/ui.ex:540
 #, elixir-autogen, elixir-format
 msgid "Link URL"
 msgstr "Link-URL"
@@ -10512,7 +10513,7 @@ msgstr "Anmelde-Codes"
 msgid "Not set up."
 msgstr "Nicht eingerichtet."
 
-#: lib/vutuv_web/components/ui.ex:430
+#: lib/vutuv_web/components/ui.ex:437
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr "Nummerierte Liste"
@@ -10529,7 +10530,7 @@ msgstr ""
 "Drucken Sie diese Seite aus oder schreiben Sie die Codes ab. "
 "Durchgestrichene Codes wurden bereits verwendet."
 
-#: lib/vutuv_web/components/ui.ex:431
+#: lib/vutuv_web/components/ui.ex:438
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr "Zitat"
@@ -10554,7 +10555,7 @@ msgstr ""
 msgid "Set up"
 msgstr "Einrichten"
 
-#: lib/vutuv_web/components/ui.ex:383
+#: lib/vutuv_web/components/ui.ex:390
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr "Durchgestrichen"
@@ -10967,14 +10968,14 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] "Sie haben %{formatted} neue Nachricht."
 msgstr[1] "Sie haben %{formatted} neue Nachrichten."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:346
+#: lib/vutuv_web/templates/settings/preferences.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 "Trennt lange Wörter an Silbengrenzen, damit der Text gleichmäßig umbricht. "
 "Hilfreich in der schmalen Smartphone-Spalte."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:277
+#: lib/vutuv_web/templates/settings/preferences.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
@@ -10982,35 +10983,35 @@ msgstr ""
 "Das sind Ihre eigenen Anzeige-Einstellungen."
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:353
+#: lib/vutuv_web/templates/settings/preferences.html.heex:397
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr "Silbentrennung am Desktop"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:357
+#: lib/vutuv_web/templates/settings/preferences.html.heex:401
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr "Silbentrennung auf dem Smartphone"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:343
+#: lib/vutuv_web/templates/settings/preferences.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr "Silbentrennung"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:300
+#: lib/vutuv_web/templates/settings/preferences.html.heex:344
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr "Zeilen am Desktop"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:309
+#: lib/vutuv_web/templates/settings/preferences.html.heex:353
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr "Zeilen auf dem Smartphone"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:295
+#: lib/vutuv_web/templates/settings/preferences.html.heex:339
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
@@ -11022,7 +11023,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr "Anzeige-Einstellungen für Beiträge gespeichert."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:292
+#: lib/vutuv_web/templates/settings/preferences.html.heex:336
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr "Beitrag kürzen nach"
@@ -11125,8 +11126,9 @@ msgstr "Einstellungen von %{name}"
 #: lib/vutuv_web/live/feed_languages_live.ex:377
 #: lib/vutuv_web/templates/settings/preferences.html.heex:101
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
-#: lib/vutuv_web/templates/settings/preferences.html.heex:259
-#: lib/vutuv_web/templates/settings/preferences.html.heex:377
+#: lib/vutuv_web/templates/settings/preferences.html.heex:239
+#: lib/vutuv_web/templates/settings/preferences.html.heex:303
+#: lib/vutuv_web/templates/settings/preferences.html.heex:421
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr "Auf die Standardwerte zurücksetzen"
@@ -11160,17 +11162,17 @@ msgstr ""
 "wählt, und was ausgeloggte Besucher sehen. Änderungen gelten sofort; "
 "Mitglieder mit eigenem Wert sind nicht betroffen."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:100
+#: lib/vutuv_web/gettext_extraction_anchors.ex:106
 #, elixir-autogen, elixir-format
 msgid "0 means posts are never shortened."
 msgstr "0 bedeutet: Beiträge werden nie gekürzt."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:106
+#: lib/vutuv_web/gettext_extraction_anchors.ex:112
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr "Aus"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:105
+#: lib/vutuv_web/gettext_extraction_anchors.ex:111
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr "An"
@@ -11230,8 +11232,8 @@ msgid "Failed"
 msgstr "Fehlgeschlagen"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
-#: lib/vutuv_web/live/post_live/composer.ex:1750
-#: lib/vutuv_web/live/post_live/composer.ex:2450
+#: lib/vutuv_web/live/post_live/composer.ex:1778
+#: lib/vutuv_web/live/post_live/composer.ex:2480
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr "Galerie"
@@ -11338,21 +11340,21 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
-#: lib/vutuv/accounts/user.ex:1225
+#: lib/vutuv/accounts/user.ex:1231
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
-#: lib/vutuv/accounts/user.ex:1230
+#: lib/vutuv/accounts/user.ex:1236
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
-#: lib/vutuv/accounts/user.ex:1228
+#: lib/vutuv/accounts/user.ex:1234
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
-#: lib/vutuv_web/live/job_posting_live/form.ex:772
+#: lib/vutuv_web/live/job_posting_live/form.ex:773
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr "Nur angemeldete Mitglieder"
@@ -11549,7 +11551,7 @@ msgstr "Ihre Ausschlussliste ist voll (max. %{count})."
 msgid "Your list is empty. Nobody is excluded yet."
 msgstr "Ihre Liste ist leer. Es ist noch niemand ausgeschlossen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:362
+#: lib/vutuv_web/live/organization_live/edit.ex:363
 #: lib/vutuv_web/views/account_event_text.ex:232
 #, elixir-autogen, elixir-format
 msgid "AI agents"
@@ -11588,7 +11590,7 @@ msgstr "Die Domain-Verifizierung ist auf dieser Installation deaktiviert."
 msgid "Edit %{name}"
 msgstr "%{name} bearbeiten"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:348
+#: lib/vutuv_web/live/organization_live/edit.ex:349
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this page and include it in the sitemap."
 msgstr ""
@@ -11599,7 +11601,7 @@ msgstr ""
 msgid "Logo"
 msgstr "Logo"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:364
+#: lib/vutuv_web/live/organization_live/edit.ex:365
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
@@ -11627,7 +11629,7 @@ msgstr "Logo entfernen"
 msgid "Search by name or city"
 msgstr "Nach Name oder Stadt suchen"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:346
+#: lib/vutuv_web/live/organization_live/edit.ex:347
 #: lib/vutuv_web/views/account_event_text.ex:231
 #, elixir-autogen, elixir-format
 msgid "Search engines"
@@ -11644,18 +11646,18 @@ msgstr "Land auswählen"
 msgid "Serve this file at:"
 msgstr "Stellen Sie diese Datei bereit unter:"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:327
+#: lib/vutuv_web/live/organization_live/edit.ex:328
 #: lib/vutuv_web/live/organization_live/new.ex:139
 #, elixir-autogen, elixir-format
 msgid "State / region (optional)"
 msgstr "Bundesland / Region (optional)"
 
-#: lib/vutuv_web/components/ui.ex:3998
+#: lib/vutuv_web/components/ui.ex:4042
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr "Dieser Dateityp ist nicht erlaubt."
 
-#: lib/vutuv_web/components/ui.ex:4000
+#: lib/vutuv_web/components/ui.ex:4044
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr "Der Upload ist fehlgeschlagen."
@@ -11695,7 +11697,7 @@ msgstr "Jetzt verifizieren"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:262
 #: lib/vutuv_web/agent_docs/text.ex:245
-#: lib/vutuv_web/live/organization_live/edit.ex:321
+#: lib/vutuv_web/live/organization_live/edit.ex:322
 #: lib/vutuv_web/live/organization_live/new.ex:130
 #, elixir-autogen, elixir-format
 msgid "Website"
@@ -11734,7 +11736,7 @@ msgid "@handle or email"
 msgstr "@handle oder E-Mail"
 
 #: lib/vutuv_web/components/organization_components.ex:333
-#: lib/vutuv_web/live/organization_live/edit.ex:424
+#: lib/vutuv_web/live/organization_live/edit.ex:425
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
 msgstr "Abkürzung"
@@ -11755,7 +11757,7 @@ msgid "Added @%{handle} to the team."
 msgstr "@%{handle} zum Team hinzugefügt."
 
 #: lib/vutuv_web/components/organization_components.ex:334
-#: lib/vutuv_web/live/organization_live/edit.ex:422
+#: lib/vutuv_web/live/organization_live/edit.ex:423
 #, elixir-autogen, elixir-format
 msgid "Alias"
 msgstr "Alias"
@@ -11772,14 +11774,14 @@ msgstr "Alias entfernt."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:436
 #: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/live/organization_live/edit.ex:387
+#: lib/vutuv_web/live/organization_live/edit.ex:388
 #: lib/vutuv_web/live/organization_live/show.ex:925
 #: lib/vutuv_web/templates/tag/single_card.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Also known as"
 msgstr "Auch bekannt als"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:418
+#: lib/vutuv_web/live/organization_live/edit.ex:419
 #, elixir-autogen, elixir-format
 msgid "Alternative name"
 msgstr "Alternativer Name"
@@ -11801,7 +11803,7 @@ msgid "Archived"
 msgstr "Archiviert"
 
 #: lib/vutuv_web/components/organization_components.ex:332
-#: lib/vutuv_web/live/organization_live/edit.ex:423
+#: lib/vutuv_web/live/organization_live/edit.ex:424
 #, elixir-autogen, elixir-format
 msgid "Brand"
 msgstr "Marke"
@@ -11948,7 +11950,7 @@ msgstr "Diese Domain entfernen?"
 msgid "Remove this member from the team?"
 msgstr "Dieses Mitglied aus dem Team entfernen?"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:404
+#: lib/vutuv_web/live/organization_live/edit.ex:405
 #, elixir-autogen, elixir-format
 msgid "Remove this name?"
 msgstr "Diesen Namen entfernen?"
@@ -12005,24 +12007,24 @@ msgstr "primär"
 msgid "verified"
 msgstr "verifiziert"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:324
+#: lib/vutuv_web/live/organization_live/edit.ex:325
 #: lib/vutuv_web/live/organization_live/new.ex:136
 #, elixir-autogen, elixir-format
 msgid "Street address (optional)"
 msgstr "Straße und Hausnummer (optional)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:325
+#: lib/vutuv_web/live/organization_live/edit.ex:326
 #: lib/vutuv_web/live/organization_live/new.ex:137
 #, elixir-autogen, elixir-format
 msgid "ZIP / postal code (optional)"
 msgstr "PLZ (optional)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:481
+#: lib/vutuv_web/live/organization_live/edit.ex:482
 #, elixir-autogen, elixir-format
 msgid "Claim"
 msgstr "Reservieren"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:450
+#: lib/vutuv_web/live/organization_live/edit.ex:451
 #, elixir-autogen, elixir-format
 msgid "Reachable at"
 msgstr "Erreichbar unter"
@@ -12032,12 +12034,12 @@ msgstr "Erreichbar unter"
 msgid "That handle is not available."
 msgstr "Dieses Handle ist nicht verfügbar."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:487
+#: lib/vutuv_web/live/organization_live/edit.ex:488
 #, elixir-autogen, elixir-format
 msgid "Danger zone"
 msgstr "Gefahrenbereich"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:498
+#: lib/vutuv_web/live/organization_live/edit.ex:499
 #, elixir-autogen, elixir-format
 msgid "Really delete %{name}? This cannot be undone."
 msgstr "%{name} wirklich löschen? Das kann nicht rückgängig gemacht werden."
@@ -12089,7 +12091,7 @@ msgstr ""
 "Der Linktext ist beliebig. Ein verstecktes <link rel=\"me\"> im Seitenkopf "
 "funktioniert ebenfalls."
 
-#: lib/vutuv_web/components/ui.ex:994
+#: lib/vutuv_web/components/ui.ex:1038
 #: lib/vutuv_web/live/section_reorder_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -12195,7 +12197,7 @@ msgstr[1] ""
 "und wurden zur Prüfung markiert. Öffnen Sie unten eine Organisation, um sie "
 "zu sehen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:389
+#: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Alternative names, brands or abbreviations this organization is findable under. A rename keeps the old name here automatically."
 msgstr ""
@@ -12271,12 +12273,12 @@ msgstr "Der Nachweis ist eine kleine technische Änderung an Ihrer Domain: ein D
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr "Diese Schritte sind technisch. Wenn Sie %{domain} nicht selbst verwalten, kopieren Sie den unten gezeigten Eintrag oder die Datei und senden Sie ihn an Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Sobald sie ihn hinzugefügt hat, kommen Sie hierher zurück und klicken auf „Jetzt verifizieren“."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:502
+#: lib/vutuv_web/live/organization_live/edit.ex:503
 #, elixir-autogen, elixir-format
 msgid "Delete this organization"
 msgstr "Diese Organisation löschen"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:489
+#: lib/vutuv_web/live/organization_live/edit.ex:490
 #, elixir-autogen, elixir-format
 msgid "Deleting this organization page is permanent. Its verified domains and its @handle are freed and can be claimed again."
 msgstr "Das Löschen dieser Organisationsseite ist endgültig. Ihre verifizierten Domains und ihr @handle werden freigegeben und können erneut beansprucht werden."
@@ -12380,7 +12382,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/agent_docs/markdown.ex:427
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:400
-#: lib/vutuv_web/components/ui.ex:4789
+#: lib/vutuv_web/components/ui.ex:4833
 #: lib/vutuv_web/controllers/settings_controller.ex:213
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
@@ -12505,7 +12507,7 @@ msgstr "hat Sie zum Administrator von %{organization} gemacht."
 msgid "made you an owner of %{organization}."
 msgstr "hat Sie zum Besitzer von %{organization} gemacht."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:471
+#: lib/vutuv_web/live/organization_live/edit.ex:472
 #, elixir-autogen, elixir-format
 msgid "your_organization"
 msgstr "ihre_organisation"
@@ -12566,17 +12568,17 @@ msgstr "Eine gefälschte, irreführende oder diskriminierende Stellenanzeige."
 msgid "A pay range is required to publish (except volunteer postings)."
 msgstr "Zum Veröffentlichen ist eine Gehaltsspanne erforderlich (außer bei Ehrenämtern)."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:749
+#: lib/vutuv_web/live/job_posting_live/form.ex:750
 #, elixir-autogen, elixir-format
 msgid "A vutuv message to me"
 msgstr "Eine vutuv-Nachricht an mich"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:747
+#: lib/vutuv_web/live/job_posting_live/form.ex:748
 #, elixir-autogen, elixir-format
 msgid "A website"
 msgstr "Eine Website"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:748
+#: lib/vutuv_web/live/job_posting_live/form.ex:749
 #, elixir-autogen, elixir-format
 msgid "An e-mail address"
 msgstr "Eine E-Mail-Adresse"
@@ -12586,12 +12588,12 @@ msgstr "Eine E-Mail-Adresse"
 msgid "Applicants must be located in"
 msgstr "Bewerber:innen müssen ansässig sein in"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:753
+#: lib/vutuv_web/live/job_posting_live/form.ex:754
 #, elixir-autogen, elixir-format
 msgid "Application URL"
 msgstr "Bewerbungs-URL"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:759
+#: lib/vutuv_web/live/job_posting_live/form.ex:760
 #, elixir-autogen, elixir-format
 msgid "Application e-mail"
 msgstr "Bewerbungs-E-Mail"
@@ -12601,7 +12603,7 @@ msgstr "Bewerbungs-E-Mail"
 msgid "Application: %{title}"
 msgstr "Bewerbung: %{title}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:745
+#: lib/vutuv_web/live/job_posting_live/form.ex:746
 #, elixir-autogen, elixir-format
 msgid "Applications go to"
 msgstr "Bewerbungen gehen an"
@@ -12633,7 +12635,7 @@ msgstr "Geschlossen"
 msgid "Contract"
 msgstr "Freie Mitarbeit"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:692
+#: lib/vutuv_web/live/job_posting_live/form.ex:693
 #, elixir-autogen, elixir-format
 msgid "Describe the role. Markdown is supported."
 msgstr "Beschreiben Sie die Stelle. Markdown wird unterstützt."
@@ -12674,7 +12676,7 @@ msgstr "Name des Arbeitgebers (optional)"
 msgid "Employment type"
 msgstr "Anstellungsart"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:771
+#: lib/vutuv_web/live/job_posting_live/form.ex:772
 #, elixir-autogen, elixir-format
 msgid "Everyone (public)"
 msgstr "Alle (öffentlich)"
@@ -12697,12 +12699,12 @@ msgstr "Vollzeit"
 msgid "Highlighted tags match your profile."
 msgstr "Hervorgehobene Tags passen zu Ihrem Profil."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:743
+#: lib/vutuv_web/live/job_posting_live/form.ex:744
 #, elixir-autogen, elixir-format
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
 
-#: lib/vutuv/accounts/user.ex:1199
+#: lib/vutuv/accounts/user.ex:1205
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12713,7 +12715,7 @@ msgstr "Hybrid"
 msgid "I'm interested in your posting: %{url}"
 msgstr "Ich interessiere mich für Ihre Anzeige: %{url}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:691
+#: lib/vutuv_web/live/job_posting_live/form.ex:692
 #, elixir-autogen, elixir-format
 msgid "Job description"
 msgstr "Stellenbeschreibung"
@@ -12734,7 +12736,7 @@ msgstr "Stellenbezeichnung"
 msgid "Jobs"
 msgstr "Jobs"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:781
+#: lib/vutuv_web/live/job_posting_live/form.ex:782
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this posting."
 msgstr "Suchmaschinen dürfen diese Anzeige indexieren."
@@ -12795,7 +12797,7 @@ msgstr "Neue Anzeige"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:292
 #: lib/vutuv_web/agent_docs/text.ex:275
-#: lib/vutuv_web/live/job_posting_live/form.ex:731
+#: lib/vutuv_web/live/job_posting_live/form.ex:732
 #: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
@@ -12816,12 +12818,12 @@ msgstr "Hier ist noch nichts. Jobs mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Jobs you like show up here."
 msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:787
+#: lib/vutuv_web/live/job_posting_live/form.ex:788
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
 
-#: lib/vutuv/accounts/user.ex:1198
+#: lib/vutuv/accounts/user.ex:1204
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12898,12 +12900,12 @@ msgstr "Sprache der Anzeige"
 msgid "Posting not found."
 msgstr "Anzeige nicht gefunden."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:804
+#: lib/vutuv_web/live/job_posting_live/form.ex:805
 #, elixir-autogen, elixir-format
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: lib/vutuv/accounts/user.ex:1200
+#: lib/vutuv/accounts/user.ex:1206
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
 #: lib/vutuv_web/agent_docs/markdown.ex:466
@@ -12923,7 +12925,7 @@ msgstr "Diese Anzeige melden"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:291
 #: lib/vutuv_web/agent_docs/text.ex:274
-#: lib/vutuv_web/live/job_posting_live/form.ex:721
+#: lib/vutuv_web/live/job_posting_live/form.ex:722
 #: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
@@ -12963,7 +12965,7 @@ msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
 msgid "Street (optional)"
 msgstr "Straße (optional)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:718
+#: lib/vutuv_web/live/job_posting_live/form.ex:719
 #, elixir-autogen, elixir-format
 msgid "Tags match your posting to members. Separate them with commas; a tag may be several words long, like Ruby on Rails."
 msgstr "Tags bringen Ihre Anzeige mit Mitgliedern zusammen. Mit Kommas trennen; ein Tag darf aus mehreren Wörtern bestehen, zum Beispiel Ruby on Rails."
@@ -13015,7 +13017,7 @@ msgstr "Ehrenamtlich"
 msgid "Volunteer"
 msgstr "Ehrenamt"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:769
+#: lib/vutuv_web/live/job_posting_live/form.ex:770
 #: lib/vutuv_web/templates/email/form_content.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Who can see it"
@@ -13610,7 +13612,7 @@ msgstr "Suche speichern"
 msgid "Saved search deleted."
 msgstr "Gespeicherte Suche gelöscht."
 
-#: lib/vutuv_web/components/ui.ex:4729
+#: lib/vutuv_web/components/ui.ex:4773
 #: lib/vutuv_web/controllers/settings_controller.ex:620
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13765,7 +13767,7 @@ msgstr "Wird eine Organisation ausgeschlossen, ist die Anzeige auch für ihre be
 msgid "Hide from specific viewers"
 msgstr "Vor bestimmten Personen verbergen"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:793
+#: lib/vutuv_web/live/job_posting_live/form.ex:794
 #, elixir-autogen, elixir-format
 msgid "Hide from specific viewers (competitors, your own staff, a person) →"
 msgstr "Vor bestimmten Personen verbergen (Wettbewerber, eigene Belegschaft, Einzelpersonen) →"
@@ -13786,7 +13788,7 @@ msgstr "Ausschlussliste"
 msgid "Job exclusions – %{name}"
 msgstr "Ausschlussliste – %{name}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:796
+#: lib/vutuv_web/live/job_posting_live/form.ex:797
 #, elixir-autogen, elixir-format
 msgid "Keep this posting on the board for everyone except a chosen few."
 msgstr "Halten Sie diese Anzeige für alle im Stellenmarkt sichtbar, außer für wenige Ausgewählte."
@@ -13932,7 +13934,7 @@ msgstr "Screenshot entfernt."
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
-#: lib/vutuv/accounts/user.ex:1243
+#: lib/vutuv/accounts/user.ex:1249
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13943,19 +13945,19 @@ msgstr "Nur das Alter, ohne das Datum"
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
-#: lib/vutuv/accounts/user.ex:1246
+#: lib/vutuv/accounts/user.ex:1252
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
-#: lib/vutuv/accounts/user.ex:1249
+#: lib/vutuv/accounts/user.ex:1255
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
-#: lib/vutuv/accounts/user.ex:1240
+#: lib/vutuv/accounts/user.ex:1246
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13995,32 +13997,32 @@ msgstr[1] "Wir haben %{formatted} Beiträge aktualisiert, die Ihren alten Handle
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "hat den Handle von @%{old} auf @%{new} geändert."
 
-#: lib/vutuv_web/components/ui.ex:406
+#: lib/vutuv_web/components/ui.ex:413
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr "Zentriert"
 
-#: lib/vutuv_web/components/ui.ex:403
+#: lib/vutuv_web/components/ui.ex:410
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr "Linksbündig (Text umfließt)"
 
-#: lib/vutuv_web/components/ui.ex:409
+#: lib/vutuv_web/components/ui.ex:416
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr "Rechtsbündig (Text umfließt)"
 
-#: lib/vutuv_web/components/ui.ex:400
+#: lib/vutuv_web/components/ui.ex:407
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr "Volle Breite"
 
-#: lib/vutuv_web/components/ui.ex:433
+#: lib/vutuv_web/components/ui.ex:440
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr "Bild einfügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2841
+#: lib/vutuv_web/live/post_live/composer.ex:2871
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr "In den Text einfügen"
@@ -14082,7 +14084,7 @@ msgstr ""
 "Personen tauchen in Ihren Vorschlägen auf. Einem Tag folgen Sie auf seiner "
 "Seite."
 
-#: lib/vutuv_web/components/ui.ex:4712
+#: lib/vutuv_web/components/ui.ex:4756
 #: lib/vutuv_web/controllers/settings_controller.ex:634
 #: lib/vutuv_web/live/post_live/feed.ex:712
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -14159,7 +14161,7 @@ msgstr "Messenger wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:63
-#: lib/vutuv_web/components/ui.ex:4683
+#: lib/vutuv_web/components/ui.ex:4727
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -14187,14 +14189,14 @@ msgstr "Messenger von %{name}"
 msgid "Select a messenger"
 msgstr "Messenger auswählen"
 
-#: lib/vutuv_web/components/ui.ex:4083
+#: lib/vutuv_web/components/ui.ex:4127
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] "Meinen Follower darüber informieren"
 msgstr[1] "Meine %{formatted} Follower darüber informieren"
 
-#: lib/vutuv_web/components/ui.ex:4093
+#: lib/vutuv_web/components/ui.ex:4137
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
@@ -14418,12 +14420,12 @@ msgstr "hat Sie für %{tags} empfohlen."
 msgid "by:"
 msgstr "von:"
 
-#: lib/vutuv_web/components/ui.ex:2159
+#: lib/vutuv_web/components/ui.ex:2203
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr "Empfohlen von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:2163
+#: lib/vutuv_web/components/ui.ex:2207
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -14553,22 +14555,22 @@ msgid "proof document"
 msgstr "Nachweis"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:331
+#: lib/vutuv_web/templates/settings/preferences.html.heex:375
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr "Zeilen in Benachrichtigungen"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:101
+#: lib/vutuv_web/gettext_extraction_anchors.ex:107
 #, elixir-autogen, elixir-format
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr "Wie viel von einem Beitrag eine Benachrichtigung zitiert, bevor abgeschnitten wird."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:322
+#: lib/vutuv_web/templates/settings/preferences.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr "Zitierte Beiträge in Benachrichtigungen"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:325
+#: lib/vutuv_web/templates/settings/preferences.html.heex:369
 #, elixir-autogen, elixir-format
 msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
@@ -14705,13 +14707,13 @@ msgstr "Erwähnung"
 msgid "mentioned you in a post."
 msgstr "hat Sie in einem Beitrag erwähnt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1240
+#: lib/vutuv_web/live/post_live/composer.ex:1251
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr "Dieser Beitrag lässt sich nicht mehr bearbeiten: jemand hat ihn geliked, geteilt oder beantwortet."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1243
+#: lib/vutuv_web/live/post_live/composer.ex:1254
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14998,7 +15000,7 @@ msgstr "Blenden Sie Beiträge aus Ihrem Feed aus, die ein Tag tragen oder ein Wo
 msgid "Match whole words only (word/phrase)"
 msgstr "Nur ganze Wörter treffen (Wort/Phrase)"
 
-#: lib/vutuv_web/components/ui.ex:4697
+#: lib/vutuv_web/components/ui.ex:4741
 #: lib/vutuv_web/controllers/settings_controller.ex:700
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -15633,252 +15635,252 @@ msgstr "Ihr Server"
 msgid "moved to %{address}"
 msgstr "umgezogen nach %{address}"
 
-#: lib/vutuv_web/components/ui.ex:4625
+#: lib/vutuv_web/components/ui.ex:4669
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr "Name, Foto, Titelbild, Kurzbeschreibung"
 
-#: lib/vutuv_web/components/ui.ex:4630
+#: lib/vutuv_web/components/ui.ex:4674
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr "handle spitzname nutzername umbenennen slug profiladresse url erwähnung"
 
-#: lib/vutuv_web/components/ui.ex:4633
+#: lib/vutuv_web/components/ui.ex:4677
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr "Die Stationen in Ihrem Lebenslauf"
 
-#: lib/vutuv_web/components/ui.ex:4634
+#: lib/vutuv_web/components/ui.ex:4678
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr "lebenslauf cv karriere beruf arbeitgeber position stelle job firma"
 
-#: lib/vutuv_web/components/ui.ex:4637
+#: lib/vutuv_web/components/ui.ex:4681
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr "Schulen, Hochschulen, Abschlüsse"
 
-#: lib/vutuv_web/components/ui.ex:4638
+#: lib/vutuv_web/components/ui.ex:4682
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr "lebenslauf studium schule universität hochschule abschluss ausbildung"
 
-#: lib/vutuv_web/components/ui.ex:4641
+#: lib/vutuv_web/components/ui.ex:4685
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr "Nachweise, mit Belegdokumenten"
 
-#: lib/vutuv_web/components/ui.ex:4642
+#: lib/vutuv_web/components/ui.ex:4686
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr "zertifikat lizenz urkunde diplom nachweis beleg auszeichnung dokument"
 
-#: lib/vutuv_web/components/ui.ex:4649
+#: lib/vutuv_web/components/ui.ex:4693
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr "Sprachkenntnisse"
 
-#: lib/vutuv_web/components/ui.ex:4650
+#: lib/vutuv_web/components/ui.ex:4694
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr "Die Sprachen, die Sie sprechen"
 
-#: lib/vutuv_web/components/ui.ex:4651
+#: lib/vutuv_web/components/ui.ex:4695
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr "sprache sprachen sprechen fließend muttersprache verhandlungssicher"
 
-#: lib/vutuv_web/components/ui.ex:4654
+#: lib/vutuv_web/components/ui.ex:4698
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr "Die Themen, für die Sie bekannt sind"
 
-#: lib/vutuv_web/components/ui.ex:4655
+#: lib/vutuv_web/components/ui.ex:4699
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr "fähigkeit kenntnis thema stichwort schlagwort expertise empfehlung"
 
-#: lib/vutuv_web/components/ui.ex:4790
+#: lib/vutuv_web/components/ui.ex:4834
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr "Organisationsseiten, die Sie verwalten"
 
-#: lib/vutuv_web/components/ui.ex:4791
+#: lib/vutuv_web/components/ui.ex:4835
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr "firma unternehmen arbeitgeber betrieb organisation seite"
 
-#: lib/vutuv_web/components/ui.ex:4658
+#: lib/vutuv_web/components/ui.ex:4702
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr "Kontaktdaten"
 
-#: lib/vutuv_web/components/ui.ex:4661
+#: lib/vutuv_web/components/ui.ex:4705
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr "Wo wir Sie erreichen, und welche Adresse öffentlich ist"
 
-#: lib/vutuv_web/components/ui.ex:4662
+#: lib/vutuv_web/components/ui.ex:4706
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr "mail e-mail email adresse hauptadresse primär"
 
-#: lib/vutuv_web/components/ui.ex:4665
+#: lib/vutuv_web/components/ui.ex:4709
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr "Festnetz, Mobil, Fax"
 
-#: lib/vutuv_web/components/ui.ex:4666
+#: lib/vutuv_web/components/ui.ex:4710
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr "telefon handy mobil festnetz fax nummer rufnummer"
 
-#: lib/vutuv_web/components/ui.ex:4669
+#: lib/vutuv_web/components/ui.ex:4713
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr "Postanschriften auf Ihrem Profil"
 
-#: lib/vutuv_web/components/ui.ex:4670
+#: lib/vutuv_web/components/ui.ex:4714
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr "straße stadt ort postleitzahl plz land anschrift karte"
 
-#: lib/vutuv_web/components/ui.ex:4672
+#: lib/vutuv_web/components/ui.ex:4716
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr "Webseiten & Links"
 
-#: lib/vutuv_web/components/ui.ex:4673
+#: lib/vutuv_web/components/ui.ex:4717
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr "Ihre Homepage und weitere Links"
 
-#: lib/vutuv_web/components/ui.ex:4674
+#: lib/vutuv_web/components/ui.ex:4718
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr "url webseite website homepage blog link verifizieren bestätigen rel=me"
 
-#: lib/vutuv_web/components/ui.ex:4676
+#: lib/vutuv_web/components/ui.ex:4720
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr "Social-Media-Profile"
 
-#: lib/vutuv_web/components/ui.ex:4677
+#: lib/vutuv_web/components/ui.ex:4721
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr "Mastodon, Bluesky, GitHub und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:4679
+#: lib/vutuv_web/components/ui.ex:4723
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr "mastodon bluesky github gitlab codeberg linkedin x twitter instagram soziale netzwerke"
 
-#: lib/vutuv_web/components/ui.ex:4684
+#: lib/vutuv_web/components/ui.ex:4728
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr "Signal, Threema, Matrix und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:4685
+#: lib/vutuv_web/components/ui.ex:4729
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr "signal threema matrix xmpp telegram whatsapp chat messenger nachrichten"
 
-#: lib/vutuv_web/components/ui.ex:4688
+#: lib/vutuv_web/components/ui.ex:4732
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr "Mitteilungen & Feed"
 
-#: lib/vutuv_web/components/ui.ex:4691
+#: lib/vutuv_web/components/ui.ex:4735
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr "Welche E-Mails wir schicken, und was die Glocke meldet"
 
-#: lib/vutuv_web/components/ui.ex:4698
+#: lib/vutuv_web/components/ui.ex:4742
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr "Beiträge aus Ihrem Feed heraushalten"
 
-#: lib/vutuv_web/components/ui.ex:4699
+#: lib/vutuv_web/components/ui.ex:4743
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr "stummschalten ausblenden verbergen filter wort begriff tag feed blockieren"
 
-#: lib/vutuv_web/components/ui.ex:4713
+#: lib/vutuv_web/components/ui.ex:4757
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr "Themen, deren Beiträge in Ihrem Feed landen"
 
-#: lib/vutuv_web/components/ui.ex:4714
+#: lib/vutuv_web/components/ui.ex:4758
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr "tag thema abonnieren folgen feed"
 
-#: lib/vutuv_web/components/ui.ex:4730
+#: lib/vutuv_web/components/ui.ex:4774
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr "Job- und Personensuchen, die Ihnen neue Treffer mailen"
 
-#: lib/vutuv_web/components/ui.ex:4731
+#: lib/vutuv_web/components/ui.ex:4775
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr "job stelle stellenangebot suchauftrag suche alarm benachrichtigung merkliste"
 
-#: lib/vutuv_web/components/ui.ex:4737
+#: lib/vutuv_web/components/ui.ex:4781
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr "Suchmaschinen, KI, Online-Status"
 
-#: lib/vutuv_web/components/ui.ex:4738
+#: lib/vutuv_web/components/ui.ex:4782
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr "privatsphäre datenschutz google suchmaschine ki ai llm crawler noindex online punkt öffentlich sichtbar"
 
-#: lib/vutuv_web/components/ui.ex:4741
+#: lib/vutuv_web/components/ui.ex:4785
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr "Personen, die nicht mit Ihnen interagieren können"
 
-#: lib/vutuv_web/components/ui.ex:4742
+#: lib/vutuv_web/components/ui.ex:4786
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr "blockieren sperren bannen stummschalten melden missbrauch belästigung"
 
-#: lib/vutuv_web/components/ui.ex:4763
+#: lib/vutuv_web/components/ui.ex:4807
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr "Passkeys, angemeldete Geräte, Anmeldecodes"
 
-#: lib/vutuv_web/components/ui.ex:4764
+#: lib/vutuv_web/components/ui.ex:4808
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr "passwort kennwort anmelden abmelden login logout sitzung gerät passkey totp 2fa pin sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:4782
+#: lib/vutuv_web/components/ui.ex:4826
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr "Ihre Daten von LinkedIn übernehmen"
 
-#: lib/vutuv_web/components/ui.ex:4783
+#: lib/vutuv_web/components/ui.ex:4827
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr "linkedin hochladen zip übernehmen importieren umzug"
 
-#: lib/vutuv_web/components/ui.ex:4786
+#: lib/vutuv_web/components/ui.ex:4830
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr "Alles herunterladen, was wir über Sie speichern"
 
-#: lib/vutuv_web/components/ui.ex:4787
+#: lib/vutuv_web/components/ui.ex:4831
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr "herunterladen download dsgvo gdpr daten sicherung json lebenslauf auskunft"
 
-#: lib/vutuv_web/components/ui.ex:4801
+#: lib/vutuv_web/components/ui.ex:4845
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr "Ihr Konto und alles darauf entfernen"
 
-#: lib/vutuv_web/components/ui.ex:4802
+#: lib/vutuv_web/components/ui.ex:4846
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr "löschen entfernen schließen kündigen beenden verlassen"
@@ -16353,7 +16355,7 @@ msgstr "API-Token erstellt"
 msgid "Access token revoked"
 msgstr "API-Token widerrufen"
 
-#: lib/vutuv_web/components/ui.ex:4766
+#: lib/vutuv_web/components/ui.ex:4810
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16700,7 +16702,7 @@ msgstr "Was sich an einem Konto geändert hat, wann, von wo und wie es bestätig
 msgid "What changed on your account, and exactly when."
 msgstr "Was sich an Ihrem Konto geändert hat, und wann genau."
 
-#: lib/vutuv_web/components/ui.ex:4767
+#: lib/vutuv_web/components/ui.ex:4811
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr "Was sich an Ihrem Konto geändert hat, und wann"
@@ -16736,7 +16738,7 @@ msgstr "durch den Betreiber"
 msgid "from a signed-in session"
 msgstr "aus einer angemeldeten Sitzung"
 
-#: lib/vutuv_web/components/ui.ex:4769
+#: lib/vutuv_web/components/ui.ex:4813
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr "protokoll verlauf historie chronik audit sicherheit war ich das wer hat wann geaendert geändert log"
@@ -16853,7 +16855,7 @@ msgstr ""
 "in eckigen Klammern, wie eine Lautschrift geschrieben wird; die Klammern "
 "ergänzen wir für Sie. Bleibt das Feld leer, wird nichts angezeigt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2854
+#: lib/vutuv_web/live/post_live/composer.ex:2884
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr "Diese Einstellungen für alle Fotos übernehmen"
@@ -16883,49 +16885,49 @@ msgstr "CC BY-SA 4.0 (Namensnennung, gleiche Bedingungen)"
 msgid "CC0 1.0 (no rights reserved)"
 msgstr "CC0 1.0 (keine Rechte vorbehalten)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2278
+#: lib/vutuv_web/live/post_live/composer.ex:2308
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Titelbild"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2692
+#: lib/vutuv_web/live/post_live/composer.ex:2722
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1294
 #: lib/vutuv_web/agent_docs/text.ex:807
-#: lib/vutuv_web/components/ui.ex:2823
+#: lib/vutuv_web/components/ui.ex:2867
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Original herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2791
+#: lib/vutuv_web/live/post_live/composer.ex:2821
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr "Alle Metadaten bleiben erhalten, auch alles, was Ihre Kamera hineingeschrieben hat."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2747
+#: lib/vutuv_web/live/post_live/composer.ex:2777
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr "Alle dürfen dieses Foto herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2749
+#: lib/vutuv_web/live/post_live/composer.ex:2779
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr "Volle Auflösung, direkt aus dem Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2768
+#: lib/vutuv_web/live/post_live/composer.ex:2798
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr "Nur das Bild"
 
-#: lib/vutuv_web/components/ui.ex:2822
+#: lib/vutuv_web/components/ui.ex:2866
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Nächstes Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2297
+#: lib/vutuv_web/live/post_live/composer.ex:2327
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
@@ -16945,8 +16947,8 @@ msgstr "Foto %{n} von %{total}"
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2250
-#: lib/vutuv_web/live/post_live/composer.ex:2251
+#: lib/vutuv_web/live/post_live/composer.ex:2280
+#: lib/vutuv_web/live/post_live/composer.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr "Foto-Einstellungen"
@@ -16958,23 +16960,23 @@ msgstr "Foto-Einstellungen"
 msgid "Photos:"
 msgstr "Fotos:"
 
-#: lib/vutuv_web/components/ui.ex:2821
+#: lib/vutuv_web/components/ui.ex:2865
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2310
-#: lib/vutuv_web/live/post_live/composer.ex:2311
+#: lib/vutuv_web/live/post_live/composer.ex:2340
+#: lib/vutuv_web/live/post_live/composer.ex:2341
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr "Foto entfernen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2770
+#: lib/vutuv_web/live/post_live/composer.ex:2800
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qualität unverändert."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2711
+#: lib/vutuv_web/live/post_live/composer.ex:2741
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
@@ -16984,17 +16986,17 @@ msgstr "Kameradaten anzeigen"
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2789
+#: lib/vutuv_web/live/post_live/composer.ex:2819
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr "Die Datei genau so, wie ich sie hochgeladen habe"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2825
+#: lib/vutuv_web/live/post_live/composer.ex:2855
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen Sie das Foto, wenn Sie das nicht möchten."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2817
+#: lib/vutuv_web/live/post_live/composer.ex:2847
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
@@ -17019,12 +17021,12 @@ msgstr "Diese Seite nimmt nicht am Fediverse teil."
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2568
+#: lib/vutuv_web/live/post_live/composer.ex:2598
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr "Wer diese Fotos weiterverwenden darf"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1267
+#: lib/vutuv_web/live/post_live/composer.ex:1278
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
@@ -17034,7 +17036,7 @@ msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke gesc
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1281
+#: lib/vutuv_web/live/post_live/composer.ex:1292
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
@@ -17049,65 +17051,65 @@ msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fedive
 msgid "© All rights reserved"
 msgstr "© Alle Rechte vorbehalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2193
+#: lib/vutuv_web/live/post_live/composer.ex:2223
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr "Fotos hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2563
+#: lib/vutuv_web/live/post_live/composer.ex:2593
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2682
+#: lib/vutuv_web/live/post_live/composer.ex:2712
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr "Bildunterschrift (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1494
-#: lib/vutuv_web/live/post_live/composer.ex:1557
-#: lib/vutuv_web/live/post_live/composer.ex:1615
-#: lib/vutuv_web/live/post_live/composer.ex:1962
+#: lib/vutuv_web/live/post_live/composer.ex:1522
+#: lib/vutuv_web/live/post_live/composer.ex:1585
+#: lib/vutuv_web/live/post_live/composer.ex:1643
+#: lib/vutuv_web/live/post_live/composer.ex:1990
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr "Entwurf verwerfen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1487
+#: lib/vutuv_web/live/post_live/composer.ex:1515
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr "Weiter, wo Sie aufgehört haben."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2616
+#: lib/vutuv_web/live/post_live/composer.ex:2646
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr "Eine Datei, deren Format sich nicht säubern lässt, wird exakt so weitergegeben, wie sie hochgeladen wurde."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2130
+#: lib/vutuv_web/live/post_live/composer.ex:2158
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr "Pro Foto verschieden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2129
+#: lib/vutuv_web/live/post_live/composer.ex:2157
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr "Original, exakt wie hochgeladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2128
+#: lib/vutuv_web/live/post_live/composer.ex:2156
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr "Original, ohne Metadaten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2133
+#: lib/vutuv_web/live/post_live/composer.ex:2161
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr "Nur Web-Versionen (%{format})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2586
+#: lib/vutuv_web/live/post_live/composer.ex:2616
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr "Was Besucher speichern können"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2605
+#: lib/vutuv_web/live/post_live/composer.ex:2635
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -17226,8 +17228,8 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr "Rücknahme"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1751
-#: lib/vutuv_web/live/post_live/composer.ex:2450
+#: lib/vutuv_web/live/post_live/composer.ex:1779
+#: lib/vutuv_web/live/post_live/composer.ex:2480
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr "Fotodetails"
@@ -17257,7 +17259,7 @@ msgstr "Ein Konto in einem anderen Netzwerk"
 msgid "Cancel request"
 msgstr "Anfrage zurückziehen"
 
-#: lib/vutuv_web/components/ui.ex:4753
+#: lib/vutuv_web/components/ui.ex:4797
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Konten auf Mastodon folgen, und von dort gefolgt werden"
@@ -17460,7 +17462,7 @@ msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, desh
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr "Ihr Konto ist derzeit gesperrt, deshalb geht nichts von Ihnen an andere Netzwerke und Sie können dort niemandem folgen. Das endet von selbst, sobald die Sperre abläuft."
 
-#: lib/vutuv_web/components/ui.ex:4755
+#: lib/vutuv_web/components/ui.ex:4799
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr "mastodon activitypub foederation federation follower folgen folge umzug migration entferntes konto"
@@ -17848,12 +17850,12 @@ msgstr ""
 "Ihr Feed zeigt die Beiträge der Mitglieder, denen Sie folgen. Folgen Sie ein "
 "paar Mitgliedern, um ihn zu füllen."
 
-#: lib/vutuv_web/components/ui.ex:227
+#: lib/vutuv_web/components/ui.ex:228
 #, elixir-autogen, elixir-format
 msgid "Add another tag"
 msgstr "Weiteren Tag hinzufügen"
 
-#: lib/vutuv_web/components/ui.ex:250
+#: lib/vutuv_web/components/ui.ex:251
 #, elixir-autogen, elixir-format
 msgid "Remove the tag %{name}"
 msgstr "Tag %{name} entfernen"
@@ -17978,7 +17980,7 @@ msgstr "Ihr Benutzername ist hier Ihre öffentliche Identität. Er ändert sich 
 msgid "Your username is your public identity here. It changes only once you confirm with your passkey or a valid code below."
 msgstr "Ihr Benutzername ist hier Ihre öffentliche Identität. Er ändert sich erst, wenn Sie unten mit Ihrem Passkey oder einem gültigen Code bestätigen."
 
-#: lib/vutuv_web/components/ui.ex:531
+#: lib/vutuv_web/components/ui.ex:575
 #, elixir-autogen, elixir-format
 msgid "Markdown help"
 msgstr "Markdown-Hilfe"
@@ -18107,104 +18109,104 @@ msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, desh
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr "Einen nachgeschlagenen Beitrag bewahrt vutuv genauso sechs Monate lang auf wie jeden anderen Beitrag aus einem anderen Netzwerk. Der Server der verfassenden Person wird sonst nichts gefragt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1668
+#: lib/vutuv_web/live/post_live/composer.ex:1696
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr "Zuschnitt übernehmen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2356
+#: lib/vutuv_web/live/post_live/composer.ex:2386
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr "Großes Foto links"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2357
+#: lib/vutuv_web/live/post_live/composer.ex:2387
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr "Großes Foto rechts"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2362
+#: lib/vutuv_web/live/post_live/composer.ex:2392
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr "Spalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2359
+#: lib/vutuv_web/live/post_live/composer.ex:2389
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr "Titelbild links"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2360
+#: lib/vutuv_web/live/post_live/composer.ex:2390
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr "Titelbild oben"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2361
+#: lib/vutuv_web/live/post_live/composer.ex:2391
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr "Titelbild rechts"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1664
-#: lib/vutuv_web/live/post_live/composer.ex:2327
-#: lib/vutuv_web/live/post_live/composer.ex:2328
+#: lib/vutuv_web/live/post_live/composer.ex:1692
+#: lib/vutuv_web/live/post_live/composer.ex:2357
+#: lib/vutuv_web/live/post_live/composer.ex:2358
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr "Foto zuschneiden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2286
+#: lib/vutuv_web/live/post_live/composer.ex:2316
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr "Zugeschnitten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1586
+#: lib/vutuv_web/live/post_live/composer.ex:1614
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr "Fotos hier ablegen, um sie hinzuzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2363
+#: lib/vutuv_web/live/post_live/composer.ex:2393
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr "Raster"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2364
+#: lib/vutuv_web/live/post_live/composer.ex:2394
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr "Mosaik"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1666
+#: lib/vutuv_web/live/post_live/composer.ex:1694
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr "Wählen Sie ein Format, dann verschieben und zoomen Sie. Der gerahmte Ausschnitt ist das, was der Beitrag zeigt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2355
+#: lib/vutuv_web/live/post_live/composer.ex:2385
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr "Nebeneinander"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2358
+#: lib/vutuv_web/live/post_live/composer.ex:2388
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr "Übereinander"
 
-#: lib/vutuv_web/live/post_live/composer.ex:496
+#: lib/vutuv_web/live/post_live/composer.ex:497
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr "Das Foto konnte nicht zugeschnitten werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2804
+#: lib/vutuv_web/live/post_live/composer.ex:2834
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr "Dieses Foto ist zugeschnitten: Downloads geben das zugeschnittene Bild heraus, die unveränderte Originaldatei bleibt privat."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1670
+#: lib/vutuv_web/live/post_live/composer.ex:1698
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr "Ganzes Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2553
+#: lib/vutuv_web/live/post_live/composer.ex:2583
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr "Kacheln füllen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2537
+#: lib/vutuv_web/live/post_live/composer.ex:2567
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr "Ganze Fotos"
@@ -18507,8 +18509,8 @@ msgstr "Mehr von %{name}"
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr "Das ist die Kopie, die vutuv von einem auf %{host} veröffentlichten Beitrag hat. Sie bleibt erhalten, solange hier jemand diesem Konto folgt."
 
-#: lib/vutuv_web/components/ui.ex:1330
-#: lib/vutuv_web/components/ui.ex:1331
+#: lib/vutuv_web/components/ui.ex:1374
+#: lib/vutuv_web/components/ui.ex:1375
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr "Diesen Feed in Ihrem RSS-Reader abonnieren"
@@ -18518,7 +18520,7 @@ msgstr "Diesen Feed in Ihrem RSS-Reader abonnieren"
 msgid "A CV with positions, education, certificates including proof, spoken languages and tags other members endorse you for."
 msgstr "Ein Lebenslauf mit Stationen, Ausbildung, Zertifikaten samt Nachweis, Sprachen und Tags, für die andere Mitglieder Sie empfehlen."
 
-#: lib/vutuv_web/templates/page/index.html.heex:435
+#: lib/vutuv_web/templates/page/index.html.heex:465
 #, elixir-autogen, elixir-format
 msgid "A business network that is free, does not lock your data in, and is yours to run yourself if you want to."
 msgstr "Ein Business-Netzwerk, das kostenlos ist, Ihre Daten nicht einsperrt und das Sie auf Wunsch selbst betreiben können."
@@ -18538,22 +18540,22 @@ msgstr "Eine feste öffentliche Adresse, ohne Konto lesbar und als vCard herunte
 msgid "CV download as PDF, Word, OpenDocument, LaTeX or JSON Resume, and you pick what goes in before you download it."
 msgstr "Lebenslauf-Download als PDF, Word, OpenDocument, LaTeX oder JSON Resume, und Sie wählen vor dem Download aus, was darin steht."
 
-#: lib/vutuv_web/templates/page/index.html.heex:488
+#: lib/vutuv_web/templates/page/index.html.heex:518
 #, elixir-autogen, elixir-format
 msgid "Developer documentation"
 msgstr "Entwicklerdokumentation"
 
-#: lib/vutuv_web/templates/page/index.html.heex:448
+#: lib/vutuv_web/templates/page/index.html.heex:478
 #, elixir-autogen, elixir-format
 msgid "Every public page here is also served as Markdown, plain text, JSON and XML under the same address. No scraping, no API key, no account."
 msgstr "Jede öffentliche Seite hier gibt es unter derselben Adresse auch als Markdown, reinen Text, JSON und XML. Ohne Scraping, ohne API-Schlüssel, ohne Konto."
 
-#: lib/vutuv_web/templates/page/index.html.heex:455
+#: lib/vutuv_web/templates/page/index.html.heex:485
 #, elixir-autogen, elixir-format
 msgid "For machines"
 msgstr "Für Maschinen"
 
-#: lib/vutuv_web/templates/page/index.html.heex:445
+#: lib/vutuv_web/templates/page/index.html.heex:475
 #, elixir-autogen, elixir-format
 msgid "Open by default"
 msgstr "Offen von Haus aus"
@@ -18578,12 +18580,12 @@ msgstr "Menschen, Beiträge, Jobs"
 msgid "Posts, likes, reposts, replies and 1:1 messages, in real time."
 msgstr "Beiträge, Likes, Reposts, Antworten und 1:1-Nachrichten, in Echtzeit."
 
-#: lib/vutuv_web/templates/page/index.html.heex:446
+#: lib/vutuv_web/templates/page/index.html.heex:476
 #, elixir-autogen, elixir-format
 msgid "Readable by people, by machines, and on your own server"
 msgstr "Lesbar für Menschen, für Maschinen und auf Ihrem eigenen Server"
 
-#: lib/vutuv_web/templates/page/index.html.heex:471
+#: lib/vutuv_web/templates/page/index.html.heex:501
 #, elixir-autogen, elixir-format
 msgid "Run it yourself"
 msgstr "Selbst hosten"
@@ -18593,23 +18595,23 @@ msgstr "Selbst hosten"
 msgid "Sign in without a password, by emailed PIN, passkey, authenticator app or a printed list of codes."
 msgstr "Einloggen ohne Passwort, per PIN in der E-Mail, Passkey, Authenticator-App oder gedruckter Kennwortliste."
 
-#: lib/vutuv_web/templates/page/index.html.heex:482
-#: lib/vutuv_web/templates/page/index.html.heex:569
+#: lib/vutuv_web/templates/page/index.html.heex:512
+#: lib/vutuv_web/templates/page/index.html.heex:599
 #, elixir-autogen, elixir-format
 msgid "Source code"
 msgstr "Quellcode"
 
-#: lib/vutuv_web/templates/page/index.html.heex:317
+#: lib/vutuv_web/templates/page/index.html.heex:347
 #, elixir-autogen, elixir-format
 msgid "This is what a vutuv profile looks like"
 msgstr "So sieht ein Profil auf vutuv aus"
 
-#: lib/vutuv_web/templates/page/index.html.heex:433
+#: lib/vutuv_web/templates/page/index.html.heex:463
 #, elixir-autogen, elixir-format
 msgid "What vutuv can do"
 msgstr "Was vutuv kann"
 
-#: lib/vutuv_web/templates/page/index.html.heex:432
+#: lib/vutuv_web/templates/page/index.html.heex:462
 #, elixir-autogen, elixir-format
 msgid "What you get"
 msgstr "Was Sie bekommen"
@@ -18619,12 +18621,12 @@ msgstr "Was Sie bekommen"
 msgid "Your independence"
 msgstr "Ihre Unabhängigkeit"
 
-#: lib/vutuv_web/templates/page/index.html.heex:473
+#: lib/vutuv_web/templates/page/index.html.heex:503
 #, elixir-autogen, elixir-format
 msgid "vutuv is open source under the MIT license. Run it for a company, an association or a school, on the internet or air-gapped inside your own network."
 msgstr "vutuv ist Open Source unter der MIT-Lizenz. Betreiben Sie es für ein Unternehmen, einen Verein oder eine Schule, im Internet oder abgeschottet im eigenen Netz."
 
-#: lib/vutuv_web/templates/page/index.html.heex:316
+#: lib/vutuv_web/templates/page/index.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "A look inside"
 msgstr "Ein Blick hinein"
@@ -18634,7 +18636,7 @@ msgstr "Ein Blick hinein"
 msgid "A vutuv profile: cover picture, photo, name, tagline and job title, follower counts and the first posts, with contact details and social media profiles in a column on the right."
 msgstr "Ein vutuv-Profil: Titelbild, Foto, Name, Motto und Position, die Follower-Zahlen und die ersten Beiträge, rechts daneben eine Spalte mit Kontaktdaten und Profilen in sozialen Netzwerken."
 
-#: lib/vutuv_web/templates/page/index.html.heex:338
+#: lib/vutuv_web/templates/page/index.html.heex:368
 #, elixir-autogen, elixir-format
 msgid "Browse real profiles"
 msgstr "Echte Profile durchstöbern"
@@ -18654,17 +18656,17 @@ msgstr "Dasselbe Profil weiter unten: Tags mit der Zahl der Mitglieder, die sie 
 msgid "Try it out:"
 msgstr "Probieren Sie es aus:"
 
-#: lib/vutuv_web/templates/page/index.html.heex:464
+#: lib/vutuv_web/templates/page/index.html.heex:494
 #, elixir-autogen, elixir-format
 msgid "Plus a sitemap, JSON-LD and a REST API with OAuth 2 and personal access tokens."
 msgstr "Dazu eine Sitemap, JSON-LD und eine REST-API mit OAuth 2 und persönlichen Zugriffstokens."
 
-#: lib/vutuv_web/templates/page/index.html.heex:319
+#: lib/vutuv_web/templates/page/index.html.heex:349
 #, elixir-autogen, elixir-format
 msgid "Work experience, education, certificates, languages, links and tags others endorse you for. Anyone can read a profile, entirely without a vutuv account. Unlike LinkedIn, where you hit a login wall in short order."
 msgstr "Berufserfahrung, Ausbildung, Zertifikate, Sprachen, Links und Tags, für die andere Sie empfehlen. Ein Profil kann jeder lesen, ganz ohne vutuv-Konto. Anders als bei LinkedIn, wo Sie schnell vor einer Anmeldeschranke stehen."
 
-#: lib/vutuv_web/templates/page/index.html.heex:419
+#: lib/vutuv_web/templates/page/index.html.heex:449
 #, elixir-autogen, elixir-format
 msgid "Talking to people"
 msgstr "Miteinander reden"
@@ -18684,77 +18686,77 @@ msgstr "Der vutuv-Feed mit ausgewähltem Fediverse-Reiter: Beiträge von Nachric
 msgid "The Fediverse: let people follow you from Mastodon, and your public posts show up there. You choose at sign-up, and can change it later."
 msgstr "Das Fediverse: Menschen können Ihnen von Mastodon aus folgen, und Ihre öffentlichen Beiträge erscheinen dort. Sie entscheiden das bei der Anmeldung und können es später ändern."
 
-#: lib/vutuv_web/templates/page/index.html.heex:420
+#: lib/vutuv_web/templates/page/index.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "Posts, messages, and the Fediverse along with them"
 msgstr "Beiträge, Nachrichten und das Fediverse gleich dazu"
 
-#: lib/vutuv_web/templates/page/index.html.heex:422
+#: lib/vutuv_web/templates/page/index.html.heex:452
 #, elixir-autogen, elixir-format
 msgid "Write a post, react with a heart, a repost or a reply, or message somebody privately. And you are not stuck among vutuv members: vutuv is part of the Fediverse, the union of independent networks that Mastodon belongs to as well. Follow an account over there and its posts arrive in your feed; the other way round, people there can follow you and see your public posts. Both directions, and entirely your choice: at sign-up you decide whether to use vutuv with or without the Fediverse, and you can change that at any time in the settings."
 msgstr "Beitrag schreiben, mit Herz, Repost oder Antwort reagieren, oder jemandem privat schreiben. Und Sie bleiben nicht unter vutuv-Mitgliedern: vutuv gehört zum Fediverse, dem Verbund unabhängiger Netzwerke, zu dem auch Mastodon zählt. Folgen Sie dort einem Konto, und dessen Beiträge landen in Ihrem Feed; umgekehrt können Leute von dort Ihnen folgen und Ihre öffentlichen Beiträge sehen. In beide Richtungen, und ganz Ihre Entscheidung: Sie wählen bei der Anmeldung, ob Sie vutuv mit oder ohne Fediverse benutzen möchten, und können das jederzeit in den Einstellungen ändern."
 
-#: lib/vutuv_web/templates/page/index.html.heex:535
+#: lib/vutuv_web/templates/page/index.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Download everything you have here at any time, in a machine-readable file. Not on request, not after a waiting period: from your settings, whenever you like."
 msgstr "Laden Sie jederzeit alles herunter, was Sie hier haben, als maschinenlesbare Datei. Nicht auf Anfrage, nicht nach einer Wartezeit: in Ihren Einstellungen, wann immer Sie möchten."
 
-#: lib/vutuv_web/templates/page/index.html.heex:510
+#: lib/vutuv_web/templates/page/index.html.heex:540
 #, elixir-autogen, elixir-format
 msgid "Fair and transparent, in plain words"
 msgstr "Fair und transparent, in klaren Worten"
 
-#: lib/vutuv_web/templates/page/index.html.heex:524
+#: lib/vutuv_web/templates/page/index.html.heex:554
 #, elixir-autogen, elixir-format
 msgid "No third-party cookies"
 msgstr "Keine Cookies von Dritten"
 
-#: lib/vutuv_web/templates/page/index.html.heex:516
+#: lib/vutuv_web/templates/page/index.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "On our own servers in %{place}, not in somebody else's cloud. We do not hand your profile to a third party, and there is no tracking network reading along."
 msgstr "Auf unseren eigenen Servern in %{place}, nicht in der Cloud eines anderen. Wir geben Ihr Profil an niemanden weiter, und es liest kein Tracking-Netzwerk mit."
 
-#: lib/vutuv_web/templates/page/index.html.heex:514
+#: lib/vutuv_web/templates/page/index.html.heex:544
 #, elixir-autogen, elixir-format
 msgid "Where your data lives"
 msgstr "Wo Ihre Daten liegen"
 
-#: lib/vutuv_web/templates/page/index.html.heex:509
+#: lib/vutuv_web/templates/page/index.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "Your data"
 msgstr "Ihre Daten"
 
-#: lib/vutuv_web/templates/page/index.html.heex:526
+#: lib/vutuv_web/templates/page/index.html.heex:556
 #, elixir-autogen, elixir-format
 msgid "vutuv sets one cookie, the one that keeps you signed in. No advertising network, no analytics service, nothing loaded from anybody else's server."
 msgstr "vutuv setzt ein einziges Cookie, das Sie eingeloggt hält. Kein Werbenetzwerk, kein Analysedienst, nichts, was von fremden Servern nachgeladen wird."
 
-#: lib/vutuv_web/templates/page/index.html.heex:542
+#: lib/vutuv_web/templates/page/index.html.heex:572
 #, elixir-autogen, elixir-format
 msgid "Leave whenever you like"
 msgstr "Jederzeit wieder gehen"
 
-#: lib/vutuv_web/templates/page/index.html.heex:558
+#: lib/vutuv_web/templates/page/index.html.heex:588
 #, elixir-autogen, elixir-format
 msgid "Open source"
 msgstr "Open Source"
 
-#: lib/vutuv_web/templates/page/index.html.heex:560
+#: lib/vutuv_web/templates/page/index.html.heex:590
 #, elixir-autogen, elixir-format
 msgid "You can check at any time how exactly vutuv works. The whole source code is public under the MIT license, so everything said above about your data can be read rather than taken on trust."
 msgstr "Sie können jederzeit nachsehen, wie vutuv genau funktioniert. Der komplette Quellcode ist öffentlich, unter der MIT-Lizenz. Alles, was oben über Ihre Daten steht, lässt sich also nachlesen, statt es uns glauben zu müssen."
 
-#: lib/vutuv_web/templates/page/index.html.heex:533
+#: lib/vutuv_web/templates/page/index.html.heex:563
 #, elixir-autogen, elixir-format
 msgid "Your data stays with you"
 msgstr "Ihre Daten bleiben Ihnen"
 
-#: lib/vutuv_web/templates/page/index.html.heex:549
+#: lib/vutuv_web/templates/page/index.html.heex:579
 #, elixir-autogen, elixir-format
 msgid "Delete your account yourself, without writing to anybody. No questions asked, and you are welcome back any time."
 msgstr "Löschen Sie Ihr Konto selbst, ohne jemandem schreiben zu müssen. No questions asked! Und Sie können jederzeit gerne wiederkommen."
 
-#: lib/vutuv_web/components/ui.ex:256
+#: lib/vutuv_web/components/ui.ex:257
 #, elixir-autogen, elixir-format
 msgid "At most %{max} tags. Remove one to add another."
 msgstr "Höchstens %{max} Tags. Entfernen Sie eines, um ein anderes hinzuzufügen."
@@ -18801,7 +18803,7 @@ msgstr "Meinen Namen bei Beiträgen zeigen, die mir gefallen"
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr "Wenn aus, sehen andere Mitglieder Sie nicht mehr bei den Likes eines Beitrags. Die Autorin oder der Autor des Beitrags sieht es weiterhin: In der Benachrichtigung von damals haben wir Sie namentlich genannt. Der Beitrag hat in beiden Fällen gleich viele Likes."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:857
+#: lib/vutuv_web/controllers/settings_controller.ex:877
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr "Ihre Likes folgen wieder dem Standardwert der Website."
@@ -18910,7 +18912,7 @@ msgstr "Arbeitszeugnis aktualisiert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:4644
+#: lib/vutuv_web/components/ui.ex:4688
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -19106,7 +19108,7 @@ msgstr "In der Warteschlange, Ihres ist als Nächstes dran."
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr "Sie haben den Text nach dieser Prüfung geändert. Sie beschreibt die frühere Fassung."
 
-#: lib/vutuv_web/components/ui.ex:4645
+#: lib/vutuv_web/components/ui.ex:4689
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr "Ihre Arbeitszeugnisse, privat bis Sie sie veröffentlichen"
@@ -19117,7 +19119,7 @@ msgstr "Ihre Arbeitszeugnisse, privat bis Sie sie veröffentlichen"
 msgid "Zwischenzeugnis"
 msgstr "Zwischenzeugnis"
 
-#: lib/vutuv_web/components/ui.ex:4647
+#: lib/vutuv_web/components/ui.ex:4691
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr "arbeitszeugnis zeugnis referenz beurteilung arbeitgeber bewertung prüfung"
@@ -19372,7 +19374,7 @@ msgstr "Datei hierher ziehen oder eine auswählen"
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr "PDF, JPG, PNG oder WebP, bis %{limit}"
 
-#: lib/vutuv_web/components/ui.ex:3984
+#: lib/vutuv_web/components/ui.ex:4028
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -19621,7 +19623,7 @@ msgstr "Ihr Zeugnis bleibt auf unseren Servern in %{country}."
 msgid "You have reached your limit of %{limit} reviews. Please try again in %{window}."
 msgstr "Sie haben Ihr Limit von %{limit} Prüfungen erreicht. Bitte versuchen Sie es in %{window} wieder."
 
-#: lib/vutuv_web/templates/page/index.html.heex:379
+#: lib/vutuv_web/templates/page/index.html.heex:409
 #, elixir-autogen, elixir-format
 msgid "Employment reference"
 msgstr "Arbeitszeugnis"
@@ -19631,7 +19633,7 @@ msgstr "Arbeitszeugnis"
 msgid "Employment references: upload them, keep them private, and have the wording read and graded on our own servers."
 msgstr "Arbeitszeugnisse hochladen, privat halten und die Formulierungen auf unseren eigenen Servern lesen und benoten lassen."
 
-#: lib/vutuv_web/templates/page/index.html.heex:356
+#: lib/vutuv_web/templates/page/index.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "Job applications"
 msgstr "Bewerbungsunterlagen"
@@ -19646,7 +19648,7 @@ msgstr "Der Lebenslauf-Baukasten: eine Liste zum Abhaken mit allem, was in den L
 msgid "The finished CV ready to print: name, tagline and contact details at the top, below them the positions held with employer and period, and further down the tags and the spoken languages."
 msgstr "Der fertige Lebenslauf in der Druckansicht: oben Name, Kurzbeschreibung und Kontaktdaten, darunter die Stationen mit Arbeitgeber und Zeitraum, weiter unten die Tags und die Sprachkenntnisse."
 
-#: lib/vutuv_web/templates/page/index.html.heex:399
+#: lib/vutuv_web/templates/page/index.html.heex:429
 #, elixir-autogen, elixir-format
 msgid "The review is a text analysis, not legal advice, and it covers German employment references."
 msgstr "Die Prüfung ist eine Textanalyse, keine Rechtsberatung, und sie deckt deutsche Arbeitszeugnisse ab."
@@ -19661,22 +19663,22 @@ msgstr "Die Prüfung eines einzelnen Arbeitszeugnisses: die Gesamtnote in einem 
 msgid "The uploaded employment references, each marked private: one graded 1 (very good) on a green panel, one graded 4 to 5 (poor to unsatisfactory) on a red one, each with a link to its full report."
 msgstr "Die hochgeladenen Arbeitszeugnisse, jedes als privat gekennzeichnet: eines mit der Note 1 (sehr gut) in einem grünen Feld, eines mit der Note 4 bis 5 (mangelhaft bis ungenügend) in einem roten, jeweils mit einem Link zum vollständigen Bericht."
 
-#: lib/vutuv_web/templates/page/index.html.heex:382
+#: lib/vutuv_web/templates/page/index.html.heex:412
 #, elixir-autogen, elixir-format
 msgid "Upload your employment references and have them read sentence by sentence: a grade, a traffic light, and the explanation of how a recruiter reads that wording. It takes a few minutes, then the report is there. Nothing becomes public before you release it."
 msgstr "Laden Sie Ihre Arbeitszeugnisse hoch und lassen Sie sie Satz für Satz durchlesen: Note, Ampel und die Erklärung, wie ein Personaler die Formulierung liest. Das dauert ein paar Minuten, dann steht der Bericht da. Öffentlich wird nichts davon, bevor Sie es freigeben."
 
-#: lib/vutuv_web/templates/page/index.html.heex:380
+#: lib/vutuv_web/templates/page/index.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "What your employment reference really says"
 msgstr "Was in Ihrem Arbeitszeugnis wirklich steht"
 
-#: lib/vutuv_web/templates/page/index.html.heex:359
+#: lib/vutuv_web/templates/page/index.html.heex:389
 #, elixir-autogen, elixir-format
 msgid "What your profile already says becomes a CV. You tick what should go in, then download it as PDF, Word, OpenDocument, LaTeX or JSON Resume. Anonymously as well, if you would rather show what you can do before you show who you are."
 msgstr "Was auf Ihrem Profil steht, wird auf Wunsch ein Lebenslauf. Sie haken an, was hinein soll, und laden ihn als PDF, Word, OpenDocument, LaTeX oder JSON Resume herunter. Auch anonym, wenn Sie lieber erst zeigen, was Sie können, bevor Sie zeigen, wer Sie sind."
 
-#: lib/vutuv_web/templates/page/index.html.heex:357
+#: lib/vutuv_web/templates/page/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "Your CV, ready to send"
 msgstr "Ihr Lebenslauf, fertig zum Verschicken"
@@ -19727,14 +19729,14 @@ msgstr "6-stellige PIN"
 msgid "Enter the PIN from the email"
 msgstr "PIN aus der E-Mail eingeben"
 
-#: lib/vutuv_web/components/ui.ex:763
+#: lib/vutuv_web/components/ui.ex:807
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 "Wenn Sie Ihrem vutuv-Konto weitere Adressen hinzugefügt haben, melden Sie "
 "sich stattdessen mit einer davon an."
 
-#: lib/vutuv_web/components/ui.ex:791
+#: lib/vutuv_web/components/ui.ex:835
 #, elixir-autogen, elixir-format
 msgid "Cancel registration"
 msgstr "Registrierung abbrechen"
@@ -19752,24 +19754,24 @@ msgstr ""
 msgid "Follow other members"
 msgstr "Anderen Mitgliedern folgen"
 
-#: lib/vutuv_web/components/ui.ex:746
+#: lib/vutuv_web/components/ui.ex:790
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 "Kommt keine PIN an? Ist die E-Mail-Adresse {email} korrekt? Haben Sie einmal "
 "in Ihren Spam-Ordner geschaut?"
 
-#: lib/vutuv/accounts/user.ex:1346
+#: lib/vutuv/accounts/user.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/vutuv/accounts/user.ex:1344
+#: lib/vutuv/accounts/user.ex:1350
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Weiblich"
 
-#: lib/vutuv/accounts/user.ex:1345
+#: lib/vutuv/accounts/user.ex:1351
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
@@ -19781,7 +19783,7 @@ msgstr ""
 "Anteile bezogen auf die %{answered} Mitglieder mit Angabe. %{unanswered} ohne "
 "Angabe."
 
-#: lib/vutuv_web/components/ui.ex:4626
+#: lib/vutuv_web/components/ui.ex:4670
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr "avatar profilbild portrait foto bild geburtstag geburtsdatum geschlecht über mich"
@@ -19877,7 +19879,7 @@ msgstr "Ebenfalls löschen"
 msgid "Always keep"
 msgstr "Immer behalten"
 
-#: lib/vutuv_web/components/ui.ex:4746
+#: lib/vutuv_web/components/ui.ex:4790
 #: lib/vutuv_web/controllers/settings_controller.ex:247
 #: lib/vutuv_web/controllers/settings_controller.ex:326
 #: lib/vutuv_web/controllers/settings_controller.ex:338
@@ -19974,7 +19976,7 @@ msgstr "Fotobeiträge behalten"
 msgid "Keep posts that did well"
 msgstr "Beiträge behalten, die gut liefen"
 
-#: lib/vutuv_web/components/ui.ex:4748
+#: lib/vutuv_web/components/ui.ex:4792
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr "Ihre Beiträge nach einer selbst gewählten Zeit auslaufen lassen"
@@ -20083,7 +20085,7 @@ msgstr "Sie können vorher alles herunterladen, was Sie hier haben:"
 msgid "Your rule"
 msgstr "Ihre Regel"
 
-#: lib/vutuv_web/components/ui.ex:4750
+#: lib/vutuv_web/components/ui.ex:4794
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr "löschen entfernen beiträge alter alt ablaufen verfallen automatisch aufräumen aufbewahrung"
@@ -20517,17 +20519,17 @@ msgstr "Der Besitzer vergibt die Rollen der anderen Mitglieder auf der Seite und
 msgid "Nothing published yet."
 msgstr "Noch nichts veröffentlicht."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1897
+#: lib/vutuv_web/live/post_live/composer.ex:1925
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr "Als %{name} veröffentlichen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1260
+#: lib/vutuv_web/live/post_live/composer.ex:1271
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1874
+#: lib/vutuv_web/live/post_live/composer.ex:1902
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr "Ein Beitrag im Namen einer Organisation ist immer öffentlich."
@@ -20814,12 +20816,12 @@ msgstr "Diese Seite war früher auf anderen Netzwerken sichtbar. Server, die noc
 msgid "This vutuv exchanges nothing with other networks, so nothing here has any effect."
 msgstr "Dieses vutuv tauscht nichts mit anderen Netzwerken aus, hier hat also nichts eine Wirkung."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:442
+#: lib/vutuv_web/live/organization_live/edit.ex:443
 #, elixir-autogen, elixir-format
 msgid "Claim a short @name so this organization has an address of its own, like a member. Letters, numbers and underscores, %{min} to %{max} characters."
 msgstr "Reservieren Sie einen kurzen @-Namen, damit diese Organisation eine eigene Adresse bekommt, so wie ein Mitglied. Buchstaben, Zahlen und Unterstriche, %{min} bis %{max} Zeichen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:440
+#: lib/vutuv_web/live/organization_live/edit.ex:441
 #, elixir-autogen, elixir-format
 msgid "The organization's @name"
 msgstr "Der @-Name der Organisation"
@@ -20874,22 +20876,22 @@ msgstr "Neu registrieren"
 msgid "The PIN has expired."
 msgstr "Die PIN ist abgelaufen."
 
-#: lib/vutuv_web/components/ui.ex:867
+#: lib/vutuv_web/components/ui.ex:911
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr "Die PIN ist noch eine Minute gültig."
 
-#: lib/vutuv_web/components/ui.ex:869
+#: lib/vutuv_web/components/ui.ex:913
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr "Die PIN ist noch eine Sekunde gültig."
 
-#: lib/vutuv_web/components/ui.ex:868
+#: lib/vutuv_web/components/ui.ex:912
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr "Die PIN ist noch {n} Minuten gültig."
 
-#: lib/vutuv_web/components/ui.ex:870
+#: lib/vutuv_web/components/ui.ex:914
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr "Die PIN ist noch {n} Sekunden gültig."
@@ -21327,17 +21329,17 @@ msgstr "Sie haben %{used} von %{max} Tags."
 msgid "{n} of {max} free slots selected."
 msgstr "{n} von {max} freien Plätzen ausgewählt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1939
+#: lib/vutuv_web/live/post_live/composer.ex:1967
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr "Weitere Sprachen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1924
+#: lib/vutuv_web/live/post_live/composer.ex:1952
 #, elixir-autogen, elixir-format
 msgid "Post language"
 msgstr "Sprache des Beitrags"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1929
+#: lib/vutuv_web/live/post_live/composer.ex:1957
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr "Die Sprache, in der dieser Beitrag geschrieben ist"
@@ -21373,7 +21375,7 @@ msgid "Feed language settings reset to the site defaults."
 msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
 
 #: lib/vutuv_web/components/post_components.ex:4697
-#: lib/vutuv_web/components/ui.ex:4705
+#: lib/vutuv_web/components/ui.ex:4749
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -21401,7 +21403,7 @@ msgstr "In meine Sprache übersetzen"
 msgid "What your feed does with posts outside your chosen languages: show them as they are, translate them for you, or hide them. Posts that declare no language always show."
 msgstr "Was Ihr Feed mit Beiträgen außerhalb Ihrer gewählten Sprachen macht: im Original zeigen, für Sie übersetzen oder ausblenden. Beiträge ohne Sprachangabe werden immer gezeigt."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:110
+#: lib/vutuv_web/gettext_extraction_anchors.ex:116
 #, elixir-autogen, elixir-format
 msgid "Date & time"
 msgstr "Datum & Uhrzeit"
@@ -21411,12 +21413,12 @@ msgstr "Datum & Uhrzeit"
 msgid "Date and time settings reset to the site defaults."
 msgstr "Datum und Uhrzeit folgen wieder den Voreinstellungen der Website."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:108
+#: lib/vutuv_web/gettext_extraction_anchors.ex:114
 #, elixir-autogen, elixir-format
 msgid "Date format"
 msgstr "Datumsformat"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:118
+#: lib/vutuv_web/gettext_extraction_anchors.ex:124
 #, elixir-autogen, elixir-format
 msgid "Germany, Austria, Switzerland"
 msgstr "Deutschland, Österreich, Schweiz"
@@ -21426,27 +21428,27 @@ msgstr "Deutschland, Österreich, Schweiz"
 msgid "Language and region saved."
 msgstr "Sprache und Region gespeichert."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:114
+#: lib/vutuv_web/gettext_extraction_anchors.ex:120
 #, elixir-autogen, elixir-format
 msgid "Posts, messages and notifications are stamped in this zone. New accounts take it from the browser."
 msgstr "Beiträge, Nachrichten und Benachrichtigungen tragen die Uhrzeit dieser Zeitzone. Neue Konten übernehmen sie vom Browser."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:111
+#: lib/vutuv_web/gettext_extraction_anchors.ex:117
 #, elixir-autogen, elixir-format
 msgid "The order and punctuation of every date you read here, and whether times run on a 12- or 24-hour clock."
 msgstr "Reihenfolge und Trennzeichen aller Datumsangaben, die Sie hier lesen, und ob Uhrzeiten im 12- oder 24-Stunden-Format stehen."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:109
+#: lib/vutuv_web/gettext_extraction_anchors.ex:115
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "Zeitzone"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:119
+#: lib/vutuv_web/gettext_extraction_anchors.ex:125
 #, elixir-autogen, elixir-format
 msgid "United Kingdom, France, Brazil"
 msgstr "Vereinigtes Königreich, Frankreich, Brasilien"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:120
+#: lib/vutuv_web/gettext_extraction_anchors.ex:126
 #, elixir-autogen, elixir-format
 msgid "United States"
 msgstr "Vereinigte Staaten"
@@ -21456,7 +21458,7 @@ msgstr "Vereinigte Staaten"
 msgid "Your browser says: {zone}"
 msgstr "Ihr Browser meldet: {zone}"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:121
+#: lib/vutuv_web/gettext_extraction_anchors.ex:127
 #, elixir-autogen, elixir-format
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr "ISO 8601 (Schweden, Japan, China)"
@@ -21583,7 +21585,7 @@ msgstr "Damit können Sie sich von einer Mastodon-kompatiblen App aus bei diesem
 msgid "Mastodon app access changed"
 msgstr "Mastodon-App-Zugriff geändert"
 
-#: lib/vutuv_web/components/ui.ex:4794
+#: lib/vutuv_web/components/ui.ex:4838
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr "Mastodon-Apps, verbundene Apps und Zugriffstoken"
@@ -21629,7 +21631,7 @@ msgstr "Wer etwas geschrieben hat, wird weiter festgehalten, das Team kann also 
 msgid "Your account is then %{handle}."
 msgstr "Dein Konto heißt dann %{handle}."
 
-#: lib/vutuv_web/components/ui.ex:4796
+#: lib/vutuv_web/components/ui.ex:4840
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr "api token oauth entwickler verbunden drittanbieter schnittstelle mastodon app handy telefon client ivory tusky ice cubes anmelden"
@@ -21665,7 +21667,7 @@ msgstr "Bekannte aus LinkedIn finden"
 msgid "Find your LinkedIn contacts"
 msgstr "Ihre LinkedIn-Kontakte finden"
 
-#: lib/vutuv_web/components/ui.ex:4721
+#: lib/vutuv_web/components/ui.ex:4765
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format
@@ -21773,7 +21775,7 @@ msgstr "Nach Namen suchen"
 msgid "See which of them are already on vutuv"
 msgstr "Sehen Sie, wer davon schon auf vutuv ist"
 
-#: lib/vutuv_web/components/ui.ex:4723
+#: lib/vutuv_web/components/ui.ex:4767
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr "Sehen, wer aus Ihren LinkedIn-Kontakten schon auf vutuv ist"
@@ -21845,7 +21847,7 @@ msgstr "Ihre Kontakte auf vutuv"
 msgid "Your export also lists your LinkedIn contacts."
 msgstr "Ihr Export enthält auch Ihre LinkedIn-Kontakte."
 
-#: lib/vutuv_web/components/ui.ex:4725
+#: lib/vutuv_web/components/ui.ex:4769
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr "linkedin kontakte verbindungen adressbuch bekannte kollegen finden folgen zip import netzwerk"
@@ -21989,7 +21991,7 @@ msgctxt "qualification detail"
 msgid "Jobs"
 msgstr "Jobs"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:835
+#: lib/vutuv_web/live/job_posting_live/form.ex:836
 #, elixir-autogen, elixir-format
 msgid "%{formatted} country chosen."
 msgid_plural "%{formatted} countries chosen."
@@ -22101,7 +22103,7 @@ msgstr "Wenn etwas eintrifft, während vutuv in einem Tab offen ist, den Sie ger
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr "Sie haben Browser-Benachrichtigungen eingeschaltet. Dieser Browser wurde noch nicht um Erlaubnis gebeten."
 
-#: lib/vutuv_web/components/ui.ex:4693
+#: lib/vutuv_web/components/ui.ex:4737
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr "e-mail email mail abbestellen abmelden newsletter glocke benachrichtigung weniger ruhe browser desktop popup push hinweis mitteilung"
@@ -22162,43 +22164,43 @@ msgstr "Andere Mitglieder begrüßen"
 msgid "New here"
 msgstr "Neu dabei"
 
-#: lib/vutuv_web/components/ui.ex:1499
+#: lib/vutuv_web/components/ui.ex:1543
 #, elixir-autogen, elixir-format
 msgid "New public posts arrive in any feed reader. No account needed either."
 msgstr "Neue öffentliche Beiträge landen in jedem Feed-Reader. Auch dafür brauchen Sie kein Konto."
 
-#: lib/vutuv_web/components/ui.ex:1495
+#: lib/vutuv_web/components/ui.ex:1539
 #, elixir-autogen, elixir-format
 msgid "Or with an RSS reader"
 msgstr "Oder mit einem RSS-Reader"
 
-#: lib/vutuv_web/components/ui.ex:1375
-#: lib/vutuv_web/components/ui.ex:1444
+#: lib/vutuv_web/components/ui.ex:1419
+#: lib/vutuv_web/components/ui.ex:1488
 #, elixir-autogen, elixir-format
 msgid "Subscribe"
 msgstr "Abonnieren"
 
-#: lib/vutuv_web/components/ui.ex:1496
+#: lib/vutuv_web/components/ui.ex:1540
 #, elixir-autogen, elixir-format
 msgid "With an RSS reader"
 msgstr "Mit einem RSS-Reader"
 
-#: lib/vutuv_web/components/ui.ex:1456
+#: lib/vutuv_web/components/ui.ex:1500
 #, elixir-autogen, elixir-format
 msgid "Create a free account"
 msgstr "Kostenloses Konto erstellen"
 
-#: lib/vutuv_web/components/ui.ex:1471
+#: lib/vutuv_web/components/ui.ex:1515
 #, elixir-autogen, elixir-format
 msgid "No vutuv account? These ways work too:"
 msgstr "Kein vutuv-Konto? Das geht auch:"
 
-#: lib/vutuv_web/components/ui.ex:1449
+#: lib/vutuv_web/components/ui.ex:1493
 #, elixir-autogen, elixir-format
 msgid "The best way: follow %{name} here. New posts land in your feed, and you can reply and join in."
 msgstr "Der beste Weg: Folgen Sie %{name} hier. Neue Beiträge landen in Ihrem Feed, und Sie können antworten und mitreden."
 
-#: lib/vutuv_web/components/ui.ex:1447
+#: lib/vutuv_web/components/ui.ex:1491
 #, elixir-autogen, elixir-format
 msgid "With a vutuv account"
 msgstr "Mit einem vutuv-Konto"
@@ -22210,7 +22212,7 @@ msgstr ""
 "Ein paar der neuesten Mitglieder. Ihnen zu folgen ist eine herzliche "
 "Begrüßung."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:234
+#: lib/vutuv_web/templates/settings/preferences.html.heex:278
 #, elixir-autogen, elixir-format
 msgid "Example"
 msgstr "Beispiel"
@@ -22225,12 +22227,12 @@ msgstr "Feed-Reiter"
 msgid "Just flashed the new release, boot is under two seconds now"
 msgstr "Neue Version geflasht, der Bootvorgang liegt jetzt unter zwei Sekunden"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:244
+#: lib/vutuv_web/templates/settings/preferences.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "Play the example"
 msgstr "Beispiel abspielen"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:99
+#: lib/vutuv_web/gettext_extraction_anchors.ex:105
 #, elixir-autogen, elixir-format
 msgid "Between 4 and 20 seconds."
 msgstr "Zwischen 4 und 20 Sekunden."
@@ -22333,26 +22335,26 @@ msgstr "Wird in Ihrem Feed ausgeblendet."
 msgid "Shown in the language it was written in."
 msgstr "Wird in der Sprache gezeigt, in der es geschrieben wurde."
 
-#: lib/vutuv_web/components/ui.ex:4706
+#: lib/vutuv_web/components/ui.ex:4750
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr "Welche Sprachen Sie erreichen und was mit dem Rest geschieht"
 
-#: lib/vutuv_web/components/ui.ex:4708
+#: lib/vutuv_web/components/ui.ex:4752
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr ""
 "sprache übersetzen übersetzung deutsch englisch original ausblenden "
 "fremdsprache reihenfolge rang feed language translate"
 
-#: lib/vutuv_web/components/ui.ex:4773
+#: lib/vutuv_web/components/ui.ex:4817
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr ""
 "Anzeigesprache, Datumsformat und Zeitzone, Karten, wie Beiträge gekürzt "
 "werden"
 
-#: lib/vutuv_web/components/ui.ex:4777
+#: lib/vutuv_web/components/ui.ex:4821
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -22389,7 +22391,7 @@ msgstr[0] "+%{formatted} weiterer Beitrag"
 msgstr[1] "+%{formatted} weitere Beiträge"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:94
-#: lib/vutuv_web/templates/settings/preferences.html.heex:210
+#: lib/vutuv_web/templates/settings/preferences.html.heex:254
 #, elixir-autogen, elixir-format
 msgid "Browser tab"
 msgstr "Browser-Tab"
@@ -22414,12 +22416,12 @@ msgstr "Nur solange Sie einen anderen Tab ansehen, und nur für ein paar Sekunde
 msgid "Tease new posts in the browser tab"
 msgstr "Neue Beiträge im Browser-Tab anreißen"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:236
+#: lib/vutuv_web/templates/settings/preferences.html.heex:280
 #, elixir-autogen, elixir-format
 msgid "Watch this tab's title, above."
 msgstr "Achten Sie oben auf den Titel dieses Tabs."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:212
+#: lib/vutuv_web/templates/settings/preferences.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "While you are reading another tab, a new post can page its first words through this tab's title, a line at a time, and then hand the title back."
 msgstr "Während Sie einen anderen Tab lesen, kann ein neuer Beitrag seine ersten Worte durch den Titel dieses Tabs blättern, Zeile für Zeile, und den Titel danach wieder freigeben."
@@ -22481,7 +22483,7 @@ msgstr "Keine bezahlten Premium-Accounts."
 msgid "Your LinkedIn profile can come along."
 msgstr "Ihr LinkedIn-Profil kann mitkommen."
 
-#: lib/vutuv_web/components/ui.ex:1067
+#: lib/vutuv_web/components/ui.ex:1111
 #, elixir-autogen, elixir-format
 msgid "Being checked"
 msgstr "Wird geprüft"
@@ -22705,7 +22707,7 @@ msgstr "Mehr Ihrer %{formatted} Konten"
 msgid "Move %{card}"
 msgstr "%{card} verschieben"
 
-#: lib/vutuv_web/components/ui.ex:350
+#: lib/vutuv_web/components/ui.ex:544
 #: lib/vutuv_web/live/post_live/filter_band.ex:583
 #, elixir-autogen, elixir-format
 msgid "No account found."
@@ -22874,7 +22876,7 @@ msgstr ""
 "Ihre Organisationsseite wurde aktualisiert, aber dieses Bild konnte nicht als "
 "Logo verwendet werden. Bitte wählen Sie ein anderes."
 
-#: lib/vutuv_web/components/ui.ex:3990
+#: lib/vutuv_web/components/ui.ex:4034
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -23036,12 +23038,12 @@ msgstr "Zitiert %{name}: %{url}"
 msgid "Quotes %{url}"
 msgstr "Zitiert %{url}"
 
-#: lib/vutuv_web/components/ui.ex:349
+#: lib/vutuv_web/components/ui.ex:543
 #, elixir-autogen, elixir-format
 msgid "Mention an account"
 msgstr "Ein Konto erwähnen"
 
-#: lib/vutuv_web/components/ui.ex:352
+#: lib/vutuv_web/components/ui.ex:546
 #, elixir-autogen, elixir-format
 msgid "{used} of {max} mentions"
 msgstr "{used} von {max} Erwähnungen"
@@ -23072,7 +23074,7 @@ msgstr "Bleibt das Account-Feld leer, gilt die Regel für alle; %{example} grenz
 msgid "Only these accounts (empty = all) …"
 msgstr "Nur diese Accounts (leer = alle) …"
 
-#: lib/vutuv_web/components/ui.ex:3115
+#: lib/vutuv_web/components/ui.ex:3159
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr "nur %{account}"
@@ -23122,33 +23124,33 @@ msgid_plural "shared this."
 msgstr[0] "hat das geteilt."
 msgstr[1] "haben das geteilt."
 
-#: lib/vutuv_web/components/ui.ex:475
+#: lib/vutuv_web/components/ui.ex:482
 #, elixir-autogen, elixir-format
 msgid "Editor view"
 msgstr "Ansicht"
 
-#: lib/vutuv_web/components/ui.ex:423
+#: lib/vutuv_web/components/ui.ex:430
 #, elixir-autogen, elixir-format
 msgid "Insert a block"
 msgstr "Block einfügen"
 
-#: lib/vutuv_web/components/ui.ex:435
+#: lib/vutuv_web/components/ui.ex:442
 #, elixir-autogen, elixir-format
 msgid "Nothing matches."
 msgstr "Nichts gefunden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1750
-#: lib/vutuv_web/live/post_live/composer.ex:2483
+#: lib/vutuv_web/live/post_live/composer.ex:1778
+#: lib/vutuv_web/live/post_live/composer.ex:2513
 #, elixir-autogen, elixir-format
 msgid "Automatic"
 msgstr "Automatisch"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1755
+#: lib/vutuv_web/live/post_live/composer.ex:1783
 #, elixir-autogen, elixir-format
 msgid "Drag one photo onto another to swap them."
 msgstr "Ein Foto auf ein anderes ziehen, um sie zu tauschen."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1702
+#: lib/vutuv_web/live/post_live/composer.ex:1730
 #, elixir-autogen, elixir-format
 msgid "Not shown in the gallery — drag one into it to swap."
 msgstr "Nicht in der Galerie zu sehen — eines hineinziehen, um zu tauschen."
@@ -23205,32 +23207,63 @@ msgstr "Anfrage wirklich zurückziehen?"
 msgid "Unmute %{host}"
 msgstr "%{host} wieder einschalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1510
+#: lib/vutuv_web/live/post_live/composer.ex:1538
 #, elixir-autogen, elixir-format
 msgid "Draft discarded."
 msgstr "Entwurf gelöscht."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1549
+#: lib/vutuv_web/live/post_live/composer.ex:1577
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr "Behalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1540
+#: lib/vutuv_web/live/post_live/composer.ex:1568
 #, elixir-autogen, elixir-format
 msgid "Keep this draft for later?"
 msgstr "Diesen Entwurf für später behalten?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1175
+#: lib/vutuv_web/live/post_live/composer.ex:1186
 #, elixir-autogen, elixir-format
 msgid "Hidden from some"
 msgstr "Für manche verborgen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1857
+#: lib/vutuv_web/live/post_live/composer.ex:1885
 #, elixir-autogen, elixir-format
 msgid "Post options"
 msgstr "Beitragsoptionen"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:314
+#: lib/vutuv_web/live/organization_live/edit.ex:315
 #, elixir-autogen, elixir-format
 msgid "Describe the organization. Markdown is supported."
 msgstr "Beschreiben Sie die Organisation. Markdown wird unterstützt."
+
+#: lib/vutuv_web/templates/page/index.html.heex:286
+#: lib/vutuv_web/templates/settings/preferences.html.heex:205
+#, elixir-autogen, elixir-format
+msgid "Bandwidth"
+msgstr "Bandbreite"
+
+#: lib/vutuv_web/controllers/settings_controller.ex:868
+#, elixir-autogen, elixir-format
+msgid "Bandwidth settings reset to the site defaults."
+msgstr "Einstellungen zur Bandbreite auf die Website-Vorgaben zurückgesetzt."
+
+#: lib/vutuv_web/controllers/settings_controller.ex:862
+#, elixir-autogen, elixir-format
+msgid "Bandwidth settings saved."
+msgstr "Einstellungen zur Bandbreite gespeichert."
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:207
+#, elixir-autogen, elixir-format
+msgid "If you are on a slow or metered connection, vutuv can leave out the parts of the page that cost the most to download."
+msgstr "Wenn Ihre Verbindung langsam ist oder Ihr Datenvolumen begrenzt, kann vutuv die Teile der Seite weglassen, die beim Laden am meisten kosten."
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:101
+#, elixir-autogen, elixir-format
+msgid "Low-bandwidth mode"
+msgstr "Datensparmodus"
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:102
+#, elixir-autogen, elixir-format
+msgid "Writing a post or a message then uses a plain Markdown box instead of the formatting editor, which saves about 150 kB of download. Everything you write still looks the same to everyone who reads it."
+msgstr "Beiträge und Nachrichten schreiben Sie dann in einem einfachen Markdown-Feld statt im Editor mit Formatierung. Das spart etwa 150 kB Download. Für alle, die Ihren Text lesen, sieht er genauso aus wie sonst."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -17,12 +17,12 @@ msgstr ""
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4370
-#: lib/vutuv_web/components/ui.ex:4375
+#: lib/vutuv_web/components/ui.ex:4414
+#: lib/vutuv_web/components/ui.ex:4419
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
 #: lib/vutuv_web/live/organization_live/domains.ex:272
-#: lib/vutuv_web/live/organization_live/edit.ex:430
+#: lib/vutuv_web/live/organization_live/edit.ex:431
 #: lib/vutuv_web/live/organization_live/roles.ex:214
 #, elixir-autogen
 msgid "Add"
@@ -64,7 +64,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/text.ex:71
-#: lib/vutuv_web/components/ui.ex:4668
+#: lib/vutuv_web/components/ui.ex:4712
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -77,14 +77,14 @@ msgstr ""
 msgid "Addresses"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1462
-#: lib/vutuv_web/templates/page/index.html.heex:290
+#: lib/vutuv_web/components/ui.ex:1506
+#: lib/vutuv_web/templates/page/index.html.heex:320
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4165
-#: lib/vutuv_web/components/ui.ex:4259
+#: lib/vutuv_web/components/ui.ex:4209
+#: lib/vutuv_web/components/ui.ex:4303
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -112,14 +112,14 @@ msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:114
-#: lib/vutuv_web/components/ui.ex:4159
+#: lib/vutuv_web/components/ui.ex:4203
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
-#: lib/vutuv_web/live/job_posting_live/form.ex:811
-#: lib/vutuv_web/live/organization_live/edit.ex:381
+#: lib/vutuv_web/live/job_posting_live/form.ex:812
+#: lib/vutuv_web/live/organization_live/edit.ex:382
 #: lib/vutuv_web/live/organization_live/new.ex:231
-#: lib/vutuv_web/live/post_live/composer.ex:1669
+#: lib/vutuv_web/live/post_live/composer.ex:1697
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -163,7 +163,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3586
-#: lib/vutuv_web/components/ui.ex:4262
+#: lib/vutuv_web/components/ui.ex:4306
 #: lib/vutuv_web/live/admin/job_live.ex:489
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -179,7 +179,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:686
 #: lib/vutuv_web/live/organization_live/edit.ex:301
-#: lib/vutuv_web/live/organization_live/edit.ex:313
+#: lib/vutuv_web/live/organization_live/edit.ex:314
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
 #: lib/vutuv_web/templates/address/form_en.html.heex:11
 #: lib/vutuv_web/templates/address/form_generic.html.heex:13
@@ -203,7 +203,7 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:438
-#: lib/vutuv_web/live/post_live/composer.ex:2579
+#: lib/vutuv_web/live/post_live/composer.ex:2609
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
@@ -211,7 +211,7 @@ msgid "Download"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3551
-#: lib/vutuv_web/components/ui.ex:4253
+#: lib/vutuv_web/components/ui.ex:4297
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -285,7 +285,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:4632
+#: lib/vutuv_web/components/ui.ex:4676
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -326,8 +326,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:632
 #: lib/vutuv_web/agent_docs/text.ex:596
 #: lib/vutuv_web/components/fediverse_components.ex:400
-#: lib/vutuv_web/components/ui.ex:2661
-#: lib/vutuv_web/components/ui.ex:2696
+#: lib/vutuv_web/components/ui.ex:2705
+#: lib/vutuv_web/components/ui.ex:2740
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:608
@@ -603,7 +603,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1881
+#: lib/vutuv_web/live/post_live/composer.ex:1909
 #: lib/vutuv_web/live/section_reorder_live.ex:270
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -613,9 +613,9 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4158
-#: lib/vutuv_web/live/organization_live/edit.ex:375
-#: lib/vutuv_web/live/post_live/composer.ex:1896
+#: lib/vutuv_web/components/ui.ex:4202
+#: lib/vutuv_web/live/organization_live/edit.ex:376
+#: lib/vutuv_web/live/post_live/composer.ex:1924
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -625,8 +625,9 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
 #: lib/vutuv_web/templates/settings/preferences.html.heex:157
-#: lib/vutuv_web/templates/settings/preferences.html.heex:229
-#: lib/vutuv_web/templates/settings/preferences.html.heex:362
+#: lib/vutuv_web/templates/settings/preferences.html.heex:224
+#: lib/vutuv_web/templates/settings/preferences.html.heex:273
+#: lib/vutuv_web/templates/settings/preferences.html.heex:406
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:462
@@ -665,7 +666,7 @@ msgstr ""
 msgid "Show"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:269
+#: lib/vutuv_web/templates/page/index.html.heex:299
 #, elixir-autogen
 msgid "Sign up for a free account"
 msgstr ""
@@ -788,7 +789,7 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4628
+#: lib/vutuv_web/components/ui.ex:4672
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -840,7 +841,7 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1269
+#: lib/vutuv_web/components/ui.ex:1313
 #: lib/vutuv_web/views/user_html.ex:562
 #: lib/vutuv_web/views/user_html.ex:563
 #: lib/vutuv_web/views/user_html.ex:577
@@ -848,17 +849,17 @@ msgstr ""
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4323
+#: lib/vutuv_web/components/ui.ex:4367
 #: lib/vutuv_web/templates/user/show.html.heex:973
 #: lib/vutuv_web/templates/user/show.html.heex:996
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4736
+#: lib/vutuv_web/components/ui.ex:4780
 #: lib/vutuv_web/controllers/settings_controller.ex:171
-#: lib/vutuv_web/live/job_posting_live/form.ex:767
-#: lib/vutuv_web/live/organization_live/edit.ex:334
+#: lib/vutuv_web/live/job_posting_live/form.ex:768
+#: lib/vutuv_web/live/organization_live/edit.ex:335
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:295
@@ -872,7 +873,7 @@ msgstr ""
 msgid "We can't find em' cap'n!"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:293
+#: lib/vutuv_web/templates/page/index.html.heex:323
 #, elixir-autogen
 msgid "We reserve the right to stop this service or delete your account anytime without warning."
 msgstr ""
@@ -952,7 +953,7 @@ msgstr ""
 msgid "Allow others to view your email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:279
+#: lib/vutuv_web/templates/page/index.html.heex:309
 #, elixir-autogen, elixir-format
 msgid "By creating an account you accept our {nutzungsbedingungen} and confirm that you have read our {datenschutz}."
 msgstr ""
@@ -1076,7 +1077,7 @@ msgstr ""
 msgid "Listings"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:399
+#: lib/vutuv_web/controllers/page_controller.ex:418
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1375,7 +1376,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:522
 #: lib/vutuv_web/agent_docs/text.ex:768
-#: lib/vutuv_web/components/ui.ex:4653
+#: lib/vutuv_web/components/ui.ex:4697
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1386,7 +1387,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:444
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
-#: lib/vutuv_web/live/job_posting_live/form.ex:716
+#: lib/vutuv_web/live/job_posting_live/form.ex:717
 #: lib/vutuv_web/live/search_live.ex:344
 #: lib/vutuv_web/live/search_live.ex:822
 #: lib/vutuv_web/live/tag_new_live.ex:35
@@ -1563,7 +1564,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:776
 #: lib/vutuv_web/live/job_board_live.ex:360
 #: lib/vutuv_web/live/job_posting_live/form.ex:548
-#: lib/vutuv_web/live/organization_live/edit.ex:330
+#: lib/vutuv_web/live/organization_live/edit.ex:331
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
 #: lib/vutuv_web/templates/address/country_input.html.heex:5
@@ -1616,15 +1617,15 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2820
+#: lib/vutuv_web/components/ui.ex:2864
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:480
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1525
-#: lib/vutuv_web/live/post_live/composer.ex:1627
-#: lib/vutuv_web/live/post_live/composer.ex:1628
-#: lib/vutuv_web/live/post_live/composer.ex:2456
-#: lib/vutuv_web/live/post_live/composer.ex:2722
+#: lib/vutuv_web/live/post_live/composer.ex:1553
+#: lib/vutuv_web/live/post_live/composer.ex:1655
+#: lib/vutuv_web/live/post_live/composer.ex:1656
+#: lib/vutuv_web/live/post_live/composer.ex:2486
+#: lib/vutuv_web/live/post_live/composer.ex:2752
 #: lib/vutuv_web/templates/layout/app.html.heex:188
 #: lib/vutuv_web/templates/layout/app.html.heex:194
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
@@ -1647,7 +1648,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/page_controller.ex:254
 #: lib/vutuv_web/templates/layout/app.html.heex:117
-#: lib/vutuv_web/templates/page/index.html.heex:286
+#: lib/vutuv_web/templates/page/index.html.heex:316
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
@@ -1655,7 +1656,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/page_controller.ex:260
 #: lib/vutuv_web/templates/layout/app.html.heex:118
-#: lib/vutuv_web/templates/page/index.html.heex:286
+#: lib/vutuv_web/templates/page/index.html.heex:316
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Nutzungsbedingungen"
@@ -1673,20 +1674,20 @@ msgstr ""
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1981
-#: lib/vutuv_web/components/ui.ex:1990
-#: lib/vutuv_web/components/ui.ex:2468
+#: lib/vutuv_web/components/ui.ex:2025
+#: lib/vutuv_web/components/ui.ex:2034
+#: lib/vutuv_web/components/ui.ex:2512
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:236
-#: lib/vutuv_web/components/ui.ex:2626
-#: lib/vutuv_web/components/ui.ex:2626
-#: lib/vutuv_web/components/ui.ex:2643
-#: lib/vutuv_web/components/ui.ex:2652
-#: lib/vutuv_web/components/ui.ex:2668
-#: lib/vutuv_web/components/ui.ex:2730
+#: lib/vutuv_web/components/ui.ex:2670
+#: lib/vutuv_web/components/ui.ex:2670
+#: lib/vutuv_web/components/ui.ex:2687
+#: lib/vutuv_web/components/ui.ex:2696
+#: lib/vutuv_web/components/ui.ex:2712
+#: lib/vutuv_web/components/ui.ex:2774
 #: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:311
@@ -1758,7 +1759,7 @@ msgid "Network"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:450
-#: lib/vutuv_web/components/ui.ex:4372
+#: lib/vutuv_web/components/ui.ex:4416
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
@@ -1774,7 +1775,7 @@ msgid "Nothing new yet."
 msgstr ""
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:4690
+#: lib/vutuv_web/components/ui.ex:4734
 #: lib/vutuv_web/controllers/page_controller.ex:228
 #: lib/vutuv_web/live/notification_live/index.ex:146
 #: lib/vutuv_web/live/notification_live/index.ex:384
@@ -1800,7 +1801,7 @@ msgid "Pardon us! Something went wrong."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:911
+#: lib/vutuv_web/live/message_live/index.ex:912
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
@@ -1874,8 +1875,8 @@ msgstr ""
 msgid "Who to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:900
 #: lib/vutuv_web/live/message_live/index.ex:901
+#: lib/vutuv_web/live/message_live/index.ex:902
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr ""
@@ -1920,15 +1921,15 @@ msgstr ""
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3651
-#: lib/vutuv_web/components/ui.ex:3804
+#: lib/vutuv_web/components/ui.ex:3695
+#: lib/vutuv_web/components/ui.ex:3848
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4397
+#: lib/vutuv_web/components/ui.ex:4441
 #: lib/vutuv_web/live/organization_live/activity.ex:151
 #: lib/vutuv_web/live/organization_live/feed.ex:210
 #: lib/vutuv_web/live/organization_live/show.ex:777
@@ -1941,13 +1942,13 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4168
+#: lib/vutuv_web/components/ui.ex:4212
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1662
-#: lib/vutuv_web/components/ui.ex:1672
+#: lib/vutuv_web/components/ui.ex:1706
+#: lib/vutuv_web/components/ui.ex:1716
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr ""
@@ -1986,12 +1987,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3174
+#: lib/vutuv_web/components/ui.ex:3218
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3178
+#: lib/vutuv_web/components/ui.ex:3222
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -2016,37 +2017,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3182
+#: lib/vutuv_web/components/ui.ex:3226
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3172
+#: lib/vutuv_web/components/ui.ex:3216
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3171
+#: lib/vutuv_web/components/ui.ex:3215
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3177
+#: lib/vutuv_web/components/ui.ex:3221
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3176
+#: lib/vutuv_web/components/ui.ex:3220
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3173
+#: lib/vutuv_web/components/ui.ex:3217
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3175
+#: lib/vutuv_web/components/ui.ex:3219
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2061,17 +2062,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3181
+#: lib/vutuv_web/components/ui.ex:3225
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3180
+#: lib/vutuv_web/components/ui.ex:3224
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3179
+#: lib/vutuv_web/components/ui.ex:3223
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2083,12 +2084,12 @@ msgstr ""
 msgid "Markdown is supported: bold, italics, links and lists."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:709
+#: lib/vutuv_web/live/job_posting_live/form.ex:710
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2074
+#: lib/vutuv_web/live/post_live/composer.ex:2102
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2099,7 +2100,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1767
+#: lib/vutuv_web/live/post_live/composer.ex:1795
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2144,12 +2145,12 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2050
+#: lib/vutuv_web/live/post_live/composer.ex:2078
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1978
+#: lib/vutuv_web/live/post_live/composer.ex:2006
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
@@ -2160,13 +2161,13 @@ msgstr ""
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2020
+#: lib/vutuv_web/live/post_live/composer.ex:2048
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1284
-#: lib/vutuv_web/live/post_live/composer.ex:1332
+#: lib/vutuv_web/live/post_live/composer.ex:1295
+#: lib/vutuv_web/live/post_live/composer.ex:1343
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
@@ -2176,23 +2177,23 @@ msgstr ""
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1250
+#: lib/vutuv_web/live/post_live/composer.ex:1261
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2010
+#: lib/vutuv_web/live/post_live/composer.ex:2038
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2000
+#: lib/vutuv_web/live/post_live/composer.ex:2028
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:416
-#: lib/vutuv_web/live/post_live/composer.ex:1898
+#: lib/vutuv_web/live/post_live/composer.ex:1926
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2207,7 +2208,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/post_controller.ex:62
 #: lib/vutuv_web/controllers/post_controller.ex:74
 #: lib/vutuv_web/controllers/user_controller.ex:76
-#: lib/vutuv_web/gettext_extraction_anchors.ex:103
+#: lib/vutuv_web/gettext_extraction_anchors.ex:109
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:388
 #: lib/vutuv_web/live/notification_live/index.ex:1125
@@ -2215,7 +2216,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:345
 #: lib/vutuv_web/live/search_live.ex:836
-#: lib/vutuv_web/templates/settings/preferences.html.heex:275
+#: lib/vutuv_web/templates/settings/preferences.html.heex:319
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
@@ -2240,9 +2241,9 @@ msgstr ""
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:246
-#: lib/vutuv_web/live/organization_live/edit.ex:407
+#: lib/vutuv_web/live/organization_live/edit.ex:408
 #: lib/vutuv_web/live/organization_live/roles.ex:247
-#: lib/vutuv_web/live/post_live/composer.ex:2036
+#: lib/vutuv_web/live/post_live/composer.ex:2064
 #: lib/vutuv_web/live/post_live/filter_band.ex:455
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
@@ -2257,7 +2258,7 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1888
+#: lib/vutuv_web/live/post_live/composer.ex:1916
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
@@ -2274,12 +2275,12 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1358
+#: lib/vutuv_web/live/post_live/composer.ex:1369
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1232
+#: lib/vutuv_web/live/post_live/composer.ex:1243
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2289,17 +2290,17 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2871
+#: lib/vutuv_web/live/post_live/composer.ex:2901
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2872
+#: lib/vutuv_web/live/post_live/composer.ex:2902
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4990
+#: lib/vutuv_web/components/ui.ex:5034
 #: lib/vutuv_web/live/shell_live.ex:1307
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2308,12 +2309,12 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2149
+#: lib/vutuv_web/live/post_live/composer.ex:2179
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2150
+#: lib/vutuv_web/live/post_live/composer.ex:2180
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
@@ -2343,23 +2344,23 @@ msgstr ""
 msgid "people you don't follow"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3252
+#: lib/vutuv_web/components/ui.ex:3296
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1803
+#: lib/vutuv_web/live/post_live/composer.ex:1831
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2862
+#: lib/vutuv_web/live/post_live/composer.ex:2892
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2866
+#: lib/vutuv_web/live/post_live/composer.ex:2896
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2381,7 +2382,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2033
 #: lib/vutuv_web/components/post_components.ex:5535
-#: lib/vutuv_web/components/ui.ex:3726
+#: lib/vutuv_web/components/ui.ex:3770
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2400,7 +2401,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1986
 #: lib/vutuv_web/components/post_components.ex:5771
-#: lib/vutuv_web/components/ui.ex:3712
+#: lib/vutuv_web/components/ui.ex:3756
 #: lib/vutuv_web/live/notification_live/index.ex:1271
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
@@ -2472,9 +2473,9 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:430
 #: lib/vutuv_web/components/post_components.ex:2648
-#: lib/vutuv_web/components/ui.ex:2621
-#: lib/vutuv_web/components/ui.ex:2621
-#: lib/vutuv_web/components/ui.ex:2697
+#: lib/vutuv_web/components/ui.ex:2665
+#: lib/vutuv_web/components/ui.ex:2665
+#: lib/vutuv_web/components/ui.ex:2741
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:611
@@ -2516,13 +2517,13 @@ msgstr ""
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1235
-#: lib/vutuv_web/live/post_live/composer.ex:1876
+#: lib/vutuv_web/live/post_live/composer.ex:1246
+#: lib/vutuv_web/live/post_live/composer.ex:1904
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2081
+#: lib/vutuv_web/live/post_live/composer.ex:2109
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2562,7 +2563,7 @@ msgstr ""
 msgid "%{name} is typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:923
+#: lib/vutuv_web/live/message_live/index.ex:924
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr ""
@@ -2608,7 +2609,7 @@ msgstr ""
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2944
+#: lib/vutuv_web/components/ui.ex:2988
 #: lib/vutuv_web/live/message_live/index.ex:760
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2619,7 +2620,7 @@ msgstr ""
 msgid "Requests"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:932
+#: lib/vutuv_web/live/message_live/index.ex:933
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr ""
@@ -2695,7 +2696,7 @@ msgstr ""
 msgid "Okay, let's start over."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:771
+#: lib/vutuv_web/components/ui.ex:815
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr ""
@@ -2706,7 +2707,7 @@ msgstr ""
 msgid "Too many PIN requests. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:792
+#: lib/vutuv_web/components/ui.ex:836
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr ""
@@ -2756,8 +2757,8 @@ msgstr ""
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3892
-#: lib/vutuv_web/components/ui.ex:4325
+#: lib/vutuv_web/components/ui.ex:3936
+#: lib/vutuv_web/components/ui.ex:4369
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:104
@@ -2809,7 +2810,7 @@ msgstr[1] ""
 msgid "Connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1260
+#: lib/vutuv_web/components/ui.ex:1304
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2819,17 +2820,17 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1276
+#: lib/vutuv_web/components/ui.ex:1320
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1990
+#: lib/vutuv_web/live/post_live/composer.ex:2018
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1261
+#: lib/vutuv_web/components/ui.ex:1305
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -3159,7 +3160,7 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4622
+#: lib/vutuv_web/components/ui.ex:4666
 #: lib/vutuv_web/live/shell_live.ex:1128
 #: lib/vutuv_web/live/shell_live.ex:1425
 #: lib/vutuv_web/templates/import/new.html.heex:16
@@ -3270,7 +3271,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3601
+#: lib/vutuv_web/components/ui.ex:3645
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3875,7 +3876,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:157
 #: lib/vutuv_web/agent_docs/text.ex:112
 #: lib/vutuv_web/agent_docs/text.ex:143
-#: lib/vutuv_web/live/job_posting_live/form.ex:699
+#: lib/vutuv_web/live/job_posting_live/form.ex:700
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr ""
@@ -4062,7 +4063,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
 #: lib/vutuv_web/live/job_posting_live/form.ex:542
-#: lib/vutuv_web/live/organization_live/edit.ex:326
+#: lib/vutuv_web/live/organization_live/edit.ex:327
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
 #: lib/vutuv_web/templates/address/form_en.html.heex:33
@@ -4344,12 +4345,12 @@ msgstr ""
 msgid "Bookings are open through %{last}. Next available day: %{day}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3204
+#: lib/vutuv_web/components/ui.ex:3248
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3200
+#: lib/vutuv_web/components/ui.ex:3244
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr ""
@@ -4359,27 +4360,27 @@ msgstr ""
 msgid "One ad per calendar day: pick a free day in the calendar; struck-through days are already booked."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3205
+#: lib/vutuv_web/components/ui.ex:3249
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3206
+#: lib/vutuv_web/components/ui.ex:3250
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3203
+#: lib/vutuv_web/components/ui.ex:3247
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3201
+#: lib/vutuv_web/components/ui.ex:3245
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3202
+#: lib/vutuv_web/components/ui.ex:3246
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr ""
@@ -4511,7 +4512,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4740
+#: lib/vutuv_web/components/ui.ex:4784
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -5277,7 +5278,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4800
+#: lib/vutuv_web/components/ui.ex:4844
 #: lib/vutuv_web/controllers/settings_controller.ex:157
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5313,7 +5314,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1253
+#: lib/vutuv_web/live/post_live/composer.ex:1264
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5356,10 +5357,10 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4897
-#: lib/vutuv_web/components/ui.ex:4902
-#: lib/vutuv_web/components/ui.ex:4981
-#: lib/vutuv_web/components/ui.ex:5045
+#: lib/vutuv_web/components/ui.ex:4941
+#: lib/vutuv_web/components/ui.ex:4946
+#: lib/vutuv_web/components/ui.ex:5025
+#: lib/vutuv_web/components/ui.ex:5089
 #: lib/vutuv_web/controllers/settings_controller.ex:64
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5477,7 +5478,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4760
+#: lib/vutuv_web/components/ui.ex:4804
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5488,7 +5489,7 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:481
+#: lib/vutuv_web/live/organization_live/edit.ex:482
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr ""
@@ -5498,7 +5499,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4660
+#: lib/vutuv_web/components/ui.ex:4704
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5527,13 +5528,13 @@ msgstr ""
 msgid "Personal tokens for the vutuv API."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2192
+#: lib/vutuv_web/live/post_live/composer.ex:2222
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4734
+#: lib/vutuv_web/components/ui.ex:4778
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/templates/page/index.html.heex:191
 #, elixir-autogen, elixir-format
@@ -5646,7 +5647,7 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4793
+#: lib/vutuv_web/components/ui.ex:4837
 #: lib/vutuv_web/controllers/settings_controller.ex:181
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5851,28 +5852,28 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3261
+#: lib/vutuv_web/components/ui.ex:3305
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3260
+#: lib/vutuv_web/components/ui.ex:3304
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3259
+#: lib/vutuv_web/components/ui.ex:3303
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:923
+#: lib/vutuv_web/controllers/settings_controller.ex:943
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5912,7 +5913,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:910
+#: lib/vutuv_web/controllers/settings_controller.ex:930
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -5932,7 +5933,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3258
+#: lib/vutuv_web/components/ui.ex:3302
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -6074,7 +6075,7 @@ msgstr ""
 msgid "Tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:389
+#: lib/vutuv_web/components/ui.ex:396
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:907
@@ -6135,7 +6136,7 @@ msgstr ""
 msgid "Use photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1671
+#: lib/vutuv_web/live/post_live/composer.ex:1699
 #: lib/vutuv_web/templates/user/edit.html.heex:54
 #: lib/vutuv_web/templates/user/edit.html.heex:139
 #, elixir-autogen, elixir-format
@@ -6259,9 +6260,9 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1981
-#: lib/vutuv_web/components/ui.ex:1990
-#: lib/vutuv_web/components/ui.ex:2469
+#: lib/vutuv_web/components/ui.ex:2025
+#: lib/vutuv_web/components/ui.ex:2034
+#: lib/vutuv_web/components/ui.ex:2513
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6282,7 +6283,7 @@ msgstr ""
 msgid "Map services to show"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:104
+#: lib/vutuv_web/gettext_extraction_anchors.ex:110
 #: lib/vutuv_web/templates/settings/preferences.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Maps"
@@ -6295,7 +6296,7 @@ msgstr ""
 msgid "Open in %{name}"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:102
+#: lib/vutuv_web/gettext_extraction_anchors.ex:108
 #: lib/vutuv_web/templates/settings/preferences.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Opens first, as the main button. The others appear as alternatives."
@@ -6322,7 +6323,7 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2422
+#: lib/vutuv_web/components/ui.ex:2466
 #: lib/vutuv_web/live/notification_live/index.ex:684
 #: lib/vutuv_web/live/notification_live/index.ex:699
 #: lib/vutuv_web/live/notification_live/index.ex:1012
@@ -6619,7 +6620,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2628
 #: lib/vutuv_web/components/post_components.ex:3603
-#: lib/vutuv_web/components/ui.ex:2769
+#: lib/vutuv_web/components/ui.ex:2813
 #: lib/vutuv_web/live/fediverse_account_live.ex:375
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
@@ -6647,7 +6648,7 @@ msgid "Remove this connection? You will stop following them."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3603
-#: lib/vutuv_web/components/ui.ex:2768
+#: lib/vutuv_web/components/ui.ex:2812
 #: lib/vutuv_web/live/fediverse_account_live.ex:373
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
@@ -7028,7 +7029,7 @@ msgstr ""
 msgid "Save audience"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:808
+#: lib/vutuv_web/live/job_posting_live/form.ex:809
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:16
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:11
 #, elixir-autogen, elixir-format
@@ -7247,13 +7248,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3664
+#: lib/vutuv_web/components/ui.ex:3708
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3680
+#: lib/vutuv_web/components/ui.ex:3724
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7288,7 +7289,7 @@ msgid "Removed:"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:979
-#: lib/vutuv_web/live/post_live/composer.ex:1519
+#: lib/vutuv_web/live/post_live/composer.ex:1547
 #: lib/vutuv_web/live/post_live/filter_band.ex:532
 #, elixir-autogen, elixir-format
 msgid "Undo"
@@ -8001,7 +8002,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3667
+#: lib/vutuv_web/components/ui.ex:3711
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8131,7 +8132,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:4636
+#: lib/vutuv_web/components/ui.ex:4680
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8186,7 +8187,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4781
+#: lib/vutuv_web/components/ui.ex:4825
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8215,7 +8216,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4664
+#: lib/vutuv_web/components/ui.ex:4708
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8309,7 +8310,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3944
+#: lib/vutuv_web/components/ui.ex:3988
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8384,13 +8385,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4624
+#: lib/vutuv_web/components/ui.ex:4668
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4771
+#: lib/vutuv_web/components/ui.ex:4815
 #: lib/vutuv_web/controllers/settings_controller.ex:125
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8402,7 +8403,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4762
+#: lib/vutuv_web/components/ui.ex:4806
 #: lib/vutuv_web/controllers/settings_controller.ex:108
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8412,7 +8413,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4785
+#: lib/vutuv_web/components/ui.ex:4829
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8521,7 +8522,7 @@ msgstr[1] ""
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1278
+#: lib/vutuv_web/components/ui.ex:1322
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -8617,8 +8618,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:586
 #: lib/vutuv_web/agent_docs/text.ex:590
 #: lib/vutuv_web/components/organization_components.ex:276
-#: lib/vutuv_web/components/ui.ex:1479
-#: lib/vutuv_web/components/ui.ex:4752
+#: lib/vutuv_web/components/ui.ex:1523
+#: lib/vutuv_web/components/ui.ex:4796
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:357
 #: lib/vutuv_web/controllers/settings_controller.ex:424
@@ -8768,7 +8769,7 @@ msgstr ""
 msgid "This is the print view of this CV. Use your browser's print dialog (Ctrl+P or Cmd+P) and choose \"Save as PDF\" to get a PDF file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1568
+#: lib/vutuv_web/components/ui.ex:1612
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr ""
@@ -8806,7 +8807,7 @@ msgstr ""
 msgid "Header"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1578
+#: lib/vutuv_web/components/ui.ex:1622
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -8838,7 +8839,7 @@ msgstr ""
 msgid "The CV is public, on your profile: a visitor's download contains only what they can see there anyway, and private email addresses appear only in your own."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1570
+#: lib/vutuv_web/components/ui.ex:1614
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -8992,8 +8993,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2025
-#: lib/vutuv_web/components/ui.ex:2026
+#: lib/vutuv_web/components/ui.ex:2069
+#: lib/vutuv_web/components/ui.ex:2070
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9436,7 +9437,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1187
+#: lib/vutuv/accounts/user.ex:1193
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9447,7 +9448,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1184
+#: lib/vutuv/accounts/user.ex:1190
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9562,7 +9563,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:4640
+#: lib/vutuv_web/components/ui.ex:4684
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -9758,13 +9759,13 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3374
+#: lib/vutuv_web/components/ui.ex:3418
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3373
-#: lib/vutuv_web/components/ui.ex:3381
+#: lib/vutuv_web/components/ui.ex:3417
+#: lib/vutuv_web/components/ui.ex:3425
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -9938,17 +9939,17 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:377
+#: lib/vutuv_web/components/ui.ex:384
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:429
+#: lib/vutuv_web/components/ui.ex:436
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:432
+#: lib/vutuv_web/components/ui.ex:439
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr ""
@@ -9963,13 +9964,13 @@ msgstr ""
 msgid "Delete your code list? All its codes stop working immediately."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:373
+#: lib/vutuv_web/components/ui.ex:380
 #, elixir-autogen, elixir-format
 msgid "Formatting"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:496
-#: lib/vutuv_web/components/ui.ex:497
+#: lib/vutuv_web/components/ui.ex:503
+#: lib/vutuv_web/components/ui.ex:504
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr ""
@@ -9984,27 +9985,27 @@ msgstr ""
 msgid "Generate code list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:427
+#: lib/vutuv_web/components/ui.ex:434
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:428
+#: lib/vutuv_web/components/ui.ex:435
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:386
+#: lib/vutuv_web/components/ui.ex:393
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:380
+#: lib/vutuv_web/components/ui.ex:387
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:346
+#: lib/vutuv_web/components/ui.ex:540
 #, elixir-autogen, elixir-format
 msgid "Link URL"
 msgstr ""
@@ -10020,7 +10021,7 @@ msgstr ""
 msgid "Not set up."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:430
+#: lib/vutuv_web/components/ui.ex:437
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr ""
@@ -10035,7 +10036,7 @@ msgstr ""
 msgid "Print this page or write the codes down. Crossed-out codes have been used."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:431
+#: lib/vutuv_web/components/ui.ex:438
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr ""
@@ -10056,7 +10057,7 @@ msgstr ""
 msgid "Set up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:383
+#: lib/vutuv_web/components/ui.ex:390
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr ""
@@ -10434,46 +10435,46 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:346
+#: lib/vutuv_web/templates/settings/preferences.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:277
+#: lib/vutuv_web/templates/settings/preferences.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:353
+#: lib/vutuv_web/templates/settings/preferences.html.heex:397
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:357
+#: lib/vutuv_web/templates/settings/preferences.html.heex:401
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:343
+#: lib/vutuv_web/templates/settings/preferences.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:300
+#: lib/vutuv_web/templates/settings/preferences.html.heex:344
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:309
+#: lib/vutuv_web/templates/settings/preferences.html.heex:353
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:295
+#: lib/vutuv_web/templates/settings/preferences.html.heex:339
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
@@ -10483,7 +10484,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:292
+#: lib/vutuv_web/templates/settings/preferences.html.heex:336
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr ""
@@ -10571,8 +10572,9 @@ msgstr ""
 #: lib/vutuv_web/live/feed_languages_live.ex:377
 #: lib/vutuv_web/templates/settings/preferences.html.heex:101
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
-#: lib/vutuv_web/templates/settings/preferences.html.heex:259
-#: lib/vutuv_web/templates/settings/preferences.html.heex:377
+#: lib/vutuv_web/templates/settings/preferences.html.heex:239
+#: lib/vutuv_web/templates/settings/preferences.html.heex:303
+#: lib/vutuv_web/templates/settings/preferences.html.heex:421
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr ""
@@ -10603,17 +10605,17 @@ msgstr ""
 msgid "What every member gets until they choose for themselves on their settings pages, and what logged-out visitors see. Changes apply immediately; members who set their own value are not affected."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:100
+#: lib/vutuv_web/gettext_extraction_anchors.ex:106
 #, elixir-autogen, elixir-format
 msgid "0 means posts are never shortened."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:106
+#: lib/vutuv_web/gettext_extraction_anchors.ex:112
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:105
+#: lib/vutuv_web/gettext_extraction_anchors.ex:111
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr ""
@@ -10664,8 +10666,8 @@ msgid "Failed"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
-#: lib/vutuv_web/live/post_live/composer.ex:1750
-#: lib/vutuv_web/live/post_live/composer.ex:2450
+#: lib/vutuv_web/live/post_live/composer.ex:1778
+#: lib/vutuv_web/live/post_live/composer.ex:2480
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr ""
@@ -10765,21 +10767,21 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1225
+#: lib/vutuv/accounts/user.ex:1231
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1230
+#: lib/vutuv/accounts/user.ex:1236
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1228
+#: lib/vutuv/accounts/user.ex:1234
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
-#: lib/vutuv_web/live/job_posting_live/form.ex:772
+#: lib/vutuv_web/live/job_posting_live/form.ex:773
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr ""
@@ -10961,7 +10963,7 @@ msgstr ""
 msgid "Your list is empty. Nobody is excluded yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:362
+#: lib/vutuv_web/live/organization_live/edit.ex:363
 #: lib/vutuv_web/views/account_event_text.ex:232
 #, elixir-autogen, elixir-format
 msgid "AI agents"
@@ -11000,7 +11002,7 @@ msgstr ""
 msgid "Edit %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:348
+#: lib/vutuv_web/live/organization_live/edit.ex:349
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this page and include it in the sitemap."
 msgstr ""
@@ -11010,7 +11012,7 @@ msgstr ""
 msgid "Logo"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:364
+#: lib/vutuv_web/live/organization_live/edit.ex:365
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
@@ -11036,7 +11038,7 @@ msgstr ""
 msgid "Search by name or city"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:346
+#: lib/vutuv_web/live/organization_live/edit.ex:347
 #: lib/vutuv_web/views/account_event_text.ex:231
 #, elixir-autogen, elixir-format
 msgid "Search engines"
@@ -11053,18 +11055,18 @@ msgstr ""
 msgid "Serve this file at:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:327
+#: lib/vutuv_web/live/organization_live/edit.ex:328
 #: lib/vutuv_web/live/organization_live/new.ex:139
 #, elixir-autogen, elixir-format
 msgid "State / region (optional)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3998
+#: lib/vutuv_web/components/ui.ex:4042
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4000
+#: lib/vutuv_web/components/ui.ex:4044
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr ""
@@ -11104,7 +11106,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:262
 #: lib/vutuv_web/agent_docs/text.ex:245
-#: lib/vutuv_web/live/organization_live/edit.ex:321
+#: lib/vutuv_web/live/organization_live/edit.ex:322
 #: lib/vutuv_web/live/organization_live/new.ex:130
 #, elixir-autogen, elixir-format
 msgid "Website"
@@ -11141,7 +11143,7 @@ msgid "@handle or email"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:333
-#: lib/vutuv_web/live/organization_live/edit.ex:424
+#: lib/vutuv_web/live/organization_live/edit.ex:425
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
 msgstr ""
@@ -11162,7 +11164,7 @@ msgid "Added @%{handle} to the team."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:334
-#: lib/vutuv_web/live/organization_live/edit.ex:422
+#: lib/vutuv_web/live/organization_live/edit.ex:423
 #, elixir-autogen, elixir-format
 msgid "Alias"
 msgstr ""
@@ -11179,14 +11181,14 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:436
 #: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/live/organization_live/edit.ex:387
+#: lib/vutuv_web/live/organization_live/edit.ex:388
 #: lib/vutuv_web/live/organization_live/show.ex:925
 #: lib/vutuv_web/templates/tag/single_card.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Also known as"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:418
+#: lib/vutuv_web/live/organization_live/edit.ex:419
 #, elixir-autogen, elixir-format
 msgid "Alternative name"
 msgstr ""
@@ -11208,7 +11210,7 @@ msgid "Archived"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:332
-#: lib/vutuv_web/live/organization_live/edit.ex:423
+#: lib/vutuv_web/live/organization_live/edit.ex:424
 #, elixir-autogen, elixir-format
 msgid "Brand"
 msgstr ""
@@ -11349,7 +11351,7 @@ msgstr ""
 msgid "Remove this member from the team?"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:404
+#: lib/vutuv_web/live/organization_live/edit.ex:405
 #, elixir-autogen, elixir-format
 msgid "Remove this name?"
 msgstr ""
@@ -11406,24 +11408,24 @@ msgstr ""
 msgid "verified"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:324
+#: lib/vutuv_web/live/organization_live/edit.ex:325
 #: lib/vutuv_web/live/organization_live/new.ex:136
 #, elixir-autogen, elixir-format
 msgid "Street address (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:325
+#: lib/vutuv_web/live/organization_live/edit.ex:326
 #: lib/vutuv_web/live/organization_live/new.ex:137
 #, elixir-autogen, elixir-format
 msgid "ZIP / postal code (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:481
+#: lib/vutuv_web/live/organization_live/edit.ex:482
 #, elixir-autogen, elixir-format
 msgid "Claim"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:450
+#: lib/vutuv_web/live/organization_live/edit.ex:451
 #, elixir-autogen, elixir-format
 msgid "Reachable at"
 msgstr ""
@@ -11433,12 +11435,12 @@ msgstr ""
 msgid "That handle is not available."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:487
+#: lib/vutuv_web/live/organization_live/edit.ex:488
 #, elixir-autogen, elixir-format
 msgid "Danger zone"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:498
+#: lib/vutuv_web/live/organization_live/edit.ex:499
 #, elixir-autogen, elixir-format
 msgid "Really delete %{name}? This cannot be undone."
 msgstr ""
@@ -11484,7 +11486,7 @@ msgstr ""
 msgid "The link text can be anything. A hidden <link rel=\"me\"> in the page head works too."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:994
+#: lib/vutuv_web/components/ui.ex:1038
 #: lib/vutuv_web/live/section_reorder_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -11580,7 +11582,7 @@ msgid_plural "%{count} aliases match another verified organization and are flagg
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:389
+#: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Alternative names, brands or abbreviations this organization is findable under. A rename keeps the old name here automatically."
 msgstr ""
@@ -11644,12 +11646,12 @@ msgstr ""
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:502
+#: lib/vutuv_web/live/organization_live/edit.ex:503
 #, elixir-autogen, elixir-format
 msgid "Delete this organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:489
+#: lib/vutuv_web/live/organization_live/edit.ex:490
 #, elixir-autogen, elixir-format
 msgid "Deleting this organization page is permanent. Its verified domains and its @handle are freed and can be claimed again."
 msgstr ""
@@ -11752,7 +11754,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:427
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:400
-#: lib/vutuv_web/components/ui.ex:4789
+#: lib/vutuv_web/components/ui.ex:4833
 #: lib/vutuv_web/controllers/settings_controller.ex:213
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
@@ -11869,7 +11871,7 @@ msgstr ""
 msgid "made you an owner of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:471
+#: lib/vutuv_web/live/organization_live/edit.ex:472
 #, elixir-autogen, elixir-format
 msgid "your_organization"
 msgstr ""
@@ -11925,17 +11927,17 @@ msgstr ""
 msgid "A pay range is required to publish (except volunteer postings)."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:749
+#: lib/vutuv_web/live/job_posting_live/form.ex:750
 #, elixir-autogen, elixir-format
 msgid "A vutuv message to me"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:747
+#: lib/vutuv_web/live/job_posting_live/form.ex:748
 #, elixir-autogen, elixir-format
 msgid "A website"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:748
+#: lib/vutuv_web/live/job_posting_live/form.ex:749
 #, elixir-autogen, elixir-format
 msgid "An e-mail address"
 msgstr ""
@@ -11945,12 +11947,12 @@ msgstr ""
 msgid "Applicants must be located in"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:753
+#: lib/vutuv_web/live/job_posting_live/form.ex:754
 #, elixir-autogen, elixir-format
 msgid "Application URL"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:759
+#: lib/vutuv_web/live/job_posting_live/form.ex:760
 #, elixir-autogen, elixir-format
 msgid "Application e-mail"
 msgstr ""
@@ -11960,7 +11962,7 @@ msgstr ""
 msgid "Application: %{title}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:745
+#: lib/vutuv_web/live/job_posting_live/form.ex:746
 #, elixir-autogen, elixir-format
 msgid "Applications go to"
 msgstr ""
@@ -11992,7 +11994,7 @@ msgstr ""
 msgid "Contract"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:692
+#: lib/vutuv_web/live/job_posting_live/form.ex:693
 #, elixir-autogen, elixir-format
 msgid "Describe the role. Markdown is supported."
 msgstr ""
@@ -12033,7 +12035,7 @@ msgstr ""
 msgid "Employment type"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:771
+#: lib/vutuv_web/live/job_posting_live/form.ex:772
 #, elixir-autogen, elixir-format
 msgid "Everyone (public)"
 msgstr ""
@@ -12056,12 +12058,12 @@ msgstr ""
 msgid "Highlighted tags match your profile."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:743
+#: lib/vutuv_web/live/job_posting_live/form.ex:744
 #, elixir-autogen, elixir-format
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1199
+#: lib/vutuv/accounts/user.ex:1205
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12072,7 +12074,7 @@ msgstr ""
 msgid "I'm interested in your posting: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:691
+#: lib/vutuv_web/live/job_posting_live/form.ex:692
 #, elixir-autogen, elixir-format
 msgid "Job description"
 msgstr ""
@@ -12093,7 +12095,7 @@ msgstr ""
 msgid "Jobs"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:781
+#: lib/vutuv_web/live/job_posting_live/form.ex:782
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this posting."
 msgstr ""
@@ -12154,7 +12156,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:292
 #: lib/vutuv_web/agent_docs/text.ex:275
-#: lib/vutuv_web/live/job_posting_live/form.ex:731
+#: lib/vutuv_web/live/job_posting_live/form.ex:732
 #: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
@@ -12175,12 +12177,12 @@ msgstr ""
 msgid "Nothing here yet. Jobs you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:787
+#: lib/vutuv_web/live/job_posting_live/form.ex:788
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1198
+#: lib/vutuv/accounts/user.ex:1204
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12257,12 +12259,12 @@ msgstr ""
 msgid "Posting not found."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:804
+#: lib/vutuv_web/live/job_posting_live/form.ex:805
 #, elixir-autogen, elixir-format
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1200
+#: lib/vutuv/accounts/user.ex:1206
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
 #: lib/vutuv_web/agent_docs/markdown.ex:466
@@ -12282,7 +12284,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:291
 #: lib/vutuv_web/agent_docs/text.ex:274
-#: lib/vutuv_web/live/job_posting_live/form.ex:721
+#: lib/vutuv_web/live/job_posting_live/form.ex:722
 #: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
@@ -12322,7 +12324,7 @@ msgstr ""
 msgid "Street (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:718
+#: lib/vutuv_web/live/job_posting_live/form.ex:719
 #, elixir-autogen, elixir-format
 msgid "Tags match your posting to members. Separate them with commas; a tag may be several words long, like Ruby on Rails."
 msgstr ""
@@ -12374,7 +12376,7 @@ msgstr ""
 msgid "Volunteer"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:769
+#: lib/vutuv_web/live/job_posting_live/form.ex:770
 #: lib/vutuv_web/templates/email/form_content.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Who can see it"
@@ -12964,7 +12966,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4729
+#: lib/vutuv_web/components/ui.ex:4773
 #: lib/vutuv_web/controllers/settings_controller.ex:620
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13112,7 +13114,7 @@ msgstr ""
 msgid "Hide from specific viewers"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:793
+#: lib/vutuv_web/live/job_posting_live/form.ex:794
 #, elixir-autogen, elixir-format
 msgid "Hide from specific viewers (competitors, your own staff, a person) →"
 msgstr ""
@@ -13133,7 +13135,7 @@ msgstr ""
 msgid "Job exclusions – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:796
+#: lib/vutuv_web/live/job_posting_live/form.ex:797
 #, elixir-autogen, elixir-format
 msgid "Keep this posting on the board for everyone except a chosen few."
 msgstr ""
@@ -13277,7 +13279,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1243
+#: lib/vutuv/accounts/user.ex:1249
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13288,19 +13290,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1246
+#: lib/vutuv/accounts/user.ex:1252
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1249
+#: lib/vutuv/accounts/user.ex:1255
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1240
+#: lib/vutuv/accounts/user.ex:1246
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13340,32 +13342,32 @@ msgstr[1] ""
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:406
+#: lib/vutuv_web/components/ui.ex:413
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:403
+#: lib/vutuv_web/components/ui.ex:410
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:409
+#: lib/vutuv_web/components/ui.ex:416
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:400
+#: lib/vutuv_web/components/ui.ex:407
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:433
+#: lib/vutuv_web/components/ui.ex:440
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2841
+#: lib/vutuv_web/live/post_live/composer.ex:2871
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -13422,7 +13424,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4712
+#: lib/vutuv_web/components/ui.ex:4756
 #: lib/vutuv_web/controllers/settings_controller.ex:634
 #: lib/vutuv_web/live/post_live/feed.ex:712
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13497,7 +13499,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:63
-#: lib/vutuv_web/components/ui.ex:4683
+#: lib/vutuv_web/components/ui.ex:4727
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13525,14 +13527,14 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4083
+#: lib/vutuv_web/components/ui.ex:4127
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:4093
+#: lib/vutuv_web/components/ui.ex:4137
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
@@ -13756,12 +13758,12 @@ msgstr ""
 msgid "by:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2159
+#: lib/vutuv_web/components/ui.ex:2203
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2163
+#: lib/vutuv_web/components/ui.ex:2207
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -13891,22 +13893,22 @@ msgid "proof document"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:331
+#: lib/vutuv_web/templates/settings/preferences.html.heex:375
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:101
+#: lib/vutuv_web/gettext_extraction_anchors.ex:107
 #, elixir-autogen, elixir-format
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:322
+#: lib/vutuv_web/templates/settings/preferences.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:325
+#: lib/vutuv_web/templates/settings/preferences.html.heex:369
 #, elixir-autogen, elixir-format
 msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
@@ -14028,13 +14030,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1240
+#: lib/vutuv_web/live/post_live/composer.ex:1251
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1243
+#: lib/vutuv_web/live/post_live/composer.ex:1254
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14314,7 +14316,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4697
+#: lib/vutuv_web/components/ui.ex:4741
 #: lib/vutuv_web/controllers/settings_controller.ex:700
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -14947,252 +14949,252 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4625
+#: lib/vutuv_web/components/ui.ex:4669
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4630
+#: lib/vutuv_web/components/ui.ex:4674
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4633
+#: lib/vutuv_web/components/ui.ex:4677
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4634
+#: lib/vutuv_web/components/ui.ex:4678
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4637
+#: lib/vutuv_web/components/ui.ex:4681
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4638
+#: lib/vutuv_web/components/ui.ex:4682
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4641
+#: lib/vutuv_web/components/ui.ex:4685
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4642
+#: lib/vutuv_web/components/ui.ex:4686
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4649
+#: lib/vutuv_web/components/ui.ex:4693
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4650
+#: lib/vutuv_web/components/ui.ex:4694
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4651
+#: lib/vutuv_web/components/ui.ex:4695
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4654
+#: lib/vutuv_web/components/ui.ex:4698
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4655
+#: lib/vutuv_web/components/ui.ex:4699
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4790
+#: lib/vutuv_web/components/ui.ex:4834
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4791
+#: lib/vutuv_web/components/ui.ex:4835
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4658
+#: lib/vutuv_web/components/ui.ex:4702
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4661
+#: lib/vutuv_web/components/ui.ex:4705
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4662
+#: lib/vutuv_web/components/ui.ex:4706
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4665
+#: lib/vutuv_web/components/ui.ex:4709
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4666
+#: lib/vutuv_web/components/ui.ex:4710
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4669
+#: lib/vutuv_web/components/ui.ex:4713
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4670
+#: lib/vutuv_web/components/ui.ex:4714
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4672
+#: lib/vutuv_web/components/ui.ex:4716
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4673
+#: lib/vutuv_web/components/ui.ex:4717
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4674
+#: lib/vutuv_web/components/ui.ex:4718
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4676
+#: lib/vutuv_web/components/ui.ex:4720
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4677
+#: lib/vutuv_web/components/ui.ex:4721
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4679
+#: lib/vutuv_web/components/ui.ex:4723
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4684
+#: lib/vutuv_web/components/ui.ex:4728
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4685
+#: lib/vutuv_web/components/ui.ex:4729
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4688
+#: lib/vutuv_web/components/ui.ex:4732
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4691
+#: lib/vutuv_web/components/ui.ex:4735
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4698
+#: lib/vutuv_web/components/ui.ex:4742
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4699
+#: lib/vutuv_web/components/ui.ex:4743
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4713
+#: lib/vutuv_web/components/ui.ex:4757
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4714
+#: lib/vutuv_web/components/ui.ex:4758
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4730
+#: lib/vutuv_web/components/ui.ex:4774
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4731
+#: lib/vutuv_web/components/ui.ex:4775
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4737
+#: lib/vutuv_web/components/ui.ex:4781
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4738
+#: lib/vutuv_web/components/ui.ex:4782
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4741
+#: lib/vutuv_web/components/ui.ex:4785
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4742
+#: lib/vutuv_web/components/ui.ex:4786
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4763
+#: lib/vutuv_web/components/ui.ex:4807
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4764
+#: lib/vutuv_web/components/ui.ex:4808
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4782
+#: lib/vutuv_web/components/ui.ex:4826
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4783
+#: lib/vutuv_web/components/ui.ex:4827
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4786
+#: lib/vutuv_web/components/ui.ex:4830
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4787
+#: lib/vutuv_web/components/ui.ex:4831
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4801
+#: lib/vutuv_web/components/ui.ex:4845
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4802
+#: lib/vutuv_web/components/ui.ex:4846
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15649,7 +15651,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4766
+#: lib/vutuv_web/components/ui.ex:4810
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -15996,7 +15998,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4767
+#: lib/vutuv_web/components/ui.ex:4811
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -16032,7 +16034,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4769
+#: lib/vutuv_web/components/ui.ex:4813
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16143,7 +16145,7 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2854
+#: lib/vutuv_web/live/post_live/composer.ex:2884
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16173,49 +16175,49 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2278
+#: lib/vutuv_web/live/post_live/composer.ex:2308
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2692
+#: lib/vutuv_web/live/post_live/composer.ex:2722
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1294
 #: lib/vutuv_web/agent_docs/text.ex:807
-#: lib/vutuv_web/components/ui.ex:2823
+#: lib/vutuv_web/components/ui.ex:2867
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2791
+#: lib/vutuv_web/live/post_live/composer.ex:2821
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2747
+#: lib/vutuv_web/live/post_live/composer.ex:2777
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2749
+#: lib/vutuv_web/live/post_live/composer.ex:2779
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2768
+#: lib/vutuv_web/live/post_live/composer.ex:2798
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2822
+#: lib/vutuv_web/components/ui.ex:2866
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2297
+#: lib/vutuv_web/live/post_live/composer.ex:2327
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
@@ -16235,8 +16237,8 @@ msgstr ""
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2250
-#: lib/vutuv_web/live/post_live/composer.ex:2251
+#: lib/vutuv_web/live/post_live/composer.ex:2280
+#: lib/vutuv_web/live/post_live/composer.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
@@ -16248,23 +16250,23 @@ msgstr ""
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2821
+#: lib/vutuv_web/components/ui.ex:2865
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2310
-#: lib/vutuv_web/live/post_live/composer.ex:2311
+#: lib/vutuv_web/live/post_live/composer.ex:2340
+#: lib/vutuv_web/live/post_live/composer.ex:2341
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2770
+#: lib/vutuv_web/live/post_live/composer.ex:2800
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2711
+#: lib/vutuv_web/live/post_live/composer.ex:2741
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr ""
@@ -16274,17 +16276,17 @@ msgstr ""
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2789
+#: lib/vutuv_web/live/post_live/composer.ex:2819
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2825
+#: lib/vutuv_web/live/post_live/composer.ex:2855
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2817
+#: lib/vutuv_web/live/post_live/composer.ex:2847
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
@@ -16309,12 +16311,12 @@ msgstr ""
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2568
+#: lib/vutuv_web/live/post_live/composer.ex:2598
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1267
+#: lib/vutuv_web/live/post_live/composer.ex:1278
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -16324,7 +16326,7 @@ msgstr ""
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1281
+#: lib/vutuv_web/live/post_live/composer.ex:1292
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -16339,65 +16341,65 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2193
+#: lib/vutuv_web/live/post_live/composer.ex:2223
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2563
+#: lib/vutuv_web/live/post_live/composer.ex:2593
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2682
+#: lib/vutuv_web/live/post_live/composer.ex:2712
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1494
-#: lib/vutuv_web/live/post_live/composer.ex:1557
-#: lib/vutuv_web/live/post_live/composer.ex:1615
-#: lib/vutuv_web/live/post_live/composer.ex:1962
+#: lib/vutuv_web/live/post_live/composer.ex:1522
+#: lib/vutuv_web/live/post_live/composer.ex:1585
+#: lib/vutuv_web/live/post_live/composer.ex:1643
+#: lib/vutuv_web/live/post_live/composer.ex:1990
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1487
+#: lib/vutuv_web/live/post_live/composer.ex:1515
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2616
+#: lib/vutuv_web/live/post_live/composer.ex:2646
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2130
+#: lib/vutuv_web/live/post_live/composer.ex:2158
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2129
+#: lib/vutuv_web/live/post_live/composer.ex:2157
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2128
+#: lib/vutuv_web/live/post_live/composer.ex:2156
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2133
+#: lib/vutuv_web/live/post_live/composer.ex:2161
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2586
+#: lib/vutuv_web/live/post_live/composer.ex:2616
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2605
+#: lib/vutuv_web/live/post_live/composer.ex:2635
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -16507,8 +16509,8 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1751
-#: lib/vutuv_web/live/post_live/composer.ex:2450
+#: lib/vutuv_web/live/post_live/composer.ex:1779
+#: lib/vutuv_web/live/post_live/composer.ex:2480
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr ""
@@ -16538,7 +16540,7 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4753
+#: lib/vutuv_web/components/ui.ex:4797
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
@@ -16741,7 +16743,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4755
+#: lib/vutuv_web/components/ui.ex:4799
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -17116,12 +17118,12 @@ msgstr[1] ""
 msgid "Your feed shows the posts of members you follow. Follow a few to fill it."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:227
+#: lib/vutuv_web/components/ui.ex:228
 #, elixir-autogen, elixir-format
 msgid "Add another tag"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:250
+#: lib/vutuv_web/components/ui.ex:251
 #, elixir-autogen, elixir-format
 msgid "Remove the tag %{name}"
 msgstr ""
@@ -17246,7 +17248,7 @@ msgstr ""
 msgid "Your username is your public identity here. It changes only once you confirm with your passkey or a valid code below."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:531
+#: lib/vutuv_web/components/ui.ex:575
 #, elixir-autogen, elixir-format
 msgid "Markdown help"
 msgstr ""
@@ -17375,104 +17377,104 @@ msgstr ""
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1668
+#: lib/vutuv_web/live/post_live/composer.ex:1696
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2356
+#: lib/vutuv_web/live/post_live/composer.ex:2386
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2357
+#: lib/vutuv_web/live/post_live/composer.ex:2387
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2362
+#: lib/vutuv_web/live/post_live/composer.ex:2392
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2359
+#: lib/vutuv_web/live/post_live/composer.ex:2389
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2360
+#: lib/vutuv_web/live/post_live/composer.ex:2390
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2361
+#: lib/vutuv_web/live/post_live/composer.ex:2391
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1664
-#: lib/vutuv_web/live/post_live/composer.ex:2327
-#: lib/vutuv_web/live/post_live/composer.ex:2328
+#: lib/vutuv_web/live/post_live/composer.ex:1692
+#: lib/vutuv_web/live/post_live/composer.ex:2357
+#: lib/vutuv_web/live/post_live/composer.ex:2358
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2286
+#: lib/vutuv_web/live/post_live/composer.ex:2316
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1586
+#: lib/vutuv_web/live/post_live/composer.ex:1614
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2363
+#: lib/vutuv_web/live/post_live/composer.ex:2393
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2364
+#: lib/vutuv_web/live/post_live/composer.ex:2394
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1666
+#: lib/vutuv_web/live/post_live/composer.ex:1694
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2355
+#: lib/vutuv_web/live/post_live/composer.ex:2385
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2358
+#: lib/vutuv_web/live/post_live/composer.ex:2388
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:496
+#: lib/vutuv_web/live/post_live/composer.ex:497
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2804
+#: lib/vutuv_web/live/post_live/composer.ex:2834
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1670
+#: lib/vutuv_web/live/post_live/composer.ex:1698
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2553
+#: lib/vutuv_web/live/post_live/composer.ex:2583
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2537
+#: lib/vutuv_web/live/post_live/composer.ex:2567
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr ""
@@ -17772,8 +17774,8 @@ msgstr ""
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1330
-#: lib/vutuv_web/components/ui.ex:1331
+#: lib/vutuv_web/components/ui.ex:1374
+#: lib/vutuv_web/components/ui.ex:1375
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr ""
@@ -17783,7 +17785,7 @@ msgstr ""
 msgid "A CV with positions, education, certificates including proof, spoken languages and tags other members endorse you for."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:435
+#: lib/vutuv_web/templates/page/index.html.heex:465
 #, elixir-autogen, elixir-format
 msgid "A business network that is free, does not lock your data in, and is yours to run yourself if you want to."
 msgstr ""
@@ -17803,22 +17805,22 @@ msgstr ""
 msgid "CV download as PDF, Word, OpenDocument, LaTeX or JSON Resume, and you pick what goes in before you download it."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:488
+#: lib/vutuv_web/templates/page/index.html.heex:518
 #, elixir-autogen, elixir-format
 msgid "Developer documentation"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:448
+#: lib/vutuv_web/templates/page/index.html.heex:478
 #, elixir-autogen, elixir-format
 msgid "Every public page here is also served as Markdown, plain text, JSON and XML under the same address. No scraping, no API key, no account."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:455
+#: lib/vutuv_web/templates/page/index.html.heex:485
 #, elixir-autogen, elixir-format
 msgid "For machines"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:445
+#: lib/vutuv_web/templates/page/index.html.heex:475
 #, elixir-autogen, elixir-format
 msgid "Open by default"
 msgstr ""
@@ -17843,12 +17845,12 @@ msgstr ""
 msgid "Posts, likes, reposts, replies and 1:1 messages, in real time."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:446
+#: lib/vutuv_web/templates/page/index.html.heex:476
 #, elixir-autogen, elixir-format
 msgid "Readable by people, by machines, and on your own server"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:471
+#: lib/vutuv_web/templates/page/index.html.heex:501
 #, elixir-autogen, elixir-format
 msgid "Run it yourself"
 msgstr ""
@@ -17858,23 +17860,23 @@ msgstr ""
 msgid "Sign in without a password, by emailed PIN, passkey, authenticator app or a printed list of codes."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:482
-#: lib/vutuv_web/templates/page/index.html.heex:569
+#: lib/vutuv_web/templates/page/index.html.heex:512
+#: lib/vutuv_web/templates/page/index.html.heex:599
 #, elixir-autogen, elixir-format
 msgid "Source code"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:317
+#: lib/vutuv_web/templates/page/index.html.heex:347
 #, elixir-autogen, elixir-format
 msgid "This is what a vutuv profile looks like"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:433
+#: lib/vutuv_web/templates/page/index.html.heex:463
 #, elixir-autogen, elixir-format
 msgid "What vutuv can do"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:432
+#: lib/vutuv_web/templates/page/index.html.heex:462
 #, elixir-autogen, elixir-format
 msgid "What you get"
 msgstr ""
@@ -17884,12 +17886,12 @@ msgstr ""
 msgid "Your independence"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:473
+#: lib/vutuv_web/templates/page/index.html.heex:503
 #, elixir-autogen, elixir-format
 msgid "vutuv is open source under the MIT license. Run it for a company, an association or a school, on the internet or air-gapped inside your own network."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:316
+#: lib/vutuv_web/templates/page/index.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "A look inside"
 msgstr ""
@@ -17899,7 +17901,7 @@ msgstr ""
 msgid "A vutuv profile: cover picture, photo, name, tagline and job title, follower counts and the first posts, with contact details and social media profiles in a column on the right."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:338
+#: lib/vutuv_web/templates/page/index.html.heex:368
 #, elixir-autogen, elixir-format
 msgid "Browse real profiles"
 msgstr ""
@@ -17919,17 +17921,17 @@ msgstr ""
 msgid "Try it out:"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:464
+#: lib/vutuv_web/templates/page/index.html.heex:494
 #, elixir-autogen, elixir-format
 msgid "Plus a sitemap, JSON-LD and a REST API with OAuth 2 and personal access tokens."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:319
+#: lib/vutuv_web/templates/page/index.html.heex:349
 #, elixir-autogen, elixir-format
 msgid "Work experience, education, certificates, languages, links and tags others endorse you for. Anyone can read a profile, entirely without a vutuv account. Unlike LinkedIn, where you hit a login wall in short order."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:419
+#: lib/vutuv_web/templates/page/index.html.heex:449
 #, elixir-autogen, elixir-format
 msgid "Talking to people"
 msgstr ""
@@ -17949,77 +17951,77 @@ msgstr ""
 msgid "The Fediverse: let people follow you from Mastodon, and your public posts show up there. You choose at sign-up, and can change it later."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:420
+#: lib/vutuv_web/templates/page/index.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "Posts, messages, and the Fediverse along with them"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:422
+#: lib/vutuv_web/templates/page/index.html.heex:452
 #, elixir-autogen, elixir-format
 msgid "Write a post, react with a heart, a repost or a reply, or message somebody privately. And you are not stuck among vutuv members: vutuv is part of the Fediverse, the union of independent networks that Mastodon belongs to as well. Follow an account over there and its posts arrive in your feed; the other way round, people there can follow you and see your public posts. Both directions, and entirely your choice: at sign-up you decide whether to use vutuv with or without the Fediverse, and you can change that at any time in the settings."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:535
+#: lib/vutuv_web/templates/page/index.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Download everything you have here at any time, in a machine-readable file. Not on request, not after a waiting period: from your settings, whenever you like."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:510
+#: lib/vutuv_web/templates/page/index.html.heex:540
 #, elixir-autogen, elixir-format
 msgid "Fair and transparent, in plain words"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:524
+#: lib/vutuv_web/templates/page/index.html.heex:554
 #, elixir-autogen, elixir-format
 msgid "No third-party cookies"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:516
+#: lib/vutuv_web/templates/page/index.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "On our own servers in %{place}, not in somebody else's cloud. We do not hand your profile to a third party, and there is no tracking network reading along."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:514
+#: lib/vutuv_web/templates/page/index.html.heex:544
 #, elixir-autogen, elixir-format
 msgid "Where your data lives"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:509
+#: lib/vutuv_web/templates/page/index.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "Your data"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:526
+#: lib/vutuv_web/templates/page/index.html.heex:556
 #, elixir-autogen, elixir-format
 msgid "vutuv sets one cookie, the one that keeps you signed in. No advertising network, no analytics service, nothing loaded from anybody else's server."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:542
+#: lib/vutuv_web/templates/page/index.html.heex:572
 #, elixir-autogen, elixir-format
 msgid "Leave whenever you like"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:558
+#: lib/vutuv_web/templates/page/index.html.heex:588
 #, elixir-autogen, elixir-format
 msgid "Open source"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:560
+#: lib/vutuv_web/templates/page/index.html.heex:590
 #, elixir-autogen, elixir-format
 msgid "You can check at any time how exactly vutuv works. The whole source code is public under the MIT license, so everything said above about your data can be read rather than taken on trust."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:533
+#: lib/vutuv_web/templates/page/index.html.heex:563
 #, elixir-autogen, elixir-format
 msgid "Your data stays with you"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:549
+#: lib/vutuv_web/templates/page/index.html.heex:579
 #, elixir-autogen, elixir-format
 msgid "Delete your account yourself, without writing to anybody. No questions asked, and you are welcome back any time."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:256
+#: lib/vutuv_web/components/ui.ex:257
 #, elixir-autogen, elixir-format
 msgid "At most %{max} tags. Remove one to add another."
 msgstr ""
@@ -18066,7 +18068,7 @@ msgstr ""
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:857
+#: lib/vutuv_web/controllers/settings_controller.ex:877
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr ""
@@ -18173,7 +18175,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:4644
+#: lib/vutuv_web/components/ui.ex:4688
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -18369,7 +18371,7 @@ msgstr ""
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4645
+#: lib/vutuv_web/components/ui.ex:4689
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
@@ -18380,7 +18382,7 @@ msgstr ""
 msgid "Zwischenzeugnis"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4647
+#: lib/vutuv_web/components/ui.ex:4691
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -18635,7 +18637,7 @@ msgstr ""
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3984
+#: lib/vutuv_web/components/ui.ex:4028
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -18884,7 +18886,7 @@ msgstr ""
 msgid "You have reached your limit of %{limit} reviews. Please try again in %{window}."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:379
+#: lib/vutuv_web/templates/page/index.html.heex:409
 #, elixir-autogen, elixir-format
 msgid "Employment reference"
 msgstr ""
@@ -18894,7 +18896,7 @@ msgstr ""
 msgid "Employment references: upload them, keep them private, and have the wording read and graded on our own servers."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:356
+#: lib/vutuv_web/templates/page/index.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "Job applications"
 msgstr ""
@@ -18909,7 +18911,7 @@ msgstr ""
 msgid "The finished CV ready to print: name, tagline and contact details at the top, below them the positions held with employer and period, and further down the tags and the spoken languages."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:399
+#: lib/vutuv_web/templates/page/index.html.heex:429
 #, elixir-autogen, elixir-format
 msgid "The review is a text analysis, not legal advice, and it covers German employment references."
 msgstr ""
@@ -18924,22 +18926,22 @@ msgstr ""
 msgid "The uploaded employment references, each marked private: one graded 1 (very good) on a green panel, one graded 4 to 5 (poor to unsatisfactory) on a red one, each with a link to its full report."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:382
+#: lib/vutuv_web/templates/page/index.html.heex:412
 #, elixir-autogen, elixir-format
 msgid "Upload your employment references and have them read sentence by sentence: a grade, a traffic light, and the explanation of how a recruiter reads that wording. It takes a few minutes, then the report is there. Nothing becomes public before you release it."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:380
+#: lib/vutuv_web/templates/page/index.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "What your employment reference really says"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:359
+#: lib/vutuv_web/templates/page/index.html.heex:389
 #, elixir-autogen, elixir-format
 msgid "What your profile already says becomes a CV. You tick what should go in, then download it as PDF, Word, OpenDocument, LaTeX or JSON Resume. Anonymously as well, if you would rather show what you can do before you show who you are."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:357
+#: lib/vutuv_web/templates/page/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "Your CV, ready to send"
 msgstr ""
@@ -18981,12 +18983,12 @@ msgstr ""
 msgid "Enter the PIN from the email"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:763
+#: lib/vutuv_web/components/ui.ex:807
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:791
+#: lib/vutuv_web/components/ui.ex:835
 #, elixir-autogen, elixir-format
 msgid "Cancel registration"
 msgstr ""
@@ -19001,22 +19003,22 @@ msgstr ""
 msgid "Follow other members"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:746
+#: lib/vutuv_web/components/ui.ex:790
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1346
+#: lib/vutuv/accounts/user.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1344
+#: lib/vutuv/accounts/user.ex:1350
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1345
+#: lib/vutuv/accounts/user.ex:1351
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19026,7 +19028,7 @@ msgstr ""
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4626
+#: lib/vutuv_web/components/ui.ex:4670
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
@@ -19122,7 +19124,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4746
+#: lib/vutuv_web/components/ui.ex:4790
 #: lib/vutuv_web/controllers/settings_controller.ex:247
 #: lib/vutuv_web/controllers/settings_controller.ex:326
 #: lib/vutuv_web/controllers/settings_controller.ex:338
@@ -19219,7 +19221,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4748
+#: lib/vutuv_web/components/ui.ex:4792
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -19328,7 +19330,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4750
+#: lib/vutuv_web/components/ui.ex:4794
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -19762,17 +19764,17 @@ msgstr ""
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1897
+#: lib/vutuv_web/live/post_live/composer.ex:1925
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1260
+#: lib/vutuv_web/live/post_live/composer.ex:1271
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1874
+#: lib/vutuv_web/live/post_live/composer.ex:1902
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr ""
@@ -20059,12 +20061,12 @@ msgstr ""
 msgid "This vutuv exchanges nothing with other networks, so nothing here has any effect."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:442
+#: lib/vutuv_web/live/organization_live/edit.ex:443
 #, elixir-autogen, elixir-format
 msgid "Claim a short @name so this organization has an address of its own, like a member. Letters, numbers and underscores, %{min} to %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:440
+#: lib/vutuv_web/live/organization_live/edit.ex:441
 #, elixir-autogen, elixir-format
 msgid "The organization's @name"
 msgstr ""
@@ -20119,22 +20121,22 @@ msgstr ""
 msgid "The PIN has expired."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:867
+#: lib/vutuv_web/components/ui.ex:911
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:869
+#: lib/vutuv_web/components/ui.ex:913
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:868
+#: lib/vutuv_web/components/ui.ex:912
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:870
+#: lib/vutuv_web/components/ui.ex:914
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr ""
@@ -20553,17 +20555,17 @@ msgstr ""
 msgid "{n} of {max} free slots selected."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1939
+#: lib/vutuv_web/live/post_live/composer.ex:1967
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1924
+#: lib/vutuv_web/live/post_live/composer.ex:1952
 #, elixir-autogen, elixir-format
 msgid "Post language"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1929
+#: lib/vutuv_web/live/post_live/composer.ex:1957
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr ""
@@ -20599,7 +20601,7 @@ msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:4697
-#: lib/vutuv_web/components/ui.ex:4705
+#: lib/vutuv_web/components/ui.ex:4749
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -20627,7 +20629,7 @@ msgstr ""
 msgid "What your feed does with posts outside your chosen languages: show them as they are, translate them for you, or hide them. Posts that declare no language always show."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:110
+#: lib/vutuv_web/gettext_extraction_anchors.ex:116
 #, elixir-autogen, elixir-format
 msgid "Date & time"
 msgstr ""
@@ -20637,12 +20639,12 @@ msgstr ""
 msgid "Date and time settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:108
+#: lib/vutuv_web/gettext_extraction_anchors.ex:114
 #, elixir-autogen, elixir-format
 msgid "Date format"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:118
+#: lib/vutuv_web/gettext_extraction_anchors.ex:124
 #, elixir-autogen, elixir-format
 msgid "Germany, Austria, Switzerland"
 msgstr ""
@@ -20652,27 +20654,27 @@ msgstr ""
 msgid "Language and region saved."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:114
+#: lib/vutuv_web/gettext_extraction_anchors.ex:120
 #, elixir-autogen, elixir-format
 msgid "Posts, messages and notifications are stamped in this zone. New accounts take it from the browser."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:111
+#: lib/vutuv_web/gettext_extraction_anchors.ex:117
 #, elixir-autogen, elixir-format
 msgid "The order and punctuation of every date you read here, and whether times run on a 12- or 24-hour clock."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:109
+#: lib/vutuv_web/gettext_extraction_anchors.ex:115
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:119
+#: lib/vutuv_web/gettext_extraction_anchors.ex:125
 #, elixir-autogen, elixir-format
 msgid "United Kingdom, France, Brazil"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:120
+#: lib/vutuv_web/gettext_extraction_anchors.ex:126
 #, elixir-autogen, elixir-format
 msgid "United States"
 msgstr ""
@@ -20682,7 +20684,7 @@ msgstr ""
 msgid "Your browser says: {zone}"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:121
+#: lib/vutuv_web/gettext_extraction_anchors.ex:127
 #, elixir-autogen, elixir-format
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr ""
@@ -20809,7 +20811,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4794
+#: lib/vutuv_web/components/ui.ex:4838
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
@@ -20855,7 +20857,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4796
+#: lib/vutuv_web/components/ui.ex:4840
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -20891,7 +20893,7 @@ msgstr ""
 msgid "Find your LinkedIn contacts"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4721
+#: lib/vutuv_web/components/ui.ex:4765
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format
@@ -20999,7 +21001,7 @@ msgstr ""
 msgid "See which of them are already on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4723
+#: lib/vutuv_web/components/ui.ex:4767
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr ""
@@ -21071,7 +21073,7 @@ msgstr ""
 msgid "Your export also lists your LinkedIn contacts."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4725
+#: lib/vutuv_web/components/ui.ex:4769
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr ""
@@ -21215,7 +21217,7 @@ msgctxt "qualification detail"
 msgid "Jobs"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:835
+#: lib/vutuv_web/live/job_posting_live/form.ex:836
 #, elixir-autogen, elixir-format
 msgid "%{formatted} country chosen."
 msgid_plural "%{formatted} countries chosen."
@@ -21327,7 +21329,7 @@ msgstr ""
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4693
+#: lib/vutuv_web/components/ui.ex:4737
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
@@ -21387,43 +21389,43 @@ msgstr ""
 msgid "New here"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1499
+#: lib/vutuv_web/components/ui.ex:1543
 #, elixir-autogen, elixir-format
 msgid "New public posts arrive in any feed reader. No account needed either."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1495
+#: lib/vutuv_web/components/ui.ex:1539
 #, elixir-autogen, elixir-format
 msgid "Or with an RSS reader"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1375
-#: lib/vutuv_web/components/ui.ex:1444
+#: lib/vutuv_web/components/ui.ex:1419
+#: lib/vutuv_web/components/ui.ex:1488
 #, elixir-autogen, elixir-format
 msgid "Subscribe"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1496
+#: lib/vutuv_web/components/ui.ex:1540
 #, elixir-autogen, elixir-format
 msgid "With an RSS reader"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1456
+#: lib/vutuv_web/components/ui.ex:1500
 #, elixir-autogen, elixir-format
 msgid "Create a free account"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1471
+#: lib/vutuv_web/components/ui.ex:1515
 #, elixir-autogen, elixir-format
 msgid "No vutuv account? These ways work too:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1449
+#: lib/vutuv_web/components/ui.ex:1493
 #, elixir-autogen, elixir-format
 msgid "The best way: follow %{name} here. New posts land in your feed, and you can reply and join in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1447
+#: lib/vutuv_web/components/ui.ex:1491
 #, elixir-autogen, elixir-format
 msgid "With a vutuv account"
 msgstr ""
@@ -21433,7 +21435,7 @@ msgstr ""
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:234
+#: lib/vutuv_web/templates/settings/preferences.html.heex:278
 #, elixir-autogen, elixir-format
 msgid "Example"
 msgstr ""
@@ -21448,12 +21450,12 @@ msgstr ""
 msgid "Just flashed the new release, boot is under two seconds now"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:244
+#: lib/vutuv_web/templates/settings/preferences.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "Play the example"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:99
+#: lib/vutuv_web/gettext_extraction_anchors.ex:105
 #, elixir-autogen, elixir-format
 msgid "Between 4 and 20 seconds."
 msgstr ""
@@ -21548,22 +21550,22 @@ msgstr ""
 msgid "Shown in the language it was written in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4706
+#: lib/vutuv_web/components/ui.ex:4750
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4708
+#: lib/vutuv_web/components/ui.ex:4752
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4773
+#: lib/vutuv_web/components/ui.ex:4817
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4777
+#: lib/vutuv_web/components/ui.ex:4821
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -21596,7 +21598,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:94
-#: lib/vutuv_web/templates/settings/preferences.html.heex:210
+#: lib/vutuv_web/templates/settings/preferences.html.heex:254
 #, elixir-autogen, elixir-format
 msgid "Browser tab"
 msgstr ""
@@ -21621,12 +21623,12 @@ msgstr ""
 msgid "Tease new posts in the browser tab"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:236
+#: lib/vutuv_web/templates/settings/preferences.html.heex:280
 #, elixir-autogen, elixir-format
 msgid "Watch this tab's title, above."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:212
+#: lib/vutuv_web/templates/settings/preferences.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "While you are reading another tab, a new post can page its first words through this tab's title, a line at a time, and then hand the title back."
 msgstr ""
@@ -21681,7 +21683,7 @@ msgstr ""
 msgid "Your LinkedIn profile can come along."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1067
+#: lib/vutuv_web/components/ui.ex:1111
 #, elixir-autogen, elixir-format
 msgid "Being checked"
 msgstr ""
@@ -21905,7 +21907,7 @@ msgstr ""
 msgid "Move %{card}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:350
+#: lib/vutuv_web/components/ui.ex:544
 #: lib/vutuv_web/live/post_live/filter_band.ex:583
 #, elixir-autogen, elixir-format
 msgid "No account found."
@@ -22070,7 +22072,7 @@ msgstr ""
 msgid "Your organization page was updated, but that picture could not be used as a logo. Please pick another one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3990
+#: lib/vutuv_web/components/ui.ex:4034
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -22232,12 +22234,12 @@ msgstr ""
 msgid "Quotes %{url}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:349
+#: lib/vutuv_web/components/ui.ex:543
 #, elixir-autogen, elixir-format
 msgid "Mention an account"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:352
+#: lib/vutuv_web/components/ui.ex:546
 #, elixir-autogen, elixir-format
 msgid "{used} of {max} mentions"
 msgstr ""
@@ -22268,7 +22270,7 @@ msgstr ""
 msgid "Only these accounts (empty = all) …"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3115
+#: lib/vutuv_web/components/ui.ex:3159
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr ""
@@ -22318,33 +22320,33 @@ msgid_plural "shared this."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:475
+#: lib/vutuv_web/components/ui.ex:482
 #, elixir-autogen, elixir-format
 msgid "Editor view"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:423
+#: lib/vutuv_web/components/ui.ex:430
 #, elixir-autogen, elixir-format
 msgid "Insert a block"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:435
+#: lib/vutuv_web/components/ui.ex:442
 #, elixir-autogen, elixir-format
 msgid "Nothing matches."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1750
-#: lib/vutuv_web/live/post_live/composer.ex:2483
+#: lib/vutuv_web/live/post_live/composer.ex:1778
+#: lib/vutuv_web/live/post_live/composer.ex:2513
 #, elixir-autogen, elixir-format
 msgid "Automatic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1755
+#: lib/vutuv_web/live/post_live/composer.ex:1783
 #, elixir-autogen, elixir-format
 msgid "Drag one photo onto another to swap them."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1702
+#: lib/vutuv_web/live/post_live/composer.ex:1730
 #, elixir-autogen, elixir-format
 msgid "Not shown in the gallery — drag one into it to swap."
 msgstr ""
@@ -22401,32 +22403,63 @@ msgstr ""
 msgid "Unmute %{host}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1510
+#: lib/vutuv_web/live/post_live/composer.ex:1538
 #, elixir-autogen, elixir-format
 msgid "Draft discarded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1549
+#: lib/vutuv_web/live/post_live/composer.ex:1577
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1540
+#: lib/vutuv_web/live/post_live/composer.ex:1568
 #, elixir-autogen, elixir-format
 msgid "Keep this draft for later?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1175
+#: lib/vutuv_web/live/post_live/composer.ex:1186
 #, elixir-autogen, elixir-format
 msgid "Hidden from some"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1857
+#: lib/vutuv_web/live/post_live/composer.ex:1885
 #, elixir-autogen, elixir-format
 msgid "Post options"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:314
+#: lib/vutuv_web/live/organization_live/edit.ex:315
 #, elixir-autogen, elixir-format
 msgid "Describe the organization. Markdown is supported."
+msgstr ""
+
+#: lib/vutuv_web/templates/page/index.html.heex:286
+#: lib/vutuv_web/templates/settings/preferences.html.heex:205
+#, elixir-autogen, elixir-format
+msgid "Bandwidth"
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:868
+#, elixir-autogen, elixir-format
+msgid "Bandwidth settings reset to the site defaults."
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:862
+#, elixir-autogen, elixir-format
+msgid "Bandwidth settings saved."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:207
+#, elixir-autogen, elixir-format
+msgid "If you are on a slow or metered connection, vutuv can leave out the parts of the page that cost the most to download."
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:101
+#, elixir-autogen, elixir-format
+msgid "Low-bandwidth mode"
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:102
+#, elixir-autogen, elixir-format
+msgid "Writing a post or a message then uses a plain Markdown box instead of the formatting editor, which saves about 150 kB of download. Everything you write still looks the same to everyone who reads it."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -15,12 +15,12 @@ msgstr "Language: en\n"
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4370
-#: lib/vutuv_web/components/ui.ex:4375
+#: lib/vutuv_web/components/ui.ex:4414
+#: lib/vutuv_web/components/ui.ex:4419
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
 #: lib/vutuv_web/live/organization_live/domains.ex:272
-#: lib/vutuv_web/live/organization_live/edit.ex:430
+#: lib/vutuv_web/live/organization_live/edit.ex:431
 #: lib/vutuv_web/live/organization_live/roles.ex:214
 #, elixir-autogen
 msgid "Add"
@@ -62,7 +62,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/text.ex:71
-#: lib/vutuv_web/components/ui.ex:4668
+#: lib/vutuv_web/components/ui.ex:4712
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -75,14 +75,14 @@ msgstr ""
 msgid "Addresses"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1462
-#: lib/vutuv_web/templates/page/index.html.heex:290
+#: lib/vutuv_web/components/ui.ex:1506
+#: lib/vutuv_web/templates/page/index.html.heex:320
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4165
-#: lib/vutuv_web/components/ui.ex:4259
+#: lib/vutuv_web/components/ui.ex:4209
+#: lib/vutuv_web/components/ui.ex:4303
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -110,14 +110,14 @@ msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:114
-#: lib/vutuv_web/components/ui.ex:4159
+#: lib/vutuv_web/components/ui.ex:4203
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
-#: lib/vutuv_web/live/job_posting_live/form.ex:811
-#: lib/vutuv_web/live/organization_live/edit.ex:381
+#: lib/vutuv_web/live/job_posting_live/form.ex:812
+#: lib/vutuv_web/live/organization_live/edit.ex:382
 #: lib/vutuv_web/live/organization_live/new.ex:231
-#: lib/vutuv_web/live/post_live/composer.ex:1669
+#: lib/vutuv_web/live/post_live/composer.ex:1697
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -161,7 +161,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3586
-#: lib/vutuv_web/components/ui.ex:4262
+#: lib/vutuv_web/components/ui.ex:4306
 #: lib/vutuv_web/live/admin/job_live.ex:489
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -177,7 +177,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:686
 #: lib/vutuv_web/live/organization_live/edit.ex:301
-#: lib/vutuv_web/live/organization_live/edit.ex:313
+#: lib/vutuv_web/live/organization_live/edit.ex:314
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
 #: lib/vutuv_web/templates/address/form_en.html.heex:11
 #: lib/vutuv_web/templates/address/form_generic.html.heex:13
@@ -201,7 +201,7 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:438
-#: lib/vutuv_web/live/post_live/composer.ex:2579
+#: lib/vutuv_web/live/post_live/composer.ex:2609
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
@@ -209,7 +209,7 @@ msgid "Download"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3551
-#: lib/vutuv_web/components/ui.ex:4253
+#: lib/vutuv_web/components/ui.ex:4297
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -283,7 +283,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:4632
+#: lib/vutuv_web/components/ui.ex:4676
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -324,8 +324,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:632
 #: lib/vutuv_web/agent_docs/text.ex:596
 #: lib/vutuv_web/components/fediverse_components.ex:400
-#: lib/vutuv_web/components/ui.ex:2661
-#: lib/vutuv_web/components/ui.ex:2696
+#: lib/vutuv_web/components/ui.ex:2705
+#: lib/vutuv_web/components/ui.ex:2740
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:608
@@ -601,7 +601,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1881
+#: lib/vutuv_web/live/post_live/composer.ex:1909
 #: lib/vutuv_web/live/section_reorder_live.ex:270
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -611,9 +611,9 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4158
-#: lib/vutuv_web/live/organization_live/edit.ex:375
-#: lib/vutuv_web/live/post_live/composer.ex:1896
+#: lib/vutuv_web/components/ui.ex:4202
+#: lib/vutuv_web/live/organization_live/edit.ex:376
+#: lib/vutuv_web/live/post_live/composer.ex:1924
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -623,8 +623,9 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
 #: lib/vutuv_web/templates/settings/preferences.html.heex:157
-#: lib/vutuv_web/templates/settings/preferences.html.heex:229
-#: lib/vutuv_web/templates/settings/preferences.html.heex:362
+#: lib/vutuv_web/templates/settings/preferences.html.heex:224
+#: lib/vutuv_web/templates/settings/preferences.html.heex:273
+#: lib/vutuv_web/templates/settings/preferences.html.heex:406
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:462
@@ -663,7 +664,7 @@ msgstr ""
 msgid "Show"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:269
+#: lib/vutuv_web/templates/page/index.html.heex:299
 #, elixir-autogen
 msgid "Sign up for a free account"
 msgstr ""
@@ -786,7 +787,7 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4628
+#: lib/vutuv_web/components/ui.ex:4672
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -838,7 +839,7 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1269
+#: lib/vutuv_web/components/ui.ex:1313
 #: lib/vutuv_web/views/user_html.ex:562
 #: lib/vutuv_web/views/user_html.ex:563
 #: lib/vutuv_web/views/user_html.ex:577
@@ -846,17 +847,17 @@ msgstr ""
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4323
+#: lib/vutuv_web/components/ui.ex:4367
 #: lib/vutuv_web/templates/user/show.html.heex:973
 #: lib/vutuv_web/templates/user/show.html.heex:996
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4736
+#: lib/vutuv_web/components/ui.ex:4780
 #: lib/vutuv_web/controllers/settings_controller.ex:171
-#: lib/vutuv_web/live/job_posting_live/form.ex:767
-#: lib/vutuv_web/live/organization_live/edit.ex:334
+#: lib/vutuv_web/live/job_posting_live/form.ex:768
+#: lib/vutuv_web/live/organization_live/edit.ex:335
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:295
@@ -870,7 +871,7 @@ msgstr ""
 msgid "We can't find em' cap'n!"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:293
+#: lib/vutuv_web/templates/page/index.html.heex:323
 #, elixir-autogen
 msgid "We reserve the right to stop this service or delete your account anytime without warning."
 msgstr ""
@@ -950,7 +951,7 @@ msgstr ""
 msgid "Allow others to view your email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:279
+#: lib/vutuv_web/templates/page/index.html.heex:309
 #, elixir-autogen, elixir-format
 msgid "By creating an account you accept our {nutzungsbedingungen} and confirm that you have read our {datenschutz}."
 msgstr ""
@@ -1074,7 +1075,7 @@ msgstr ""
 msgid "Listings"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:399
+#: lib/vutuv_web/controllers/page_controller.ex:418
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1373,7 +1374,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:522
 #: lib/vutuv_web/agent_docs/text.ex:768
-#: lib/vutuv_web/components/ui.ex:4653
+#: lib/vutuv_web/components/ui.ex:4697
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1384,7 +1385,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:444
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
-#: lib/vutuv_web/live/job_posting_live/form.ex:716
+#: lib/vutuv_web/live/job_posting_live/form.ex:717
 #: lib/vutuv_web/live/search_live.ex:344
 #: lib/vutuv_web/live/search_live.ex:822
 #: lib/vutuv_web/live/tag_new_live.ex:35
@@ -1561,7 +1562,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:776
 #: lib/vutuv_web/live/job_board_live.ex:360
 #: lib/vutuv_web/live/job_posting_live/form.ex:548
-#: lib/vutuv_web/live/organization_live/edit.ex:330
+#: lib/vutuv_web/live/organization_live/edit.ex:331
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
 #: lib/vutuv_web/templates/address/country_input.html.heex:5
@@ -1614,15 +1615,15 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2820
+#: lib/vutuv_web/components/ui.ex:2864
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:480
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1525
-#: lib/vutuv_web/live/post_live/composer.ex:1627
-#: lib/vutuv_web/live/post_live/composer.ex:1628
-#: lib/vutuv_web/live/post_live/composer.ex:2456
-#: lib/vutuv_web/live/post_live/composer.ex:2722
+#: lib/vutuv_web/live/post_live/composer.ex:1553
+#: lib/vutuv_web/live/post_live/composer.ex:1655
+#: lib/vutuv_web/live/post_live/composer.ex:1656
+#: lib/vutuv_web/live/post_live/composer.ex:2486
+#: lib/vutuv_web/live/post_live/composer.ex:2752
 #: lib/vutuv_web/templates/layout/app.html.heex:188
 #: lib/vutuv_web/templates/layout/app.html.heex:194
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
@@ -1645,7 +1646,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/page_controller.ex:254
 #: lib/vutuv_web/templates/layout/app.html.heex:117
-#: lib/vutuv_web/templates/page/index.html.heex:286
+#: lib/vutuv_web/templates/page/index.html.heex:316
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
@@ -1653,7 +1654,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/page_controller.ex:260
 #: lib/vutuv_web/templates/layout/app.html.heex:118
-#: lib/vutuv_web/templates/page/index.html.heex:286
+#: lib/vutuv_web/templates/page/index.html.heex:316
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Nutzungsbedingungen"
@@ -1671,20 +1672,20 @@ msgstr ""
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1981
-#: lib/vutuv_web/components/ui.ex:1990
-#: lib/vutuv_web/components/ui.ex:2468
+#: lib/vutuv_web/components/ui.ex:2025
+#: lib/vutuv_web/components/ui.ex:2034
+#: lib/vutuv_web/components/ui.ex:2512
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:236
-#: lib/vutuv_web/components/ui.ex:2626
-#: lib/vutuv_web/components/ui.ex:2626
-#: lib/vutuv_web/components/ui.ex:2643
-#: lib/vutuv_web/components/ui.ex:2652
-#: lib/vutuv_web/components/ui.ex:2668
-#: lib/vutuv_web/components/ui.ex:2730
+#: lib/vutuv_web/components/ui.ex:2670
+#: lib/vutuv_web/components/ui.ex:2670
+#: lib/vutuv_web/components/ui.ex:2687
+#: lib/vutuv_web/components/ui.ex:2696
+#: lib/vutuv_web/components/ui.ex:2712
+#: lib/vutuv_web/components/ui.ex:2774
 #: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:311
@@ -1756,7 +1757,7 @@ msgid "Network"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:450
-#: lib/vutuv_web/components/ui.ex:4372
+#: lib/vutuv_web/components/ui.ex:4416
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
@@ -1772,7 +1773,7 @@ msgid "Nothing new yet."
 msgstr ""
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:4690
+#: lib/vutuv_web/components/ui.ex:4734
 #: lib/vutuv_web/controllers/page_controller.ex:228
 #: lib/vutuv_web/live/notification_live/index.ex:146
 #: lib/vutuv_web/live/notification_live/index.ex:384
@@ -1798,7 +1799,7 @@ msgid "Pardon us! Something went wrong."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:911
+#: lib/vutuv_web/live/message_live/index.ex:912
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
@@ -1872,8 +1873,8 @@ msgstr ""
 msgid "Who to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:900
 #: lib/vutuv_web/live/message_live/index.ex:901
+#: lib/vutuv_web/live/message_live/index.ex:902
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr ""
@@ -1918,15 +1919,15 @@ msgstr ""
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3651
-#: lib/vutuv_web/components/ui.ex:3804
+#: lib/vutuv_web/components/ui.ex:3695
+#: lib/vutuv_web/components/ui.ex:3848
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4397
+#: lib/vutuv_web/components/ui.ex:4441
 #: lib/vutuv_web/live/organization_live/activity.ex:151
 #: lib/vutuv_web/live/organization_live/feed.ex:210
 #: lib/vutuv_web/live/organization_live/show.ex:777
@@ -1939,13 +1940,13 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4168
+#: lib/vutuv_web/components/ui.ex:4212
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1662
-#: lib/vutuv_web/components/ui.ex:1672
+#: lib/vutuv_web/components/ui.ex:1706
+#: lib/vutuv_web/components/ui.ex:1716
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr ""
@@ -1984,12 +1985,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3174
+#: lib/vutuv_web/components/ui.ex:3218
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3178
+#: lib/vutuv_web/components/ui.ex:3222
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -2014,37 +2015,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3182
+#: lib/vutuv_web/components/ui.ex:3226
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3172
+#: lib/vutuv_web/components/ui.ex:3216
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3171
+#: lib/vutuv_web/components/ui.ex:3215
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3177
+#: lib/vutuv_web/components/ui.ex:3221
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3176
+#: lib/vutuv_web/components/ui.ex:3220
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3173
+#: lib/vutuv_web/components/ui.ex:3217
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3175
+#: lib/vutuv_web/components/ui.ex:3219
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2059,17 +2060,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3181
+#: lib/vutuv_web/components/ui.ex:3225
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3180
+#: lib/vutuv_web/components/ui.ex:3224
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3179
+#: lib/vutuv_web/components/ui.ex:3223
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2081,12 +2082,12 @@ msgstr ""
 msgid "Markdown is supported: bold, italics, links and lists."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:709
+#: lib/vutuv_web/live/job_posting_live/form.ex:710
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2074
+#: lib/vutuv_web/live/post_live/composer.ex:2102
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2097,7 +2098,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1767
+#: lib/vutuv_web/live/post_live/composer.ex:1795
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2142,12 +2143,12 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2050
+#: lib/vutuv_web/live/post_live/composer.ex:2078
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1978
+#: lib/vutuv_web/live/post_live/composer.ex:2006
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
@@ -2158,13 +2159,13 @@ msgstr ""
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2020
+#: lib/vutuv_web/live/post_live/composer.ex:2048
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1284
-#: lib/vutuv_web/live/post_live/composer.ex:1332
+#: lib/vutuv_web/live/post_live/composer.ex:1295
+#: lib/vutuv_web/live/post_live/composer.ex:1343
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
@@ -2174,23 +2175,23 @@ msgstr ""
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1250
+#: lib/vutuv_web/live/post_live/composer.ex:1261
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2010
+#: lib/vutuv_web/live/post_live/composer.ex:2038
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2000
+#: lib/vutuv_web/live/post_live/composer.ex:2028
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:416
-#: lib/vutuv_web/live/post_live/composer.ex:1898
+#: lib/vutuv_web/live/post_live/composer.ex:1926
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2205,7 +2206,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/post_controller.ex:62
 #: lib/vutuv_web/controllers/post_controller.ex:74
 #: lib/vutuv_web/controllers/user_controller.ex:76
-#: lib/vutuv_web/gettext_extraction_anchors.ex:103
+#: lib/vutuv_web/gettext_extraction_anchors.ex:109
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:388
 #: lib/vutuv_web/live/notification_live/index.ex:1125
@@ -2213,7 +2214,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:345
 #: lib/vutuv_web/live/search_live.ex:836
-#: lib/vutuv_web/templates/settings/preferences.html.heex:275
+#: lib/vutuv_web/templates/settings/preferences.html.heex:319
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
@@ -2238,9 +2239,9 @@ msgstr ""
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:246
-#: lib/vutuv_web/live/organization_live/edit.ex:407
+#: lib/vutuv_web/live/organization_live/edit.ex:408
 #: lib/vutuv_web/live/organization_live/roles.ex:247
-#: lib/vutuv_web/live/post_live/composer.ex:2036
+#: lib/vutuv_web/live/post_live/composer.ex:2064
 #: lib/vutuv_web/live/post_live/filter_band.ex:455
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
@@ -2255,7 +2256,7 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1888
+#: lib/vutuv_web/live/post_live/composer.ex:1916
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
@@ -2272,12 +2273,12 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1358
+#: lib/vutuv_web/live/post_live/composer.ex:1369
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1232
+#: lib/vutuv_web/live/post_live/composer.ex:1243
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2287,17 +2288,17 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2871
+#: lib/vutuv_web/live/post_live/composer.ex:2901
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2872
+#: lib/vutuv_web/live/post_live/composer.ex:2902
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4990
+#: lib/vutuv_web/components/ui.ex:5034
 #: lib/vutuv_web/live/shell_live.ex:1307
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2306,12 +2307,12 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2149
+#: lib/vutuv_web/live/post_live/composer.ex:2179
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2150
+#: lib/vutuv_web/live/post_live/composer.ex:2180
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
@@ -2341,23 +2342,23 @@ msgstr ""
 msgid "people you don't follow"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3252
+#: lib/vutuv_web/components/ui.ex:3296
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1803
+#: lib/vutuv_web/live/post_live/composer.ex:1831
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2862
+#: lib/vutuv_web/live/post_live/composer.ex:2892
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2866
+#: lib/vutuv_web/live/post_live/composer.ex:2896
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2379,7 +2380,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2033
 #: lib/vutuv_web/components/post_components.ex:5535
-#: lib/vutuv_web/components/ui.ex:3726
+#: lib/vutuv_web/components/ui.ex:3770
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2398,7 +2399,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1986
 #: lib/vutuv_web/components/post_components.ex:5771
-#: lib/vutuv_web/components/ui.ex:3712
+#: lib/vutuv_web/components/ui.ex:3756
 #: lib/vutuv_web/live/notification_live/index.ex:1271
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
@@ -2470,9 +2471,9 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:430
 #: lib/vutuv_web/components/post_components.ex:2648
-#: lib/vutuv_web/components/ui.ex:2621
-#: lib/vutuv_web/components/ui.ex:2621
-#: lib/vutuv_web/components/ui.ex:2697
+#: lib/vutuv_web/components/ui.ex:2665
+#: lib/vutuv_web/components/ui.ex:2665
+#: lib/vutuv_web/components/ui.ex:2741
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:611
@@ -2514,13 +2515,13 @@ msgstr ""
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1235
-#: lib/vutuv_web/live/post_live/composer.ex:1876
+#: lib/vutuv_web/live/post_live/composer.ex:1246
+#: lib/vutuv_web/live/post_live/composer.ex:1904
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2081
+#: lib/vutuv_web/live/post_live/composer.ex:2109
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2560,7 +2561,7 @@ msgstr ""
 msgid "%{name} is typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:923
+#: lib/vutuv_web/live/message_live/index.ex:924
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr ""
@@ -2606,7 +2607,7 @@ msgstr ""
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2944
+#: lib/vutuv_web/components/ui.ex:2988
 #: lib/vutuv_web/live/message_live/index.ex:760
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2617,7 +2618,7 @@ msgstr ""
 msgid "Requests"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:932
+#: lib/vutuv_web/live/message_live/index.ex:933
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr ""
@@ -2693,7 +2694,7 @@ msgstr ""
 msgid "Okay, let's start over."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:771
+#: lib/vutuv_web/components/ui.ex:815
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr ""
@@ -2704,7 +2705,7 @@ msgstr ""
 msgid "Too many PIN requests. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:792
+#: lib/vutuv_web/components/ui.ex:836
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr ""
@@ -2754,8 +2755,8 @@ msgstr ""
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3892
-#: lib/vutuv_web/components/ui.ex:4325
+#: lib/vutuv_web/components/ui.ex:3936
+#: lib/vutuv_web/components/ui.ex:4369
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:104
@@ -2807,7 +2808,7 @@ msgstr[1] ""
 msgid "Connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1260
+#: lib/vutuv_web/components/ui.ex:1304
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2817,17 +2818,17 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1276
+#: lib/vutuv_web/components/ui.ex:1320
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1990
+#: lib/vutuv_web/live/post_live/composer.ex:2018
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1261
+#: lib/vutuv_web/components/ui.ex:1305
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -3157,7 +3158,7 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4622
+#: lib/vutuv_web/components/ui.ex:4666
 #: lib/vutuv_web/live/shell_live.ex:1128
 #: lib/vutuv_web/live/shell_live.ex:1425
 #: lib/vutuv_web/templates/import/new.html.heex:16
@@ -3268,7 +3269,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3601
+#: lib/vutuv_web/components/ui.ex:3645
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3873,7 +3874,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:157
 #: lib/vutuv_web/agent_docs/text.ex:112
 #: lib/vutuv_web/agent_docs/text.ex:143
-#: lib/vutuv_web/live/job_posting_live/form.ex:699
+#: lib/vutuv_web/live/job_posting_live/form.ex:700
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr ""
@@ -4060,7 +4061,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
 #: lib/vutuv_web/live/job_posting_live/form.ex:542
-#: lib/vutuv_web/live/organization_live/edit.ex:326
+#: lib/vutuv_web/live/organization_live/edit.ex:327
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
 #: lib/vutuv_web/templates/address/form_en.html.heex:33
@@ -4342,12 +4343,12 @@ msgstr ""
 msgid "Bookings are open through %{last}. Next available day: %{day}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3204
+#: lib/vutuv_web/components/ui.ex:3248
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3200
+#: lib/vutuv_web/components/ui.ex:3244
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr ""
@@ -4357,27 +4358,27 @@ msgstr ""
 msgid "One ad per calendar day: pick a free day in the calendar; struck-through days are already booked."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3205
+#: lib/vutuv_web/components/ui.ex:3249
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3206
+#: lib/vutuv_web/components/ui.ex:3250
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3203
+#: lib/vutuv_web/components/ui.ex:3247
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3201
+#: lib/vutuv_web/components/ui.ex:3245
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3202
+#: lib/vutuv_web/components/ui.ex:3246
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr ""
@@ -4509,7 +4510,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4740
+#: lib/vutuv_web/components/ui.ex:4784
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -5275,7 +5276,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4800
+#: lib/vutuv_web/components/ui.ex:4844
 #: lib/vutuv_web/controllers/settings_controller.ex:157
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5311,7 +5312,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1253
+#: lib/vutuv_web/live/post_live/composer.ex:1264
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5354,10 +5355,10 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4897
-#: lib/vutuv_web/components/ui.ex:4902
-#: lib/vutuv_web/components/ui.ex:4981
-#: lib/vutuv_web/components/ui.ex:5045
+#: lib/vutuv_web/components/ui.ex:4941
+#: lib/vutuv_web/components/ui.ex:4946
+#: lib/vutuv_web/components/ui.ex:5025
+#: lib/vutuv_web/components/ui.ex:5089
 #: lib/vutuv_web/controllers/settings_controller.ex:64
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5475,7 +5476,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4760
+#: lib/vutuv_web/components/ui.ex:4804
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5486,7 +5487,7 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:481
+#: lib/vutuv_web/live/organization_live/edit.ex:482
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr ""
@@ -5496,7 +5497,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4660
+#: lib/vutuv_web/components/ui.ex:4704
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5525,13 +5526,13 @@ msgstr ""
 msgid "Personal tokens for the vutuv API."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2192
+#: lib/vutuv_web/live/post_live/composer.ex:2222
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4734
+#: lib/vutuv_web/components/ui.ex:4778
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/templates/page/index.html.heex:191
 #, elixir-autogen, elixir-format
@@ -5644,7 +5645,7 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4793
+#: lib/vutuv_web/components/ui.ex:4837
 #: lib/vutuv_web/controllers/settings_controller.ex:181
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5849,28 +5850,28 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3261
+#: lib/vutuv_web/components/ui.ex:3305
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3260
+#: lib/vutuv_web/components/ui.ex:3304
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3259
+#: lib/vutuv_web/components/ui.ex:3303
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:923
+#: lib/vutuv_web/controllers/settings_controller.ex:943
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5910,7 +5911,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:910
+#: lib/vutuv_web/controllers/settings_controller.ex:930
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -5930,7 +5931,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3258
+#: lib/vutuv_web/components/ui.ex:3302
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -6072,7 +6073,7 @@ msgstr ""
 msgid "Tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:389
+#: lib/vutuv_web/components/ui.ex:396
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:907
@@ -6133,7 +6134,7 @@ msgstr ""
 msgid "Use photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1671
+#: lib/vutuv_web/live/post_live/composer.ex:1699
 #: lib/vutuv_web/templates/user/edit.html.heex:54
 #: lib/vutuv_web/templates/user/edit.html.heex:139
 #, elixir-autogen, elixir-format
@@ -6257,9 +6258,9 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1981
-#: lib/vutuv_web/components/ui.ex:1990
-#: lib/vutuv_web/components/ui.ex:2469
+#: lib/vutuv_web/components/ui.ex:2025
+#: lib/vutuv_web/components/ui.ex:2034
+#: lib/vutuv_web/components/ui.ex:2513
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6280,7 +6281,7 @@ msgstr ""
 msgid "Map services to show"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:104
+#: lib/vutuv_web/gettext_extraction_anchors.ex:110
 #: lib/vutuv_web/templates/settings/preferences.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Maps"
@@ -6293,7 +6294,7 @@ msgstr ""
 msgid "Open in %{name}"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:102
+#: lib/vutuv_web/gettext_extraction_anchors.ex:108
 #: lib/vutuv_web/templates/settings/preferences.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Opens first, as the main button. The others appear as alternatives."
@@ -6320,7 +6321,7 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2422
+#: lib/vutuv_web/components/ui.ex:2466
 #: lib/vutuv_web/live/notification_live/index.ex:684
 #: lib/vutuv_web/live/notification_live/index.ex:699
 #: lib/vutuv_web/live/notification_live/index.ex:1012
@@ -6617,7 +6618,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2628
 #: lib/vutuv_web/components/post_components.ex:3603
-#: lib/vutuv_web/components/ui.ex:2769
+#: lib/vutuv_web/components/ui.ex:2813
 #: lib/vutuv_web/live/fediverse_account_live.ex:375
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
@@ -6645,7 +6646,7 @@ msgid "Remove this connection? You will stop following them."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3603
-#: lib/vutuv_web/components/ui.ex:2768
+#: lib/vutuv_web/components/ui.ex:2812
 #: lib/vutuv_web/live/fediverse_account_live.ex:373
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
@@ -7026,7 +7027,7 @@ msgstr ""
 msgid "Save audience"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:808
+#: lib/vutuv_web/live/job_posting_live/form.ex:809
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:16
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:11
 #, elixir-autogen, elixir-format
@@ -7245,13 +7246,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3664
+#: lib/vutuv_web/components/ui.ex:3708
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3680
+#: lib/vutuv_web/components/ui.ex:3724
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7286,7 +7287,7 @@ msgid "Removed:"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:979
-#: lib/vutuv_web/live/post_live/composer.ex:1519
+#: lib/vutuv_web/live/post_live/composer.ex:1547
 #: lib/vutuv_web/live/post_live/filter_band.ex:532
 #, elixir-autogen, elixir-format
 msgid "Undo"
@@ -7999,7 +8000,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3667
+#: lib/vutuv_web/components/ui.ex:3711
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8129,7 +8130,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:4636
+#: lib/vutuv_web/components/ui.ex:4680
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8184,7 +8185,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4781
+#: lib/vutuv_web/components/ui.ex:4825
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8213,7 +8214,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4664
+#: lib/vutuv_web/components/ui.ex:4708
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8307,7 +8308,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3944
+#: lib/vutuv_web/components/ui.ex:3988
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8382,13 +8383,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4624
+#: lib/vutuv_web/components/ui.ex:4668
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4771
+#: lib/vutuv_web/components/ui.ex:4815
 #: lib/vutuv_web/controllers/settings_controller.ex:125
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8400,7 +8401,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4762
+#: lib/vutuv_web/components/ui.ex:4806
 #: lib/vutuv_web/controllers/settings_controller.ex:108
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8410,7 +8411,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4785
+#: lib/vutuv_web/components/ui.ex:4829
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8519,7 +8520,7 @@ msgstr[1] ""
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1278
+#: lib/vutuv_web/components/ui.ex:1322
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -8615,8 +8616,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:586
 #: lib/vutuv_web/agent_docs/text.ex:590
 #: lib/vutuv_web/components/organization_components.ex:276
-#: lib/vutuv_web/components/ui.ex:1479
-#: lib/vutuv_web/components/ui.ex:4752
+#: lib/vutuv_web/components/ui.ex:1523
+#: lib/vutuv_web/components/ui.ex:4796
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:357
 #: lib/vutuv_web/controllers/settings_controller.ex:424
@@ -8766,7 +8767,7 @@ msgstr ""
 msgid "This is the print view of this CV. Use your browser's print dialog (Ctrl+P or Cmd+P) and choose \"Save as PDF\" to get a PDF file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1568
+#: lib/vutuv_web/components/ui.ex:1612
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr ""
@@ -8804,7 +8805,7 @@ msgstr ""
 msgid "Header"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1578
+#: lib/vutuv_web/components/ui.ex:1622
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -8836,7 +8837,7 @@ msgstr ""
 msgid "The CV is public, on your profile: a visitor's download contains only what they can see there anyway, and private email addresses appear only in your own."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1570
+#: lib/vutuv_web/components/ui.ex:1614
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -8990,8 +8991,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2025
-#: lib/vutuv_web/components/ui.ex:2026
+#: lib/vutuv_web/components/ui.ex:2069
+#: lib/vutuv_web/components/ui.ex:2070
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9434,7 +9435,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1187
+#: lib/vutuv/accounts/user.ex:1193
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9445,7 +9446,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1184
+#: lib/vutuv/accounts/user.ex:1190
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9560,7 +9561,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:4640
+#: lib/vutuv_web/components/ui.ex:4684
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -9756,13 +9757,13 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3374
+#: lib/vutuv_web/components/ui.ex:3418
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3373
-#: lib/vutuv_web/components/ui.ex:3381
+#: lib/vutuv_web/components/ui.ex:3417
+#: lib/vutuv_web/components/ui.ex:3425
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -9936,17 +9937,17 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:377
+#: lib/vutuv_web/components/ui.ex:384
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:429
+#: lib/vutuv_web/components/ui.ex:436
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:432
+#: lib/vutuv_web/components/ui.ex:439
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr ""
@@ -9961,13 +9962,13 @@ msgstr ""
 msgid "Delete your code list? All its codes stop working immediately."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:373
+#: lib/vutuv_web/components/ui.ex:380
 #, elixir-autogen, elixir-format
 msgid "Formatting"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:496
-#: lib/vutuv_web/components/ui.ex:497
+#: lib/vutuv_web/components/ui.ex:503
+#: lib/vutuv_web/components/ui.ex:504
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr ""
@@ -9982,27 +9983,27 @@ msgstr ""
 msgid "Generate code list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:427
+#: lib/vutuv_web/components/ui.ex:434
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:428
+#: lib/vutuv_web/components/ui.ex:435
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:386
+#: lib/vutuv_web/components/ui.ex:393
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:380
+#: lib/vutuv_web/components/ui.ex:387
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:346
+#: lib/vutuv_web/components/ui.ex:540
 #, elixir-autogen, elixir-format
 msgid "Link URL"
 msgstr ""
@@ -10018,7 +10019,7 @@ msgstr ""
 msgid "Not set up."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:430
+#: lib/vutuv_web/components/ui.ex:437
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr ""
@@ -10033,7 +10034,7 @@ msgstr ""
 msgid "Print this page or write the codes down. Crossed-out codes have been used."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:431
+#: lib/vutuv_web/components/ui.ex:438
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr ""
@@ -10054,7 +10055,7 @@ msgstr ""
 msgid "Set up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:383
+#: lib/vutuv_web/components/ui.ex:390
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr ""
@@ -10432,46 +10433,46 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:346
+#: lib/vutuv_web/templates/settings/preferences.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:277
+#: lib/vutuv_web/templates/settings/preferences.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:353
+#: lib/vutuv_web/templates/settings/preferences.html.heex:397
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:357
+#: lib/vutuv_web/templates/settings/preferences.html.heex:401
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:343
+#: lib/vutuv_web/templates/settings/preferences.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:300
+#: lib/vutuv_web/templates/settings/preferences.html.heex:344
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:309
+#: lib/vutuv_web/templates/settings/preferences.html.heex:353
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:295
+#: lib/vutuv_web/templates/settings/preferences.html.heex:339
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
@@ -10481,7 +10482,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:292
+#: lib/vutuv_web/templates/settings/preferences.html.heex:336
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr ""
@@ -10569,8 +10570,9 @@ msgstr ""
 #: lib/vutuv_web/live/feed_languages_live.ex:377
 #: lib/vutuv_web/templates/settings/preferences.html.heex:101
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
-#: lib/vutuv_web/templates/settings/preferences.html.heex:259
-#: lib/vutuv_web/templates/settings/preferences.html.heex:377
+#: lib/vutuv_web/templates/settings/preferences.html.heex:239
+#: lib/vutuv_web/templates/settings/preferences.html.heex:303
+#: lib/vutuv_web/templates/settings/preferences.html.heex:421
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr ""
@@ -10601,17 +10603,17 @@ msgstr ""
 msgid "What every member gets until they choose for themselves on their settings pages, and what logged-out visitors see. Changes apply immediately; members who set their own value are not affected."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:100
+#: lib/vutuv_web/gettext_extraction_anchors.ex:106
 #, elixir-autogen, elixir-format
 msgid "0 means posts are never shortened."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:106
+#: lib/vutuv_web/gettext_extraction_anchors.ex:112
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:105
+#: lib/vutuv_web/gettext_extraction_anchors.ex:111
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr ""
@@ -10662,8 +10664,8 @@ msgid "Failed"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
-#: lib/vutuv_web/live/post_live/composer.ex:1750
-#: lib/vutuv_web/live/post_live/composer.ex:2450
+#: lib/vutuv_web/live/post_live/composer.ex:1778
+#: lib/vutuv_web/live/post_live/composer.ex:2480
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr ""
@@ -10763,21 +10765,21 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1225
+#: lib/vutuv/accounts/user.ex:1231
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1230
+#: lib/vutuv/accounts/user.ex:1236
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1228
+#: lib/vutuv/accounts/user.ex:1234
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
-#: lib/vutuv_web/live/job_posting_live/form.ex:772
+#: lib/vutuv_web/live/job_posting_live/form.ex:773
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr ""
@@ -10959,7 +10961,7 @@ msgstr ""
 msgid "Your list is empty. Nobody is excluded yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:362
+#: lib/vutuv_web/live/organization_live/edit.ex:363
 #: lib/vutuv_web/views/account_event_text.ex:232
 #, elixir-autogen, elixir-format
 msgid "AI agents"
@@ -10998,7 +11000,7 @@ msgstr ""
 msgid "Edit %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:348
+#: lib/vutuv_web/live/organization_live/edit.ex:349
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this page and include it in the sitemap."
 msgstr ""
@@ -11008,7 +11010,7 @@ msgstr ""
 msgid "Logo"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:364
+#: lib/vutuv_web/live/organization_live/edit.ex:365
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
@@ -11034,7 +11036,7 @@ msgstr ""
 msgid "Search by name or city"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:346
+#: lib/vutuv_web/live/organization_live/edit.ex:347
 #: lib/vutuv_web/views/account_event_text.ex:231
 #, elixir-autogen, elixir-format
 msgid "Search engines"
@@ -11051,18 +11053,18 @@ msgstr ""
 msgid "Serve this file at:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:327
+#: lib/vutuv_web/live/organization_live/edit.ex:328
 #: lib/vutuv_web/live/organization_live/new.ex:139
 #, elixir-autogen, elixir-format
 msgid "State / region (optional)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3998
+#: lib/vutuv_web/components/ui.ex:4042
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4000
+#: lib/vutuv_web/components/ui.ex:4044
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr ""
@@ -11102,7 +11104,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:262
 #: lib/vutuv_web/agent_docs/text.ex:245
-#: lib/vutuv_web/live/organization_live/edit.ex:321
+#: lib/vutuv_web/live/organization_live/edit.ex:322
 #: lib/vutuv_web/live/organization_live/new.ex:130
 #, elixir-autogen, elixir-format
 msgid "Website"
@@ -11139,7 +11141,7 @@ msgid "@handle or email"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:333
-#: lib/vutuv_web/live/organization_live/edit.ex:424
+#: lib/vutuv_web/live/organization_live/edit.ex:425
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
 msgstr ""
@@ -11160,7 +11162,7 @@ msgid "Added @%{handle} to the team."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:334
-#: lib/vutuv_web/live/organization_live/edit.ex:422
+#: lib/vutuv_web/live/organization_live/edit.ex:423
 #, elixir-autogen, elixir-format
 msgid "Alias"
 msgstr ""
@@ -11177,14 +11179,14 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:436
 #: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/live/organization_live/edit.ex:387
+#: lib/vutuv_web/live/organization_live/edit.ex:388
 #: lib/vutuv_web/live/organization_live/show.ex:925
 #: lib/vutuv_web/templates/tag/single_card.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Also known as"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:418
+#: lib/vutuv_web/live/organization_live/edit.ex:419
 #, elixir-autogen, elixir-format
 msgid "Alternative name"
 msgstr ""
@@ -11206,7 +11208,7 @@ msgid "Archived"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:332
-#: lib/vutuv_web/live/organization_live/edit.ex:423
+#: lib/vutuv_web/live/organization_live/edit.ex:424
 #, elixir-autogen, elixir-format
 msgid "Brand"
 msgstr ""
@@ -11347,7 +11349,7 @@ msgstr ""
 msgid "Remove this member from the team?"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:404
+#: lib/vutuv_web/live/organization_live/edit.ex:405
 #, elixir-autogen, elixir-format
 msgid "Remove this name?"
 msgstr ""
@@ -11404,24 +11406,24 @@ msgstr ""
 msgid "verified"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:324
+#: lib/vutuv_web/live/organization_live/edit.ex:325
 #: lib/vutuv_web/live/organization_live/new.ex:136
 #, elixir-autogen, elixir-format
 msgid "Street address (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:325
+#: lib/vutuv_web/live/organization_live/edit.ex:326
 #: lib/vutuv_web/live/organization_live/new.ex:137
 #, elixir-autogen, elixir-format
 msgid "ZIP / postal code (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:481
+#: lib/vutuv_web/live/organization_live/edit.ex:482
 #, elixir-autogen, elixir-format
 msgid "Claim"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:450
+#: lib/vutuv_web/live/organization_live/edit.ex:451
 #, elixir-autogen, elixir-format
 msgid "Reachable at"
 msgstr ""
@@ -11431,12 +11433,12 @@ msgstr ""
 msgid "That handle is not available."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:487
+#: lib/vutuv_web/live/organization_live/edit.ex:488
 #, elixir-autogen, elixir-format
 msgid "Danger zone"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:498
+#: lib/vutuv_web/live/organization_live/edit.ex:499
 #, elixir-autogen, elixir-format
 msgid "Really delete %{name}? This cannot be undone."
 msgstr ""
@@ -11482,7 +11484,7 @@ msgstr ""
 msgid "The link text can be anything. A hidden <link rel=\"me\"> in the page head works too."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:994
+#: lib/vutuv_web/components/ui.ex:1038
 #: lib/vutuv_web/live/section_reorder_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -11578,7 +11580,7 @@ msgid_plural "%{count} aliases match another verified organization and are flagg
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:389
+#: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Alternative names, brands or abbreviations this organization is findable under. A rename keeps the old name here automatically."
 msgstr ""
@@ -11642,12 +11644,12 @@ msgstr ""
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:502
+#: lib/vutuv_web/live/organization_live/edit.ex:503
 #, elixir-autogen, elixir-format
 msgid "Delete this organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:489
+#: lib/vutuv_web/live/organization_live/edit.ex:490
 #, elixir-autogen, elixir-format
 msgid "Deleting this organization page is permanent. Its verified domains and its @handle are freed and can be claimed again."
 msgstr ""
@@ -11750,7 +11752,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:427
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:400
-#: lib/vutuv_web/components/ui.ex:4789
+#: lib/vutuv_web/components/ui.ex:4833
 #: lib/vutuv_web/controllers/settings_controller.ex:213
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
@@ -11867,7 +11869,7 @@ msgstr ""
 msgid "made you an owner of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:471
+#: lib/vutuv_web/live/organization_live/edit.ex:472
 #, elixir-autogen, elixir-format
 msgid "your_organization"
 msgstr ""
@@ -11923,17 +11925,17 @@ msgstr ""
 msgid "A pay range is required to publish (except volunteer postings)."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:749
+#: lib/vutuv_web/live/job_posting_live/form.ex:750
 #, elixir-autogen, elixir-format
 msgid "A vutuv message to me"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:747
+#: lib/vutuv_web/live/job_posting_live/form.ex:748
 #, elixir-autogen, elixir-format
 msgid "A website"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:748
+#: lib/vutuv_web/live/job_posting_live/form.ex:749
 #, elixir-autogen, elixir-format
 msgid "An e-mail address"
 msgstr ""
@@ -11943,12 +11945,12 @@ msgstr ""
 msgid "Applicants must be located in"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:753
+#: lib/vutuv_web/live/job_posting_live/form.ex:754
 #, elixir-autogen, elixir-format
 msgid "Application URL"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:759
+#: lib/vutuv_web/live/job_posting_live/form.ex:760
 #, elixir-autogen, elixir-format
 msgid "Application e-mail"
 msgstr ""
@@ -11958,7 +11960,7 @@ msgstr ""
 msgid "Application: %{title}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:745
+#: lib/vutuv_web/live/job_posting_live/form.ex:746
 #, elixir-autogen, elixir-format
 msgid "Applications go to"
 msgstr ""
@@ -11990,7 +11992,7 @@ msgstr ""
 msgid "Contract"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:692
+#: lib/vutuv_web/live/job_posting_live/form.ex:693
 #, elixir-autogen, elixir-format
 msgid "Describe the role. Markdown is supported."
 msgstr ""
@@ -12031,7 +12033,7 @@ msgstr ""
 msgid "Employment type"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:771
+#: lib/vutuv_web/live/job_posting_live/form.ex:772
 #, elixir-autogen, elixir-format
 msgid "Everyone (public)"
 msgstr ""
@@ -12054,12 +12056,12 @@ msgstr ""
 msgid "Highlighted tags match your profile."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:743
+#: lib/vutuv_web/live/job_posting_live/form.ex:744
 #, elixir-autogen, elixir-format
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1199
+#: lib/vutuv/accounts/user.ex:1205
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12070,7 +12072,7 @@ msgstr ""
 msgid "I'm interested in your posting: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:691
+#: lib/vutuv_web/live/job_posting_live/form.ex:692
 #, elixir-autogen, elixir-format
 msgid "Job description"
 msgstr ""
@@ -12091,7 +12093,7 @@ msgstr ""
 msgid "Jobs"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:781
+#: lib/vutuv_web/live/job_posting_live/form.ex:782
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this posting."
 msgstr ""
@@ -12152,7 +12154,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:292
 #: lib/vutuv_web/agent_docs/text.ex:275
-#: lib/vutuv_web/live/job_posting_live/form.ex:731
+#: lib/vutuv_web/live/job_posting_live/form.ex:732
 #: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
@@ -12173,12 +12175,12 @@ msgstr ""
 msgid "Nothing here yet. Jobs you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:787
+#: lib/vutuv_web/live/job_posting_live/form.ex:788
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1198
+#: lib/vutuv/accounts/user.ex:1204
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12255,12 +12257,12 @@ msgstr ""
 msgid "Posting not found."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:804
+#: lib/vutuv_web/live/job_posting_live/form.ex:805
 #, elixir-autogen, elixir-format
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1200
+#: lib/vutuv/accounts/user.ex:1206
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
 #: lib/vutuv_web/agent_docs/markdown.ex:466
@@ -12280,7 +12282,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:291
 #: lib/vutuv_web/agent_docs/text.ex:274
-#: lib/vutuv_web/live/job_posting_live/form.ex:721
+#: lib/vutuv_web/live/job_posting_live/form.ex:722
 #: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
@@ -12320,7 +12322,7 @@ msgstr ""
 msgid "Street (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:718
+#: lib/vutuv_web/live/job_posting_live/form.ex:719
 #, elixir-autogen, elixir-format
 msgid "Tags match your posting to members. Separate them with commas; a tag may be several words long, like Ruby on Rails."
 msgstr ""
@@ -12372,7 +12374,7 @@ msgstr ""
 msgid "Volunteer"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:769
+#: lib/vutuv_web/live/job_posting_live/form.ex:770
 #: lib/vutuv_web/templates/email/form_content.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Who can see it"
@@ -12962,7 +12964,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4729
+#: lib/vutuv_web/components/ui.ex:4773
 #: lib/vutuv_web/controllers/settings_controller.ex:620
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13110,7 +13112,7 @@ msgstr ""
 msgid "Hide from specific viewers"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:793
+#: lib/vutuv_web/live/job_posting_live/form.ex:794
 #, elixir-autogen, elixir-format
 msgid "Hide from specific viewers (competitors, your own staff, a person) →"
 msgstr ""
@@ -13131,7 +13133,7 @@ msgstr ""
 msgid "Job exclusions – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:796
+#: lib/vutuv_web/live/job_posting_live/form.ex:797
 #, elixir-autogen, elixir-format
 msgid "Keep this posting on the board for everyone except a chosen few."
 msgstr ""
@@ -13275,7 +13277,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1243
+#: lib/vutuv/accounts/user.ex:1249
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13286,19 +13288,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1246
+#: lib/vutuv/accounts/user.ex:1252
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1249
+#: lib/vutuv/accounts/user.ex:1255
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1240
+#: lib/vutuv/accounts/user.ex:1246
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13338,32 +13340,32 @@ msgstr[1] ""
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:406
+#: lib/vutuv_web/components/ui.ex:413
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:403
+#: lib/vutuv_web/components/ui.ex:410
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:409
+#: lib/vutuv_web/components/ui.ex:416
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:400
+#: lib/vutuv_web/components/ui.ex:407
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:433
+#: lib/vutuv_web/components/ui.ex:440
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2841
+#: lib/vutuv_web/live/post_live/composer.ex:2871
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -13420,7 +13422,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4712
+#: lib/vutuv_web/components/ui.ex:4756
 #: lib/vutuv_web/controllers/settings_controller.ex:634
 #: lib/vutuv_web/live/post_live/feed.ex:712
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13495,7 +13497,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:63
-#: lib/vutuv_web/components/ui.ex:4683
+#: lib/vutuv_web/components/ui.ex:4727
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13523,14 +13525,14 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4083
+#: lib/vutuv_web/components/ui.ex:4127
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:4093
+#: lib/vutuv_web/components/ui.ex:4137
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
@@ -13754,12 +13756,12 @@ msgstr ""
 msgid "by:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2159
+#: lib/vutuv_web/components/ui.ex:2203
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2163
+#: lib/vutuv_web/components/ui.ex:2207
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -13889,22 +13891,22 @@ msgid "proof document"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:331
+#: lib/vutuv_web/templates/settings/preferences.html.heex:375
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:101
+#: lib/vutuv_web/gettext_extraction_anchors.ex:107
 #, elixir-autogen, elixir-format
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:322
+#: lib/vutuv_web/templates/settings/preferences.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:325
+#: lib/vutuv_web/templates/settings/preferences.html.heex:369
 #, elixir-autogen, elixir-format
 msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
@@ -14026,13 +14028,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1240
+#: lib/vutuv_web/live/post_live/composer.ex:1251
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1243
+#: lib/vutuv_web/live/post_live/composer.ex:1254
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14312,7 +14314,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4697
+#: lib/vutuv_web/components/ui.ex:4741
 #: lib/vutuv_web/controllers/settings_controller.ex:700
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -14945,252 +14947,252 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4625
+#: lib/vutuv_web/components/ui.ex:4669
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4630
+#: lib/vutuv_web/components/ui.ex:4674
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4633
+#: lib/vutuv_web/components/ui.ex:4677
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4634
+#: lib/vutuv_web/components/ui.ex:4678
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4637
+#: lib/vutuv_web/components/ui.ex:4681
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4638
+#: lib/vutuv_web/components/ui.ex:4682
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4641
+#: lib/vutuv_web/components/ui.ex:4685
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4642
+#: lib/vutuv_web/components/ui.ex:4686
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4649
+#: lib/vutuv_web/components/ui.ex:4693
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4650
+#: lib/vutuv_web/components/ui.ex:4694
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4651
+#: lib/vutuv_web/components/ui.ex:4695
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4654
+#: lib/vutuv_web/components/ui.ex:4698
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4655
+#: lib/vutuv_web/components/ui.ex:4699
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4790
+#: lib/vutuv_web/components/ui.ex:4834
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4791
+#: lib/vutuv_web/components/ui.ex:4835
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4658
+#: lib/vutuv_web/components/ui.ex:4702
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4661
+#: lib/vutuv_web/components/ui.ex:4705
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4662
+#: lib/vutuv_web/components/ui.ex:4706
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4665
+#: lib/vutuv_web/components/ui.ex:4709
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4666
+#: lib/vutuv_web/components/ui.ex:4710
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4669
+#: lib/vutuv_web/components/ui.ex:4713
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4670
+#: lib/vutuv_web/components/ui.ex:4714
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4672
+#: lib/vutuv_web/components/ui.ex:4716
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4673
+#: lib/vutuv_web/components/ui.ex:4717
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4674
+#: lib/vutuv_web/components/ui.ex:4718
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4676
+#: lib/vutuv_web/components/ui.ex:4720
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4677
+#: lib/vutuv_web/components/ui.ex:4721
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4679
+#: lib/vutuv_web/components/ui.ex:4723
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4684
+#: lib/vutuv_web/components/ui.ex:4728
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4685
+#: lib/vutuv_web/components/ui.ex:4729
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4688
+#: lib/vutuv_web/components/ui.ex:4732
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4691
+#: lib/vutuv_web/components/ui.ex:4735
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4698
+#: lib/vutuv_web/components/ui.ex:4742
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4699
+#: lib/vutuv_web/components/ui.ex:4743
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4713
+#: lib/vutuv_web/components/ui.ex:4757
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4714
+#: lib/vutuv_web/components/ui.ex:4758
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4730
+#: lib/vutuv_web/components/ui.ex:4774
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4731
+#: lib/vutuv_web/components/ui.ex:4775
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4737
+#: lib/vutuv_web/components/ui.ex:4781
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4738
+#: lib/vutuv_web/components/ui.ex:4782
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4741
+#: lib/vutuv_web/components/ui.ex:4785
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4742
+#: lib/vutuv_web/components/ui.ex:4786
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4763
+#: lib/vutuv_web/components/ui.ex:4807
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4764
+#: lib/vutuv_web/components/ui.ex:4808
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4782
+#: lib/vutuv_web/components/ui.ex:4826
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4783
+#: lib/vutuv_web/components/ui.ex:4827
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4786
+#: lib/vutuv_web/components/ui.ex:4830
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4787
+#: lib/vutuv_web/components/ui.ex:4831
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4801
+#: lib/vutuv_web/components/ui.ex:4845
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4802
+#: lib/vutuv_web/components/ui.ex:4846
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15647,7 +15649,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4766
+#: lib/vutuv_web/components/ui.ex:4810
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -15994,7 +15996,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4767
+#: lib/vutuv_web/components/ui.ex:4811
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -16030,7 +16032,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4769
+#: lib/vutuv_web/components/ui.ex:4813
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16141,7 +16143,7 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2854
+#: lib/vutuv_web/live/post_live/composer.ex:2884
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16171,49 +16173,49 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2278
+#: lib/vutuv_web/live/post_live/composer.ex:2308
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2692
+#: lib/vutuv_web/live/post_live/composer.ex:2722
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1294
 #: lib/vutuv_web/agent_docs/text.ex:807
-#: lib/vutuv_web/components/ui.ex:2823
+#: lib/vutuv_web/components/ui.ex:2867
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2791
+#: lib/vutuv_web/live/post_live/composer.ex:2821
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2747
+#: lib/vutuv_web/live/post_live/composer.ex:2777
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2749
+#: lib/vutuv_web/live/post_live/composer.ex:2779
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2768
+#: lib/vutuv_web/live/post_live/composer.ex:2798
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2822
+#: lib/vutuv_web/components/ui.ex:2866
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2297
+#: lib/vutuv_web/live/post_live/composer.ex:2327
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
@@ -16233,8 +16235,8 @@ msgstr ""
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2250
-#: lib/vutuv_web/live/post_live/composer.ex:2251
+#: lib/vutuv_web/live/post_live/composer.ex:2280
+#: lib/vutuv_web/live/post_live/composer.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
@@ -16246,23 +16248,23 @@ msgstr ""
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2821
+#: lib/vutuv_web/components/ui.ex:2865
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2310
-#: lib/vutuv_web/live/post_live/composer.ex:2311
+#: lib/vutuv_web/live/post_live/composer.ex:2340
+#: lib/vutuv_web/live/post_live/composer.ex:2341
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2770
+#: lib/vutuv_web/live/post_live/composer.ex:2800
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2711
+#: lib/vutuv_web/live/post_live/composer.ex:2741
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Show camera settings"
 msgstr ""
@@ -16272,17 +16274,17 @@ msgstr ""
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2789
+#: lib/vutuv_web/live/post_live/composer.ex:2819
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2825
+#: lib/vutuv_web/live/post_live/composer.ex:2855
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2817
+#: lib/vutuv_web/live/post_live/composer.ex:2847
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
@@ -16307,12 +16309,12 @@ msgstr ""
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2568
+#: lib/vutuv_web/live/post_live/composer.ex:2598
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1267
+#: lib/vutuv_web/live/post_live/composer.ex:1278
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -16322,7 +16324,7 @@ msgstr ""
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1281
+#: lib/vutuv_web/live/post_live/composer.ex:1292
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -16337,65 +16339,65 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2193
+#: lib/vutuv_web/live/post_live/composer.ex:2223
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2563
+#: lib/vutuv_web/live/post_live/composer.ex:2593
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2682
+#: lib/vutuv_web/live/post_live/composer.ex:2712
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1494
-#: lib/vutuv_web/live/post_live/composer.ex:1557
-#: lib/vutuv_web/live/post_live/composer.ex:1615
-#: lib/vutuv_web/live/post_live/composer.ex:1962
+#: lib/vutuv_web/live/post_live/composer.ex:1522
+#: lib/vutuv_web/live/post_live/composer.ex:1585
+#: lib/vutuv_web/live/post_live/composer.ex:1643
+#: lib/vutuv_web/live/post_live/composer.ex:1990
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1487
+#: lib/vutuv_web/live/post_live/composer.ex:1515
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2616
+#: lib/vutuv_web/live/post_live/composer.ex:2646
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2130
+#: lib/vutuv_web/live/post_live/composer.ex:2158
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2129
+#: lib/vutuv_web/live/post_live/composer.ex:2157
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2128
+#: lib/vutuv_web/live/post_live/composer.ex:2156
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2133
+#: lib/vutuv_web/live/post_live/composer.ex:2161
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2586
+#: lib/vutuv_web/live/post_live/composer.ex:2616
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2605
+#: lib/vutuv_web/live/post_live/composer.ex:2635
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -16505,8 +16507,8 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1751
-#: lib/vutuv_web/live/post_live/composer.ex:2450
+#: lib/vutuv_web/live/post_live/composer.ex:1779
+#: lib/vutuv_web/live/post_live/composer.ex:2480
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr ""
@@ -16536,7 +16538,7 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4753
+#: lib/vutuv_web/components/ui.ex:4797
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
@@ -16739,7 +16741,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4755
+#: lib/vutuv_web/components/ui.ex:4799
 #, elixir-autogen, elixir-format, fuzzy
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -17114,12 +17116,12 @@ msgstr[1] ""
 msgid "Your feed shows the posts of members you follow. Follow a few to fill it."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:227
+#: lib/vutuv_web/components/ui.ex:228
 #, elixir-autogen, elixir-format
 msgid "Add another tag"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:250
+#: lib/vutuv_web/components/ui.ex:251
 #, elixir-autogen, elixir-format
 msgid "Remove the tag %{name}"
 msgstr ""
@@ -17244,7 +17246,7 @@ msgstr ""
 msgid "Your username is your public identity here. It changes only once you confirm with your passkey or a valid code below."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:531
+#: lib/vutuv_web/components/ui.ex:575
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Markdown help"
 msgstr ""
@@ -17373,104 +17375,104 @@ msgstr ""
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1668
+#: lib/vutuv_web/live/post_live/composer.ex:1696
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2356
+#: lib/vutuv_web/live/post_live/composer.ex:2386
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2357
+#: lib/vutuv_web/live/post_live/composer.ex:2387
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2362
+#: lib/vutuv_web/live/post_live/composer.ex:2392
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2359
+#: lib/vutuv_web/live/post_live/composer.ex:2389
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2360
+#: lib/vutuv_web/live/post_live/composer.ex:2390
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover on top"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2361
+#: lib/vutuv_web/live/post_live/composer.ex:2391
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1664
-#: lib/vutuv_web/live/post_live/composer.ex:2327
-#: lib/vutuv_web/live/post_live/composer.ex:2328
+#: lib/vutuv_web/live/post_live/composer.ex:1692
+#: lib/vutuv_web/live/post_live/composer.ex:2357
+#: lib/vutuv_web/live/post_live/composer.ex:2358
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Crop photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2286
+#: lib/vutuv_web/live/post_live/composer.ex:2316
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cropped"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1586
+#: lib/vutuv_web/live/post_live/composer.ex:1614
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2363
+#: lib/vutuv_web/live/post_live/composer.ex:2393
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2364
+#: lib/vutuv_web/live/post_live/composer.ex:2394
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1666
+#: lib/vutuv_web/live/post_live/composer.ex:1694
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2355
+#: lib/vutuv_web/live/post_live/composer.ex:2385
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2358
+#: lib/vutuv_web/live/post_live/composer.ex:2388
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:496
+#: lib/vutuv_web/live/post_live/composer.ex:497
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2804
+#: lib/vutuv_web/live/post_live/composer.ex:2834
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1670
+#: lib/vutuv_web/live/post_live/composer.ex:1698
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Whole photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2553
+#: lib/vutuv_web/live/post_live/composer.ex:2583
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2537
+#: lib/vutuv_web/live/post_live/composer.ex:2567
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Whole photos"
 msgstr ""
@@ -17770,8 +17772,8 @@ msgstr ""
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1330
-#: lib/vutuv_web/components/ui.ex:1331
+#: lib/vutuv_web/components/ui.ex:1374
+#: lib/vutuv_web/components/ui.ex:1375
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr ""
@@ -17781,7 +17783,7 @@ msgstr ""
 msgid "A CV with positions, education, certificates including proof, spoken languages and tags other members endorse you for."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:435
+#: lib/vutuv_web/templates/page/index.html.heex:465
 #, elixir-autogen, elixir-format
 msgid "A business network that is free, does not lock your data in, and is yours to run yourself if you want to."
 msgstr ""
@@ -17801,22 +17803,22 @@ msgstr ""
 msgid "CV download as PDF, Word, OpenDocument, LaTeX or JSON Resume, and you pick what goes in before you download it."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:488
+#: lib/vutuv_web/templates/page/index.html.heex:518
 #, elixir-autogen, elixir-format
 msgid "Developer documentation"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:448
+#: lib/vutuv_web/templates/page/index.html.heex:478
 #, elixir-autogen, elixir-format
 msgid "Every public page here is also served as Markdown, plain text, JSON and XML under the same address. No scraping, no API key, no account."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:455
+#: lib/vutuv_web/templates/page/index.html.heex:485
 #, elixir-autogen, elixir-format
 msgid "For machines"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:445
+#: lib/vutuv_web/templates/page/index.html.heex:475
 #, elixir-autogen, elixir-format
 msgid "Open by default"
 msgstr ""
@@ -17841,12 +17843,12 @@ msgstr ""
 msgid "Posts, likes, reposts, replies and 1:1 messages, in real time."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:446
+#: lib/vutuv_web/templates/page/index.html.heex:476
 #, elixir-autogen, elixir-format
 msgid "Readable by people, by machines, and on your own server"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:471
+#: lib/vutuv_web/templates/page/index.html.heex:501
 #, elixir-autogen, elixir-format
 msgid "Run it yourself"
 msgstr ""
@@ -17856,23 +17858,23 @@ msgstr ""
 msgid "Sign in without a password, by emailed PIN, passkey, authenticator app or a printed list of codes."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:482
-#: lib/vutuv_web/templates/page/index.html.heex:569
+#: lib/vutuv_web/templates/page/index.html.heex:512
+#: lib/vutuv_web/templates/page/index.html.heex:599
 #, elixir-autogen, elixir-format
 msgid "Source code"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:317
+#: lib/vutuv_web/templates/page/index.html.heex:347
 #, elixir-autogen, elixir-format
 msgid "This is what a vutuv profile looks like"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:433
+#: lib/vutuv_web/templates/page/index.html.heex:463
 #, elixir-autogen, elixir-format
 msgid "What vutuv can do"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:432
+#: lib/vutuv_web/templates/page/index.html.heex:462
 #, elixir-autogen, elixir-format
 msgid "What you get"
 msgstr ""
@@ -17882,12 +17884,12 @@ msgstr ""
 msgid "Your independence"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:473
+#: lib/vutuv_web/templates/page/index.html.heex:503
 #, elixir-autogen, elixir-format
 msgid "vutuv is open source under the MIT license. Run it for a company, an association or a school, on the internet or air-gapped inside your own network."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:316
+#: lib/vutuv_web/templates/page/index.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "A look inside"
 msgstr ""
@@ -17897,7 +17899,7 @@ msgstr ""
 msgid "A vutuv profile: cover picture, photo, name, tagline and job title, follower counts and the first posts, with contact details and social media profiles in a column on the right."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:338
+#: lib/vutuv_web/templates/page/index.html.heex:368
 #, elixir-autogen, elixir-format
 msgid "Browse real profiles"
 msgstr ""
@@ -17917,17 +17919,17 @@ msgstr ""
 msgid "Try it out:"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:464
+#: lib/vutuv_web/templates/page/index.html.heex:494
 #, elixir-autogen, elixir-format
 msgid "Plus a sitemap, JSON-LD and a REST API with OAuth 2 and personal access tokens."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:319
+#: lib/vutuv_web/templates/page/index.html.heex:349
 #, elixir-autogen, elixir-format
 msgid "Work experience, education, certificates, languages, links and tags others endorse you for. Anyone can read a profile, entirely without a vutuv account. Unlike LinkedIn, where you hit a login wall in short order."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:419
+#: lib/vutuv_web/templates/page/index.html.heex:449
 #, elixir-autogen, elixir-format
 msgid "Talking to people"
 msgstr ""
@@ -17947,77 +17949,77 @@ msgstr ""
 msgid "The Fediverse: let people follow you from Mastodon, and your public posts show up there. You choose at sign-up, and can change it later."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:420
+#: lib/vutuv_web/templates/page/index.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "Posts, messages, and the Fediverse along with them"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:422
+#: lib/vutuv_web/templates/page/index.html.heex:452
 #, elixir-autogen, elixir-format
 msgid "Write a post, react with a heart, a repost or a reply, or message somebody privately. And you are not stuck among vutuv members: vutuv is part of the Fediverse, the union of independent networks that Mastodon belongs to as well. Follow an account over there and its posts arrive in your feed; the other way round, people there can follow you and see your public posts. Both directions, and entirely your choice: at sign-up you decide whether to use vutuv with or without the Fediverse, and you can change that at any time in the settings."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:535
+#: lib/vutuv_web/templates/page/index.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Download everything you have here at any time, in a machine-readable file. Not on request, not after a waiting period: from your settings, whenever you like."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:510
+#: lib/vutuv_web/templates/page/index.html.heex:540
 #, elixir-autogen, elixir-format
 msgid "Fair and transparent, in plain words"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:524
+#: lib/vutuv_web/templates/page/index.html.heex:554
 #, elixir-autogen, elixir-format
 msgid "No third-party cookies"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:516
+#: lib/vutuv_web/templates/page/index.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "On our own servers in %{place}, not in somebody else's cloud. We do not hand your profile to a third party, and there is no tracking network reading along."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:514
+#: lib/vutuv_web/templates/page/index.html.heex:544
 #, elixir-autogen, elixir-format
 msgid "Where your data lives"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:509
+#: lib/vutuv_web/templates/page/index.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "Your data"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:526
+#: lib/vutuv_web/templates/page/index.html.heex:556
 #, elixir-autogen, elixir-format
 msgid "vutuv sets one cookie, the one that keeps you signed in. No advertising network, no analytics service, nothing loaded from anybody else's server."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:542
+#: lib/vutuv_web/templates/page/index.html.heex:572
 #, elixir-autogen, elixir-format
 msgid "Leave whenever you like"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:558
+#: lib/vutuv_web/templates/page/index.html.heex:588
 #, elixir-autogen, elixir-format
 msgid "Open source"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:560
+#: lib/vutuv_web/templates/page/index.html.heex:590
 #, elixir-autogen, elixir-format
 msgid "You can check at any time how exactly vutuv works. The whole source code is public under the MIT license, so everything said above about your data can be read rather than taken on trust."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:533
+#: lib/vutuv_web/templates/page/index.html.heex:563
 #, elixir-autogen, elixir-format
 msgid "Your data stays with you"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:549
+#: lib/vutuv_web/templates/page/index.html.heex:579
 #, elixir-autogen, elixir-format
 msgid "Delete your account yourself, without writing to anybody. No questions asked, and you are welcome back any time."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:256
+#: lib/vutuv_web/components/ui.ex:257
 #, elixir-autogen, elixir-format
 msgid "At most %{max} tags. Remove one to add another."
 msgstr ""
@@ -18064,7 +18066,7 @@ msgstr ""
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:857
+#: lib/vutuv_web/controllers/settings_controller.ex:877
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr ""
@@ -18171,7 +18173,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:4644
+#: lib/vutuv_web/components/ui.ex:4688
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -18367,7 +18369,7 @@ msgstr ""
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4645
+#: lib/vutuv_web/components/ui.ex:4689
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
@@ -18378,7 +18380,7 @@ msgstr ""
 msgid "Zwischenzeugnis"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4647
+#: lib/vutuv_web/components/ui.ex:4691
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -18633,7 +18635,7 @@ msgstr ""
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3984
+#: lib/vutuv_web/components/ui.ex:4028
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -18882,7 +18884,7 @@ msgstr ""
 msgid "You have reached your limit of %{limit} reviews. Please try again in %{window}."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:379
+#: lib/vutuv_web/templates/page/index.html.heex:409
 #, elixir-autogen, elixir-format
 msgid "Employment reference"
 msgstr ""
@@ -18892,7 +18894,7 @@ msgstr ""
 msgid "Employment references: upload them, keep them private, and have the wording read and graded on our own servers."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:356
+#: lib/vutuv_web/templates/page/index.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "Job applications"
 msgstr ""
@@ -18907,7 +18909,7 @@ msgstr ""
 msgid "The finished CV ready to print: name, tagline and contact details at the top, below them the positions held with employer and period, and further down the tags and the spoken languages."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:399
+#: lib/vutuv_web/templates/page/index.html.heex:429
 #, elixir-autogen, elixir-format
 msgid "The review is a text analysis, not legal advice, and it covers German employment references."
 msgstr ""
@@ -18922,22 +18924,22 @@ msgstr ""
 msgid "The uploaded employment references, each marked private: one graded 1 (very good) on a green panel, one graded 4 to 5 (poor to unsatisfactory) on a red one, each with a link to its full report."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:382
+#: lib/vutuv_web/templates/page/index.html.heex:412
 #, elixir-autogen, elixir-format
 msgid "Upload your employment references and have them read sentence by sentence: a grade, a traffic light, and the explanation of how a recruiter reads that wording. It takes a few minutes, then the report is there. Nothing becomes public before you release it."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:380
+#: lib/vutuv_web/templates/page/index.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "What your employment reference really says"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:359
+#: lib/vutuv_web/templates/page/index.html.heex:389
 #, elixir-autogen, elixir-format
 msgid "What your profile already says becomes a CV. You tick what should go in, then download it as PDF, Word, OpenDocument, LaTeX or JSON Resume. Anonymously as well, if you would rather show what you can do before you show who you are."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:357
+#: lib/vutuv_web/templates/page/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "Your CV, ready to send"
 msgstr ""
@@ -18979,12 +18981,12 @@ msgstr ""
 msgid "Enter the PIN from the email"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:763
+#: lib/vutuv_web/components/ui.ex:807
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:791
+#: lib/vutuv_web/components/ui.ex:835
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cancel registration"
 msgstr ""
@@ -18999,22 +19001,22 @@ msgstr ""
 msgid "Follow other members"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:746
+#: lib/vutuv_web/components/ui.ex:790
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1346
+#: lib/vutuv/accounts/user.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1344
+#: lib/vutuv/accounts/user.ex:1350
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1345
+#: lib/vutuv/accounts/user.ex:1351
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19024,7 +19026,7 @@ msgstr ""
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4626
+#: lib/vutuv_web/components/ui.ex:4670
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
@@ -19120,7 +19122,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4746
+#: lib/vutuv_web/components/ui.ex:4790
 #: lib/vutuv_web/controllers/settings_controller.ex:247
 #: lib/vutuv_web/controllers/settings_controller.ex:326
 #: lib/vutuv_web/controllers/settings_controller.ex:338
@@ -19217,7 +19219,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4748
+#: lib/vutuv_web/components/ui.ex:4792
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -19326,7 +19328,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4750
+#: lib/vutuv_web/components/ui.ex:4794
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -19760,17 +19762,17 @@ msgstr ""
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1897
+#: lib/vutuv_web/live/post_live/composer.ex:1925
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1260
+#: lib/vutuv_web/live/post_live/composer.ex:1271
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1874
+#: lib/vutuv_web/live/post_live/composer.ex:1902
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr ""
@@ -20057,12 +20059,12 @@ msgstr ""
 msgid "This vutuv exchanges nothing with other networks, so nothing here has any effect."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:442
+#: lib/vutuv_web/live/organization_live/edit.ex:443
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Claim a short @name so this organization has an address of its own, like a member. Letters, numbers and underscores, %{min} to %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:440
+#: lib/vutuv_web/live/organization_live/edit.ex:441
 #, elixir-autogen, elixir-format
 msgid "The organization's @name"
 msgstr ""
@@ -20117,22 +20119,22 @@ msgstr ""
 msgid "The PIN has expired."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:867
+#: lib/vutuv_web/components/ui.ex:911
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:869
+#: lib/vutuv_web/components/ui.ex:913
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:868
+#: lib/vutuv_web/components/ui.ex:912
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:870
+#: lib/vutuv_web/components/ui.ex:914
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr ""
@@ -20551,17 +20553,17 @@ msgstr ""
 msgid "{n} of {max} free slots selected."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1939
+#: lib/vutuv_web/live/post_live/composer.ex:1967
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1924
+#: lib/vutuv_web/live/post_live/composer.ex:1952
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post language"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1929
+#: lib/vutuv_web/live/post_live/composer.ex:1957
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr ""
@@ -20597,7 +20599,7 @@ msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:4697
-#: lib/vutuv_web/components/ui.ex:4705
+#: lib/vutuv_web/components/ui.ex:4749
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -20625,7 +20627,7 @@ msgstr ""
 msgid "What your feed does with posts outside your chosen languages: show them as they are, translate them for you, or hide them. Posts that declare no language always show."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:110
+#: lib/vutuv_web/gettext_extraction_anchors.ex:116
 #, elixir-autogen, elixir-format
 msgid "Date & time"
 msgstr ""
@@ -20635,12 +20637,12 @@ msgstr ""
 msgid "Date and time settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:108
+#: lib/vutuv_web/gettext_extraction_anchors.ex:114
 #, elixir-autogen, elixir-format
 msgid "Date format"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:118
+#: lib/vutuv_web/gettext_extraction_anchors.ex:124
 #, elixir-autogen, elixir-format
 msgid "Germany, Austria, Switzerland"
 msgstr ""
@@ -20650,27 +20652,27 @@ msgstr ""
 msgid "Language and region saved."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:114
+#: lib/vutuv_web/gettext_extraction_anchors.ex:120
 #, elixir-autogen, elixir-format
 msgid "Posts, messages and notifications are stamped in this zone. New accounts take it from the browser."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:111
+#: lib/vutuv_web/gettext_extraction_anchors.ex:117
 #, elixir-autogen, elixir-format
 msgid "The order and punctuation of every date you read here, and whether times run on a 12- or 24-hour clock."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:109
+#: lib/vutuv_web/gettext_extraction_anchors.ex:115
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:119
+#: lib/vutuv_web/gettext_extraction_anchors.ex:125
 #, elixir-autogen, elixir-format
 msgid "United Kingdom, France, Brazil"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:120
+#: lib/vutuv_web/gettext_extraction_anchors.ex:126
 #, elixir-autogen, elixir-format
 msgid "United States"
 msgstr ""
@@ -20680,7 +20682,7 @@ msgstr ""
 msgid "Your browser says: {zone}"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:121
+#: lib/vutuv_web/gettext_extraction_anchors.ex:127
 #, elixir-autogen, elixir-format, fuzzy
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr ""
@@ -20807,7 +20809,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4794
+#: lib/vutuv_web/components/ui.ex:4838
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
@@ -20853,7 +20855,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4796
+#: lib/vutuv_web/components/ui.ex:4840
 #, elixir-autogen, elixir-format, fuzzy
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -20889,7 +20891,7 @@ msgstr ""
 msgid "Find your LinkedIn contacts"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4721
+#: lib/vutuv_web/components/ui.ex:4765
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format, fuzzy
@@ -20997,7 +20999,7 @@ msgstr ""
 msgid "See which of them are already on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4723
+#: lib/vutuv_web/components/ui.ex:4767
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr ""
@@ -21069,7 +21071,7 @@ msgstr ""
 msgid "Your export also lists your LinkedIn contacts."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4725
+#: lib/vutuv_web/components/ui.ex:4769
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr ""
@@ -21213,7 +21215,7 @@ msgctxt "qualification detail"
 msgid "Jobs"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:835
+#: lib/vutuv_web/live/job_posting_live/form.ex:836
 #, elixir-autogen, elixir-format
 msgid "%{formatted} country chosen."
 msgid_plural "%{formatted} countries chosen."
@@ -21325,7 +21327,7 @@ msgstr ""
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4693
+#: lib/vutuv_web/components/ui.ex:4737
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
@@ -21385,43 +21387,43 @@ msgstr ""
 msgid "New here"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1499
+#: lib/vutuv_web/components/ui.ex:1543
 #, elixir-autogen, elixir-format
 msgid "New public posts arrive in any feed reader. No account needed either."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1495
+#: lib/vutuv_web/components/ui.ex:1539
 #, elixir-autogen, elixir-format
 msgid "Or with an RSS reader"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1375
-#: lib/vutuv_web/components/ui.ex:1444
+#: lib/vutuv_web/components/ui.ex:1419
+#: lib/vutuv_web/components/ui.ex:1488
 #, elixir-autogen, elixir-format
 msgid "Subscribe"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1496
+#: lib/vutuv_web/components/ui.ex:1540
 #, elixir-autogen, elixir-format
 msgid "With an RSS reader"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1456
+#: lib/vutuv_web/components/ui.ex:1500
 #, elixir-autogen, elixir-format
 msgid "Create a free account"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1471
+#: lib/vutuv_web/components/ui.ex:1515
 #, elixir-autogen, elixir-format
 msgid "No vutuv account? These ways work too:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1449
+#: lib/vutuv_web/components/ui.ex:1493
 #, elixir-autogen, elixir-format
 msgid "The best way: follow %{name} here. New posts land in your feed, and you can reply and join in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1447
+#: lib/vutuv_web/components/ui.ex:1491
 #, elixir-autogen, elixir-format
 msgid "With a vutuv account"
 msgstr ""
@@ -21431,7 +21433,7 @@ msgstr ""
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:234
+#: lib/vutuv_web/templates/settings/preferences.html.heex:278
 #, elixir-autogen, elixir-format
 msgid "Example"
 msgstr ""
@@ -21446,12 +21448,12 @@ msgstr ""
 msgid "Just flashed the new release, boot is under two seconds now"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:244
+#: lib/vutuv_web/templates/settings/preferences.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "Play the example"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:99
+#: lib/vutuv_web/gettext_extraction_anchors.ex:105
 #, elixir-autogen, elixir-format
 msgid "Between 4 and 20 seconds."
 msgstr ""
@@ -21546,22 +21548,22 @@ msgstr ""
 msgid "Shown in the language it was written in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4706
+#: lib/vutuv_web/components/ui.ex:4750
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4708
+#: lib/vutuv_web/components/ui.ex:4752
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4773
+#: lib/vutuv_web/components/ui.ex:4817
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4777
+#: lib/vutuv_web/components/ui.ex:4821
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -21594,7 +21596,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:94
-#: lib/vutuv_web/templates/settings/preferences.html.heex:210
+#: lib/vutuv_web/templates/settings/preferences.html.heex:254
 #, elixir-autogen, elixir-format
 msgid "Browser tab"
 msgstr ""
@@ -21619,12 +21621,12 @@ msgstr ""
 msgid "Tease new posts in the browser tab"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:236
+#: lib/vutuv_web/templates/settings/preferences.html.heex:280
 #, elixir-autogen, elixir-format
 msgid "Watch this tab's title, above."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:212
+#: lib/vutuv_web/templates/settings/preferences.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "While you are reading another tab, a new post can page its first words through this tab's title, a line at a time, and then hand the title back."
 msgstr ""
@@ -21679,7 +21681,7 @@ msgstr ""
 msgid "Your LinkedIn profile can come along."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1067
+#: lib/vutuv_web/components/ui.ex:1111
 #, elixir-autogen, elixir-format
 msgid "Being checked"
 msgstr ""
@@ -21903,7 +21905,7 @@ msgstr ""
 msgid "Move %{card}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:350
+#: lib/vutuv_web/components/ui.ex:544
 #: lib/vutuv_web/live/post_live/filter_band.ex:583
 #, elixir-autogen, elixir-format
 msgid "No account found."
@@ -22068,7 +22070,7 @@ msgstr ""
 msgid "Your organization page was updated, but that picture could not be used as a logo. Please pick another one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3990
+#: lib/vutuv_web/components/ui.ex:4034
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -22230,12 +22232,12 @@ msgstr ""
 msgid "Quotes %{url}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:349
+#: lib/vutuv_web/components/ui.ex:543
 #, elixir-autogen, elixir-format
 msgid "Mention an account"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:352
+#: lib/vutuv_web/components/ui.ex:546
 #, elixir-autogen, elixir-format
 msgid "{used} of {max} mentions"
 msgstr ""
@@ -22266,7 +22268,7 @@ msgstr ""
 msgid "Only these accounts (empty = all) …"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3115
+#: lib/vutuv_web/components/ui.ex:3159
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr ""
@@ -22316,33 +22318,33 @@ msgid_plural "shared this."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:475
+#: lib/vutuv_web/components/ui.ex:482
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Editor view"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:423
+#: lib/vutuv_web/components/ui.ex:430
 #, elixir-autogen, elixir-format
 msgid "Insert a block"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:435
+#: lib/vutuv_web/components/ui.ex:442
 #, elixir-autogen, elixir-format
 msgid "Nothing matches."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1750
-#: lib/vutuv_web/live/post_live/composer.ex:2483
+#: lib/vutuv_web/live/post_live/composer.ex:1778
+#: lib/vutuv_web/live/post_live/composer.ex:2513
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Automatic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1755
+#: lib/vutuv_web/live/post_live/composer.ex:1783
 #, elixir-autogen, elixir-format
 msgid "Drag one photo onto another to swap them."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1702
+#: lib/vutuv_web/live/post_live/composer.ex:1730
 #, elixir-autogen, elixir-format
 msgid "Not shown in the gallery — drag one into it to swap."
 msgstr ""
@@ -22399,32 +22401,63 @@ msgstr ""
 msgid "Unmute %{host}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1510
+#: lib/vutuv_web/live/post_live/composer.ex:1538
 #, elixir-autogen, elixir-format
 msgid "Draft discarded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1549
+#: lib/vutuv_web/live/post_live/composer.ex:1577
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1540
+#: lib/vutuv_web/live/post_live/composer.ex:1568
 #, elixir-autogen, elixir-format
 msgid "Keep this draft for later?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1175
+#: lib/vutuv_web/live/post_live/composer.ex:1186
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Hidden from some"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1857
+#: lib/vutuv_web/live/post_live/composer.ex:1885
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post options"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:314
+#: lib/vutuv_web/live/organization_live/edit.ex:315
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Describe the organization. Markdown is supported."
+msgstr ""
+
+#: lib/vutuv_web/templates/page/index.html.heex:286
+#: lib/vutuv_web/templates/settings/preferences.html.heex:205
+#, elixir-autogen, elixir-format
+msgid "Bandwidth"
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:868
+#, elixir-autogen, elixir-format
+msgid "Bandwidth settings reset to the site defaults."
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:862
+#, elixir-autogen, elixir-format
+msgid "Bandwidth settings saved."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:207
+#, elixir-autogen, elixir-format
+msgid "If you are on a slow or metered connection, vutuv can leave out the parts of the page that cost the most to download."
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:101
+#, elixir-autogen, elixir-format
+msgid "Low-bandwidth mode"
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:102
+#, elixir-autogen, elixir-format
+msgid "Writing a post or a message then uses a plain Markdown box instead of the formatting editor, which saves about 150 kB of download. Everything you write still looks the same to everyone who reads it."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -17,12 +17,12 @@ msgstr ""
 msgid "About us"
 msgstr "Note legali"
 
-#: lib/vutuv_web/components/ui.ex:4370
-#: lib/vutuv_web/components/ui.ex:4375
+#: lib/vutuv_web/components/ui.ex:4414
+#: lib/vutuv_web/components/ui.ex:4419
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
 #: lib/vutuv_web/live/organization_live/domains.ex:272
-#: lib/vutuv_web/live/organization_live/edit.ex:430
+#: lib/vutuv_web/live/organization_live/edit.ex:431
 #: lib/vutuv_web/live/organization_live/roles.ex:214
 #, elixir-autogen
 msgid "Add"
@@ -64,7 +64,7 @@ msgstr "Indirizzo aggiornato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/text.ex:71
-#: lib/vutuv_web/components/ui.ex:4668
+#: lib/vutuv_web/components/ui.ex:4712
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -77,14 +77,14 @@ msgstr "Indirizzo aggiornato."
 msgid "Addresses"
 msgstr "Indirizzi"
 
-#: lib/vutuv_web/components/ui.ex:1462
-#: lib/vutuv_web/templates/page/index.html.heex:290
+#: lib/vutuv_web/components/ui.ex:1506
+#: lib/vutuv_web/templates/page/index.html.heex:320
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr "È già iscritto? Acceda qui."
 
-#: lib/vutuv_web/components/ui.ex:4165
-#: lib/vutuv_web/components/ui.ex:4259
+#: lib/vutuv_web/components/ui.ex:4209
+#: lib/vutuv_web/components/ui.ex:4303
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -112,14 +112,14 @@ msgid "Birthday"
 msgstr "Compleanno"
 
 #: lib/vutuv_web/components/saved_search_components.ex:114
-#: lib/vutuv_web/components/ui.ex:4159
+#: lib/vutuv_web/components/ui.ex:4203
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
-#: lib/vutuv_web/live/job_posting_live/form.ex:811
-#: lib/vutuv_web/live/organization_live/edit.ex:381
+#: lib/vutuv_web/live/job_posting_live/form.ex:812
+#: lib/vutuv_web/live/organization_live/edit.ex:382
 #: lib/vutuv_web/live/organization_live/new.ex:231
-#: lib/vutuv_web/live/post_live/composer.ex:1669
+#: lib/vutuv_web/live/post_live/composer.ex:1697
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -163,7 +163,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr "Non è stato possibile ricambiare il follow a %{name}."
 
 #: lib/vutuv_web/components/post_components.ex:3586
-#: lib/vutuv_web/components/ui.ex:4262
+#: lib/vutuv_web/components/ui.ex:4306
 #: lib/vutuv_web/live/admin/job_live.ex:489
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -179,7 +179,7 @@ msgstr "Elimina"
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:686
 #: lib/vutuv_web/live/organization_live/edit.ex:301
-#: lib/vutuv_web/live/organization_live/edit.ex:313
+#: lib/vutuv_web/live/organization_live/edit.ex:314
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
 #: lib/vutuv_web/templates/address/form_en.html.heex:11
 #: lib/vutuv_web/templates/address/form_generic.html.heex:13
@@ -203,7 +203,7 @@ msgid "Disable"
 msgstr "Disattiva"
 
 #: lib/vutuv_web/live/cv_live.ex:438
-#: lib/vutuv_web/live/post_live/composer.ex:2579
+#: lib/vutuv_web/live/post_live/composer.ex:2609
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
@@ -211,7 +211,7 @@ msgid "Download"
 msgstr "Scarica"
 
 #: lib/vutuv_web/components/post_components.ex:3551
-#: lib/vutuv_web/components/ui.ex:4253
+#: lib/vutuv_web/components/ui.ex:4297
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -285,7 +285,7 @@ msgstr "Inserisca il Suo indirizzo e-mail"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:4632
+#: lib/vutuv_web/components/ui.ex:4676
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -326,8 +326,8 @@ msgstr "Follower"
 #: lib/vutuv_web/agent_docs/markdown.ex:632
 #: lib/vutuv_web/agent_docs/text.ex:596
 #: lib/vutuv_web/components/fediverse_components.ex:400
-#: lib/vutuv_web/components/ui.ex:2661
-#: lib/vutuv_web/components/ui.ex:2696
+#: lib/vutuv_web/components/ui.ex:2705
+#: lib/vutuv_web/components/ui.ex:2740
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:608
@@ -605,7 +605,7 @@ msgstr "Profili di "
 msgid "Provider"
 msgstr "Piattaforma"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1881
+#: lib/vutuv_web/live/post_live/composer.ex:1909
 #: lib/vutuv_web/live/section_reorder_live.ex:270
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -615,9 +615,9 @@ msgstr "Piattaforma"
 msgid "Public"
 msgstr "Pubblico"
 
-#: lib/vutuv_web/components/ui.ex:4158
-#: lib/vutuv_web/live/organization_live/edit.ex:375
-#: lib/vutuv_web/live/post_live/composer.ex:1896
+#: lib/vutuv_web/components/ui.ex:4202
+#: lib/vutuv_web/live/organization_live/edit.ex:376
+#: lib/vutuv_web/live/post_live/composer.ex:1924
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -627,8 +627,9 @@ msgstr "Pubblico"
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
 #: lib/vutuv_web/templates/settings/preferences.html.heex:157
-#: lib/vutuv_web/templates/settings/preferences.html.heex:229
-#: lib/vutuv_web/templates/settings/preferences.html.heex:362
+#: lib/vutuv_web/templates/settings/preferences.html.heex:224
+#: lib/vutuv_web/templates/settings/preferences.html.heex:273
+#: lib/vutuv_web/templates/settings/preferences.html.heex:406
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:462
@@ -667,7 +668,7 @@ msgstr "Cerca"
 msgid "Show"
 msgstr "Mostra"
 
-#: lib/vutuv_web/templates/page/index.html.heex:269
+#: lib/vutuv_web/templates/page/index.html.heex:299
 #, elixir-autogen
 msgid "Sign up for a free account"
 msgstr "Crei un account gratuito"
@@ -790,7 +791,7 @@ msgstr "Utente aggiornato."
 msgid "User verified successfully."
 msgstr "Utente verificato."
 
-#: lib/vutuv_web/components/ui.ex:4628
+#: lib/vutuv_web/components/ui.ex:4672
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -842,7 +843,7 @@ msgstr "Nome utente"
 msgid "Users"
 msgstr "Utenti"
 
-#: lib/vutuv_web/components/ui.ex:1269
+#: lib/vutuv_web/components/ui.ex:1313
 #: lib/vutuv_web/views/user_html.ex:562
 #: lib/vutuv_web/views/user_html.ex:563
 #: lib/vutuv_web/views/user_html.ex:577
@@ -850,17 +851,17 @@ msgstr "Utenti"
 msgid "vCard"
 msgstr "vCard"
 
-#: lib/vutuv_web/components/ui.ex:4323
+#: lib/vutuv_web/components/ui.ex:4367
 #: lib/vutuv_web/templates/user/show.html.heex:973
 #: lib/vutuv_web/templates/user/show.html.heex:996
 #, elixir-autogen
 msgid "View All"
 msgstr "Mostra tutti"
 
-#: lib/vutuv_web/components/ui.ex:4736
+#: lib/vutuv_web/components/ui.ex:4780
 #: lib/vutuv_web/controllers/settings_controller.ex:171
-#: lib/vutuv_web/live/job_posting_live/form.ex:767
-#: lib/vutuv_web/live/organization_live/edit.ex:334
+#: lib/vutuv_web/live/job_posting_live/form.ex:768
+#: lib/vutuv_web/live/organization_live/edit.ex:335
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:295
@@ -874,7 +875,7 @@ msgstr "Visibilità"
 msgid "We can't find em' cap'n!"
 msgstr "Niente da fare, capitano."
 
-#: lib/vutuv_web/templates/page/index.html.heex:293
+#: lib/vutuv_web/templates/page/index.html.heex:323
 #, elixir-autogen
 msgid "We reserve the right to stop this service or delete your account anytime without warning."
 msgstr ""
@@ -962,7 +963,7 @@ msgstr ""
 msgid "Allow others to view your email address"
 msgstr "Consentire ad altri di vedere il mio indirizzo e-mail"
 
-#: lib/vutuv_web/templates/page/index.html.heex:279
+#: lib/vutuv_web/templates/page/index.html.heex:309
 #, elixir-autogen, elixir-format
 msgid "By creating an account you accept our {nutzungsbedingungen} and confirm that you have read our {datenschutz}."
 msgstr ""
@@ -1096,7 +1097,7 @@ msgstr "Accedi a vutuv"
 msgid "Listings"
 msgstr "Elenchi"
 
-#: lib/vutuv_web/controllers/page_controller.ex:399
+#: lib/vutuv_web/controllers/page_controller.ex:418
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1401,7 +1402,7 @@ msgstr "URL dei tag"
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:522
 #: lib/vutuv_web/agent_docs/text.ex:768
-#: lib/vutuv_web/components/ui.ex:4653
+#: lib/vutuv_web/components/ui.ex:4697
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1412,7 +1413,7 @@ msgstr "URL dei tag"
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:444
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
-#: lib/vutuv_web/live/job_posting_live/form.ex:716
+#: lib/vutuv_web/live/job_posting_live/form.ex:717
 #: lib/vutuv_web/live/search_live.ex:344
 #: lib/vutuv_web/live/search_live.ex:822
 #: lib/vutuv_web/live/tag_new_live.ex:35
@@ -1594,7 +1595,7 @@ msgstr "Riceverà un'e-mail con un link di accesso."
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:776
 #: lib/vutuv_web/live/job_board_live.ex:360
 #: lib/vutuv_web/live/job_posting_live/form.ex:548
-#: lib/vutuv_web/live/organization_live/edit.ex:330
+#: lib/vutuv_web/live/organization_live/edit.ex:331
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
 #: lib/vutuv_web/templates/address/country_input.html.heex:5
@@ -1647,15 +1648,15 @@ msgstr "Torna alla pagina iniziale"
 msgid "Check your inbox"
 msgstr "Controlli la Sua casella di posta"
 
-#: lib/vutuv_web/components/ui.ex:2820
+#: lib/vutuv_web/components/ui.ex:2864
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:480
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1525
-#: lib/vutuv_web/live/post_live/composer.ex:1627
-#: lib/vutuv_web/live/post_live/composer.ex:1628
-#: lib/vutuv_web/live/post_live/composer.ex:2456
-#: lib/vutuv_web/live/post_live/composer.ex:2722
+#: lib/vutuv_web/live/post_live/composer.ex:1553
+#: lib/vutuv_web/live/post_live/composer.ex:1655
+#: lib/vutuv_web/live/post_live/composer.ex:1656
+#: lib/vutuv_web/live/post_live/composer.ex:2486
+#: lib/vutuv_web/live/post_live/composer.ex:2752
 #: lib/vutuv_web/templates/layout/app.html.heex:188
 #: lib/vutuv_web/templates/layout/app.html.heex:194
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
@@ -1678,7 +1679,7 @@ msgstr "Confermi l'eliminazione dell'account"
 
 #: lib/vutuv_web/controllers/page_controller.ex:254
 #: lib/vutuv_web/templates/layout/app.html.heex:117
-#: lib/vutuv_web/templates/page/index.html.heex:286
+#: lib/vutuv_web/templates/page/index.html.heex:316
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
@@ -1686,7 +1687,7 @@ msgstr "Informativa sulla privacy"
 
 #: lib/vutuv_web/controllers/page_controller.ex:260
 #: lib/vutuv_web/templates/layout/app.html.heex:118
-#: lib/vutuv_web/templates/page/index.html.heex:286
+#: lib/vutuv_web/templates/page/index.html.heex:316
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Nutzungsbedingungen"
@@ -1704,20 +1705,20 @@ msgstr "Elimina il mio account"
 msgid "Edit profile"
 msgstr "Modifica profilo"
 
-#: lib/vutuv_web/components/ui.ex:1981
-#: lib/vutuv_web/components/ui.ex:1990
-#: lib/vutuv_web/components/ui.ex:2468
+#: lib/vutuv_web/components/ui.ex:2025
+#: lib/vutuv_web/components/ui.ex:2034
+#: lib/vutuv_web/components/ui.ex:2512
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr "Conferma"
 
 #: lib/vutuv_web/components/fediverse_components.ex:236
-#: lib/vutuv_web/components/ui.ex:2626
-#: lib/vutuv_web/components/ui.ex:2626
-#: lib/vutuv_web/components/ui.ex:2643
-#: lib/vutuv_web/components/ui.ex:2652
-#: lib/vutuv_web/components/ui.ex:2668
-#: lib/vutuv_web/components/ui.ex:2730
+#: lib/vutuv_web/components/ui.ex:2670
+#: lib/vutuv_web/components/ui.ex:2670
+#: lib/vutuv_web/components/ui.ex:2687
+#: lib/vutuv_web/components/ui.ex:2696
+#: lib/vutuv_web/components/ui.ex:2712
+#: lib/vutuv_web/components/ui.ex:2774
 #: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:311
@@ -1791,7 +1792,7 @@ msgid "Network"
 msgstr "Rete"
 
 #: lib/vutuv_web/components/post_components.ex:450
-#: lib/vutuv_web/components/ui.ex:4372
+#: lib/vutuv_web/components/ui.ex:4416
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
@@ -1807,7 +1808,7 @@ msgid "Nothing new yet."
 msgstr "Ancora nessuna novità."
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:4690
+#: lib/vutuv_web/components/ui.ex:4734
 #: lib/vutuv_web/controllers/page_controller.ex:228
 #: lib/vutuv_web/live/notification_live/index.ex:146
 #: lib/vutuv_web/live/notification_live/index.ex:384
@@ -1833,7 +1834,7 @@ msgid "Pardon us! Something went wrong."
 msgstr "Ci scusi, qualcosa è andato storto."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:911
+#: lib/vutuv_web/live/message_live/index.ex:912
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
@@ -1913,8 +1914,8 @@ msgstr ""
 msgid "Who to follow"
 msgstr "Chi seguire"
 
-#: lib/vutuv_web/live/message_live/index.ex:900
 #: lib/vutuv_web/live/message_live/index.ex:901
+#: lib/vutuv_web/live/message_live/index.ex:902
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr "Scriva un messaggio…"
@@ -1959,15 +1960,15 @@ msgstr "ora è collegato con Lei."
 msgid "started following you."
 msgstr "ha iniziato a seguirla."
 
-#: lib/vutuv_web/components/ui.ex:3651
-#: lib/vutuv_web/components/ui.ex:3804
+#: lib/vutuv_web/components/ui.ex:3695
+#: lib/vutuv_web/components/ui.ex:3848
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr "Paginazione"
 
-#: lib/vutuv_web/components/ui.ex:4397
+#: lib/vutuv_web/components/ui.ex:4441
 #: lib/vutuv_web/live/organization_live/activity.ex:151
 #: lib/vutuv_web/live/organization_live/feed.ex:210
 #: lib/vutuv_web/live/organization_live/show.ex:777
@@ -1982,13 +1983,13 @@ msgstr ""
 "L'indirizzo non può essere modificato. Per usarne un altro, lo aggiunga come"
 " nuovo indirizzo e-mail ed elimini questo."
 
-#: lib/vutuv_web/components/ui.ex:4168
+#: lib/vutuv_web/components/ui.ex:4212
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Elimina voce"
 
-#: lib/vutuv_web/components/ui.ex:1662
-#: lib/vutuv_web/components/ui.ex:1672
+#: lib/vutuv_web/components/ui.ex:1706
+#: lib/vutuv_web/components/ui.ex:1716
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr "Opzioni"
@@ -2027,12 +2028,12 @@ msgstr "Aggiungi un'immagine di copertina"
 msgid "Add cover photo"
 msgstr "Aggiungi immagine di copertina"
 
-#: lib/vutuv_web/components/ui.ex:3174
+#: lib/vutuv_web/components/ui.ex:3218
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr "Aprile"
 
-#: lib/vutuv_web/components/ui.ex:3178
+#: lib/vutuv_web/components/ui.ex:3222
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr "Agosto"
@@ -2057,37 +2058,37 @@ msgstr "Immagine di copertina"
 msgid "Cover photo of %{name}"
 msgstr "Immagine di copertina di %{name}"
 
-#: lib/vutuv_web/components/ui.ex:3182
+#: lib/vutuv_web/components/ui.ex:3226
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr "Dicembre"
 
-#: lib/vutuv_web/components/ui.ex:3172
+#: lib/vutuv_web/components/ui.ex:3216
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr "Febbraio"
 
-#: lib/vutuv_web/components/ui.ex:3171
+#: lib/vutuv_web/components/ui.ex:3215
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr "Gennaio"
 
-#: lib/vutuv_web/components/ui.ex:3177
+#: lib/vutuv_web/components/ui.ex:3221
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr "Luglio"
 
-#: lib/vutuv_web/components/ui.ex:3176
+#: lib/vutuv_web/components/ui.ex:3220
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr "Giugno"
 
-#: lib/vutuv_web/components/ui.ex:3173
+#: lib/vutuv_web/components/ui.ex:3217
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr "Marzo"
 
-#: lib/vutuv_web/components/ui.ex:3175
+#: lib/vutuv_web/components/ui.ex:3219
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr "Maggio"
@@ -2102,17 +2103,17 @@ msgstr "Membro da %{month} %{year}"
 msgid "Member since %{year}"
 msgstr "Membro dal %{year}"
 
-#: lib/vutuv_web/components/ui.ex:3181
+#: lib/vutuv_web/components/ui.ex:3225
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr "Novembre"
 
-#: lib/vutuv_web/components/ui.ex:3180
+#: lib/vutuv_web/components/ui.ex:3224
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr "Ottobre"
 
-#: lib/vutuv_web/components/ui.ex:3179
+#: lib/vutuv_web/components/ui.ex:3223
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr "Settembre"
@@ -2124,12 +2125,12 @@ msgstr "Settembre"
 msgid "Markdown is supported: bold, italics, links and lists."
 msgstr "Markdown è supportato: grassetto, corsivo, link ed elenchi."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:709
+#: lib/vutuv_web/live/job_posting_live/form.ex:710
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr "Aggiungi immagini"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2074
+#: lib/vutuv_web/live/post_live/composer.ex:2102
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2142,7 +2143,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr "Torna al post"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1767
+#: lib/vutuv_web/live/post_live/composer.ex:1795
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Annulla il caricamento"
@@ -2187,12 +2188,12 @@ msgstr "Segua %{name} per leggerlo."
 msgid "Hidden from:"
 msgstr "Nascosto a:"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2050
+#: lib/vutuv_web/live/post_live/composer.ex:2078
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr "Nascondi a una persona specifica…"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1978
+#: lib/vutuv_web/live/post_live/composer.ex:2006
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr "Nascondi questo post a…"
@@ -2203,13 +2204,13 @@ msgstr "Nascondi questo post a…"
 msgid "Limited audience"
 msgstr "Pubblico limitato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2020
+#: lib/vutuv_web/live/post_live/composer.ex:2048
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr "Visitatori non connessi"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1284
-#: lib/vutuv_web/live/post_live/composer.ex:1332
+#: lib/vutuv_web/live/post_live/composer.ex:1295
+#: lib/vutuv_web/live/post_live/composer.ex:1343
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
@@ -2221,23 +2222,23 @@ msgstr ""
 "Qui non c'è ancora nulla. Segua altre persone per riempire il Suo feed, "
 "oppure scriva il Suo primo post."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1250
+#: lib/vutuv_web/live/post_live/composer.ex:1261
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr "Non è stato possibile allegare una delle immagini."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2010
+#: lib/vutuv_web/live/post_live/composer.ex:2038
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr "Persone che non seguo"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2000
+#: lib/vutuv_web/live/post_live/composer.ex:2028
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr "Persone che non mi seguono"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:416
-#: lib/vutuv_web/live/post_live/composer.ex:1898
+#: lib/vutuv_web/live/post_live/composer.ex:1926
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2252,7 +2253,7 @@ msgstr "Post eliminato."
 #: lib/vutuv_web/controllers/post_controller.ex:62
 #: lib/vutuv_web/controllers/post_controller.ex:74
 #: lib/vutuv_web/controllers/user_controller.ex:76
-#: lib/vutuv_web/gettext_extraction_anchors.ex:103
+#: lib/vutuv_web/gettext_extraction_anchors.ex:109
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:388
 #: lib/vutuv_web/live/notification_live/index.ex:1125
@@ -2260,7 +2261,7 @@ msgstr "Post eliminato."
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:345
 #: lib/vutuv_web/live/search_live.ex:836
-#: lib/vutuv_web/templates/settings/preferences.html.heex:275
+#: lib/vutuv_web/templates/settings/preferences.html.heex:319
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
@@ -2285,9 +2286,9 @@ msgstr "Mostra meno"
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:246
-#: lib/vutuv_web/live/organization_live/edit.ex:407
+#: lib/vutuv_web/live/organization_live/edit.ex:408
 #: lib/vutuv_web/live/organization_live/roles.ex:247
-#: lib/vutuv_web/live/post_live/composer.ex:2036
+#: lib/vutuv_web/live/post_live/composer.ex:2064
 #: lib/vutuv_web/live/post_live/filter_band.ex:455
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
@@ -2304,7 +2305,7 @@ msgstr ""
 "I post con pubblico limitato sono nascosti anche ai visitatori non connessi "
 "e ai motori di ricerca."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1888
+#: lib/vutuv_web/live/post_live/composer.ex:1916
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr "Salvataggio…"
@@ -2321,12 +2322,12 @@ msgstr[1] "Mostra %{formatted} nuovi post"
 msgid "Sorry, that page could not be found."
 msgstr "Spiacenti, la pagina non è stata trovata."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1358
+#: lib/vutuv_web/live/post_live/composer.ex:1369
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Non è stato possibile elaborare il file."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1232
+#: lib/vutuv_web/live/post_live/composer.ex:1243
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr "La selezione del pubblico non è valida."
@@ -2336,17 +2337,17 @@ msgstr "La selezione del pubblico non è valida."
 msgid "This post is for followers of %{name}"
 msgstr "Questo post è per i follower di %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2871
+#: lib/vutuv_web/live/post_live/composer.ex:2901
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Troppi file."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2872
+#: lib/vutuv_web/live/post_live/composer.ex:2902
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Caricamento non riuscito."
 
-#: lib/vutuv_web/components/ui.ex:4990
+#: lib/vutuv_web/components/ui.ex:5034
 #: lib/vutuv_web/live/shell_live.ex:1307
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2355,12 +2356,12 @@ msgstr "Caricamento non riuscito."
 msgid "View profile"
 msgstr "Vedi il profilo"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2149
+#: lib/vutuv_web/live/post_live/composer.ex:2179
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr "Che c'è di nuovo?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2150
+#: lib/vutuv_web/live/post_live/composer.ex:2180
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr "Che c'è di nuovo? Markdown è supportato."
@@ -2390,23 +2391,23 @@ msgstr "persone che non La seguono"
 msgid "people you don't follow"
 msgstr "persone che non segue"
 
-#: lib/vutuv_web/components/ui.ex:3252
+#: lib/vutuv_web/components/ui.ex:3296
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr "sconosciuto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1803
+#: lib/vutuv_web/live/post_live/composer.ex:1831
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr "Tag separati da virgole (max. %{max})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2862
+#: lib/vutuv_web/live/post_live/composer.ex:2892
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr "Il file supera %{mb} MB."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2866
+#: lib/vutuv_web/live/post_live/composer.ex:2896
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr "Tipo di file non supportato (ammessi: %{types})."
@@ -2428,7 +2429,7 @@ msgstr "Tutti i post"
 
 #: lib/vutuv_web/components/post_components.ex:2033
 #: lib/vutuv_web/components/post_components.ex:5535
-#: lib/vutuv_web/components/ui.ex:3726
+#: lib/vutuv_web/components/ui.ex:3770
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2447,7 +2448,7 @@ msgstr "Salvati"
 
 #: lib/vutuv_web/components/post_components.ex:1986
 #: lib/vutuv_web/components/post_components.ex:5771
-#: lib/vutuv_web/components/ui.ex:3712
+#: lib/vutuv_web/components/ui.ex:3756
 #: lib/vutuv_web/live/notification_live/index.ex:1271
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
@@ -2519,9 +2520,9 @@ msgstr "Togli Mi piace"
 
 #: lib/vutuv_web/components/fediverse_components.ex:430
 #: lib/vutuv_web/components/post_components.ex:2648
-#: lib/vutuv_web/components/ui.ex:2621
-#: lib/vutuv_web/components/ui.ex:2621
-#: lib/vutuv_web/components/ui.ex:2697
+#: lib/vutuv_web/components/ui.ex:2665
+#: lib/vutuv_web/components/ui.ex:2665
+#: lib/vutuv_web/components/ui.ex:2741
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:611
@@ -2563,15 +2564,15 @@ msgstr "Rispondi"
 msgid "Reply to a deleted post"
 msgstr "Risposta a un post eliminato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1235
-#: lib/vutuv_web/live/post_live/composer.ex:1876
+#: lib/vutuv_web/live/post_live/composer.ex:1246
+#: lib/vutuv_web/live/post_live/composer.ex:1904
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 "Il pubblico non può essere limitato finché esistono ripubblicazioni o "
 "risposte."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2081
+#: lib/vutuv_web/live/post_live/composer.ex:2109
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2614,7 +2615,7 @@ msgstr "%{names} stanno scrivendo…"
 msgid "%{name} is typing…"
 msgstr "%{name} sta scrivendo…"
 
-#: lib/vutuv_web/live/message_live/index.ex:923
+#: lib/vutuv_web/live/message_live/index.ex:924
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr "@%{slug} non ha ancora accettato la Sua richiesta di messaggio."
@@ -2660,7 +2661,7 @@ msgstr "Membro non trovato."
 msgid "No conversations yet."
 msgstr "Ancora nessuna conversazione."
 
-#: lib/vutuv_web/components/ui.ex:2944
+#: lib/vutuv_web/components/ui.ex:2988
 #: lib/vutuv_web/live/message_live/index.ex:760
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2671,7 +2672,7 @@ msgstr "Online"
 msgid "Requests"
 msgstr "Richieste"
 
-#: lib/vutuv_web/live/message_live/index.ex:932
+#: lib/vutuv_web/live/message_live/index.ex:933
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr "Selezioni una conversazione."
@@ -2749,7 +2750,7 @@ msgstr "Un nuovo PIN è in arrivo nella Sua casella di posta."
 msgid "Okay, let's start over."
 msgstr "Va bene, ricominciamo."
 
-#: lib/vutuv_web/components/ui.ex:771
+#: lib/vutuv_web/components/ui.ex:815
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr "Invia di nuovo il PIN"
@@ -2760,7 +2761,7 @@ msgstr "Invia di nuovo il PIN"
 msgid "Too many PIN requests. Please try again later."
 msgstr "Troppe richieste di PIN. Riprovi più tardi."
 
-#: lib/vutuv_web/components/ui.ex:792
+#: lib/vutuv_web/components/ui.ex:836
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr "Usa un altro indirizzo e-mail"
@@ -2810,8 +2811,8 @@ msgstr "Aggiungi un'esperienza lavorativa"
 msgid "Write your first post"
 msgstr "Scriva il Suo primo post"
 
-#: lib/vutuv_web/components/ui.ex:3892
-#: lib/vutuv_web/components/ui.ex:4325
+#: lib/vutuv_web/components/ui.ex:3936
+#: lib/vutuv_web/components/ui.ex:4369
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:104
@@ -2863,7 +2864,7 @@ msgstr[1] "+%{formatted} altri tag"
 msgid "Connections"
 msgstr "Collegamenti"
 
-#: lib/vutuv_web/components/ui.ex:1260
+#: lib/vutuv_web/components/ui.ex:1304
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr "Markdown"
@@ -2873,17 +2874,17 @@ msgstr "Markdown"
 msgid "No connections yet."
 msgstr "Ancora nessun collegamento."
 
-#: lib/vutuv_web/components/ui.ex:1276
+#: lib/vutuv_web/components/ui.ex:1320
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr "Altri formati"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1990
+#: lib/vutuv_web/live/post_live/composer.ex:2018
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr "Persone che non sono miei collegamenti"
 
-#: lib/vutuv_web/components/ui.ex:1261
+#: lib/vutuv_web/components/ui.ex:1305
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr "Solo testo"
@@ -3237,7 +3238,7 @@ msgstr ""
 msgid "Private message"
 msgstr "Messaggio privato"
 
-#: lib/vutuv_web/components/ui.ex:4622
+#: lib/vutuv_web/components/ui.ex:4666
 #: lib/vutuv_web/live/shell_live.ex:1128
 #: lib/vutuv_web/live/shell_live.ex:1425
 #: lib/vutuv_web/templates/import/new.html.heex:16
@@ -3352,7 +3353,7 @@ msgstr ""
 "Le segnalazioni sono anonime; non diciamo mai chi ha segnalato. Le nostre "
 "regole:"
 
-#: lib/vutuv_web/components/ui.ex:3601
+#: lib/vutuv_web/components/ui.ex:3645
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -4009,7 +4010,7 @@ msgstr "Follower di %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:157
 #: lib/vutuv_web/agent_docs/text.ex:112
 #: lib/vutuv_web/agent_docs/text.ex:143
-#: lib/vutuv_web/live/job_posting_live/form.ex:699
+#: lib/vutuv_web/live/job_posting_live/form.ex:700
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr "Immagini"
@@ -4198,7 +4199,7 @@ msgstr "Per prenotare serve un accesso a vutuv."
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
 #: lib/vutuv_web/live/job_posting_live/form.ex:542
-#: lib/vutuv_web/live/organization_live/edit.ex:326
+#: lib/vutuv_web/live/organization_live/edit.ex:327
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
 #: lib/vutuv_web/templates/address/form_en.html.heex:33
@@ -4504,12 +4505,12 @@ msgstr ""
 "Le prenotazioni sono aperte fino al %{last}. Prossimo giorno disponibile: "
 "%{day}"
 
-#: lib/vutuv_web/components/ui.ex:3204
+#: lib/vutuv_web/components/ui.ex:3248
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr "Ve"
 
-#: lib/vutuv_web/components/ui.ex:3200
+#: lib/vutuv_web/components/ui.ex:3244
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr "Lu"
@@ -4521,27 +4522,27 @@ msgstr ""
 "Una pubblicità al giorno: scelga un giorno libero nel calendario; i giorni "
 "barrati sono già prenotati."
 
-#: lib/vutuv_web/components/ui.ex:3205
+#: lib/vutuv_web/components/ui.ex:3249
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr "Sa"
 
-#: lib/vutuv_web/components/ui.ex:3206
+#: lib/vutuv_web/components/ui.ex:3250
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr "Do"
 
-#: lib/vutuv_web/components/ui.ex:3203
+#: lib/vutuv_web/components/ui.ex:3247
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr "Gi"
 
-#: lib/vutuv_web/components/ui.ex:3201
+#: lib/vutuv_web/components/ui.ex:3245
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr "Ma"
 
-#: lib/vutuv_web/components/ui.ex:3202
+#: lib/vutuv_web/components/ui.ex:3246
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr "Me"
@@ -4684,7 +4685,7 @@ msgstr ""
 " la vostra conversazione e impedisce ogni interazione in entrambe le "
 "direzioni. Sbloccare non ripristina ciò che è stato rimosso."
 
-#: lib/vutuv_web/components/ui.ex:4740
+#: lib/vutuv_web/components/ui.ex:4784
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -5491,7 +5492,7 @@ msgstr "Token API (%{date})"
 msgid "API documentation"
 msgstr "Documentazione dell'API"
 
-#: lib/vutuv_web/components/ui.ex:4800
+#: lib/vutuv_web/components/ui.ex:4844
 #: lib/vutuv_web/controllers/settings_controller.ex:157
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5531,7 +5532,7 @@ msgstr ""
 "Questo elimina definitivamente il Suo profilo, i post, i messaggi e tutto il"
 " resto. Le inviamo un PIN per e-mail per confermare. Non si può annullare."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1253
+#: lib/vutuv_web/live/post_live/composer.ex:1264
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr "Non può più rispondere a questo post."
@@ -5574,10 +5575,10 @@ msgstr "Scorciatoie da tastiera"
 msgid "Navigation"
 msgstr "Navigazione"
 
-#: lib/vutuv_web/components/ui.ex:4897
-#: lib/vutuv_web/components/ui.ex:4902
-#: lib/vutuv_web/components/ui.ex:4981
-#: lib/vutuv_web/components/ui.ex:5045
+#: lib/vutuv_web/components/ui.ex:4941
+#: lib/vutuv_web/components/ui.ex:4946
+#: lib/vutuv_web/components/ui.ex:5025
+#: lib/vutuv_web/components/ui.ex:5089
 #: lib/vutuv_web/controllers/settings_controller.ex:64
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5695,7 +5696,7 @@ msgstr "Tipo di indirizzo e-mail"
 msgid "About you"
 msgstr "Su di Lei"
 
-#: lib/vutuv_web/components/ui.ex:4760
+#: lib/vutuv_web/components/ui.ex:4804
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5706,7 +5707,7 @@ msgstr "Su di Lei"
 msgid "Account"
 msgstr "Account"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:481
+#: lib/vutuv_web/live/organization_live/edit.ex:482
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr "Modifica"
@@ -5716,7 +5717,7 @@ msgstr "Modifica"
 msgid "Download everything vutuv stores about you, as one file."
 msgstr "Scarichi in un unico file tutto ciò che vutuv conserva su di Lei."
 
-#: lib/vutuv_web/components/ui.ex:4660
+#: lib/vutuv_web/components/ui.ex:4704
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5745,13 +5746,13 @@ msgstr "Persone che non possono interagire con Lei."
 msgid "Personal tokens for the vutuv API."
 msgstr "Token personali per l'API di vutuv."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2192
+#: lib/vutuv_web/live/post_live/composer.ex:2222
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
 msgstr "Foto"
 
-#: lib/vutuv_web/components/ui.ex:4734
+#: lib/vutuv_web/components/ui.ex:4778
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/templates/page/index.html.heex:191
 #, elixir-autogen, elixir-format
@@ -5866,7 +5867,7 @@ msgstr "@%{slug} ha iniziato a seguirla su vutuv"
 msgid "Apps"
 msgstr "App"
 
-#: lib/vutuv_web/components/ui.ex:4793
+#: lib/vutuv_web/components/ui.ex:4837
 #: lib/vutuv_web/controllers/settings_controller.ex:181
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -6074,28 +6075,28 @@ msgid "Sort"
 msgstr "Ordina"
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3261
+#: lib/vutuv_web/components/ui.ex:3305
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "%{count} giorno fa"
 msgstr[1] "%{count} giorni fa"
 
-#: lib/vutuv_web/components/ui.ex:3260
+#: lib/vutuv_web/components/ui.ex:3304
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "%{count} ora fa"
 msgstr[1] "%{count} ore fa"
 
-#: lib/vutuv_web/components/ui.ex:3259
+#: lib/vutuv_web/components/ui.ex:3303
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] "%{count} minuto fa"
 msgstr[1] "%{count} minuti fa"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:923
+#: lib/vutuv_web/controllers/settings_controller.ex:943
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr "Tutti gli altri dispositivi sono stati disconnessi."
@@ -6135,7 +6136,7 @@ msgstr "Nuovo accesso al Suo account vutuv"
 msgid "Signed-in devices"
 msgstr "Dispositivi connessi"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:910
+#: lib/vutuv_web/controllers/settings_controller.ex:930
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr "Quel dispositivo è stato disconnesso."
@@ -6155,7 +6156,7 @@ msgstr "Questo dispositivo"
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr "È il primo accesso che vediamo da questo dispositivo o browser."
 
-#: lib/vutuv_web/components/ui.ex:3258
+#: lib/vutuv_web/components/ui.ex:3302
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "adesso"
@@ -6304,7 +6305,7 @@ msgstr "Aggiungi una descrizione breve"
 msgid "Tagline"
 msgstr "Descrizione breve"
 
-#: lib/vutuv_web/components/ui.ex:389
+#: lib/vutuv_web/components/ui.ex:396
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:907
@@ -6367,7 +6368,7 @@ msgstr "Posizioni la Sua foto"
 msgid "Use photo"
 msgstr "Usa questa foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1671
+#: lib/vutuv_web/live/post_live/composer.ex:1699
 #: lib/vutuv_web/templates/user/edit.html.heex:54
 #: lib/vutuv_web/templates/user/edit.html.heex:139
 #, elixir-autogen, elixir-format
@@ -6495,9 +6496,9 @@ msgstr "Sposta giù"
 msgid "Move up"
 msgstr "Sposta su"
 
-#: lib/vutuv_web/components/ui.ex:1981
-#: lib/vutuv_web/components/ui.ex:1990
-#: lib/vutuv_web/components/ui.ex:2469
+#: lib/vutuv_web/components/ui.ex:2025
+#: lib/vutuv_web/components/ui.ex:2034
+#: lib/vutuv_web/components/ui.ex:2513
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr "Ritira la conferma"
@@ -6518,7 +6519,7 @@ msgstr "Preferenze delle mappe salvate."
 msgid "Map services to show"
 msgstr "Servizi di mappe da mostrare"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:104
+#: lib/vutuv_web/gettext_extraction_anchors.ex:110
 #: lib/vutuv_web/templates/settings/preferences.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Maps"
@@ -6531,7 +6532,7 @@ msgstr "Mappe"
 msgid "Open in %{name}"
 msgstr "Apri in %{name}"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:102
+#: lib/vutuv_web/gettext_extraction_anchors.ex:108
 #: lib/vutuv_web/templates/settings/preferences.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Opens first, as the main button. The others appear as alternatives."
@@ -6562,7 +6563,7 @@ msgstr "Membri che hanno confermato %{name} per %{tag}"
 msgid "No endorsements yet."
 msgstr "Ancora nessuna conferma."
 
-#: lib/vutuv_web/components/ui.ex:2422
+#: lib/vutuv_web/components/ui.ex:2466
 #: lib/vutuv_web/live/notification_live/index.ex:684
 #: lib/vutuv_web/live/notification_live/index.ex:699
 #: lib/vutuv_web/live/notification_live/index.ex:1012
@@ -6886,7 +6887,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2628
 #: lib/vutuv_web/components/post_components.ex:3603
-#: lib/vutuv_web/components/ui.ex:2769
+#: lib/vutuv_web/components/ui.ex:2813
 #: lib/vutuv_web/live/fediverse_account_live.ex:375
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
@@ -6914,7 +6915,7 @@ msgid "Remove this connection? You will stop following them."
 msgstr "Rimuovere questo collegamento? Smetterà di seguire questa persona."
 
 #: lib/vutuv_web/components/post_components.ex:3603
-#: lib/vutuv_web/components/ui.ex:2768
+#: lib/vutuv_web/components/ui.ex:2812
 #: lib/vutuv_web/live/fediverse_account_live.ex:373
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
@@ -7307,7 +7308,7 @@ msgstr "Azzera"
 msgid "Save audience"
 msgstr "Salva il gruppo destinatari"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:808
+#: lib/vutuv_web/live/job_posting_live/form.ex:809
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:16
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:11
 #, elixir-autogen, elixir-format
@@ -7536,13 +7537,13 @@ msgstr "I loro membri vengono aggiunti a questo (unione)."
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr "pagina %{page} di %{pages}, %{total} in totale"
 
-#: lib/vutuv_web/components/ui.ex:3664
+#: lib/vutuv_web/components/ui.ex:3708
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Precedente"
 
-#: lib/vutuv_web/components/ui.ex:3680
+#: lib/vutuv_web/components/ui.ex:3724
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7579,7 +7580,7 @@ msgid "Removed:"
 msgstr "Rimossi:"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:979
-#: lib/vutuv_web/live/post_live/composer.ex:1519
+#: lib/vutuv_web/live/post_live/composer.ex:1547
 #: lib/vutuv_web/live/post_live/filter_band.ex:532
 #, elixir-autogen, elixir-format
 msgid "Undo"
@@ -8343,7 +8344,7 @@ msgstr "PIN scaduto"
 msgid "PIN registered"
 msgstr "Registrato con PIN"
 
-#: lib/vutuv_web/components/ui.ex:3667
+#: lib/vutuv_web/components/ui.ex:3711
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr "Pagina %{page} di %{pages}"
@@ -8482,7 +8483,7 @@ msgstr "Titolo di studio"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:4636
+#: lib/vutuv_web/components/ui.ex:4680
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8541,7 +8542,7 @@ msgstr ""
 "Ecco cosa abbiamo trovato nella Sua esportazione. Tolga la spunta a ciò che "
 "non desidera. Le voci già presenti sul Suo profilo sono già senza spunta."
 
-#: lib/vutuv_web/components/ui.ex:4781
+#: lib/vutuv_web/components/ui.ex:4825
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importa"
@@ -8570,7 +8571,7 @@ msgstr "Importati: %{items}."
 msgid "Nothing new to import."
 msgstr "Nulla di nuovo da importare."
 
-#: lib/vutuv_web/components/ui.ex:4664
+#: lib/vutuv_web/components/ui.ex:4708
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8666,7 +8667,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Troppe importazioni. Riprovi tra poco."
 
-#: lib/vutuv_web/components/ui.ex:3944
+#: lib/vutuv_web/components/ui.ex:3988
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8756,13 +8757,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr "Trascini qui il Suo file ZIP, oppure prema per sceglierne uno."
 
-#: lib/vutuv_web/components/ui.ex:4624
+#: lib/vutuv_web/components/ui.ex:4668
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr "Dati di base e foto"
 
-#: lib/vutuv_web/components/ui.ex:4771
+#: lib/vutuv_web/components/ui.ex:4815
 #: lib/vutuv_web/controllers/settings_controller.ex:125
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8774,7 +8775,7 @@ msgstr "Lingua e visualizzazione"
 msgid "More profile sections"
 msgstr "Altre sezioni del profilo"
 
-#: lib/vutuv_web/components/ui.ex:4762
+#: lib/vutuv_web/components/ui.ex:4806
 #: lib/vutuv_web/controllers/settings_controller.ex:108
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8784,7 +8785,7 @@ msgstr "Altre sezioni del profilo"
 msgid "Sign-in & security"
 msgstr "Accesso e sicurezza"
 
-#: lib/vutuv_web/components/ui.ex:4785
+#: lib/vutuv_web/components/ui.ex:4829
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8900,7 +8901,7 @@ msgstr[1] "%{formatted} membri"
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr "La pagina %{letter} dell'elenco dei membri, ordinata per cognome."
 
-#: lib/vutuv_web/components/ui.ex:1278
+#: lib/vutuv_web/components/ui.ex:1322
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -9008,8 +9009,8 @@ msgstr "La scriva in Amministrazione › Pagine legali"
 #: lib/vutuv_web/agent_docs/text.ex:586
 #: lib/vutuv_web/agent_docs/text.ex:590
 #: lib/vutuv_web/components/organization_components.ex:276
-#: lib/vutuv_web/components/ui.ex:1479
-#: lib/vutuv_web/components/ui.ex:4752
+#: lib/vutuv_web/components/ui.ex:1523
+#: lib/vutuv_web/components/ui.ex:4796
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:357
 #: lib/vutuv_web/controllers/settings_controller.ex:424
@@ -9168,7 +9169,7 @@ msgstr ""
 "Questa è la versione di stampa del CV. Usi la finestra di stampa del browser"
 " (Ctrl+P o Cmd+P) e scelga \"Salva come PDF\" per ottenere un file PDF."
 
-#: lib/vutuv_web/components/ui.ex:1568
+#: lib/vutuv_web/components/ui.ex:1612
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr "Download del CV"
@@ -9206,7 +9207,7 @@ msgstr "Ogni download rispecchia le parti che ha selezionato."
 msgid "Header"
 msgstr "Intestazione"
 
-#: lib/vutuv_web/components/ui.ex:1578
+#: lib/vutuv_web/components/ui.ex:1622
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -9243,7 +9244,7 @@ msgstr ""
 "solo ciò che può già vedere lì, e gli indirizzi e-mail privati compaiono "
 "solo nel Suo."
 
-#: lib/vutuv_web/components/ui.ex:1570
+#: lib/vutuv_web/components/ui.ex:1614
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -9416,8 +9417,8 @@ msgstr "Questo tag può essere rimosso solo da un amministratore del sito."
 msgid "Yes"
 msgstr "Sì"
 
-#: lib/vutuv_web/components/ui.ex:2025
-#: lib/vutuv_web/components/ui.ex:2026
+#: lib/vutuv_web/components/ui.ex:2069
+#: lib/vutuv_web/components/ui.ex:2070
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9860,7 +9861,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Situazione lavorativa"
 
-#: lib/vutuv/accounts/user.ex:1187
+#: lib/vutuv/accounts/user.ex:1193
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9871,7 +9872,7 @@ msgstr "In cerca di lavoro"
 msgid "Not open to work"
 msgstr "Non in cerca di lavoro"
 
-#: lib/vutuv/accounts/user.ex:1184
+#: lib/vutuv/accounts/user.ex:1190
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9996,7 +9997,7 @@ msgstr "Certificati"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:4640
+#: lib/vutuv_web/components/ui.ex:4684
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -10199,13 +10200,13 @@ msgstr "Link permanente al profilo"
 msgid "Dismiss"
 msgstr "Chiudi"
 
-#: lib/vutuv_web/components/ui.ex:3374
+#: lib/vutuv_web/components/ui.ex:3418
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Copiato"
 
-#: lib/vutuv_web/components/ui.ex:3373
-#: lib/vutuv_web/components/ui.ex:3381
+#: lib/vutuv_web/components/ui.ex:3417
+#: lib/vutuv_web/components/ui.ex:3425
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Copia"
@@ -10397,17 +10398,17 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr "App di autenticazione disattivata."
 
-#: lib/vutuv_web/components/ui.ex:377
+#: lib/vutuv_web/components/ui.ex:384
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr "Grassetto"
 
-#: lib/vutuv_web/components/ui.ex:429
+#: lib/vutuv_web/components/ui.ex:436
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr "Elenco puntato"
 
-#: lib/vutuv_web/components/ui.ex:432
+#: lib/vutuv_web/components/ui.ex:439
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr "Blocco di codice"
@@ -10424,13 +10425,13 @@ msgstr ""
 "Eliminare il Suo elenco di codici? Tutti i suoi codici smettono subito di "
 "funzionare."
 
-#: lib/vutuv_web/components/ui.ex:373
+#: lib/vutuv_web/components/ui.ex:380
 #, elixir-autogen, elixir-format
 msgid "Formatting"
 msgstr "Formattazione"
 
-#: lib/vutuv_web/components/ui.ex:496
-#: lib/vutuv_web/components/ui.ex:497
+#: lib/vutuv_web/components/ui.ex:503
+#: lib/vutuv_web/components/ui.ex:504
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr "Schermo intero"
@@ -10445,27 +10446,27 @@ msgstr "Genera un nuovo elenco"
 msgid "Generate code list"
 msgstr "Genera l'elenco dei codici"
 
-#: lib/vutuv_web/components/ui.ex:427
+#: lib/vutuv_web/components/ui.ex:434
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr "Titolo 1"
 
-#: lib/vutuv_web/components/ui.ex:428
+#: lib/vutuv_web/components/ui.ex:435
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr "Titolo 2"
 
-#: lib/vutuv_web/components/ui.ex:386
+#: lib/vutuv_web/components/ui.ex:393
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr "Codice in linea"
 
-#: lib/vutuv_web/components/ui.ex:380
+#: lib/vutuv_web/components/ui.ex:387
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr "Corsivo"
 
-#: lib/vutuv_web/components/ui.ex:346
+#: lib/vutuv_web/components/ui.ex:540
 #, elixir-autogen, elixir-format
 msgid "Link URL"
 msgstr "URL del link"
@@ -10481,7 +10482,7 @@ msgstr "Codici di accesso"
 msgid "Not set up."
 msgstr "Non configurata."
 
-#: lib/vutuv_web/components/ui.ex:430
+#: lib/vutuv_web/components/ui.ex:437
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr "Elenco numerato"
@@ -10498,7 +10499,7 @@ msgstr ""
 "Stampi questa pagina o annoti i codici. I codici barrati sono già stati "
 "usati."
 
-#: lib/vutuv_web/components/ui.ex:431
+#: lib/vutuv_web/components/ui.ex:438
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr "Citazione"
@@ -10524,7 +10525,7 @@ msgstr ""
 msgid "Set up"
 msgstr "Configura"
 
-#: lib/vutuv_web/components/ui.ex:383
+#: lib/vutuv_web/components/ui.ex:390
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr "Barrato"
@@ -10935,14 +10936,14 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] "Ha %{formatted} nuovo messaggio."
 msgstr[1] "Ha %{formatted} nuovi messaggi."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:346
+#: lib/vutuv_web/templates/settings/preferences.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 "Spezza le parole lunghe in corrispondenza delle sillabe, così il testo va a "
 "capo in modo uniforme. Utile nella colonna stretta del telefono."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:277
+#: lib/vutuv_web/templates/settings/preferences.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
@@ -10950,35 +10951,35 @@ msgstr ""
 "le Sue preferenze di lettura personali."
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:353
+#: lib/vutuv_web/templates/settings/preferences.html.heex:397
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr "Sillabazione su computer"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:357
+#: lib/vutuv_web/templates/settings/preferences.html.heex:401
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr "Sillabazione su telefono"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:343
+#: lib/vutuv_web/templates/settings/preferences.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr "Sillabazione"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:300
+#: lib/vutuv_web/templates/settings/preferences.html.heex:344
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr "Righe su computer"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:309
+#: lib/vutuv_web/templates/settings/preferences.html.heex:353
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr "Righe su telefono"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:295
+#: lib/vutuv_web/templates/settings/preferences.html.heex:339
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
@@ -10990,7 +10991,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr "Impostazioni di visualizzazione dei post salvate."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:292
+#: lib/vutuv_web/templates/settings/preferences.html.heex:336
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr "Accorcia un post dopo"
@@ -11092,8 +11093,9 @@ msgstr "Preferenze di %{name}"
 #: lib/vutuv_web/live/feed_languages_live.ex:377
 #: lib/vutuv_web/templates/settings/preferences.html.heex:101
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
-#: lib/vutuv_web/templates/settings/preferences.html.heex:259
-#: lib/vutuv_web/templates/settings/preferences.html.heex:377
+#: lib/vutuv_web/templates/settings/preferences.html.heex:239
+#: lib/vutuv_web/templates/settings/preferences.html.heex:303
+#: lib/vutuv_web/templates/settings/preferences.html.heex:421
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr "Riporta ai valori predefiniti del sito"
@@ -11128,17 +11130,17 @@ msgstr ""
 "valgono subito; i membri che hanno impostato un valore proprio non sono "
 "interessati."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:100
+#: lib/vutuv_web/gettext_extraction_anchors.ex:106
 #, elixir-autogen, elixir-format
 msgid "0 means posts are never shortened."
 msgstr "0 significa che i post non vengono mai accorciati."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:106
+#: lib/vutuv_web/gettext_extraction_anchors.ex:112
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr "Disattivato"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:105
+#: lib/vutuv_web/gettext_extraction_anchors.ex:111
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr "Attivato"
@@ -11199,8 +11201,8 @@ msgid "Failed"
 msgstr "Non riuscito"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
-#: lib/vutuv_web/live/post_live/composer.ex:1750
-#: lib/vutuv_web/live/post_live/composer.ex:2450
+#: lib/vutuv_web/live/post_live/composer.ex:1778
+#: lib/vutuv_web/live/post_live/composer.ex:2480
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr "Galleria"
@@ -11306,21 +11308,21 @@ msgstr ""
 "Sua disponibilità ma non può garantirla, perché chiunque può creare un "
 "account. Scelga \"Nessuno\" per conservare lo stato senza mostrarlo."
 
-#: lib/vutuv/accounts/user.ex:1225
+#: lib/vutuv/accounts/user.ex:1231
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Tutti, compresi i visitatori non connessi"
 
-#: lib/vutuv/accounts/user.ex:1230
+#: lib/vutuv/accounts/user.ex:1236
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Nessuno"
 
-#: lib/vutuv/accounts/user.ex:1228
+#: lib/vutuv/accounts/user.ex:1234
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
-#: lib/vutuv_web/live/job_posting_live/form.ex:772
+#: lib/vutuv_web/live/job_posting_live/form.ex:773
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr "Solo i membri connessi"
@@ -11518,7 +11520,7 @@ msgstr "Il Suo elenco di esclusioni è pieno (max %{count})."
 msgid "Your list is empty. Nobody is excluded yet."
 msgstr "Il Suo elenco è vuoto. Non è ancora escluso nessuno."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:362
+#: lib/vutuv_web/live/organization_live/edit.ex:363
 #: lib/vutuv_web/views/account_event_text.ex:232
 #, elixir-autogen, elixir-format
 msgid "AI agents"
@@ -11557,7 +11559,7 @@ msgstr "La verifica dei domini è disattivata su questa installazione."
 msgid "Edit %{name}"
 msgstr "Modifica %{name}"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:348
+#: lib/vutuv_web/live/organization_live/edit.ex:349
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this page and include it in the sitemap."
 msgstr ""
@@ -11569,7 +11571,7 @@ msgstr ""
 msgid "Logo"
 msgstr "Logo"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:364
+#: lib/vutuv_web/live/organization_live/edit.ex:365
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
@@ -11597,7 +11599,7 @@ msgstr "Rimuovi il logo"
 msgid "Search by name or city"
 msgstr "Cerchi per nome o città"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:346
+#: lib/vutuv_web/live/organization_live/edit.ex:347
 #: lib/vutuv_web/views/account_event_text.ex:231
 #, elixir-autogen, elixir-format
 msgid "Search engines"
@@ -11614,18 +11616,18 @@ msgstr "Selezioni un paese"
 msgid "Serve this file at:"
 msgstr "Pubblichi questo file all'indirizzo:"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:327
+#: lib/vutuv_web/live/organization_live/edit.ex:328
 #: lib/vutuv_web/live/organization_live/new.ex:139
 #, elixir-autogen, elixir-format
 msgid "State / region (optional)"
 msgstr "Provincia / regione (facoltativo)"
 
-#: lib/vutuv_web/components/ui.ex:3998
+#: lib/vutuv_web/components/ui.ex:4042
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr "Questo tipo di file non è ammesso."
 
-#: lib/vutuv_web/components/ui.ex:4000
+#: lib/vutuv_web/components/ui.ex:4044
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr "Il caricamento non è riuscito."
@@ -11665,7 +11667,7 @@ msgstr "Verifica ora"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:262
 #: lib/vutuv_web/agent_docs/text.ex:245
-#: lib/vutuv_web/live/organization_live/edit.ex:321
+#: lib/vutuv_web/live/organization_live/edit.ex:322
 #: lib/vutuv_web/live/organization_live/new.ex:130
 #, elixir-autogen, elixir-format
 msgid "Website"
@@ -11704,7 +11706,7 @@ msgid "@handle or email"
 msgstr "@handle o e-mail"
 
 #: lib/vutuv_web/components/organization_components.ex:333
-#: lib/vutuv_web/live/organization_live/edit.ex:424
+#: lib/vutuv_web/live/organization_live/edit.ex:425
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
 msgstr "Sigla"
@@ -11725,7 +11727,7 @@ msgid "Added @%{handle} to the team."
 msgstr "@%{handle} è stato aggiunto al team."
 
 #: lib/vutuv_web/components/organization_components.ex:334
-#: lib/vutuv_web/live/organization_live/edit.ex:422
+#: lib/vutuv_web/live/organization_live/edit.ex:423
 #, elixir-autogen, elixir-format
 msgid "Alias"
 msgstr "Alias"
@@ -11742,14 +11744,14 @@ msgstr "Alias rimosso."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:436
 #: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/live/organization_live/edit.ex:387
+#: lib/vutuv_web/live/organization_live/edit.ex:388
 #: lib/vutuv_web/live/organization_live/show.ex:925
 #: lib/vutuv_web/templates/tag/single_card.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Also known as"
 msgstr "Noto anche come"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:418
+#: lib/vutuv_web/live/organization_live/edit.ex:419
 #, elixir-autogen, elixir-format
 msgid "Alternative name"
 msgstr "Nome alternativo"
@@ -11771,7 +11773,7 @@ msgid "Archived"
 msgstr "Archiviata"
 
 #: lib/vutuv_web/components/organization_components.ex:332
-#: lib/vutuv_web/live/organization_live/edit.ex:423
+#: lib/vutuv_web/live/organization_live/edit.ex:424
 #, elixir-autogen, elixir-format
 msgid "Brand"
 msgstr "Marchio"
@@ -11916,7 +11918,7 @@ msgstr "Rimuovere questo dominio?"
 msgid "Remove this member from the team?"
 msgstr "Rimuovere questo membro dal team?"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:404
+#: lib/vutuv_web/live/organization_live/edit.ex:405
 #, elixir-autogen, elixir-format
 msgid "Remove this name?"
 msgstr "Rimuovere questo nome?"
@@ -11973,24 +11975,24 @@ msgstr "principale"
 msgid "verified"
 msgstr "verificato"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:324
+#: lib/vutuv_web/live/organization_live/edit.ex:325
 #: lib/vutuv_web/live/organization_live/new.ex:136
 #, elixir-autogen, elixir-format
 msgid "Street address (optional)"
 msgstr "Via e numero (facoltativo)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:325
+#: lib/vutuv_web/live/organization_live/edit.ex:326
 #: lib/vutuv_web/live/organization_live/new.ex:137
 #, elixir-autogen, elixir-format
 msgid "ZIP / postal code (optional)"
 msgstr "CAP (facoltativo)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:481
+#: lib/vutuv_web/live/organization_live/edit.ex:482
 #, elixir-autogen, elixir-format
 msgid "Claim"
 msgstr "Rivendica"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:450
+#: lib/vutuv_web/live/organization_live/edit.ex:451
 #, elixir-autogen, elixir-format
 msgid "Reachable at"
 msgstr "Raggiungibile a"
@@ -12000,12 +12002,12 @@ msgstr "Raggiungibile a"
 msgid "That handle is not available."
 msgstr "Questo handle non è disponibile."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:487
+#: lib/vutuv_web/live/organization_live/edit.ex:488
 #, elixir-autogen, elixir-format
 msgid "Danger zone"
 msgstr "Zona pericolosa"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:498
+#: lib/vutuv_web/live/organization_live/edit.ex:499
 #, elixir-autogen, elixir-format
 msgid "Really delete %{name}? This cannot be undone."
 msgstr "Eliminare davvero %{name}? L'operazione non si può annullare."
@@ -12057,7 +12059,7 @@ msgstr ""
 "Il testo del link può essere qualsiasi. Va bene anche un <link rel=\"me\"> "
 "nascosto nell'head della pagina."
 
-#: lib/vutuv_web/components/ui.ex:994
+#: lib/vutuv_web/components/ui.ex:1038
 #: lib/vutuv_web/live/section_reorder_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -12162,7 +12164,7 @@ msgstr[1] ""
 "%{count} alias coincidono con un'altra organizzazione verificata e sono "
 "segnalati per la revisione. Apra un'organizzazione qui sotto per vederli."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:389
+#: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Alternative names, brands or abbreviations this organization is findable under. A rename keeps the old name here automatically."
 msgstr ""
@@ -12250,12 +12252,12 @@ msgstr ""
 "o il file mostrato qui sotto e lo invii al Suo reparto IT o a chi gestisce "
 "il sito. Quando l'avranno aggiunto, torni qui e prema Verifica ora."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:502
+#: lib/vutuv_web/live/organization_live/edit.ex:503
 #, elixir-autogen, elixir-format
 msgid "Delete this organization"
 msgstr "Elimina questa organizzazione"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:489
+#: lib/vutuv_web/live/organization_live/edit.ex:490
 #, elixir-autogen, elixir-format
 msgid "Deleting this organization page is permanent. Its verified domains and its @handle are freed and can be claimed again."
 msgstr ""
@@ -12364,7 +12366,7 @@ msgstr "Organizzazione sbloccata."
 #: lib/vutuv_web/agent_docs/markdown.ex:427
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:400
-#: lib/vutuv_web/components/ui.ex:4789
+#: lib/vutuv_web/components/ui.ex:4833
 #: lib/vutuv_web/controllers/settings_controller.ex:213
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
@@ -12489,7 +12491,7 @@ msgstr "L'ha nominata amministratore di %{organization}."
 msgid "made you an owner of %{organization}."
 msgstr "L'ha nominata proprietario di %{organization}."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:471
+#: lib/vutuv_web/live/organization_live/edit.ex:472
 #, elixir-autogen, elixir-format
 msgid "your_organization"
 msgstr "la_sua_organizzazione"
@@ -12553,17 +12555,17 @@ msgstr ""
 "Per pubblicare serve una fascia retributiva (tranne che per gli annunci di "
 "volontariato)."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:749
+#: lib/vutuv_web/live/job_posting_live/form.ex:750
 #, elixir-autogen, elixir-format
 msgid "A vutuv message to me"
 msgstr "Un messaggio vutuv a me"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:747
+#: lib/vutuv_web/live/job_posting_live/form.ex:748
 #, elixir-autogen, elixir-format
 msgid "A website"
 msgstr "Un sito web"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:748
+#: lib/vutuv_web/live/job_posting_live/form.ex:749
 #, elixir-autogen, elixir-format
 msgid "An e-mail address"
 msgstr "Un indirizzo e-mail"
@@ -12573,12 +12575,12 @@ msgstr "Un indirizzo e-mail"
 msgid "Applicants must be located in"
 msgstr "I candidati devono trovarsi in"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:753
+#: lib/vutuv_web/live/job_posting_live/form.ex:754
 #, elixir-autogen, elixir-format
 msgid "Application URL"
 msgstr "URL per la candidatura"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:759
+#: lib/vutuv_web/live/job_posting_live/form.ex:760
 #, elixir-autogen, elixir-format
 msgid "Application e-mail"
 msgstr "Indirizzo e-mail per la candidatura"
@@ -12588,7 +12590,7 @@ msgstr "Indirizzo e-mail per la candidatura"
 msgid "Application: %{title}"
 msgstr "Candidatura: %{title}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:745
+#: lib/vutuv_web/live/job_posting_live/form.ex:746
 #, elixir-autogen, elixir-format
 msgid "Applications go to"
 msgstr "Le candidature arrivano a"
@@ -12620,7 +12622,7 @@ msgstr "Chiuso"
 msgid "Contract"
 msgstr "Collaborazione"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:692
+#: lib/vutuv_web/live/job_posting_live/form.ex:693
 #, elixir-autogen, elixir-format
 msgid "Describe the role. Markdown is supported."
 msgstr "Descriva il ruolo. Markdown è supportato."
@@ -12661,7 +12663,7 @@ msgstr "Nome del datore di lavoro (facoltativo)"
 msgid "Employment type"
 msgstr "Tipo di contratto"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:771
+#: lib/vutuv_web/live/job_posting_live/form.ex:772
 #, elixir-autogen, elixir-format
 msgid "Everyone (public)"
 msgstr "Tutti (pubblico)"
@@ -12684,12 +12686,12 @@ msgstr "Tempo pieno"
 msgid "Highlighted tags match your profile."
 msgstr "I tag evidenziati corrispondono al Suo profilo."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:743
+#: lib/vutuv_web/live/job_posting_live/form.ex:744
 #, elixir-autogen, elixir-format
 msgid "How to apply"
 msgstr "Come candidarsi"
 
-#: lib/vutuv/accounts/user.ex:1199
+#: lib/vutuv/accounts/user.ex:1205
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12700,7 +12702,7 @@ msgstr "Ibrido"
 msgid "I'm interested in your posting: %{url}"
 msgstr "Mi interessa il Suo annuncio: %{url}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:691
+#: lib/vutuv_web/live/job_posting_live/form.ex:692
 #, elixir-autogen, elixir-format
 msgid "Job description"
 msgstr "Descrizione della posizione"
@@ -12721,7 +12723,7 @@ msgstr "Titolo della posizione"
 msgid "Jobs"
 msgstr "Lavoro"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:781
+#: lib/vutuv_web/live/job_posting_live/form.ex:782
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this posting."
 msgstr "Consenti ai motori di ricerca di indicizzare questo annuncio."
@@ -12782,7 +12784,7 @@ msgstr "Nuovo annuncio"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:292
 #: lib/vutuv_web/agent_docs/text.ex:275
-#: lib/vutuv_web/live/job_posting_live/form.ex:731
+#: lib/vutuv_web/live/job_posting_live/form.ex:732
 #: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
@@ -12804,14 +12806,14 @@ msgid "Nothing here yet. Jobs you like show up here."
 msgstr ""
 "Qui non c'è ancora nulla. Gli annunci a cui mette Mi piace compaiono qui."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:787
+#: lib/vutuv_web/live/job_posting_live/form.ex:788
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 "Offri i formati leggibili dalle macchine (.md/.txt/.json/.xml) agli agenti "
 "IA."
 
-#: lib/vutuv/accounts/user.ex:1198
+#: lib/vutuv/accounts/user.ex:1204
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12890,12 +12892,12 @@ msgstr "Lingua dell'annuncio"
 msgid "Posting not found."
 msgstr "Annuncio non trovato."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:804
+#: lib/vutuv_web/live/job_posting_live/form.ex:805
 #, elixir-autogen, elixir-format
 msgid "Publish"
 msgstr "Pubblica"
 
-#: lib/vutuv/accounts/user.ex:1200
+#: lib/vutuv/accounts/user.ex:1206
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
 #: lib/vutuv_web/agent_docs/markdown.ex:466
@@ -12915,7 +12917,7 @@ msgstr "Segnala questo annuncio"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:291
 #: lib/vutuv_web/agent_docs/text.ex:274
-#: lib/vutuv_web/live/job_posting_live/form.ex:721
+#: lib/vutuv_web/live/job_posting_live/form.ex:722
 #: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
@@ -12955,7 +12957,7 @@ msgstr "Qualcosa è andato storto. Riprovi."
 msgid "Street (optional)"
 msgstr "Via (facoltativo)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:718
+#: lib/vutuv_web/live/job_posting_live/form.ex:719
 #, elixir-autogen, elixir-format
 msgid "Tags match your posting to members. Separate them with commas; a tag may be several words long, like Ruby on Rails."
 msgstr ""
@@ -13012,7 +13014,7 @@ msgstr "Volontariato"
 msgid "Volunteer"
 msgstr "Volontario"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:769
+#: lib/vutuv_web/live/job_posting_live/form.ex:770
 #: lib/vutuv_web/templates/email/form_content.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Who can see it"
@@ -13644,7 +13646,7 @@ msgstr "Salva la ricerca"
 msgid "Saved search deleted."
 msgstr "Ricerca salvata eliminata."
 
-#: lib/vutuv_web/components/ui.ex:4729
+#: lib/vutuv_web/components/ui.ex:4773
 #: lib/vutuv_web/controllers/settings_controller.ex:620
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13809,7 +13811,7 @@ msgstr ""
 msgid "Hide from specific viewers"
 msgstr "Nascondi a lettori specifici"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:793
+#: lib/vutuv_web/live/job_posting_live/form.ex:794
 #, elixir-autogen, elixir-format
 msgid "Hide from specific viewers (competitors, your own staff, a person) →"
 msgstr ""
@@ -13831,7 +13833,7 @@ msgstr "Esclusioni sugli annunci"
 msgid "Job exclusions – %{name}"
 msgstr "Esclusioni sugli annunci – %{name}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:796
+#: lib/vutuv_web/live/job_posting_live/form.ex:797
 #, elixir-autogen, elixir-format
 msgid "Keep this posting on the board for everyone except a chosen few."
 msgstr ""
@@ -13995,7 +13997,7 @@ msgstr ""
 "Se è venuto male (ad esempio con un avviso sui cookie che copre la pagina), "
 "può rimuoverlo."
 
-#: lib/vutuv/accounts/user.ex:1243
+#: lib/vutuv/accounts/user.ex:1249
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -14009,19 +14011,19 @@ msgstr ""
 "la data esatta, \"Giorno e mese\" nasconde l'anno (e la Sua età) e \"Non "
 "mostrare\" lo conserva ma lo tiene fuori dal profilo."
 
-#: lib/vutuv/accounts/user.ex:1246
+#: lib/vutuv/accounts/user.ex:1252
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Giorno e mese, senza l'anno"
 
-#: lib/vutuv/accounts/user.ex:1249
+#: lib/vutuv/accounts/user.ex:1255
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Non mostrare il mio compleanno"
 
-#: lib/vutuv/accounts/user.ex:1240
+#: lib/vutuv/accounts/user.ex:1246
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14072,32 +14074,32 @@ msgstr[1] ""
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "ha cambiato il proprio handle da @%{old} a @%{new}."
 
-#: lib/vutuv_web/components/ui.ex:406
+#: lib/vutuv_web/components/ui.ex:413
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr "Al centro"
 
-#: lib/vutuv_web/components/ui.ex:403
+#: lib/vutuv_web/components/ui.ex:410
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr "Allinea a sinistra"
 
-#: lib/vutuv_web/components/ui.ex:409
+#: lib/vutuv_web/components/ui.ex:416
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr "Allinea a destra"
 
-#: lib/vutuv_web/components/ui.ex:400
+#: lib/vutuv_web/components/ui.ex:407
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr "A tutta larghezza"
 
-#: lib/vutuv_web/components/ui.ex:433
+#: lib/vutuv_web/components/ui.ex:440
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr "Inserisci un'immagine"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2841
+#: lib/vutuv_web/live/post_live/composer.ex:2871
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr "Inserisci nel testo"
@@ -14159,7 +14161,7 @@ msgstr ""
 "persone note per quel tag compaiono tra i Suoi suggerimenti. Segua un tag "
 "dalla sua pagina."
 
-#: lib/vutuv_web/components/ui.ex:4712
+#: lib/vutuv_web/components/ui.ex:4756
 #: lib/vutuv_web/controllers/settings_controller.ex:634
 #: lib/vutuv_web/live/post_live/feed.ex:712
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -14239,7 +14241,7 @@ msgstr "Messenger aggiornato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:63
-#: lib/vutuv_web/components/ui.ex:4683
+#: lib/vutuv_web/components/ui.ex:4727
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -14267,14 +14269,14 @@ msgstr "Messenger di %{name}"
 msgid "Select a messenger"
 msgstr "Selezioni un messenger"
 
-#: lib/vutuv_web/components/ui.ex:4083
+#: lib/vutuv_web/components/ui.ex:4127
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] "Avvisa il mio follower"
 msgstr[1] "Avvisa i miei %{formatted} follower"
 
-#: lib/vutuv_web/components/ui.ex:4093
+#: lib/vutuv_web/components/ui.ex:4137
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
@@ -14505,12 +14507,12 @@ msgstr "L'ha confermata per %{tags}."
 msgid "by:"
 msgstr "di:"
 
-#: lib/vutuv_web/components/ui.ex:2159
+#: lib/vutuv_web/components/ui.ex:2203
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr "Confermato da %{name}"
 
-#: lib/vutuv_web/components/ui.ex:2163
+#: lib/vutuv_web/components/ui.ex:2207
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -14644,23 +14646,23 @@ msgid "proof document"
 msgstr "documento di prova"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:331
+#: lib/vutuv_web/templates/settings/preferences.html.heex:375
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr "Righe nelle notifiche"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:101
+#: lib/vutuv_web/gettext_extraction_anchors.ex:107
 #, elixir-autogen, elixir-format
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr ""
 "Quanta parte di un post viene citata in una notifica prima del taglio."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:322
+#: lib/vutuv_web/templates/settings/preferences.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr "Post citati nelle notifiche"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:325
+#: lib/vutuv_web/templates/settings/preferences.html.heex:369
 #, elixir-autogen, elixir-format
 msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
@@ -14794,7 +14796,7 @@ msgstr "Menzione"
 msgid "mentioned you in a post."
 msgstr "L'ha menzionata in un post."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1240
+#: lib/vutuv_web/live/post_live/composer.ex:1251
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
@@ -14802,7 +14804,7 @@ msgstr ""
 "Questo post non può più essere modificato: qualcuno gli ha messo Mi piace, "
 "lo ha ripubblicato o gli ha risposto."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1243
+#: lib/vutuv_web/live/post_live/composer.ex:1254
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -15121,7 +15123,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr "Corrispondenza solo su parole intere (parola o frase)"
 
-#: lib/vutuv_web/components/ui.ex:4697
+#: lib/vutuv_web/components/ui.ex:4741
 #: lib/vutuv_web/controllers/settings_controller.ex:700
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -15825,259 +15827,259 @@ msgstr "Il Suo server"
 msgid "moved to %{address}"
 msgstr "spostato a %{address}"
 
-#: lib/vutuv_web/components/ui.ex:4625
+#: lib/vutuv_web/components/ui.ex:4669
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr "Nome, foto, immagine di copertina, descrizione breve"
 
-#: lib/vutuv_web/components/ui.ex:4630
+#: lib/vutuv_web/components/ui.ex:4674
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr "handle soprannome rinomina slug profilo indirizzo url menzione"
 
-#: lib/vutuv_web/components/ui.ex:4633
+#: lib/vutuv_web/components/ui.ex:4677
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr "Gli impieghi e i ruoli nel Suo CV"
 
-#: lib/vutuv_web/components/ui.ex:4634
+#: lib/vutuv_web/components/ui.ex:4678
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr "cv curriculum carriera datore di lavoro posizione qualifica azienda"
 
-#: lib/vutuv_web/components/ui.ex:4637
+#: lib/vutuv_web/components/ui.ex:4681
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr "Scuole, università, titoli di studio"
 
-#: lib/vutuv_web/components/ui.ex:4638
+#: lib/vutuv_web/components/ui.ex:4682
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr "cv curriculum studio studi scuola università laurea titolo"
 
-#: lib/vutuv_web/components/ui.ex:4641
+#: lib/vutuv_web/components/ui.ex:4685
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr "Credenziali, con documenti di prova"
 
-#: lib/vutuv_web/components/ui.ex:4642
+#: lib/vutuv_web/components/ui.ex:4686
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 "certificato abilitazione diploma credenziale riconoscimento prova documento"
 
-#: lib/vutuv_web/components/ui.ex:4649
+#: lib/vutuv_web/components/ui.ex:4693
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr "Competenze linguistiche"
 
-#: lib/vutuv_web/components/ui.ex:4650
+#: lib/vutuv_web/components/ui.ex:4694
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr "Le lingue che parla"
 
-#: lib/vutuv_web/components/ui.ex:4651
+#: lib/vutuv_web/components/ui.ex:4695
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr "lingua parlare parlata fluente madrelingua"
 
-#: lib/vutuv_web/components/ui.ex:4654
+#: lib/vutuv_web/components/ui.ex:4698
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr "Gli argomenti per cui è conosciuto"
 
-#: lib/vutuv_web/components/ui.ex:4655
+#: lib/vutuv_web/components/ui.ex:4699
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr "competenza argomento parola chiave esperienza conferma"
 
-#: lib/vutuv_web/components/ui.ex:4790
+#: lib/vutuv_web/components/ui.ex:4834
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr "Pagine aziendali che gestisce"
 
-#: lib/vutuv_web/components/ui.ex:4791
+#: lib/vutuv_web/components/ui.ex:4835
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr "azienda datore di lavoro impresa attività organizzazione pagina"
 
-#: lib/vutuv_web/components/ui.ex:4658
+#: lib/vutuv_web/components/ui.ex:4702
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr "Recapiti"
 
-#: lib/vutuv_web/components/ui.ex:4661
+#: lib/vutuv_web/components/ui.ex:4705
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr "Dove La raggiungiamo, e quale indirizzo è pubblico"
 
-#: lib/vutuv_web/components/ui.ex:4662
+#: lib/vutuv_web/components/ui.ex:4706
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr "posta e-mail indirizzo principale"
 
-#: lib/vutuv_web/components/ui.ex:4665
+#: lib/vutuv_web/components/ui.ex:4709
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr "Fisso, cellulare, fax"
 
-#: lib/vutuv_web/components/ui.ex:4666
+#: lib/vutuv_web/components/ui.ex:4710
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr "telefono cellulare fax numero"
 
-#: lib/vutuv_web/components/ui.ex:4669
+#: lib/vutuv_web/components/ui.ex:4713
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr "Indirizzi postali sul Suo profilo"
 
-#: lib/vutuv_web/components/ui.ex:4670
+#: lib/vutuv_web/components/ui.ex:4714
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr "via città cap paese posta mappa"
 
-#: lib/vutuv_web/components/ui.ex:4672
+#: lib/vutuv_web/components/ui.ex:4716
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr "Siti web e link"
 
-#: lib/vutuv_web/components/ui.ex:4673
+#: lib/vutuv_web/components/ui.ex:4717
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr "Il Suo sito e gli altri link"
 
-#: lib/vutuv_web/components/ui.ex:4674
+#: lib/vutuv_web/components/ui.ex:4718
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr "url sito web homepage blog link verifica rel=me"
 
-#: lib/vutuv_web/components/ui.ex:4676
+#: lib/vutuv_web/components/ui.ex:4720
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr "Profili sui social"
 
-#: lib/vutuv_web/components/ui.ex:4677
+#: lib/vutuv_web/components/ui.ex:4721
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr "Mastodon, Bluesky, GitHub e gli altri"
 
-#: lib/vutuv_web/components/ui.ex:4679
+#: lib/vutuv_web/components/ui.ex:4723
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 
-#: lib/vutuv_web/components/ui.ex:4684
+#: lib/vutuv_web/components/ui.ex:4728
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr "Signal, Threema, Matrix e gli altri"
 
-#: lib/vutuv_web/components/ui.ex:4685
+#: lib/vutuv_web/components/ui.ex:4729
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr "signal threema matrix xmpp telegram whatsapp chat messenger"
 
-#: lib/vutuv_web/components/ui.ex:4688
+#: lib/vutuv_web/components/ui.ex:4732
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr "Notifiche e feed"
 
-#: lib/vutuv_web/components/ui.ex:4691
+#: lib/vutuv_web/components/ui.ex:4735
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr "Quali e-mail inviamo, e cosa Le dice la campanella"
 
-#: lib/vutuv_web/components/ui.ex:4698
+#: lib/vutuv_web/components/ui.ex:4742
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr "Tenga dei post fuori dal Suo feed"
 
-#: lib/vutuv_web/components/ui.ex:4699
+#: lib/vutuv_web/components/ui.ex:4743
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr "silenzia blocca nascondi filtro parola chiave parola tag feed"
 
-#: lib/vutuv_web/components/ui.ex:4713
+#: lib/vutuv_web/components/ui.ex:4757
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr "Argomenti i cui post arrivano nel Suo feed"
 
-#: lib/vutuv_web/components/ui.ex:4714
+#: lib/vutuv_web/components/ui.ex:4758
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr "tag argomento iscriviti segui feed"
 
-#: lib/vutuv_web/components/ui.ex:4730
+#: lib/vutuv_web/components/ui.ex:4774
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 "Ricerche di lavoro e di persone che Le inviano per e-mail le nuove "
 "corrispondenze"
 
-#: lib/vutuv_web/components/ui.ex:4731
+#: lib/vutuv_web/components/ui.ex:4775
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr "lavoro avviso ricerca agente osservati"
 
-#: lib/vutuv_web/components/ui.ex:4737
+#: lib/vutuv_web/components/ui.ex:4781
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr "Motori di ricerca, IA, stato online"
 
-#: lib/vutuv_web/components/ui.ex:4738
+#: lib/vutuv_web/components/ui.ex:4782
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 "privacy google motore di ricerca ia llm crawler noindex online pallino "
 "pubblico"
 
-#: lib/vutuv_web/components/ui.ex:4741
+#: lib/vutuv_web/components/ui.ex:4785
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr "Persone che non possono interagire con Lei"
 
-#: lib/vutuv_web/components/ui.ex:4742
+#: lib/vutuv_web/components/ui.ex:4786
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr "blocca bandisci silenzia segnala abuso molestie stalker"
 
-#: lib/vutuv_web/components/ui.ex:4763
+#: lib/vutuv_web/components/ui.ex:4807
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr "Passkey, dispositivi connessi, codici di accesso"
 
-#: lib/vutuv_web/components/ui.ex:4764
+#: lib/vutuv_web/components/ui.ex:4808
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 "password accesso entrare uscire sessione dispositivo passkey totp 2fa pin"
 
-#: lib/vutuv_web/components/ui.ex:4782
+#: lib/vutuv_web/components/ui.ex:4826
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr "Porti i Suoi dati da LinkedIn"
 
-#: lib/vutuv_web/components/ui.ex:4783
+#: lib/vutuv_web/components/ui.ex:4827
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr "linkedin caricamento zip migrazione trasferimento"
 
-#: lib/vutuv_web/components/ui.ex:4786
+#: lib/vutuv_web/components/ui.ex:4830
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr "Scarichi tutto ciò che conserviamo su di Lei"
 
-#: lib/vutuv_web/components/ui.ex:4787
+#: lib/vutuv_web/components/ui.ex:4831
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr "download gdpr rgpd dati backup json cv"
 
-#: lib/vutuv_web/components/ui.ex:4801
+#: lib/vutuv_web/components/ui.ex:4845
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr "Rimuova il Suo account e tutto ciò che contiene"
 
-#: lib/vutuv_web/components/ui.ex:4802
+#: lib/vutuv_web/components/ui.ex:4846
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr "elimina rimuovi chiudi esci cancella abbandona"
@@ -16575,7 +16577,7 @@ msgstr "Token di accesso creato"
 msgid "Access token revoked"
 msgstr "Token di accesso revocato"
 
-#: lib/vutuv_web/components/ui.ex:4766
+#: lib/vutuv_web/components/ui.ex:4810
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16936,7 +16938,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr "Cosa è cambiato sul Suo account, ed esattamente quando."
 
-#: lib/vutuv_web/components/ui.ex:4767
+#: lib/vutuv_web/components/ui.ex:4811
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr "Cosa è cambiato sul Suo account, e quando"
@@ -16972,7 +16974,7 @@ msgstr "da chi gestisce il sito"
 msgid "from a signed-in session"
 msgstr "da una sessione connessa"
 
-#: lib/vutuv_web/components/ui.ex:4769
+#: lib/vutuv_web/components/ui.ex:4813
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -17095,7 +17097,7 @@ msgstr ""
 "profilo, come si scrive una trascrizione, e le parentesi le aggiungiamo noi."
 " Se lo lascia vuoto non viene mostrato nulla."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2854
+#: lib/vutuv_web/live/post_live/composer.ex:2884
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr "Applica queste impostazioni a tutte le foto"
@@ -17125,51 +17127,51 @@ msgstr "CC BY-SA 4.0 (attribuzione, stessa licenza)"
 msgid "CC0 1.0 (no rights reserved)"
 msgstr "CC0 1.0 (nessun diritto riservato)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2278
+#: lib/vutuv_web/live/post_live/composer.ex:2308
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Copertina"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2692
+#: lib/vutuv_web/live/post_live/composer.ex:2722
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr "Descriva la foto per chi non può vederla"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1294
 #: lib/vutuv_web/agent_docs/text.ex:807
-#: lib/vutuv_web/components/ui.ex:2823
+#: lib/vutuv_web/components/ui.ex:2867
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Scarica l'originale"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2791
+#: lib/vutuv_web/live/post_live/composer.ex:2821
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 "Tutti i campi di metadati conservati, compreso ciò che ha scritto la Sua "
 "fotocamera."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2747
+#: lib/vutuv_web/live/post_live/composer.ex:2777
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr "Chiunque può scaricare questa foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2749
+#: lib/vutuv_web/live/post_live/composer.ex:2779
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr "Risoluzione piena, direttamente dal post."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2768
+#: lib/vutuv_web/live/post_live/composer.ex:2798
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr "Solo l'immagine"
 
-#: lib/vutuv_web/components/ui.ex:2822
+#: lib/vutuv_web/components/ui.ex:2866
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Foto successiva"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2297
+#: lib/vutuv_web/live/post_live/composer.ex:2327
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr "Ancora nessuna descrizione dell'immagine"
@@ -17189,8 +17191,8 @@ msgstr "Foto %{n} di %{total}"
 msgid "Photo is being checked"
 msgstr "La foto è in fase di controllo"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2250
-#: lib/vutuv_web/live/post_live/composer.ex:2251
+#: lib/vutuv_web/live/post_live/composer.ex:2280
+#: lib/vutuv_web/live/post_live/composer.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr "Opzioni della foto"
@@ -17202,25 +17204,25 @@ msgstr "Opzioni della foto"
 msgid "Photos:"
 msgstr "Foto:"
 
-#: lib/vutuv_web/components/ui.ex:2821
+#: lib/vutuv_web/components/ui.ex:2865
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Foto precedente"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2310
-#: lib/vutuv_web/live/post_live/composer.ex:2311
+#: lib/vutuv_web/live/post_live/composer.ex:2340
+#: lib/vutuv_web/live/post_live/composer.ex:2341
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr "Rimuovi la foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2770
+#: lib/vutuv_web/live/post_live/composer.ex:2800
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 "Gli stessi pixel e nient'altro: posizione e numeri di serie rimossi, qualità"
 " intatta."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2711
+#: lib/vutuv_web/live/post_live/composer.ex:2741
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr "Mostra le impostazioni della fotocamera"
@@ -17232,19 +17234,19 @@ msgstr ""
 "Quel server è bloccato su questo sito, quindi non gli si può inviare alcuna "
 "risposta."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2789
+#: lib/vutuv_web/live/post_live/composer.ex:2819
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr "Il file esattamente come l'ho caricato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2825
+#: lib/vutuv_web/live/post_live/composer.ex:2855
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 "Questo formato di file può essere consegnato solo così com'è. Rimuova la "
 "foto se non è ciò che desidera."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2817
+#: lib/vutuv_web/live/post_live/composer.ex:2847
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
@@ -17276,12 +17278,12 @@ msgstr "Questo sito non partecipa al Fediverso."
 msgid "Turn on Fediverse participation to answer"
 msgstr "Attivi la partecipazione al Fediverso per rispondere"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2568
+#: lib/vutuv_web/live/post_live/composer.ex:2598
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr "Chi può riutilizzare queste foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1267
+#: lib/vutuv_web/live/post_live/composer.ex:1278
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -17294,7 +17296,7 @@ msgstr ""
 "Ha spostato il Suo account del Fediverso su un altro server, quindi da qui "
 "non vengono più inviate risposte."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1281
+#: lib/vutuv_web/live/post_live/composer.ex:1292
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -17313,67 +17315,67 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr "© Tutti i diritti riservati"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2193
+#: lib/vutuv_web/live/post_live/composer.ex:2223
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr "Aggiungi foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2563
+#: lib/vutuv_web/live/post_live/composer.ex:2593
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr "Licenza"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2682
+#: lib/vutuv_web/live/post_live/composer.ex:2712
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr "Didascalia (facoltativa)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1494
-#: lib/vutuv_web/live/post_live/composer.ex:1557
-#: lib/vutuv_web/live/post_live/composer.ex:1615
-#: lib/vutuv_web/live/post_live/composer.ex:1962
+#: lib/vutuv_web/live/post_live/composer.ex:1522
+#: lib/vutuv_web/live/post_live/composer.ex:1585
+#: lib/vutuv_web/live/post_live/composer.ex:1643
+#: lib/vutuv_web/live/post_live/composer.ex:1990
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr "Scarta la bozza"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1487
+#: lib/vutuv_web/live/post_live/composer.ex:1515
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr "Ripreso da dove aveva lasciato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2616
+#: lib/vutuv_web/live/post_live/composer.ex:2646
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 "Un file il cui formato non può essere ripulito viene consegnato esattamente "
 "come caricato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2130
+#: lib/vutuv_web/live/post_live/composer.ex:2158
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr "Diverso per ogni foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2129
+#: lib/vutuv_web/live/post_live/composer.ex:2157
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr "Originale, esattamente come caricato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2128
+#: lib/vutuv_web/live/post_live/composer.ex:2156
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr "Originale, senza metadati"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2133
+#: lib/vutuv_web/live/post_live/composer.ex:2161
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr "Solo versioni per il web (%{format})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2586
+#: lib/vutuv_web/live/post_live/composer.ex:2616
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr "Cosa può salvare un visitatore"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2605
+#: lib/vutuv_web/live/post_live/composer.ex:2635
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -17496,8 +17498,8 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr "Richiesta di ritiro"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1751
-#: lib/vutuv_web/live/post_live/composer.ex:2450
+#: lib/vutuv_web/live/post_live/composer.ex:1779
+#: lib/vutuv_web/live/post_live/composer.ex:2480
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr "Dettagli della foto"
@@ -17527,7 +17529,7 @@ msgstr "Un account su un'altra rete"
 msgid "Cancel request"
 msgstr "Annulla la richiesta"
 
-#: lib/vutuv_web/components/ui.ex:4753
+#: lib/vutuv_web/components/ui.ex:4797
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Segua account su Mastodon, e si faccia seguire da lì"
@@ -17763,7 +17765,7 @@ msgstr ""
 "reti e non può seguire nessuno lì. La sospensione decade da sé quando "
 "termina."
 
-#: lib/vutuv_web/components/ui.ex:4755
+#: lib/vutuv_web/components/ui.ex:4799
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -18199,12 +18201,12 @@ msgstr ""
 "Il Suo feed mostra i post dei membri che segue. Ne segua qualcuno per "
 "riempirlo."
 
-#: lib/vutuv_web/components/ui.ex:227
+#: lib/vutuv_web/components/ui.ex:228
 #, elixir-autogen, elixir-format
 msgid "Add another tag"
 msgstr "Aggiungi un altro tag"
 
-#: lib/vutuv_web/components/ui.ex:250
+#: lib/vutuv_web/components/ui.ex:251
 #, elixir-autogen, elixir-format
 msgid "Remove the tag %{name}"
 msgstr "Rimuovi il tag %{name}"
@@ -18345,7 +18347,7 @@ msgstr ""
 "Il Suo nome utente è la Sua identità pubblica qui. Cambia solo dopo che avrà"
 " confermato con la Sua passkey o con un codice valido qui sotto."
 
-#: lib/vutuv_web/components/ui.ex:531
+#: lib/vutuv_web/components/ui.ex:575
 #, elixir-autogen, elixir-format
 msgid "Markdown help"
 msgstr "Guida a Markdown"
@@ -18490,108 +18492,108 @@ msgstr ""
 "previsti per ogni altro post da un'altra rete, e al server del suo autore "
 "non viene chiesto nient'altro."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1668
+#: lib/vutuv_web/live/post_live/composer.ex:1696
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr "Applica il ritaglio"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2356
+#: lib/vutuv_web/live/post_live/composer.ex:2386
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr "Foto grande a sinistra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2357
+#: lib/vutuv_web/live/post_live/composer.ex:2387
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr "Foto grande a destra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2362
+#: lib/vutuv_web/live/post_live/composer.ex:2392
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr "Colonne"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2359
+#: lib/vutuv_web/live/post_live/composer.ex:2389
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr "Copertina a sinistra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2360
+#: lib/vutuv_web/live/post_live/composer.ex:2390
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr "Copertina in alto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2361
+#: lib/vutuv_web/live/post_live/composer.ex:2391
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr "Copertina a destra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1664
-#: lib/vutuv_web/live/post_live/composer.ex:2327
-#: lib/vutuv_web/live/post_live/composer.ex:2328
+#: lib/vutuv_web/live/post_live/composer.ex:1692
+#: lib/vutuv_web/live/post_live/composer.ex:2357
+#: lib/vutuv_web/live/post_live/composer.ex:2358
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr "Ritaglia la foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2286
+#: lib/vutuv_web/live/post_live/composer.ex:2316
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr "Ritagliata"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1586
+#: lib/vutuv_web/live/post_live/composer.ex:1614
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr "Trascini qui le foto per aggiungerle"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2363
+#: lib/vutuv_web/live/post_live/composer.ex:2393
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr "Griglia"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2364
+#: lib/vutuv_web/live/post_live/composer.ex:2394
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr "Mosaico"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1666
+#: lib/vutuv_web/live/post_live/composer.ex:1694
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 "Scelga una forma, poi trascini e ingrandisca. La parte nel riquadro è quella"
 " che il post mostra."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2355
+#: lib/vutuv_web/live/post_live/composer.ex:2385
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr "Affiancate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2358
+#: lib/vutuv_web/live/post_live/composer.ex:2388
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr "Impilate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:496
+#: lib/vutuv_web/live/post_live/composer.ex:497
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr "Non è stato possibile ritagliare la foto."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2804
+#: lib/vutuv_web/live/post_live/composer.ex:2834
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 "Questa foto è ritagliata: i download consegnano l'immagine ritagliata, e il "
 "caricamento intatto resta privato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1670
+#: lib/vutuv_web/live/post_live/composer.ex:1698
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr "Foto intera"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2553
+#: lib/vutuv_web/live/post_live/composer.ex:2583
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr "Riempi le caselle"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2537
+#: lib/vutuv_web/live/post_live/composer.ex:2567
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr "Foto intere"
@@ -18919,8 +18921,8 @@ msgstr ""
 "Questa è la copia vutuv di un post pubblicato su %{host}. Viene conservata "
 "finché qualcuno qui segue il suo autore."
 
-#: lib/vutuv_web/components/ui.ex:1330
-#: lib/vutuv_web/components/ui.ex:1331
+#: lib/vutuv_web/components/ui.ex:1374
+#: lib/vutuv_web/components/ui.ex:1375
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr "Si iscriva a questo feed nel Suo lettore RSS"
@@ -18932,7 +18934,7 @@ msgstr ""
 "Un CV con posizioni, formazione, certificati con tanto di prova, lingue "
 "parlate e tag per cui altri membri La confermano."
 
-#: lib/vutuv_web/templates/page/index.html.heex:435
+#: lib/vutuv_web/templates/page/index.html.heex:465
 #, elixir-autogen, elixir-format
 msgid "A business network that is free, does not lock your data in, and is yours to run yourself if you want to."
 msgstr ""
@@ -18960,12 +18962,12 @@ msgstr ""
 "Download del CV in PDF, Word, OpenDocument, LaTeX o JSON Resume, e sceglie "
 "Lei cosa includere prima di scaricarlo."
 
-#: lib/vutuv_web/templates/page/index.html.heex:488
+#: lib/vutuv_web/templates/page/index.html.heex:518
 #, elixir-autogen, elixir-format
 msgid "Developer documentation"
 msgstr "Documentazione per sviluppatori"
 
-#: lib/vutuv_web/templates/page/index.html.heex:448
+#: lib/vutuv_web/templates/page/index.html.heex:478
 #, elixir-autogen, elixir-format
 msgid "Every public page here is also served as Markdown, plain text, JSON and XML under the same address. No scraping, no API key, no account."
 msgstr ""
@@ -18973,12 +18975,12 @@ msgstr ""
 " XML allo stesso indirizzo. Niente scraping, niente chiave API, niente "
 "account."
 
-#: lib/vutuv_web/templates/page/index.html.heex:455
+#: lib/vutuv_web/templates/page/index.html.heex:485
 #, elixir-autogen, elixir-format
 msgid "For machines"
 msgstr "Per le macchine"
 
-#: lib/vutuv_web/templates/page/index.html.heex:445
+#: lib/vutuv_web/templates/page/index.html.heex:475
 #, elixir-autogen, elixir-format
 msgid "Open by default"
 msgstr "Aperto per impostazione predefinita"
@@ -19009,12 +19011,12 @@ msgstr ""
 "Post, Mi piace, ripubblicazioni, risposte e messaggi uno a uno, in tempo "
 "reale."
 
-#: lib/vutuv_web/templates/page/index.html.heex:446
+#: lib/vutuv_web/templates/page/index.html.heex:476
 #, elixir-autogen, elixir-format
 msgid "Readable by people, by machines, and on your own server"
 msgstr "Leggibile dalle persone, dalle macchine e sul Suo server"
 
-#: lib/vutuv_web/templates/page/index.html.heex:471
+#: lib/vutuv_web/templates/page/index.html.heex:501
 #, elixir-autogen, elixir-format
 msgid "Run it yourself"
 msgstr "Lo gestisca Lei"
@@ -19026,23 +19028,23 @@ msgstr ""
 "Acceda senza password, con un PIN via e-mail, una passkey, un'app di "
 "autenticazione o un elenco di codici stampato."
 
-#: lib/vutuv_web/templates/page/index.html.heex:482
-#: lib/vutuv_web/templates/page/index.html.heex:569
+#: lib/vutuv_web/templates/page/index.html.heex:512
+#: lib/vutuv_web/templates/page/index.html.heex:599
 #, elixir-autogen, elixir-format
 msgid "Source code"
 msgstr "Codice sorgente"
 
-#: lib/vutuv_web/templates/page/index.html.heex:317
+#: lib/vutuv_web/templates/page/index.html.heex:347
 #, elixir-autogen, elixir-format
 msgid "This is what a vutuv profile looks like"
 msgstr "Ecco come si presenta un profilo vutuv"
 
-#: lib/vutuv_web/templates/page/index.html.heex:433
+#: lib/vutuv_web/templates/page/index.html.heex:463
 #, elixir-autogen, elixir-format
 msgid "What vutuv can do"
 msgstr "Cosa sa fare vutuv"
 
-#: lib/vutuv_web/templates/page/index.html.heex:432
+#: lib/vutuv_web/templates/page/index.html.heex:462
 #, elixir-autogen, elixir-format
 msgid "What you get"
 msgstr "Cosa ottiene"
@@ -19052,14 +19054,14 @@ msgstr "Cosa ottiene"
 msgid "Your independence"
 msgstr "La Sua indipendenza"
 
-#: lib/vutuv_web/templates/page/index.html.heex:473
+#: lib/vutuv_web/templates/page/index.html.heex:503
 #, elixir-autogen, elixir-format
 msgid "vutuv is open source under the MIT license. Run it for a company, an association or a school, on the internet or air-gapped inside your own network."
 msgstr ""
 "vutuv è open source con licenza MIT. Lo faccia girare per un'azienda, "
 "un'associazione o una scuola, su internet o isolato dentro la Sua rete."
 
-#: lib/vutuv_web/templates/page/index.html.heex:316
+#: lib/vutuv_web/templates/page/index.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "A look inside"
 msgstr "Uno sguardo dentro"
@@ -19072,7 +19074,7 @@ msgstr ""
 "qualifica, numero di follower e i primi post, con recapiti e profili social "
 "in una colonna a destra."
 
-#: lib/vutuv_web/templates/page/index.html.heex:338
+#: lib/vutuv_web/templates/page/index.html.heex:368
 #, elixir-autogen, elixir-format
 msgid "Browse real profiles"
 msgstr "Sfogli profili veri"
@@ -19098,14 +19100,14 @@ msgstr ""
 msgid "Try it out:"
 msgstr "Lo provi:"
 
-#: lib/vutuv_web/templates/page/index.html.heex:464
+#: lib/vutuv_web/templates/page/index.html.heex:494
 #, elixir-autogen, elixir-format
 msgid "Plus a sitemap, JSON-LD and a REST API with OAuth 2 and personal access tokens."
 msgstr ""
 "In più una sitemap, JSON-LD e un'API REST con OAuth 2 e token di accesso "
 "personali."
 
-#: lib/vutuv_web/templates/page/index.html.heex:319
+#: lib/vutuv_web/templates/page/index.html.heex:349
 #, elixir-autogen, elixir-format
 msgid "Work experience, education, certificates, languages, links and tags others endorse you for. Anyone can read a profile, entirely without a vutuv account. Unlike LinkedIn, where you hit a login wall in short order."
 msgstr ""
@@ -19114,7 +19116,7 @@ msgstr ""
 "vutuv. A differenza di LinkedIn, dove in poco tempo si sbatte contro una "
 "richiesta di accesso."
 
-#: lib/vutuv_web/templates/page/index.html.heex:419
+#: lib/vutuv_web/templates/page/index.html.heex:449
 #, elixir-autogen, elixir-format
 msgid "Talking to people"
 msgstr "Parlare con le persone"
@@ -19143,12 +19145,12 @@ msgstr ""
 "compariranno lì. Sceglie al momento dell'iscrizione, e può cambiare idea in "
 "seguito."
 
-#: lib/vutuv_web/templates/page/index.html.heex:420
+#: lib/vutuv_web/templates/page/index.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "Posts, messages, and the Fediverse along with them"
 msgstr "Post, messaggi e con essi il Fediverso"
 
-#: lib/vutuv_web/templates/page/index.html.heex:422
+#: lib/vutuv_web/templates/page/index.html.heex:452
 #, elixir-autogen, elixir-format
 msgid "Write a post, react with a heart, a repost or a reply, or message somebody privately. And you are not stuck among vutuv members: vutuv is part of the Fediverse, the union of independent networks that Mastodon belongs to as well. Follow an account over there and its posts arrive in your feed; the other way round, people there can follow you and see your public posts. Both directions, and entirely your choice: at sign-up you decide whether to use vutuv with or without the Fediverse, and you can change that at any time in the settings."
 msgstr ""
@@ -19161,7 +19163,7 @@ msgstr ""
 "tutto Sua: al momento dell'iscrizione decide se usare vutuv con o senza il "
 "Fediverso, e può cambiare in qualsiasi momento dalle impostazioni."
 
-#: lib/vutuv_web/templates/page/index.html.heex:535
+#: lib/vutuv_web/templates/page/index.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Download everything you have here at any time, in a machine-readable file. Not on request, not after a waiting period: from your settings, whenever you like."
 msgstr ""
@@ -19169,17 +19171,17 @@ msgstr ""
 "dalle macchine. Non su richiesta, non dopo un periodo di attesa: dalle Sue "
 "impostazioni, quando vuole."
 
-#: lib/vutuv_web/templates/page/index.html.heex:510
+#: lib/vutuv_web/templates/page/index.html.heex:540
 #, elixir-autogen, elixir-format
 msgid "Fair and transparent, in plain words"
 msgstr "Corretto e trasparente, detto in parole semplici"
 
-#: lib/vutuv_web/templates/page/index.html.heex:524
+#: lib/vutuv_web/templates/page/index.html.heex:554
 #, elixir-autogen, elixir-format
 msgid "No third-party cookies"
 msgstr "Nessun cookie di terze parti"
 
-#: lib/vutuv_web/templates/page/index.html.heex:516
+#: lib/vutuv_web/templates/page/index.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "On our own servers in %{place}, not in somebody else's cloud. We do not hand your profile to a third party, and there is no tracking network reading along."
 msgstr ""
@@ -19187,17 +19189,17 @@ msgstr ""
 "consegniamo il Suo profilo a terzi, e non c'è alcuna rete di tracciamento "
 "che legge insieme a noi."
 
-#: lib/vutuv_web/templates/page/index.html.heex:514
+#: lib/vutuv_web/templates/page/index.html.heex:544
 #, elixir-autogen, elixir-format
 msgid "Where your data lives"
 msgstr "Dove stanno i Suoi dati"
 
-#: lib/vutuv_web/templates/page/index.html.heex:509
+#: lib/vutuv_web/templates/page/index.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "Your data"
 msgstr "I Suoi dati"
 
-#: lib/vutuv_web/templates/page/index.html.heex:526
+#: lib/vutuv_web/templates/page/index.html.heex:556
 #, elixir-autogen, elixir-format
 msgid "vutuv sets one cookie, the one that keeps you signed in. No advertising network, no analytics service, nothing loaded from anybody else's server."
 msgstr ""
@@ -19205,17 +19207,17 @@ msgstr ""
 "pubblicitaria, nessun servizio di statistiche, nulla caricato dal server di "
 "qualcun altro."
 
-#: lib/vutuv_web/templates/page/index.html.heex:542
+#: lib/vutuv_web/templates/page/index.html.heex:572
 #, elixir-autogen, elixir-format
 msgid "Leave whenever you like"
 msgstr "Se ne vada quando vuole"
 
-#: lib/vutuv_web/templates/page/index.html.heex:558
+#: lib/vutuv_web/templates/page/index.html.heex:588
 #, elixir-autogen, elixir-format
 msgid "Open source"
 msgstr "Open source"
 
-#: lib/vutuv_web/templates/page/index.html.heex:560
+#: lib/vutuv_web/templates/page/index.html.heex:590
 #, elixir-autogen, elixir-format
 msgid "You can check at any time how exactly vutuv works. The whole source code is public under the MIT license, so everything said above about your data can be read rather than taken on trust."
 msgstr ""
@@ -19224,19 +19226,19 @@ msgstr ""
 " è stato detto qui sopra sui Suoi dati si può leggere invece che credere "
 "sulla parola."
 
-#: lib/vutuv_web/templates/page/index.html.heex:533
+#: lib/vutuv_web/templates/page/index.html.heex:563
 #, elixir-autogen, elixir-format
 msgid "Your data stays with you"
 msgstr "I Suoi dati restano Suoi"
 
-#: lib/vutuv_web/templates/page/index.html.heex:549
+#: lib/vutuv_web/templates/page/index.html.heex:579
 #, elixir-autogen, elixir-format
 msgid "Delete your account yourself, without writing to anybody. No questions asked, and you are welcome back any time."
 msgstr ""
 "Elimini il Suo account da sé, senza scrivere a nessuno. Nessuna domanda, e "
 "può tornare quando vuole."
 
-#: lib/vutuv_web/components/ui.ex:256
+#: lib/vutuv_web/components/ui.ex:257
 #, elixir-autogen, elixir-format
 msgid "At most %{max} tags. Remove one to add another."
 msgstr "Al massimo %{max} tag. Ne rimuova uno per aggiungerne un altro."
@@ -19291,7 +19293,7 @@ msgstr ""
 "ha ricevuto quando ha messo Mi piace. In ogni caso il post mantiene lo "
 "stesso numero di Mi piace."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:857
+#: lib/vutuv_web/controllers/settings_controller.ex:877
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr "I Suoi Mi piace tornano a seguire il valore predefinito del sito."
@@ -19401,7 +19403,7 @@ msgstr "Attestato di lavoro aggiornato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:4644
+#: lib/vutuv_web/components/ui.ex:4688
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -19606,7 +19608,7 @@ msgstr ""
 "Ha modificato il testo dopo questa analisi. L'analisi descrive la versione "
 "precedente."
 
-#: lib/vutuv_web/components/ui.ex:4645
+#: lib/vutuv_web/components/ui.ex:4689
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr "I Suoi Arbeitszeugnisse, privati finché non li pubblica"
@@ -19617,7 +19619,7 @@ msgstr "I Suoi Arbeitszeugnisse, privati finché non li pubblica"
 msgid "Zwischenzeugnis"
 msgstr "Zwischenzeugnis"
 
-#: lib/vutuv_web/components/ui.ex:4647
+#: lib/vutuv_web/components/ui.ex:4691
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -19893,7 +19895,7 @@ msgstr "Trascini qui il file, oppure ne scelga uno"
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr "PDF, JPG, PNG o WebP, fino a %{limit}"
 
-#: lib/vutuv_web/components/ui.ex:3984
+#: lib/vutuv_web/components/ui.ex:4028
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -20167,7 +20169,7 @@ msgid "You have reached your limit of %{limit} reviews. Please try again in %{wi
 msgstr ""
 "Ha raggiunto il Suo limite di %{limit} analisi. Riprovi fra %{window}."
 
-#: lib/vutuv_web/templates/page/index.html.heex:379
+#: lib/vutuv_web/templates/page/index.html.heex:409
 #, elixir-autogen, elixir-format
 msgid "Employment reference"
 msgstr "Attestato di lavoro"
@@ -20179,7 +20181,7 @@ msgstr ""
 "Attestati di lavoro: li carichi, li tenga privati e faccia leggere e "
 "valutare il loro testo sui nostri server."
 
-#: lib/vutuv_web/templates/page/index.html.heex:356
+#: lib/vutuv_web/templates/page/index.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "Job applications"
 msgstr "Candidature"
@@ -20200,7 +20202,7 @@ msgstr ""
 "recapiti, sotto le posizioni ricoperte con datore di lavoro e periodo, e più"
 " in basso i tag e le lingue parlate."
 
-#: lib/vutuv_web/templates/page/index.html.heex:399
+#: lib/vutuv_web/templates/page/index.html.heex:429
 #, elixir-autogen, elixir-format
 msgid "The review is a text analysis, not legal advice, and it covers German employment references."
 msgstr ""
@@ -20223,7 +20225,7 @@ msgstr ""
 "con voto 1 (ottimo) su un riquadro verde, uno con voto da 4 a 5 (scarso o "
 "insufficiente) su uno rosso, ciascuno con un link al rapporto completo."
 
-#: lib/vutuv_web/templates/page/index.html.heex:382
+#: lib/vutuv_web/templates/page/index.html.heex:412
 #, elixir-autogen, elixir-format
 msgid "Upload your employment references and have them read sentence by sentence: a grade, a traffic light, and the explanation of how a recruiter reads that wording. It takes a few minutes, then the report is there. Nothing becomes public before you release it."
 msgstr ""
@@ -20232,12 +20234,12 @@ msgstr ""
 "formulazione. Ci vogliono pochi minuti, poi il rapporto è pronto. Nulla "
 "diventa pubblico prima che lo autorizzi Lei."
 
-#: lib/vutuv_web/templates/page/index.html.heex:380
+#: lib/vutuv_web/templates/page/index.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "What your employment reference really says"
 msgstr "Cosa dice davvero il Suo attestato di lavoro"
 
-#: lib/vutuv_web/templates/page/index.html.heex:359
+#: lib/vutuv_web/templates/page/index.html.heex:389
 #, elixir-autogen, elixir-format
 msgid "What your profile already says becomes a CV. You tick what should go in, then download it as PDF, Word, OpenDocument, LaTeX or JSON Resume. Anonymously as well, if you would rather show what you can do before you show who you are."
 msgstr ""
@@ -20245,7 +20247,7 @@ msgstr ""
 "poi lo scarica in PDF, Word, OpenDocument, LaTeX o JSON Resume. Anche in "
 "forma anonima, se preferisce mostrare cosa sa fare prima di mostrare chi è."
 
-#: lib/vutuv_web/templates/page/index.html.heex:357
+#: lib/vutuv_web/templates/page/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "Your CV, ready to send"
 msgstr "Il Suo CV, pronto da inviare"
@@ -20297,14 +20299,14 @@ msgstr "PIN di 6 cifre"
 msgid "Enter the PIN from the email"
 msgstr "Inserisca il PIN che trova nell'e-mail"
 
-#: lib/vutuv_web/components/ui.ex:763
+#: lib/vutuv_web/components/ui.ex:807
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 "Se ha aggiunto altri indirizzi al Suo account vutuv, provi ad accedere con "
 "uno di quelli."
 
-#: lib/vutuv_web/components/ui.ex:791
+#: lib/vutuv_web/components/ui.ex:835
 #, elixir-autogen, elixir-format
 msgid "Cancel registration"
 msgstr "Annulla la registrazione"
@@ -20321,24 +20323,24 @@ msgstr ""
 msgid "Follow other members"
 msgstr "Segua altri membri"
 
-#: lib/vutuv_web/components/ui.ex:746
+#: lib/vutuv_web/components/ui.ex:790
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 "Il PIN non arriva? L'indirizzo e-mail {email} è corretto? Ha controllato la "
 "cartella dello spam?"
 
-#: lib/vutuv/accounts/user.ex:1346
+#: lib/vutuv/accounts/user.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Non binario"
 
-#: lib/vutuv/accounts/user.ex:1344
+#: lib/vutuv/accounts/user.ex:1350
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Femminile"
 
-#: lib/vutuv/accounts/user.ex:1345
+#: lib/vutuv/accounts/user.ex:1351
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Maschile"
@@ -20350,7 +20352,7 @@ msgstr ""
 "Le percentuali si riferiscono ai %{answered} membri che hanno risposto. "
 "%{unanswered} non hanno risposto."
 
-#: lib/vutuv_web/components/ui.ex:4626
+#: lib/vutuv_web/components/ui.ex:4670
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr "immagine profilo ritratto foto compleanno genere su di me"
@@ -20452,7 +20454,7 @@ msgstr "Elimina anche"
 msgid "Always keep"
 msgstr "Conserva sempre"
 
-#: lib/vutuv_web/components/ui.ex:4746
+#: lib/vutuv_web/components/ui.ex:4790
 #: lib/vutuv_web/controllers/settings_controller.ex:247
 #: lib/vutuv_web/controllers/settings_controller.ex:326
 #: lib/vutuv_web/controllers/settings_controller.ex:338
@@ -20562,7 +20564,7 @@ msgstr "Conserva i post con foto"
 msgid "Keep posts that did well"
 msgstr "Conserva i post andati bene"
 
-#: lib/vutuv_web/components/ui.ex:4748
+#: lib/vutuv_web/components/ui.ex:4792
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr "Lasci scadere i Suoi post dopo un tempo che decide Lei"
@@ -20686,7 +20688,7 @@ msgstr "Prima può scaricare tutto ciò che ha qui:"
 msgid "Your rule"
 msgstr "La Sua regola"
 
-#: lib/vutuv_web/components/ui.ex:4750
+#: lib/vutuv_web/components/ui.ex:4794
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -21167,17 +21169,17 @@ msgstr ""
 msgid "Nothing published yet."
 msgstr "Ancora nulla di pubblicato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1897
+#: lib/vutuv_web/live/post_live/composer.ex:1925
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr "Pubblica come %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1260
+#: lib/vutuv_web/live/post_live/composer.ex:1271
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr "Non può più scrivere a nome di questa organizzazione."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1874
+#: lib/vutuv_web/live/post_live/composer.ex:1902
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr "Un post a nome di un'organizzazione è sempre pubblico."
@@ -21492,7 +21494,7 @@ msgid "This vutuv exchanges nothing with other networks, so nothing here has any
 msgstr ""
 "Questo vutuv non scambia nulla con altre reti, quindi qui nulla ha effetto."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:442
+#: lib/vutuv_web/live/organization_live/edit.ex:443
 #, elixir-autogen, elixir-format
 msgid "Claim a short @name so this organization has an address of its own, like a member. Letters, numbers and underscores, %{min} to %{max} characters."
 msgstr ""
@@ -21500,7 +21502,7 @@ msgstr ""
 "suo, come un membro. Lettere, numeri e trattini bassi, da %{min} a %{max} "
 "caratteri."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:440
+#: lib/vutuv_web/live/organization_live/edit.ex:441
 #, elixir-autogen, elixir-format
 msgid "The organization's @name"
 msgstr "L'@nome dell'organizzazione"
@@ -21565,22 +21567,22 @@ msgstr "Si registri di nuovo"
 msgid "The PIN has expired."
 msgstr "Il PIN è scaduto."
 
-#: lib/vutuv_web/components/ui.ex:867
+#: lib/vutuv_web/components/ui.ex:911
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr "Il PIN è valido per un altro minuto."
 
-#: lib/vutuv_web/components/ui.ex:869
+#: lib/vutuv_web/components/ui.ex:913
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr "Il PIN è valido per un altro secondo."
 
-#: lib/vutuv_web/components/ui.ex:868
+#: lib/vutuv_web/components/ui.ex:912
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr "Il PIN è valido per altri {n} minuti."
 
-#: lib/vutuv_web/components/ui.ex:870
+#: lib/vutuv_web/components/ui.ex:914
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr "Il PIN è valido per altri {n} secondi."
@@ -22043,17 +22045,17 @@ msgstr "Ha %{used} tag su %{max}."
 msgid "{n} of {max} free slots selected."
 msgstr "Selezionati {n} posti liberi su {max}."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1939
+#: lib/vutuv_web/live/post_live/composer.ex:1967
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr "Altre lingue"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1924
+#: lib/vutuv_web/live/post_live/composer.ex:1952
 #, elixir-autogen, elixir-format
 msgid "Post language"
 msgstr "Lingua del post"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1929
+#: lib/vutuv_web/live/post_live/composer.ex:1957
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr "La lingua in cui è scritto questo post"
@@ -22090,7 +22092,7 @@ msgstr ""
 "Impostazioni delle lingue del feed riportate ai valori predefiniti del sito."
 
 #: lib/vutuv_web/components/post_components.ex:4697
-#: lib/vutuv_web/components/ui.ex:4705
+#: lib/vutuv_web/components/ui.ex:4749
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -22121,7 +22123,7 @@ msgstr ""
 "così come sono, tradurglieli o nasconderli. I post che non dichiarano una "
 "lingua vengono sempre mostrati."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:110
+#: lib/vutuv_web/gettext_extraction_anchors.ex:116
 #, elixir-autogen, elixir-format
 msgid "Date & time"
 msgstr "Data e ora"
@@ -22131,12 +22133,12 @@ msgstr "Data e ora"
 msgid "Date and time settings reset to the site defaults."
 msgstr "Impostazioni di data e ora riportate ai valori predefiniti del sito."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:108
+#: lib/vutuv_web/gettext_extraction_anchors.ex:114
 #, elixir-autogen, elixir-format
 msgid "Date format"
 msgstr "Formato della data"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:118
+#: lib/vutuv_web/gettext_extraction_anchors.ex:124
 #, elixir-autogen, elixir-format
 msgid "Germany, Austria, Switzerland"
 msgstr "Germania, Austria, Svizzera"
@@ -22146,31 +22148,31 @@ msgstr "Germania, Austria, Svizzera"
 msgid "Language and region saved."
 msgstr "Lingua e regione salvate."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:114
+#: lib/vutuv_web/gettext_extraction_anchors.ex:120
 #, elixir-autogen, elixir-format
 msgid "Posts, messages and notifications are stamped in this zone. New accounts take it from the browser."
 msgstr ""
 "Post, messaggi e notifiche vengono datati in questo fuso. I nuovi account lo"
 " ricavano dal browser."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:111
+#: lib/vutuv_web/gettext_extraction_anchors.ex:117
 #, elixir-autogen, elixir-format
 msgid "The order and punctuation of every date you read here, and whether times run on a 12- or 24-hour clock."
 msgstr ""
 "L'ordine e la punteggiatura di ogni data che legge qui, e se gli orari usano"
 " il formato a 12 o a 24 ore."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:109
+#: lib/vutuv_web/gettext_extraction_anchors.ex:115
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "Fuso orario"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:119
+#: lib/vutuv_web/gettext_extraction_anchors.ex:125
 #, elixir-autogen, elixir-format
 msgid "United Kingdom, France, Brazil"
 msgstr "Regno Unito, Francia, Brasile"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:120
+#: lib/vutuv_web/gettext_extraction_anchors.ex:126
 #, elixir-autogen, elixir-format
 msgid "United States"
 msgstr "Stati Uniti"
@@ -22180,7 +22182,7 @@ msgstr "Stati Uniti"
 msgid "Your browser says: {zone}"
 msgstr "Il Suo browser dice: {zone}"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:121
+#: lib/vutuv_web/gettext_extraction_anchors.ex:127
 #, elixir-autogen, elixir-format
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr "ISO 8601 (Svezia, Giappone, Cina)"
@@ -22331,7 +22333,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr "Accesso delle app Mastodon modificato"
 
-#: lib/vutuv_web/components/ui.ex:4794
+#: lib/vutuv_web/components/ui.ex:4838
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr "App Mastodon, app collegate e token di accesso"
@@ -22387,7 +22389,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr "Il Suo account è allora %{handle}."
 
-#: lib/vutuv_web/components/ui.ex:4796
+#: lib/vutuv_web/components/ui.ex:4840
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -22425,7 +22427,7 @@ msgstr "Trovi le persone che conosce da LinkedIn"
 msgid "Find your LinkedIn contacts"
 msgstr "Trovi i Suoi contatti LinkedIn"
 
-#: lib/vutuv_web/components/ui.ex:4721
+#: lib/vutuv_web/components/ui.ex:4765
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format
@@ -22539,7 +22541,7 @@ msgstr "Cerchi per nome"
 msgid "See which of them are already on vutuv"
 msgstr "Veda quali di loro sono già su vutuv"
 
-#: lib/vutuv_web/components/ui.ex:4723
+#: lib/vutuv_web/components/ui.ex:4767
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr "Veda quali dei Suoi contatti LinkedIn sono già su vutuv"
@@ -22623,7 +22625,7 @@ msgstr "I Suoi contatti su vutuv"
 msgid "Your export also lists your LinkedIn contacts."
 msgstr "La Sua esportazione elenca anche i Suoi contatti LinkedIn."
 
-#: lib/vutuv_web/components/ui.ex:4725
+#: lib/vutuv_web/components/ui.ex:4769
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr ""
@@ -22782,7 +22784,7 @@ msgctxt "qualification detail"
 msgid "Jobs"
 msgstr "Impieghi"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:835
+#: lib/vutuv_web/live/job_posting_live/form.ex:836
 #, elixir-autogen, elixir-format
 msgid "%{formatted} country chosen."
 msgid_plural "%{formatted} countries chosen."
@@ -22908,7 +22910,7 @@ msgstr ""
 "Ha attivato le notifiche del browser. A questo browser non è ancora stato "
 "chiesto il permesso."
 
-#: lib/vutuv_web/components/ui.ex:4693
+#: lib/vutuv_web/components/ui.ex:4737
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
@@ -22974,47 +22976,47 @@ msgstr "Saluti gli altri membri"
 msgid "New here"
 msgstr "Nuovi qui"
 
-#: lib/vutuv_web/components/ui.ex:1499
+#: lib/vutuv_web/components/ui.ex:1543
 #, elixir-autogen, elixir-format
 msgid "New public posts arrive in any feed reader. No account needed either."
 msgstr ""
 "I nuovi post pubblici arrivano in qualsiasi lettore di feed. Anche qui non "
 "serve un account."
 
-#: lib/vutuv_web/components/ui.ex:1495
+#: lib/vutuv_web/components/ui.ex:1539
 #, elixir-autogen, elixir-format
 msgid "Or with an RSS reader"
 msgstr "Oppure con un lettore RSS"
 
-#: lib/vutuv_web/components/ui.ex:1375
-#: lib/vutuv_web/components/ui.ex:1444
+#: lib/vutuv_web/components/ui.ex:1419
+#: lib/vutuv_web/components/ui.ex:1488
 #, elixir-autogen, elixir-format
 msgid "Subscribe"
 msgstr "Iscriviti"
 
-#: lib/vutuv_web/components/ui.ex:1496
+#: lib/vutuv_web/components/ui.ex:1540
 #, elixir-autogen, elixir-format
 msgid "With an RSS reader"
 msgstr "Con un lettore RSS"
 
-#: lib/vutuv_web/components/ui.ex:1456
+#: lib/vutuv_web/components/ui.ex:1500
 #, elixir-autogen, elixir-format
 msgid "Create a free account"
 msgstr "Crei un account gratuito"
 
-#: lib/vutuv_web/components/ui.ex:1471
+#: lib/vutuv_web/components/ui.ex:1515
 #, elixir-autogen, elixir-format
 msgid "No vutuv account? These ways work too:"
 msgstr "Non ha un account vutuv? Funzionano anche questi modi:"
 
-#: lib/vutuv_web/components/ui.ex:1449
+#: lib/vutuv_web/components/ui.ex:1493
 #, elixir-autogen, elixir-format
 msgid "The best way: follow %{name} here. New posts land in your feed, and you can reply and join in."
 msgstr ""
 "Il modo migliore: segua %{name} qui. I nuovi post arrivano nel Suo feed, e "
 "può rispondere e partecipare."
 
-#: lib/vutuv_web/components/ui.ex:1447
+#: lib/vutuv_web/components/ui.ex:1491
 #, elixir-autogen, elixir-format
 msgid "With a vutuv account"
 msgstr "Con un account vutuv"
@@ -23024,7 +23026,7 @@ msgstr "Con un account vutuv"
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr "Alcuni fra i membri più recenti. Seguirli è un bel benvenuto."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:234
+#: lib/vutuv_web/templates/settings/preferences.html.heex:278
 #, elixir-autogen, elixir-format
 msgid "Example"
 msgstr "Esempio"
@@ -23040,12 +23042,12 @@ msgid "Just flashed the new release, boot is under two seconds now"
 msgstr ""
 "Appena installata la nuova versione, l'avvio ora sta sotto i due secondi"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:244
+#: lib/vutuv_web/templates/settings/preferences.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "Play the example"
 msgstr "Riproduci l'esempio"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:99
+#: lib/vutuv_web/gettext_extraction_anchors.ex:105
 #, elixir-autogen, elixir-format
 msgid "Between 4 and 20 seconds."
 msgstr "Fra 4 e 20 secondi."
@@ -23142,22 +23144,22 @@ msgstr "Vengono nascosti dal Suo feed."
 msgid "Shown in the language it was written in."
 msgstr "Vengono mostrati nella lingua in cui sono stati scritti."
 
-#: lib/vutuv_web/components/ui.ex:4706
+#: lib/vutuv_web/components/ui.ex:4750
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr "Quali lingue arrivano fino a Lei e cosa succede al resto"
 
-#: lib/vutuv_web/components/ui.ex:4708
+#: lib/vutuv_web/components/ui.ex:4752
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr "lingua tradurre traduzione italiano tedesco inglese originale nascondere lingua straniera ordine priorità feed language translate sprache"
 
-#: lib/vutuv_web/components/ui.ex:4773
+#: lib/vutuv_web/components/ui.ex:4817
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr "Lingua dell'interfaccia, formato della data e fuso orario, mappe, come vengono accorciati i post"
 
-#: lib/vutuv_web/components/ui.ex:4777
+#: lib/vutuv_web/components/ui.ex:4821
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr "italiano tedesco inglese lingua mappa carattere lunghezza sillabazione fuso orario timezone utc data ora orologio 24 ore formato della data"
@@ -23190,7 +23192,7 @@ msgstr[0] "+%{formatted} altro post"
 msgstr[1] "+%{formatted} altri post"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:94
-#: lib/vutuv_web/templates/settings/preferences.html.heex:210
+#: lib/vutuv_web/templates/settings/preferences.html.heex:254
 #, elixir-autogen, elixir-format
 msgid "Browser tab"
 msgstr "Scheda del browser"
@@ -23215,12 +23217,12 @@ msgstr "Solo mentre sta guardando un'altra scheda, e solo per qualche secondo. I
 msgid "Tease new posts in the browser tab"
 msgstr "Anticipa i nuovi post nella scheda del browser"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:236
+#: lib/vutuv_web/templates/settings/preferences.html.heex:280
 #, elixir-autogen, elixir-format
 msgid "Watch this tab's title, above."
 msgstr "Guardi il titolo di questa scheda, qui sopra."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:212
+#: lib/vutuv_web/templates/settings/preferences.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "While you are reading another tab, a new post can page its first words through this tab's title, a line at a time, and then hand the title back."
 msgstr "Mentre sta leggendo un'altra scheda, un nuovo post può far scorrere le sue prime parole nel titolo di questa scheda, una riga alla volta, per poi restituire il titolo."
@@ -23281,7 +23283,7 @@ msgstr "Nessun account premium a pagamento."
 msgid "Your LinkedIn profile can come along."
 msgstr "Il suo profilo LinkedIn può venire con lei."
 
-#: lib/vutuv_web/components/ui.ex:1067
+#: lib/vutuv_web/components/ui.ex:1111
 #, elixir-autogen, elixir-format
 msgid "Being checked"
 msgstr "In verifica"
@@ -23505,7 +23507,7 @@ msgstr "Altri dei tuoi %{formatted} account"
 msgid "Move %{card}"
 msgstr "Sposta %{card}"
 
-#: lib/vutuv_web/components/ui.ex:350
+#: lib/vutuv_web/components/ui.ex:544
 #: lib/vutuv_web/live/post_live/filter_band.ex:583
 #, elixir-autogen, elixir-format
 msgid "No account found."
@@ -23674,7 +23676,7 @@ msgstr ""
 "La pagina della Sua organizzazione è stata aggiornata, ma non è stato "
 "possibile usare quell'immagine come logo. Ne scelga un'altra."
 
-#: lib/vutuv_web/components/ui.ex:3990
+#: lib/vutuv_web/components/ui.ex:4034
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -23836,12 +23838,12 @@ msgstr "Cita %{name}: %{url}"
 msgid "Quotes %{url}"
 msgstr "Cita %{url}"
 
-#: lib/vutuv_web/components/ui.ex:349
+#: lib/vutuv_web/components/ui.ex:543
 #, elixir-autogen, elixir-format
 msgid "Mention an account"
 msgstr "Menziona un account"
 
-#: lib/vutuv_web/components/ui.ex:352
+#: lib/vutuv_web/components/ui.ex:546
 #, elixir-autogen, elixir-format
 msgid "{used} of {max} mentions"
 msgstr "{used} di {max} menzioni"
@@ -23872,7 +23874,7 @@ msgstr "Lascia vuoto il campo degli account e la regola vale per tutti; %{exampl
 msgid "Only these accounts (empty = all) …"
 msgstr "Solo questi account (vuoto = tutti) …"
 
-#: lib/vutuv_web/components/ui.ex:3115
+#: lib/vutuv_web/components/ui.ex:3159
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr "solo %{account}"
@@ -23922,33 +23924,33 @@ msgid_plural "shared this."
 msgstr[0] "lo ha condiviso."
 msgstr[1] "lo hanno condiviso."
 
-#: lib/vutuv_web/components/ui.ex:475
+#: lib/vutuv_web/components/ui.ex:482
 #, elixir-autogen, elixir-format
 msgid "Editor view"
 msgstr "Vista"
 
-#: lib/vutuv_web/components/ui.ex:423
+#: lib/vutuv_web/components/ui.ex:430
 #, elixir-autogen, elixir-format
 msgid "Insert a block"
 msgstr "Inserisci un blocco"
 
-#: lib/vutuv_web/components/ui.ex:435
+#: lib/vutuv_web/components/ui.ex:442
 #, elixir-autogen, elixir-format
 msgid "Nothing matches."
 msgstr "Nessun risultato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1750
-#: lib/vutuv_web/live/post_live/composer.ex:2483
+#: lib/vutuv_web/live/post_live/composer.ex:1778
+#: lib/vutuv_web/live/post_live/composer.ex:2513
 #, elixir-autogen, elixir-format
 msgid "Automatic"
 msgstr "Automatico"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1755
+#: lib/vutuv_web/live/post_live/composer.ex:1783
 #, elixir-autogen, elixir-format
 msgid "Drag one photo onto another to swap them."
 msgstr "Trascina una foto su un'altra per scambiarle."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1702
+#: lib/vutuv_web/live/post_live/composer.ex:1730
 #, elixir-autogen, elixir-format
 msgid "Not shown in the gallery — drag one into it to swap."
 msgstr "Non nella galleria — trascinane una dentro per scambiarla."
@@ -24005,32 +24007,63 @@ msgstr "Ritirare davvero la richiesta?"
 msgid "Unmute %{host}"
 msgstr "Riattiva %{host}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1510
+#: lib/vutuv_web/live/post_live/composer.ex:1538
 #, elixir-autogen, elixir-format
 msgid "Draft discarded."
 msgstr "Bozza eliminata."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1549
+#: lib/vutuv_web/live/post_live/composer.ex:1577
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr "Conserva"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1540
+#: lib/vutuv_web/live/post_live/composer.ex:1568
 #, elixir-autogen, elixir-format
 msgid "Keep this draft for later?"
 msgstr "Conservare questa bozza per dopo?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1175
+#: lib/vutuv_web/live/post_live/composer.ex:1186
 #, elixir-autogen, elixir-format
 msgid "Hidden from some"
 msgstr "Nascosto ad alcuni"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1857
+#: lib/vutuv_web/live/post_live/composer.ex:1885
 #, elixir-autogen, elixir-format
 msgid "Post options"
 msgstr "Opzioni del post"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:314
+#: lib/vutuv_web/live/organization_live/edit.ex:315
 #, elixir-autogen, elixir-format
 msgid "Describe the organization. Markdown is supported."
 msgstr "Descriva l'organizzazione. Markdown è supportato."
+
+#: lib/vutuv_web/templates/page/index.html.heex:286
+#: lib/vutuv_web/templates/settings/preferences.html.heex:205
+#, elixir-autogen, elixir-format
+msgid "Bandwidth"
+msgstr "Larghezza di banda"
+
+#: lib/vutuv_web/controllers/settings_controller.ex:868
+#, elixir-autogen, elixir-format
+msgid "Bandwidth settings reset to the site defaults."
+msgstr "Impostazioni della larghezza di banda ripristinate ai valori predefiniti del sito."
+
+#: lib/vutuv_web/controllers/settings_controller.ex:862
+#, elixir-autogen, elixir-format
+msgid "Bandwidth settings saved."
+msgstr "Impostazioni della larghezza di banda salvate."
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:207
+#, elixir-autogen, elixir-format
+msgid "If you are on a slow or metered connection, vutuv can leave out the parts of the page that cost the most to download."
+msgstr "Se la Sua connessione è lenta o a consumo, vutuv può tralasciare le parti della pagina che pesano di più da scaricare."
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:101
+#, elixir-autogen, elixir-format
+msgid "Low-bandwidth mode"
+msgstr "Modalità risparmio dati"
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:102
+#, elixir-autogen, elixir-format
+msgid "Writing a post or a message then uses a plain Markdown box instead of the formatting editor, which saves about 150 kB of download. Everything you write still looks the same to everyone who reads it."
+msgstr "Per scrivere un post o un messaggio userà un semplice campo Markdown invece dell'editor con formattazione, il che risparmia circa 150 kB di download. Per chi legge, il testo resta identico."

--- a/priv/repo/migrations/20260902061823_add_low_bandwidth_to_users.exs
+++ b/priv/repo/migrations/20260902061823_add_low_bandwidth_to_users.exs
@@ -1,0 +1,13 @@
+defmodule Vutuv.Repo.Migrations.AddLowBandwidthToUsers do
+  use Ecto.Migration
+
+  # One nullable column, no default: nil has to stay distinguishable from a
+  # member who deliberately chose "off", because nil is what inherits the
+  # installation default (Vutuv.Prefs). Plain addition, so it is N-1 safe —
+  # the running release never reads or writes it.
+  def change do
+    alter table(:users) do
+      add(:low_bandwidth?, :boolean)
+    end
+  end
+end

--- a/test/vutuv_web/components/markdown_editor_test.exs
+++ b/test/vutuv_web/components/markdown_editor_test.exs
@@ -251,14 +251,74 @@ defmodule VutuvWeb.MarkdownEditorTest do
     end
   end
 
-  test "low-bandwidth mode is a per-member answer, not a site-wide one" do
-    # Two members, one page render each: the switch has to follow whoever is
-    # writing, or a shared component would answer it once for everybody.
-    assert thrifty_editor() =~ "data-mde-source"
-    refute thrifty_editor() =~ "data-mde-src"
+  # The gate costs the OTHER member nothing.
+  #
+  # Two shapes make this component re-send its whole attribute list on every
+  # keystroke, and both are the tidier-looking way to write the gate: collecting
+  # the attributes into a `{editor_hook(assigns)}` spread (handing `assigns` to
+  # a function is a strong taint in Phoenix.LiveView.Engine), and deriving
+  # `low_bandwidth?` with `assign/3` instead of `Map.put/3` (which marks it
+  # changed on every render). Either one re-sends the 1.6 kB fence-language
+  # table per keystroke, to every member who did NOT turn low bandwidth on —
+  # the exact opposite of the point. Both were measured at 2,353 bytes against
+  # 422 here, which is also what the component cost before the feature existed.
+  test "a keystroke does not re-send the editor's constants (change tracking)" do
+    assigns = %{
+      id: "ed",
+      name: "post[body]",
+      user: nil,
+      value: String.duplicate("a", 200),
+      label: "Body",
+      placeholder: "Write",
+      rows: 6,
+      submit_on: nil,
+      compact: false,
+      seed: nil,
+      images: false,
+      help: false,
+      mention_limit: nil,
+      class: nil,
+      rest: %{},
+      # What LiveView hands a component on a re-render where only the body moved.
+      __changed__: %{value: true}
+    }
 
+    rendered = VutuvWeb.UI.markdown_editor(assigns)
+
+    # The language table is the canary: it is a compile-time constant, so it
+    # must ride the full render and never a keystroke.
+    assert langs?(rendered, false), "the fence-language table is not being sent at all"
+    refute langs?(rendered, true), "the fence-language table is re-sent on every keystroke"
+
+    # And the whole re-send stays in the hundreds of bytes, not the thousands.
+    assert diff_size(rendered, true) < 1_000
+  end
+
+  # Every byte the socket would carry for this render, following nested
+  # Rendered structs the way the diff engine does. `track?` false is a full
+  # render, true is what a re-render actually re-sends.
+  defp diff_size(%Phoenix.LiveView.Rendered{dynamic: dynamic}, track?),
+    do: dynamic.(track?) |> Enum.map(&diff_size(&1, track?)) |> Enum.sum()
+
+  defp diff_size(list, track?) when is_list(list),
+    do: list |> Enum.map(&diff_size(&1, track?)) |> Enum.sum()
+
+  defp diff_size(binary, _track?) when is_binary(binary), do: byte_size(binary)
+  defp diff_size(_other, _track?), do: 0
+
+  defp langs?(%Phoenix.LiveView.Rendered{dynamic: dynamic}, track?),
+    do: dynamic.(track?) |> Enum.any?(&langs?(&1, track?))
+
+  defp langs?(list, track?) when is_list(list), do: Enum.any?(list, &langs?(&1, track?))
+  defp langs?(binary, _track?) when is_binary(binary), do: String.contains?(binary, "php:PHP")
+  defp langs?(_other, _track?), do: false
+
+  test "an explicit no and an untouched nil both still get the editor" do
+    # The three states of a Prefs boolean, and only one of them is thrifty
+    # (that one is the test above). An explicit false is a member who said no;
+    # nil is a member who never chose and inherits the installation default,
+    # which ships off.
     assert editor(%{user: %User{low_bandwidth?: false}}) =~ "data-mde-src"
-    # nil = never chose = inherit the installation default (off as shipped).
     assert editor(%{user: %User{low_bandwidth?: nil}}) =~ "data-mde-src"
   end
 

--- a/test/vutuv_web/components/markdown_editor_test.exs
+++ b/test/vutuv_web/components/markdown_editor_test.exs
@@ -10,12 +10,18 @@ defmodule VutuvWeb.MarkdownEditorTest do
   use ExUnit.Case, async: true
   import Phoenix.LiveViewTest
 
+  alias Vutuv.Accounts.User
+
+  # `user: nil` resolves the low-bandwidth pref to the installation default,
+  # which in the test env is the shipped one (the Prefs cache is off here) —
+  # so the plain `editor()` below is the full-bandwidth editor everybody gets.
   defp editor(overrides \\ %{}) do
     assigns =
       Map.merge(
         %{
           id: "ed",
           name: "post[body]",
+          user: nil,
           value: "hello **world**",
           label: "Body",
           placeholder: "Write something…"
@@ -24,6 +30,12 @@ defmodule VutuvWeb.MarkdownEditorTest do
       )
 
     render_component(&VutuvWeb.UI.markdown_editor/1, assigns)
+  end
+
+  # A member who asked for low-bandwidth mode. No DB: `Prefs.get/2` reads the
+  # struct's own column and only falls back to the defaults when it is nil.
+  defp thrifty_editor(overrides \\ %{}) do
+    editor(Map.put(overrides, :user, %User{low_bandwidth?: true}))
   end
 
   test "the hidden textarea stays the form field and the no-JS fallback" do
@@ -180,6 +192,74 @@ defmodule VutuvWeb.MarkdownEditorTest do
     assert html =~ "Aufzählung"
     assert html =~ "Codeblock"
     refute html =~ ">Heading 1<"
+  end
+
+  # ── Low-bandwidth mode ──
+  #
+  # Every refute below is paired with the assert that proves it is not vacuous:
+  # a refute on a misspelt attribute passes for the wrong reason and would hide
+  # exactly the regression these tests exist to catch.
+
+  test "a low-bandwidth member is never told where the editor bundle lives" do
+    full = editor()
+    thrifty = thrifty_editor()
+
+    # The whole mechanism. A browser cannot fetch a URL that is not on the
+    # page, so this one refute is the promise the setting makes.
+    assert full =~ ~s(data-mde-src="/assets/markdown_editor.js")
+    refute thrifty =~ "markdown_editor.js"
+    refute thrifty =~ "data-mde-src"
+
+    # And no hook to go looking for it either.
+    assert full =~ ~s(phx-hook="MarkdownEditor")
+    refute thrifty =~ "phx-hook"
+  end
+
+  test "a low-bandwidth member still gets a working Markdown field" do
+    html = thrifty_editor()
+
+    # The point of the setting is a cheaper composer, not a broken one: this is
+    # the same real form field the no-JS fallback has always shown, carrying
+    # the same value, and components.css shows it whenever data-mde-ready is
+    # absent.
+    assert html =~ ~s(<textarea)
+    assert html =~ ~s(name="post[body]")
+    assert html =~ "data-mde-source"
+    assert html =~ "hello **world**"
+    assert html =~ ~s(placeholder="Write something…")
+    # The sr-only label keeps the field named for a screen reader.
+    assert html =~ "Body"
+  end
+
+  test "none of the editor's furniture is rendered for a low-bandwidth member" do
+    full = editor(%{images: true, mention_limit: 5})
+    thrifty = thrifty_editor(%{images: true, mention_limit: 5})
+
+    # The frame, the mount point, the bubble and the slash menu are the
+    # editor's own scaffolding — dead markup without the hook, and on a slow
+    # line the bytes are the thing being saved.
+    for marker <- ["mde__frame", "data-mde-mount", "data-mde-bubble", "data-mde-slash"] do
+      assert full =~ marker, "the full editor should render #{marker}"
+      refute thrifty =~ marker, "low bandwidth should not render #{marker}"
+    end
+
+    # Nor the words, endpoints and language registry that only ever fed it.
+    # data-mde-langs is the biggest single attribute on the root.
+    for marker <- ["data-mde-langs", "data-mention-url", "data-mde-value", "data-mde-images"] do
+      assert full =~ marker, "the full editor should carry #{marker}"
+      refute thrifty =~ marker, "low bandwidth should not carry #{marker}"
+    end
+  end
+
+  test "low-bandwidth mode is a per-member answer, not a site-wide one" do
+    # Two members, one page render each: the switch has to follow whoever is
+    # writing, or a shared component would answer it once for everybody.
+    assert thrifty_editor() =~ "data-mde-source"
+    refute thrifty_editor() =~ "data-mde-src"
+
+    assert editor(%{user: %User{low_bandwidth?: false}}) =~ "data-mde-src"
+    # nil = never chose = inherit the installation default (off as shipped).
+    assert editor(%{user: %User{low_bandwidth?: nil}}) =~ "data-mde-src"
   end
 
   test "the fence-language labels ride the editor root (issues #1108/#1137/#1138)" do

--- a/test/vutuv_web/controllers/page_controller_test.exs
+++ b/test/vutuv_web/controllers/page_controller_test.exs
@@ -490,27 +490,47 @@ defmodule VutuvWeb.PageControllerTest do
     # One home for the visibility choices. The email address's own "may others
     # see it" box used to sit up beside the address while the other three sat in
     # a block of their own, so four identical-looking checkboxes appeared in two
-    # unrelated places on one short form. Asserting that the form holds no
-    # checkbox OUTSIDE this fieldset is the part that keeps it that way.
-    test "every visibility choice sits in the one Privacy fieldset", %{conn: conn} do
+    # unrelated places on one short form.
+    #
+    # What keeps it that way is the second half: no checkbox may float LOOSE in
+    # this form. It used to be spelt "every checkbox is in the Privacy
+    # fieldset", which was the same sentence while privacy was the only thing
+    # the form asked with a box. Low-bandwidth mode is not a visibility choice
+    # and must not sit under a "Privacy" legend, so the rule is now the one it
+    # always meant: every box belongs to a named group, and the visibility ones
+    # belong to that group.
+    test "every checkbox sits in a named fieldset, the visibility ones in Privacy",
+         %{conn: conn} do
       doc = conn |> get(~p"/") |> html_response(200) |> LazyHTML.from_document()
 
-      in_fieldset =
+      in_privacy =
         doc
         |> LazyHTML.query(~s(#signup-privacy input[type="checkbox"]))
         |> LazyHTML.attribute("name")
 
-      assert "user[emails][0][public?]" in in_fieldset
-      assert "user[noindex?]" in in_fieldset
-      assert "user[noai?]" in in_fieldset
-      assert "user[fediverse_followers?]" in in_fieldset
+      assert "user[emails][0][public?]" in in_privacy
+      assert "user[noindex?]" in in_privacy
+      assert "user[noai?]" in in_privacy
+      assert "user[fediverse_followers?]" in in_privacy
 
       in_form =
         doc
         |> LazyHTML.query(~s(#registration-form input[type="checkbox"]))
         |> LazyHTML.attribute("name")
 
-      assert Enum.sort(in_form) == Enum.sort(in_fieldset)
+      in_a_fieldset =
+        doc
+        |> LazyHTML.query(~s(#registration-form fieldset input[type="checkbox"]))
+        |> LazyHTML.attribute("name")
+
+      assert Enum.sort(in_form) == Enum.sort(in_a_fieldset)
+
+      # And every one of those groups says what it is, or the grouping is
+      # invisible to the person reading the form.
+      for id <- ~w(signup-privacy signup-bandwidth) do
+        assert [_] = Enum.to_list(LazyHTML.query(doc, ~s(##{id} > legend))),
+               "the #{id} fieldset has no legend"
+      end
     end
   end
 

--- a/test/vutuv_web/live/post_feed_live_test.exs
+++ b/test/vutuv_web/live/post_feed_live_test.exs
@@ -566,6 +566,61 @@ defmodule VutuvWeb.PostFeedLiveTest do
       })
     end
 
+    # The same button on a low-bandwidth composer, which has no editor to push
+    # the picture into. It would sit there doing nothing - which a member reads
+    # as a failed upload, not as a setting they turned on - so the server
+    # writes the reference into the Markdown instead.
+    test "low bandwidth: Insert writes the reference into the Markdown itself", %{conn: conn} do
+      tmp =
+        Path.join(System.tmp_dir!(), "vutuv_feed_lowbw_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp)
+      prev = Application.fetch_env(:vutuv, :uploads_dir_prefix)
+      Application.put_env(:vutuv, :uploads_dir_prefix, tmp)
+
+      on_exit(fn ->
+        File.rm_rf(tmp)
+
+        case prev do
+          {:ok, was} -> Application.put_env(:vutuv, :uploads_dir_prefix, was)
+          :error -> Application.delete_env(:vutuv, :uploads_dir_prefix)
+        end
+      end)
+
+      {conn, user} = create_and_login_user(conn)
+
+      user
+      |> Ecto.Changeset.change(%{low_bandwidth?: true})
+      |> Vutuv.Repo.update!()
+
+      {:ok, live, html} = live(conn, ~p"/feed")
+      # The premise: this composer really is the cheap one.
+      refute html =~ "markdown_editor.js"
+
+      {:ok, image} = Image.new(64, 64, color: [10, 100, 200])
+      {:ok, png} = Image.write(image, :memory, suffix: ".png")
+
+      live
+      |> file_input("#composer-form", :images, [
+        %{name: "photo.png", content: png, type: "image/png"}
+      ])
+      |> render_upload("photo.png")
+
+      [stored] = Vutuv.Repo.all(PostImage)
+
+      live
+      |> element(~s(button[phx-click="photo-open"][phx-value-id="#{stored.id}"]))
+      |> render_click()
+
+      live
+      |> element(~s(button[phx-click="insert-inline"][phx-value-id="#{stored.id}"]))
+      |> render_click()
+
+      # The reference is in the field the form actually submits, so pressing
+      # Post now publishes a picture in the prose exactly as the editor would.
+      assert render(live) =~ "![](#{PostImage.url(stored, "feed")})"
+    end
+
     test "an inline-referenced image renders inside the preview body, not below it", %{
       conn: conn
     } do

--- a/test/vutuv_web/live/post_feed_live_test.exs
+++ b/test/vutuv_web/live/post_feed_live_test.exs
@@ -14,6 +14,29 @@ defmodule VutuvWeb.PostFeedLiveTest do
 
   defp other_user(attrs \\ []), do: insert(:user, Keyword.merge([email_confirmed?: true], attrs))
 
+  # Real files land on disk, so each upload test gets an uploads root of its
+  # own. Captured with `fetch_env/2`, not `get_env/2`: that one answers nil both
+  # for "absent" and for "holds nil", so the naive restore writes nil back as a
+  # real value and every later reader in the run gets nil instead of the
+  # configured default.
+  defp isolate_uploads_root! do
+    tmp = Path.join(System.tmp_dir!(), "vutuv_feed_uploads_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    original = Application.fetch_env(:vutuv, :uploads_dir_prefix)
+    Application.put_env(:vutuv, :uploads_dir_prefix, tmp)
+
+    on_exit(fn ->
+      File.rm_rf(tmp)
+
+      case original do
+        {:ok, was} -> Application.put_env(:vutuv, :uploads_dir_prefix, was)
+        :error -> Application.delete_env(:vutuv, :uploads_dir_prefix)
+      end
+    end)
+
+    tmp
+  end
+
   # How many timeline rows are drawn but hidden — the waiting posts. Counted off
   # the row wrapper's own class, so it cannot catch a `hidden` somewhere inside
   # a card.
@@ -453,21 +476,7 @@ defmodule VutuvWeb.PostFeedLiveTest do
     # post_edit_live_test.exs.
 
     test "publishes a photo-only post (upload, no text)", %{conn: conn} do
-      # Real files land on disk: isolate the uploads root per test.
-      tmp =
-        Path.join(System.tmp_dir!(), "vutuv_feed_upload_#{System.unique_integer([:positive])}")
-
-      File.mkdir_p!(tmp)
-      prev = Application.get_env(:vutuv, :uploads_dir_prefix)
-      Application.put_env(:vutuv, :uploads_dir_prefix, tmp)
-
-      on_exit(fn ->
-        File.rm_rf(tmp)
-
-        if prev,
-          do: Application.put_env(:vutuv, :uploads_dir_prefix, prev),
-          else: Application.delete_env(:vutuv, :uploads_dir_prefix)
-      end)
+      isolate_uploads_root!()
 
       {conn, user} = create_and_login_user(conn)
       {:ok, live, _html} = live(conn, ~p"/feed")
@@ -499,20 +508,7 @@ defmodule VutuvWeb.PostFeedLiveTest do
     test "an uploaded image gets alt + remove + inline-insert controls", %{
       conn: conn
     } do
-      tmp =
-        Path.join(System.tmp_dir!(), "vutuv_feed_inline_#{System.unique_integer([:positive])}")
-
-      File.mkdir_p!(tmp)
-      prev = Application.get_env(:vutuv, :uploads_dir_prefix)
-      Application.put_env(:vutuv, :uploads_dir_prefix, tmp)
-
-      on_exit(fn ->
-        File.rm_rf(tmp)
-
-        if prev,
-          do: Application.put_env(:vutuv, :uploads_dir_prefix, prev),
-          else: Application.delete_env(:vutuv, :uploads_dir_prefix)
-      end)
+      isolate_uploads_root!()
 
       {conn, _user} = create_and_login_user(conn)
       {:ok, live, _html} = live(conn, ~p"/feed")
@@ -571,21 +567,7 @@ defmodule VutuvWeb.PostFeedLiveTest do
     # as a failed upload, not as a setting they turned on - so the server
     # writes the reference into the Markdown instead.
     test "low bandwidth: Insert writes the reference into the Markdown itself", %{conn: conn} do
-      tmp =
-        Path.join(System.tmp_dir!(), "vutuv_feed_lowbw_#{System.unique_integer([:positive])}")
-
-      File.mkdir_p!(tmp)
-      prev = Application.fetch_env(:vutuv, :uploads_dir_prefix)
-      Application.put_env(:vutuv, :uploads_dir_prefix, tmp)
-
-      on_exit(fn ->
-        File.rm_rf(tmp)
-
-        case prev do
-          {:ok, was} -> Application.put_env(:vutuv, :uploads_dir_prefix, was)
-          :error -> Application.delete_env(:vutuv, :uploads_dir_prefix)
-        end
-      end)
+      isolate_uploads_root!()
 
       {conn, user} = create_and_login_user(conn)
 

--- a/test/vutuv_web/low_bandwidth_test.exs
+++ b/test/vutuv_web/low_bandwidth_test.exs
@@ -1,0 +1,179 @@
+defmodule VutuvWeb.LowBandwidthTest do
+  @moduledoc """
+  Low-bandwidth mode end to end: the box on the sign-up form, the card on
+  /settings/preferences, and the thing both of them are for — a composer that
+  never fetches the 155 kB WYSIWYG editor.
+
+  `VutuvWeb.MarkdownEditorTest` covers what the component renders either way.
+  What is asserted here is the wiring around it: that the answer survives the
+  round trip from a sign-up form into the column, that "did not tick the box"
+  stays distinguishable from "chose off", and that a real page really does
+  come back without the bundle's URL anywhere in it.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Accounts
+  alias Vutuv.Accounts.User
+  alias Vutuv.Prefs
+
+  describe "the sign-up form" do
+    test "offers the box, unticked", %{conn: conn} do
+      body = conn |> get(~p"/") |> html_response(200)
+
+      assert body =~ "user[low_bandwidth?]"
+      assert body =~ Prefs.label(:low_bandwidth?)
+      # Off by default: the editor is what most people expect from a composer,
+      # and a first-time visitor cannot judge this trade for themselves.
+      refute checkbox_checked?(body, "user[low_bandwidth?]")
+    end
+
+    test "the explanation says what the switch actually does", %{conn: conn} do
+      body = conn |> get(~p"/") |> html_response(200)
+
+      # The member is being asked to give something up, so the box has to name
+      # both halves: what changes for them, and what does not change for their
+      # readers.
+      assert body =~ "plain Markdown box"
+      assert body =~ "looks the same to everyone who reads it"
+    end
+
+    # vutuv is a German site, and a one-word label is both the likeliest thing
+    # `gettext.extract --merge` fuzzy-fills with something unrelated and the
+    # least likely to be noticed. Assert the German by name.
+    test "the box is German for a German visitor", %{conn: conn} do
+      body =
+        conn
+        |> put_req_header("accept-language", "de-DE,de;q=0.9")
+        |> get(~p"/")
+        |> html_response(200)
+
+      assert body =~ "Datensparmodus"
+      assert body =~ "Bandbreite"
+      assert body =~ "einfachen Markdown-Feld"
+      # The English must not leak through beside it.
+      refute body =~ "Low-bandwidth mode"
+      # And not the social sense of "Connection", which is what the obvious
+      # msgid would have rendered here.
+      refute body =~ "Vernetzung"
+    end
+
+    test "ticking it is stored as a choice", %{conn: conn} do
+      attrs = low_bandwidth_attrs("lowbw-on", "true")
+      post(conn, ~p"/new_registration", user: attrs)
+
+      assert registered(attrs).low_bandwidth?
+    end
+
+    # The subtle one, and the reason `drop_untouched_low_bandwidth/1` exists.
+    # A checkbox posts its hidden "false" for the box nobody touched. Storing
+    # that would write indifference into the column as a decision and cut the
+    # member off from the installation default for good — on exactly the kind
+    # of installation this switch is for, where an admin turns it on for
+    # everybody at /admin/preferences.
+    test "walking past it leaves the column NULL, so it still inherits", %{conn: conn} do
+      attrs = low_bandwidth_attrs("lowbw-off", "false")
+      post(conn, ~p"/new_registration", user: attrs)
+
+      user = registered(attrs)
+      assert is_nil(user.low_bandwidth?)
+      # NULL is what inherits: an installation that turns the default on at
+      # /admin/preferences reaches this member, an explicit false never would.
+      # (`Vutuv.PrefsTest` owns the inheritance mechanism itself - it injects
+      # installation defaults into a node-global cache and is sync for it.)
+      refute Prefs.get(user, :low_bandwidth?)
+    end
+
+    test "a form that carries no box at all is the same as not ticking it", %{conn: conn} do
+      attrs = registration_attrs("lowbw-absent")
+      post(conn, ~p"/new_registration", user: attrs)
+
+      assert is_nil(registered(attrs).low_bandwidth?)
+    end
+  end
+
+  describe "/settings/preferences" do
+    test "shows the card and saves the switch", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      body = conn |> get(~p"/settings/preferences") |> html_response(200)
+      assert body =~ "Bandwidth"
+      assert body =~ Prefs.label(:low_bandwidth?)
+      refute checkbox_checked?(body, "user[low_bandwidth?]")
+
+      conn = put(conn, ~p"/settings/low_bandwidth", user: %{"low_bandwidth?" => "true"})
+      assert redirected_to(conn) == ~p"/settings/preferences"
+      assert Accounts.get_user(user.id).low_bandwidth?
+    end
+
+    # Unticking HERE is a real choice, unlike walking past the sign-up box, so
+    # it is stored as one — and the reset link is the way back to inheriting.
+    test "unticking is stored as an explicit no, and reset restores inheriting", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      put(conn, ~p"/settings/low_bandwidth", user: %{"low_bandwidth?" => "true"})
+      put(conn, ~p"/settings/low_bandwidth", user: %{"low_bandwidth?" => "false"})
+      assert Accounts.get_user(user.id).low_bandwidth? == false
+
+      # An explicit "false" is what the reset link is offered for.
+      body = conn |> get(~p"/settings/preferences") |> html_response(200)
+      assert body =~ "reset-low-bandwidth"
+
+      post(conn, ~p"/settings/low_bandwidth/reset")
+      assert is_nil(Accounts.get_user(user.id).low_bandwidth?)
+    end
+  end
+
+  describe "the composer a low-bandwidth member gets" do
+    # The end-to-end version of the promise. A component test can only say
+    # what the component rendered; this says what actually came back over the
+    # wire for a real member on a real page.
+    test "/feed comes back without the editor bundle anywhere in it", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      {:ok, _view, html} = live(conn, ~p"/feed")
+      assert html =~ "markdown_editor.js"
+
+      set_low_bandwidth(user, true)
+      {:ok, _view, html} = live(conn, ~p"/feed")
+      refute html =~ "markdown_editor.js"
+      refute html =~ "data-mde-src"
+
+      # Still a composer: the plain Markdown field is right there.
+      assert html =~ "data-mde-source"
+      assert html =~ ~s(name="post[body]")
+    end
+
+    # The message composer only exists once a conversation is open - without
+    # one the page carries no editor at all, and the refute below would pass
+    # for the wrong reason.
+    test "the messages page too", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      conversation = insert_conversation_between(user, insert(:user))
+
+      {:ok, _view, html} = live(conn, ~p"/messages/#{conversation.id}")
+      assert html =~ "data-mde-source"
+      assert html =~ "markdown_editor.js"
+
+      set_low_bandwidth(user, true)
+      {:ok, _view, html} = live(conn, ~p"/messages/#{conversation.id}")
+      assert html =~ "data-mde-source"
+      refute html =~ "markdown_editor.js"
+    end
+  end
+
+  defp low_bandwidth_attrs(prefix, value) do
+    prefix |> registration_attrs() |> Map.put("low_bandwidth?", value)
+  end
+
+  defp set_low_bandwidth(user, value) do
+    user
+    |> Ecto.Changeset.change(%{low_bandwidth?: value})
+    |> Repo.update!()
+  end
+
+  defp registered(%{"emails" => %{"0" => %{"value" => email}}}) do
+    Repo.one!(from(u in User, join: e in assoc(u, :emails), where: e.value == ^email))
+  end
+end


### PR DESCRIPTION
The WYSIWYG composer bundle is 155 kB gzipped, two and a half times the rest of `app.js`. On a slow or metered line it is the most expensive thing on the page, and nothing let a member decline it.

A new `low_bandwidth?` preference does. `VutuvWeb.UI.markdown_editor/1` now takes a required `user=`; when the preference is on it renders no `phx-hook`, no `data-mde-src` and no editor frame, so the browser is never told where the bundle lives and cannot fetch it. What is left is the plain Markdown textarea that has always been the no-JavaScript fallback. Posts come out byte for byte the same.

The box is asked once on the sign-up form (unticked) and lives on `/settings/preferences`; operators can flip the default at `/admin/preferences`. An unticked sign-up box is dropped rather than stored, because `Vutuv.Prefs` needs NULL to mean "inherit".

Verified in a browser at `/feed`: with the preference on, zero requests for `markdown_editor.js`; with it off, exactly one.

To decide: "Bandbreite" / "Datensparmodus" as the German wording, and whether low-bandwidth mode should later cover more than the composer.

https://claude.ai/code/session_015m8cUwUQYgkff4Whj8vmAo
