### PR TITLE
A picture from another network appears as soon as its bytes land

### DIFF
--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -911,7 +911,8 @@ federates without that picture. None of this applies when
 
 Readers *here* are not kept waiting meanwhile: a held picture shows as its
 pixelated preview (see `IMAGE_PIXELATION_WINDOW_SECONDS`) and swaps itself for the real one
-when the verdict lands.
+when the verdict lands. Both steps reach an open page on their own — the
+preview appears the moment the picture has been downloaded, without a reload.
 
 **Followers who leave without saying so.** Somebody on another server who
 unfollows, or who deletes their account and whose server announces it, disappears

--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -1746,13 +1746,29 @@ so the first draw of a boosted photo post is the wordless tile — and it was al
 the last. Measured on production, a picture was approved 88 seconds before the
 screenshot that reported the bug.
 
-So both verdicts broadcast `{:remote_images_settled, %{remote_post_id: id}}` on
+So both verdicts broadcast `{:remote_images_changed, %{remote_post_id: id}}` on
 `Fediverse.remote_images_topic/0` — **one** topic, the arrangement
-`counts_topic/0` makes and for the same reason: a verdict is rare, and each
+`counts_topic/0` makes and for the same reason: these are rare, and each
 listener keeps only the cards it is showing. The alternative, a topic per
 waiting picture, would make every listening page walk its own entries at mount
 and again on each append, which is a great deal of bookkeeping for an event this
 quiet. A verdict that lost its race announces nothing, having changed no row.
+
+**And the verdict was only half of it** (issue #1927). The card is drawn at
+delivery, when the row exists and its bytes do not; a second later they do, and
+from that moment there is a mosaic preview to stand in for the picture
+(`Vutuv.Moderation.Pixelation`, issue #1720) — or, where no vision model runs,
+the picture itself. Announcing only the verdict meant nobody watching a feed
+ever saw that mosaic: the wordless tile held the card for the whole scan, a
+median of 97 seconds on production data, against a median of one second for the
+download it was really waiting on. `Media.try_once/1` therefore announces the
+bytes landing on the same topic, and `Screenshots` announces a **link capture**
+the same way — at capture time, not only at its verdict, for the same reason,
+and for a member's own post as well as a cached one (there the audience is the
+author's followers' feeds, `Posts.broadcast_screenshot_ready/1`). A rejection is
+announced too, on both paths: it deletes the very file the mosaic on an open
+card names, so a page nobody tells goes on asking for it and draws a broken
+image.
 
 Listening is `VutuvWeb.Live.RemoteImages`, an `on_mount` hook, because the
 waiting tile prints its promise from **one shared component on six pages** (the

--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -404,6 +404,13 @@ about it are deliberate:
   flips the state, because an interruption between the two should cost a reader
   the last seconds of a preview (the grey tile instead) rather than leave an
   orphan file nothing will ever look at again. A rejection wipes the directory.
+- **Announced when it is written, not only when it goes** (issue #1927). The
+  preview exists for the wait, so the moment it exists is the moment a card
+  needs to hear about it: a picture cached from another network and a link
+  capture both reach an open page as soon as their bytes are stored, and the
+  cards re-read again on the verdict. Announcing only the verdict meant nobody
+  watching a feed ever saw a preview — the card was drawn a second before the
+  download finished and kept its grey tile for the whole scan.
 
 Where it exists: post photos (`post_images/<token>/pixelated.avif`, served by
 the proxy at `pixelated.avif` — which redirects to the real picture once

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -135,7 +135,8 @@ defmodule Vutuv.Fediverse do
   # well-known collection URI whose spelling the audience readers depend on.
   @followers_suffix "/followers"
 
-  # One topic for every picture leaving the AI gate; see `remote_images_topic/0`.
+  # One topic for every picture a cached post's card draws; see
+  # `remote_images_topic/0`.
   @remote_images_topic "fediverse:remote_images"
 
   @doc "The installation-wide switch (FEDIVERSE_ENABLED; off = no endpoints, no deliveries)."
@@ -3511,41 +3512,58 @@ defmodule Vutuv.Fediverse do
     do: [remote_post_id] |> list_remote_images() |> Map.get(remote_post_id, [])
 
   @doc """
-  The topic every open page listens on for a picture leaving the AI gate
+  The link capture of one cached post, or `nil`.
+
+  The card's *other* picture, and it waits the same two waits: the capture
+  browser has to get there (a median 13 seconds after the post is cached), and
+  then the AI gate has to look at what it brought back. So a page re-reading a
+  post's pictures re-reads this beside them — the row it hangs off is the same
+  one, and a reader does not sort a card's pictures by which table they came
+  from.
+  """
+  def remote_screenshot(remote_post_id) when is_binary(remote_post_id),
+    do: %RemotePost{id: remote_post_id} |> Ecto.assoc(:screenshot) |> Repo.one()
+
+  @doc """
+  The topic every open page listens on for a picture on a cached post moving
   (issue #1801).
 
   **One** topic rather than one per waiting post, the arrangement
-  `counts_topic/0` makes and for the same reason: a verdict is rare (a few an
-  hour on a busy installation, against a counts refresh every couple of
-  minutes), and each listener keeps only the cards it is showing. The
-  alternative — subscribing per picture that happens to be waiting — makes
-  every one of those six surfaces walk its own entries at mount and again on
-  every page append, which is a great deal of bookkeeping for an event this
-  quiet.
+  `counts_topic/0` makes and for the same reason: these are a handful an hour
+  on a busy installation, against a counts refresh every couple of minutes, and
+  each listener keeps only the cards it is showing. The alternative —
+  subscribing per picture that happens to be waiting — makes every one of those
+  six surfaces walk its own entries at mount and again on every page append,
+  which is a great deal of bookkeeping for an event this quiet.
   """
   def remote_images_topic, do: @remote_images_topic
 
-  @doc "Listen for pictures leaving the AI gate. See `remote_images_topic/0`."
+  @doc "Listen for a cached post's pictures moving. See `remote_images_topic/0`."
   def subscribe_remote_images, do: Phoenix.PubSub.subscribe(Vutuv.PubSub, @remote_images_topic)
 
   @doc """
-  Tells every open page that one of a cached post's pictures has left the AI
-  gate (issue #1801).
+  Tells every open page that a picture on a cached post has moved (issue #1801),
+  so the cards showing that post re-read what they draw.
 
-  **Both verdicts**, because both change the row a card was drawn from: an
-  approval swaps the picture in for the waiting tile, a rejection clears the
-  file. What the tile then *says* about a rejected picture is a separate
-  question and still the wrong answer — it goes on claiming a check is running
-  for a picture that will never arrive.
+  **Four moments, not one**, because each of them changes what a reader could
+  be shown:
 
-  Until this existed the verdict was a database flip and nothing else. Every
-  other image kind announces itself through
-  `Vutuv.Activity.broadcast(scan.owner_user_id, …)`, and a picture we fetched
-  has no owner here, so a card kept whatever it was first drawn with. That is
-  not a corner case: a delivery records the picture and nudges the open feeds
-  in the same breath, a second before the bytes land, so the *first* draw of a
-  boosted photo post is the wordless "picture is being checked" tile — and
-  without this it was also the last.
+    * an attachment's bytes land — from here on there is a mosaic preview to
+      stand in for the picture (issue #1720), or the picture itself on an
+      installation that runs no vision model;
+    * its verdict lands, either way: an approval swaps the picture in, a
+      rejection clears the file;
+    * the post's link capture is taken, which is the same "there is something
+      to show now" as the bytes landing;
+    * that capture's verdict lands.
+
+  The verdict alone was not enough, and the shape of the miss is worth keeping:
+  a delivery records the picture and nudges the open feeds in the same breath,
+  a second before the bytes land, so the *first* draw of a photo post from
+  another network is the wordless "picture is being checked" tile. Announcing
+  only the verdict left that tile standing for the whole scan — a median of 97
+  seconds — while the mosaic that exists precisely to fill it sat on disk
+  unseen.
 
   **A remote account's avatar is deliberately not announced**, though it is the
   other ownerless scan kind and goes just as quiet: an avatar the gate has not
@@ -3557,15 +3575,15 @@ defmodule Vutuv.Fediverse do
   recipient: the retention sweep can take the post while the model is still
   looking at its picture.
   """
-  def broadcast_remote_images_settled(remote_post_id) when is_binary(remote_post_id) do
+  def broadcast_remote_images_changed(remote_post_id) when is_binary(remote_post_id) do
     Phoenix.PubSub.broadcast(
       Vutuv.PubSub,
       @remote_images_topic,
-      {:remote_images_settled, %{remote_post_id: remote_post_id}}
+      {:remote_images_changed, %{remote_post_id: remote_post_id}}
     )
   end
 
-  def broadcast_remote_images_settled(_remote_post_id), do: :ok
+  def broadcast_remote_images_changed(_remote_post_id), do: :ok
 
   @doc """
   The **cached reply** each of `post_ids` answers, keyed by post id (issue

--- a/lib/vutuv/fediverse/media.ex
+++ b/lib/vutuv/fediverse/media.ex
@@ -27,6 +27,7 @@ defmodule Vutuv.Fediverse.Media do
 
   import Ecto.Query, only: [from: 2]
 
+  alias Vutuv.Fediverse
   alias Vutuv.Fediverse.RemoteImage
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.RemoteMedia
@@ -225,6 +226,13 @@ defmodule Vutuv.Fediverse.Media do
            RemoteMedia.store_post_image(bytes, image.id),
          {:ok, _stored} <- store_file(image, %{file: file, width: width, height: height}) do
       ImageScans.enqueue("remote_post_image", image.id, nil, file)
+      # The bytes are what the card was missing, not the verdict (issue #1927).
+      # It was drawn a second ago, when this row had no file and there was
+      # nothing to show; now there is the mosaic preview standing in for the
+      # picture — or the picture itself where no vision model runs. Waiting for
+      # the gate to announce it meant the wordless tile held the card for the
+      # whole scan, which is a median of 97 seconds.
+      Fediverse.broadcast_remote_images_changed(image.remote_post_id)
       :ok
     else
       # `RemoteMedia.store_post_image/2` answers `{:error, reason}` for bytes

--- a/lib/vutuv/moderation/image_subjects.ex
+++ b/lib/vutuv/moderation/image_subjects.ex
@@ -28,6 +28,7 @@ defmodule Vutuv.Moderation.ImageSubjects do
   alias Vutuv.Posts.PostImage
   alias Vutuv.Posts.PostReview
   alias Vutuv.Posts.PostScreenshot
+  alias Vutuv.Posts.Screenshots
   alias Vutuv.Profiles.Qualification
   alias Vutuv.Profiles.Url
   alias Vutuv.QualificationDocument
@@ -406,11 +407,7 @@ defmodule Vutuv.Moderation.ImageSubjects do
       {1, _} ->
         ps = Repo.get!(PostScreenshot, scan.subject_id)
         Vutuv.Screenshot.promote_from_quarantine(ps)
-        # The card upgrade was deliberately held back at capture time; the
-        # screenshot is only announced once it is released. A remote-owned row
-        # (`remote_post_id`) has no member post and nobody watching — its card
-        # simply shows the screenshot on the next feed load.
-        if ps.post_id, do: Vutuv.Posts.broadcast_screenshot_ready(ps.post_id)
+        Screenshots.announce(ps, :ready)
         :ok
 
       _ ->
@@ -586,7 +583,13 @@ defmodule Vutuv.Moderation.ImageSubjects do
   def apply_rejected(%ImageScan{kind: "post_screenshot"} = scan) do
     cleared =
       from(ps in PostScreenshot,
-        where: ps.id == ^scan.subject_id and ps.screenshot == ^scan.fingerprint
+        where: ps.id == ^scan.subject_id and ps.screenshot == ^scan.fingerprint,
+        # Which card to tell comes back with the write rather than from a second
+        # read: the flip has the row in hand and the announcement needs nothing
+        # but its owner (issue #1927). A `select` on the query, not the
+        # `:returning` option — that one is silently ignored here and answers
+        # `{1, nil}`.
+        select: ps
       )
       |> Repo.update_all(
         set: [
@@ -598,8 +601,9 @@ defmodule Vutuv.Moderation.ImageSubjects do
       )
 
     case cleared do
-      {1, _} ->
+      {1, [%PostScreenshot{} = cleared_row]} ->
         Vutuv.Screenshot.delete(%PostScreenshot{id: scan.subject_id})
+        Screenshots.announce(cleared_row, :gone)
         :ok
 
       _ ->
@@ -745,7 +749,7 @@ defmodule Vutuv.Moderation.ImageSubjects do
   # standing (a rejection clears `file` and keeps it). A row the retention sweep
   # has taken meanwhile reads as `nil`, which the broadcast takes as a no-op.
   defp announce_when_applied(:ok, %ImageScan{subject_id: subject_id}) do
-    Fediverse.broadcast_remote_images_settled(remote_post_id_of(subject_id))
+    Fediverse.broadcast_remote_images_changed(remote_post_id_of(subject_id))
     :ok
   end
 

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -6727,11 +6727,17 @@ defmodule Vutuv.Posts do
     broadcast_post_followers_event(post_id, :post_screenshot_ready)
   end
 
-  # The counterpart to `broadcast_screenshot_ready/1`: the author removed a
-  # post's auto link screenshot, so open feeds/profiles drop it from the card
-  # with no reload. Fans out to the same recipients (author topic + followers'
-  # feeds).
-  defp broadcast_screenshot_removed(post_id) when is_binary(post_id) do
+  @doc """
+  The counterpart to `broadcast_screenshot_ready/1`: a post's auto link
+  screenshot is gone, so open feeds/profiles drop it from the card with no
+  reload. Fans out to the same recipients (author topic + followers' feeds).
+
+  Two ways for it to go, and a card cannot tell them apart: the author removed
+  it, or the AI gate refused it. The second one matters because the card may be
+  showing the mosaic preview of a capture that is still being judged — a file
+  the rejection deletes, which without this leaves an open page asking for it.
+  """
+  def broadcast_screenshot_removed(post_id) when is_binary(post_id) do
     broadcast_post_followers_event(post_id, :post_screenshot_removed)
   end
 

--- a/lib/vutuv/posts/screenshots.ex
+++ b/lib/vutuv/posts/screenshots.ex
@@ -574,23 +574,49 @@ defmodule Vutuv.Posts.Screenshots do
       )
       |> Repo.update()
 
-    if moderation == "approved" do
-      announce_ready(ready)
-    else
+    if moderation != "approved" do
       ImageScans.enqueue("post_screenshot", ready.id, owner_user_id(ready), ready.screenshot)
     end
+
+    # Announced whether or not the gate still has it (issue #1927). It used to
+    # wait for the verdict, which was right while a held capture drew nothing:
+    # since issue #1720 it draws its mosaic preview, so the capture landing is
+    # itself something to show, and the card that has been sitting there
+    # picture-less since the post arrived can stop being picture-less.
+    announce(ready, :ready)
 
     ready
   end
 
-  # Open feeds/profiles upgrade a member post's card to show the screenshot
-  # with no reload. A cached remote post has no author watching their fresh
-  # post and no topic of its own, so it simply shows the screenshot on the
-  # next feed load — no broadcast.
-  defp announce_ready(%PostScreenshot{post_id: post_id}) when is_binary(post_id),
+  @doc """
+  Tells whoever is drawing this capture that it moved: `:ready` when there is
+  something new to show of it, `:gone` when there is not any more.
+
+  **Two audiences, one decision, and it lives here** — the module that owns the
+  row — because a capture hangs off either kind of post: a member's own reaches
+  their followers' feeds and their profile, a cached post's reaches whoever has
+  a card of it open, over the one topic those six surfaces already listen on.
+  `Vutuv.Moderation.ImageSubjects` announces the same row's verdicts and calls
+  this rather than keeping a second copy of the routing, which had already
+  drifted apart on the rejection.
+
+  `:gone` matters because a rejection deletes the very file an open card may be
+  showing as its mosaic preview; the cached-post side has no second word for it,
+  where both verdicts are the same "re-read what you draw".
+  """
+  def announce(screenshot, verdict \\ :ready)
+
+  def announce(%PostScreenshot{post_id: post_id}, :ready) when is_binary(post_id),
     do: Vutuv.Posts.broadcast_screenshot_ready(post_id)
 
-  defp announce_ready(%PostScreenshot{}), do: :ok
+  def announce(%PostScreenshot{post_id: post_id}, :gone) when is_binary(post_id),
+    do: Vutuv.Posts.broadcast_screenshot_removed(post_id)
+
+  def announce(%PostScreenshot{remote_post_id: id}, _verdict) when is_binary(id),
+    do: Fediverse.broadcast_remote_images_changed(id)
+
+  # A row the retention sweep has taken between the verdict and this.
+  def announce(_screenshot, _verdict), do: :ok
 
   # The AI scan's owning member: the post's author, or nobody for a remote
   # post's capture (the same ownerless shape the "remote_post_image" and

--- a/lib/vutuv_web/live/fediverse_account_live.ex
+++ b/lib/vutuv_web/live/fediverse_account_live.ex
@@ -53,9 +53,11 @@ defmodule VutuvWeb.FediverseAccountLive do
   # while this page is open (issue #1283). One line, no handler.
   on_mount(VutuvWeb.Live.RemoteCounts)
 
-  # And a picture on any of the cards appears the moment the AI gate releases it
-  # (issue #1801). One line, no handler: `@images` is the map keyed by post id.
-  on_mount({VutuvWeb.Live.RemoteImages, :assigns})
+  # And a picture on any of the cards appears the moment there is something to
+  # show of it (issues #1801, #1927). One line, no handler: `@images` is the map
+  # keyed by post id, and `@posts` the cards themselves, each carrying its own
+  # link capture.
+  on_mount({VutuvWeb.Live.RemoteImages, {:assigns, :posts}})
 
   @impl true
   def mount(%{"id" => id}, _session, socket) do

--- a/lib/vutuv_web/live/fediverse_lookup_live.ex
+++ b/lib/vutuv_web/live/fediverse_lookup_live.ex
@@ -59,9 +59,10 @@ defmodule VutuvWeb.FediverseLookupLive do
   # while this page is open (issue #1283). One line, no handler.
   on_mount(VutuvWeb.Live.RemoteCounts)
 
-  # And a picture on the result appears the moment the AI gate releases it
-  # (issue #1801). One line, no handler: `@images` is a plain list.
-  on_mount({VutuvWeb.Live.RemoteImages, :assigns})
+  # And a picture on the result appears the moment there is something to show of
+  # it (issues #1801, #1927). One line, no handler: `@images` is a plain list
+  # and the result itself is `@post`, which carries the link capture.
+  on_mount({VutuvWeb.Live.RemoteImages, {:assigns, :post}})
 
   @impl true
   def mount(_params, _session, socket) do

--- a/lib/vutuv_web/live/fediverse_post_live.ex
+++ b/lib/vutuv_web/live/fediverse_post_live.ex
@@ -52,10 +52,12 @@ defmodule VutuvWeb.FediversePostLive do
   # while this page is open (issue #1283). One line, no handler.
   on_mount(VutuvWeb.Live.RemoteCounts)
 
-  # And its pictures appear the moment the AI gate releases them (issue #1801).
-  # This page is the one a reader opens *because* of the picture, so a tile that
-  # waits for a reload is the plainest form of the broken promise it prints.
-  on_mount({VutuvWeb.Live.RemoteImages, :assigns})
+  # And its pictures appear the moment there is something to show of them
+  # (issues #1801, #1927). This page is the one a reader opens *because* of the
+  # picture, so a tile that waits for a reload is the plainest form of the
+  # broken promise it prints. The hook needs both assigns it writes: `@images`
+  # by that name, the post by the one named here.
+  on_mount({VutuvWeb.Live.RemoteImages, {:assigns, :remote_post}})
 
   @impl true
   def mount(%{"id" => id}, _session, socket) do

--- a/lib/vutuv_web/live/organization_live/feed.ex
+++ b/lib/vutuv_web/live/organization_live/feed.ex
@@ -43,7 +43,6 @@ defmodule VutuvWeb.OrganizationLive.Feed do
   import VutuvWeb.OrganizationComponents, only: [manage_header: 1]
   import VutuvWeb.PostComponents, only: [post_thread_entry: 1, remote_post_card: 1]
 
-  alias Vutuv.Fediverse
   alias Vutuv.Organizations
   alias Vutuv.Posts
   alias VutuvWeb.Live.InitAssigns
@@ -122,20 +121,20 @@ defmodule VutuvWeb.OrganizationLive.Feed do
   end
 
   @impl true
-  def handle_info({:remote_images_settled, %{remote_post_id: id}}, socket) do
+  def handle_info({:remote_images_changed, %{remote_post_id: id}}, socket) do
     {:noreply, restate_remote_images(socket, id)}
   end
 
   def handle_info(_message, socket), do: {:noreply, socket}
 
-  # Every open page hears every verdict, so the cheap "is it even on this page"
-  # question comes before the read.
+  # Every open page hears every picture that moves anywhere, so the cheap "is it
+  # even on this page" question comes before the read.
   defp restate_remote_images(socket, remote_post_id) do
     if Enum.any?(socket.assigns.entries, &RemoteImages.draws?(&1, remote_post_id)) do
-      images = Fediverse.remote_images(remote_post_id)
+      pictures = RemoteImages.pictures(remote_post_id)
 
       update(socket, :entries, fn entries ->
-        Enum.map(entries, &RemoteImages.restate_entry(&1, remote_post_id, images))
+        Enum.map(entries, &RemoteImages.restate_entry(&1, remote_post_id, pictures))
       end)
     else
       socket

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -62,9 +62,9 @@ defmodule VutuvWeb.PostLive.Feed do
   # while this page is open (issue #1283). One line, no handler.
   on_mount(VutuvWeb.Live.RemoteCounts)
 
-  # A picture on such a card appears the moment the AI gate releases it (issue
-  # #1801). The timeline mode: the cards are in a stream, so this listens and
-  # `handle_info({:remote_images_settled, …}, …)` below does the redraw.
+  # A picture on such a card appears the moment there is something to show of it
+  # (issues #1801, #1927). The timeline mode: the cards are in a stream, so this
+  # listens and `handle_info({:remote_images_changed, …}, …)` does the redraw.
   on_mount(VutuvWeb.Live.RemoteImages)
 
   # What a mount loads, and what every older page after it adds. The arrival
@@ -2009,8 +2009,10 @@ defmodule VutuvWeb.PostLive.Feed do
   # The same for a picture on a cached post from another network (issue #1801).
   # It matters more here than for a member's own photo: a delivery draws the
   # card in the second between recording the picture and its bytes landing, so
-  # the reader's FIRST sight of a boosted photo post is the waiting tile.
-  def handle_info({:remote_images_settled, %{remote_post_id: id}}, socket) do
+  # the reader's FIRST sight of a boosted photo post is the waiting tile — and
+  # since issue #1927 that second is exactly what this announces, rather than
+  # the verdict a minute and a half later.
+  def handle_info({:remote_images_changed, %{remote_post_id: id}}, socket) do
     {:noreply, refresh_remote_images(socket, id)}
   end
 
@@ -2435,15 +2437,10 @@ defmodule VutuvWeb.PostLive.Feed do
   end
 
   defp restream_remote_images(socket, remote_post_id) do
-    images = Fediverse.remote_images(remote_post_id)
+    pictures = RemoteImages.pictures(remote_post_id)
 
     {entries, changed} =
-      Enum.map_reduce(socket.assigns.entries, [], fn entry, changed ->
-        case RemoteImages.restate_entry(entry, remote_post_id, images) do
-          ^entry -> {entry, changed}
-          updated -> {updated, [updated | changed]}
-        end
-      end)
+      RemoteImages.restate_entries(socket.assigns.entries, remote_post_id, pictures)
 
     socket = assign(socket, :entries, entries)
     Enum.reduce(changed, socket, &stream_insert(&2, :posts, &1, update_only: true))

--- a/lib/vutuv_web/live/remote_images.ex
+++ b/lib/vutuv_web/live/remote_images.ex
@@ -1,7 +1,7 @@
 defmodule VutuvWeb.Live.RemoteImages do
   @moduledoc """
-  Makes a picture on a cached post appear the moment the AI gate releases it,
-  on every page that draws one (issue #1801).
+  Makes a picture on a cached post appear the moment there is something to show
+  of it, on every page that draws one (issues #1801, #1927).
 
   The waiting tile prints a promise — "It appears here by itself once it is
   through" — and `VutuvWeb.PostComponents.remote_post_images/1` prints it on
@@ -13,6 +13,14 @@ defmodule VutuvWeb.Live.RemoteImages do
   reader pressed reload — which for a boosted photo post is the wordless tile,
   the delivery drawing the card a second before the bytes land.
 
+  **The verdict was only half of it.** A card is drawn at delivery, when the
+  picture is recorded and its bytes are not here yet; a second later they are,
+  and from then on there is a mosaic preview to stand in for the picture
+  (issue #1720). Waiting for the gate to say so meant nobody ever saw that
+  mosaic on a post arriving in front of them — the wordless tile held the card
+  for the whole scan, a median of 97 seconds. So `Vutuv.Fediverse.Media` now
+  announces the bytes landing as well, and this hook re-reads on both.
+
   It is an `on_mount` hook for the reason `VutuvWeb.Live.RemoteCounts` is one: a
   guarantee the shared component makes on six pages must not depend on six hosts
   each remembering to subscribe, and a host that forgets simply never updates —
@@ -20,19 +28,23 @@ defmodule VutuvWeb.Live.RemoteImages do
 
   ## Two modes, because the pictures are held in two shapes
 
-      on_mount({VutuvWeb.Live.RemoteImages, :assigns})
+      on_mount({VutuvWeb.Live.RemoteImages, {:assigns, :remote_post}})
 
-  for a page whose pictures are one `@images` assign: a bare list where the page
-  is about a single cached post, or the `%{post_id => [picture]}` map a listing
-  holds. The hook owns it end to end and the host writes no `handle_info/2` at
-  all.
+  for a page whose pictures are one `@images` assign — a bare list where the
+  page is about a single cached post, or the `%{post_id => [picture]}` map a
+  listing holds — plus the cached post itself, under the assign named here (one
+  `%RemotePost{}` or a list of them), because the post carries the other
+  picture a card draws: its link capture. The hook owns both end to end and the
+  host writes no `handle_info/2` at all. The name is stated rather than hunted
+  for, and `Map.fetch!/2` raises on the next event if it ever stops being true;
+  the three pages call it `:remote_post`, `:post` and `:posts`.
 
       on_mount(VutuvWeb.Live.RemoteImages)
 
   for a timeline, whose pictures ride each entry and whose cards live in a
   stream. That cannot be done from here — the stream's name and the entry's
   identity are the host's — so the hook only subscribes and the host writes one
-  `handle_info/2` clause over `restate_entry/3`.
+  `handle_info/2` clause over `restate_entries/3`.
   """
 
   import Phoenix.Component, only: [assign: 3]
@@ -49,50 +61,68 @@ defmodule VutuvWeb.Live.RemoteImages do
     {:cont, socket}
   end
 
-  def on_mount(:assigns, _params, _session, socket) do
+  def on_mount({:assigns, post_key}, _params, _session, socket) do
     if connected?(socket) do
       Fediverse.subscribe_remote_images()
-      {:cont, attach_hook(socket, :remote_images, :handle_info, &reload_assign/2)}
+      hook = &reload_assigns(&1, &2, post_key)
+      {:cont, attach_hook(socket, :remote_images, :handle_info, hook)}
     else
       {:cont, socket}
     end
   end
 
-  defp reload_assign({:remote_images_settled, %{remote_post_id: id}}, socket) do
-    {:halt, assign(socket, :images, reload(socket.assigns.images, id))}
+  defp reload_assigns({:remote_images_changed, %{remote_post_id: id}}, socket, post_key) do
+    {:halt, restate_assigns(socket, post_key, id)}
   end
 
-  defp reload_assign(_other, socket), do: {:cont, socket}
+  defp reload_assigns(_other, socket, _post_key), do: {:cont, socket}
 
   @doc """
-  One page's pictures with `remote_post_id`'s set re-read, keeping the shape it
-  was given.
+  Every picture one cached post's card draws: the author's attachments and,
+  where there are none, the link capture taken of the one URL such a post can
+  carry.
 
-  Answers the assign unchanged — and reads nothing — when this page is not
-  showing that post, which is the common case on a topic every page hears.
+  One read, because both arrive at a card together and a reader does not sort a
+  card's pictures by which table they came from. The capture is read **only for
+  a post with no attachments**, which is the only case a card draws one at all
+  (`remote_link_screenshot/2` matches an empty picture list), so a photo post —
+  exactly what the byte-landing announcement fires for — pays one query rather
+  than two.
   """
-  def reload(images, remote_post_id) when is_map(images) do
-    if Map.has_key?(images, remote_post_id),
-      do: Map.put(images, remote_post_id, Fediverse.remote_images(remote_post_id)),
-      else: images
-  end
-
-  def reload(images, remote_post_id) when is_list(images) do
-    if Enum.any?(images, &(&1.remote_post_id == remote_post_id)),
-      do: Fediverse.remote_images(remote_post_id),
-      else: images
+  def pictures(remote_post_id) when is_binary(remote_post_id) do
+    case Fediverse.remote_images(remote_post_id) do
+      [] -> %{images: [], screenshot: Fediverse.remote_screenshot(remote_post_id)}
+      images -> %{images: images, screenshot: :unread}
+    end
   end
 
   @doc """
   Whether one feed entry draws `remote_post_id` at all — as its own card, or as
   the parent it nests.
 
-  The timeline twin of the check `reload/2` makes for itself, and it exists for
-  the same reason: every open page hears every verdict, so a host must be able
-  to answer "not mine" without going to the database.
+  The timeline twin of the check the `:assigns` mode makes for itself, and it
+  exists for the same reason: every open page hears about every picture, so a
+  host must be able to answer "not mine" without going to the database.
   """
   def draws?(entry, remote_post_id),
     do: Enum.any?(cards(entry), &match?(%{remote_post: %RemotePost{id: ^remote_post_id}}, &1))
+
+  @doc """
+  A timeline's entries with `remote_post_id`'s pictures re-read, and the ones
+  that really moved.
+
+  Returns `{entries, changed}` — the host knows its stream's name and nothing
+  else about this, so it spends the second element on `stream_insert/4` and
+  keeps the first.
+  """
+  def restate_entries(entries, remote_post_id, pictures) do
+    Enum.map_reduce(entries, [], fn entry, changed ->
+      case restate_entry(entry, remote_post_id, pictures) do
+        ^entry -> {entry, changed}
+        updated -> {updated, [updated | changed]}
+      end
+    end)
+  end
 
   @doc """
   The same for one feed entry: the cached post it draws, plus any it nests as a
@@ -101,23 +131,83 @@ defmodule VutuvWeb.Live.RemoteImages do
   Returns the entry unchanged when it draws neither, so a caller can compare
   identity to find the cards that really moved.
   """
-  def restate_entry(entry, remote_post_id, images) do
+  def restate_entry(entry, remote_post_id, pictures) do
     entry
-    |> restate_card(remote_post_id, images)
+    |> restate_card(remote_post_id, pictures)
     |> Map.replace_lazy(:remote_parents, fn parents ->
-      Map.new(parents, fn {key, parent} -> {key, restate_card(parent, remote_post_id, images)} end)
+      Map.new(parents, fn {key, parent} ->
+        {key, restate_card(parent, remote_post_id, pictures)}
+      end)
     end)
   end
 
   # One card, whether it is the entry itself or the parent another card nests:
   # both are built by `Vutuv.Posts.attach_remote_images/1`, so both are the same
-  # shape.
-  defp restate_card(%{remote_post: %RemotePost{id: id}} = card, id, images),
-    do: Map.put(card, :images, images)
+  # shape. The capture rides the post it hangs off rather than an assign of its
+  # own, which is why it is written back onto the struct here.
+  defp restate_card(%{remote_post: %RemotePost{id: id}} = card, id, pictures) do
+    card
+    |> Map.put(:images, pictures.images)
+    |> Map.put(:remote_post, put_screenshot(card.remote_post, id, pictures.screenshot))
+  end
 
-  defp restate_card(card, _remote_post_id, _images), do: card
+  defp restate_card(card, _remote_post_id, _pictures), do: card
 
   # An entry draws one cached post of its own at most, and nests at most one per
   # thread post above it (`Vutuv.Posts.attach_remote_parents/3`).
   defp cards(entry), do: [entry | Map.values(entry[:remote_parents] || %{})]
+
+  # The `:assigns` mode's own restate: the `@images` assign the mode is named
+  # for, and the cached post, which carries the link capture. Every open page
+  # hears about every picture, so the two cheap "is it even on this page"
+  # questions come before the read.
+  defp restate_assigns(socket, post_key, remote_post_id) do
+    images = socket.assigns.images
+    posts = Map.fetch!(socket.assigns, post_key)
+
+    if holds_images?(images, remote_post_id) or holds_post?(posts, remote_post_id) do
+      pictures = pictures(remote_post_id)
+
+      socket
+      |> assign(:images, put_images(images, remote_post_id, pictures.images))
+      |> assign(post_key, put_screenshot(posts, remote_post_id, pictures.screenshot))
+    else
+      socket
+    end
+  end
+
+  defp holds_images?(images, remote_post_id) when is_map(images),
+    do: Map.has_key?(images, remote_post_id)
+
+  defp holds_images?(images, remote_post_id) when is_list(images),
+    do: Enum.any?(images, &(&1.remote_post_id == remote_post_id))
+
+  defp holds_post?(%RemotePost{id: id}, id), do: true
+
+  defp holds_post?(values, remote_post_id) when is_list(values),
+    do: Enum.any?(values, &holds_post?(&1, remote_post_id))
+
+  defp holds_post?(_value, _remote_post_id), do: false
+
+  # A listing keeps a map keyed by post id, and the fresh set goes in whether or
+  # not the post had a key: an author can add a picture to a post that had none.
+  defp put_images(images, remote_post_id, fresh) when is_map(images),
+    do: Map.put(images, remote_post_id, fresh)
+
+  # A bare list is one post's pictures, and the caller has already established
+  # that this page is showing that post, so the fresh set replaces it whole.
+  defp put_images(images, _remote_post_id, fresh) when is_list(images), do: fresh
+
+  # `:unread` is `pictures/1` saying it did not look at the capture, because a
+  # post with attachments never draws one — so leave the post's own alone rather
+  # than writing a nil nobody read.
+  defp put_screenshot(post, _remote_post_id, :unread), do: post
+
+  defp put_screenshot(%RemotePost{id: id} = post, id, screenshot),
+    do: %{post | screenshot: screenshot}
+
+  defp put_screenshot(values, remote_post_id, screenshot) when is_list(values),
+    do: Enum.map(values, &put_screenshot(&1, remote_post_id, screenshot))
+
+  defp put_screenshot(value, _remote_post_id, _screenshot), do: value
 end

--- a/lib/vutuv_web/live/tag_live/timeline.ex
+++ b/lib/vutuv_web/live/tag_live/timeline.ex
@@ -123,11 +123,12 @@ defmodule VutuvWeb.TagLive.Timeline do
     RemotePostActions.report(socket, id, &drop_remote_entry(&1, id))
   end
 
-  # A picture on a cached post left the AI gate (issue #1801): the tile the card
-  # is showing becomes the picture, with no reload. Every open page hears every
-  # verdict, so the cheap "is it even on this page" question comes first.
+  # A picture on a cached post moved (issues #1801, #1927): the tile the card is
+  # showing becomes the mosaic preview, and then the picture, with no reload.
+  # Every open page hears every one of these, so the cheap "is it even on this
+  # page" question comes first.
   @impl true
-  def handle_info({:remote_images_settled, %{remote_post_id: id}}, socket) do
+  def handle_info({:remote_images_changed, %{remote_post_id: id}}, socket) do
     {:noreply, restate_remote_images(socket, id)}
   end
 
@@ -138,15 +139,10 @@ defmodule VutuvWeb.TagLive.Timeline do
   end
 
   defp restream_remote_images(socket, remote_post_id) do
-    images = Fediverse.remote_images(remote_post_id)
+    pictures = RemoteImages.pictures(remote_post_id)
 
     {entries, changed} =
-      Enum.map_reduce(socket.assigns.entries, [], fn entry, changed ->
-        case RemoteImages.restate_entry(entry, remote_post_id, images) do
-          ^entry -> {entry, changed}
-          updated -> {updated, [updated | changed]}
-        end
-      end)
+      RemoteImages.restate_entries(socket.assigns.entries, remote_post_id, pictures)
 
     socket = assign(socket, :entries, entries)
     Enum.reduce(changed, socket, &stream_insert(&2, :entries, &1, update_only: true))

--- a/test/vutuv/fediverse_media_test.exs
+++ b/test/vutuv/fediverse_media_test.exs
@@ -150,6 +150,24 @@ defmodule Vutuv.FediverseMediaTest do
       assert scan.owner_user_id == nil
     end
 
+    test "the bytes landing is announced, verdict or no verdict (issue #1927)" do
+      # What every open card was missing. It was drawn a second ago, when this
+      # row had no file and there was nothing to show; from here on there is the
+      # mosaic preview standing in for the picture, and the gate's own
+      # announcement is a median of 97 seconds away.
+      with_moderation()
+      serving_bytes(jpeg_bytes())
+      post = cached_post(account())
+      [image] = Media.record_attachments(post, [attachment()], false)
+      Fediverse.subscribe_remote_images()
+
+      assert :ok = Media.fetch_now(image)
+
+      assert_receive {:remote_images_changed, %{remote_post_id: id}}
+      assert id == post.id
+      assert Repo.get!(RemoteImage, image.id).moderation == "pending"
+    end
+
     test "a server that does not answer leaves the post readable" do
       stub_download(fn conn -> Plug.Conn.send_resp(conn, 500, "") end)
       post = cached_post(account())

--- a/test/vutuv/fediverse_remote_post_screenshots_test.exs
+++ b/test/vutuv/fediverse_remote_post_screenshots_test.exs
@@ -308,12 +308,31 @@ defmodule Vutuv.FediverseRemotePostScreenshotsTest do
       assert is_nil(scan.owner_user_id)
       assert scan.fingerprint == job.screenshot
     end
+
+    test "the capture is announced although the gate still has it (issue #1927)" do
+      # The card has been picture-less since the post was cached, and from this
+      # moment there is a mosaic preview to stand in for the capture. Waiting
+      # for the verdict left every open card as it was for the whole scan — and
+      # a cached post has no author watching who might reload it either.
+      Application.put_env(:vutuv, :moderate_images, true)
+      on_exit(fn -> Application.put_env(:vutuv, :moderate_images, false) end)
+
+      post = recorded_post()
+      Fediverse.subscribe_remote_images()
+
+      Screenshots.deliver_due(force: true, capture: ok_capture())
+
+      assert_receive {:remote_images_changed, %{remote_post_id: id}}
+      assert id == post.id
+      assert job_of(post).moderation == "pending"
+    end
   end
 
   describe "moderation verdicts on a remote-owned row" do
     test "an approval releases the screenshot (and needs no member post)" do
       post = recorded_post()
       job = make_ready(job_of(post), "pending")
+      Fediverse.subscribe_remote_images()
 
       scan = %ImageScan{
         kind: "post_screenshot",
@@ -323,6 +342,12 @@ defmodule Vutuv.FediverseRemotePostScreenshotsTest do
 
       assert :ok = ImageSubjects.apply_approved(scan)
       assert PostScreenshot.ready?(job_of(post))
+
+      # Announced on the cached post's own topic: there is no member post here,
+      # so the author-and-followers fan-out every other capture uses would
+      # reach nobody (issue #1927).
+      assert_receive {:remote_images_changed, %{remote_post_id: announced}}
+      assert announced == post.id
     end
 
     test "a rejection clears the capture" do
@@ -335,12 +360,19 @@ defmodule Vutuv.FediverseRemotePostScreenshotsTest do
         fingerprint: job.screenshot
       }
 
+      Fediverse.subscribe_remote_images()
+
       assert :ok = ImageSubjects.apply_rejected(scan)
 
       job = job_of(post)
       assert job.status == "failed"
       assert job.moderation == "rejected"
       assert is_nil(job.screenshot)
+
+      # Announced too, because a card drawn during the scan is showing the
+      # mosaic preview of the very file this verdict has just deleted.
+      assert_receive {:remote_images_changed, %{remote_post_id: announced}}
+      assert announced == post.id
     end
 
     test "a stranded pending row is found for re-enqueue, owner-less" do

--- a/test/vutuv/moderation/remote_image_settled_test.exs
+++ b/test/vutuv/moderation/remote_image_settled_test.exs
@@ -45,7 +45,7 @@ defmodule Vutuv.Moderation.RemoteImageSettledTest do
 
     assert :ok = ImageSubjects.apply_approved(scan_for(image, image.file))
 
-    assert_receive {:remote_images_settled, %{remote_post_id: id}}
+    assert_receive {:remote_images_changed, %{remote_post_id: id}}
     assert id == post.id
     assert Repo.get!(RemoteImage, image.id).moderation == "approved"
   end
@@ -59,7 +59,7 @@ defmodule Vutuv.Moderation.RemoteImageSettledTest do
 
     assert :ok = ImageSubjects.apply_rejected(scan_for(image, image.file))
 
-    assert_receive {:remote_images_settled, %{remote_post_id: id}}
+    assert_receive {:remote_images_changed, %{remote_post_id: id}}
     assert id == post.id
   end
 
@@ -72,7 +72,7 @@ defmodule Vutuv.Moderation.RemoteImageSettledTest do
 
     assert :stale = ImageSubjects.apply_approved(scan_for(image, "img-stale.avif"))
 
-    refute_receive {:remote_images_settled, _}
+    refute_receive {:remote_images_changed, _}
   end
 
   test "a picture whose post is already gone announces nothing and does not raise" do
@@ -84,6 +84,6 @@ defmodule Vutuv.Moderation.RemoteImageSettledTest do
 
     assert :stale = ImageSubjects.apply_approved(scan_for(image, image.file))
 
-    refute_receive {:remote_images_settled, _}
+    refute_receive {:remote_images_changed, _}
   end
 end

--- a/test/vutuv/posts/screenshots_test.exs
+++ b/test/vutuv/posts/screenshots_test.exs
@@ -9,6 +9,8 @@ defmodule Vutuv.Posts.ScreenshotsTest do
 
   import Vutuv.PostsHelpers
 
+  alias Vutuv.Moderation.ImageScan
+  alias Vutuv.Moderation.ImageSubjects
   alias Vutuv.Posts
   alias Vutuv.Posts.PostImage
   alias Vutuv.Posts.PostScreenshot
@@ -301,6 +303,52 @@ defmodule Vutuv.Posts.ScreenshotsTest do
 
       assert_receive {:post_screenshot_ready, %{post_id: ready_id}}
       assert ready_id == post.id
+    end
+
+    test "a capture the AI gate still holds is announced too (issue #1927)" do
+      # It used to wait for the verdict, which was right while a held capture
+      # drew nothing at all. Since issue #1720 it draws its mosaic preview, so
+      # the capture landing is itself something to show — and the author has
+      # been looking at a picture-less card since they posted the link.
+      Application.put_env(:vutuv, :moderate_images, true)
+      on_exit(fn -> Application.put_env(:vutuv, :moderate_images, false) end)
+
+      author = user()
+      Vutuv.Activity.subscribe(author.id)
+      post = url_post(author)
+      {:ok, _job} = Screenshots.reconcile(post)
+
+      Screenshots.deliver_due(force: true, capture: ok_capture())
+
+      assert_receive {:post_screenshot_ready, %{post_id: ready_id}}
+      assert ready_id == post.id
+      assert Repo.get_by!(PostScreenshot, post_id: post.id).moderation == "pending"
+    end
+
+    test "a refused capture is announced, so an open card drops its mosaic" do
+      # The other end of the same wait: the verdict deletes the file the mosaic
+      # on an open card names, so a page nobody tells goes on asking for it and
+      # draws a broken image.
+      Application.put_env(:vutuv, :moderate_images, true)
+      on_exit(fn -> Application.put_env(:vutuv, :moderate_images, false) end)
+
+      author = user()
+      post = url_post(author)
+      {:ok, _job} = Screenshots.reconcile(post)
+      Screenshots.deliver_due(force: true, capture: ok_capture())
+      job = Repo.get_by!(PostScreenshot, post_id: post.id)
+
+      Vutuv.Activity.subscribe(author.id)
+
+      assert :ok =
+               ImageSubjects.apply_rejected(%ImageScan{
+                 kind: "post_screenshot",
+                 subject_id: job.id,
+                 fingerprint: job.screenshot
+               })
+
+      assert_receive {:post_screenshot_removed, %{post_id: gone_id}}
+      assert gone_id == post.id
     end
 
     test "a transient failure keeps the job pending with backoff" do

--- a/test/vutuv_web/live/feed_remote_image_settles_test.exs
+++ b/test/vutuv_web/live/feed_remote_image_settles_test.exs
@@ -57,7 +57,7 @@ defmodule VutuvWeb.FeedRemoteImageSettlesTest do
     |> Ecto.Changeset.change(file: "img-abc.avif", moderation: "approved")
     |> Repo.update!()
 
-    Fediverse.broadcast_remote_images_settled(image.remote_post_id)
+    Fediverse.broadcast_remote_images_changed(image.remote_post_id)
   end
 
   test "the waiting tile becomes the picture with no reload", %{conn: conn} do

--- a/test/vutuv_web/live/remote_picture_arrives_test.exs
+++ b/test/vutuv_web/live/remote_picture_arrives_test.exs
@@ -1,0 +1,157 @@
+defmodule VutuvWeb.RemotePictureArrivesTest do
+  @moduledoc """
+  A picture on a cached post arrives while the reader is looking, and the card
+  shows it without a reload (issue #1927) — the half issue #1801 left out.
+
+  #1801 announced the AI gate's **verdict**, which is the end of a wait whose
+  median is 97 seconds. The wait a reader actually watches starts a whole
+  minute and a half earlier: the card is drawn at delivery, when the picture is
+  recorded and its bytes are not here yet, and about a second later they are —
+  from then on there is a mosaic preview to stand in for the picture
+  (issue #1720), or the picture itself where no vision model runs. Nobody ever
+  saw that mosaic on a post arriving in front of them, because nothing said the
+  bytes had landed.
+
+  The same second question is the link capture's: it reaches a cached post's
+  card ~13 seconds after delivery and, until this, only on the next page load.
+
+  `async: false` — flips `:moderate_images` and `:uploads_dir_prefix`, which the
+  SQL sandbox does not roll back, and stubs the fediverse HTTP client.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Vutuv.MastodonHelpers
+
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.Media
+  alias Vutuv.Posts.PostScreenshot
+  alias Vutuv.Posts.Screenshots
+  alias Vutuv.Screenshot
+
+  setup do
+    tmp =
+      Path.join(System.tmp_dir!(), "vutuv_picture_arrives_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmp)
+
+    put_config(:uploads_dir_prefix, tmp)
+    put_config(:moderate_images, true)
+
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    {:ok, tmp: tmp}
+  end
+
+  defp put_config(key, value) do
+    original = Application.fetch_env(:vutuv, key)
+    Application.put_env(:vutuv, key, value)
+
+    on_exit(fn ->
+      case original do
+        {:ok, was} -> Application.put_env(:vutuv, key, was)
+        :error -> Application.delete_env(:vutuv, key)
+      end
+    end)
+  end
+
+  # A real, decodable JPEG — the store runs libvips over it, and the mosaic is
+  # derived from those very pixels, so a fake binary would test nothing.
+  defp jpeg_bytes do
+    {:ok, image} = Image.new(64, 64, color: [40, 90, 160])
+    {:ok, bytes} = Image.write(image, :memory, suffix: ".jpg")
+    bytes
+  end
+
+  defp serving_bytes(bytes) do
+    Application.put_env(:vutuv, :fediverse_req_options,
+      plug: fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("image/jpeg")
+        |> Plug.Conn.send_resp(200, bytes)
+      end
+    )
+
+    on_exit(fn -> Application.delete_env(:vutuv, :fediverse_req_options) end)
+  end
+
+  defp followed_post(user, attrs) do
+    account = remote_account()
+
+    Repo.insert!(%Follow{
+      user_id: user.id,
+      remote_account_id: account.id,
+      state: "accepted",
+      follow_activity_id: "https://vutuv.test/#{user.id}/actor#follows/1"
+    })
+
+    cached_post(account, attrs)
+  end
+
+  defp attachment,
+    do: %{
+      "type" => "Document",
+      "mediaType" => "image/jpeg",
+      "url" => "https://social.example/media/#{System.unique_integer([:positive])}.jpg",
+      "name" => "Ein Zug"
+    }
+
+  test "the wordless tile becomes the mosaic the moment the bytes land", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    post = followed_post(user, content_text: "Kinder.")
+    [image] = Media.record_attachments(post, [attachment()], false)
+    serving_bytes(jpeg_bytes())
+
+    {:ok, view, html} = live(conn, ~p"/feed")
+
+    # What a delivery draws: the row is here, the download is not.
+    assert html =~ "data-remote-image-pending"
+    refute html =~ "data-remote-image-pixelated"
+
+    assert :ok = Media.fetch_now(image)
+
+    html = render(view)
+    assert html =~ "data-remote-image-pixelated"
+    refute html =~ "data-remote-image-pending"
+
+    # Still waiting for the verdict, so the line under the card still says what
+    # the wait is — the picture has not been released, only stood in for.
+    assert has_element?(view, "[data-remote-images-checking]")
+    assert Repo.reload!(image).moderation == "pending"
+  end
+
+  test "a link capture reaches the post's own page with no reload", %{conn: conn, tmp: tmp} do
+    # The `:assigns` half of the same question, and the other picture a card
+    # draws: the capture is taken ~13 seconds after the post is cached, long
+    # after a reader who followed the link from their feed has the page open.
+    {conn, user} = create_and_login_user(conn)
+    post = followed_post(user, content_text: "Lesenswert: https://blog.example/entry")
+    {:ok, _job} = Screenshots.reconcile(post)
+
+    {:ok, view, html} = live(conn, ~p"/system/fediverse/post/#{post.id}")
+    refute html =~ "data-screenshot-pixelated"
+
+    Screenshots.deliver_due(force: true, capture: capture(tmp))
+
+    # The gate still has it, so what appears is the mosaic — which is the whole
+    # point: there was nothing to show before, and this is something.
+    assert render(view) =~ "data-screenshot-pixelated"
+    assert Repo.get_by!(PostScreenshot, remote_post_id: post.id).moderation == "pending"
+  end
+
+  # The capture worker's Chromium seam, with a real picture stored the way the
+  # browser path stores one — the mosaic preview is written from those bytes.
+  defp capture(tmp) do
+    fn job ->
+      {:ok, stored} = Screenshot.store({upload(tmp), job})
+      {:ok, %{screenshot: stored, width: 400, height: 264}}
+    end
+  end
+
+  defp upload(tmp) do
+    path = Path.join(tmp, "capture-#{System.unique_integer([:positive])}.png")
+    {:ok, image} = Image.new(400, 264, color: [30, 90, 160])
+    {:ok, _} = Image.write(image, path)
+    %Plug.Upload{filename: Path.basename(path), path: path, content_type: "image/png"}
+  end
+end


### PR DESCRIPTION
A photo post from another network showed the grey "picture is being checked"
tile for the whole AI scan, although the mosaic preview meant to stand in for it
(#1720) is on disk a second later. The card is drawn at delivery, when the row
exists and its bytes do not, and the only live signal was the verdict: median
97 s against a median of 1 s for the download (788 rows of the production copy).

`Vutuv.Fediverse.Media.try_once/1` now announces the bytes landing on the same
topic, a link capture announces itself when it is taken rather than only when it
is judged, and a refusal announces too, since it deletes the file an open card
is showing.

Not smoke-tested in a browser: triggering it needs an inbound delivery from
another server. Follow-up in #1928.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01PgPp7VzpyMmUXid8GGoPH7
