### PR TITLE
Gate this repository, not every repository

### DIFF
--- a/.claude/hooks/precommit-before-push.sh
+++ b/.claude/hooks/precommit-before-push.sh
@@ -8,8 +8,8 @@
 # The tool call arrives as JSON on stdin. Exit 2 blocks the call and feeds the
 # reason back to Claude; exit 0 lets it through.
 #
-# Three rules this script exists to honour, each learned the hard way (the
-# first two on 2026-08-02, the third on 2026-08-28):
+# Four rules this script exists to honour, each learned the hard way (the
+# first two on 2026-08-02, the third on 2026-08-28, the fourth on 2026-09-02):
 #
 #   1. CHECK THE TREE THE PUSH COMES FROM. This used to `cd $CLAUDE_PROJECT_DIR`,
 #      which names the *session's* project directory, not the worktree the push
@@ -34,6 +34,15 @@
 #      carrying only those buys nothing — #1774 paid that run nine times for
 #      one Markdown file. Such a push is now skipped; see the exemption below
 #      for what counts and, more importantly, what does not.
+#
+#   4. GATE THIS REPOSITORY, NOT EVERY REPOSITORY. Being a session-wide
+#      `PreToolUse` on Bash, this sees pushes that have nothing to do with
+#      vutuv, and it used to answer them by shape — a `mix.exs` at the top —
+#      which blocked every foreign repository without one and would have run
+#      our precommit inside every foreign repository with one. The user's own
+#      `!` command is blocked the same way, so there was no way past it from
+#      an open session; it stranded a dotfiles commit exactly so. The
+#      identity question below is asked first and by repository, not shape.
 #
 # LIMITS — read this as a backstop, not a sandbox. It sees `git` invoked
 # directly in a segment of one Bash tool call. It cannot see a push made through
@@ -236,20 +245,60 @@ toplevel=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)
 [ -n "$toplevel" ] ||
   block "cannot tell which git worktree this push comes from (looked in: ${dir:-<empty>}). Refusing to guess."
 
-# A GitHub wiki lives in a repository of its own (`<repo>.wiki.git`) and can
-# never hold a mix.exs: no suite, no CI, no deploy, so precommit has nothing to
-# vouch for here and the gate would only make a wiki page unpublishable. Scoped
-# to that one shape, the remote URL ENDING in `.wiki.git`, and a remote that
-# cannot be read is not an exemption but an unanswered question, so it falls
-# through to the block below.
-if [ ! -f "$toplevel/mix.exs" ]; then
-  origin=$(git -C "$toplevel" remote get-url origin 2>/dev/null)
-  case "$origin" in
-    *.wiki.git) allow ;;
-  esac
+# ── Is this push out of THIS repository? ───────────────────────────────────
+# Asked here, before the `mix.exs` test below, and the order is the whole
+# point. Testing for a `mix.exs` first says "gate every Elixir project", which
+# on this machine is 26 of them: the hook would `cd` into a stranger's
+# checkout and run OUR precommit there, failing outright in the nine that have
+# no `precommit` alias — the same stranding rule 4 is about, with different
+# victims. Identity first, and shape only once the answer is yes.
+#
+# Two ways to answer yes, because one of them alone fails in the permissive
+# direction:
+#
+#   * the same `--git-common-dir` — every worktree of this repository shares
+#     one, and `--path-format=absolute` canonicalizes symlinks, so the two
+#     answers can be compared as strings;
+#   * the same origin, spellings folded — a second full CLONE has a common dir
+#     of its own and would otherwise read as a stranger, and it can really
+#     push vutuv code to vutuv's `main`. Scheme, `user@`, the ssh colon, a
+#     trailing `.git` and case all fold; an explicit ssh port does not, and
+#     that spelling would read as foreign.
+#
+# Everything else is somebody else's repository, and `git push` sends the
+# objects of the tree it resolved, so it cannot carry a line of vutuv code:
+# a dotfiles checkout (where `~/.claude/CLAUDE.md` actually lives), a GitHub
+# wiki (`<repo>.wiki.git` is a repository of its own), any other project.
+# Failing to identify OUR OWN repository, though, is an unanswered question
+# and blocks rather than waving every push through.
+common_dir_of() {
+  git -C "$1" rev-parse --path-format=absolute --git-common-dir 2>/dev/null
+}
 
-  block "$toplevel is not the vutuv project root (no mix.exs), so the precommit gate cannot vouch for this push."
+origin_of() {
+  git -C "$1" remote get-url origin 2>/dev/null |
+    sed -e 's#^[a-z][a-z0-9+.-]*://##' -e 's#^[^@/]*@##' -e 's#:#/#' -e 's#/*$##' -e 's#\.git$##' |
+    tr '[:upper:]' '[:lower:]'
+}
+
+hook_repo=${BASH_SOURCE[0]%/*}
+ours=$(common_dir_of "$hook_repo")
+[ -n "$ours" ] ||
+  block "this hook cannot find the repository it belongs to (looked in: $hook_repo), so it cannot tell a vutuv push from any other."
+
+theirs=$(common_dir_of "$toplevel")
+[ -n "$theirs" ] ||
+  block "cannot tell which repository $toplevel belongs to. Refusing to guess."
+
+if [ "$ours" != "$theirs" ]; then
+  our_origin=$(origin_of "$hook_repo")
+  their_origin=$(origin_of "$toplevel")
+
+  [ -n "$our_origin" ] && [ "$our_origin" = "$their_origin" ] || allow
 fi
+
+[ -f "$toplevel/mix.exs" ] ||
+  block "$toplevel belongs to this repository but has no mix.exs, so the precommit gate cannot vouch for this push."
 
 # ── Does this push carry anything precommit could look at? ──────────────────
 # The exemption is narrow on purpose: skip only when EVERY file the push newly

--- a/test/vutuv/precommit_hook_test.exs
+++ b/test/vutuv/precommit_hook_test.exs
@@ -115,19 +115,6 @@ defmodule Vutuv.PrecommitHookTest do
       assert decision =~ "cannot tell which git worktree"
     end
 
-    test "a push from a tree that is not the project blocks", ctx do
-      # Resolvable as a git repo is not enough — it must be the vutuv checkout,
-      # or precommit would vouch for the wrong thing. This repository has no
-      # remote, so it is also the degraded path of the wiki exemption below:
-      # an unreadable remote is an unanswered question, not an exemption.
-      tmp = tmp_repo()
-
-      decision = decide(ctx, "git -C #{tmp} push")
-
-      assert decision =~ "BLOCK", "expected a block, got: #{decision}"
-      assert decision =~ "not the vutuv project root"
-    end
-
     test "without jq a push is refused rather than waved through", ctx do
       # The dependency this hook reads its input with, removed. Silence must
       # mean "block", never "allow".
@@ -141,31 +128,43 @@ defmodule Vutuv.PrecommitHookTest do
     end
   end
 
-  describe "the wiki exemption" do
-    # A GitHub wiki lives in a repository of its own (`<repo>.wiki.git`): no
-    # mix.exs, no suite, no deploy, so precommit has nothing to vouch for and
-    # the gate would make a wiki page unpublishable. The exemption is scoped to
-    # that one shape, and every other reading of it still blocks.
-    test "a push from a wiki clone is allowed, ssh or https", ctx do
-      ssh = tmp_repo(remote: "git@github.com:wintermeyer/vutuv.wiki.git")
-      https = tmp_repo(remote: "https://github.com/wintermeyer/vutuv.wiki.git")
-
-      assert decide(ctx, "git -C #{ssh} push origin master") == "ALLOW"
-      assert decide(ctx, "git -C #{https} push") == "ALLOW"
+  describe "the foreign-repository exemption" do
+    # This hook is a session-wide `PreToolUse` on Bash, so it sees every push
+    # made while a vutuv session is open — including pushes that have nothing
+    # to do with vutuv. `git push` sends the objects of the tree it resolved,
+    # so a push out of another repository cannot carry a line of vutuv code and
+    # precommit has nothing to vouch for. Blocking those made them impossible
+    # from a vutuv session, the user's own `!` command included, which is how
+    # the dotfiles commit holding this very rule got stranded.
+    test "a push from another repository is allowed", ctx do
+      # The dotfiles checkout that holds `~/.claude/CLAUDE.md`, a wiki clone
+      # (`<repo>.wiki.git` is a repository of its own), any other project.
+      assert decide(ctx, "git -C #{tmp_repo()} push") == "ALLOW"
     end
 
-    test "a remote that only looks like one still blocks", ctx do
-      # Calibration against a false positive: the URL has to *end* in
-      # `.wiki.git`, not merely mention it. The repository with no remote at
-      # all is the test above this describe block.
-      backup = tmp_repo(remote: "git@github.com:wintermeyer/vutuv.wiki.git.backup")
-      foreign = tmp_repo(remote: "git@github.com:someone/something.git")
+    test "another Elixir project is a stranger too", ctx do
+      # The half a `mix.exs`-first rule got backwards. There are two dozen
+      # other mix projects on this machine, and answering by shape sends the
+      # hook into one of them to run *our* precommit — which simply fails in
+      # the ones that have no `precommit` alias, with no way past it.
+      stranger = tmp_repo()
+      File.write!(Path.join(stranger, "mix.exs"), "# somebody else's project\n")
 
-      decision = decide(ctx, "git -C #{backup} push")
+      assert decide(ctx, "git -C #{stranger} push") == "ALLOW"
+    end
+
+    test "another clone of this repository is not a stranger", ctx do
+      # Calibration against reading the exemption as "a different checkout is
+      # somebody else's". A second full clone has a `--git-common-dir` of its
+      # own, so identity falls to the origin, and it really can push vutuv
+      # code to vutuv's main. Without a `mix.exs` that is our tree looking
+      # wrong — an unanswered question, not an exemption.
+      clone = tmp_repo(remote: origin_url(ctx.root))
+
+      decision = decide(ctx, "git -C #{clone} push")
 
       assert decision =~ "BLOCK", "expected a block, got: #{decision}"
-      assert decision =~ "not the vutuv project root"
-      assert decide(ctx, "git -C #{foreign} push") =~ "BLOCK"
+      assert decision =~ "has no mix.exs"
     end
   end
 
@@ -339,6 +338,14 @@ defmodule Vutuv.PrecommitHookTest do
     tmp
   end
 
+  # What the hook compares a foreign repository's origin against. Read from the
+  # checkout rather than written down, so the clone fixture matches whatever
+  # spelling this machine or CI cloned with.
+  defp origin_url(root) do
+    {url, 0} = System.cmd("git", ["-C", root, "remote", "get-url", "origin"])
+    String.trim(url)
+  end
+
   # A throwaway repository shaped like the vutuv checkout: a `mix.exs` on a base
   # commit registered as `upstream/main`, then one commit on branch `work`
   # touching `paths`. That second commit is what a push from it would carry.
@@ -348,7 +355,10 @@ defmodule Vutuv.PrecommitHookTest do
   # gains a source file, and the branch takes that in the two ways a long-lived
   # PR does.
   defp tmp_project(paths, opts \\ []) do
-    repo = tmp_repo()
+    # The origin is what makes this fixture a checkout of *this* project rather
+    # than a stranger with a mix.exs — the hook asks which repository before it
+    # asks what shape the tree has.
+    repo = tmp_repo(remote: origin_url(File.cwd!()))
     git = fn args -> {_, 0} = System.cmd("git", ["-C", repo | args]) end
 
     git.(["config", "user.email", "hook-test@example.com"])
@@ -389,11 +399,13 @@ defmodule Vutuv.PrecommitHookTest do
   # decoration: `@{upstream}` resolves through its fetch refspec and NOT through
   # `branch.work.merge` alone, so without it git answers nothing, and a fixture
   # built to tell two bases apart quietly stops telling them apart. Nothing ever
-  # contacts the address.
+  # contacts the address. It is deliberately not called `origin`: that name
+  # carries the fixture's identity as a checkout of this project, and the hook
+  # reads it to tell our repository from a stranger's.
   defp track(repo, git) do
-    git.(["remote", "add", "origin", Path.join(repo, "origin.git")])
-    git.(["update-ref", "refs/remotes/origin/work", "HEAD"])
-    git.(["branch", "--quiet", "--set-upstream-to=origin/work", "work"])
+    git.(["remote", "add", "pushed", Path.join(repo, "pushed.git")])
+    git.(["update-ref", "refs/remotes/pushed/work", "HEAD"])
+    git.(["branch", "--quiet", "--set-upstream-to=pushed/work", "work"])
   end
 
   # The branch has been pushed once, and main has moved since. The tracking ref


### PR DESCRIPTION
The push gate is a session-wide `PreToolUse` on Bash, so it sees every push made while a vutuv session is open. It answered them by the shape of the tree, a `mix.exs` at the top, and got both directions wrong. A push into an unrelated repository was blocked for want of one, from the Bash tool and from the user's own bang command alike, so there was no way past it while a session was open; that is how a dotfiles commit got stranded. A push out of one of the two dozen other Elixir projects on this machine went the other way, into the full gate, which simply fails in the ones with no `precommit` alias.

`.claude/hooks/precommit-before-push.sh` now asks which repository first and what shape it has second. Two ways to answer "ours": the same `--git-common-dir`, which every worktree shares, or the same origin with spellings folded, which catches a second full clone — that one has a common dir of its own and really can push vutuv code to `main`. Anything else is a stranger and goes through untouched. Failing to identify our own repository blocks, as every degraded path in that file does.

The test fixtures used to impersonate the project by carrying a `mix.exs`; they now do it by origin, so `track/2` names its tracking remote `pushed`.

Docs and tooling only, hot deploy.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01VYpGJqFTxRzpWU44GcVHn3
