### PR TITLE
The handle in a post header opens the account card

### DIFF
--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -306,9 +306,20 @@ LiveView can sit on either style.
   (the `/username` placeholder helper uses it to own up to a broken newsletter
   link); it is the one non-muted line, distinct from the grey `.error-page__hint`.
 - **The mention card is a body-level panel, not a page element** (`.actor-card*`
-  in `components.css`, `assets/js/mention_card.js`). A `@user@host` mention keeps
-  its link to that server; a plain left click by a signed-in member opens a
-  small card under the word instead. It answers three questions in that order:
+  in `components.css`, `assets/js/mention_card.js`). Every remote handle keeps
+  its own link; a plain left click by a signed-in member opens a small card
+  under it instead. Two surfaces write the `a[data-remote-actor]` hook the JS
+  binds to: a `@user@host` in rendered text (`VutuvWeb.Markdown`, which leaves
+  for that server) and every remote handle a post card draws — its header and
+  its reaction chips alike — through the one function that owns where such a
+  handle leads and what a press does, `PostComponents.remote_actor_link/3`
+  (which leads to that account's page here). Both from that one place, because a
+  chip answering "who is this" differently from the card it sits under is what
+  that function exists to prevent. Those anchors are `<.link navigate>`, so the
+  JS stops the click's bubble as well as its default: LiveView's nav listener on
+  `window` reads `data-phx-link` without asking whether the default was
+  prevented — which also swallows `phx-click-away`, dispatched from the same
+  listener and used nowhere in the app today. It answers three questions in that order:
   **who is this** (a `.actor-card__chip` carrying the globe and the host, then
   name, address and a two-line self-description), **is it worth it**
   (`.actor-card__stats` — how many of their posts we hold for *this* reader and
@@ -319,7 +330,17 @@ LiveView can sit on either style.
   the refusal in red on hover — never a status pill beside a loud Unfollow,
   which said the same thing twice and made the one unwanted act the loudest
   control — a `.actor-card__more` ⋯ holding both mutes and the address, and
-  `.actor-card__links`, both ways onward in one weight). **One fragment serves
+  `.actor-card__links`, both ways onward in one weight — the one that leaves
+  this site **names where it goes** ("View the original on
+  chaos.social/@feed", `RemoteActorCardHTML.origin_address/1`, which borrows
+  both halves: `RemoteHtml.display_form/1` drops the scheme, the `www.` and a
+  trailing slash — case-insensitively, since the string is a remote server's and
+  may well say `HTTPS://` — and `SocialFeed.Post.truncate/2` cuts it at 40, a
+  measurement of *this* card, so the host at the front can never be the part
+  that goes. An actor URI need not be spelled like the `@user@host` above it, so
+  the destination is not guessable from the card, and `overflow-wrap: anywhere`
+  is what lets an address with no spaces in it wrap rather than overflow).
+  **One fragment serves
   both shapes**: `.actor-card--sheet` restyles it for the phone (grab bar,
   stacked full-width targets, the ⋯ menu in the flow rather than floating, the
   links as full-width rows), and the only thing that cannot be CSS travels as an

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -3891,6 +3891,11 @@ html.lightbox-open { overflow: hidden; }
   color: var(--color-brand-600);
   font-weight: 600;
   text-decoration: none;
+  /* The way out names its destination, and an address has no spaces to break
+     at. `anywhere` and not `break-word`: only the former lowers the box's
+     min-content width, which is what a flex item (the sheet form's rows) sizes
+     against — with `break-word` the row simply overflows instead. */
+  overflow-wrap: anywhere;
 }
 .actor-card__links a:hover { text-decoration: underline; }
 .actor-card__go { opacity: 0.6; }

--- a/assets/js/mention_card.js
+++ b/assets/js/mention_card.js
@@ -1,16 +1,21 @@
-// The card behind a `@user@host` mention.
+// The card behind a remote handle.
 //
-// The mention stays a link to that server (`VutuvWeb.Markdown`), and this
-// intercepts the plain left click on it to open a small card instead: who that
-// account is, one Follow button, and the two ways onward (their page here, the
-// original out there). Every other way of following the link is left alone —
-// a modified click, a middle click, "copy link address", a visitor who is not
-// signed in, and a page whose JavaScript never arrived all get today's
-// behaviour, because the `href` is still the whole truth of that anchor.
+// The handle keeps its own link, and this intercepts the plain left click on it
+// to open a small card instead: who that account is, one Follow button, and the
+// two ways onward (their page here, the original out there). Every other way of
+// following the link is left alone — a modified click, a middle click, "copy
+// link address", a visitor who is not signed in, and a page whose JavaScript
+// never arrived all get today's behaviour, because the `href` is still the
+// whole truth of that anchor.
 //
-// It reaches every rendered `@user@host`, which is more than posts: a chat
-// message and a work-experience description run through the same renderer, and
-// the same reader wants the same thing there.
+// It binds to `a[data-remote-actor]`, wherever that is written. Two places
+// write it. A `@user@host` inside rendered text (`VutuvWeb.Markdown`), which is
+// more than posts — a chat message and a work-experience description run
+// through the same renderer. And the handle in the header of a card from
+// another network (`VutuvWeb.PostComponents`), where the reader is asking the
+// same question about the same account and until now got a page they had to
+// come back from. The two anchors lead different places when the card cannot
+// open, which is why `followTheLink` reads the target rather than assuming one.
 //
 // The card's markup comes from the server on every act
 // (`VutuvWeb.RemoteActorCardController`), so no sentence about a follow, a
@@ -168,14 +173,33 @@ const ACTS = {
   "mute-host": { path: "/mute", method: "POST", extra: "&scope=host" },
 }
 
-// The mention's own link, taken as soon as the enhancement gives up: a session
-// that expired, a server that answered with something else. `window.open`
-// keeps the new tab the anchor asks for; a blocked popup falls back to this
-// tab, which is still where the reader wanted to go.
+// The anchor's own link, taken as soon as the enhancement gives up: a session
+// that expired, a server that answered with something else. Where it leads is
+// the anchor's business and not this file's — a mention leaves for the other
+// server in a new tab, a card header's handle leads to that account's page here
+// and belongs in this one — so the anchor's target decides. A blocked popup
+// falls back to this tab, which is still where the reader wanted to go.
 function followTheLink(link) {
   const href = link.getAttribute("href")
   if (!href) return
-  if (!window.open(href, "_blank", "noopener,noreferrer")) window.location.assign(href)
+  if (link.target === "_blank" && window.open(href, "_blank", "noopener,noreferrer")) return
+  window.location.assign(href)
+}
+
+// The click is ours, and saying so takes both halves. `preventDefault` alone is
+// enough for a mention, which is a plain anchor — but a card header's handle is
+// a `<.link navigate>`, and LiveView's own nav listener on `window` never asks
+// whether the default was prevented: it reads `data-phx-link` and navigates, so
+// the card would open and the page would leave underneath it in one gesture.
+// Stopping the bubble at `document` keeps the event from reaching that listener
+// at all, and only ever on the presses this file has taken over.
+//
+// The one thing this also swallows is `phx-click-away`, which LiveView dispatches
+// from the same window listener. The app uses none today; the day a page with
+// remote cards does, this is where it goes quiet.
+function keepTheClick(e) {
+  e.preventDefault()
+  e.stopPropagation()
 }
 
 async function open(link) {
@@ -346,11 +370,11 @@ document.addEventListener("click", (e) => {
       return
     }
 
-    // A click anywhere else closes it — and on the mention it belongs to, that
+    // A click anywhere else closes it — and on the anchor it belongs to, that
     // is the whole gesture: pressing the word again puts the card away.
     const sameMention = anchor === link
     close()
-    if (sameMention) return e.preventDefault()
+    if (sameMention) return keepTheClick(e)
   }
 
   if (!link) return
@@ -364,7 +388,7 @@ document.addEventListener("click", (e) => {
   if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return
   if (!document.querySelector("[data-account-menu]")) return
 
-  e.preventDefault()
+  keepTheClick(e)
   open(link)
 })
 

--- a/lib/vutuv/fediverse/handle.ex
+++ b/lib/vutuv/fediverse/handle.ex
@@ -96,6 +96,34 @@ defmodule Vutuv.Fediverse.Handle do
 
   def short(handle), do: handle
 
+  @doc """
+  The bare `user@host` an `@user@host` handle names, or nil when the handle
+  names none: `"@tagesschau@ard.social"` → `"tagesschau@ard.social"`.
+
+  The address form is what a surface hands to the account card
+  (`assets/js/mention_card.js` reads it off `data-remote-actor`) and what
+  `Vutuv.Fediverse.RemoteFollow.parse_address/1` takes on the way back in. Here
+  rather than at those call sites because this module already owns the two
+  halves of a handle — it is `short/1`'s split, read the other way round — and a
+  handle is not always an address: `display/2` falls back to `@name` and to a
+  bare `@host` when the actor document carried no username, and nil is what says
+  so.
+
+  Deliberately **not** `RemoteFollow.parse_address/1`, which is for a string
+  somebody typed or pasted: its two charset regexes are re-validating a handle
+  this server composed moments earlier (measured at 2.9 µs against 0.17 µs for
+  the split), and the surface that reads the attribute back parses it properly
+  anyway.
+  """
+  def address("@" <> rest) do
+    case String.split(rest, "@", parts: 2) do
+      [name, host] when name != "" and host != "" -> rest
+      _no_address -> nil
+    end
+  end
+
+  def address(_handle), do: nil
+
   @doc "The server an account URI names, or nil."
   def host(uri) when is_binary(uri) do
     case URI.parse(uri) do

--- a/lib/vutuv/remote_html.ex
+++ b/lib/vutuv/remote_html.ex
@@ -348,14 +348,21 @@ defmodule Vutuv.RemoteHtml do
     end
   end
 
-  # Both sides reduced to what a server *shows* of an address: no scheme, no
-  # `www.`, no trailing slash. The label is written in that form and the `href`
-  # is not, so neither can be compared to the other as it stands. The scheme
-  # goes by a case-insensitive match on purpose (a remote server may well write
-  # `HTTPS://`), which is also why `Vutuv.WebVerification.normalize_url/1`
-  # cannot serve here: it works on a parsed `%URI{}`, and a cut label does not
-  # parse as one.
-  defp display_form(url) do
+  @doc """
+  What a server *shows* of an address: no scheme, no `www.`, no trailing slash.
+
+  Written for comparing a cut anchor label against its own `href` (neither is in
+  the other's form as it stands), and public because it is also how an address
+  is written when a **reader** is meant to check where a link goes — the account
+  card's way out (`VutuvWeb.RemoteActorCardHTML.origin_address/1`) reduces an
+  actor URI with it before cutting it to the card's width.
+
+  The scheme goes by a case-insensitive match on purpose (a remote server may
+  well write `HTTPS://`), which is also why `Vutuv.WebVerification.normalize_url/1`
+  cannot serve here: it works on a parsed `%URI{}`, and a cut label does not
+  parse as one.
+  """
+  def display_form(url) do
     url
     |> String.replace(~r{\Ahttps?://}i, "")
     |> String.replace_prefix("www.", "")

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -1553,7 +1553,7 @@ defmodule VutuvWeb.PostComponents do
           {@author}
         </span>
         <.link
-          {remote_actor_destination(@account_id, @actor_uri)}
+          {remote_actor_link(@account_id, @actor_uri, @handle)}
           data-remote-account={@account_id}
           data-remote-handle={@handle}
           title={@handle}
@@ -1635,7 +1635,8 @@ defmodule VutuvWeb.PostComponents do
     "inline-flex max-w-full items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300"
   end
 
-  # Where a remote handle leads, as the attributes to splat onto a `<.link>`.
+  # Where a remote handle leads and what a press on it does, as the attributes
+  # to splat onto a `<.link>`.
   #
   # Inward when we know the account (issue #1162): the handle is the thing a
   # reader taps to ask "who is this", and the answer to that is a page here
@@ -1644,14 +1645,38 @@ defmodule VutuvWeb.PostComponents do
   # in the footer. Straight out when we do not know them, since there would be
   # nothing to show.
   #
+  # And a plain left click answers that question without going anywhere at all:
+  # `data-remote-actor` is what `assets/js/mention_card.js` binds to, so it opens
+  # the account card over the handle — who this is, one Follow button, both ways
+  # onward — the same card a `@user@host` written inside a post body already
+  # opens. Everything else about the anchor is untouched, so a middle click, a
+  # copied link, a reader who is not signed in and a page whose JavaScript never
+  # arrived all still land on the destination above.
+  #
   # One definition, because the header of every remote card and the reaction
   # chips ask the same question, and a chip that answered it differently from
-  # the card above it would be the same handle leading two places.
+  # the card above it would be the same handle leading two places. The hook
+  # therefore lives here rather than at either call site — which is also why
+  # this takes the handle: nothing else on the way in carries the address.
+  defp remote_actor_link(account_id, actor_uri, handle),
+    do: remote_actor_destination(account_id, actor_uri) ++ card_hook(handle)
+
   defp remote_actor_destination(nil, actor_uri),
     do: [href: actor_uri, target: "_blank", rel: "nofollow noopener noreferrer"]
 
   defp remote_actor_destination(account_id, _actor_uri),
     do: [navigate: ~p"/system/fediverse/account/#{account_id}"]
+
+  # Nothing, for a handle that is not an address: `Handle.display/2` falls back
+  # to `@name` and to a bare `@host` when the actor document carried no
+  # username, and the card cannot resolve either. Such a handle keeps today's
+  # behaviour rather than opening a card that can only say it failed.
+  defp card_hook(handle) do
+    case Handle.address(handle) do
+      nil -> []
+      address -> ["data-remote-actor": address]
+    end
+  end
 
   # The lock line. The same glyph a restricted vutuv post wears, so "not
   # everybody sees this" reads the same way across the app; the sentence is the
@@ -5653,12 +5678,14 @@ defmodule VutuvWeb.PostComponents do
         <p :if={@shown != []} class="flex flex-wrap items-center gap-x-2 gap-y-1">
           <%!-- A chip is somebody the reader may well want to know more about —
                 that is the whole point of naming them — so it goes wherever the
-                handle on a remote card goes (`remote_actor_destination/2`): to
-                their page here when we know them, out to their own server when
-                we do not. Only the destination differs; the chip is one. --%>
+                handle on a remote card goes (`remote_actor_link/3`): a press
+                opens the account card, and where the card cannot open the chip
+                leads to their page here when we know them, out to their own
+                server when we do not. Only the destination differs; the chip is
+                one. --%>
           <.link
             :for={actor <- @shown}
-            {remote_actor_destination(actor.account_id, actor.uri)}
+            {remote_actor_link(actor.account_id, actor.uri, actor.handle)}
             data-fediverse-reaction={actor.kind}
             data-remote-account={actor.account_id}
             title={reaction_title(actor)}

--- a/lib/vutuv_web/templates/remote_actor_card/card.html.heex
+++ b/lib/vutuv_web/templates/remote_actor_card/card.html.heex
@@ -240,8 +240,19 @@ renders the same element. --%>
       {gettext("Their account page here")}
       <span class="actor-card__go" aria-hidden="true">›</span>
     </.link>
-    <a href={origin} target="_blank" rel="nofollow noopener noreferrer">
-      {gettext("View the original")}
+    <%!-- And out to their server, named. "View the original" said only that
+    there was one; a reader about to leave this site for somebody else's reads
+    the address first, the way they would read a browser's status bar. It is not
+    guessable from the card either — an actor URI need not be spelled like the
+    `@user@host` above it (`/users/them`, `/u/them`, `/profile/them`). The name
+    is only a label: the `href` stays the whole URL.
+
+    `:if={origin}` rather than a second wording for a card with no address at
+    all: this used to render the sentence on an anchor carrying no `href`, which
+    is a way out that goes nowhere. There is nothing to link to in that state —
+    the account page above is gated on the same missing row. --%>
+    <a :if={origin} href={origin} target="_blank" rel="nofollow noopener noreferrer">
+      {gettext("View the original on %{url}", url: origin_address(origin))}
       <span class="actor-card__go" aria-hidden="true">↗</span>
     </a>
   </div>

--- a/lib/vutuv_web/views/remote_actor_card_html.ex
+++ b/lib/vutuv_web/views/remote_actor_card_html.ex
@@ -9,6 +9,8 @@ defmodule VutuvWeb.RemoteActorCardHTML do
   alias Vutuv.Fediverse.Handle
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemoteFollow
+  alias Vutuv.RemoteHtml
+  alias Vutuv.SocialFeed.Post
 
   embed_templates("../templates/remote_actor_card/*")
 
@@ -61,6 +63,42 @@ defmodule VutuvWeb.RemoteActorCardHTML do
       _unparsable -> nil
     end
   end
+
+  # How much of the address the way out may carry. Measured in the browser on
+  # the 20rem popover, where the whole sentence wraps to two lines at any real
+  # length and to three past ~45 characters: 40 is what leaves the account name
+  # whole for every ordinary actor URI while keeping the two lines. It was 32
+  # for one afternoon, which is one character short of
+  # `social.heise.de/users/heiseonline` and cut the account's name two letters
+  # from its end — the worst place for the cut to land, since the name is what
+  # the reader is checking. The number lives here and not beside the other
+  # display-URL caps because it is a measurement of *this* card.
+  @origin_address_max 40
+
+  @doc """
+  The destination, written the way a reader checks a link before following it:
+  the address as a server shows it, cut at the end when it is longer than the
+  card is wide.
+
+  Worth spelling out because the destination is **not** guessable from the card:
+  an actor URI need not be spelled like the `@user@host` above it
+  (`/users/them`, `/u/them`, `/profile/them` are all in use), and this is the one
+  control that takes the reader off this site.
+
+  Both halves are borrowed. `Vutuv.RemoteHtml.display_form/1` drops the scheme,
+  the `www.` and a trailing slash — and drops the scheme case-insensitively,
+  which matters here because the input is a *remote* server's actor URI and one
+  writing `HTTPS://` would otherwise spend eight of these characters saying that
+  a link is a link. `Vutuv.SocialFeed.Post.truncate/2` does the cut; its
+  word-boundary half never fires on a URL, which has no whitespace to find, so
+  what is left is the blunt cut this wants.
+
+  Only ever cut, never elided in the middle: the host leads the string and is
+  the fact this is carrying, so the part naming which server can never be the
+  part that goes.
+  """
+  def origin_address(url) when is_binary(url),
+    do: url |> RemoteHtml.display_form() |> Post.truncate(@origin_address_max)
 
   @doc """
   The colours the one state-carrying follow button wears, as a modifier rather

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -9,19 +9,19 @@
 msgid ""
 msgstr "Language: de\n"
 
-#: lib/vutuv_web/controllers/page_controller.ex:250
+#: lib/vutuv_web/controllers/page_controller.ex:251
 #: lib/vutuv_web/templates/layout/app.html.heex:111
 #, elixir-autogen
 msgid "About us"
 msgstr "Impressum"
 
-#: lib/vutuv_web/components/ui.ex:4414
-#: lib/vutuv_web/components/ui.ex:4419
+#: lib/vutuv_web/components/ui.ex:4522
+#: lib/vutuv_web/components/ui.ex:4527
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
-#: lib/vutuv_web/live/organization_live/domains.ex:272
-#: lib/vutuv_web/live/organization_live/edit.ex:431
-#: lib/vutuv_web/live/organization_live/roles.ex:214
+#: lib/vutuv_web/live/organization_live/domains.ex:267
+#: lib/vutuv_web/live/organization_live/edit.ex:414
+#: lib/vutuv_web/live/organization_live/roles.ex:210
 #, elixir-autogen
 msgid "Add"
 msgstr "Eintrag hinzufügen"
@@ -33,7 +33,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
 #: lib/vutuv_web/live/organization_live/fediverse.ex:115
-#: lib/vutuv_web/live/organization_live/show.ex:915
+#: lib/vutuv_web/live/organization_live/show.ex:910
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -62,7 +62,7 @@ msgstr "Eine Adresse wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/text.ex:71
-#: lib/vutuv_web/components/ui.ex:4712
+#: lib/vutuv_web/components/ui.ex:4820
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -75,14 +75,14 @@ msgstr "Eine Adresse wurde geändert."
 msgid "Addresses"
 msgstr "Adressen"
 
-#: lib/vutuv_web/components/ui.ex:1506
-#: lib/vutuv_web/templates/page/index.html.heex:320
+#: lib/vutuv_web/components/ui.ex:1530
+#: lib/vutuv_web/templates/page/index.html.heex:319
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr "Schon ein Mitglied? Einloggen."
 
-#: lib/vutuv_web/components/ui.ex:4209
-#: lib/vutuv_web/components/ui.ex:4303
+#: lib/vutuv_web/components/ui.ex:4313
+#: lib/vutuv_web/components/ui.ex:4412
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -95,7 +95,7 @@ msgstr "Sind Sie sicher?"
 msgid "Avatar"
 msgstr "Avatar"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:412
+#: lib/vutuv_web/templates/user/edit.html.heex:407
 #, elixir-autogen
 msgid "Birthdate"
 msgstr "Geburtstag"
@@ -109,29 +109,29 @@ msgstr "Geburtstag"
 msgid "Birthday"
 msgstr "Geburtstag"
 
-#: lib/vutuv_web/components/saved_search_components.ex:114
-#: lib/vutuv_web/components/ui.ex:4203
-#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
-#: lib/vutuv_web/live/admin/user_delete_live.ex:212
-#: lib/vutuv_web/live/job_posting_live/form.ex:812
-#: lib/vutuv_web/live/organization_live/edit.ex:382
-#: lib/vutuv_web/live/organization_live/new.ex:231
-#: lib/vutuv_web/live/post_live/composer.ex:1697
+#: lib/vutuv_web/components/saved_search_components.ex:104
+#: lib/vutuv_web/components/ui.ex:4307
+#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
+#: lib/vutuv_web/live/admin/user_delete_live.ex:202
+#: lib/vutuv_web/live/job_posting_live/form.ex:806
+#: lib/vutuv_web/live/organization_live/edit.ex:369
+#: lib/vutuv_web/live/organization_live/new.ex:222
+#: lib/vutuv_web/live/post_live/composer.ex:1673
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:113
 #: lib/vutuv_web/templates/report/new.html.heex:103
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:259
-#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:26
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:255
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:53
-#: lib/vutuv_web/templates/user/edit.html.heex:138
-#: lib/vutuv_web/templates/user/edit.html.heex:467
-#: lib/vutuv_web/templates/user/edit.html.heex:516
-#: lib/vutuv_web/templates/username/confirm.html.heex:222
+#: lib/vutuv_web/templates/user/edit.html.heex:133
+#: lib/vutuv_web/templates/user/edit.html.heex:463
+#: lib/vutuv_web/templates/user/edit.html.heex:508
+#: lib/vutuv_web/templates/username/confirm.html.heex:220
 #, elixir-autogen
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -162,24 +162,24 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:3586
-#: lib/vutuv_web/components/ui.ex:4306
-#: lib/vutuv_web/live/admin/job_live.ex:489
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
-#: lib/vutuv_web/live/admin/organization_live.ex:398
-#: lib/vutuv_web/live/admin/user_delete_live.ex:172
+#: lib/vutuv_web/components/post_components.ex:3608
+#: lib/vutuv_web/components/ui.ex:4414
+#: lib/vutuv_web/live/admin/job_live.ex:486
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:657
+#: lib/vutuv_web/live/admin/organization_live.ex:399
+#: lib/vutuv_web/live/admin/user_delete_live.ex:167
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:28
 #: lib/vutuv_web/templates/dev_app/show.html.heex:135
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:59
-#: lib/vutuv_web/templates/settings/saved_searches.html.heex:75
+#: lib/vutuv_web/templates/settings/saved_searches.html.heex:70
 #, elixir-autogen
 msgid "Delete"
 msgstr "Löschen"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:686
-#: lib/vutuv_web/live/organization_live/edit.ex:301
-#: lib/vutuv_web/live/organization_live/edit.ex:314
+#: lib/vutuv_web/live/job_posting_live/form.ex:685
+#: lib/vutuv_web/live/organization_live/edit.ex:296
+#: lib/vutuv_web/live/organization_live/edit.ex:309
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
 #: lib/vutuv_web/templates/address/form_en.html.heex:11
 #: lib/vutuv_web/templates/address/form_generic.html.heex:13
@@ -202,20 +202,20 @@ msgstr "Beschreibung"
 msgid "Disable"
 msgstr "Inaktivieren"
 
-#: lib/vutuv_web/live/cv_live.ex:438
-#: lib/vutuv_web/live/post_live/composer.ex:2609
+#: lib/vutuv_web/live/cv_live.ex:428
+#: lib/vutuv_web/live/post_live/composer.ex:2548
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:3551
-#: lib/vutuv_web/components/ui.ex:4297
+#: lib/vutuv_web/components/post_components.ex:3573
+#: lib/vutuv_web/components/ui.ex:4405
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
-#: lib/vutuv_web/live/job_posting_live/show.ex:178
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
+#: lib/vutuv_web/live/job_posting_live/show.ex:173
 #: lib/vutuv_web/live/organization_live/show.ex:149
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
@@ -285,7 +285,7 @@ msgstr "E-Mail-Adresse eingeben"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:4676
+#: lib/vutuv_web/components/ui.ex:4784
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -306,7 +306,7 @@ msgid "Fax"
 msgstr "Fax"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:596
-#: lib/vutuv_web/templates/user/edit.html.heex:169
+#: lib/vutuv_web/templates/user/edit.html.heex:164
 #, elixir-autogen
 msgid "First Name"
 msgstr "Vorname"
@@ -325,9 +325,9 @@ msgstr "Follower"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:632
 #: lib/vutuv_web/agent_docs/text.ex:596
-#: lib/vutuv_web/components/fediverse_components.ex:400
-#: lib/vutuv_web/components/ui.ex:2705
-#: lib/vutuv_web/components/ui.ex:2740
+#: lib/vutuv_web/components/fediverse_components.ex:397
+#: lib/vutuv_web/components/ui.ex:2807
+#: lib/vutuv_web/components/ui.ex:2842
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:608
@@ -340,8 +340,8 @@ msgid "Following"
 msgstr "Folge ich"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:195
-#: lib/vutuv_web/templates/page/index.html.heex:118
-#: lib/vutuv_web/templates/user/edit.html.heex:206
+#: lib/vutuv_web/templates/page/index.html.heex:123
+#: lib/vutuv_web/templates/user/edit.html.heex:201
 #: lib/vutuv_web/views/account_event_text.ex:219
 #, elixir-autogen
 msgid "Gender"
@@ -374,7 +374,7 @@ msgstr "Sie folgen aktuell keinem anderen Account."
 msgid "Job Title"
 msgstr "Stellenbezeichnung"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:757
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:752
 #: lib/vutuv_web/templates/language/form_content.html.heex:5
 #: lib/vutuv_web/templates/language/show.html.heex:19
 #, elixir-autogen
@@ -382,7 +382,7 @@ msgid "Language"
 msgstr "Sprache"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:598
-#: lib/vutuv_web/templates/user/edit.html.heex:174
+#: lib/vutuv_web/templates/user/edit.html.heex:169
 #, elixir-autogen
 msgid "Last Name"
 msgstr "Nachname"
@@ -411,7 +411,7 @@ msgstr "Link wurde geändert."
 #: lib/vutuv_web/cv/html.ex:202
 #: lib/vutuv_web/cv/latex.ex:164
 #: lib/vutuv_web/cv/odt.ex:176
-#: lib/vutuv_web/live/cv_live.ex:336
+#: lib/vutuv_web/live/cv_live.ex:326
 #: lib/vutuv_web/templates/import/new.html.heex:13
 #: lib/vutuv_web/templates/url/edit.html.heex:4
 #: lib/vutuv_web/templates/url/index.html.heex:10
@@ -440,8 +440,8 @@ msgstr "Einloggen"
 msgid "Log Out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/live/shell_live.ex:1369
-#: lib/vutuv_web/live/shell_live.ex:1435
+#: lib/vutuv_web/live/shell_live.ex:1361
+#: lib/vutuv_web/live/shell_live.ex:1426
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -449,7 +449,7 @@ msgid "Log in"
 msgstr "Einloggen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:597
-#: lib/vutuv_web/templates/user/edit.html.heex:179
+#: lib/vutuv_web/templates/user/edit.html.heex:174
 #, elixir-autogen
 msgid "Middle Name"
 msgstr "Zweiter Vorname"
@@ -473,7 +473,7 @@ msgstr "Mehr"
 msgid "Name"
 msgstr "Name"
 
-#: lib/vutuv_web/components/post_components.ex:714
+#: lib/vutuv_web/components/post_components.ex:715
 #: lib/vutuv_web/live/notification_live/index.ex:742
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -486,7 +486,7 @@ msgid "New"
 msgstr "Neu"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:600
-#: lib/vutuv_web/templates/user/edit.html.heex:184
+#: lib/vutuv_web/templates/user/edit.html.heex:179
 #, elixir-autogen
 msgid "Nickname"
 msgstr "Spitzname"
@@ -567,7 +567,7 @@ msgid "Phone number updated successfully."
 msgstr "Telefonnummer wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:595
-#: lib/vutuv_web/templates/user/edit.html.heex:189
+#: lib/vutuv_web/templates/user/edit.html.heex:184
 #, elixir-autogen
 msgid "Prefix"
 msgstr "Titel"
@@ -603,7 +603,7 @@ msgstr "Profile von "
 msgid "Provider"
 msgstr "Provider"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1909
+#: lib/vutuv_web/live/post_live/composer.ex:1911
 #: lib/vutuv_web/live/section_reorder_live.ex:270
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -613,9 +613,9 @@ msgstr "Provider"
 msgid "Public"
 msgstr "Öffentlich"
 
-#: lib/vutuv_web/components/ui.ex:4202
-#: lib/vutuv_web/live/organization_live/edit.ex:376
-#: lib/vutuv_web/live/post_live/composer.ex:1924
+#: lib/vutuv_web/components/ui.ex:4306
+#: lib/vutuv_web/live/organization_live/edit.ex:367
+#: lib/vutuv_web/live/post_live/composer.ex:1926
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -625,40 +625,39 @@ msgstr "Öffentlich"
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
 #: lib/vutuv_web/templates/settings/preferences.html.heex:157
-#: lib/vutuv_web/templates/settings/preferences.html.heex:224
-#: lib/vutuv_web/templates/settings/preferences.html.heex:273
-#: lib/vutuv_web/templates/settings/preferences.html.heex:406
+#: lib/vutuv_web/templates/settings/preferences.html.heex:262
+#: lib/vutuv_web/templates/settings/preferences.html.heex:395
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
-#: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
-#: lib/vutuv_web/templates/user/edit.html.heex:462
+#: lib/vutuv_web/templates/settings/saved_searches.html.heex:61
+#: lib/vutuv_web/templates/user/edit.html.heex:458
 #: lib/vutuv_web/views/settings_html.ex:212
 #, elixir-autogen
 msgid "Save"
 msgstr "Speichern"
 
 #: lib/vutuv_web/components/browse_table.ex:346
-#: lib/vutuv_web/controllers/page_controller.ex:226
+#: lib/vutuv_web/controllers/page_controller.ex:227
 #: lib/vutuv_web/live/account_activity_live.ex:149
 #: lib/vutuv_web/live/admin/activity_live.ex:193
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:219
 #: lib/vutuv_web/live/directory_search_live.ex:181
-#: lib/vutuv_web/live/job_board_live.ex:418
+#: lib/vutuv_web/live/job_board_live.ex:410
 #: lib/vutuv_web/live/search_live.ex:60
-#: lib/vutuv_web/live/search_live.ex:658
-#: lib/vutuv_web/live/search_live.ex:684
-#: lib/vutuv_web/live/shell_live.ex:1234
-#: lib/vutuv_web/live/shell_live.ex:1418
-#: lib/vutuv_web/live/tag_live/timeline.ex:323
+#: lib/vutuv_web/live/search_live.ex:651
+#: lib/vutuv_web/live/search_live.ex:677
+#: lib/vutuv_web/live/shell_live.ex:1230
+#: lib/vutuv_web/live/shell_live.ex:1409
+#: lib/vutuv_web/live/tag_live/timeline.ex:319
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
-#: lib/vutuv_web/templates/admin/account/index.html.heex:39
+#: lib/vutuv_web/templates/admin/account/index.html.heex:35
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
 #: lib/vutuv_web/templates/layout/app.html.heex:155
 #, elixir-autogen
 msgid "Search"
 msgstr "Suche"
 
-#: lib/vutuv_web/components/post_components.ex:1759
+#: lib/vutuv_web/components/post_components.ex:1781
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -666,7 +665,7 @@ msgstr "Suche"
 msgid "Show"
 msgstr "Anzeigen"
 
-#: lib/vutuv_web/templates/page/index.html.heex:299
+#: lib/vutuv_web/templates/page/index.html.heex:298
 #, elixir-autogen
 msgid "Sign up for a free account"
 msgstr "Gratis-Konto erstellen"
@@ -686,7 +685,7 @@ msgstr "Slug"
 #: lib/vutuv_web/cv/latex.ex:179
 #: lib/vutuv_web/cv/odt.ex:185
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:760
-#: lib/vutuv_web/live/cv_live.ex:410
+#: lib/vutuv_web/live/cv_live.ex:400
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:10
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
@@ -723,12 +722,12 @@ msgstr "Profil wurde geändert."
 msgid "Profile deleted successfully."
 msgstr "Profil wurde gelöscht."
 
-#: lib/vutuv_web/views/user_html.ex:1019
+#: lib/vutuv_web/views/user_html.ex:1025
 #, elixir-autogen, elixir-format
 msgid "Social networks"
 msgstr "Soziale Netzwerke"
 
-#: lib/vutuv_web/views/user_html.ex:1026
+#: lib/vutuv_web/views/user_html.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Code & repositories"
 msgstr "Code & Repositorys"
@@ -747,7 +746,7 @@ msgid "Submit a bugreport or a feature request."
 msgstr "Fehler auf der Seite melden."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:599
-#: lib/vutuv_web/templates/user/edit.html.heex:194
+#: lib/vutuv_web/templates/user/edit.html.heex:189
 #, elixir-autogen
 msgid "Suffix"
 msgstr "Namenszusatz"
@@ -791,15 +790,15 @@ msgstr "Profil aktualisiert."
 msgid "User verified successfully."
 msgstr "User wurde verifiziert."
 
-#: lib/vutuv_web/components/ui.ex:4672
+#: lib/vutuv_web/components/ui.ex:4780
 #: lib/vutuv_web/controllers/username_controller.ex:428
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:832
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
 #: lib/vutuv_web/live/directory_search_live.ex:134
 #: lib/vutuv_web/live/notification_live/index.ex:1281
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
-#: lib/vutuv_web/templates/admin/account/index.html.heex:56
+#: lib/vutuv_web/templates/admin/account/index.html.heex:51
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
 #: lib/vutuv_web/templates/settings/security.html.heex:23
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:5
@@ -843,7 +842,7 @@ msgstr "Benutzername"
 msgid "Users"
 msgstr "Benutzer"
 
-#: lib/vutuv_web/components/ui.ex:1313
+#: lib/vutuv_web/components/ui.ex:1337
 #: lib/vutuv_web/views/user_html.ex:562
 #: lib/vutuv_web/views/user_html.ex:563
 #: lib/vutuv_web/views/user_html.ex:577
@@ -851,17 +850,17 @@ msgstr "Benutzer"
 msgid "vCard"
 msgstr "vCard"
 
-#: lib/vutuv_web/components/ui.ex:4367
+#: lib/vutuv_web/components/ui.ex:4475
 #: lib/vutuv_web/templates/user/show.html.heex:973
 #: lib/vutuv_web/templates/user/show.html.heex:996
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
 
-#: lib/vutuv_web/components/ui.ex:4780
+#: lib/vutuv_web/components/ui.ex:4888
 #: lib/vutuv_web/controllers/settings_controller.ex:171
-#: lib/vutuv_web/live/job_posting_live/form.ex:768
-#: lib/vutuv_web/live/organization_live/edit.ex:335
+#: lib/vutuv_web/live/job_posting_live/form.ex:767
+#: lib/vutuv_web/live/organization_live/edit.ex:330
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:295
@@ -875,7 +874,7 @@ msgstr "Sichtbarkeit"
 msgid "We can't find em' cap'n!"
 msgstr "Nichts zu finden, Käpt'n!"
 
-#: lib/vutuv_web/templates/page/index.html.heex:323
+#: lib/vutuv_web/templates/page/index.html.heex:322
 #, elixir-autogen
 msgid "We reserve the right to stop this service or delete your account anytime without warning."
 msgstr ""
@@ -956,12 +955,12 @@ msgstr "unserem Blog"
 msgid "An email has been sent to your email address with instructions on how to delete your account."
 msgstr "Eine E-Mail mit einem Löschlink wurde gerade an Sie verschickt."
 
-#: lib/vutuv_web/templates/page/index.html.heex:198
+#: lib/vutuv_web/templates/page/index.html.heex:203
 #, elixir-autogen
 msgid "Allow others to view your email address"
 msgstr "Diese E-Mail-Adresse soll auf meinem Profil öffentlich sichtbar sein."
 
-#: lib/vutuv_web/templates/page/index.html.heex:309
+#: lib/vutuv_web/templates/page/index.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "By creating an account you accept our {nutzungsbedingungen} and confirm that you have read our {datenschutz}."
 msgstr ""
@@ -1065,7 +1064,7 @@ msgstr "Es gab einen Fehler."
 msgid "General Info"
 msgstr "Allgemeines"
 
-#: lib/vutuv_web/live/admin/user_live.ex:346
+#: lib/vutuv_web/live/admin/user_live.ex:345
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:32
 #, elixir-autogen
 msgid "Verify"
@@ -1096,7 +1095,7 @@ msgstr "vutuv Login-PIN"
 msgid "Listings"
 msgstr "Listen"
 
-#: lib/vutuv_web/controllers/page_controller.ex:418
+#: lib/vutuv_web/controllers/page_controller.ex:408
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1152,8 +1151,8 @@ msgstr "Die URL kann nicht gefunden werden"
 msgid "Our search will try to match similar names to your search, so don't worry about spelling."
 msgstr "Die Suche nach Vor- und Nachnamen ist fuzzy (unscharf)."
 
-#: lib/vutuv_web/live/search_live.ex:737
-#: lib/vutuv_web/live/search_live.ex:762
+#: lib/vutuv_web/live/search_live.ex:730
+#: lib/vutuv_web/live/search_live.ex:755
 #, elixir-autogen
 msgid "Search Tips"
 msgstr "Hilfe bei der Suche"
@@ -1178,15 +1177,15 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:127
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:638
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:637
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:688
 #: lib/vutuv_web/live/admin/organization_live.ex:189
 #: lib/vutuv_web/live/admin/screenshot_live.ex:182
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:443
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
-#: lib/vutuv_web/live/admin/user_detail_live.ex:68
+#: lib/vutuv_web/live/admin/user_detail_live.ex:63
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1341
+#: lib/vutuv_web/live/shell_live.ex:1337
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1401,7 +1400,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:522
 #: lib/vutuv_web/agent_docs/text.ex:768
-#: lib/vutuv_web/components/ui.ex:4697
+#: lib/vutuv_web/components/ui.ex:4805
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1410,11 +1409,11 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:444
-#: lib/vutuv_web/live/cv_live.ex:315
-#: lib/vutuv_web/live/job_board_live.ex:277
-#: lib/vutuv_web/live/job_posting_live/form.ex:717
+#: lib/vutuv_web/live/cv_live.ex:305
+#: lib/vutuv_web/live/job_board_live.ex:276
+#: lib/vutuv_web/live/job_posting_live/form.ex:716
 #: lib/vutuv_web/live/search_live.ex:344
-#: lib/vutuv_web/live/search_live.ex:822
+#: lib/vutuv_web/live/search_live.ex:815
 #: lib/vutuv_web/live/tag_new_live.ex:35
 #: lib/vutuv_web/live/tag_new_live.ex:46
 #: lib/vutuv_web/live/tag_new_live.ex:53
@@ -1424,7 +1423,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/templates/admin/tag/new.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:5
 #: lib/vutuv_web/templates/import/new.html.heex:12
-#: lib/vutuv_web/templates/page/index.html.heex:133
+#: lib/vutuv_web/templates/page/index.html.heex:138
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:28
 #: lib/vutuv_web/templates/tag/show.html.heex:45
@@ -1591,10 +1590,10 @@ msgstr ""
 "Sie bekommen in den nächsten Sekunden oder Minuten eine E-Mail mit einem "
 "Login-Link."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:776
-#: lib/vutuv_web/live/job_board_live.ex:360
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:771
+#: lib/vutuv_web/live/job_board_live.ex:356
 #: lib/vutuv_web/live/job_posting_live/form.ex:548
-#: lib/vutuv_web/live/organization_live/edit.ex:331
+#: lib/vutuv_web/live/organization_live/edit.ex:326
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
 #: lib/vutuv_web/templates/address/country_input.html.heex:5
@@ -1628,7 +1627,7 @@ msgstr "Adressen von %{name}"
 msgid "Admin control panel"
 msgstr "Admin-Bereich"
 
-#: lib/vutuv_web/live/shell_live.ex:1421
+#: lib/vutuv_web/live/shell_live.ex:1412
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Mitteilungen"
@@ -1647,15 +1646,15 @@ msgstr "Zur Startseite"
 msgid "Check your inbox"
 msgstr "Schauen Sie in Ihr Postfach"
 
-#: lib/vutuv_web/components/ui.ex:2864
+#: lib/vutuv_web/components/ui.ex:2966
 #: lib/vutuv_web/live/admin/job_live.ex:321
-#: lib/vutuv_web/live/admin/job_live.ex:480
+#: lib/vutuv_web/live/admin/job_live.ex:477
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1553
-#: lib/vutuv_web/live/post_live/composer.ex:1655
-#: lib/vutuv_web/live/post_live/composer.ex:1656
-#: lib/vutuv_web/live/post_live/composer.ex:2486
-#: lib/vutuv_web/live/post_live/composer.ex:2752
+#: lib/vutuv_web/live/post_live/composer.ex:1529
+#: lib/vutuv_web/live/post_live/composer.ex:1631
+#: lib/vutuv_web/live/post_live/composer.ex:1632
+#: lib/vutuv_web/live/post_live/composer.ex:2425
+#: lib/vutuv_web/live/post_live/composer.ex:2691
 #: lib/vutuv_web/templates/layout/app.html.heex:188
 #: lib/vutuv_web/templates/layout/app.html.heex:194
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
@@ -1666,7 +1665,7 @@ msgstr "Schließen"
 
 #: lib/vutuv_web/templates/email/confirm.html.heex:9
 #: lib/vutuv_web/templates/username/confirm.html.heex:25
-#: lib/vutuv_web/templates/username/confirm.html.heex:165
+#: lib/vutuv_web/templates/username/confirm.html.heex:163
 #, elixir-autogen, elixir-format
 msgid "Confirm"
 msgstr "Bestätigen"
@@ -1676,17 +1675,17 @@ msgstr "Bestätigen"
 msgid "Confirm account deletion"
 msgstr "Kontolöschung bestätigen"
 
-#: lib/vutuv_web/controllers/page_controller.ex:254
+#: lib/vutuv_web/controllers/page_controller.ex:255
 #: lib/vutuv_web/templates/layout/app.html.heex:117
-#: lib/vutuv_web/templates/page/index.html.heex:316
+#: lib/vutuv_web/templates/page/index.html.heex:315
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
 msgstr "Datenschutzerklärung"
 
-#: lib/vutuv_web/controllers/page_controller.ex:260
+#: lib/vutuv_web/controllers/page_controller.ex:261
 #: lib/vutuv_web/templates/layout/app.html.heex:118
-#: lib/vutuv_web/templates/page/index.html.heex:316
+#: lib/vutuv_web/templates/page/index.html.heex:315
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Nutzungsbedingungen"
@@ -1704,23 +1703,23 @@ msgstr "Mein Konto löschen"
 msgid "Edit profile"
 msgstr "Profil bearbeiten"
 
-#: lib/vutuv_web/components/ui.ex:2025
-#: lib/vutuv_web/components/ui.ex:2034
-#: lib/vutuv_web/components/ui.ex:2512
+#: lib/vutuv_web/components/ui.ex:2049
+#: lib/vutuv_web/components/ui.ex:2058
+#: lib/vutuv_web/components/ui.ex:2536
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr "Empfehlen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:236
-#: lib/vutuv_web/components/ui.ex:2670
-#: lib/vutuv_web/components/ui.ex:2670
-#: lib/vutuv_web/components/ui.ex:2687
-#: lib/vutuv_web/components/ui.ex:2696
-#: lib/vutuv_web/components/ui.ex:2712
-#: lib/vutuv_web/components/ui.ex:2774
-#: lib/vutuv_web/live/fediverse_account_live.ex:381
+#: lib/vutuv_web/components/ui.ex:2772
+#: lib/vutuv_web/components/ui.ex:2772
+#: lib/vutuv_web/components/ui.ex:2789
+#: lib/vutuv_web/components/ui.ex:2798
+#: lib/vutuv_web/components/ui.ex:2814
+#: lib/vutuv_web/components/ui.ex:2876
+#: lib/vutuv_web/live/fediverse_account_live.ex:391
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:311
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:312
 #: lib/vutuv_web/live/organization_live/following.ex:331
 #: lib/vutuv_web/live/organization_live/following.ex:412
 #: lib/vutuv_web/live/organization_live/show.ex:569
@@ -1746,7 +1745,7 @@ msgstr ""
 " von jemandem, den Sie kennen oder interessant finden, und klicken Sie auf "
 "Folgen!"
 
-#: lib/vutuv_web/live/shell_live.ex:1360
+#: lib/vutuv_web/live/shell_live.ex:1356
 #: lib/vutuv_web/views/settings_html.ex:299
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1760,7 +1759,7 @@ msgstr "Ausloggen"
 #: lib/vutuv_web/live/admin/user_live.ex:154
 #: lib/vutuv_web/live/message_live/index.ex:538
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:32
-#: lib/vutuv_web/templates/admin/account/index.html.heex:55
+#: lib/vutuv_web/templates/admin/account/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:28
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:24
 #, elixir-autogen, elixir-format
@@ -1775,29 +1774,29 @@ msgstr "Mitglied"
 msgid "Message"
 msgstr "Nachricht"
 
-#: lib/vutuv_web/controllers/page_controller.ex:227
+#: lib/vutuv_web/controllers/page_controller.ex:228
 #: lib/vutuv_web/live/message_live/index.ex:49
-#: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1252
-#: lib/vutuv_web/live/shell_live.ex:1420
+#: lib/vutuv_web/live/message_live/index.ex:624
+#: lib/vutuv_web/live/shell_live.ex:1248
+#: lib/vutuv_web/live/shell_live.ex:1411
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: lib/vutuv_web/live/shell_live.ex:1136
+#: lib/vutuv_web/live/shell_live.ex:1132
 #: lib/vutuv_web/templates/layout/app.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr "Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:450
-#: lib/vutuv_web/components/ui.ex:4416
+#: lib/vutuv_web/components/post_components.ex:451
+#: lib/vutuv_web/components/ui.ex:4524
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
 #: lib/vutuv_web/live/admin/user_live.ex:286
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:122
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr "Hier gibt es noch nichts."
@@ -1808,18 +1807,18 @@ msgid "Nothing new yet."
 msgstr "Noch nichts Neues."
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:4734
-#: lib/vutuv_web/controllers/page_controller.ex:228
+#: lib/vutuv_web/components/ui.ex:4842
+#: lib/vutuv_web/controllers/page_controller.ex:229
 #: lib/vutuv_web/live/notification_live/index.ex:146
 #: lib/vutuv_web/live/notification_live/index.ex:384
-#: lib/vutuv_web/live/shell_live.ex:1264
+#: lib/vutuv_web/live/shell_live.ex:1260
 #: lib/vutuv_web/templates/layout/app.html.heex:153
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr "Mitteilungen"
 
-#: lib/vutuv_web/live/admin/user_detail_live.ex:93
+#: lib/vutuv_web/live/admin/user_detail_live.ex:88
 #: lib/vutuv_web/live/admin/user_live.ex:322
 #: lib/vutuv_web/templates/email/confirm.html.heex:25
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:17
@@ -1834,7 +1833,7 @@ msgid "Pardon us! Something went wrong."
 msgstr "Entschuldigung! Etwas ist schiefgelaufen."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:912
+#: lib/vutuv_web/live/message_live/index.ex:902
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
@@ -1883,7 +1882,7 @@ msgstr "Zu viele Versuche. Bitte versuchen Sie es später erneut."
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
 #: lib/vutuv_web/templates/user/show.html.heex:209
-#: lib/vutuv_web/views/user_html.ex:1071
+#: lib/vutuv_web/views/user_html.ex:1077
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
 msgstr "Verifiziertes Profil"
@@ -1914,8 +1913,8 @@ msgstr ""
 msgid "Who to follow"
 msgstr "Vorgeschlagene Profile"
 
-#: lib/vutuv_web/live/message_live/index.ex:901
-#: lib/vutuv_web/live/message_live/index.ex:902
+#: lib/vutuv_web/live/message_live/index.ex:891
+#: lib/vutuv_web/live/message_live/index.ex:892
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr "Nachricht schreiben…"
@@ -1960,17 +1959,16 @@ msgstr "ist jetzt mit Ihnen vernetzt."
 msgid "started following you."
 msgstr "folgt Ihnen jetzt."
 
-#: lib/vutuv_web/components/ui.ex:3695
-#: lib/vutuv_web/components/ui.ex:3848
+#: lib/vutuv_web/components/ui.ex:3807
+#: lib/vutuv_web/components/ui.ex:3952
 #: lib/vutuv_web/live/import_connections_live.ex:638
-#: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr "Seitennavigation"
 
-#: lib/vutuv_web/components/ui.ex:4441
+#: lib/vutuv_web/components/ui.ex:4549
 #: lib/vutuv_web/live/organization_live/activity.ex:151
-#: lib/vutuv_web/live/organization_live/feed.ex:210
+#: lib/vutuv_web/live/organization_live/feed.ex:209
 #: lib/vutuv_web/live/organization_live/show.ex:777
 #, elixir-autogen, elixir-format
 msgid "Load more"
@@ -1983,13 +1981,13 @@ msgstr ""
 "Die Adresse selbst kann nicht geändert werden. Um eine andere zu verwenden, "
 "legen Sie sie als neue E-Mail-Adresse an und löschen Sie diese hier."
 
-#: lib/vutuv_web/components/ui.ex:4212
+#: lib/vutuv_web/components/ui.ex:4316
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Eintrag löschen"
 
-#: lib/vutuv_web/components/ui.ex:1706
-#: lib/vutuv_web/components/ui.ex:1716
+#: lib/vutuv_web/components/ui.ex:1730
+#: lib/vutuv_web/components/ui.ex:1740
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr "Optionen"
@@ -2028,12 +2026,12 @@ msgstr "Titelbild hinzufügen"
 msgid "Add cover photo"
 msgstr "Titelbild hinzufügen"
 
-#: lib/vutuv_web/components/ui.ex:3218
+#: lib/vutuv_web/components/ui.ex:3320
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr "April"
 
-#: lib/vutuv_web/components/ui.ex:3222
+#: lib/vutuv_web/components/ui.ex:3324
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr "August"
@@ -2048,7 +2046,7 @@ msgstr "Titelbild ändern"
 msgid "Change cover photo"
 msgstr "Titelbild ändern"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:101
+#: lib/vutuv_web/templates/user/edit.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
 msgstr "Titelbild"
@@ -2058,37 +2056,37 @@ msgstr "Titelbild"
 msgid "Cover photo of %{name}"
 msgstr "Titelbild von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:3226
+#: lib/vutuv_web/components/ui.ex:3328
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr "Dezember"
 
-#: lib/vutuv_web/components/ui.ex:3216
+#: lib/vutuv_web/components/ui.ex:3318
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr "Februar"
 
-#: lib/vutuv_web/components/ui.ex:3215
+#: lib/vutuv_web/components/ui.ex:3317
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr "Januar"
 
-#: lib/vutuv_web/components/ui.ex:3221
+#: lib/vutuv_web/components/ui.ex:3323
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr "Juli"
 
-#: lib/vutuv_web/components/ui.ex:3220
+#: lib/vutuv_web/components/ui.ex:3322
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr "Juni"
 
-#: lib/vutuv_web/components/ui.ex:3217
+#: lib/vutuv_web/components/ui.ex:3319
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr "März"
 
-#: lib/vutuv_web/components/ui.ex:3219
+#: lib/vutuv_web/components/ui.ex:3321
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr "Mai"
@@ -2103,34 +2101,34 @@ msgstr "Mitglied seit %{month} %{year}"
 msgid "Member since %{year}"
 msgstr "Mitglied seit %{year}"
 
-#: lib/vutuv_web/components/ui.ex:3225
+#: lib/vutuv_web/components/ui.ex:3327
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr "November"
 
-#: lib/vutuv_web/components/ui.ex:3224
+#: lib/vutuv_web/components/ui.ex:3326
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr "Oktober"
 
-#: lib/vutuv_web/components/ui.ex:3223
+#: lib/vutuv_web/components/ui.ex:3325
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr "September"
 
 #: lib/vutuv_web/templates/education/form_content.html.heex:32
-#: lib/vutuv_web/templates/user/edit.html.heex:254
+#: lib/vutuv_web/templates/user/edit.html.heex:249
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Markdown is supported: bold, italics, links and lists."
 msgstr "Markdown wird unterstützt: Fett, Kursiv, Links und Listen."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:710
+#: lib/vutuv_web/live/job_posting_live/form.ex:709
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr "Bilder hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2102
+#: lib/vutuv_web/live/post_live/composer.ex:2040
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und Suchmaschinen den Beitrag nicht mehr."
@@ -2141,7 +2139,7 @@ msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und
 msgid "Back to the post"
 msgstr "Zurück zum Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1795
+#: lib/vutuv_web/live/post_live/composer.ex:1771
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Upload abbrechen"
@@ -2151,7 +2149,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:3583
+#: lib/vutuv_web/components/post_components.ex:3605
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2165,12 +2163,12 @@ msgstr "Beitrag bearbeiten"
 
 #: lib/vutuv_web/components/organization_components.ex:265
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
-#: lib/vutuv_web/live/organization_live/feed.ex:155
+#: lib/vutuv_web/live/organization_live/feed.ex:154
 #: lib/vutuv_web/live/post_live/feed.ex:317
-#: lib/vutuv_web/live/post_live/feed.ex:2899
+#: lib/vutuv_web/live/post_live/feed.ex:2896
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1114
-#: lib/vutuv_web/live/shell_live.ex:1413
+#: lib/vutuv_web/live/shell_live.ex:1110
+#: lib/vutuv_web/live/shell_live.ex:1404
 #: lib/vutuv_web/templates/layout/app.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2186,57 +2184,57 @@ msgstr "Folgen Sie %{name}, um ihn zu lesen."
 msgid "Hidden from:"
 msgstr "Verborgen vor:"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2078
+#: lib/vutuv_web/live/post_live/composer.ex:2016
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr "Vor einer bestimmten Person verbergen…"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2006
+#: lib/vutuv_web/live/post_live/composer.ex:1944
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:3537
-#: lib/vutuv_web/components/post_components.ex:3539
+#: lib/vutuv_web/components/post_components.ex:3559
+#: lib/vutuv_web/components/post_components.ex:3561
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2048
+#: lib/vutuv_web/live/post_live/composer.ex:1986
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr "Nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1295
-#: lib/vutuv_web/live/post_live/composer.ex:1343
+#: lib/vutuv_web/live/post_live/composer.ex:1270
+#: lib/vutuv_web/live/post_live/composer.ex:1318
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3153
+#: lib/vutuv_web/live/post_live/feed.ex:3150
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 "Hier ist noch nichts. Folgen Sie anderen, um Ihren Feed zu füllen, oder "
 "schreiben Sie Ihren ersten Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1261
+#: lib/vutuv_web/live/post_live/composer.ex:1236
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr "Eines der Bilder konnte nicht angehängt werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2038
+#: lib/vutuv_web/live/post_live/composer.ex:1976
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr "Personen, denen ich nicht folge"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2028
+#: lib/vutuv_web/live/post_live/composer.ex:1966
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr "Personen, die mir nicht folgen"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:416
-#: lib/vutuv_web/live/post_live/composer.ex:1926
+#: lib/vutuv_web/live/post_live/composer.ex:1928
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2253,40 +2251,40 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/controllers/user_controller.ex:76
 #: lib/vutuv_web/gettext_extraction_anchors.ex:109
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
-#: lib/vutuv_web/live/fediverse_account_live.ex:388
+#: lib/vutuv_web/live/fediverse_account_live.ex:398
 #: lib/vutuv_web/live/notification_live/index.ex:1125
 #: lib/vutuv_web/live/organization_live/show.ex:700
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:345
-#: lib/vutuv_web/live/search_live.ex:836
-#: lib/vutuv_web/templates/settings/preferences.html.heex:319
+#: lib/vutuv_web/live/search_live.ex:829
+#: lib/vutuv_web/templates/settings/preferences.html.heex:308
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:3998
-#: lib/vutuv_web/components/post_components.ex:4002
+#: lib/vutuv_web/components/post_components.ex:4020
+#: lib/vutuv_web/components/post_components.ex:4024
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:3999
-#: lib/vutuv_web/live/fediverse_account_live.ex:334
+#: lib/vutuv_web/components/post_components.ex:4021
+#: lib/vutuv_web/live/fediverse_account_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr "Weniger anzeigen"
 
-#: lib/vutuv_web/components/fediverse_components.ex:429
-#: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1353
+#: lib/vutuv_web/components/fediverse_components.ex:426
+#: lib/vutuv_web/components/job_exclusion_components.ex:189
+#: lib/vutuv_web/components/post_components.ex:1354
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
-#: lib/vutuv_web/live/job_search_exclusions_live.ex:234
-#: lib/vutuv_web/live/organization_live/domains.ex:246
-#: lib/vutuv_web/live/organization_live/edit.ex:408
-#: lib/vutuv_web/live/organization_live/roles.ex:247
-#: lib/vutuv_web/live/post_live/composer.ex:2064
+#: lib/vutuv_web/live/job_search_exclusions_live.ex:229
+#: lib/vutuv_web/live/organization_live/domains.ex:245
+#: lib/vutuv_web/live/organization_live/edit.ex:395
+#: lib/vutuv_web/live/organization_live/roles.ex:242
+#: lib/vutuv_web/live/post_live/composer.ex:2002
 #: lib/vutuv_web/live/post_live/filter_band.ex:455
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
@@ -2303,12 +2301,12 @@ msgstr ""
 "Eingeschränkte Beiträge sind auch für nicht eingeloggte Besucher und "
 "Suchmaschinen unsichtbar."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1916
+#: lib/vutuv_web/live/post_live/composer.ex:1918
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2224
+#: lib/vutuv_web/live/post_live/feed.ex:2226
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2320,12 +2318,12 @@ msgstr[1] "%{formatted} neue Beiträge anzeigen"
 msgid "Sorry, that page could not be found."
 msgstr "Diese Seite konnte leider nicht gefunden werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1369
+#: lib/vutuv_web/live/post_live/composer.ex:1344
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Diese Datei konnte nicht verarbeitet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1243
+#: lib/vutuv_web/live/post_live/composer.ex:1218
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr "Die Sichtbarkeitsauswahl ist ungültig."
@@ -2335,18 +2333,18 @@ msgstr "Die Sichtbarkeitsauswahl ist ungültig."
 msgid "This post is for followers of %{name}"
 msgstr "Dieser Beitrag ist für Follower von %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2901
+#: lib/vutuv_web/live/post_live/composer.ex:2840
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2902
+#: lib/vutuv_web/live/post_live/composer.ex:2841
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
-#: lib/vutuv_web/components/ui.ex:5034
-#: lib/vutuv_web/live/shell_live.ex:1307
+#: lib/vutuv_web/components/ui.ex:5142
+#: lib/vutuv_web/live/shell_live.ex:1303
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:246
@@ -2354,58 +2352,58 @@ msgstr "Upload fehlgeschlagen."
 msgid "View profile"
 msgstr "Profil ansehen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2179
+#: lib/vutuv_web/live/post_live/composer.ex:2117
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr "Was gibt's Neues?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2180
+#: lib/vutuv_web/live/post_live/composer.ex:2118
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:3534
+#: lib/vutuv_web/components/post_components.ex:3556
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:5439
+#: lib/vutuv_web/components/post_components.ex:5461
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:5443
+#: lib/vutuv_web/components/post_components.ex:5465
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:5441
+#: lib/vutuv_web/components/post_components.ex:5463
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:5442
+#: lib/vutuv_web/components/post_components.ex:5464
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
 
-#: lib/vutuv_web/components/ui.ex:3296
+#: lib/vutuv_web/components/ui.ex:3398
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr "unbekannt"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1831
+#: lib/vutuv_web/live/post_live/composer.ex:1807
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr "Tags, durch Komma getrennt (max. %{max})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2892
+#: lib/vutuv_web/live/post_live/composer.ex:2831
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr "Die Datei ist größer als %{mb} MB."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2896
+#: lib/vutuv_web/live/post_live/composer.ex:2835
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
@@ -2425,9 +2423,9 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:2033
-#: lib/vutuv_web/components/post_components.ex:5535
-#: lib/vutuv_web/components/ui.ex:3770
+#: lib/vutuv_web/components/post_components.ex:2055
+#: lib/vutuv_web/components/post_components.ex:5557
+#: lib/vutuv_web/components/ui.ex:3874
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2436,17 +2434,17 @@ msgstr "Lesezeichen setzen"
 #: lib/vutuv_web/agent_docs/markdown.ex:1145
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:1244
-#: lib/vutuv_web/live/shell_live.ex:1312
+#: lib/vutuv_web/live/shell_live.ex:1240
+#: lib/vutuv_web/live/shell_live.ex:1308
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:1986
-#: lib/vutuv_web/components/post_components.ex:5771
-#: lib/vutuv_web/components/ui.ex:3756
+#: lib/vutuv_web/components/post_components.ex:2008
+#: lib/vutuv_web/components/post_components.ex:5793
+#: lib/vutuv_web/components/ui.ex:3860
 #: lib/vutuv_web/live/notification_live/index.ex:1271
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
@@ -2454,11 +2452,11 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1144
-#: lib/vutuv_web/components/post_components.ex:5781
+#: lib/vutuv_web/components/post_components.ex:5803
 #: lib/vutuv_web/live/notification_live/index.ex:1204
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:1315
+#: lib/vutuv_web/live/shell_live.ex:1311
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2476,57 +2474,57 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:5523
+#: lib/vutuv_web/components/post_components.ex:5545
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:2032
-#: lib/vutuv_web/components/post_components.ex:5534
+#: lib/vutuv_web/components/post_components.ex:2054
+#: lib/vutuv_web/components/post_components.ex:5556
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:2014
-#: lib/vutuv_web/components/post_components.ex:5520
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
+#: lib/vutuv_web/components/post_components.ex:2036
+#: lib/vutuv_web/components/post_components.ex:5542
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:2279
-#: lib/vutuv_web/components/post_components.ex:4615
+#: lib/vutuv_web/components/post_components.ex:2301
+#: lib/vutuv_web/components/post_components.ex:4637
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:2013
-#: lib/vutuv_web/components/post_components.ex:5519
+#: lib/vutuv_web/components/post_components.ex:2035
+#: lib/vutuv_web/components/post_components.ex:5541
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:1985
-#: lib/vutuv_web/components/post_components.ex:5770
+#: lib/vutuv_web/components/post_components.ex:2007
+#: lib/vutuv_web/components/post_components.ex:5792
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr "Gefällt mir entfernen"
 
-#: lib/vutuv_web/components/fediverse_components.ex:430
-#: lib/vutuv_web/components/post_components.ex:2648
-#: lib/vutuv_web/components/ui.ex:2665
-#: lib/vutuv_web/components/ui.ex:2665
-#: lib/vutuv_web/components/ui.ex:2741
+#: lib/vutuv_web/components/fediverse_components.ex:427
+#: lib/vutuv_web/components/post_components.ex:2670
+#: lib/vutuv_web/components/ui.ex:2767
+#: lib/vutuv_web/components/ui.ex:2767
+#: lib/vutuv_web/components/ui.ex:2843
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:611
 #: lib/vutuv_web/live/post_live/feed.ex:890
 #: lib/vutuv_web/templates/followee/index.html.heex:30
-#: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
+#: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
 #: lib/vutuv_web/views/user_html.ex:618
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2537,38 +2535,38 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:5825
+#: lib/vutuv_web/components/post_components.ex:5847
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
-#: lib/vutuv_web/components/post_components.ex:408
+#: lib/vutuv_web/components/post_components.ex:409
 #: lib/vutuv_web/live/notification_live/index.ex:1205
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1999
-#: lib/vutuv_web/components/post_components.ex:5808
-#: lib/vutuv_web/components/post_components.ex:5809
+#: lib/vutuv_web/components/post_components.ex:2021
+#: lib/vutuv_web/components/post_components.ex:5830
+#: lib/vutuv_web/components/post_components.ex:5831
 #: lib/vutuv_web/live/notification_live/index.ex:1268
 #: lib/vutuv_web/live/post_live/reply.ex:46
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:3501
+#: lib/vutuv_web/components/post_components.ex:3523
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1246
-#: lib/vutuv_web/live/post_live/composer.ex:1904
+#: lib/vutuv_web/live/post_live/composer.ex:1221
+#: lib/vutuv_web/live/post_live/composer.ex:1906
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr "Solange es geteilte Beiträge oder Antworten gibt, lässt sich der Empfängerkreis nicht einschränken."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2109
+#: lib/vutuv_web/live/post_live/composer.ex:2047
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beiträge oder Antworten gibt, bleibt er öffentlich; löschen können Sie ihn weiterhin."
@@ -2578,7 +2576,7 @@ msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beitr
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/components/post_components.ex:3037
+#: lib/vutuv_web/components/post_components.ex:3059
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:60
@@ -2586,49 +2584,49 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:3475
+#: lib/vutuv_web/components/post_components.ex:3497
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:3466
-#: lib/vutuv_web/components/post_components.ex:3493
-#: lib/vutuv_web/components/post_components.ex:3496
+#: lib/vutuv_web/components/post_components.ex:3488
+#: lib/vutuv_web/components/post_components.ex:3515
+#: lib/vutuv_web/components/post_components.ex:3518
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
 
-#: lib/vutuv_web/live/message_live/index.ex:613
+#: lib/vutuv_web/live/message_live/index.ex:603
 #, elixir-autogen, elixir-format
 msgid "%{names} are typing…"
 msgstr "%{names} schreiben…"
 
-#: lib/vutuv_web/live/message_live/index.ex:612
+#: lib/vutuv_web/live/message_live/index.ex:602
 #, elixir-autogen, elixir-format
 msgid "%{name} is typing…"
 msgstr "%{name} schreibt…"
 
-#: lib/vutuv_web/live/message_live/index.ex:924
+#: lib/vutuv_web/live/message_live/index.ex:914
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr "@%{slug} hat Ihre Nachrichtenanfrage noch nicht angenommen."
 
-#: lib/vutuv_web/live/message_live/index.ex:875
+#: lib/vutuv_web/live/message_live/index.ex:865
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to message you."
 msgstr "@%{slug} möchte Ihnen Nachrichten schicken."
 
-#: lib/vutuv_web/live/message_live/index.ex:596
+#: lib/vutuv_web/live/message_live/index.ex:591
 #, elixir-autogen, elixir-format
 msgid "Accept"
 msgstr "Annehmen"
 
-#: lib/vutuv_web/live/message_live/index.ex:738
+#: lib/vutuv_web/live/message_live/index.ex:728
 #, elixir-autogen, elixir-format
 msgid "Back to conversations"
 msgstr "Zurück zu den Unterhaltungen"
 
-#: lib/vutuv_web/live/message_live/index.ex:603
+#: lib/vutuv_web/live/message_live/index.ex:593
 #, elixir-autogen, elixir-format
 msgid "Decline"
 msgstr "Ablehnen"
@@ -2638,7 +2636,7 @@ msgstr "Ablehnen"
 msgid "Deleted account"
 msgstr "Gelöschtes Konto"
 
-#: lib/vutuv_web/live/message_live/index.ex:784
+#: lib/vutuv_web/live/message_live/index.ex:774
 #, elixir-autogen, elixir-format
 msgid "Load older messages"
 msgstr "Ältere Nachrichten laden"
@@ -2649,23 +2647,23 @@ msgstr "Ältere Nachrichten laden"
 msgid "Member not found."
 msgstr "Mitglied nicht gefunden."
 
-#: lib/vutuv_web/live/message_live/index.ex:717
+#: lib/vutuv_web/live/message_live/index.ex:707
 #, elixir-autogen, elixir-format
 msgid "No conversations yet."
 msgstr "Noch keine Unterhaltungen."
 
-#: lib/vutuv_web/components/ui.ex:2988
-#: lib/vutuv_web/live/message_live/index.ex:760
+#: lib/vutuv_web/components/ui.ex:3090
+#: lib/vutuv_web/live/message_live/index.ex:750
 #, elixir-autogen, elixir-format
 msgid "Online"
 msgstr "Online"
 
-#: lib/vutuv_web/live/message_live/index.ex:666
+#: lib/vutuv_web/live/message_live/index.ex:656
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr "Anfragen"
 
-#: lib/vutuv_web/live/message_live/index.ex:933
+#: lib/vutuv_web/live/message_live/index.ex:923
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr "Wählen Sie eine Unterhaltung aus."
@@ -2722,7 +2720,7 @@ msgstr "Willkommen zurück!"
 msgid "Founder of vutuv"
 msgstr "Gründer von vutuv"
 
-#: lib/vutuv_web/templates/page/index.html.heex:206
+#: lib/vutuv_web/templates/page/index.html.heex:211
 #: lib/vutuv_web/templates/settings/privacy.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Allow search engines to index your profile"
@@ -2743,7 +2741,7 @@ msgstr "Eine neue PIN ist unterwegs zu Ihrer E-Mail-Adresse."
 msgid "Okay, let's start over."
 msgstr "Alles klar, fangen wir neu an."
 
-#: lib/vutuv_web/components/ui.ex:815
+#: lib/vutuv_web/components/ui.ex:839
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr "PIN erneut senden"
@@ -2754,7 +2752,7 @@ msgstr "PIN erneut senden"
 msgid "Too many PIN requests. Please try again later."
 msgstr "Zu viele PIN-Anfragen. Bitte versuchen Sie es später erneut."
 
-#: lib/vutuv_web/components/ui.ex:836
+#: lib/vutuv_web/components/ui.ex:860
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr "Andere E-Mail-Adresse verwenden"
@@ -2804,11 +2802,11 @@ msgstr "Berufserfahrung hinzufügen"
 msgid "Write your first post"
 msgstr "Ersten Beitrag schreiben"
 
-#: lib/vutuv_web/components/ui.ex:3936
-#: lib/vutuv_web/components/ui.ex:4369
+#: lib/vutuv_web/components/ui.ex:4040
+#: lib/vutuv_web/components/ui.ex:4477
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
-#: lib/vutuv_web/templates/settings/organizations.html.heex:104
+#: lib/vutuv_web/templates/settings/organizations.html.heex:109
 #: lib/vutuv_web/templates/settings/preferences.html.heex:195
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
@@ -2818,8 +2816,8 @@ msgstr "Ersten Beitrag schreiben"
 msgid "Manage"
 msgstr "Verwalten"
 
-#: lib/vutuv_web/controllers/page_controller.ex:225
-#: lib/vutuv_web/live/post_live/feed.ex:2280
+#: lib/vutuv_web/controllers/page_controller.ex:226
+#: lib/vutuv_web/live/post_live/feed.ex:2282
 #: lib/vutuv_web/templates/user/show.html.heex:499
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2857,7 +2855,7 @@ msgstr[1] "+%{formatted} weitere Tags"
 msgid "Connections"
 msgstr "Vernetzungen"
 
-#: lib/vutuv_web/components/ui.ex:1304
+#: lib/vutuv_web/components/ui.ex:1328
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr "Markdown"
@@ -2867,17 +2865,17 @@ msgstr "Markdown"
 msgid "No connections yet."
 msgstr "Noch keine Vernetzungen."
 
-#: lib/vutuv_web/components/ui.ex:1320
+#: lib/vutuv_web/components/ui.ex:1344
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr "Andere Formate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2018
+#: lib/vutuv_web/live/post_live/composer.ex:1956
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr "Personen, mit denen ich nicht vernetzt bin"
 
-#: lib/vutuv_web/components/ui.ex:1305
+#: lib/vutuv_web/components/ui.ex:1329
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr "Nur Text"
@@ -2895,12 +2893,12 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:5440
+#: lib/vutuv_web/components/post_components.ex:5462
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
 
-#: lib/vutuv_web/live/message_live/index.ex:718
+#: lib/vutuv_web/live/message_live/index.ex:708
 #, elixir-autogen, elixir-format
 msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
@@ -3004,7 +3002,7 @@ msgstr "Mobbing oder Belästigung"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:343
 #: lib/vutuv_web/agent_docs/text.ex:324
-#: lib/vutuv_web/controllers/page_controller.ex:90
+#: lib/vutuv_web/controllers/page_controller.ex:91
 #: lib/vutuv_web/templates/layout/app.html.heex:119
 #: lib/vutuv_web/templates/page/community.html.heex:4
 #, elixir-autogen, elixir-format
@@ -3075,7 +3073,7 @@ msgstr ""
 msgid "Hidden. You can settle this yourself - see below."
 msgstr "Verborgen. Sie können das selbst klären, siehe unten."
 
-#: lib/vutuv_web/live/message_live/index.ex:813
+#: lib/vutuv_web/live/message_live/index.ex:803
 #, elixir-autogen, elixir-format
 msgid "Hidden: reported, under review"
 msgstr "Verborgen: gemeldet, wird geprüft"
@@ -3176,7 +3174,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:3442
+#: lib/vutuv_web/components/post_components.ex:3464
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3229,9 +3227,9 @@ msgstr ""
 msgid "Private message"
 msgstr "Private Nachricht"
 
-#: lib/vutuv_web/components/ui.ex:4666
-#: lib/vutuv_web/live/shell_live.ex:1128
-#: lib/vutuv_web/live/shell_live.ex:1425
+#: lib/vutuv_web/components/ui.ex:4774
+#: lib/vutuv_web/live/shell_live.ex:1124
+#: lib/vutuv_web/live/shell_live.ex:1416
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3255,9 +3253,9 @@ msgstr "Abgelehnt"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
-#: lib/vutuv_web/components/post_components.ex:1363
-#: lib/vutuv_web/components/post_components.ex:2660
-#: lib/vutuv_web/components/post_components.ex:3606
+#: lib/vutuv_web/components/post_components.ex:1364
+#: lib/vutuv_web/components/post_components.ex:2682
+#: lib/vutuv_web/components/post_components.ex:3628
 #: lib/vutuv_web/live/organization_live/show.ex:651
 #: lib/vutuv_web/templates/user/show.html.heex:229
 #, elixir-autogen, elixir-format
@@ -3285,8 +3283,8 @@ msgstr "Meldung abgelehnt; der Inhalt ist wieder sichtbar."
 msgid "Report this content"
 msgstr "Diesen Inhalt melden"
 
-#: lib/vutuv_web/live/message_live/index.ex:831
-#: lib/vutuv_web/live/message_live/index.ex:832
+#: lib/vutuv_web/live/message_live/index.ex:821
+#: lib/vutuv_web/live/message_live/index.ex:822
 #, elixir-autogen, elixir-format
 msgid "Report this message"
 msgstr "Diese Nachricht melden"
@@ -3343,7 +3341,7 @@ msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 "Meldungen sind anonym; wir verraten nie, wer gemeldet hat. Unsere Regeln:"
 
-#: lib/vutuv_web/components/ui.ex:3645
+#: lib/vutuv_web/components/ui.ex:3747
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3401,7 +3399,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/organization_live.ex:246
 #: lib/vutuv_web/live/admin/screenshot_live.ex:414
 #: lib/vutuv_web/live/admin/user_live.ex:299
-#: lib/vutuv_web/templates/admin/account/index.html.heex:57
+#: lib/vutuv_web/templates/admin/account/index.html.heex:52
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:59
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:19
 #: lib/vutuv_web/templates/admin/newsletter/index.html.heex:50
@@ -4000,7 +3998,7 @@ msgstr "Follower von %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:157
 #: lib/vutuv_web/agent_docs/text.ex:112
 #: lib/vutuv_web/agent_docs/text.ex:143
-#: lib/vutuv_web/live/job_posting_live/form.ex:700
+#: lib/vutuv_web/live/job_posting_live/form.ex:699
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr "Bilder"
@@ -4189,7 +4187,7 @@ msgstr "Für die Buchung ist ein vutuv-Login erforderlich."
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
 #: lib/vutuv_web/live/job_posting_live/form.ex:542
-#: lib/vutuv_web/live/organization_live/edit.ex:327
+#: lib/vutuv_web/live/organization_live/edit.ex:322
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
 #: lib/vutuv_web/templates/address/form_en.html.heex:33
@@ -4491,12 +4489,12 @@ msgstr "Buchbar bis einschließlich %{last}."
 msgid "Bookings are open through %{last}. Next available day: %{day}"
 msgstr "Buchbar bis einschließlich %{last}. Nächster freier Tag: %{day}"
 
-#: lib/vutuv_web/components/ui.ex:3248
+#: lib/vutuv_web/components/ui.ex:3350
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr "Fr"
 
-#: lib/vutuv_web/components/ui.ex:3244
+#: lib/vutuv_web/components/ui.ex:3346
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr "Mo"
@@ -4508,27 +4506,27 @@ msgstr ""
 "Eine Anzeige pro Kalendertag: Wählen Sie einen freien Tag im Kalender; "
 "durchgestrichene Tage sind bereits vergeben."
 
-#: lib/vutuv_web/components/ui.ex:3249
+#: lib/vutuv_web/components/ui.ex:3351
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr "Sa"
 
-#: lib/vutuv_web/components/ui.ex:3250
+#: lib/vutuv_web/components/ui.ex:3352
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr "So"
 
-#: lib/vutuv_web/components/ui.ex:3247
+#: lib/vutuv_web/components/ui.ex:3349
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr "Do"
 
-#: lib/vutuv_web/components/ui.ex:3245
+#: lib/vutuv_web/components/ui.ex:3347
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr "Di"
 
-#: lib/vutuv_web/components/ui.ex:3246
+#: lib/vutuv_web/components/ui.ex:3348
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr "Mi"
@@ -4571,7 +4569,7 @@ msgstr "Vorschau (wie Besucher sie sehen)"
 msgid "by"
 msgstr "von"
 
-#: lib/vutuv_web/templates/ad/preview.html.heex:83
+#: lib/vutuv_web/templates/ad/preview.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Book now (binding, by invoice)"
 msgstr "Kostenpflichtig buchen (Zahlung per Rechnung)"
@@ -4583,12 +4581,12 @@ msgstr ""
 "Die Buchung ist verbindlich; Zahlung per Rechnung. Wir prüfen und schalten "
 "jede Anzeige vor der Ausspielung frei."
 
-#: lib/vutuv_web/templates/ad/preview.html.heex:77
+#: lib/vutuv_web/templates/ad/preview.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "Edit the ad"
 msgstr "Anzeige bearbeiten"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1004
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:999
 #: lib/vutuv_web/live/tag_new_live.ex:78
 #: lib/vutuv_web/templates/ad/preview.html.heex:3
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:122
@@ -4672,7 +4670,7 @@ msgstr ""
 "beide Richtungen unterbunden. Eine Aufhebung der Blockierung stellt das "
 "Entfernte nicht wieder her."
 
-#: lib/vutuv_web/components/ui.ex:4784
+#: lib/vutuv_web/components/ui.ex:4892
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4721,12 +4719,12 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3158
+#: lib/vutuv_web/live/post_live/feed.ex:3155
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
 
-#: lib/vutuv_web/live/message_live/index.ex:721
+#: lib/vutuv_web/live/message_live/index.ex:711
 #, elixir-autogen, elixir-format
 msgid "Find members"
 msgstr "Mitglieder finden"
@@ -4767,12 +4765,12 @@ msgstr "Folgt noch niemandem."
 msgid "This area is reserved for administrators."
 msgstr "Dieser Bereich ist Administratoren vorbehalten."
 
-#: lib/vutuv_web/live/search_live.ex:884
+#: lib/vutuv_web/live/search_live.ex:877
 #, elixir-autogen, elixir-format
 msgid "No results for \"%{query}\""
 msgstr "Keine Ergebnisse für \"%{query}\""
 
-#: lib/vutuv_web/live/search_live.ex:805
+#: lib/vutuv_web/live/search_live.ex:798
 #, elixir-autogen, elixir-format
 msgid "Not an exact match, but sounds like your search."
 msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
@@ -4784,25 +4782,25 @@ msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 #: lib/vutuv_web/live/organization_live/show.ex:787
 #: lib/vutuv_web/live/post_live/saved.ex:523
 #: lib/vutuv_web/live/search_live.ex:343
-#: lib/vutuv_web/live/search_live.ex:778
+#: lib/vutuv_web/live/search_live.ex:771
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr "Personen"
 
-#: lib/vutuv_web/live/search_live.ex:719
+#: lib/vutuv_web/live/search_live.ex:712
 #, elixir-autogen, elixir-format
 msgid "Results appear once you have typed at least three letters."
 msgstr ""
 "Ergebnisse erscheinen, sobald Sie mindestens drei Buchstaben eingegeben "
 "haben."
 
-#: lib/vutuv_web/live/search_live.ex:802
+#: lib/vutuv_web/live/search_live.ex:795
 #, elixir-autogen, elixir-format
 msgid "Similar names"
 msgstr "Ähnliche Namen"
 
-#: lib/vutuv_web/components/post_components.ex:405
-#: lib/vutuv_web/components/post_components.ex:424
+#: lib/vutuv_web/components/post_components.ex:406
+#: lib/vutuv_web/components/post_components.ex:425
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -4813,7 +4811,7 @@ msgstr "Ähnliche Namen"
 msgid "All"
 msgstr "Alle"
 
-#: lib/vutuv_web/live/search_live.ex:702
+#: lib/vutuv_web/live/search_live.ex:695
 #, elixir-autogen, elixir-format
 msgid "Exact matches only"
 msgstr "Nur exakte Treffer"
@@ -4853,7 +4851,7 @@ msgstr "müller"
 msgid "searches first names only (last: for last names)"
 msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 
-#: lib/vutuv_web/live/job_board_live.ex:388
+#: lib/vutuv_web/live/job_board_live.ex:384
 #: lib/vutuv_web/live/tag_new_live.ex:47
 #: lib/vutuv_web/live/user_profile_live.ex:1336
 #: lib/vutuv_web/templates/user/show.html.heex:602
@@ -4906,8 +4904,8 @@ msgstr "Ihr Profil und seine Bereiche bearbeiten"
 #: lib/vutuv_web/agent_docs/markdown.ex:286
 #: lib/vutuv_web/agent_docs/text.ex:270
 #: lib/vutuv_web/live/admin/job_live.ex:389
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
-#: lib/vutuv_web/live/job_posting_live/show.ex:136
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:140
+#: lib/vutuv_web/live/job_posting_live/show.ex:131
 #: lib/vutuv_web/templates/access_token/new.html.heex:42
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:45
 #: lib/vutuv_web/templates/qualification/show.html.heex:38
@@ -5106,14 +5104,14 @@ msgid "API applications"
 msgstr "API-Anwendungen"
 
 #: lib/vutuv_web/live/admin/api_app_live.ex:98
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:180
 #: lib/vutuv_web/views/settings_html.ex:90
 #: lib/vutuv_web/views/settings_html.ex:290
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr "Aktiv"
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:82
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Allow access"
 msgstr "Zugriff erlauben"
@@ -5177,7 +5175,7 @@ msgstr ""
 "\"%{name}\" löschen? Alle Freigaben von Mitgliedern und alle Tokens dieser "
 "Anwendung funktionieren sofort nicht mehr."
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:91
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Deny"
 msgstr "Ablehnen"
@@ -5478,7 +5476,7 @@ msgstr ""
 "Webhook-Dokumentation). Nur https://; http://localhost ist für die "
 "Entwicklung erlaubt."
 
-#: lib/vutuv_web/templates/page/index.html.heex:211
+#: lib/vutuv_web/templates/page/index.html.heex:216
 #: lib/vutuv_web/templates/settings/privacy.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "Allow AI agents and LLMs to use your profile"
@@ -5494,14 +5492,14 @@ msgstr "API-Token (%{date})"
 msgid "API documentation"
 msgstr "API-Dokumentation"
 
-#: lib/vutuv_web/components/ui.ex:4844
+#: lib/vutuv_web/components/ui.ex:4952
 #: lib/vutuv_web/controllers/settings_controller.ex:157
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_delete_live.ex:109
-#: lib/vutuv_web/live/admin/user_delete_live.ex:221
+#: lib/vutuv_web/live/admin/user_delete_live.ex:209
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:136
 #: lib/vutuv_web/templates/settings/delete_account.html.heex:9
 #: lib/vutuv_web/templates/settings/delete_account.html.heex:11
@@ -5509,7 +5507,7 @@ msgstr "API-Dokumentation"
 msgid "Delete account"
 msgstr "Konto löschen"
 
-#: lib/vutuv_web/templates/settings/delete_account.html.heex:53
+#: lib/vutuv_web/templates/settings/delete_account.html.heex:54
 #, elixir-autogen, elixir-format
 msgid "Start deleting your account? We will email you a PIN to confirm."
 msgstr ""
@@ -5535,7 +5533,7 @@ msgstr ""
 "dauerhaft. Wir senden Ihnen zur Bestätigung eine PIN per E-Mail. Es kann "
 "nicht rückgängig gemacht werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1264
+#: lib/vutuv_web/live/post_live/composer.ex:1239
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
@@ -5545,7 +5543,7 @@ msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
 msgid "Content under review"
 msgstr "Inhalte in Prüfung"
 
-#: lib/vutuv_web/live/shell_live.ex:1294
+#: lib/vutuv_web/live/shell_live.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Kontomenü"
@@ -5567,7 +5565,7 @@ msgstr "Menüs und Dialoge schließen"
 msgid "General"
 msgstr "Allgemeines"
 
-#: lib/vutuv_web/live/shell_live.ex:1351
+#: lib/vutuv_web/live/shell_live.ex:1347
 #: lib/vutuv_web/templates/layout/app.html.heex:183
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5578,15 +5576,15 @@ msgstr "Tastaturkürzel"
 msgid "Navigation"
 msgstr "Navigation"
 
-#: lib/vutuv_web/components/ui.ex:4941
-#: lib/vutuv_web/components/ui.ex:4946
-#: lib/vutuv_web/components/ui.ex:5025
-#: lib/vutuv_web/components/ui.ex:5089
+#: lib/vutuv_web/components/ui.ex:5049
+#: lib/vutuv_web/components/ui.ex:5054
+#: lib/vutuv_web/components/ui.ex:5133
+#: lib/vutuv_web/components/ui.ex:5197
 #: lib/vutuv_web/controllers/settings_controller.ex:64
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:276
-#: lib/vutuv_web/live/shell_live.ex:1331
+#: lib/vutuv_web/live/shell_live.ex:1327
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5640,8 +5638,8 @@ msgstr "Nächster Beitrag im Feed"
 msgid "Previous post in the feed"
 msgstr "Vorheriger Beitrag im Feed"
 
-#: lib/vutuv_web/live/shell_live.ex:1103
-#: lib/vutuv_web/live/shell_live.ex:1397
+#: lib/vutuv_web/live/shell_live.ex:1099
+#: lib/vutuv_web/live/shell_live.ex:1388
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Hauptnavigation"
@@ -5651,9 +5649,9 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:3672
-#: lib/vutuv_web/components/post_components.ex:3727
-#: lib/vutuv_web/components/post_components.ex:4135
+#: lib/vutuv_web/components/post_components.ex:3694
+#: lib/vutuv_web/components/post_components.ex:3749
+#: lib/vutuv_web/components/post_components.ex:4157
 #: lib/vutuv_web/live/notification_live/index.ex:784
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
@@ -5665,7 +5663,7 @@ msgstr "Beitrag ansehen"
 msgid "Someone tried to register with your email address"
 msgstr "Registrierungsversuch mit Ihrer E-Mail-Adresse"
 
-#: lib/vutuv_web/templates/page/index.html.heex:139
+#: lib/vutuv_web/templates/page/index.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr "Ihre Tags (z.B. JavaScript, Kochen, Origami, Katze)"
@@ -5679,7 +5677,7 @@ msgstr "Andere"
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:1196
+#: lib/vutuv_web/views/user_html.ex:1202
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr "Privat"
@@ -5689,17 +5687,17 @@ msgstr "Privat"
 msgid "Type of Email"
 msgstr "Art der E-Mail"
 
-#: lib/vutuv_web/templates/page/index.html.heex:171
+#: lib/vutuv_web/templates/page/index.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "Type of email address"
 msgstr "Art der E-Mail-Adresse"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:241
+#: lib/vutuv_web/templates/user/edit.html.heex:236
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr "Über Sie"
 
-#: lib/vutuv_web/components/ui.ex:4804
+#: lib/vutuv_web/components/ui.ex:4912
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5710,7 +5708,7 @@ msgstr "Über Sie"
 msgid "Account"
 msgstr "Konto"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:482
+#: lib/vutuv_web/live/organization_live/edit.ex:461
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr "Ändern"
@@ -5721,7 +5719,7 @@ msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 "Laden Sie alles herunter, was vutuv über Sie speichert, als eine Datei."
 
-#: lib/vutuv_web/components/ui.ex:4704
+#: lib/vutuv_web/components/ui.ex:4812
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5750,15 +5748,15 @@ msgstr "Personen, die nicht mit Ihnen interagieren können."
 msgid "Personal tokens for the vutuv API."
 msgstr "Persönliche Tokens für die vutuv-API."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2222
+#: lib/vutuv_web/live/post_live/composer.ex:2161
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
 msgstr "Fotos"
 
-#: lib/vutuv_web/components/ui.ex:4778
+#: lib/vutuv_web/components/ui.ex:4886
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
-#: lib/vutuv_web/templates/page/index.html.heex:191
+#: lib/vutuv_web/templates/page/index.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr "Privatsphäre"
@@ -5778,7 +5776,7 @@ msgstr "Apps von Drittanbietern, die Sie autorisiert haben."
 msgid "View"
 msgstr "Ansehen"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:166
+#: lib/vutuv_web/templates/user/edit.html.heex:161
 #, elixir-autogen, elixir-format
 msgid "Your name"
 msgstr "Ihr Name"
@@ -5838,18 +5836,18 @@ msgstr ""
 msgid "Current avatar"
 msgstr "Aktueller Avatar"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:112
-#: lib/vutuv_web/templates/user/edit.html.heex:119
+#: lib/vutuv_web/templates/user/edit.html.heex:107
+#: lib/vutuv_web/templates/user/edit.html.heex:114
 #, elixir-autogen, elixir-format
 msgid "Current cover photo"
 msgstr "Aktuelles Titelbild"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:190
+#: lib/vutuv_web/templates/user/edit.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "e.g. Dr. or Prof."
 msgstr "z. B. Dr. oder Prof."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:195
+#: lib/vutuv_web/templates/user/edit.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "e.g. Jr. or PhD"
 msgstr "z. B. jun. oder B.Sc."
@@ -5871,7 +5869,7 @@ msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/vutuv_web/components/ui.ex:4837
+#: lib/vutuv_web/components/ui.ex:4945
 #: lib/vutuv_web/controllers/settings_controller.ex:181
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5958,7 +5956,7 @@ msgstr "Wenn jemand beginnt, Ihnen zu folgen."
 msgid "@handle"
 msgstr "@handle"
 
-#: lib/vutuv_web/live/message_live/index.ex:776
+#: lib/vutuv_web/live/message_live/index.ex:766
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}"
 msgstr "@%{slug} blockieren"
@@ -6026,7 +6024,7 @@ msgid "Name (A-Z)"
 msgstr "Name (A-Z)"
 
 #: lib/vutuv_web/live/post_live/saved.ex:491
-#: lib/vutuv_web/live/tag_live/timeline.ex:413
+#: lib/vutuv_web/live/tag_live/timeline.ex:409
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr "Neueste zuerst"
@@ -6052,7 +6050,7 @@ msgid "Nothing here yet. People you like show up here."
 msgstr "Hier ist noch nichts. Personen, die Ihnen gefallen, erscheinen hier."
 
 #: lib/vutuv_web/live/post_live/saved.ex:492
-#: lib/vutuv_web/live/tag_live/timeline.ex:414
+#: lib/vutuv_web/live/tag_live/timeline.ex:410
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr "Älteste zuerst"
@@ -6074,27 +6072,27 @@ msgid "Search saved items"
 msgstr "Gespeicherte durchsuchen"
 
 #: lib/vutuv_web/live/post_live/saved.ex:554
-#: lib/vutuv_web/live/tag_live/timeline.ex:339
+#: lib/vutuv_web/live/tag_live/timeline.ex:335
 #, elixir-autogen, elixir-format
 msgid "Sort"
 msgstr "Sortieren"
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3305
+#: lib/vutuv_web/components/ui.ex:3407
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "vor %{count} Tag"
 msgstr[1] "vor %{count} Tagen"
 
-#: lib/vutuv_web/components/ui.ex:3304
+#: lib/vutuv_web/components/ui.ex:3406
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "vor %{count} Stunde"
 msgstr[1] "vor %{count} Stunden"
 
-#: lib/vutuv_web/components/ui.ex:3303
+#: lib/vutuv_web/components/ui.ex:3405
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -6121,12 +6119,12 @@ msgstr "Zuletzt aktiv"
 msgid "Log out all other devices"
 msgstr "Alle anderen Geräte abmelden"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:85
+#: lib/vutuv_web/templates/settings/security.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Log out of every device except this one?"
 msgstr "Von allen Geräten außer diesem abmelden?"
 
-#: lib/vutuv_web/views/settings_html.ex:296
+#: lib/vutuv_web/views/settings_html.ex:297
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr "Dieses Gerät von Ihrem Konto abmelden?"
@@ -6163,7 +6161,7 @@ msgstr ""
 "Das ist die erste Anmeldung, die wir von diesem Gerät oder Browser gesehen "
 "haben."
 
-#: lib/vutuv_web/components/ui.ex:3302
+#: lib/vutuv_web/components/ui.ex:3404
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "gerade eben"
@@ -6193,12 +6191,12 @@ msgstr ""
 "Wenn ausgeschaltet, sieht niemand den grünen Punkt auf Ihrem Avatar, und Sie"
 " werden nie als online angezeigt."
 
-#: lib/vutuv_web/templates/settings/security.html.heex:145
+#: lib/vutuv_web/templates/settings/security.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Add a passkey"
 msgstr "Passkey hinzufügen"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1109
 #: lib/vutuv_web/live/admin/screenshot_live.ex:309
 #: lib/vutuv_web/live/fediverse_following_live.ex:264
 #: lib/vutuv_web/views/settings_html.ex:331
@@ -6242,7 +6240,7 @@ msgstr "Passkey entfernt."
 msgid "Passkeys"
 msgstr "Passkeys"
 
-#: lib/vutuv_web/views/settings_html.ex:342
+#: lib/vutuv_web/views/settings_html.ex:343
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr "Diesen Passkey entfernen?"
@@ -6260,7 +6258,7 @@ msgstr ""
 msgid "Sign in with a passkey"
 msgstr "Mit Passkey anmelden"
 
-#: lib/vutuv_web/templates/session/new.html.heex:19
+#: lib/vutuv_web/templates/session/new.html.heex:20
 #, elixir-autogen, elixir-format
 msgid "Sign-in failed. Please try again or use your email."
 msgstr ""
@@ -6278,7 +6276,7 @@ msgstr "Dieser Passkey konnte nicht registriert werden."
 msgid "That passkey could not be verified."
 msgstr "Dieser Passkey konnte nicht verifiziert werden."
 
-#: lib/vutuv_web/templates/settings/security.html.heex:156
+#: lib/vutuv_web/templates/settings/security.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "This browser does not support passkeys."
 msgstr "Dieser Browser unterstützt keine Passkeys."
@@ -6309,13 +6307,13 @@ msgid "Add a tagline"
 msgstr "Kurzbeschreibung hinzufügen"
 
 #: lib/vutuv_web/live/cv_live.ex:148
-#: lib/vutuv_web/templates/user/edit.html.heex:250
+#: lib/vutuv_web/templates/user/edit.html.heex:245
 #: lib/vutuv_web/views/account_event_text.ex:212
 #, elixir-autogen, elixir-format
 msgid "Tagline"
 msgstr "Kurzbeschreibung"
 
-#: lib/vutuv_web/components/ui.ex:396
+#: lib/vutuv_web/components/ui.ex:457
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:907
@@ -6334,18 +6332,18 @@ msgstr[0] "Beitrag"
 msgstr[1] "Beiträge"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:63
-#: lib/vutuv_web/templates/user/edit.html.heex:149
+#: lib/vutuv_web/templates/user/edit.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1527
+#: lib/vutuv_web/templates/user/show.html.heex:1526
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Auch auf"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:51
-#: lib/vutuv_web/templates/user/edit.html.heex:136
+#: lib/vutuv_web/templates/user/edit.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Drag to move, use the slider to zoom. The framed area is what others see."
 msgstr ""
@@ -6357,12 +6355,12 @@ msgstr ""
 msgid "New avatar preview"
 msgstr "Vorschau des neuen Avatars"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:154
+#: lib/vutuv_web/templates/user/edit.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "New cover photo preview"
 msgstr "Vorschau des neuen Titelbilds"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:135
+#: lib/vutuv_web/templates/user/edit.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Position your cover photo"
 msgstr "Titelbild positionieren"
@@ -6373,14 +6371,14 @@ msgid "Position your photo"
 msgstr "Foto positionieren"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:52
-#: lib/vutuv_web/templates/user/edit.html.heex:137
+#: lib/vutuv_web/templates/user/edit.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Use photo"
 msgstr "Foto verwenden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1699
+#: lib/vutuv_web/live/post_live/composer.ex:1675
 #: lib/vutuv_web/templates/user/edit.html.heex:54
-#: lib/vutuv_web/templates/user/edit.html.heex:139
+#: lib/vutuv_web/templates/user/edit.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr "Zoom"
@@ -6469,7 +6467,7 @@ msgid "Previous day"
 msgstr "Vorheriger Tag"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1144
-#: lib/vutuv_web/components/post_components.ex:407
+#: lib/vutuv_web/components/post_components.ex:408
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6506,9 +6504,9 @@ msgstr "Nach unten"
 msgid "Move up"
 msgstr "Nach oben"
 
-#: lib/vutuv_web/components/ui.ex:2025
-#: lib/vutuv_web/components/ui.ex:2034
-#: lib/vutuv_web/components/ui.ex:2513
+#: lib/vutuv_web/components/ui.ex:2049
+#: lib/vutuv_web/components/ui.ex:2058
+#: lib/vutuv_web/components/ui.ex:2537
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr "Empfehlung zurücknehmen"
@@ -6535,9 +6533,9 @@ msgstr "Anzuzeigende Kartendienste"
 msgid "Maps"
 msgstr "Karten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1513
-#: lib/vutuv_web/templates/user/show.html.heex:1521
-#: lib/vutuv_web/templates/user/show.html.heex:1533
+#: lib/vutuv_web/templates/user/show.html.heex:1516
+#: lib/vutuv_web/templates/user/show.html.heex:1520
+#: lib/vutuv_web/templates/user/show.html.heex:1532
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
@@ -6573,7 +6571,7 @@ msgstr "Mitglieder, die %{name} für %{tag} empfohlen haben"
 msgid "No endorsements yet."
 msgstr "Noch keine Empfehlungen."
 
-#: lib/vutuv_web/components/ui.ex:2466
+#: lib/vutuv_web/components/ui.ex:2490
 #: lib/vutuv_web/live/notification_live/index.ex:684
 #: lib/vutuv_web/live/notification_live/index.ex:699
 #: lib/vutuv_web/live/notification_live/index.ex:1012
@@ -6893,10 +6891,10 @@ msgstr ""
 "Schalten Sie einen Schalter aus, geht der passende Opt-out auf den Seiten "
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
-#: lib/vutuv_web/components/post_components.ex:2628
-#: lib/vutuv_web/components/post_components.ex:3603
-#: lib/vutuv_web/components/ui.ex:2813
-#: lib/vutuv_web/live/fediverse_account_live.ex:375
+#: lib/vutuv_web/components/post_components.ex:2650
+#: lib/vutuv_web/components/post_components.ex:3625
+#: lib/vutuv_web/components/ui.ex:2915
+#: lib/vutuv_web/live/fediverse_account_live.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:215
@@ -6922,13 +6920,13 @@ msgstr "Neue Nachrichten und neue Vernetzungen"
 msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
-#: lib/vutuv_web/components/post_components.ex:3603
-#: lib/vutuv_web/components/ui.ex:2812
-#: lib/vutuv_web/live/fediverse_account_live.ex:373
+#: lib/vutuv_web/components/post_components.ex:3625
+#: lib/vutuv_web/components/ui.ex:2914
+#: lib/vutuv_web/live/fediverse_account_live.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:215
-#: lib/vutuv_web/templates/settings/filters.html.heex:110
+#: lib/vutuv_web/templates/settings/filters.html.heex:111
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
 msgid "Unmute"
@@ -6951,12 +6949,12 @@ msgstr "Folgen Sie einander, um mit %{name} vernetzt zu sein und ihn zu lesen."
 msgid "Go to profile to follow"
 msgstr "Zum Profil, um zu folgen"
 
-#: lib/vutuv_web/views/user_html.ex:1195
+#: lib/vutuv_web/views/user_html.ex:1201
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr "Beruflich"
 
-#: lib/vutuv_web/views/user_html.ex:748
+#: lib/vutuv_web/views/user_html.ex:754
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr "Folgt Ihnen"
@@ -6976,7 +6974,7 @@ msgstr "Alle Arten"
 msgid "All statuses"
 msgstr "Alle Status"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:779
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "Any country"
 msgstr "Alle Länder"
@@ -6996,15 +6994,15 @@ msgstr "Zielgruppe %{stamp}"
 msgid "Audience deleted."
 msgstr "Zielgruppe gelöscht."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:709
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:704
 #, elixir-autogen, elixir-format
 msgid "Audience name"
 msgstr "Name der Zielgruppe"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:574
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:638
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:637
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:688
 #: lib/vutuv_web/templates/admin/newsletter/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Audiences"
@@ -7029,7 +7027,7 @@ msgstr ""
 "Newsletter an sie. Ziehen Sie eine andere Zielgruppe ab, um einen Testlauf "
 "zu machen und danach an den Rest zu senden."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:855
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:850
 #, elixir-autogen, elixir-format
 msgid "Cap group size (optional)"
 msgstr "Gruppengröße begrenzen (optional)"
@@ -7055,7 +7053,7 @@ msgid "Created"
 msgstr "Erstellt"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:619
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:659
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:655
 #, elixir-autogen, elixir-format
 msgid "Delete this audience?"
 msgstr "Diese Zielgruppe löschen?"
@@ -7126,7 +7124,7 @@ msgid "Filter"
 msgstr "Filtern"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:591
-#: lib/vutuv_web/live/tag_live/timeline.ex:305
+#: lib/vutuv_web/live/tag_live/timeline.ex:301
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr "Filter"
@@ -7153,14 +7151,14 @@ msgstr "Zielgruppen verwalten"
 msgid "Markdown is supported (headings, bold, lists, links)."
 msgstr "Markdown wird unterstützt (Überschriften, Fett, Listen, Links)."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:801
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:796
 #, elixir-autogen, elixir-format
 msgid "Maximum age"
 msgstr "Höchstalter"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:592
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:670
-#: lib/vutuv_web/live/admin/user_detail_live.ex:69
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:665
+#: lib/vutuv_web/live/admin/user_detail_live.ex:64
 #: lib/vutuv_web/live/admin/user_live.ex:28
 #: lib/vutuv_web/live/admin/user_live.ex:164
 #: lib/vutuv_web/live/admin/user_live.ex:165
@@ -7173,12 +7171,12 @@ msgstr "Höchstalter"
 msgid "Members"
 msgstr "Mitglieder"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:941
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:936
 #, elixir-autogen, elixir-format
 msgid "Members matching"
 msgstr "Passende Mitglieder"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:786
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "Minimum age"
 msgstr "Mindestalter"
@@ -7219,8 +7217,8 @@ msgstr "Newsletter gelöscht."
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:19
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:128
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:638
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:637
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:688
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/index.html.heex:2
@@ -7247,7 +7245,7 @@ msgstr "Keine Sendungen entsprechen Ihren Filtern."
 msgid "No newsletters yet."
 msgstr "Noch keine Newsletter."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:831
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:826
 #, elixir-autogen, elixir-format
 msgid "No tag with that name."
 msgstr "Kein Tag mit diesem Namen."
@@ -7262,7 +7260,7 @@ msgstr "Noch nichts versendet."
 msgid "Occasional vutuv news and announcements."
 msgstr "Gelegentliche vutuv-Neuigkeiten und Ankündigungen."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:880
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:875
 #, elixir-autogen, elixir-format
 msgid "Off: take the oldest members first (by join date)."
 msgstr "Aus: zuerst die ältesten Mitglieder (nach Beitrittsdatum)."
@@ -7272,7 +7270,7 @@ msgstr "Aus: zuerst die ältesten Mitglieder (nach Beitrittsdatum)."
 msgid "Open newsletters"
 msgstr "Newsletter öffnen"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:878
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:873
 #, elixir-autogen, elixir-format
 msgid "Pick capped members at random"
 msgstr "Begrenzte Mitglieder zufällig auswählen"
@@ -7305,19 +7303,19 @@ msgstr "Empfänger"
 msgid "Rendered with your own account data for the variables."
 msgstr "Mit Ihren eigenen Kontodaten für die Variablen dargestellt."
 
-#: lib/vutuv_web/live/cv_live.ex:241
+#: lib/vutuv_web/live/cv_live.ex:231
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:281
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Reset"
 msgstr "Zurücksetzen"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1128
 #, elixir-autogen, elixir-format
 msgid "Save audience"
 msgstr "Zielgruppe speichern"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:809
+#: lib/vutuv_web/live/job_posting_live/form.ex:804
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:16
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:11
 #, elixir-autogen, elixir-format
@@ -7379,7 +7377,7 @@ msgstr "Betreff"
 msgid "Subject line (variables allowed)"
 msgstr "Betreffzeile (Variablen erlaubt)"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:915
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:910
 #, elixir-autogen, elixir-format
 msgid "Subtract these audiences"
 msgstr "Diese Zielgruppen abziehen"
@@ -7394,7 +7392,7 @@ msgstr "Unterdrückt"
 msgid "Suppressed (bounced address)"
 msgstr "Unterdrückt (unzustellbare Adresse)"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:816
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:811
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:44
 #: lib/vutuv_web/templates/settings/filters.html.heex:29
 #: lib/vutuv_web/views/settings_html.ex:60
@@ -7402,7 +7400,7 @@ msgstr "Unterdrückt (unzustellbare Adresse)"
 msgid "Tag"
 msgstr "Tag"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:828
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:823
 #, elixir-autogen, elixir-format
 msgid "Tag found: %{name}"
 msgstr "Tag gefunden: %{name}"
@@ -7428,14 +7426,14 @@ msgstr "Test-E-Mail an %{email} gesendet."
 msgid "That audience could not be found."
 msgstr "Diese Zielgruppe wurde nicht gefunden."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:918
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:913
 #, elixir-autogen, elixir-format
 msgid "Their members are removed from this one (e.g. exclude the test group to send to \"the rest\")."
 msgstr ""
 "Ihre Mitglieder werden aus dieser entfernt (z. B. die Testgruppe abziehen, "
 "um an „den Rest“ zu senden)."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:945
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:940
 #, elixir-autogen, elixir-format
 msgid "This audience will be capped to"
 msgstr "Diese Zielgruppe wird begrenzt auf"
@@ -7463,7 +7461,7 @@ msgstr ""
 msgid "all members"
 msgstr "alle Mitglieder"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:863
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:858
 #, elixir-autogen, elixir-format
 msgid "e.g. 100 for a test run"
 msgstr "z. B. 100 für einen Testlauf"
@@ -7473,7 +7471,7 @@ msgstr "z. B. 100 für einen Testlauf"
 msgid "email or @handle"
 msgstr "E-Mail oder @Handle"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:823
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:818
 #, elixir-autogen, elixir-format
 msgid "exact tag name"
 msgstr "exakter Tag-Name"
@@ -7492,7 +7490,7 @@ msgid "open the dev email inbox"
 msgstr "Dev-Postfach öffnen"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
-#: lib/vutuv_web/views/user_html.ex:747
+#: lib/vutuv_web/views/user_html.ex:753
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr "Vernetzt"
@@ -7507,53 +7505,53 @@ msgstr "Tag: %{name}"
 msgid "max %{count}"
 msgstr "max. %{count}"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:674
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "The frozen snapshot saved with this audience. Click a name to open the profile."
 msgstr ""
 "Die mit dieser Zielgruppe gespeicherte feste Momentaufnahme. Klicken Sie auf"
 " einen Namen, um das Profil zu öffnen."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:677
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "This audience has no members."
 msgstr "Diese Zielgruppe hat keine Mitglieder."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:844
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:839
 #, elixir-autogen, elixir-format
 msgid "e.g. stefan* or *meyer"
 msgstr "z. B. stefan* oder *meyer"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:849
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:844
 #, elixir-autogen, elixir-format
 msgid "Use * as a wildcard; a plain text matches anywhere in the handle."
 msgstr ""
 "Verwenden Sie * als Platzhalter; reiner Text trifft an beliebiger Stelle im "
 "Handle."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:890
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:885
 #, elixir-autogen, elixir-format
 msgid "Add these audiences"
 msgstr "Diese Zielgruppen hinzufügen"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:893
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:888
 #, elixir-autogen, elixir-format
 msgid "Their members are added to this one (union)."
 msgstr "Ihre Mitglieder werden zu dieser hinzugefügt (Vereinigung)."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1168
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1158
 #, elixir-autogen, elixir-format
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr "Seite %{page} von %{pages}, %{total} gesamt"
 
-#: lib/vutuv_web/components/ui.ex:3708
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
+#: lib/vutuv_web/components/ui.ex:3816
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Zurück"
 
-#: lib/vutuv_web/components/ui.ex:3724
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
+#: lib/vutuv_web/components/ui.ex:3828
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr "Weiter"
@@ -7565,49 +7563,49 @@ msgid_plural "plus %{count} groups"
 msgstr[0] "plus 1 Gruppe"
 msgstr[1] "plus %{count} Gruppen"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:956
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:951
 #, elixir-autogen, elixir-format
 msgid "Choose specific accounts"
 msgstr "Bestimmte Konten auswählen"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:959
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:954
 #, elixir-autogen, elixir-format
 msgid "Tick to include an account, untick to exclude it. Search by @handle to find anyone."
 msgstr ""
 "Ankreuzen, um ein Konto aufzunehmen, abwählen, um es auszuschließen. Per "
 "@handle suchen, um jemanden zu finden."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:966
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1065
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:961
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1060
 #, elixir-autogen, elixir-format
 msgid "search by @handle…"
 msgstr "per @handle suchen…"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:973
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:968
 #, elixir-autogen, elixir-format
 msgid "Removed:"
 msgstr "Entfernt:"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:979
-#: lib/vutuv_web/live/post_live/composer.ex:1547
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:974
+#: lib/vutuv_web/live/post_live/composer.ex:1523
 #: lib/vutuv_web/live/post_live/filter_band.ex:532
 #, elixir-autogen, elixir-format
 msgid "Undo"
 msgstr "Rückgängig"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1025
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1020
 #, elixir-autogen, elixir-format
 msgid "In this audience"
 msgstr "In dieser Zielgruppe"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1005
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1098
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1000
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1093
 #, elixir-autogen, elixir-format
 msgid "Search results"
 msgstr "Suchergebnisse"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1011
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1100
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1006
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1095
 #, elixir-autogen, elixir-format
 msgid "No members."
 msgstr "Keine Mitglieder."
@@ -7617,27 +7615,27 @@ msgstr "Keine Mitglieder."
 msgid "accounts"
 msgstr "Konten"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:991
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:986
 #: lib/vutuv_web/live/post_live/filter_band.ex:509
 #: lib/vutuv_web/views/import_html.ex:230
 #, elixir-autogen, elixir-format
 msgid "Select all"
 msgstr "Alle auswählen"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:994
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:989
 #: lib/vutuv_web/views/import_html.ex:240
 #, elixir-autogen, elixir-format
 msgid "Unselect all"
 msgstr "Alle abwählen"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:997
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:992
 #, elixir-autogen, elixir-format
 msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5681
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
+#: lib/vutuv_web/components/post_components.ex:5703
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
 msgstr "+%{count} weitere"
@@ -7746,7 +7744,7 @@ msgstr ""
 "der Versand läuft weiter."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3424
+#: lib/vutuv_web/live/post_live/feed.ex:3421
 #, elixir-autogen
 msgid "Done"
 msgstr "Fertig"
@@ -7759,7 +7757,7 @@ msgstr "An %{count} Mitglieder versendet."
 msgid "View the delivery log"
 msgstr "Zum Versandprotokoll"
 
-#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:232
+#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:226
 #, elixir-autogen
 msgid "%{sent} of %{total} emails sent"
 msgstr "%{sent} von %{total} E-Mails versendet"
@@ -7769,7 +7767,7 @@ msgstr ""
 "Der Newsletter wird an %{count} Personen versendet. Das kann nicht "
 "rückgängig gemacht werden."
 
-#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:218
+#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:212
 #, elixir-autogen
 msgid "Send now"
 msgstr "Jetzt senden"
@@ -8067,61 +8065,61 @@ msgstr "Gestern"
 msgid "updates automatically"
 msgstr "aktualisiert sich automatisch"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:723
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:718
 #, elixir-autogen, elixir-format
 msgid "How to build this audience"
 msgstr "Wie diese Zielgruppe entsteht"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:736
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:731
 #, elixir-autogen, elixir-format
 msgid "From filters"
 msgstr "Aus Filtern"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:745
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:740
 #, elixir-autogen, elixir-format
 msgid "Specific accounts"
 msgstr "Bestimmte Konten"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:749
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:744
 #, elixir-autogen, elixir-format
 msgid "Pick members from filters, or hand-pick specific accounts (e.g. a small group of testers)."
 msgstr ""
 "Wählen Sie Mitglieder über Filter oder fügen Sie gezielt bestimmte Konten "
 "hinzu (z. B. eine kleine Gruppe von Testern)."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1045
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1040
 #, elixir-autogen, elixir-format
 msgid "Accounts in this audience"
 msgstr "Konten in dieser Zielgruppe"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1049
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1044
 #, elixir-autogen, elixir-format
 msgid "Only these accounts get the newsletter. Search for members below and add them one by one."
 msgstr ""
 "Nur diese Konten erhalten den Newsletter. Suchen Sie unten nach Mitgliedern "
 "und fügen Sie sie einzeln hinzu."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1058
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1053
 #, elixir-autogen, elixir-format
 msgid "Find accounts to add"
 msgstr "Konten zum Hinzufügen suchen"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1073
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Chosen accounts"
 msgstr "Ausgewählte Konten"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1076
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1071
 #, elixir-autogen, elixir-format
 msgid "No accounts yet. Search above to add some."
 msgstr "Noch keine Konten. Suchen Sie oben, um welche hinzuzufügen."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1087
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Remove from audience"
 msgstr "Aus der Zielgruppe entfernen"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1123
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1118
 #, elixir-autogen, elixir-format
 msgid "Add to audience"
 msgstr "Hinzufügen"
@@ -8241,8 +8239,8 @@ msgstr "Prüfung ausstehend"
 #: lib/vutuv_web/live/account_activity_live.ex:189
 #: lib/vutuv_web/live/admin/activity_live.ex:231
 #: lib/vutuv_web/live/admin/user_live.ex:184
-#: lib/vutuv_web/live/job_board_live.ex:257
-#: lib/vutuv_web/live/tag_live/timeline.ex:369
+#: lib/vutuv_web/live/job_board_live.ex:256
+#: lib/vutuv_web/live/tag_live/timeline.ex:365
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr "Filter zurücksetzen"
@@ -8258,7 +8256,7 @@ msgstr "Dieses Mitglied konnte nicht verifiziert werden."
 msgid "Deactivated"
 msgstr "Deaktiviert"
 
-#: lib/vutuv_web/live/admin/user_delete_live.ex:195
+#: lib/vutuv_web/live/admin/user_delete_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Delete this account?"
 msgstr "Dieses Konto löschen?"
@@ -8310,7 +8308,7 @@ msgid "Incorrect PIN"
 msgstr "Falsche PIN"
 
 #: lib/vutuv_web/live/admin/user_delete_live.ex:145
-#: lib/vutuv_web/live/admin/user_detail_live.ex:102
+#: lib/vutuv_web/live/admin/user_detail_live.ex:97
 #: lib/vutuv_web/live/admin/user_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Joined"
@@ -8324,7 +8322,7 @@ msgstr ""
 "per E-Mail benachrichtigt."
 
 #: lib/vutuv_web/live/admin/user_delete_live.ex:136
-#: lib/vutuv_web/templates/admin/account/index.html.heex:48
+#: lib/vutuv_web/templates/admin/account/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "No accounts match your search."
 msgstr "Keine Konten entsprechen Ihrer Suche."
@@ -8355,7 +8353,7 @@ msgstr "PIN abgelaufen"
 msgid "PIN registered"
 msgstr "PIN-registriert"
 
-#: lib/vutuv_web/components/ui.ex:3711
+#: lib/vutuv_web/components/ui.ex:3819
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr "Seite %{page} von %{pages}"
@@ -8378,7 +8376,7 @@ msgstr ""
 "aktualisiert sich beim Tippen, und standardmäßig werden PIN-registrierte "
 "Mitglieder angezeigt, die neuesten zuerst."
 
-#: lib/vutuv_web/live/admin/user_delete_live.ex:198
+#: lib/vutuv_web/live/admin/user_delete_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "This permanently deletes the account and everything it owns (posts, phone numbers, email addresses, tags and more). This cannot be undone. The member is not notified; a record is emailed to the operator."
 msgstr ""
@@ -8394,7 +8392,7 @@ msgstr ""
 "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das zu "
 "löschende Konto zu finden."
 
-#: lib/vutuv_web/live/admin/user_detail_live.ex:93
+#: lib/vutuv_web/live/admin/user_detail_live.ex:88
 #: lib/vutuv_web/live/admin/user_live.ex:322
 #, elixir-autogen, elixir-format
 msgid "Unconfirmed"
@@ -8494,7 +8492,7 @@ msgstr "Abschluss"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:4680
+#: lib/vutuv_web/components/ui.ex:4788
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8554,7 +8552,7 @@ msgstr ""
 " was Sie nicht übernehmen möchten. Einträge, die bereits in Ihrem Profil "
 "stehen, sind für Sie abgewählt."
 
-#: lib/vutuv_web/components/ui.ex:4825
+#: lib/vutuv_web/components/ui.ex:4933
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
@@ -8583,7 +8581,7 @@ msgstr "%{items} importiert."
 msgid "Nothing new to import."
 msgstr "Nichts Neues zu importieren."
 
-#: lib/vutuv_web/components/ui.ex:4708
+#: lib/vutuv_web/components/ui.ex:4816
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8680,7 +8678,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 
-#: lib/vutuv_web/components/ui.ex:3988
+#: lib/vutuv_web/components/ui.ex:4092
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8688,7 +8686,7 @@ msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 msgid "Please check the fields marked in red."
 msgstr "Bitte prüfen Sie die rot markierten Felder."
 
-#: lib/vutuv_web/views/user_html.ex:1080
+#: lib/vutuv_web/views/user_html.ex:1086
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
 msgstr "Beiträge werden geladen"
@@ -8774,25 +8772,25 @@ msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 "Ziehen Sie Ihre ZIP-Datei hierher oder klicken Sie, um eine auszuwählen."
 
-#: lib/vutuv_web/components/ui.ex:4668
+#: lib/vutuv_web/components/ui.ex:4776
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr "Basisdaten & Fotos"
 
-#: lib/vutuv_web/components/ui.ex:4815
+#: lib/vutuv_web/components/ui.ex:4923
 #: lib/vutuv_web/controllers/settings_controller.ex:125
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Language & display"
 msgstr "Sprache & Anzeige"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:535
+#: lib/vutuv_web/templates/user/edit.html.heex:523
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
 
-#: lib/vutuv_web/components/ui.ex:4806
+#: lib/vutuv_web/components/ui.ex:4914
 #: lib/vutuv_web/controllers/settings_controller.ex:108
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8802,7 +8800,7 @@ msgstr "Weitere Profil-Bereiche"
 msgid "Sign-in & security"
 msgstr "Anmeldung & Sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:4829
+#: lib/vutuv_web/components/ui.ex:4937
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8924,7 +8922,7 @@ msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 "Die Seite %{letter} des Mitgliederverzeichnisses, sortiert nach Nachnamen."
 
-#: lib/vutuv_web/components/ui.ex:1322
+#: lib/vutuv_web/components/ui.ex:1346
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -9032,8 +9030,8 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/agent_docs/text.ex:586
 #: lib/vutuv_web/agent_docs/text.ex:590
 #: lib/vutuv_web/components/organization_components.ex:276
-#: lib/vutuv_web/components/ui.ex:1523
-#: lib/vutuv_web/components/ui.ex:4796
+#: lib/vutuv_web/components/ui.ex:1547
+#: lib/vutuv_web/components/ui.ex:4904
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:357
 #: lib/vutuv_web/controllers/settings_controller.ex:424
@@ -9141,7 +9139,7 @@ msgstr "Berufserfahrung"
 msgid "Volunteering & hobbies"
 msgstr "Ehrenamt, Hobby & Freiwilligenarbeit"
 
-#: lib/vutuv_web/live/search_live.ex:694
+#: lib/vutuv_web/live/search_live.ex:687
 #, elixir-autogen, elixir-format
 msgid "Not available while the search uses a people filter."
 msgstr "Nicht verfügbar, solange die Suche einen Personen-Filter verwendet."
@@ -9195,12 +9193,12 @@ msgstr ""
 "Ihres Browsers (Strg+P oder Cmd+P) und wählen Sie \"Als PDF speichern\", um "
 "eine PDF-Datei zu erhalten."
 
-#: lib/vutuv_web/components/ui.ex:1612
+#: lib/vutuv_web/components/ui.ex:1636
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:4618
+#: lib/vutuv_web/components/post_components.ex:4640
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9212,28 +9210,28 @@ msgstr[1] "Repostet von %{name} und %{formatted} weiteren"
 msgid "reposted by %{name} and %{count} more"
 msgstr "repostet von %{name} und %{count} weiteren"
 
-#: lib/vutuv_web/live/cv_live.ex:233
+#: lib/vutuv_web/live/cv_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Anonymize"
 msgstr "Anonymisieren"
 
 #: lib/vutuv_web/live/cv_live.ex:149
-#: lib/vutuv_web/templates/page/index.html.heex:161
+#: lib/vutuv_web/templates/page/index.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr "E-Mail-Adresse"
 
-#: lib/vutuv_web/live/cv_live.ex:440
+#: lib/vutuv_web/live/cv_live.ex:430
 #, elixir-autogen, elixir-format
 msgid "Every download reflects the parts you selected."
 msgstr "Jeder Download enthält genau die ausgewählten Teile."
 
-#: lib/vutuv_web/live/cv_live.ex:247
+#: lib/vutuv_web/live/cv_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr "Kopfzeile"
 
-#: lib/vutuv_web/components/ui.ex:1622
+#: lib/vutuv_web/components/ui.ex:1646
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -9253,7 +9251,7 @@ msgstr ""
 "ganze Abschnitte ab, oder anonymisieren Sie den Lebenslauf, indem Sie Name, "
 "Foto und Kontaktdaten ausblenden."
 
-#: lib/vutuv_web/live/cv_live.ex:449
+#: lib/vutuv_web/live/cv_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "Print / Save as PDF"
 msgstr "Drucken / Als PDF speichern"
@@ -9271,7 +9269,7 @@ msgstr ""
 "Besuchers enthält nur, was er dort ohnehin sehen kann, und private E-Mail-"
 "Adressen erscheinen nur in Ihrem eigenen."
 
-#: lib/vutuv_web/components/ui.ex:1614
+#: lib/vutuv_web/components/ui.ex:1638
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -9312,7 +9310,7 @@ msgstr "Freiberuflich / Selbstständig"
 msgid "Other activities"
 msgstr "Sonstige Tätigkeiten"
 
-#: lib/vutuv_web/live/cv_live.ex:463
+#: lib/vutuv_web/live/cv_live.ex:453
 #, elixir-autogen, elixir-format
 msgid "For a PDF, open the print view and choose \"Save as PDF\" in your browser's print dialog. Word and OpenDocument are editable; LaTeX is the typesetting source; JSON Resume is the open %{link} format."
 msgstr ""
@@ -9321,7 +9319,7 @@ msgstr ""
 "LaTeX ist der Quelltext zum Setzen, und JSON Resume ist das offene Format "
 "von %{link}."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:263
+#: lib/vutuv_web/templates/user/edit.html.heex:258
 #, elixir-autogen, elixir-format
 msgid "characters"
 msgstr "Zeichen"
@@ -9446,8 +9444,8 @@ msgstr "Dieses Tag kann nur von einem Admin entfernt werden."
 msgid "Yes"
 msgstr "Ja"
 
-#: lib/vutuv_web/components/ui.ex:2069
-#: lib/vutuv_web/components/ui.ex:2070
+#: lib/vutuv_web/components/ui.ex:2093
+#: lib/vutuv_web/components/ui.ex:2094
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9697,7 +9695,7 @@ msgstr "Sprache erfolgreich aktualisiert."
 #: lib/vutuv_web/cv/html.ex:185
 #: lib/vutuv_web/cv/latex.ex:149
 #: lib/vutuv_web/cv/odt.ex:163
-#: lib/vutuv_web/live/cv_live.ex:386
+#: lib/vutuv_web/live/cv_live.ex:376
 #: lib/vutuv_web/templates/language/edit.html.heex:4
 #: lib/vutuv_web/templates/language/index.html.heex:10
 #: lib/vutuv_web/templates/language/manage.html.heex:4
@@ -9907,7 +9905,7 @@ msgstr "Nicht offen für Angebote"
 msgid "Open to offers"
 msgstr "Offen für Angebote"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:287
+#: lib/vutuv_web/templates/user/edit.html.heex:282
 #, elixir-autogen, elixir-format
 msgid "Shown as a badge next to your tagline so people can see whether you are open to opportunities."
 msgstr ""
@@ -10027,7 +10025,7 @@ msgstr "Zertifikate"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:4684
+#: lib/vutuv_web/components/ui.ex:4792
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -10035,7 +10033,7 @@ msgstr "Zertifikate"
 #: lib/vutuv_web/cv/html.ex:169
 #: lib/vutuv_web/cv/latex.ex:140
 #: lib/vutuv_web/cv/odt.ex:154
-#: lib/vutuv_web/live/cv_live.ex:361
+#: lib/vutuv_web/live/cv_live.ex:351
 #: lib/vutuv_web/templates/import/new.html.heex:11
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
 #: lib/vutuv_web/templates/qualification/index.html.heex:11
@@ -10072,7 +10070,7 @@ msgstr "Läuft nicht ab"
 
 #: lib/vutuv_web/live/admin/job_live.ex:164
 #: lib/vutuv_web/live/admin/job_live.ex:180
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:183
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:182
 #: lib/vutuv_web/templates/qualification/show.html.heex:43
 #: lib/vutuv_web/views/qualification_html.ex:398
 #, elixir-autogen, elixir-format
@@ -10182,18 +10180,18 @@ msgstr "+%{code} ist die Ländervorwahl von %{region}"
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:440
-#: lib/vutuv_web/templates/user/edit.html.heex:523
+#: lib/vutuv_web/templates/user/edit.html.heex:436
+#: lib/vutuv_web/templates/user/edit.html.heex:511
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr "Geburtsdatum entfernen"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:503
+#: lib/vutuv_web/templates/user/edit.html.heex:499
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr "Geburtsdatum entfernen?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:506
+#: lib/vutuv_web/templates/user/edit.html.heex:502
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -10201,14 +10199,14 @@ msgstr ""
 " angezeigt. Sie können es jederzeit wieder hinzufügen."
 
 #: lib/vutuv_web/live/directory_search_live.ex:132
-#: lib/vutuv_web/templates/page/index.html.heex:90
+#: lib/vutuv_web/templates/page/index.html.heex:95
 #: lib/vutuv_web/views/account_event_text.ex:210
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
 
 #: lib/vutuv_web/live/directory_search_live.ex:133
-#: lib/vutuv_web/templates/page/index.html.heex:95
+#: lib/vutuv_web/templates/page/index.html.heex:100
 #: lib/vutuv_web/views/account_event_text.ex:211
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -10230,13 +10228,13 @@ msgstr "Dauerhafter Profillink"
 msgid "Dismiss"
 msgstr "Schließen"
 
-#: lib/vutuv_web/components/ui.ex:3418
+#: lib/vutuv_web/components/ui.ex:3520
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Kopiert"
 
-#: lib/vutuv_web/components/ui.ex:3417
-#: lib/vutuv_web/components/ui.ex:3425
+#: lib/vutuv_web/components/ui.ex:3519
+#: lib/vutuv_web/components/ui.ex:3527
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Kopieren"
@@ -10362,12 +10360,12 @@ msgstr ""
 msgid "Removed as spam"
 msgstr "Als Spam entfernt"
 
-#: lib/vutuv_web/live/admin/user_live.ex:357
+#: lib/vutuv_web/live/admin/user_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Restore"
 msgstr "Wiederherstellen"
 
-#: lib/vutuv_web/live/admin/user_live.ex:354
+#: lib/vutuv_web/live/admin/user_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "Restore this account so the member can sign in again?"
 msgstr ""
@@ -10385,7 +10383,7 @@ msgstr ""
 "Danke für Ihre Meldung. Unsere Moderatoren wurden benachrichtigt und prüfen "
 "dieses Konto."
 
-#: lib/vutuv_web/views/admin/account_html.ex:88
+#: lib/vutuv_web/views/admin/account_html.ex:78
 #: lib/vutuv_web/views/admin/moderation_html.ex:69
 #, elixir-autogen, elixir-format
 msgid "deactivated"
@@ -10430,17 +10428,17 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr "Authenticator-App ausgeschaltet."
 
-#: lib/vutuv_web/components/ui.ex:384
+#: lib/vutuv_web/components/ui.ex:445
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr "Fett"
 
-#: lib/vutuv_web/components/ui.ex:436
+#: lib/vutuv_web/components/ui.ex:497
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr "Aufzählung"
 
-#: lib/vutuv_web/components/ui.ex:439
+#: lib/vutuv_web/components/ui.ex:500
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr "Codeblock"
@@ -10450,19 +10448,19 @@ msgstr "Codeblock"
 msgid "Delete the list"
 msgstr "Liste löschen"
 
-#: lib/vutuv_web/templates/login_code/index.html.heex:60
+#: lib/vutuv_web/templates/login_code/index.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "Delete your code list? All its codes stop working immediately."
 msgstr ""
 "Kennwortliste löschen? Alle Codes darauf funktionieren sofort nicht mehr."
 
-#: lib/vutuv_web/components/ui.ex:380
+#: lib/vutuv_web/components/ui.ex:441
 #, elixir-autogen, elixir-format
 msgid "Formatting"
 msgstr "Formatierung"
 
-#: lib/vutuv_web/components/ui.ex:503
-#: lib/vutuv_web/components/ui.ex:504
+#: lib/vutuv_web/components/ui.ex:564
+#: lib/vutuv_web/components/ui.ex:565
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr "Vollbild"
@@ -10477,43 +10475,43 @@ msgstr "Neue Liste erstellen"
 msgid "Generate code list"
 msgstr "Kennwortliste erstellen"
 
-#: lib/vutuv_web/components/ui.ex:434
+#: lib/vutuv_web/components/ui.ex:495
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr "Überschrift 1"
 
-#: lib/vutuv_web/components/ui.ex:435
+#: lib/vutuv_web/components/ui.ex:496
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr "Überschrift 2"
 
-#: lib/vutuv_web/components/ui.ex:393
+#: lib/vutuv_web/components/ui.ex:454
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr "Inline-Code"
 
-#: lib/vutuv_web/components/ui.ex:387
+#: lib/vutuv_web/components/ui.ex:448
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr "Kursiv"
 
-#: lib/vutuv_web/components/ui.ex:540
+#: lib/vutuv_web/components/ui.ex:397
 #, elixir-autogen, elixir-format
 msgid "Link URL"
 msgstr "Link-URL"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:166
+#: lib/vutuv_web/templates/settings/security.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Login codes"
 msgstr "Anmelde-Codes"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:179
+#: lib/vutuv_web/templates/settings/security.html.heex:178
 #: lib/vutuv_web/templates/settings/security.html.heex:213
 #, elixir-autogen, elixir-format
 msgid "Not set up."
 msgstr "Nicht eingerichtet."
 
-#: lib/vutuv_web/components/ui.ex:437
+#: lib/vutuv_web/components/ui.ex:498
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr "Nummerierte Liste"
@@ -10530,7 +10528,7 @@ msgstr ""
 "Drucken Sie diese Seite aus oder schreiben Sie die Codes ab. "
 "Durchgestrichene Codes wurden bereits verwendet."
 
-#: lib/vutuv_web/components/ui.ex:438
+#: lib/vutuv_web/components/ui.ex:499
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr "Zitat"
@@ -10555,7 +10553,7 @@ msgstr ""
 msgid "Set up"
 msgstr "Einrichten"
 
-#: lib/vutuv_web/components/ui.ex:390
+#: lib/vutuv_web/components/ui.ex:451
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr "Durchgestrichen"
@@ -10577,7 +10575,7 @@ msgstr "Geben Sie zum Abschluss den Code ein, den Ihre App jetzt anzeigt"
 msgid "Turn off"
 msgstr "Ausschalten"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:187
+#: lib/vutuv_web/templates/settings/security.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "Turn off the authenticator app? Its codes stop working at login; the emailed PIN is unaffected."
 msgstr ""
@@ -10589,7 +10587,7 @@ msgstr ""
 msgid "Turn on"
 msgstr "Einschalten"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:179
+#: lib/vutuv_web/templates/settings/security.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "Turned on."
 msgstr "Eingeschaltet."
@@ -10632,7 +10630,7 @@ msgstr ""
 "Kennwortliste funktioniert hier, anstelle der PIN aus der E-Mail."
 
 #: lib/vutuv_web/controllers/totp_controller.ex:90
-#: lib/vutuv_web/templates/settings/security.html.heex:176
+#: lib/vutuv_web/templates/settings/security.html.heex:175
 #: lib/vutuv_web/templates/totp/new.html.heex:2
 #: lib/vutuv_web/templates/totp/new.html.heex:6
 #, elixir-autogen, elixir-format
@@ -10647,7 +10645,7 @@ msgstr "Authenticator-App (TOTP)"
 msgid "One-time code list (OTP)"
 msgstr "Kennwortliste (OTP)"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:168
+#: lib/vutuv_web/templates/settings/security.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Sign in with a one-time code (OTP) from an authenticator app or from a printed code list, typed into the normal PIN field. Your emailed PIN always keeps working."
 msgstr ""
@@ -10677,15 +10675,15 @@ msgstr[0] "%{count} Stern"
 msgstr[1] "%{count} Sterne"
 
 #: lib/vutuv_web/live/organization_live/show.ex:638
-#: lib/vutuv_web/views/user_html.ex:944
-#: lib/vutuv_web/views/user_html.ex:1120
+#: lib/vutuv_web/views/user_html.ex:950
+#: lib/vutuv_web/views/user_html.ex:1126
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
 msgstr[0] "%{formatted} Follower"
 msgstr[1] "%{formatted} Follower"
 
-#: lib/vutuv_web/views/user_html.ex:937
+#: lib/vutuv_web/views/user_html.ex:943
 #, elixir-autogen, elixir-format
 msgid "%{formatted} star"
 msgid_plural "%{formatted} stars"
@@ -10713,7 +10711,7 @@ msgstr ""
 "dessen öffentliche Statistiken zeigen: Sterne, Repositories, Follower, "
 "Sprachen und letzte Aktivität."
 
-#: lib/vutuv_web/views/user_html.ex:951
+#: lib/vutuv_web/views/user_html.ex:957
 #, elixir-autogen, elixir-format
 msgid "Last active %{date}"
 msgstr "Zuletzt aktiv %{date}"
@@ -10740,7 +10738,7 @@ msgstr "zuletzt aktiv %{date}"
 msgid "since %{date}"
 msgstr "seit %{date}"
 
-#: lib/vutuv_web/views/user_html.ex:867
+#: lib/vutuv_web/views/user_html.ex:873
 #, elixir-autogen, elixir-format
 msgid "since %{year}"
 msgstr "seit %{year}"
@@ -10936,7 +10934,7 @@ msgstr ""
 "vutuv ist das offene Business-Netzwerk. Fachleute vernetzen sich, tauschen "
 "sich aus und werden gefunden. Kostenlos dabei."
 
-#: lib/vutuv_web/templates/page/index.html.heex:150
+#: lib/vutuv_web/templates/page/index.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "At least three tags, separated by commas. A tag may be several words long, like Ruby on Rails."
 msgstr "Mindestens drei Tags, mit Komma getrennt. Ein Tag darf aus mehreren Wörtern bestehen, zum Beispiel Ruby on Rails."
@@ -10968,14 +10966,14 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] "Sie haben %{formatted} neue Nachricht."
 msgstr[1] "Sie haben %{formatted} neue Nachrichten."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:390
+#: lib/vutuv_web/templates/settings/preferences.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 "Trennt lange Wörter an Silbengrenzen, damit der Text gleichmäßig umbricht. "
 "Hilfreich in der schmalen Smartphone-Spalte."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:321
+#: lib/vutuv_web/templates/settings/preferences.html.heex:310
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
@@ -10983,35 +10981,35 @@ msgstr ""
 "Das sind Ihre eigenen Anzeige-Einstellungen."
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:397
+#: lib/vutuv_web/templates/settings/preferences.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr "Silbentrennung am Desktop"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:401
+#: lib/vutuv_web/templates/settings/preferences.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr "Silbentrennung auf dem Smartphone"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:387
+#: lib/vutuv_web/templates/settings/preferences.html.heex:376
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr "Silbentrennung"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:344
+#: lib/vutuv_web/templates/settings/preferences.html.heex:333
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr "Zeilen am Desktop"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:353
+#: lib/vutuv_web/templates/settings/preferences.html.heex:342
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr "Zeilen auf dem Smartphone"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:339
+#: lib/vutuv_web/templates/settings/preferences.html.heex:328
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
@@ -11023,7 +11021,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr "Anzeige-Einstellungen für Beiträge gespeichert."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:336
+#: lib/vutuv_web/templates/settings/preferences.html.heex:325
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr "Beitrag kürzen nach"
@@ -11110,7 +11108,7 @@ msgstr ""
 msgid "Preference defaults"
 msgstr "Voreinstellungen"
 
-#: lib/vutuv_web/live/admin/user_detail_live.ex:155
+#: lib/vutuv_web/live/admin/user_detail_live.ex:150
 #: lib/vutuv_web/live/admin/user_live.ex:336
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:10
 #, elixir-autogen, elixir-format
@@ -11126,9 +11124,9 @@ msgstr "Einstellungen von %{name}"
 #: lib/vutuv_web/live/feed_languages_live.ex:377
 #: lib/vutuv_web/templates/settings/preferences.html.heex:101
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
-#: lib/vutuv_web/templates/settings/preferences.html.heex:239
-#: lib/vutuv_web/templates/settings/preferences.html.heex:303
-#: lib/vutuv_web/templates/settings/preferences.html.heex:421
+#: lib/vutuv_web/templates/settings/preferences.html.heex:229
+#: lib/vutuv_web/templates/settings/preferences.html.heex:292
+#: lib/vutuv_web/templates/settings/preferences.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr "Auf die Standardwerte zurücksetzen"
@@ -11214,7 +11212,7 @@ msgstr ""
 msgid "Captured screenshots"
 msgstr "Aufgenommene Screenshots"
 
-#: lib/vutuv_web/live/admin/screenshot_live.ex:525
+#: lib/vutuv_web/live/admin/screenshot_live.ex:524
 #, elixir-autogen, elixir-format
 msgid "Capturing"
 msgstr "Wird aufgenommen"
@@ -11226,14 +11224,14 @@ msgstr ""
 "Jeder aufgenommene Link-Screenshot, neueste zuerst. Jeder verlinkt auf die "
 "Seite und den zugehörigen Beitrag."
 
-#: lib/vutuv_web/live/admin/screenshot_live.ex:527
+#: lib/vutuv_web/live/admin/screenshot_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
-#: lib/vutuv_web/live/post_live/composer.ex:1778
-#: lib/vutuv_web/live/post_live/composer.ex:2480
+#: lib/vutuv_web/live/post_live/composer.ex:1754
+#: lib/vutuv_web/live/post_live/composer.ex:2419
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr "Galerie"
@@ -11272,7 +11270,7 @@ msgstr "Screenshot-Warteschlange öffnen"
 #: lib/vutuv_web/live/admin/organization_live.ex:165
 #: lib/vutuv_web/live/admin/organization_live.ex:179
 #: lib/vutuv_web/live/admin/organization_live.ex:194
-#: lib/vutuv_web/live/admin/screenshot_live.ex:524
+#: lib/vutuv_web/live/admin/screenshot_live.ex:523
 #: lib/vutuv_web/live/organization_live/domains.ex:201
 #, elixir-autogen, elixir-format
 msgid "Pending"
@@ -11289,7 +11287,7 @@ msgstr "Warteschlange"
 msgid "Queued"
 msgstr "Eingereiht"
 
-#: lib/vutuv_web/live/admin/screenshot_live.ex:526
+#: lib/vutuv_web/live/admin/screenshot_live.ex:525
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr "Fertig"
@@ -11331,7 +11329,7 @@ msgstr "Versuche"
 msgid "Views"
 msgstr "Ansichten"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:296
+#: lib/vutuv_web/templates/user/edit.html.heex:291
 #, elixir-autogen, elixir-format
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
@@ -11354,31 +11352,31 @@ msgstr "Niemand"
 
 #: lib/vutuv/accounts/user.ex:1234
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
-#: lib/vutuv_web/live/job_posting_live/form.ex:773
+#: lib/vutuv_web/live/job_posting_live/form.ex:772
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr "Nur angemeldete Mitglieder"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:293
+#: lib/vutuv_web/templates/user/edit.html.heex:288
 #: lib/vutuv_web/templates/welcome/show.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Who can see your availability?"
 msgstr "Wer kann Ihre Verfügbarkeit sehen?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:318
+#: lib/vutuv_web/templates/user/edit.html.heex:313
 #: lib/vutuv_web/templates/welcome/show.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr "Betrag"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:669
-#: lib/vutuv_web/templates/user/edit.html.heex:326
+#: lib/vutuv_web/live/job_posting_live/form.ex:668
+#: lib/vutuv_web/templates/user/edit.html.heex:321
 #: lib/vutuv_web/templates/welcome/show.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr "Währung"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:336
+#: lib/vutuv_web/templates/user/edit.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "Hidden by default, and it still does its job while hidden. \"Signed-in members only\" adds a quiet line to your profile for members; \"Everyone\" also shows it to logged-out visitors."
 msgstr ""
@@ -11386,13 +11384,13 @@ msgstr ""
 "angemeldete Mitglieder“ ergänzt Ihr Profil um eine dezente Zeile für "
 "Mitglieder; „Alle“ zeigt sie auch nicht angemeldeten Besuchern."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:309
+#: lib/vutuv_web/templates/user/edit.html.heex:304
 #: lib/vutuv_web/templates/welcome/show.html.heex:114
 #, elixir-autogen, elixir-format
 msgid "Minimum salary expectation"
 msgstr "Mindest-Gehaltsvorstellung"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:312
+#: lib/vutuv_web/templates/user/edit.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
@@ -11400,8 +11398,8 @@ msgstr ""
 "Benachrichtigungen, indem Stellen darunter herausgefiltert werden. Lassen "
 "Sie den Betrag leer, um die Angabe zu entfernen."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:676
-#: lib/vutuv_web/templates/user/edit.html.heex:322
+#: lib/vutuv_web/live/job_posting_live/form.ex:675
+#: lib/vutuv_web/templates/user/edit.html.heex:317
 #: lib/vutuv_web/templates/welcome/show.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Per"
@@ -11412,7 +11410,7 @@ msgstr "Pro"
 msgid "Salary expectation from %{amount} %{currency} per %{period}"
 msgstr "Gehaltsvorstellung ab %{amount} %{currency} pro %{period}"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:333
+#: lib/vutuv_web/templates/user/edit.html.heex:328
 #, elixir-autogen, elixir-format
 msgid "Who can see your salary expectation?"
 msgstr "Wer kann Ihre Gehaltsvorstellung sehen?"
@@ -11462,7 +11460,7 @@ msgid "Email domain"
 msgstr "E-Mail-Domain"
 
 #: lib/vutuv_web/components/job_exclusion_components.ex:110
-#: lib/vutuv_web/components/job_exclusion_components.ex:230
+#: lib/vutuv_web/components/job_exclusion_components.ex:225
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:144
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:169
 #, elixir-autogen, elixir-format
@@ -11481,7 +11479,7 @@ msgstr "Ein Mitglied ausschließen"
 msgid "Exclude an email domain"
 msgstr "Eine E-Mail-Domain ausschließen"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:389
+#: lib/vutuv_web/templates/user/edit.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr "Vor bestimmten Personen verbergen"
@@ -11492,7 +11490,7 @@ msgstr "Vor bestimmten Personen verbergen"
 msgid "Job-search exclusion list"
 msgstr "Ausschlussliste für die Jobsuche"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:392
+#: lib/vutuv_web/templates/user/edit.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
@@ -11501,7 +11499,7 @@ msgstr ""
 "Mitglieder oder E-Mail-Domains aus; sie sehen Ihre Verfügbarkeit und Ihre "
 "Gehaltsvorstellung dann nie, auch nicht bei „Alle“."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:400
+#: lib/vutuv_web/templates/user/edit.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -11551,7 +11549,7 @@ msgstr "Ihre Ausschlussliste ist voll (max. %{count})."
 msgid "Your list is empty. Nobody is excluded yet."
 msgstr "Ihre Liste ist leer. Es ist noch niemand ausgeschlossen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:363
+#: lib/vutuv_web/live/organization_live/edit.ex:358
 #: lib/vutuv_web/views/account_event_text.ex:232
 #, elixir-autogen, elixir-format
 msgid "AI agents"
@@ -11562,24 +11560,24 @@ msgstr "KI-Agenten"
 msgid "About"
 msgstr "Über die Organisation"
 
-#: lib/vutuv_web/live/organization_live/new.ex:225
+#: lib/vutuv_web/live/organization_live/new.ex:221
 #, elixir-autogen, elixir-format
 msgid "Continue to verification"
 msgstr "Weiter zur Verifizierung"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:265
-#: lib/vutuv_web/live/organization_live/domains.ex:305
+#: lib/vutuv_web/live/organization_live/domains.ex:264
+#: lib/vutuv_web/live/organization_live/domains.ex:299
 #: lib/vutuv_web/live/organization_live/new.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:1038
+#: lib/vutuv_web/live/organization_live/show.ex:1033
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
 msgstr "DNS-TXT-Eintrag"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:184
-#: lib/vutuv_web/live/organization_live/domains.ex:346
-#: lib/vutuv_web/live/organization_live/show.ex:1104
-#: lib/vutuv_web/live/organization_live/show.ex:1112
+#: lib/vutuv_web/live/organization_live/domains.ex:339
+#: lib/vutuv_web/live/organization_live/show.ex:1098
+#: lib/vutuv_web/live/organization_live/show.ex:1106
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr "Die Domain-Verifizierung ist auf dieser Installation deaktiviert."
@@ -11590,7 +11588,7 @@ msgstr "Die Domain-Verifizierung ist auf dieser Installation deaktiviert."
 msgid "Edit %{name}"
 msgstr "%{name} bearbeiten"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:349
+#: lib/vutuv_web/live/organization_live/edit.ex:344
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this page and include it in the sitemap."
 msgstr ""
@@ -11601,7 +11599,7 @@ msgstr ""
 msgid "Logo"
 msgstr "Logo"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:365
+#: lib/vutuv_web/live/organization_live/edit.ex:360
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
@@ -11614,22 +11612,22 @@ msgstr ""
 msgid "Please log in first."
 msgstr "Bitte loggen Sie sich zuerst ein."
 
-#: lib/vutuv_web/live/organization_live/show.ex:1011
+#: lib/vutuv_web/live/organization_live/show.ex:1006
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr "Weisen Sie nach, dass Ihnen %{domain} gehört, um diese Seite zu veröffentlichen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:283
+#: lib/vutuv_web/live/organization_live/edit.ex:278
 #, elixir-autogen, elixir-format
 msgid "Remove logo"
 msgstr "Logo entfernen"
 
-#: lib/vutuv_web/live/organization_live/index.ex:83
+#: lib/vutuv_web/live/organization_live/index.ex:81
 #, elixir-autogen, elixir-format
 msgid "Search by name or city"
 msgstr "Nach Name oder Stadt suchen"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:347
+#: lib/vutuv_web/live/organization_live/edit.ex:342
 #: lib/vutuv_web/views/account_event_text.ex:231
 #, elixir-autogen, elixir-format
 msgid "Search engines"
@@ -11640,35 +11638,35 @@ msgstr "Suchmaschinen"
 msgid "Select a country"
 msgstr "Land auswählen"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:1073
+#: lib/vutuv_web/live/organization_live/domains.ex:318
+#: lib/vutuv_web/live/organization_live/show.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr "Stellen Sie diese Datei bereit unter:"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:328
+#: lib/vutuv_web/live/organization_live/edit.ex:323
 #: lib/vutuv_web/live/organization_live/new.ex:139
 #, elixir-autogen, elixir-format
 msgid "State / region (optional)"
 msgstr "Bundesland / Region (optional)"
 
-#: lib/vutuv_web/components/ui.ex:4042
+#: lib/vutuv_web/components/ui.ex:4146
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr "Dieser Dateityp ist nicht erlaubt."
 
-#: lib/vutuv_web/components/ui.ex:4044
+#: lib/vutuv_web/components/ui.ex:4148
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr "Der Upload ist fehlgeschlagen."
 
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:1026
+#: lib/vutuv_web/live/organization_live/show.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr "Verifizierungsmethode"
 
-#: lib/vutuv_web/live/organization_live/show.ex:937
+#: lib/vutuv_web/live/organization_live/show.ex:932
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr "Verifizierte Domains"
@@ -11679,33 +11677,33 @@ msgstr "Verifizierte Domains"
 msgid "Verified via"
 msgstr "Verifiziert über"
 
-#: lib/vutuv_web/live/organization_live/show.ex:997
+#: lib/vutuv_web/live/organization_live/show.ex:992
 #, elixir-autogen, elixir-format
 msgid "Verified via %{domain}"
 msgstr "Verifiziert über %{domain}"
 
-#: lib/vutuv_web/live/organization_live/show.ex:1008
+#: lib/vutuv_web/live/organization_live/show.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr "%{name} verifizieren"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:340
-#: lib/vutuv_web/live/organization_live/show.ex:1098
+#: lib/vutuv_web/live/organization_live/domains.ex:333
+#: lib/vutuv_web/live/organization_live/show.ex:1092
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr "Jetzt verifizieren"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:262
 #: lib/vutuv_web/agent_docs/text.ex:245
-#: lib/vutuv_web/live/organization_live/edit.ex:322
+#: lib/vutuv_web/live/organization_live/edit.ex:317
 #: lib/vutuv_web/live/organization_live/new.ex:130
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr "Website"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:266
-#: lib/vutuv_web/live/organization_live/domains.ex:315
-#: lib/vutuv_web/live/organization_live/show.ex:1049
+#: lib/vutuv_web/live/organization_live/domains.ex:265
+#: lib/vutuv_web/live/organization_live/domains.ex:309
+#: lib/vutuv_web/live/organization_live/show.ex:1044
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11723,8 +11721,8 @@ msgstr ""
 "Im nächsten Schritt veröffentlichen Sie einen Eintrag oder eine Datei, um "
 "die Kontrolle über die Domain nachzuweisen."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:326
-#: lib/vutuv_web/live/organization_live/show.ex:1079
+#: lib/vutuv_web/live/organization_live/domains.ex:320
+#: lib/vutuv_web/live/organization_live/show.ex:1074
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11736,12 +11734,12 @@ msgid "@handle or email"
 msgstr "@handle oder E-Mail"
 
 #: lib/vutuv_web/components/organization_components.ex:333
-#: lib/vutuv_web/live/organization_live/edit.ex:425
+#: lib/vutuv_web/live/organization_live/edit.ex:412
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
 msgstr "Abkürzung"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:253
+#: lib/vutuv_web/live/organization_live/domains.ex:252
 #, elixir-autogen, elixir-format
 msgid "Add a domain"
 msgstr "Domain hinzufügen"
@@ -11757,7 +11755,7 @@ msgid "Added @%{handle} to the team."
 msgstr "@%{handle} zum Team hinzugefügt."
 
 #: lib/vutuv_web/components/organization_components.ex:334
-#: lib/vutuv_web/live/organization_live/edit.ex:423
+#: lib/vutuv_web/live/organization_live/edit.ex:410
 #, elixir-autogen, elixir-format
 msgid "Alias"
 msgstr "Alias"
@@ -11774,24 +11772,24 @@ msgstr "Alias entfernt."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:436
 #: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/live/organization_live/edit.ex:388
-#: lib/vutuv_web/live/organization_live/show.ex:925
+#: lib/vutuv_web/live/organization_live/edit.ex:375
+#: lib/vutuv_web/live/organization_live/show.ex:920
 #: lib/vutuv_web/templates/tag/single_card.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Also known as"
 msgstr "Auch bekannt als"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:419
+#: lib/vutuv_web/live/organization_live/edit.ex:406
 #, elixir-autogen, elixir-format
 msgid "Alternative name"
 msgstr "Alternativer Name"
 
-#: lib/vutuv_web/live/admin/organization_live.ex:389
+#: lib/vutuv_web/live/admin/organization_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Archive"
 msgstr "Archivieren"
 
-#: lib/vutuv_web/live/admin/organization_live.ex:386
+#: lib/vutuv_web/live/admin/organization_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Archive this page?"
 msgstr "Diese Seite archivieren?"
@@ -11803,7 +11801,7 @@ msgid "Archived"
 msgstr "Archiviert"
 
 #: lib/vutuv_web/components/organization_components.ex:332
-#: lib/vutuv_web/live/organization_live/edit.ex:424
+#: lib/vutuv_web/live/organization_live/edit.ex:411
 #, elixir-autogen, elixir-format
 msgid "Brand"
 msgstr "Marke"
@@ -11813,12 +11811,12 @@ msgstr "Marke"
 msgid "Claimed by"
 msgstr "Beansprucht von"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:220
+#: lib/vutuv_web/live/organization_live/roles.ex:215
 #, elixir-autogen, elixir-format
 msgid "Current team"
 msgstr "Aktuelles Team"
 
-#: lib/vutuv_web/live/admin/organization_live.ex:395
+#: lib/vutuv_web/live/admin/organization_live.ex:397
 #, elixir-autogen, elixir-format
 msgid "Delete this page and everything it owns? This cannot be undone."
 msgstr ""
@@ -11860,14 +11858,14 @@ msgstr "Domains – %{name}"
 msgid "Former name"
 msgstr "Früherer Name"
 
-#: lib/vutuv_web/live/admin/job_live.ex:461
-#: lib/vutuv_web/live/admin/organization_live.ex:370
-#: lib/vutuv_web/views/admin/account_html.ex:45
+#: lib/vutuv_web/live/admin/job_live.ex:460
+#: lib/vutuv_web/live/admin/organization_live.ex:373
+#: lib/vutuv_web/views/admin/account_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Freeze"
 msgstr "Einfrieren"
 
-#: lib/vutuv_web/live/admin/organization_live.ex:367
+#: lib/vutuv_web/live/admin/organization_live.ex:371
 #, elixir-autogen, elixir-format
 msgid "Freeze this page? It disappears for the public but stays visible to its owner."
 msgstr ""
@@ -11880,7 +11878,7 @@ msgstr ""
 msgid "Last checked"
 msgstr "Zuletzt geprüft"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:247
+#: lib/vutuv_web/live/organization_live/roles.ex:242
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr "Verlassen"
@@ -11895,7 +11893,7 @@ msgstr "Verlassen"
 msgid "Live"
 msgstr "Live"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:237
+#: lib/vutuv_web/live/organization_live/domains.ex:236
 #, elixir-autogen, elixir-format
 msgid "Make primary"
 msgstr "Als primär festlegen"
@@ -11945,12 +11943,12 @@ msgstr "Recruiter"
 msgid "Remove this domain?"
 msgstr "Diese Domain entfernen?"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:242
+#: lib/vutuv_web/live/organization_live/roles.ex:238
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the team?"
 msgstr "Dieses Mitglied aus dem Team entfernen?"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:405
+#: lib/vutuv_web/live/organization_live/edit.ex:393
 #, elixir-autogen, elixir-format
 msgid "Remove this name?"
 msgstr "Diesen Namen entfernen?"
@@ -11983,9 +11981,9 @@ msgstr "Das ist keine gültige Domain."
 msgid "That member could not be added."
 msgstr "Dieses Mitglied konnte nicht hinzugefügt werden."
 
-#: lib/vutuv_web/live/admin/job_live.ex:470
-#: lib/vutuv_web/live/admin/organization_live.ex:379
-#: lib/vutuv_web/views/admin/account_html.ex:31
+#: lib/vutuv_web/live/admin/job_live.ex:468
+#: lib/vutuv_web/live/admin/organization_live.ex:381
+#: lib/vutuv_web/views/admin/account_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "Unfreeze"
 msgstr "Freigeben"
@@ -12007,24 +12005,24 @@ msgstr "primär"
 msgid "verified"
 msgstr "verifiziert"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:325
+#: lib/vutuv_web/live/organization_live/edit.ex:320
 #: lib/vutuv_web/live/organization_live/new.ex:136
 #, elixir-autogen, elixir-format
 msgid "Street address (optional)"
 msgstr "Straße und Hausnummer (optional)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:326
+#: lib/vutuv_web/live/organization_live/edit.ex:321
 #: lib/vutuv_web/live/organization_live/new.ex:137
 #, elixir-autogen, elixir-format
 msgid "ZIP / postal code (optional)"
 msgstr "PLZ (optional)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:482
+#: lib/vutuv_web/live/organization_live/edit.ex:461
 #, elixir-autogen, elixir-format
 msgid "Claim"
 msgstr "Reservieren"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:451
+#: lib/vutuv_web/live/organization_live/edit.ex:433
 #, elixir-autogen, elixir-format
 msgid "Reachable at"
 msgstr "Erreichbar unter"
@@ -12034,12 +12032,12 @@ msgstr "Erreichbar unter"
 msgid "That handle is not available."
 msgstr "Dieses Handle ist nicht verfügbar."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:488
+#: lib/vutuv_web/live/organization_live/edit.ex:467
 #, elixir-autogen, elixir-format
 msgid "Danger zone"
 msgstr "Gefahrenbereich"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:499
+#: lib/vutuv_web/live/organization_live/edit.ex:479
 #, elixir-autogen, elixir-format
 msgid "Really delete %{name}? This cannot be undone."
 msgstr "%{name} wirklich löschen? Das kann nicht rückgängig gemacht werden."
@@ -12062,7 +12060,7 @@ msgid "Back-link (rel=me)"
 msgstr "Rück-Link (rel=me)"
 
 #: lib/vutuv_web/templates/url/verify.html.heex:25
-#: lib/vutuv_web/views/url_html.ex:71
+#: lib/vutuv_web/views/url_html.ex:65
 #, elixir-autogen, elixir-format
 msgid "Link verification is disabled on this installation."
 msgstr "Die Link-Verifizierung ist auf dieser Installation deaktiviert."
@@ -12091,7 +12089,7 @@ msgstr ""
 "Der Linktext ist beliebig. Ein verstecktes <link rel=\"me\"> im Seitenkopf "
 "funktioniert ebenfalls."
 
-#: lib/vutuv_web/components/ui.ex:1038
+#: lib/vutuv_web/components/ui.ex:1062
 #: lib/vutuv_web/live/section_reorder_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -12197,7 +12195,7 @@ msgstr[1] ""
 "und wurden zur Prüfung markiert. Öffnen Sie unten eine Organisation, um sie "
 "zu sehen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:390
+#: lib/vutuv_web/live/organization_live/edit.ex:377
 #, elixir-autogen, elixir-format
 msgid "Alternative names, brands or abbreviations this organization is findable under. A rename keeps the old name here automatically."
 msgstr ""
@@ -12239,11 +12237,11 @@ msgstr ""
 "Domain oder einer Subdomain davon liegt, wird ausgeschlossen. So verbergen "
 "Sie es zuverlässig vor Ihrer ganzen Organisation."
 
-#: lib/vutuv_web/live/organization_live/index.ex:70
-#: lib/vutuv_web/live/organization_live/index.ex:101
+#: lib/vutuv_web/live/organization_live/index.ex:68
+#: lib/vutuv_web/live/organization_live/index.ex:99
 #: lib/vutuv_web/live/organization_live/new.ex:28
 #: lib/vutuv_web/live/organization_live/new.ex:95
-#: lib/vutuv_web/templates/settings/organizations.html.heex:118
+#: lib/vutuv_web/templates/settings/organizations.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Add your organization"
 msgstr "Ihre Organisation hinzufügen"
@@ -12268,28 +12266,28 @@ msgstr "Vielleicht brauchen Sie Hilfe von Ihrer IT"
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr "Der Nachweis ist eine kleine technische Änderung an Ihrer Domain: ein DNS-Eintrag oder eine Datei auf Ihrer Website. Wenn Sie die Website nicht selbst verwalten, fragen Sie die Person oder das Team, das dies tut. Das ist meist Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Die genaue Anleitung zeigen wir Ihnen im nächsten Schritt, Sie können sie einfach weitergeben."
 
-#: lib/vutuv_web/live/organization_live/show.ex:1020
+#: lib/vutuv_web/live/organization_live/show.ex:1015
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr "Diese Schritte sind technisch. Wenn Sie %{domain} nicht selbst verwalten, kopieren Sie den unten gezeigten Eintrag oder die Datei und senden Sie ihn an Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Sobald sie ihn hinzugefügt hat, kommen Sie hierher zurück und klicken auf „Jetzt verifizieren“."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:503
+#: lib/vutuv_web/live/organization_live/edit.ex:482
 #, elixir-autogen, elixir-format
 msgid "Delete this organization"
 msgstr "Diese Organisation löschen"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:490
+#: lib/vutuv_web/live/organization_live/edit.ex:469
 #, elixir-autogen, elixir-format
 msgid "Deleting this organization page is permanent. Its verified domains and its @handle are freed and can be claimed again."
 msgstr "Das Löschen dieser Organisationsseite ist endgültig. Ihre verifizierten Domains und ihr @handle werden freigegeben und können erneut beansprucht werden."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:297
+#: lib/vutuv_web/live/organization_live/edit.ex:292
 #: lib/vutuv_web/live/organization_live/new.ex:126
 #, elixir-autogen, elixir-format
 msgid "Kind of organization"
 msgstr "Art der Organisation"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:241
+#: lib/vutuv_web/live/organization_live/roles.ex:237
 #, elixir-autogen, elixir-format
 msgid "Leave this organization team?"
 msgstr "Dieses Organisations-Team verlassen?"
@@ -12304,12 +12302,12 @@ msgstr "Stimmt mit einer anderen verifizierten Organisation überein"
 msgid "No organization pages match."
 msgstr "Keine passenden Organisationsseiten."
 
-#: lib/vutuv_web/live/organization_live/index.ex:92
+#: lib/vutuv_web/live/organization_live/index.ex:90
 #, elixir-autogen, elixir-format
 msgid "No organization pages yet. Be the first to add yours."
 msgstr "Noch keine Organisationsseiten. Fügen Sie die erste hinzu."
 
-#: lib/vutuv_web/live/organization_live/index.ex:94
+#: lib/vutuv_web/live/organization_live/index.ex:92
 #, elixir-autogen, elixir-format
 msgid "No organizations found for %{term}."
 msgstr "Keine Organisationen für %{term} gefunden."
@@ -12350,7 +12348,7 @@ msgstr "Organisation gelöscht."
 msgid "Organization frozen."
 msgstr "Organisation eingefroren."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:296
+#: lib/vutuv_web/live/organization_live/edit.ex:291
 #: lib/vutuv_web/live/organization_live/new.ex:125
 #, elixir-autogen, elixir-format
 msgid "Organization name"
@@ -12382,12 +12380,12 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/agent_docs/markdown.ex:427
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:400
-#: lib/vutuv_web/components/ui.ex:4833
+#: lib/vutuv_web/components/ui.ex:4941
 #: lib/vutuv_web/controllers/settings_controller.ex:213
-#: lib/vutuv_web/live/organization_live/index.ex:30
-#: lib/vutuv_web/live/organization_live/index.ex:61
+#: lib/vutuv_web/live/organization_live/index.ex:32
+#: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1322
+#: lib/vutuv_web/live/shell_live.ex:1318
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:79
@@ -12414,7 +12412,7 @@ msgstr ""
 msgid "Please log in to claim an organization page."
 msgstr "Bitte loggen Sie sich ein, um eine Organisationsseite zu beanspruchen."
 
-#: lib/vutuv_web/live/organization_live/index.ex:75
+#: lib/vutuv_web/live/organization_live/index.ex:73
 #, elixir-autogen, elixir-format
 msgid "Search organizations"
 msgstr "Organisationen durchsuchen"
@@ -12507,7 +12505,7 @@ msgstr "hat Sie zum Administrator von %{organization} gemacht."
 msgid "made you an owner of %{organization}."
 msgstr "hat Sie zum Besitzer von %{organization} gemacht."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:472
+#: lib/vutuv_web/live/organization_live/edit.ex:454
 #, elixir-autogen, elixir-format
 msgid "your_organization"
 msgstr "ihre_organisation"
@@ -12553,7 +12551,7 @@ msgid "Public authority"
 msgstr "Behörde / Öffentlich"
 
 #: lib/vutuv_web/live/admin/job_live.ex:371
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:138
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:136
 #, elixir-autogen, elixir-format
 msgid "%{views} views · %{clicks} apply clicks"
 msgstr "%{views} Aufrufe · %{clicks} Bewerbungsklicks"
@@ -12563,22 +12561,22 @@ msgstr "%{views} Aufrufe · %{clicks} Bewerbungsklicks"
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr "Eine gefälschte, irreführende oder diskriminierende Stellenanzeige."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:653
+#: lib/vutuv_web/live/job_posting_live/form.ex:652
 #, elixir-autogen, elixir-format
 msgid "A pay range is required to publish (except volunteer postings)."
 msgstr "Zum Veröffentlichen ist eine Gehaltsspanne erforderlich (außer bei Ehrenämtern)."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:750
+#: lib/vutuv_web/live/job_posting_live/form.ex:749
 #, elixir-autogen, elixir-format
 msgid "A vutuv message to me"
 msgstr "Eine vutuv-Nachricht an mich"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:748
+#: lib/vutuv_web/live/job_posting_live/form.ex:747
 #, elixir-autogen, elixir-format
 msgid "A website"
 msgstr "Eine Website"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:749
+#: lib/vutuv_web/live/job_posting_live/form.ex:748
 #, elixir-autogen, elixir-format
 msgid "An e-mail address"
 msgstr "Eine E-Mail-Adresse"
@@ -12588,12 +12586,12 @@ msgstr "Eine E-Mail-Adresse"
 msgid "Applicants must be located in"
 msgstr "Bewerber:innen müssen ansässig sein in"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:754
+#: lib/vutuv_web/live/job_posting_live/form.ex:753
 #, elixir-autogen, elixir-format
 msgid "Application URL"
 msgstr "Bewerbungs-URL"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:760
+#: lib/vutuv_web/live/job_posting_live/form.ex:759
 #, elixir-autogen, elixir-format
 msgid "Application e-mail"
 msgstr "Bewerbungs-E-Mail"
@@ -12603,17 +12601,17 @@ msgstr "Bewerbungs-E-Mail"
 msgid "Application: %{title}"
 msgstr "Bewerbung: %{title}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:746
+#: lib/vutuv_web/live/job_posting_live/form.ex:745
 #, elixir-autogen, elixir-format
 msgid "Applications go to"
 msgstr "Bewerbungen gehen an"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:275
+#: lib/vutuv_web/live/job_posting_live/show.ex:270
 #, elixir-autogen, elixir-format
 msgid "Apply by e-mail"
 msgstr "Per E-Mail bewerben"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:274
+#: lib/vutuv_web/live/job_posting_live/show.ex:269
 #, elixir-autogen, elixir-format
 msgid "Apply on website"
 msgstr "Auf Website bewerben"
@@ -12625,7 +12623,7 @@ msgstr "Ausbildung"
 
 #: lib/vutuv_web/live/admin/job_live.ex:163
 #: lib/vutuv_web/live/admin/job_live.ex:183
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:184
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:183
 #, elixir-autogen, elixir-format
 msgid "Closed"
 msgstr "Geschlossen"
@@ -12635,12 +12633,12 @@ msgstr "Geschlossen"
 msgid "Contract"
 msgstr "Freie Mitarbeit"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:693
+#: lib/vutuv_web/live/job_posting_live/form.ex:692
 #, elixir-autogen, elixir-format
 msgid "Describe the role. Markdown is supported."
 msgstr "Beschreiben Sie die Stelle. Markdown wird unterstützt."
 
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:182
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
 #, elixir-autogen, elixir-format
 msgid "Drafts"
 msgstr "Entwürfe"
@@ -12670,19 +12668,19 @@ msgstr "Name des Arbeitgebers (optional)"
 #: lib/vutuv_web/agent_docs/markdown.ex:489
 #: lib/vutuv_web/agent_docs/text.ex:265
 #: lib/vutuv_web/agent_docs/text.ex:508
-#: lib/vutuv_web/live/job_board_live.ex:367
+#: lib/vutuv_web/live/job_board_live.ex:363
 #: lib/vutuv_web/live/job_posting_live/form.ex:474
 #, elixir-autogen, elixir-format
 msgid "Employment type"
 msgstr "Anstellungsart"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:772
+#: lib/vutuv_web/live/job_posting_live/form.ex:771
 #, elixir-autogen, elixir-format
 msgid "Everyone (public)"
 msgstr "Alle (öffentlich)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:657
-#: lib/vutuv_web/live/tag_live/timeline.ex:350
+#: lib/vutuv_web/live/job_posting_live/form.ex:656
+#: lib/vutuv_web/live/tag_live/timeline.ex:346
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
 #, elixir-autogen, elixir-format
@@ -12694,12 +12692,12 @@ msgstr "Von"
 msgid "Full-time"
 msgstr "Vollzeit"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:159
+#: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
 msgid "Highlighted tags match your profile."
 msgstr "Hervorgehobene Tags passen zu Ihrem Profil."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:744
+#: lib/vutuv_web/live/job_posting_live/form.ex:743
 #, elixir-autogen, elixir-format
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
@@ -12715,7 +12713,7 @@ msgstr "Hybrid"
 msgid "I'm interested in your posting: %{url}"
 msgstr "Ich interessiere mich für Ihre Anzeige: %{url}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:692
+#: lib/vutuv_web/live/job_posting_live/form.ex:691
 #, elixir-autogen, elixir-format
 msgid "Job description"
 msgstr "Stellenbeschreibung"
@@ -12730,13 +12728,13 @@ msgstr "Stellenbezeichnung"
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1144
+#: lib/vutuv_web/live/shell_live.ex:1140
 #: lib/vutuv_web/templates/layout/app.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Jobs"
 msgstr "Jobs"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:782
+#: lib/vutuv_web/live/job_posting_live/form.ex:781
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this posting."
 msgstr "Suchmaschinen dürfen diese Anzeige indexieren."
@@ -12757,12 +12755,12 @@ msgstr "Standort"
 msgid "Mark as filled"
 msgstr "Als besetzt markieren"
 
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:157
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:158
 #, elixir-autogen, elixir-format
 msgid "Mark this posting as filled and close it?"
 msgstr "Diese Anzeige als besetzt markieren und schließen?"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:276
+#: lib/vutuv_web/live/job_posting_live/show.ex:271
 #, elixir-autogen, elixir-format
 msgid "Message the poster"
 msgstr "Anbieter:in anschreiben"
@@ -12779,7 +12777,7 @@ msgstr "Irreführende Stellenanzeige"
 
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:25
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:101
-#: lib/vutuv_web/live/job_posting_live/show.ex:181
+#: lib/vutuv_web/live/job_posting_live/show.ex:176
 #, elixir-autogen, elixir-format
 msgid "My postings"
 msgstr "Meine Anzeigen"
@@ -12789,7 +12787,7 @@ msgstr "Meine Anzeigen"
 msgid "New accounts can publish after a few days."
 msgstr "Neue Konten können nach einigen Tagen veröffentlichen."
 
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:103
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:102
 #: lib/vutuv_web/live/job_posting_live/form.ex:114
 #, elixir-autogen, elixir-format
 msgid "New posting"
@@ -12797,8 +12795,8 @@ msgstr "Neue Anzeige"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:292
 #: lib/vutuv_web/agent_docs/text.ex:275
-#: lib/vutuv_web/live/job_posting_live/form.ex:732
-#: lib/vutuv_web/live/job_posting_live/show.ex:154
+#: lib/vutuv_web/live/job_posting_live/form.ex:731
+#: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
 msgstr "Wünschenswert"
@@ -12818,7 +12816,7 @@ msgstr "Hier ist noch nichts. Jobs mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Jobs you like show up here."
 msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:788
+#: lib/vutuv_web/live/job_posting_live/form.ex:787
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
@@ -12839,7 +12837,7 @@ msgstr "Nur Sie sehen diese Anzeige, während eine Meldung dazu bearbeitet wird.
 msgid "Part-time"
 msgstr "Teilzeit"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:651
+#: lib/vutuv_web/live/job_posting_live/form.ex:650
 #, elixir-autogen, elixir-format
 msgid "Pay"
 msgstr "Bezahlung"
@@ -12884,7 +12882,7 @@ msgstr "Postleitzahl"
 #: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/text.ex:269
 #: lib/vutuv_web/agent_docs/text.ex:512
-#: lib/vutuv_web/live/job_posting_live/show.ex:133
+#: lib/vutuv_web/live/job_posting_live/show.ex:128
 #, elixir-autogen, elixir-format
 msgid "Posted"
 msgstr "Veröffentlicht"
@@ -12900,7 +12898,7 @@ msgstr "Sprache der Anzeige"
 msgid "Posting not found."
 msgstr "Anzeige nicht gefunden."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:805
+#: lib/vutuv_web/live/job_posting_live/form.ex:802
 #, elixir-autogen, elixir-format
 msgid "Publish"
 msgstr "Veröffentlichen"
@@ -12918,15 +12916,15 @@ msgstr "Veröffentlichen"
 msgid "Remote"
 msgstr "Remote"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:169
+#: lib/vutuv_web/live/job_posting_live/show.ex:164
 #, elixir-autogen, elixir-format
 msgid "Report this posting"
 msgstr "Diese Anzeige melden"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:291
 #: lib/vutuv_web/agent_docs/text.ex:274
-#: lib/vutuv_web/live/job_posting_live/form.ex:722
-#: lib/vutuv_web/live/job_posting_live/show.ex:149
+#: lib/vutuv_web/live/job_posting_live/form.ex:721
+#: lib/vutuv_web/live/job_posting_live/show.ex:144
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr "Erforderlich"
@@ -12965,7 +12963,7 @@ msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
 msgid "Street (optional)"
 msgstr "Straße (optional)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:719
+#: lib/vutuv_web/live/job_posting_live/form.ex:718
 #, elixir-autogen, elixir-format
 msgid "Tags match your posting to members. Separate them with commas; a tag may be several words long, like Ruby on Rails."
 msgstr "Tags bringen Ihre Anzeige mit Mitgliedern zusammen. Mit Kommas trennen; ein Tag darf aus mehreren Wörtern bestehen, zum Beispiel Ruby on Rails."
@@ -13001,7 +12999,7 @@ msgid "Tip: adding a gender marker like (m/w/d) helps your posting comply with t
 msgstr "Tipp: Ein Geschlechtszusatz wie (m/w/d) hilft Ihrer Anzeige, dem AGG zu entsprechen. Das ist ein Hinweis, keine Rechtsberatung."
 
 #: lib/vutuv_web/components/job_components.ex:112
-#: lib/vutuv_web/live/job_posting_live/show.ex:209
+#: lib/vutuv_web/live/job_posting_live/show.ex:204
 #, elixir-autogen, elixir-format
 msgid "Verified organization"
 msgstr "Verifizierte Organisation"
@@ -13017,7 +13015,7 @@ msgstr "Ehrenamtlich"
 msgid "Volunteer"
 msgstr "Ehrenamt"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:770
+#: lib/vutuv_web/live/job_posting_live/form.ex:769
 #: lib/vutuv_web/templates/email/form_content.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Who can see it"
@@ -13077,7 +13075,7 @@ msgstr "Ihre Organisationsseite auf vutuv verliert bald ihre Verifizierung"
 msgid "Your organization page on vutuv is no longer public"
 msgstr "Ihre Organisationsseite auf vutuv ist nicht mehr öffentlich"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:176
+#: lib/vutuv_web/live/job_posting_live/show.ex:171
 #, elixir-autogen, elixir-format
 msgid "Your posting"
 msgstr "Ihre Anzeige"
@@ -13093,7 +13091,7 @@ msgstr "Ihre Anzeige ist online."
 msgid "Yourself (personal posting)"
 msgstr "Sie selbst (persönliche Anzeige)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:663
+#: lib/vutuv_web/live/job_posting_live/form.ex:662
 #, elixir-autogen, elixir-format
 msgid "up to"
 msgstr "bis"
@@ -13135,17 +13133,17 @@ msgid_plural "Your roles"
 msgstr[0] "Ihre Rolle"
 msgstr[1] "Ihre Rollen"
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:113
+#: lib/vutuv_web/templates/settings/organizations.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Add an organization"
 msgstr "Organisation hinzufügen"
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:115
+#: lib/vutuv_web/templates/settings/organizations.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Represent a company, association or other group? Add its page and verify the domain to become its owner."
 msgstr "Vertreten Sie ein Unternehmen, einen Verein oder eine andere Gruppe? Fügen Sie die Seite hinzu und verifizieren Sie die Domain, um ihr Besitzer zu werden."
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:125
+#: lib/vutuv_web/templates/settings/organizations.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Browse all organizations"
 msgstr "Alle Organisationen ansehen"
@@ -13160,7 +13158,7 @@ msgstr "In Prüfung"
 msgid "Verification pending"
 msgstr "Verifizierung ausstehend"
 
-#: lib/vutuv_web/live/organization_live/index.ex:63
+#: lib/vutuv_web/live/organization_live/index.ex:64
 #, elixir-autogen, elixir-format
 msgid "Verified pages for companies, associations, schools, public authorities and other groups, not for single people. Every page has a proven web domain, so you know it is really them."
 msgstr "Verifizierte Seiten für Unternehmen, Vereine, Schulen, Behörden und andere Gruppen, nicht für einzelne Personen. Jede Seite hat eine nachgewiesene Web-Domain, sodass Sie wissen, dass es wirklich sie sind."
@@ -13175,14 +13173,14 @@ msgstr "DNS-Änderungen brauchen manchmal etwas, bis sie überall angekommen sin
 msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT record cannot share a name with a CNAME. Use this name instead, with the exact same value as above:"
 msgstr "Bekommen Sie einen Fehler, oder ist %{host} ein CNAME / Alias auf eine andere Adresse? Ein TXT-Eintrag kann nicht denselben Namen wie ein CNAME haben. Verwenden Sie stattdessen diesen Namen, mit exakt demselben Wert wie oben:"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:322
-#: lib/vutuv_web/live/organization_live/show.ex:1066
+#: lib/vutuv_web/live/organization_live/domains.ex:316
+#: lib/vutuv_web/live/organization_live/show.ex:1061
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr "Ist %{domain} ein CNAME / Alias (ein TXT-Eintrag kann nicht denselben Namen wie ein CNAME haben), legen Sie den Eintrag stattdessen auf %{name} an, mit demselben Wert."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:1057
+#: lib/vutuv_web/live/organization_live/domains.ex:314
+#: lib/vutuv_web/live/organization_live/show.ex:1052
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr "Legen Sie in Ihren DNS-Einstellungen einen TXT-Eintrag auf dem Namen %{domain} mit diesem Wert an:"
@@ -13221,12 +13219,12 @@ msgid_plural "%{count} weeks ago"
 msgstr[0] "vor %{count} Woche"
 msgstr[1] "vor %{count} Wochen"
 
-#: lib/vutuv_web/live/job_board_live.ex:491
+#: lib/vutuv_web/live/job_board_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "%{km} km"
 msgstr "%{km} km"
 
-#: lib/vutuv_web/live/job_board_live.ex:361
+#: lib/vutuv_web/live/job_board_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "All countries"
 msgstr "Alle Länder"
@@ -13242,43 +13240,43 @@ msgstr "Alle Stellen mit diesem Tag"
 msgid "All jobs with this tag: %{url}"
 msgstr "Alle Stellen mit diesem Tag: %{url}"
 
-#: lib/vutuv_web/live/job_board_live.ex:368
+#: lib/vutuv_web/live/job_board_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "Any employment type"
 msgstr "Alle Anstellungsarten"
 
-#: lib/vutuv_web/live/job_board_live.ex:350
+#: lib/vutuv_web/live/job_board_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "City or zip code"
 msgstr "Stadt oder Postleitzahl"
 
-#: lib/vutuv_web/live/job_board_live.ex:491
+#: lib/vutuv_web/live/job_board_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "Exact"
 msgstr "Genau"
 
-#: lib/vutuv_web/live/job_board_live.ex:249
+#: lib/vutuv_web/live/job_board_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "From my salary expectation"
 msgstr "Ab meiner Gehaltsvorstellung"
 
-#: lib/vutuv_web/live/job_board_live.ex:241
+#: lib/vutuv_web/live/job_board_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Matches my tags"
 msgstr "Passend zu meinen Tags"
 
-#: lib/vutuv_web/live/job_board_live.ex:461
+#: lib/vutuv_web/live/job_board_live.ex:452
 #, elixir-autogen, elixir-format
 msgid "Min. salary/year (%{currency})"
 msgstr "Mindestgehalt/Jahr (%{currency})"
 
-#: lib/vutuv_web/live/job_board_live.ex:410
+#: lib/vutuv_web/live/job_board_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "Minimum yearly salary"
 msgstr "Mindestgehalt pro Jahr"
 
-#: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:836
+#: lib/vutuv_web/live/job_board_live.ex:320
+#: lib/vutuv_web/live/organization_live/show.ex:831
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr "Weitere Stellen"
@@ -13293,12 +13291,12 @@ msgstr "Nächste Seite"
 msgid "Next page: %{url}"
 msgstr "Nächste Seite: %{url}"
 
-#: lib/vutuv_web/live/job_board_live.ex:499
+#: lib/vutuv_web/live/job_board_live.ex:479
 #, elixir-autogen, elixir-format
 msgid "No job postings yet."
 msgstr "Noch keine Stellenanzeigen."
 
-#: lib/vutuv_web/live/job_board_live.ex:497
+#: lib/vutuv_web/live/job_board_live.ex:477
 #, elixir-autogen, elixir-format
 msgid "No matching positions. Try adjusting the filters."
 msgstr "Keine passenden Stellen. Passen Sie die Filter an."
@@ -13319,22 +13317,22 @@ msgstr "Offene Stellen"
 msgid "Open positions on vutuv, newest first."
 msgstr "Offene Stellen auf vutuv, neueste zuerst."
 
-#: lib/vutuv_web/live/job_board_live.ex:221
+#: lib/vutuv_web/live/job_board_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Post a job"
 msgstr "Stelle ausschreiben"
 
-#: lib/vutuv_web/live/job_board_live.ex:306
+#: lib/vutuv_web/live/job_board_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Post the first one"
 msgstr "Veröffentlichen Sie die erste"
 
-#: lib/vutuv_web/live/job_board_live.ex:354
+#: lib/vutuv_web/live/job_board_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "Radius"
 msgstr "Umkreis"
 
-#: lib/vutuv_web/live/job_board_live.ex:342
+#: lib/vutuv_web/live/job_board_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "Search jobs"
 msgstr "Jobs durchsuchen"
@@ -13363,13 +13361,13 @@ msgstr "(Freitext, nicht verifiziert)"
 msgid "(no employer)"
 msgstr "(kein Arbeitgeber)"
 
-#: lib/vutuv_web/live/admin/job_live.ex:477
+#: lib/vutuv_web/live/admin/job_live.ex:475
 #, elixir-autogen, elixir-format
 msgid "Close this posting? It ends the listing (a regular ending, not a deletion)."
 msgstr "Diese Anzeige schließen? Das beendet die Anzeige regulär (keine Löschung)."
 
 #: lib/vutuv_web/live/admin/job_live.ex:414
-#: lib/vutuv_web/live/admin/user_detail_live.ex:135
+#: lib/vutuv_web/live/admin/user_detail_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "Cold outreach"
 msgstr "Kaltakquise"
@@ -13379,7 +13377,7 @@ msgstr "Kaltakquise"
 msgid "Counters"
 msgstr "Zähler"
 
-#: lib/vutuv_web/live/admin/job_live.ex:486
+#: lib/vutuv_web/live/admin/job_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Delete this posting and everything it owns? This cannot be undone."
 msgstr "Diese Anzeige und alles, was dazugehört, löschen? Das kann nicht rückgängig gemacht werden."
@@ -13412,14 +13410,14 @@ msgstr "Stellenanzeige"
 #: lib/vutuv_web/live/admin/job_live.ex:30
 #: lib/vutuv_web/live/admin/job_live.ex:198
 #: lib/vutuv_web/live/admin/job_live.ex:199
-#: lib/vutuv_web/live/admin/user_detail_live.ex:163
+#: lib/vutuv_web/live/admin/user_detail_live.ex:158
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Job postings"
 msgstr "Stellenanzeigen"
 
 #: lib/vutuv_web/live/admin/job_live.ex:402
-#: lib/vutuv_web/live/admin/user_detail_live.ex:117
+#: lib/vutuv_web/live/admin/user_detail_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Live postings"
 msgstr "Aktive Anzeigen"
@@ -13435,7 +13433,7 @@ msgid "Open case"
 msgstr "Fall öffnen"
 
 #: lib/vutuv_web/live/admin/job_live.ex:410
-#: lib/vutuv_web/live/admin/user_detail_live.ex:129
+#: lib/vutuv_web/live/admin/user_detail_live.ex:124
 #, elixir-autogen, elixir-format
 msgid "Open job cases"
 msgstr "Offene Job-Fälle"
@@ -13502,7 +13500,7 @@ msgid "Title"
 msgstr "Titel"
 
 #: lib/vutuv_web/live/admin/job_live.ex:406
-#: lib/vutuv_web/live/admin/user_detail_live.ex:123
+#: lib/vutuv_web/live/admin/user_detail_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "Total postings"
 msgstr "Anzeigen insgesamt"
@@ -13544,7 +13542,7 @@ msgstr "Benachrichtigung aktualisiert."
 msgid "Daily email"
 msgstr "Tägliche E-Mail"
 
-#: lib/vutuv_web/templates/settings/saved_searches.html.heex:72
+#: lib/vutuv_web/templates/settings/saved_searches.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Delete this saved search?"
 msgstr "Diese gespeicherte Suche löschen?"
@@ -13578,7 +13576,7 @@ msgstr "Alles"
 msgid "Manage your saved searches"
 msgstr "Gespeicherte Suchen verwalten"
 
-#: lib/vutuv_web/templates/settings/saved_searches.html.heex:87
+#: lib/vutuv_web/templates/settings/saved_searches.html.heex:82
 #, elixir-autogen, elixir-format
 msgid "Newer"
 msgstr "Neuere"
@@ -13588,7 +13586,7 @@ msgstr "Neuere"
 msgid "No emails"
 msgstr "Keine E-Mails"
 
-#: lib/vutuv_web/templates/settings/saved_searches.html.heex:95
+#: lib/vutuv_web/templates/settings/saved_searches.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "Older"
 msgstr "Ältere"
@@ -13601,8 +13599,8 @@ msgstr ""
 "vutuv schickt Ihnen eine E-Mail, sobald es einen neuen Treffer gibt. "
 "Tägliche Suchen werden jeden Tag geprüft, wöchentliche einmal pro Woche."
 
-#: lib/vutuv_web/components/saved_search_components.ex:107
-#: lib/vutuv_web/components/saved_search_components.ex:128
+#: lib/vutuv_web/components/saved_search_components.ex:103
+#: lib/vutuv_web/components/saved_search_components.ex:116
 #, elixir-autogen, elixir-format
 msgid "Save search"
 msgstr "Suche speichern"
@@ -13612,7 +13610,7 @@ msgstr "Suche speichern"
 msgid "Saved search deleted."
 msgstr "Gespeicherte Suche gelöscht."
 
-#: lib/vutuv_web/components/ui.ex:4773
+#: lib/vutuv_web/components/ui.ex:4881
 #: lib/vutuv_web/controllers/settings_controller.ex:620
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13632,7 +13630,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/components/post_components.ex:2996
+#: lib/vutuv_web/components/post_components.ex:3018
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:715
 #: lib/vutuv_web/controllers/settings_controller.ex:733
@@ -13767,7 +13765,7 @@ msgstr "Wird eine Organisation ausgeschlossen, ist die Anzeige auch für ihre be
 msgid "Hide from specific viewers"
 msgstr "Vor bestimmten Personen verbergen"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:794
+#: lib/vutuv_web/live/job_posting_live/form.ex:793
 #, elixir-autogen, elixir-format
 msgid "Hide from specific viewers (competitors, your own staff, a person) →"
 msgstr "Vor bestimmten Personen verbergen (Wettbewerber, eigene Belegschaft, Einzelpersonen) →"
@@ -13788,7 +13786,7 @@ msgstr "Ausschlussliste"
 msgid "Job exclusions – %{name}"
 msgstr "Ausschlussliste – %{name}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:797
+#: lib/vutuv_web/live/job_posting_live/form.ex:796
 #, elixir-autogen, elixir-format
 msgid "Keep this posting on the board for everyone except a chosen few."
 msgstr "Halten Sie diese Anzeige für alle im Stellenmarkt sichtbar, außer für wenige Ausgewählte."
@@ -13871,7 +13869,7 @@ msgstr ""
 "Diese Seite hat Stellenanzeigen und kann deshalb nicht gelöscht werden. "
 "Bitten Sie einen Admin, sie stattdessen zu archivieren."
 
-#: lib/vutuv_web/live/admin/user_detail_live.ex:114
+#: lib/vutuv_web/live/admin/user_detail_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Jobs footprint"
 msgstr "Job-Übersicht"
@@ -13887,7 +13885,7 @@ msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7
 msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 Tagen abgelehnt. Eine wachsende Warteschlange bedeutet meist, dass Ollama nicht erreichbar ist."
 
 #: lib/vutuv_web/templates/user/edit.html.heex:41
-#: lib/vutuv_web/templates/user/edit.html.heex:126
+#: lib/vutuv_web/templates/user/edit.html.heex:121
 #: lib/vutuv_web/templates/user/show.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "Image awaiting review, visible only to you"
@@ -13940,7 +13938,7 @@ msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstel
 msgid "Age only, without the date"
 msgstr "Nur das Alter, ohne das Datum"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:451
+#: lib/vutuv_web/templates/user/edit.html.heex:447
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
@@ -13963,7 +13961,7 @@ msgstr "Geburtstag nicht anzeigen"
 msgid "Full date and age"
 msgstr "Vollständiges Datum und Alter"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:448
+#: lib/vutuv_web/templates/user/edit.html.heex:444
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr "Geburtstag anzeigen als"
@@ -13997,44 +13995,44 @@ msgstr[1] "Wir haben %{formatted} Beiträge aktualisiert, die Ihren alten Handle
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "hat den Handle von @%{old} auf @%{new} geändert."
 
-#: lib/vutuv_web/components/ui.ex:413
+#: lib/vutuv_web/components/ui.ex:474
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr "Zentriert"
 
-#: lib/vutuv_web/components/ui.ex:410
+#: lib/vutuv_web/components/ui.ex:471
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr "Linksbündig (Text umfließt)"
 
-#: lib/vutuv_web/components/ui.ex:416
+#: lib/vutuv_web/components/ui.ex:477
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr "Rechtsbündig (Text umfließt)"
 
-#: lib/vutuv_web/components/ui.ex:407
+#: lib/vutuv_web/components/ui.ex:468
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr "Volle Breite"
 
-#: lib/vutuv_web/components/ui.ex:440
+#: lib/vutuv_web/components/ui.ex:501
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr "Bild einfügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2871
+#: lib/vutuv_web/live/post_live/composer.ex:2810
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr "In den Text einfügen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:235
 #: lib/vutuv_web/agent_docs/text.ex:218
-#: lib/vutuv_web/live/tag_live/timeline.ex:253
+#: lib/vutuv_web/live/tag_live/timeline.ex:249
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
 msgstr "Beiträge mit diesem Tag"
 
-#: lib/vutuv_web/live/search_live.ex:711
+#: lib/vutuv_web/live/search_live.ex:704
 #, elixir-autogen, elixir-format
 msgid "Your search uses a people-only filter such as city: or status:, so it only finds people."
 msgstr ""
@@ -14056,22 +14054,22 @@ msgstr "Mobil (privat)"
 msgid "Work mobile"
 msgstr "Mobil (Arbeit)"
 
-#: lib/vutuv_web/components/post_components.ex:447
+#: lib/vutuv_web/components/post_components.ex:448
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr "Noch keine Beiträge."
 
-#: lib/vutuv_web/components/post_components.ex:449
+#: lib/vutuv_web/components/post_components.ex:450
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr "Noch keine Antworten."
 
-#: lib/vutuv_web/components/post_components.ex:448
+#: lib/vutuv_web/components/post_components.ex:449
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr "Noch keine Reposts."
 
-#: lib/vutuv_web/components/post_components.ex:406
+#: lib/vutuv_web/components/post_components.ex:407
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr "Eigene Beiträge"
@@ -14084,7 +14082,7 @@ msgstr ""
 "Personen tauchen in Ihren Vorschlägen auf. Einem Tag folgen Sie auf seiner "
 "Seite."
 
-#: lib/vutuv_web/components/ui.ex:4756
+#: lib/vutuv_web/components/ui.ex:4864
 #: lib/vutuv_web/controllers/settings_controller.ex:634
 #: lib/vutuv_web/live/post_live/feed.ex:712
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -14093,34 +14091,34 @@ msgstr ""
 msgid "Tags you follow"
 msgstr "Tags, denen Sie folgen"
 
-#: lib/vutuv_web/live/job_board_live.ex:428
+#: lib/vutuv_web/live/job_board_live.ex:419
 #, elixir-autogen, elixir-format
 msgid "Looking for a role that goes by several titles? Separate them with a comma and we show postings that match any of them."
 msgstr ""
 "Ein Beruf mit mehreren möglichen Titeln? Trennen Sie sie mit Komma, dann "
 "zeigen wir Anzeigen, die zu einem davon passen."
 
-#: lib/vutuv_web/live/job_board_live.ex:424
+#: lib/vutuv_web/live/job_board_live.ex:415
 #, elixir-autogen, elixir-format
 msgid "Search tips"
 msgstr "Suchtipps"
 
-#: lib/vutuv_web/live/job_board_live.ex:482
+#: lib/vutuv_web/live/job_board_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "any of these titles"
 msgstr "einer dieser Titel"
 
-#: lib/vutuv_web/live/job_board_live.ex:484
+#: lib/vutuv_web/live/job_board_live.ex:464
 #, elixir-autogen, elixir-format
 msgid "exact wording"
 msgstr "genaue Wortfolge"
 
-#: lib/vutuv_web/live/job_board_live.ex:485
+#: lib/vutuv_web/live/job_board_live.ex:465
 #, elixir-autogen, elixir-format
 msgid "without internships"
 msgstr "ohne Praktika"
 
-#: lib/vutuv_web/live/job_board_live.ex:483
+#: lib/vutuv_web/live/job_board_live.ex:463
 #, elixir-autogen, elixir-format
 msgid "word start: also finds Entwickler, Entwicklung"
 msgstr "Wortanfang: findet auch Entwickler, Entwicklung"
@@ -14161,7 +14159,7 @@ msgstr "Messenger wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:63
-#: lib/vutuv_web/components/ui.ex:4727
+#: lib/vutuv_web/components/ui.ex:4835
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -14189,14 +14187,14 @@ msgstr "Messenger von %{name}"
 msgid "Select a messenger"
 msgstr "Messenger auswählen"
 
-#: lib/vutuv_web/components/ui.ex:4127
+#: lib/vutuv_web/components/ui.ex:4231
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] "Meinen Follower darüber informieren"
 msgstr[1] "Meine %{formatted} Follower darüber informieren"
 
-#: lib/vutuv_web/components/ui.ex:4137
+#: lib/vutuv_web/components/ui.ex:4241
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
@@ -14246,50 +14244,50 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:5289
+#: lib/vutuv_web/components/post_components.ex:5311
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1233
-#: lib/vutuv_web/components/post_components.ex:5246
+#: lib/vutuv_web/components/post_components.ex:5268
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:5290
+#: lib/vutuv_web/components/post_components.ex:5312
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:5292
+#: lib/vutuv_web/components/post_components.ex:5314
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:5288
+#: lib/vutuv_web/components/post_components.ex:5310
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1233
-#: lib/vutuv_web/components/post_components.ex:5245
+#: lib/vutuv_web/components/post_components.ex:5267
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:443
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:250
+#: lib/vutuv_web/live/fediverse_account_live.ex:453
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:5287
+#: lib/vutuv_web/components/post_components.ex:5309
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:5291
+#: lib/vutuv_web/components/post_components.ex:5313
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14309,7 +14307,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:5328
+#: lib/vutuv_web/components/post_components.ex:5350
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14317,27 +14315,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:5358
+#: lib/vutuv_web/components/post_components.ex:5380
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:5359
+#: lib/vutuv_web/components/post_components.ex:5381
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:5357
+#: lib/vutuv_web/components/post_components.ex:5379
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:5317
+#: lib/vutuv_web/components/post_components.ex:5339
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:5364
+#: lib/vutuv_web/components/post_components.ex:5386
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14367,7 +14365,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5131
+#: lib/vutuv_web/components/post_components.ex:5153
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14415,17 +14413,17 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:5122
+#: lib/vutuv_web/components/post_components.ex:5144
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
 
-#: lib/vutuv_web/components/ui.ex:2203
+#: lib/vutuv_web/components/ui.ex:2227
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr "Empfohlen von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:2207
+#: lib/vutuv_web/components/ui.ex:2231
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -14516,7 +14514,7 @@ msgstr "Nachweis (PDF oder Bild)"
 msgid "Remove file"
 msgstr "Datei entfernen"
 
-#: lib/vutuv_web/templates/qualification/form_content.html.heex:106
+#: lib/vutuv_web/templates/qualification/form_content.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Remove the uploaded file? The entry itself stays."
 msgstr "Hochgeladene Datei entfernen? Der Eintrag selbst bleibt bestehen."
@@ -14555,7 +14553,7 @@ msgid "proof document"
 msgstr "Nachweis"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:375
+#: lib/vutuv_web/templates/settings/preferences.html.heex:364
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr "Zeilen in Benachrichtigungen"
@@ -14565,12 +14563,12 @@ msgstr "Zeilen in Benachrichtigungen"
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr "Wie viel von einem Beitrag eine Benachrichtigung zitiert, bevor abgeschnitten wird."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:366
+#: lib/vutuv_web/templates/settings/preferences.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr "Zitierte Beiträge in Benachrichtigungen"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:369
+#: lib/vutuv_web/templates/settings/preferences.html.heex:358
 #, elixir-autogen, elixir-format
 msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
@@ -14620,13 +14618,13 @@ msgstr ""
 "Optional, und niemand sonst sieht es. Die Angabe filtert Stellen darunter "
 "aus Ihrer eigenen Jobsuche."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:356
+#: lib/vutuv_web/templates/user/edit.html.heex:351
 #: lib/vutuv_web/templates/welcome/show.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr "Wie möchten Sie arbeiten?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:376
+#: lib/vutuv_web/templates/user/edit.html.heex:371
 #: lib/vutuv_web/templates/welcome/show.html.heex:162
 #, elixir-autogen, elixir-format
 msgid "Shown next to your availability, and used to match you with postings."
@@ -14650,7 +14648,7 @@ msgstr "Erstmal überspringen"
 msgid "Preferred workplace"
 msgstr "Bevorzugte Arbeitsform"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:284
+#: lib/vutuv_web/templates/user/edit.html.heex:279
 #: lib/vutuv_web/templates/welcome/show.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Availability"
@@ -14707,13 +14705,13 @@ msgstr "Erwähnung"
 msgid "mentioned you in a post."
 msgstr "hat Sie in einem Beitrag erwähnt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1251
+#: lib/vutuv_web/live/post_live/composer.ex:1226
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr "Dieser Beitrag lässt sich nicht mehr bearbeiten: jemand hat ihn geliked, geteilt oder beantwortet."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1254
+#: lib/vutuv_web/live/post_live/composer.ex:1229
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14809,14 +14807,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:3269
+#: lib/vutuv_web/components/post_components.ex:3291
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:3292
+#: lib/vutuv_web/components/post_components.ex:3314
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14838,47 +14836,47 @@ msgstr "Dieser Beitrag ist Teil einer Unterhaltung mit %{formatted} Beiträgen."
 msgid "This profile is currently unavailable."
 msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 
-#: lib/vutuv_web/templates/admin/account/index.html.heex:45
+#: lib/vutuv_web/templates/admin/account/index.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:5780
+#: lib/vutuv_web/components/post_components.ex:5802
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
 
-#: lib/vutuv_web/views/admin/account_html.ex:93
+#: lib/vutuv_web/views/admin/account_html.ex:83
 #, elixir-autogen, elixir-format
 msgid "active"
 msgstr "Aktiv"
 
-#: lib/vutuv_web/views/admin/account_html.ex:109
+#: lib/vutuv_web/views/admin/account_html.ex:99
 #, elixir-autogen, elixir-format
 msgid "admin"
 msgstr "Admin"
 
-#: lib/vutuv_web/views/admin/account_html.ex:90
+#: lib/vutuv_web/views/admin/account_html.ex:80
 #, elixir-autogen, elixir-format
 msgid "frozen"
 msgstr "Eingefroren"
 
-#: lib/vutuv_web/views/admin/account_html.ex:108
+#: lib/vutuv_web/views/admin/account_html.ex:98
 #, elixir-autogen, elixir-format
 msgid "report"
 msgstr "Meldung"
 
-#: lib/vutuv_web/views/admin/account_html.ex:89
+#: lib/vutuv_web/views/admin/account_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "suspended"
 msgstr "Gesperrt"
 
-#: lib/vutuv_web/views/admin/account_html.ex:92
+#: lib/vutuv_web/views/admin/account_html.ex:82
 #, elixir-autogen, elixir-format
 msgid "unconfirmed"
 msgstr "Unbestätigt"
 
-#: lib/vutuv_web/views/admin/account_html.ex:91
+#: lib/vutuv_web/views/admin/account_html.ex:81
 #, elixir-autogen, elixir-format
 msgid "unreachable"
 msgstr "Nicht erreichbar"
@@ -14980,7 +14978,7 @@ msgstr "Alle Empfehlenden"
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr "Filter hinzugefügt. Passende Beiträge sind jetzt in Ihrem Feed ausgeblendet."
 
-#: lib/vutuv_web/live/job_board_live.ex:389
+#: lib/vutuv_web/live/job_board_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Filter by a tag"
 msgstr "Nach einem Tag filtern"
@@ -15000,7 +14998,7 @@ msgstr "Blenden Sie Beiträge aus Ihrem Feed aus, die ein Tag tragen oder ein Wo
 msgid "Match whole words only (word/phrase)"
 msgstr "Nur ganze Wörter treffen (Wort/Phrase)"
 
-#: lib/vutuv_web/components/ui.ex:4741
+#: lib/vutuv_web/components/ui.ex:4849
 #: lib/vutuv_web/controllers/settings_controller.ex:700
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -15091,7 +15089,7 @@ msgstr "Wort, Phrase oder Tag zum Stummschalten"
 msgid "You are not allowed to change this organization's handle."
 msgstr "Sie dürfen den Benutzernamen dieser Organisation nicht ändern."
 
-#: lib/vutuv_web/templates/settings/filters.html.heex:116
+#: lib/vutuv_web/templates/settings/filters.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "You have not muted anything yet."
 msgstr "Sie haben noch nichts stummgeschaltet."
@@ -15285,7 +15283,7 @@ msgid "Nothing changes on vutuv itself, and you can switch it off again."
 msgstr "Auf vutuv selbst ändert sich nichts, und Sie können es jederzeit wieder ausschalten."
 
 #: lib/vutuv_web/components/fediverse_components.ex:325
-#: lib/vutuv_web/templates/page/index.html.heex:234
+#: lib/vutuv_web/templates/page/index.html.heex:239
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "Take part in the Fediverse"
@@ -15307,7 +15305,7 @@ msgstr "Geben Sie es weiter wie eine E-Mail-Adresse. Jeder bei Mastodon und Co. 
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr "Noch niemand. Posten Sie Ihr Handle dort, wo andere es sehen, dann tauchen die ersten Follower hier auf."
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:321
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:322
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Related"
@@ -15376,7 +15374,7 @@ msgid "Send your Fediverse followers to another account. They are asked to follo
 msgstr "Schicken Sie Ihre Fediverse-Follower zu einem anderen Konto. Sie werden gebeten, stattdessen diesem zu folgen, und vutuv föderiert Ihre neuen Beiträge nicht mehr. Ihr vutuv-Profil bleibt genau wie es ist, und nichts wird gelöscht."
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:265
-#: lib/vutuv_web/live/fediverse_following_live.ex:465
+#: lib/vutuv_web/live/fediverse_following_live.ex:473
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Back to Fediverse settings"
@@ -15405,7 +15403,7 @@ msgstr "(leer lassen, wenn es noch andauert)"
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:18
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:34
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:260
-#: lib/vutuv_web/templates/page/index.html.heex:119
+#: lib/vutuv_web/templates/page/index.html.heex:124
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:66
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:75
 #, elixir-autogen, elixir-format
@@ -15557,7 +15555,7 @@ msgstr "Wir senden dorthin eine PIN, um zu bestätigen, dass die Adresse Ihnen g
 msgid "ZIP or postal code"
 msgstr "Postleitzahl"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:357
+#: lib/vutuv_web/live/tag_live/timeline.ex:353
 #: lib/vutuv_web/templates/education/form_content.html.heex:59
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:81
 #, elixir-autogen, elixir-format
@@ -15635,252 +15633,252 @@ msgstr "Ihr Server"
 msgid "moved to %{address}"
 msgstr "umgezogen nach %{address}"
 
-#: lib/vutuv_web/components/ui.ex:4669
+#: lib/vutuv_web/components/ui.ex:4777
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr "Name, Foto, Titelbild, Kurzbeschreibung"
 
-#: lib/vutuv_web/components/ui.ex:4674
+#: lib/vutuv_web/components/ui.ex:4782
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr "handle spitzname nutzername umbenennen slug profiladresse url erwähnung"
 
-#: lib/vutuv_web/components/ui.ex:4677
+#: lib/vutuv_web/components/ui.ex:4785
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr "Die Stationen in Ihrem Lebenslauf"
 
-#: lib/vutuv_web/components/ui.ex:4678
+#: lib/vutuv_web/components/ui.ex:4786
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr "lebenslauf cv karriere beruf arbeitgeber position stelle job firma"
 
-#: lib/vutuv_web/components/ui.ex:4681
+#: lib/vutuv_web/components/ui.ex:4789
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr "Schulen, Hochschulen, Abschlüsse"
 
-#: lib/vutuv_web/components/ui.ex:4682
+#: lib/vutuv_web/components/ui.ex:4790
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr "lebenslauf studium schule universität hochschule abschluss ausbildung"
 
-#: lib/vutuv_web/components/ui.ex:4685
+#: lib/vutuv_web/components/ui.ex:4793
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr "Nachweise, mit Belegdokumenten"
 
-#: lib/vutuv_web/components/ui.ex:4686
+#: lib/vutuv_web/components/ui.ex:4794
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr "zertifikat lizenz urkunde diplom nachweis beleg auszeichnung dokument"
 
-#: lib/vutuv_web/components/ui.ex:4693
+#: lib/vutuv_web/components/ui.ex:4801
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr "Sprachkenntnisse"
 
-#: lib/vutuv_web/components/ui.ex:4694
+#: lib/vutuv_web/components/ui.ex:4802
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr "Die Sprachen, die Sie sprechen"
 
-#: lib/vutuv_web/components/ui.ex:4695
+#: lib/vutuv_web/components/ui.ex:4803
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr "sprache sprachen sprechen fließend muttersprache verhandlungssicher"
 
-#: lib/vutuv_web/components/ui.ex:4698
+#: lib/vutuv_web/components/ui.ex:4806
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr "Die Themen, für die Sie bekannt sind"
 
-#: lib/vutuv_web/components/ui.ex:4699
+#: lib/vutuv_web/components/ui.ex:4807
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr "fähigkeit kenntnis thema stichwort schlagwort expertise empfehlung"
 
-#: lib/vutuv_web/components/ui.ex:4834
+#: lib/vutuv_web/components/ui.ex:4942
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr "Organisationsseiten, die Sie verwalten"
 
-#: lib/vutuv_web/components/ui.ex:4835
+#: lib/vutuv_web/components/ui.ex:4943
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr "firma unternehmen arbeitgeber betrieb organisation seite"
 
-#: lib/vutuv_web/components/ui.ex:4702
+#: lib/vutuv_web/components/ui.ex:4810
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr "Kontaktdaten"
 
-#: lib/vutuv_web/components/ui.ex:4705
+#: lib/vutuv_web/components/ui.ex:4813
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr "Wo wir Sie erreichen, und welche Adresse öffentlich ist"
 
-#: lib/vutuv_web/components/ui.ex:4706
+#: lib/vutuv_web/components/ui.ex:4814
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr "mail e-mail email adresse hauptadresse primär"
 
-#: lib/vutuv_web/components/ui.ex:4709
+#: lib/vutuv_web/components/ui.ex:4817
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr "Festnetz, Mobil, Fax"
 
-#: lib/vutuv_web/components/ui.ex:4710
+#: lib/vutuv_web/components/ui.ex:4818
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr "telefon handy mobil festnetz fax nummer rufnummer"
 
-#: lib/vutuv_web/components/ui.ex:4713
+#: lib/vutuv_web/components/ui.ex:4821
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr "Postanschriften auf Ihrem Profil"
 
-#: lib/vutuv_web/components/ui.ex:4714
+#: lib/vutuv_web/components/ui.ex:4822
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr "straße stadt ort postleitzahl plz land anschrift karte"
 
-#: lib/vutuv_web/components/ui.ex:4716
+#: lib/vutuv_web/components/ui.ex:4824
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr "Webseiten & Links"
 
-#: lib/vutuv_web/components/ui.ex:4717
+#: lib/vutuv_web/components/ui.ex:4825
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr "Ihre Homepage und weitere Links"
 
-#: lib/vutuv_web/components/ui.ex:4718
+#: lib/vutuv_web/components/ui.ex:4826
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr "url webseite website homepage blog link verifizieren bestätigen rel=me"
 
-#: lib/vutuv_web/components/ui.ex:4720
+#: lib/vutuv_web/components/ui.ex:4828
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr "Social-Media-Profile"
 
-#: lib/vutuv_web/components/ui.ex:4721
+#: lib/vutuv_web/components/ui.ex:4829
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr "Mastodon, Bluesky, GitHub und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:4723
+#: lib/vutuv_web/components/ui.ex:4831
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr "mastodon bluesky github gitlab codeberg linkedin x twitter instagram soziale netzwerke"
 
-#: lib/vutuv_web/components/ui.ex:4728
+#: lib/vutuv_web/components/ui.ex:4836
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr "Signal, Threema, Matrix und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:4729
+#: lib/vutuv_web/components/ui.ex:4837
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr "signal threema matrix xmpp telegram whatsapp chat messenger nachrichten"
 
-#: lib/vutuv_web/components/ui.ex:4732
+#: lib/vutuv_web/components/ui.ex:4840
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr "Mitteilungen & Feed"
 
-#: lib/vutuv_web/components/ui.ex:4735
+#: lib/vutuv_web/components/ui.ex:4843
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr "Welche E-Mails wir schicken, und was die Glocke meldet"
 
-#: lib/vutuv_web/components/ui.ex:4742
+#: lib/vutuv_web/components/ui.ex:4850
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr "Beiträge aus Ihrem Feed heraushalten"
 
-#: lib/vutuv_web/components/ui.ex:4743
+#: lib/vutuv_web/components/ui.ex:4851
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr "stummschalten ausblenden verbergen filter wort begriff tag feed blockieren"
 
-#: lib/vutuv_web/components/ui.ex:4757
+#: lib/vutuv_web/components/ui.ex:4865
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr "Themen, deren Beiträge in Ihrem Feed landen"
 
-#: lib/vutuv_web/components/ui.ex:4758
+#: lib/vutuv_web/components/ui.ex:4866
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr "tag thema abonnieren folgen feed"
 
-#: lib/vutuv_web/components/ui.ex:4774
+#: lib/vutuv_web/components/ui.ex:4882
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr "Job- und Personensuchen, die Ihnen neue Treffer mailen"
 
-#: lib/vutuv_web/components/ui.ex:4775
+#: lib/vutuv_web/components/ui.ex:4883
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr "job stelle stellenangebot suchauftrag suche alarm benachrichtigung merkliste"
 
-#: lib/vutuv_web/components/ui.ex:4781
+#: lib/vutuv_web/components/ui.ex:4889
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr "Suchmaschinen, KI, Online-Status"
 
-#: lib/vutuv_web/components/ui.ex:4782
+#: lib/vutuv_web/components/ui.ex:4890
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr "privatsphäre datenschutz google suchmaschine ki ai llm crawler noindex online punkt öffentlich sichtbar"
 
-#: lib/vutuv_web/components/ui.ex:4785
+#: lib/vutuv_web/components/ui.ex:4893
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr "Personen, die nicht mit Ihnen interagieren können"
 
-#: lib/vutuv_web/components/ui.ex:4786
+#: lib/vutuv_web/components/ui.ex:4894
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr "blockieren sperren bannen stummschalten melden missbrauch belästigung"
 
-#: lib/vutuv_web/components/ui.ex:4807
+#: lib/vutuv_web/components/ui.ex:4915
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr "Passkeys, angemeldete Geräte, Anmeldecodes"
 
-#: lib/vutuv_web/components/ui.ex:4808
+#: lib/vutuv_web/components/ui.ex:4916
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr "passwort kennwort anmelden abmelden login logout sitzung gerät passkey totp 2fa pin sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:4826
+#: lib/vutuv_web/components/ui.ex:4934
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr "Ihre Daten von LinkedIn übernehmen"
 
-#: lib/vutuv_web/components/ui.ex:4827
+#: lib/vutuv_web/components/ui.ex:4935
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr "linkedin hochladen zip übernehmen importieren umzug"
 
-#: lib/vutuv_web/components/ui.ex:4830
+#: lib/vutuv_web/components/ui.ex:4938
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr "Alles herunterladen, was wir über Sie speichern"
 
-#: lib/vutuv_web/components/ui.ex:4831
+#: lib/vutuv_web/components/ui.ex:4939
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr "herunterladen download dsgvo gdpr daten sicherung json lebenslauf auskunft"
 
-#: lib/vutuv_web/components/ui.ex:4845
+#: lib/vutuv_web/components/ui.ex:4953
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr "Ihr Konto und alles darauf entfernen"
 
-#: lib/vutuv_web/components/ui.ex:4846
+#: lib/vutuv_web/components/ui.ex:4954
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr "löschen entfernen schließen kündigen beenden verlassen"
@@ -15946,14 +15944,14 @@ msgstr "Benutzernamen ändern"
 msgid "This link always opens your profile, even after you change your username. It is built from a fixed id, so it never breaks on a rename. For everyday sharing the short address above is friendlier."
 msgstr "Dieser Link öffnet immer Ihr Profil, auch nachdem Sie Ihren Benutzernamen geändert haben. Er wird aus einer festen Id gebildet und geht bei einer Umbenennung nie kaputt. Für den Alltag ist die kurze Adresse oben freundlicher."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:269
-#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:35
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:261
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:29
 #, elixir-autogen, elixir-format
 msgid "I understand, switch off"
 msgstr "Verstanden, abschalten"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:267
-#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:33
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:259
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "I understand, take part"
 msgstr "Verstanden, teilnehmen"
@@ -16002,7 +16000,7 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:5726
+#: lib/vutuv_web/components/post_components.ex:5748
 #: lib/vutuv_web/live/notification_live/index.ex:1352
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -16010,7 +16008,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:5730
+#: lib/vutuv_web/components/post_components.ex:5752
 #: lib/vutuv_web/live/notification_live/index.ex:1350
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -16018,7 +16016,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:5734
+#: lib/vutuv_web/components/post_components.ex:5756
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16026,7 +16024,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1182
-#: lib/vutuv_web/components/post_components.ex:5685
+#: lib/vutuv_web/components/post_components.ex:5707
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16042,14 +16040,14 @@ msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem 
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
-#: lib/vutuv_web/components/post_components.ex:1478
-#: lib/vutuv_web/components/post_components.ex:2221
-#: lib/vutuv_web/live/fediverse_account_live.ex:296
+#: lib/vutuv_web/components/post_components.ex:1479
+#: lib/vutuv_web/components/post_components.ex:2243
+#: lib/vutuv_web/live/fediverse_account_live.ex:298
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:1351
+#: lib/vutuv_web/components/post_components.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Diese Antwort aus Ihrem Beitrag entfernen?"
@@ -16078,7 +16076,7 @@ msgstr "Antwort aus einem anderen Netzwerk"
 msgid "Reply removed."
 msgstr "Antwort entfernt."
 
-#: lib/vutuv_web/components/post_components.ex:1360
+#: lib/vutuv_web/components/post_components.ex:1361
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
@@ -16088,7 +16086,7 @@ msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
 msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
-#: lib/vutuv_web/components/post_components.ex:1374
+#: lib/vutuv_web/components/post_components.ex:1375
 #: lib/vutuv_web/live/notification_live/index.ex:910
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -16120,10 +16118,10 @@ msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1366
-#: lib/vutuv_web/components/post_components.ex:1409
-#: lib/vutuv_web/components/post_components.ex:1609
-#: lib/vutuv_web/components/post_components.ex:2910
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:244
+#: lib/vutuv_web/components/post_components.ex:1410
+#: lib/vutuv_web/components/post_components.ex:1611
+#: lib/vutuv_web/components/post_components.ex:2932
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Original ansehen"
@@ -16261,27 +16259,27 @@ msgstr "Anderen Benutzernamen wählen"
 msgid "Confirm it is you"
 msgstr "Bestätigen Sie, dass Sie es sind"
 
-#: lib/vutuv_web/templates/username/confirm.html.heex:148
+#: lib/vutuv_web/templates/username/confirm.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "That passkey could not be verified. Please try again."
 msgstr "Dieser Passkey konnte nicht überprüft werden. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/templates/username/confirm.html.heex:151
+#: lib/vutuv_web/templates/username/confirm.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "Confirm with your passkey"
 msgstr "Mit Passkey bestätigen"
 
-#: lib/vutuv_web/templates/username/confirm.html.heex:176
+#: lib/vutuv_web/templates/username/confirm.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "This browser does not support passkeys. Use a code below instead."
 msgstr "Dieser Browser unterstützt keine Passkeys. Nutzen Sie stattdessen einen Code unten."
 
-#: lib/vutuv_web/templates/username/confirm.html.heex:211
+#: lib/vutuv_web/templates/username/confirm.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "Enter your code"
 msgstr "Geben Sie Ihren Code ein"
 
-#: lib/vutuv_web/templates/username/confirm.html.heex:223
+#: lib/vutuv_web/templates/username/confirm.html.heex:221
 #, elixir-autogen, elixir-format
 msgid "Change my username"
 msgstr "Benutzernamen jetzt ändern"
@@ -16291,17 +16289,17 @@ msgstr "Benutzernamen jetzt ändern"
 msgid "Send the PIN to"
 msgstr "PIN senden an"
 
-#: lib/vutuv_web/views/username_html.ex:155
+#: lib/vutuv_web/views/username_html.ex:152
 #, elixir-autogen, elixir-format
 msgid "Send a new PIN"
 msgstr "Neue PIN senden"
 
-#: lib/vutuv_web/views/username_html.ex:155
+#: lib/vutuv_web/views/username_html.ex:152
 #, elixir-autogen, elixir-format
 msgid "Email me a PIN"
 msgstr "PIN per E-Mail schicken"
 
-#: lib/vutuv_web/views/username_html.ex:163
+#: lib/vutuv_web/views/username_html.ex:160
 #, elixir-autogen, elixir-format
 msgid "The PIN goes to %{email}."
 msgstr "Die PIN geht an %{email}."
@@ -16355,7 +16353,7 @@ msgstr "API-Token erstellt"
 msgid "Access token revoked"
 msgstr "API-Token widerrufen"
 
-#: lib/vutuv_web/components/ui.ex:4810
+#: lib/vutuv_web/components/ui.ex:4918
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16570,7 +16568,7 @@ msgstr "Hier ist noch nichts. Wenn Sie sich das nächste Mal anmelden oder eine 
 #: lib/vutuv_web/live/account_activity_live.ex:198
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/fediverse_following_live.ex:351
-#: lib/vutuv_web/live/tag_live/timeline.ex:438
+#: lib/vutuv_web/live/tag_live/timeline.ex:434
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr "Dazu passt nichts. Versuchen Sie eine kürzere Suche oder setzen Sie die Filter zurück."
@@ -16702,7 +16700,7 @@ msgstr "Was sich an einem Konto geändert hat, wann, von wo und wie es bestätig
 msgid "What changed on your account, and exactly when."
 msgstr "Was sich an Ihrem Konto geändert hat, und wann genau."
 
-#: lib/vutuv_web/components/ui.ex:4811
+#: lib/vutuv_web/components/ui.ex:4919
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr "Was sich an Ihrem Konto geändert hat, und wann"
@@ -16738,7 +16736,7 @@ msgstr "durch den Betreiber"
 msgid "from a signed-in session"
 msgstr "aus einer angemeldeten Sitzung"
 
-#: lib/vutuv_web/components/ui.ex:4813
+#: lib/vutuv_web/components/ui.ex:4921
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr "protokoll verlauf historie chronik audit sicherheit war ich das wer hat wann geaendert geändert log"
@@ -16790,22 +16788,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:3454
+#: lib/vutuv_web/components/post_components.ex:3476
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:3570
+#: lib/vutuv_web/components/post_components.ex:3592
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:3578
+#: lib/vutuv_web/components/post_components.ex:3600
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:3564
+#: lib/vutuv_web/components/post_components.ex:3586
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -16834,19 +16832,19 @@ msgstr "angehefteter Beitrag"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:560
 #: lib/vutuv_web/agent_docs/text.ex:549
-#: lib/vutuv_web/templates/user/edit.html.heex:224
+#: lib/vutuv_web/templates/user/edit.html.heex:219
 #: lib/vutuv_web/templates/user/show.html.heex:254
 #: lib/vutuv_web/views/account_event_text.ex:213
 #, elixir-autogen, elixir-format
 msgid "Name pronunciation"
 msgstr "Aussprache des Namens"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:228
+#: lib/vutuv_web/templates/user/edit.html.heex:223
 #, elixir-autogen, elixir-format
 msgid "e.g. [SHTEH-fahn VIN-ter-my-er]"
 msgstr "z. B. [SCHTEH-fan WIN-ter-mei-er]"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:231
+#: lib/vutuv_web/templates/user/edit.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
@@ -16855,7 +16853,7 @@ msgstr ""
 "in eckigen Klammern, wie eine Lautschrift geschrieben wird; die Klammern "
 "ergänzen wir für Sie. Bleibt das Feld leer, wird nichts angezeigt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2884
+#: lib/vutuv_web/live/post_live/composer.ex:2823
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr "Diese Einstellungen für alle Fotos übernehmen"
@@ -16885,123 +16883,123 @@ msgstr "CC BY-SA 4.0 (Namensnennung, gleiche Bedingungen)"
 msgid "CC0 1.0 (no rights reserved)"
 msgstr "CC0 1.0 (keine Rechte vorbehalten)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2308
+#: lib/vutuv_web/live/post_live/composer.ex:2247
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Titelbild"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2722
+#: lib/vutuv_web/live/post_live/composer.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1294
 #: lib/vutuv_web/agent_docs/text.ex:807
-#: lib/vutuv_web/components/ui.ex:2867
+#: lib/vutuv_web/components/ui.ex:2969
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Original herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2821
+#: lib/vutuv_web/live/post_live/composer.ex:2760
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr "Alle Metadaten bleiben erhalten, auch alles, was Ihre Kamera hineingeschrieben hat."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2777
+#: lib/vutuv_web/live/post_live/composer.ex:2716
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr "Alle dürfen dieses Foto herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2779
+#: lib/vutuv_web/live/post_live/composer.ex:2718
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr "Volle Auflösung, direkt aus dem Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2798
+#: lib/vutuv_web/live/post_live/composer.ex:2737
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr "Nur das Bild"
 
-#: lib/vutuv_web/components/ui.ex:2866
+#: lib/vutuv_web/components/ui.ex:2968
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Nächstes Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2327
+#: lib/vutuv_web/live/post_live/composer.ex:2266
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:3049
+#: lib/vutuv_web/components/post_components.ex:3071
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:4264
+#: lib/vutuv_web/components/post_components.ex:4286
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:4412
+#: lib/vutuv_web/components/post_components.ex:4434
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2280
-#: lib/vutuv_web/live/post_live/composer.ex:2281
+#: lib/vutuv_web/live/post_live/composer.ex:2219
+#: lib/vutuv_web/live/post_live/composer.ex:2220
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1327
 #: lib/vutuv_web/agent_docs/text.ex:794
-#: lib/vutuv_web/components/post_components.ex:4494
+#: lib/vutuv_web/components/post_components.ex:4516
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
 
-#: lib/vutuv_web/components/ui.ex:2865
+#: lib/vutuv_web/components/ui.ex:2967
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2340
-#: lib/vutuv_web/live/post_live/composer.ex:2341
+#: lib/vutuv_web/live/post_live/composer.ex:2279
+#: lib/vutuv_web/live/post_live/composer.ex:2280
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr "Foto entfernen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2800
+#: lib/vutuv_web/live/post_live/composer.ex:2739
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qualität unverändert."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2741
+#: lib/vutuv_web/live/post_live/composer.ex:2680
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:3102
+#: lib/vutuv_web/components/post_components.ex:3124
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2819
+#: lib/vutuv_web/live/post_live/composer.ex:2758
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr "Die Datei genau so, wie ich sie hochgeladen habe"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2855
+#: lib/vutuv_web/live/post_live/composer.ex:2794
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen Sie das Foto, wenn Sie das nicht möchten."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2847
+#: lib/vutuv_web/live/post_live/composer.ex:2786
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/components/post_components.ex:3093
+#: lib/vutuv_web/components/post_components.ex:3115
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
@@ -17011,37 +17009,37 @@ msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht �
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/components/post_components.ex:3111
+#: lib/vutuv_web/components/post_components.ex:3133
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Diese Seite nimmt nicht am Fediverse teil."
 
-#: lib/vutuv_web/components/post_components.ex:3045
+#: lib/vutuv_web/components/post_components.ex:3067
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2598
+#: lib/vutuv_web/live/post_live/composer.ex:2537
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr "Wer diese Fotos weiterverwenden darf"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1278
+#: lib/vutuv_web/live/post_live/composer.ex:1253
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:3106
+#: lib/vutuv_web/components/post_components.ex:3128
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1292
+#: lib/vutuv_web/live/post_live/composer.ex:1267
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
 
-#: lib/vutuv_web/components/post_components.ex:3059
+#: lib/vutuv_web/components/post_components.ex:3081
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fediverse-Follower. Auf vutuv ist sie ebenfalls ein öffentlicher Beitrag."
@@ -17051,65 +17049,64 @@ msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fedive
 msgid "© All rights reserved"
 msgstr "© Alle Rechte vorbehalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2223
+#: lib/vutuv_web/live/post_live/composer.ex:2162
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr "Fotos hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2593
+#: lib/vutuv_web/live/post_live/composer.ex:2532
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2712
+#: lib/vutuv_web/live/post_live/composer.ex:2651
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr "Bildunterschrift (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1522
-#: lib/vutuv_web/live/post_live/composer.ex:1585
-#: lib/vutuv_web/live/post_live/composer.ex:1643
-#: lib/vutuv_web/live/post_live/composer.ex:1990
+#: lib/vutuv_web/live/post_live/composer.ex:1498
+#: lib/vutuv_web/live/post_live/composer.ex:1561
+#: lib/vutuv_web/live/post_live/composer.ex:1619
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr "Entwurf verwerfen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1515
+#: lib/vutuv_web/live/post_live/composer.ex:1491
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr "Weiter, wo Sie aufgehört haben."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2646
+#: lib/vutuv_web/live/post_live/composer.ex:2585
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr "Eine Datei, deren Format sich nicht säubern lässt, wird exakt so weitergegeben, wie sie hochgeladen wurde."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2158
+#: lib/vutuv_web/live/post_live/composer.ex:2096
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr "Pro Foto verschieden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2157
+#: lib/vutuv_web/live/post_live/composer.ex:2095
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr "Original, exakt wie hochgeladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2156
+#: lib/vutuv_web/live/post_live/composer.ex:2094
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr "Original, ohne Metadaten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2161
+#: lib/vutuv_web/live/post_live/composer.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr "Nur Web-Versionen (%{format})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2616
+#: lib/vutuv_web/live/post_live/composer.ex:2555
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr "Was Besucher speichern können"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2635
+#: lib/vutuv_web/live/post_live/composer.ex:2574
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -17117,13 +17114,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1200
-#: lib/vutuv_web/components/post_components.ex:5723
+#: lib/vutuv_web/components/post_components.ex:5745
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1198
-#: lib/vutuv_web/components/post_components.ex:5720
+#: lib/vutuv_web/components/post_components.ex:5742
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17133,7 +17130,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:5612
+#: lib/vutuv_web/components/post_components.ex:5634
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17228,17 +17225,17 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr "Rücknahme"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1779
-#: lib/vutuv_web/live/post_live/composer.ex:2480
+#: lib/vutuv_web/live/post_live/composer.ex:1755
+#: lib/vutuv_web/live/post_live/composer.ex:2419
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr "Fotodetails"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:449
+#: lib/vutuv_web/live/fediverse_account_live.ex:459
 #: lib/vutuv_web/live/fediverse_following_live.ex:60
 #: lib/vutuv_web/live/fediverse_following_live.ex:274
 #: lib/vutuv_web/live/fediverse_following_live.ex:287
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:330
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:331
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Accounts you follow elsewhere"
@@ -17249,22 +17246,22 @@ msgstr "Konten, denen Sie anderswo folgen"
 msgid "Address of the account"
 msgstr "Adresse des Kontos"
 
-#: lib/vutuv_web/live/search_live.ex:521
+#: lib/vutuv_web/live/search_live.ex:514
 #, elixir-autogen, elixir-format
 msgid "An account on another network"
 msgstr "Ein Konto in einem anderen Netzwerk"
 
-#: lib/vutuv_web/components/fediverse_components.ex:431
+#: lib/vutuv_web/components/fediverse_components.ex:428
 #, elixir-autogen, elixir-format
 msgid "Cancel request"
 msgstr "Anfrage zurückziehen"
 
-#: lib/vutuv_web/components/ui.ex:4797
+#: lib/vutuv_web/components/ui.ex:4905
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Konten auf Mastodon folgen, und von dort gefolgt werden"
 
-#: lib/vutuv_web/components/fediverse_components.ex:462
+#: lib/vutuv_web/components/fediverse_components.ex:459
 #, elixir-autogen, elixir-format
 msgid "Follow request sent to %{account}."
 msgstr "Follower-Anfrage an %{account} gesendet."
@@ -17274,7 +17271,7 @@ msgstr "Follower-Anfrage an %{account} gesendet."
 msgid "Follow somebody out there"
 msgstr "Jemandem dort draußen folgen"
 
-#: lib/vutuv_web/live/search_live.ex:551
+#: lib/vutuv_web/live/search_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "Follow this account"
 msgstr "Diesem Konto folgen"
@@ -17296,7 +17293,7 @@ msgstr "Verwalten, wem Sie folgen"
 msgid "Mastodon and the other networks work like email: an address is enough. Paste one here and vutuv asks that server to let you follow the account."
 msgstr "Mastodon und die anderen Netzwerke funktionieren wie E-Mail: Eine Adresse genügt. Fügen Sie hier eine ein, und vutuv fragt den betreffenden Server, ob Sie dem Konto folgen dürfen."
 
-#: lib/vutuv_web/components/fediverse_components.ex:401
+#: lib/vutuv_web/components/fediverse_components.ex:398
 #: lib/vutuv_web/live/organization_live/following.ex:442
 #, elixir-autogen, elixir-format
 msgid "Requested"
@@ -17312,12 +17309,12 @@ msgstr "Sortierung zurücksetzen"
 msgid "Search for them here"
 msgstr "Hier nach dieser Person suchen"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:384
+#: lib/vutuv_web/live/fediverse_following_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Show only accounts on this server"
 msgstr "Nur Konten auf diesem Server anzeigen"
 
-#: lib/vutuv_web/live/search_live.ex:559
+#: lib/vutuv_web/live/search_live.ex:552
 #, elixir-autogen, elixir-format
 msgid "Sign in to follow this account"
 msgstr "Anmelden, um diesem Konto zu folgen"
@@ -17332,38 +17329,38 @@ msgstr "Status"
 msgid "Stop following %{account}?"
 msgstr "%{account} nicht mehr folgen?"
 
-#: lib/vutuv_web/components/fediverse_components.ex:484
+#: lib/vutuv_web/components/fediverse_components.ex:481
 #, elixir-autogen, elixir-format
 msgid "That account could not be loaded from its server. Try again in a little while."
 msgstr "Dieses Konto konnte von seinem Server nicht geladen werden. Versuchen Sie es in Kürze noch einmal."
 
-#: lib/vutuv_web/components/fediverse_components.ex:536
+#: lib/vutuv_web/components/fediverse_components.ex:533
 #, elixir-autogen, elixir-format
 msgid "That did not work. Check the address and try again."
 msgstr "Das hat nicht geklappt. Prüfen Sie die Adresse und versuchen Sie es erneut."
 
-#: lib/vutuv_web/components/fediverse_components.ex:473
+#: lib/vutuv_web/components/fediverse_components.ex:470
 #, elixir-autogen, elixir-format
 msgid "That does not look like an address on another network. They look like @name@server."
 msgstr "Das sieht nicht nach einer Adresse in einem anderen Netzwerk aus. Solche Adressen sehen aus wie @name@server."
 
-#: lib/vutuv_web/live/search_live.ex:526
+#: lib/vutuv_web/live/search_live.ex:519
 #, elixir-autogen, elixir-format
 msgid "That is an address on Mastodon or one of the other networks, so nobody here carries it. You can follow it from vutuv."
 msgstr "Das ist eine Adresse bei Mastodon oder einem der anderen Netzwerke, deshalb trägt sie hier niemand. Sie können ihr von vutuv aus folgen."
 
-#: lib/vutuv_web/components/fediverse_components.ex:481
+#: lib/vutuv_web/components/fediverse_components.ex:478
 #, elixir-autogen, elixir-format
 msgid "That server answered, but it has no account at that address to follow."
 msgstr "Der Server hat geantwortet, führt unter dieser Adresse aber kein Konto, dem man folgen könnte."
 
-#: lib/vutuv_web/components/fediverse_components.ex:478
-#: lib/vutuv_web/components/fediverse_components.ex:557
+#: lib/vutuv_web/components/fediverse_components.ex:475
+#: lib/vutuv_web/components/fediverse_components.ex:554
 #, elixir-autogen, elixir-format
 msgid "That server did not answer. Check the address, and that the server is online."
 msgstr "Der Server hat nicht geantwortet. Prüfen Sie die Adresse und ob der Server erreichbar ist."
 
-#: lib/vutuv_web/components/fediverse_components.ex:533
+#: lib/vutuv_web/components/fediverse_components.ex:530
 #, elixir-autogen, elixir-format
 msgid "The Fediverse is switched off on this vutuv."
 msgstr "Das Fediverse ist auf diesem vutuv abgeschaltet."
@@ -17373,7 +17370,7 @@ msgstr "Das Fediverse ist auf diesem vutuv abgeschaltet."
 msgid "The address you brought along is kept here:"
 msgstr "Die mitgebrachte Adresse bleibt hier stehen:"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:429
+#: lib/vutuv_web/live/fediverse_following_live.ex:437
 #, elixir-autogen, elixir-format
 msgid "The other server decides. Most accounts accept straight away; one that checks its followers by hand stays on \"Requested\" until somebody there says yes."
 msgstr "Der andere Server entscheidet. Die meisten Konten nehmen sofort an; eines, das seine Follower von Hand prüft, bleibt auf „Angefragt“ stehen, bis dort jemand zustimmt."
@@ -17383,7 +17380,7 @@ msgstr "Der andere Server entscheidet. Die meisten Konten nehmen sofort an; eine
 msgid "This vutuv does not exchange anything with other networks, so there is nothing to follow from here. That is an operator setting, not yours."
 msgstr "Dieses vutuv tauscht nichts mit anderen Netzwerken aus, deshalb lässt sich von hier aus niemandem folgen. Das ist eine Einstellung des Betreibers, nicht Ihre."
 
-#: lib/vutuv_web/components/fediverse_components.ex:487
+#: lib/vutuv_web/components/fediverse_components.ex:484
 #, elixir-autogen, elixir-format
 msgid "This vutuv does not exchange anything with that server."
 msgstr "Dieses vutuv tauscht nichts mit diesem Server aus."
@@ -17393,18 +17390,18 @@ msgstr "Dieses vutuv tauscht nichts mit diesem Server aus."
 msgid "To follow an account out there you need a Fediverse identity of your own: the request is signed in your name, so the other server knows who is asking."
 msgstr "Um einem Konto dort draußen zu folgen, brauchen Sie eine eigene Fediverse-Identität: Die Anfrage wird in Ihrem Namen signiert, damit der andere Server weiß, wer fragt."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:134
+#: lib/vutuv_web/live/fediverse_account_live.ex:136
 #: lib/vutuv_web/live/fediverse_following_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Unfollowed."
 msgstr "Nicht mehr gefolgt."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:426
+#: lib/vutuv_web/live/fediverse_following_live.ex:434
 #, elixir-autogen, elixir-format
 msgid "What following out there means"
 msgstr "Was Folgen dort draußen bedeutet"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:434
+#: lib/vutuv_web/live/fediverse_following_live.ex:442
 #, elixir-autogen, elixir-format
 msgid "Who you follow is yours alone. Your profile publishes how many accounts you follow out there, never which ones."
 msgstr "Wem Sie folgen, geht nur Sie etwas an. Ihr Profil veröffentlicht, wie vielen Konten Sie dort draußen folgen, nie welchen."
@@ -17419,17 +17416,17 @@ msgstr "Warum ist mein Konto gesperrt?"
 msgid "Withdraw your follow request to %{account}?"
 msgstr "Ihre Follower-Anfrage an %{account} zurückziehen?"
 
-#: lib/vutuv_web/components/fediverse_components.ex:504
+#: lib/vutuv_web/components/fediverse_components.ex:501
 #, elixir-autogen, elixir-format
 msgid "You already follow that account."
 msgstr "Sie folgen diesem Konto bereits."
 
-#: lib/vutuv_web/components/fediverse_components.ex:522
+#: lib/vutuv_web/components/fediverse_components.ex:519
 #, elixir-autogen, elixir-format
 msgid "You are following the most accounts we allow (%{max})."
 msgstr "Sie folgen bereits so vielen Konten, wie hier erlaubt sind (%{max})."
 
-#: lib/vutuv_web/components/fediverse_components.ex:512
+#: lib/vutuv_web/components/fediverse_components.ex:509
 #, elixir-autogen, elixir-format
 msgid "You are not taking part in the Fediverse at the moment, so there is no identity to sign the request with. Open the Fediverse settings to switch it on."
 msgstr "Sie nehmen derzeit nicht am Fediverse teil, deshalb gibt es keine Identität, mit der die Anfrage signiert werden könnte. Schalten Sie die Teilnahme in den Fediverse-Einstellungen ein."
@@ -17446,12 +17443,12 @@ msgid_plural "You follow %{formatted} accounts on other networks"
 msgstr[0] "Sie folgen %{formatted} Konto in einem anderen Netzwerk"
 msgstr[1] "Sie folgen %{formatted} Konten in anderen Netzwerken"
 
-#: lib/vutuv_web/components/fediverse_components.ex:518
+#: lib/vutuv_web/components/fediverse_components.ex:515
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of follow requests in the last hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Follower-Anfragen gesendet. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/fediverse_components.ex:528
+#: lib/vutuv_web/components/fediverse_components.ex:525
 #, elixir-autogen, elixir-format
 msgid "You redirected your Fediverse followers to another account, so this account no longer acts out there."
 msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, deshalb tritt dieses Konto dort draußen nicht mehr auf."
@@ -17462,7 +17459,7 @@ msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, desh
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr "Ihr Konto ist derzeit gesperrt, deshalb geht nichts von Ihnen an andere Netzwerke und Sie können dort niemandem folgen. Das endet von selbst, sobald die Sperre abläuft."
 
-#: lib/vutuv_web/components/ui.ex:4799
+#: lib/vutuv_web/components/ui.ex:4907
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr "mastodon activitypub foederation federation follower folgen folge umzug migration entferntes konto"
@@ -17482,7 +17479,7 @@ msgstr "Von hier aus wird %{follows} Konten in anderen Netzwerken gefolgt, davon
 msgid "Cached posts"
 msgstr "Zwischengespeicherte Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:2669
+#: lib/vutuv_web/components/post_components.ex:2691
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Nur für die Follower dieses Kontos"
@@ -17492,7 +17489,7 @@ msgstr "Nur für die Follower dieses Kontos"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:2909
+#: lib/vutuv_web/components/post_components.ex:2931
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -17512,17 +17509,17 @@ msgstr "Zwischengespeicherter Beitrag gemeldet, hier für alle entfernt"
 msgid "Content from other networks taken down by members"
 msgstr "Von Mitgliedern entfernte Inhalte aus anderen Netzwerken"
 
-#: lib/vutuv_web/components/post_components.ex:1762
+#: lib/vutuv_web/components/post_components.ex:1784
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Verbergen"
 
-#: lib/vutuv_web/components/post_components.ex:2850
+#: lib/vutuv_web/components/post_components.ex:2872
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Von der verfassenden Person als sensibel markiert"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:229
+#: lib/vutuv_web/live/fediverse_account_live.ex:231
 #: lib/vutuv_web/live/remote_post_actions.ex:71
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
@@ -17533,12 +17530,12 @@ msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwin
 msgid "Nobody has removed or reported anything yet."
 msgstr "Bisher hat niemand etwas entfernt oder gemeldet."
 
-#: lib/vutuv_web/components/post_components.ex:2655
+#: lib/vutuv_web/components/post_components.ex:2677
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr "Diesen Beitrag als unangemessen melden? Unsere Kopie wird sofort für alle auf diesem vutuv gelöscht."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:445
+#: lib/vutuv_web/live/fediverse_following_live.ex:453
 #, elixir-autogen, elixir-format
 msgid "To show their posts we keep a copy here for up to six months. If the author deletes or edits something, ours follows; and when you stop following an account, its posts are deleted here at once."
 msgstr "Um die Beiträge zeigen zu können, behalten wir hier bis zu sechs Monate lang eine Kopie. Löscht oder ändert die verfassende Person etwas, zieht unsere Kopie nach; und sobald Sie einem Konto nicht mehr folgen, werden dessen Beiträge hier sofort gelöscht."
@@ -17548,62 +17545,62 @@ msgstr "Um die Beiträge zeigen zu können, behalten wir hier bis zu sechs Monat
 msgid "You do not follow anybody out there yet. Once you do, what they post appears in your feed among everything else."
 msgstr "Sie folgen dort draußen noch niemandem. Sobald Sie das tun, erscheinen deren Beiträge in Ihrem Feed zwischen allem anderen."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:76
+#: lib/vutuv_web/live/fediverse_account_live.ex:78
 #, elixir-autogen, elixir-format
 msgid "%{name} (another network)"
 msgstr "%{name} (anderes Netzwerk)"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:279
+#: lib/vutuv_web/live/fediverse_account_live.ex:281
 #, elixir-autogen, elixir-format
 msgid "Account on another network"
 msgstr "Konto in einem anderen Netzwerk"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:433
+#: lib/vutuv_web/live/fediverse_account_live.ex:443
 #, elixir-autogen, elixir-format
 msgid "Look up another account"
 msgstr "Ein anderes Konto nachschlagen"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:363
+#: lib/vutuv_web/live/fediverse_account_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "Muted"
 msgstr "Stummgeschaltet"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:254
+#: lib/vutuv_web/live/fediverse_account_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "Nothing cached yet. Their posts appear here as they publish them."
 msgstr "Noch nichts zwischengespeichert. Die Beiträge erscheinen hier, sobald sie veröffentlicht werden."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:249
+#: lib/vutuv_web/live/fediverse_account_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Nothing here. vutuv only keeps an account's posts while somebody here follows it, and this page never fetches any."
 msgstr "Hier ist nichts. vutuv behält die Beiträge eines Kontos nur, solange jemand hier ihm folgt, und diese Seite ruft von sich aus keine ab."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:435
+#: lib/vutuv_web/live/fediverse_account_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "Paste an address from Mastodon and friends to open its page here."
 msgstr "Fügen Sie eine Adresse von Mastodon und Co. ein, um die zugehörige Seite hier zu öffnen."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:331
+#: lib/vutuv_web/live/fediverse_account_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Show the whole description"
 msgstr "Ganze Beschreibung anzeigen"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:418
+#: lib/vutuv_web/live/fediverse_account_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "The most recent %{count} are shown. The rest are on their own server."
 msgstr "Die neuesten %{count} werden angezeigt. Der Rest liegt auf dem eigenen Server."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:231
+#: lib/vutuv_web/live/fediverse_account_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts are back in your feed."
 msgstr "Stummschaltung aufgehoben. Die Beiträge sind wieder in Ihrem Feed."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:428
+#: lib/vutuv_web/live/fediverse_account_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "View their full profile on %{host}"
 msgstr "Vollständiges Profil auf %{host} ansehen"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:258
+#: lib/vutuv_web/live/fediverse_account_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Waiting for that server to accept your follow. Posts they addressed to their followers appear once it does."
 msgstr "Warten darauf, dass der Server Ihre Follower-Anfrage annimmt. Beiträge, die nur an die Follower gerichtet sind, erscheinen danach."
@@ -17614,7 +17611,7 @@ msgid "You redirected your Fediverse followers to another account, so this one n
 msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, deshalb folgt dieses Konto dort draußen niemandem mehr."
 
 #: lib/vutuv_web/components/fediverse_components.ex:310
-#: lib/vutuv_web/components/fediverse_components.ex:623
+#: lib/vutuv_web/components/fediverse_components.ex:620
 #, elixir-autogen, elixir-format
 msgid "Your account move"
 msgstr "Ihr Kontoumzug"
@@ -17755,27 +17752,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(ein Bild)"
 msgstr[1] "(%{count} Bilder)"
 
-#: lib/vutuv_web/components/post_components.ex:2380
+#: lib/vutuv_web/components/post_components.ex:2402
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr "Bild wird geprüft"
 
-#: lib/vutuv_web/components/post_components.ex:2408
+#: lib/vutuv_web/components/post_components.ex:2430
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Wieder verdecken"
 
-#: lib/vutuv_web/components/post_components.ex:2403
+#: lib/vutuv_web/components/post_components.ex:2425
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Heikles Motiv. Bild anzeigen."
 
-#: lib/vutuv_web/components/post_components.ex:2952
+#: lib/vutuv_web/components/post_components.ex:2974
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:2958
+#: lib/vutuv_web/components/post_components.ex:2980
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
@@ -17785,7 +17782,7 @@ msgstr "Diesen Beitrag gibt es hier nicht mehr."
 msgid "Back to the feed"
 msgstr "Zurück zum Feed"
 
-#: lib/vutuv_web/components/post_components.ex:3097
+#: lib/vutuv_web/components/post_components.ex:3119
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17805,7 +17802,7 @@ msgstr ""
 msgid "Reposted. Your followers see it now."
 msgstr "Repostet. Ihre Follower sehen es jetzt."
 
-#: lib/vutuv_web/components/fediverse_components.ex:399
+#: lib/vutuv_web/components/fediverse_components.ex:396
 #, elixir-autogen, elixir-format
 msgid "Moved"
 msgstr "Umgezogen"
@@ -17980,7 +17977,7 @@ msgstr "Ihr Benutzername ist hier Ihre öffentliche Identität. Er ändert sich 
 msgid "Your username is your public identity here. It changes only once you confirm with your passkey or a valid code below."
 msgstr "Ihr Benutzername ist hier Ihre öffentliche Identität. Er ändert sich erst, wenn Sie unten mit Ihrem Passkey oder einem gültigen Code bestätigen."
 
-#: lib/vutuv_web/components/ui.ex:575
+#: lib/vutuv_web/components/ui.ex:599
 #, elixir-autogen, elixir-format
 msgid "Markdown help"
 msgstr "Markdown-Hilfe"
@@ -17995,45 +17992,45 @@ msgstr "Auf dieser Seite"
 msgid "Read this page as Markdown"
 msgstr "Diese Seite als Markdown lesen"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:232
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Address of the post"
 msgstr "Adresse des Beitrags"
 
-#: lib/vutuv_web/components/fediverse_components.ex:620
+#: lib/vutuv_web/components/fediverse_components.ex:617
 #: lib/vutuv_web/live/post_live/remote_actions_component.ex:276
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings"
 msgstr "Fediverse-Einstellungen"
 
-#: lib/vutuv_web/components/fediverse_components.ex:597
+#: lib/vutuv_web/components/fediverse_components.ex:594
 #, elixir-autogen, elixir-format
 msgid "Fetching a post asks its server for it in your name, signed with your own key, so there is no such thing as an anonymous lookup here."
 msgstr "Einen Beitrag zu holen heißt, seinen Server in Ihrem Namen danach zu fragen, signiert mit Ihrem eigenen Schlüssel. Ein anonymes Nachschlagen gibt es hier deshalb nicht."
 
-#: lib/vutuv_web/components/fediverse_components.ex:564
+#: lib/vutuv_web/components/fediverse_components.ex:561
 #, elixir-autogen, elixir-format
 msgid "Its author published this post to their followers alone, so vutuv does not keep a copy of it."
 msgstr "Die verfassende Person hat diesen Beitrag nur an ihre Follower veröffentlicht, deshalb behält vutuv keine Kopie davon."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:460
+#: lib/vutuv_web/live/fediverse_following_live.ex:468
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Look up a post by its address"
 msgstr "Einen Beitrag über seine Adresse nachschlagen"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:70
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:196
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:71
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Look up a post from another network"
 msgstr "Einen Beitrag aus einem anderen Netzwerk nachschlagen"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:324
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Looking for an account rather than a single post?"
 msgstr "Suchen Sie ein Konto statt eines einzelnen Beitrags?"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:199
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Paste the address of a post on Mastodon and friends. vutuv fetches it, shows it here, and you can answer, like or repost it as if it had arrived on its own."
 msgstr "Fügen Sie die Adresse eines Beitrags aus Mastodon und Co. ein. vutuv holt ihn, zeigt ihn hier an, und Sie können darauf antworten, ihn mögen oder teilen, als wäre er von selbst hier gelandet."
@@ -18043,170 +18040,170 @@ msgstr "Fügen Sie die Adresse eines Beitrags aus Mastodon und Co. ein. vutuv ho
 msgid "Read something out there that you want to answer from here?"
 msgstr "Etwas dort draußen gelesen, worauf Sie von hier aus antworten möchten?"
 
-#: lib/vutuv_web/components/fediverse_components.ex:549
+#: lib/vutuv_web/components/fediverse_components.ex:546
 #, elixir-autogen, elixir-format
 msgid "That does not look like a link to a post. Copy the address of the post itself, for example https://server/@name/12345."
 msgstr "Das sieht nicht nach dem Link zu einem Beitrag aus. Kopieren Sie die Adresse des Beitrags selbst, zum Beispiel https://server/@name/12345."
 
-#: lib/vutuv_web/components/fediverse_components.ex:554
+#: lib/vutuv_web/components/fediverse_components.ex:551
 #, elixir-autogen, elixir-format
 msgid "That is a link on this vutuv, not on another network."
 msgstr "Das ist ein Link auf dieses vutuv, nicht auf ein anderes Netzwerk."
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:316
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:317
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:240
 #, elixir-autogen, elixir-format
 msgid "Their account page here"
 msgstr "Die Seite dieses Kontos hier"
 
-#: lib/vutuv_web/components/fediverse_components.ex:560
+#: lib/vutuv_web/components/fediverse_components.ex:557
 #, elixir-autogen, elixir-format
 msgid "There is no post to show at that address."
 msgstr "Unter dieser Adresse gibt es keinen Beitrag zu sehen."
 
-#: lib/vutuv_web/components/fediverse_components.ex:591
+#: lib/vutuv_web/components/fediverse_components.ex:588
 #, elixir-autogen, elixir-format
 msgid "This account no longer acts out there"
 msgstr "Dieses Konto ist dort draußen nicht mehr aktiv"
 
-#: lib/vutuv_web/components/fediverse_components.ex:609
+#: lib/vutuv_web/components/fediverse_components.ex:606
 #, elixir-autogen, elixir-format
 msgid "This vutuv does not exchange anything with other networks. That is an operator setting, not yours."
 msgstr "Dieses vutuv tauscht nichts mit anderen Netzwerken aus. Das ist eine Einstellung des Betreibers, nicht Ihre."
 
-#: lib/vutuv_web/components/fediverse_components.ex:592
+#: lib/vutuv_web/components/fediverse_components.ex:589
 #, elixir-autogen, elixir-format
 msgid "This vutuv stays to itself"
 msgstr "Dieses vutuv bleibt unter sich"
 
-#: lib/vutuv_web/components/fediverse_components.ex:589
+#: lib/vutuv_web/components/fediverse_components.ex:586
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to look up"
 msgstr "Fediverse-Teilnahme einschalten, um nachzuschlagen"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:454
+#: lib/vutuv_web/live/fediverse_following_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "Want to answer one particular post rather than follow its author?"
 msgstr "Möchten Sie auf einen bestimmten Beitrag antworten, statt der verfassenden Person zu folgen?"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:288
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:289
 #, elixir-autogen, elixir-format
 msgid "Who wrote this"
 msgstr "Wer das geschrieben hat"
 
-#: lib/vutuv_web/components/fediverse_components.ex:569
+#: lib/vutuv_web/components/fediverse_components.ex:566
 #, elixir-autogen, elixir-format
 msgid "You have looked a lot of posts up in the last hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Beiträge nachgeschlagen. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/fediverse_components.ex:603
+#: lib/vutuv_web/components/fediverse_components.ex:600
 #, elixir-autogen, elixir-format
 msgid "You redirected your Fediverse followers to another account, so nothing is fetched or sent from this one any more."
 msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, deshalb wird von diesem Konto aus nichts mehr geholt und nichts mehr gesendet."
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:334
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:335
 #, elixir-autogen, elixir-format
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr "Einen nachgeschlagenen Beitrag bewahrt vutuv genauso sechs Monate lang auf wie jeden anderen Beitrag aus einem anderen Netzwerk. Der Server der verfassenden Person wird sonst nichts gefragt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1696
+#: lib/vutuv_web/live/post_live/composer.ex:1672
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr "Zuschnitt übernehmen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2386
+#: lib/vutuv_web/live/post_live/composer.ex:2325
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr "Großes Foto links"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2387
+#: lib/vutuv_web/live/post_live/composer.ex:2326
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr "Großes Foto rechts"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2392
+#: lib/vutuv_web/live/post_live/composer.ex:2331
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr "Spalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2389
+#: lib/vutuv_web/live/post_live/composer.ex:2328
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr "Titelbild links"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2390
+#: lib/vutuv_web/live/post_live/composer.ex:2329
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr "Titelbild oben"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2391
+#: lib/vutuv_web/live/post_live/composer.ex:2330
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr "Titelbild rechts"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1692
-#: lib/vutuv_web/live/post_live/composer.ex:2357
-#: lib/vutuv_web/live/post_live/composer.ex:2358
+#: lib/vutuv_web/live/post_live/composer.ex:1668
+#: lib/vutuv_web/live/post_live/composer.ex:2296
+#: lib/vutuv_web/live/post_live/composer.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr "Foto zuschneiden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2316
+#: lib/vutuv_web/live/post_live/composer.ex:2255
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr "Zugeschnitten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1614
+#: lib/vutuv_web/live/post_live/composer.ex:1590
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr "Fotos hier ablegen, um sie hinzuzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2393
+#: lib/vutuv_web/live/post_live/composer.ex:2332
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr "Raster"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2394
+#: lib/vutuv_web/live/post_live/composer.ex:2333
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr "Mosaik"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1694
+#: lib/vutuv_web/live/post_live/composer.ex:1670
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr "Wählen Sie ein Format, dann verschieben und zoomen Sie. Der gerahmte Ausschnitt ist das, was der Beitrag zeigt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2385
+#: lib/vutuv_web/live/post_live/composer.ex:2324
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr "Nebeneinander"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2388
+#: lib/vutuv_web/live/post_live/composer.ex:2327
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr "Übereinander"
 
-#: lib/vutuv_web/live/post_live/composer.ex:497
+#: lib/vutuv_web/live/post_live/composer.ex:493
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr "Das Foto konnte nicht zugeschnitten werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2834
+#: lib/vutuv_web/live/post_live/composer.ex:2773
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr "Dieses Foto ist zugeschnitten: Downloads geben das zugeschnittene Bild heraus, die unveränderte Originaldatei bleibt privat."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1698
+#: lib/vutuv_web/live/post_live/composer.ex:1674
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr "Ganzes Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2583
+#: lib/vutuv_web/live/post_live/composer.ex:2522
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr "Kacheln füllen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2567
+#: lib/vutuv_web/live/post_live/composer.ex:2506
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr "Ganze Fotos"
@@ -18241,12 +18238,12 @@ msgstr "Wenn das wiederholt passiert, sagen Sie es uns bitte mit einer Fehlermel
 msgid "The most helpful detail in such a report is the exact time of the error. Right now it is %{time}."
 msgstr "Das hilfreichste Detail in so einer Meldung ist die genaue Uhrzeit des Fehlers. Gerade ist es %{time}."
 
-#: lib/vutuv_web/components/fediverse_components.ex:448
+#: lib/vutuv_web/components/fediverse_components.ex:445
 #, elixir-autogen, elixir-format
 msgid "@%{handle} is on this vutuv, so you now follow them here."
 msgstr "@%{handle} ist auf diesem vutuv. Sie folgen dem Mitglied jetzt direkt hier."
 
-#: lib/vutuv_web/components/fediverse_components.ex:493
+#: lib/vutuv_web/components/fediverse_components.ex:490
 #, elixir-autogen, elixir-format
 msgid "That address is on this vutuv, but it names no member here."
 msgstr "Diese Adresse gehört zu diesem vutuv, aber es gibt hier kein Mitglied mit diesem Namen."
@@ -18256,7 +18253,7 @@ msgstr "Diese Adresse gehört zu diesem vutuv, aber es gibt hier kein Mitglied m
 msgid "That address is on this vutuv. Sign in and use the Follow button on this profile."
 msgstr "Diese Adresse gehört zu diesem vutuv. Melden Sie sich an, dann können Sie diesem Mitglied direkt hier folgen."
 
-#: lib/vutuv_web/components/fediverse_components.ex:498
+#: lib/vutuv_web/components/fediverse_components.ex:495
 #, elixir-autogen, elixir-format
 msgid "That is your own address. You cannot follow yourself."
 msgstr "Das ist Ihre eigene Adresse. Sie können sich nicht selbst folgen."
@@ -18418,14 +18415,14 @@ msgstr "Seiten, von denen nie ein Screenshot entsteht, weil ein Browser ohne Anz
 msgid "Screenshot blocklist"
 msgstr "Screenshot-Blockliste"
 
-#: lib/vutuv_web/components/post_components.ex:439
+#: lib/vutuv_web/components/post_components.ex:440
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 "Noch nichts aus dem Fediverse. Folgen Sie Konten dort draußen, um diesen Tab "
 "zu füllen."
 
-#: lib/vutuv_web/components/post_components.ex:436
+#: lib/vutuv_web/components/post_components.ex:437
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
@@ -18436,39 +18433,39 @@ msgstr ""
 msgid "View the conversation"
 msgstr "Unterhaltung ansehen"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:256
+#: lib/vutuv_web/live/tag_live/timeline.ex:252
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post"
 msgid_plural "%{formatted} posts"
 msgstr[0] "%{formatted} Beitrag"
 msgstr[1] "%{formatted} Beiträge"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:415
+#: lib/vutuv_web/live/tag_live/timeline.ex:411
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr "Meiste Likes"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:446
+#: lib/vutuv_web/live/tag_live/timeline.ex:442
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr "Zu diesem Tag gibt es noch keine Beiträge."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:444
+#: lib/vutuv_web/live/tag_live/timeline.ex:440
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr "Aus anderen Netzwerken gibt es zu diesem Tag noch keine Beiträge."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:441
+#: lib/vutuv_web/live/tag_live/timeline.ex:437
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr "Auf vutuv gibt es zu diesem Tag noch keine Beiträge."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:332
+#: lib/vutuv_web/live/tag_live/timeline.ex:328
 #, elixir-autogen, elixir-format
 msgid "word in a post"
 msgstr "Wort in einem Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:2955
+#: lib/vutuv_web/components/post_components.ex:2977
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Diese Antwort gibt es hier nicht mehr."
@@ -18489,28 +18486,28 @@ msgstr "Noch nichts aus anderen Netzwerken gespeichert. Das Lesezeichen an einem
 msgid "Other networks"
 msgstr "Andere Netzwerke"
 
-#: lib/vutuv_web/live/fediverse_post_live.ex:80
+#: lib/vutuv_web/live/fediverse_post_live.ex:82
 #, elixir-autogen, elixir-format
 msgid "A post by %{name} (another network)"
 msgstr "Ein Beitrag von %{name} (anderes Netzwerk)"
 
-#: lib/vutuv_web/live/fediverse_post_live.ex:120
+#: lib/vutuv_web/live/fediverse_post_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "A post from another network"
 msgstr "Ein Beitrag aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/live/fediverse_post_live.ex:146
+#: lib/vutuv_web/live/fediverse_post_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "More from %{name}"
 msgstr "Mehr von %{name}"
 
-#: lib/vutuv_web/live/fediverse_post_live.ex:126
+#: lib/vutuv_web/live/fediverse_post_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr "Das ist die Kopie, die vutuv von einem auf %{host} veröffentlichten Beitrag hat. Sie bleibt erhalten, solange hier jemand diesem Konto folgt."
 
-#: lib/vutuv_web/components/ui.ex:1374
-#: lib/vutuv_web/components/ui.ex:1375
+#: lib/vutuv_web/components/ui.ex:1398
+#: lib/vutuv_web/components/ui.ex:1399
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr "Diesen Feed in Ihrem RSS-Reader abonnieren"
@@ -18520,7 +18517,7 @@ msgstr "Diesen Feed in Ihrem RSS-Reader abonnieren"
 msgid "A CV with positions, education, certificates including proof, spoken languages and tags other members endorse you for."
 msgstr "Ein Lebenslauf mit Stationen, Ausbildung, Zertifikaten samt Nachweis, Sprachen und Tags, für die andere Mitglieder Sie empfehlen."
 
-#: lib/vutuv_web/templates/page/index.html.heex:465
+#: lib/vutuv_web/templates/page/index.html.heex:464
 #, elixir-autogen, elixir-format
 msgid "A business network that is free, does not lock your data in, and is yours to run yourself if you want to."
 msgstr "Ein Business-Netzwerk, das kostenlos ist, Ihre Daten nicht einsperrt und das Sie auf Wunsch selbst betreiben können."
@@ -18540,22 +18537,22 @@ msgstr "Eine feste öffentliche Adresse, ohne Konto lesbar und als vCard herunte
 msgid "CV download as PDF, Word, OpenDocument, LaTeX or JSON Resume, and you pick what goes in before you download it."
 msgstr "Lebenslauf-Download als PDF, Word, OpenDocument, LaTeX oder JSON Resume, und Sie wählen vor dem Download aus, was darin steht."
 
-#: lib/vutuv_web/templates/page/index.html.heex:518
+#: lib/vutuv_web/templates/page/index.html.heex:517
 #, elixir-autogen, elixir-format
 msgid "Developer documentation"
 msgstr "Entwicklerdokumentation"
 
-#: lib/vutuv_web/templates/page/index.html.heex:478
+#: lib/vutuv_web/templates/page/index.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "Every public page here is also served as Markdown, plain text, JSON and XML under the same address. No scraping, no API key, no account."
 msgstr "Jede öffentliche Seite hier gibt es unter derselben Adresse auch als Markdown, reinen Text, JSON und XML. Ohne Scraping, ohne API-Schlüssel, ohne Konto."
 
-#: lib/vutuv_web/templates/page/index.html.heex:485
+#: lib/vutuv_web/templates/page/index.html.heex:484
 #, elixir-autogen, elixir-format
 msgid "For machines"
 msgstr "Für Maschinen"
 
-#: lib/vutuv_web/templates/page/index.html.heex:475
+#: lib/vutuv_web/templates/page/index.html.heex:474
 #, elixir-autogen, elixir-format
 msgid "Open by default"
 msgstr "Offen von Haus aus"
@@ -18580,12 +18577,12 @@ msgstr "Menschen, Beiträge, Jobs"
 msgid "Posts, likes, reposts, replies and 1:1 messages, in real time."
 msgstr "Beiträge, Likes, Reposts, Antworten und 1:1-Nachrichten, in Echtzeit."
 
-#: lib/vutuv_web/templates/page/index.html.heex:476
+#: lib/vutuv_web/templates/page/index.html.heex:475
 #, elixir-autogen, elixir-format
 msgid "Readable by people, by machines, and on your own server"
 msgstr "Lesbar für Menschen, für Maschinen und auf Ihrem eigenen Server"
 
-#: lib/vutuv_web/templates/page/index.html.heex:501
+#: lib/vutuv_web/templates/page/index.html.heex:500
 #, elixir-autogen, elixir-format
 msgid "Run it yourself"
 msgstr "Selbst hosten"
@@ -18595,23 +18592,23 @@ msgstr "Selbst hosten"
 msgid "Sign in without a password, by emailed PIN, passkey, authenticator app or a printed list of codes."
 msgstr "Einloggen ohne Passwort, per PIN in der E-Mail, Passkey, Authenticator-App oder gedruckter Kennwortliste."
 
-#: lib/vutuv_web/templates/page/index.html.heex:512
-#: lib/vutuv_web/templates/page/index.html.heex:599
+#: lib/vutuv_web/templates/page/index.html.heex:511
+#: lib/vutuv_web/templates/page/index.html.heex:598
 #, elixir-autogen, elixir-format
 msgid "Source code"
 msgstr "Quellcode"
 
-#: lib/vutuv_web/templates/page/index.html.heex:347
+#: lib/vutuv_web/templates/page/index.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "This is what a vutuv profile looks like"
 msgstr "So sieht ein Profil auf vutuv aus"
 
-#: lib/vutuv_web/templates/page/index.html.heex:463
+#: lib/vutuv_web/templates/page/index.html.heex:462
 #, elixir-autogen, elixir-format
 msgid "What vutuv can do"
 msgstr "Was vutuv kann"
 
-#: lib/vutuv_web/templates/page/index.html.heex:462
+#: lib/vutuv_web/templates/page/index.html.heex:461
 #, elixir-autogen, elixir-format
 msgid "What you get"
 msgstr "Was Sie bekommen"
@@ -18621,12 +18618,12 @@ msgstr "Was Sie bekommen"
 msgid "Your independence"
 msgstr "Ihre Unabhängigkeit"
 
-#: lib/vutuv_web/templates/page/index.html.heex:503
+#: lib/vutuv_web/templates/page/index.html.heex:502
 #, elixir-autogen, elixir-format
 msgid "vutuv is open source under the MIT license. Run it for a company, an association or a school, on the internet or air-gapped inside your own network."
 msgstr "vutuv ist Open Source unter der MIT-Lizenz. Betreiben Sie es für ein Unternehmen, einen Verein oder eine Schule, im Internet oder abgeschottet im eigenen Netz."
 
-#: lib/vutuv_web/templates/page/index.html.heex:346
+#: lib/vutuv_web/templates/page/index.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "A look inside"
 msgstr "Ein Blick hinein"
@@ -18636,7 +18633,7 @@ msgstr "Ein Blick hinein"
 msgid "A vutuv profile: cover picture, photo, name, tagline and job title, follower counts and the first posts, with contact details and social media profiles in a column on the right."
 msgstr "Ein vutuv-Profil: Titelbild, Foto, Name, Motto und Position, die Follower-Zahlen und die ersten Beiträge, rechts daneben eine Spalte mit Kontaktdaten und Profilen in sozialen Netzwerken."
 
-#: lib/vutuv_web/templates/page/index.html.heex:368
+#: lib/vutuv_web/templates/page/index.html.heex:367
 #, elixir-autogen, elixir-format
 msgid "Browse real profiles"
 msgstr "Echte Profile durchstöbern"
@@ -18656,17 +18653,17 @@ msgstr "Dasselbe Profil weiter unten: Tags mit der Zahl der Mitglieder, die sie 
 msgid "Try it out:"
 msgstr "Probieren Sie es aus:"
 
-#: lib/vutuv_web/templates/page/index.html.heex:494
+#: lib/vutuv_web/templates/page/index.html.heex:493
 #, elixir-autogen, elixir-format
 msgid "Plus a sitemap, JSON-LD and a REST API with OAuth 2 and personal access tokens."
 msgstr "Dazu eine Sitemap, JSON-LD und eine REST-API mit OAuth 2 und persönlichen Zugriffstokens."
 
-#: lib/vutuv_web/templates/page/index.html.heex:349
+#: lib/vutuv_web/templates/page/index.html.heex:348
 #, elixir-autogen, elixir-format
 msgid "Work experience, education, certificates, languages, links and tags others endorse you for. Anyone can read a profile, entirely without a vutuv account. Unlike LinkedIn, where you hit a login wall in short order."
 msgstr "Berufserfahrung, Ausbildung, Zertifikate, Sprachen, Links und Tags, für die andere Sie empfehlen. Ein Profil kann jeder lesen, ganz ohne vutuv-Konto. Anders als bei LinkedIn, wo Sie schnell vor einer Anmeldeschranke stehen."
 
-#: lib/vutuv_web/templates/page/index.html.heex:449
+#: lib/vutuv_web/templates/page/index.html.heex:448
 #, elixir-autogen, elixir-format
 msgid "Talking to people"
 msgstr "Miteinander reden"
@@ -18686,72 +18683,72 @@ msgstr "Der vutuv-Feed mit ausgewähltem Fediverse-Reiter: Beiträge von Nachric
 msgid "The Fediverse: let people follow you from Mastodon, and your public posts show up there. You choose at sign-up, and can change it later."
 msgstr "Das Fediverse: Menschen können Ihnen von Mastodon aus folgen, und Ihre öffentlichen Beiträge erscheinen dort. Sie entscheiden das bei der Anmeldung und können es später ändern."
 
-#: lib/vutuv_web/templates/page/index.html.heex:450
+#: lib/vutuv_web/templates/page/index.html.heex:449
 #, elixir-autogen, elixir-format
 msgid "Posts, messages, and the Fediverse along with them"
 msgstr "Beiträge, Nachrichten und das Fediverse gleich dazu"
 
-#: lib/vutuv_web/templates/page/index.html.heex:452
+#: lib/vutuv_web/templates/page/index.html.heex:451
 #, elixir-autogen, elixir-format
 msgid "Write a post, react with a heart, a repost or a reply, or message somebody privately. And you are not stuck among vutuv members: vutuv is part of the Fediverse, the union of independent networks that Mastodon belongs to as well. Follow an account over there and its posts arrive in your feed; the other way round, people there can follow you and see your public posts. Both directions, and entirely your choice: at sign-up you decide whether to use vutuv with or without the Fediverse, and you can change that at any time in the settings."
 msgstr "Beitrag schreiben, mit Herz, Repost oder Antwort reagieren, oder jemandem privat schreiben. Und Sie bleiben nicht unter vutuv-Mitgliedern: vutuv gehört zum Fediverse, dem Verbund unabhängiger Netzwerke, zu dem auch Mastodon zählt. Folgen Sie dort einem Konto, und dessen Beiträge landen in Ihrem Feed; umgekehrt können Leute von dort Ihnen folgen und Ihre öffentlichen Beiträge sehen. In beide Richtungen, und ganz Ihre Entscheidung: Sie wählen bei der Anmeldung, ob Sie vutuv mit oder ohne Fediverse benutzen möchten, und können das jederzeit in den Einstellungen ändern."
 
-#: lib/vutuv_web/templates/page/index.html.heex:565
+#: lib/vutuv_web/templates/page/index.html.heex:564
 #, elixir-autogen, elixir-format
 msgid "Download everything you have here at any time, in a machine-readable file. Not on request, not after a waiting period: from your settings, whenever you like."
 msgstr "Laden Sie jederzeit alles herunter, was Sie hier haben, als maschinenlesbare Datei. Nicht auf Anfrage, nicht nach einer Wartezeit: in Ihren Einstellungen, wann immer Sie möchten."
 
-#: lib/vutuv_web/templates/page/index.html.heex:540
+#: lib/vutuv_web/templates/page/index.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "Fair and transparent, in plain words"
 msgstr "Fair und transparent, in klaren Worten"
 
-#: lib/vutuv_web/templates/page/index.html.heex:554
+#: lib/vutuv_web/templates/page/index.html.heex:553
 #, elixir-autogen, elixir-format
 msgid "No third-party cookies"
 msgstr "Keine Cookies von Dritten"
 
-#: lib/vutuv_web/templates/page/index.html.heex:546
+#: lib/vutuv_web/templates/page/index.html.heex:545
 #, elixir-autogen, elixir-format
 msgid "On our own servers in %{place}, not in somebody else's cloud. We do not hand your profile to a third party, and there is no tracking network reading along."
 msgstr "Auf unseren eigenen Servern in %{place}, nicht in der Cloud eines anderen. Wir geben Ihr Profil an niemanden weiter, und es liest kein Tracking-Netzwerk mit."
 
-#: lib/vutuv_web/templates/page/index.html.heex:544
+#: lib/vutuv_web/templates/page/index.html.heex:543
 #, elixir-autogen, elixir-format
 msgid "Where your data lives"
 msgstr "Wo Ihre Daten liegen"
 
-#: lib/vutuv_web/templates/page/index.html.heex:539
+#: lib/vutuv_web/templates/page/index.html.heex:538
 #, elixir-autogen, elixir-format
 msgid "Your data"
 msgstr "Ihre Daten"
 
-#: lib/vutuv_web/templates/page/index.html.heex:556
+#: lib/vutuv_web/templates/page/index.html.heex:555
 #, elixir-autogen, elixir-format
 msgid "vutuv sets one cookie, the one that keeps you signed in. No advertising network, no analytics service, nothing loaded from anybody else's server."
 msgstr "vutuv setzt ein einziges Cookie, das Sie eingeloggt hält. Kein Werbenetzwerk, kein Analysedienst, nichts, was von fremden Servern nachgeladen wird."
 
-#: lib/vutuv_web/templates/page/index.html.heex:572
+#: lib/vutuv_web/templates/page/index.html.heex:571
 #, elixir-autogen, elixir-format
 msgid "Leave whenever you like"
 msgstr "Jederzeit wieder gehen"
 
-#: lib/vutuv_web/templates/page/index.html.heex:588
+#: lib/vutuv_web/templates/page/index.html.heex:587
 #, elixir-autogen, elixir-format
 msgid "Open source"
 msgstr "Open Source"
 
-#: lib/vutuv_web/templates/page/index.html.heex:590
+#: lib/vutuv_web/templates/page/index.html.heex:589
 #, elixir-autogen, elixir-format
 msgid "You can check at any time how exactly vutuv works. The whole source code is public under the MIT license, so everything said above about your data can be read rather than taken on trust."
 msgstr "Sie können jederzeit nachsehen, wie vutuv genau funktioniert. Der komplette Quellcode ist öffentlich, unter der MIT-Lizenz. Alles, was oben über Ihre Daten steht, lässt sich also nachlesen, statt es uns glauben zu müssen."
 
-#: lib/vutuv_web/templates/page/index.html.heex:563
+#: lib/vutuv_web/templates/page/index.html.heex:562
 #, elixir-autogen, elixir-format
 msgid "Your data stays with you"
 msgstr "Ihre Daten bleiben Ihnen"
 
-#: lib/vutuv_web/templates/page/index.html.heex:579
+#: lib/vutuv_web/templates/page/index.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "Delete your account yourself, without writing to anybody. No questions asked, and you are welcome back any time."
 msgstr "Löschen Sie Ihr Konto selbst, ohne jemandem schreiben zu müssen. No questions asked! Und Sie können jederzeit gerne wiederkommen."
@@ -18771,19 +18768,19 @@ msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:4788
+#: lib/vutuv_web/components/post_components.ex:4810
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4790
+#: lib/vutuv_web/components/post_components.ex:4812
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:4801
+#: lib/vutuv_web/components/post_components.ex:4823
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
@@ -18836,7 +18833,7 @@ msgid "A published reference then appears next to the entry it documents."
 msgstr "Ein veröffentlichtes Zeugnis erscheint dann neben der Station, die es belegt."
 
 #: lib/vutuv_web/controllers/job_reference_controller.ex:252
-#: lib/vutuv_web/live/reference_check_live.ex:420
+#: lib/vutuv_web/live/reference_check_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "A review for this reference is already running."
 msgstr "Für dieses Zeugnis läuft bereits eine Prüfung."
@@ -18912,7 +18909,7 @@ msgstr "Arbeitszeugnis aktualisiert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:4688
+#: lib/vutuv_web/components/ui.ex:4796
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -18957,7 +18954,7 @@ msgstr "Ausstellungsdatum"
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3176
+#: lib/vutuv_web/live/post_live/feed.ex:3173
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -19000,7 +18997,7 @@ msgstr "Zeugnis"
 msgid "Review result"
 msgstr "Prüfergebnis"
 
-#: lib/vutuv_web/live/reference_check_live.ex:303
+#: lib/vutuv_web/live/reference_check_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Reviewing your reference. This takes a few minutes."
 msgstr "Ihr Zeugnis wird geprüft. Das dauert einige Minuten."
@@ -19011,7 +19008,7 @@ msgid "Show this reference publicly on my profile"
 msgstr "Dieses Zeugnis öffentlich auf meinem Profil zeigen"
 
 #: lib/vutuv_web/templates/job_reference/show.html.heex:39
-#: lib/vutuv_web/templates/job_reference/view.html.heex:89
+#: lib/vutuv_web/templates/job_reference/view.html.heex:86
 #: lib/vutuv_web/views/account_event_text.ex:227
 #, elixir-autogen, elixir-format
 msgid "Text"
@@ -19039,22 +19036,22 @@ msgid "The AI review reads German employment law and is therefore offered for Ge
 msgstr "Die KI-Prüfung liest deutsches Arbeitsrecht und wird deshalb nur für deutsche Arbeitszeugnisse angeboten."
 
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:55
-#: lib/vutuv_web/templates/job_reference/view.html.heex:47
+#: lib/vutuv_web/templates/job_reference/view.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "The document"
 msgstr "Das Dokument"
 
-#: lib/vutuv_web/live/reference_check_live.ex:359
+#: lib/vutuv_web/live/reference_check_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "The review could not be completed."
 msgstr "Die Prüfung konnte nicht abgeschlossen werden."
 
-#: lib/vutuv_web/live/reference_check_live.ex:428
+#: lib/vutuv_web/live/reference_check_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "The review could not be started."
 msgstr "Die Prüfung konnte nicht gestartet werden."
 
-#: lib/vutuv_web/live/reference_check_live.ex:426
+#: lib/vutuv_web/live/reference_check_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "The review covers German Arbeitszeugnisse only."
 msgstr "Die Prüfung gilt nur für deutsche Arbeitszeugnisse."
@@ -19075,12 +19072,12 @@ msgid "The review is not available on this installation."
 msgstr "Die Prüfung steht auf dieser Installation nicht zur Verfügung."
 
 #: lib/vutuv_web/controllers/job_reference_controller.ex:259
-#: lib/vutuv_web/live/reference_check_live.ex:423
+#: lib/vutuv_web/live/reference_check_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "There is no text to review yet. Upload the document or paste the text."
 msgstr "Es gibt noch keinen Text zum Prüfen. Laden Sie das Dokument hoch oder fügen Sie den Text ein."
 
-#: lib/vutuv_web/live/reference_check_live.ex:366
+#: lib/vutuv_web/live/reference_check_live.ex:349
 #: lib/vutuv_web/templates/service_worker/offline.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "Try again"
@@ -19091,14 +19088,14 @@ msgstr "Erneut versuchen"
 msgid "Upload your Arbeitszeugnisse, attach them to your CV, and have them reviewed. Nothing is public until you say so."
 msgstr "Laden Sie Ihre Arbeitszeugnisse hoch, verknüpfen Sie sie mit Ihrem Lebenslauf und lassen Sie sie prüfen. Nichts wird öffentlich, bevor Sie es freigeben."
 
-#: lib/vutuv_web/live/reference_check_live.ex:272
+#: lib/vutuv_web/live/reference_check_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Waiting — %{count} review ahead of yours."
 msgid_plural "Waiting — %{count} reviews ahead of yours."
 msgstr[0] "In der Warteschlange, %{count} Prüfung liegt vor Ihrer."
 msgstr[1] "In der Warteschlange, %{count} Prüfungen liegen vor Ihrer."
 
-#: lib/vutuv_web/live/reference_check_live.ex:278
+#: lib/vutuv_web/live/reference_check_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Waiting — yours is next."
 msgstr "In der Warteschlange, Ihres ist als Nächstes dran."
@@ -19108,7 +19105,7 @@ msgstr "In der Warteschlange, Ihres ist als Nächstes dran."
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr "Sie haben den Text nach dieser Prüfung geändert. Sie beschreibt die frühere Fassung."
 
-#: lib/vutuv_web/components/ui.ex:4689
+#: lib/vutuv_web/components/ui.ex:4797
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr "Ihre Arbeitszeugnisse, privat bis Sie sie veröffentlichen"
@@ -19119,7 +19116,7 @@ msgstr "Ihre Arbeitszeugnisse, privat bis Sie sie veröffentlichen"
 msgid "Zwischenzeugnis"
 msgstr "Zwischenzeugnis"
 
-#: lib/vutuv_web/components/ui.ex:4691
+#: lib/vutuv_web/components/ui.ex:4799
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr "arbeitszeugnis zeugnis referenz beurteilung arbeitgeber bewertung prüfung"
@@ -19129,27 +19126,27 @@ msgstr "arbeitszeugnis zeugnis referenz beurteilung arbeitgeber bewertung prüfu
 msgid "e.g. Zeugnis Muster GmbH 2019–2026"
 msgstr "z. B. Zeugnis Muster GmbH 2019–2026"
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:116
+#: lib/vutuv_web/templates/job_reference/check.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "For a binding assessment please ask a lawyer, ideally a Fachanwalt für Arbeitsrecht."
 msgstr "Für eine verbindliche Beurteilung wenden Sie sich bitte an einen Anwalt, am besten an einen Fachanwalt für Arbeitsrecht."
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:123
+#: lib/vutuv_web/templates/job_reference/check.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "The analysis follows the freely available Arbeitszeugnis-Prüfer prompt"
 msgstr "Die Einordnung folgt dem frei verfügbaren Arbeitszeugnis-Prüfer-Prompt"
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:110
+#: lib/vutuv_web/templates/job_reference/check.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "This is not legal advice."
 msgstr "Das ist keine Rechtsberatung."
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:113
+#: lib/vutuv_web/templates/job_reference/check.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "We do not assess your case. What you see is an automated reading of the wording of your document, produced on our own servers by a language model."
 msgstr "Wir prüfen Ihren Fall nicht. Sie sehen eine automatische Einordnung des Wortlauts Ihres Dokuments, erstellt von einem Sprachmodell auf unseren eigenen Servern."
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:139
+#: lib/vutuv_web/templates/job_reference/check.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "We wrote neither the prompt nor the model."
 msgstr "Weder den Prompt noch das Modell haben wir geschrieben."
@@ -19164,13 +19161,13 @@ msgstr "Arbeitszeugnisse von %{name}"
 msgid "document"
 msgstr "Dokument"
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:151
+#: lib/vutuv_web/templates/job_reference/check.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Back to your employment references"
 msgstr "Zurück zu Ihren Arbeitszeugnissen"
 
-#: lib/vutuv_web/live/reference_check_live.ex:332
-#: lib/vutuv_web/templates/job_reference/view.html.heex:41
+#: lib/vutuv_web/live/reference_check_live.ex:321
+#: lib/vutuv_web/templates/job_reference/view.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "Read the review"
 msgstr "Prüfergebnis lesen"
@@ -19190,18 +19187,18 @@ msgstr "Gesamtnote"
 msgid "Reviewed on"
 msgstr "Geprüft am"
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:90
+#: lib/vutuv_web/templates/job_reference/check.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Check the text"
 msgstr "Text prüfen"
 
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:116
-#: lib/vutuv_web/templates/job_reference/view.html.heex:104
+#: lib/vutuv_web/templates/job_reference/view.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Delete this reference, its document and its review? This cannot be undone."
 msgstr "Dieses Zeugnis mitsamt Datei und Prüfergebnis löschen? Das lässt sich nicht rückgängig machen."
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:157
+#: lib/vutuv_web/templates/job_reference/check.html.heex:153
 #, elixir-autogen, elixir-format
 msgid "Edit this reference"
 msgstr "Zeugnis ändern"
@@ -19211,8 +19208,8 @@ msgstr "Zeugnis ändern"
 msgid "Open the file"
 msgstr "Datei öffnen"
 
-#: lib/vutuv_web/live/reference_check_live.ex:348
-#: lib/vutuv_web/templates/job_reference/check.html.heex:72
+#: lib/vutuv_web/live/reference_check_live.ex:332
+#: lib/vutuv_web/templates/job_reference/check.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Review again"
 msgstr "Erneut prüfen"
@@ -19222,7 +19219,7 @@ msgstr "Erneut prüfen"
 msgid "Uploaded file"
 msgstr "Hochgeladene Datei"
 
-#: lib/vutuv_web/live/reference_check_live.ex:341
+#: lib/vutuv_web/live/reference_check_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "You changed the text after this review."
 msgstr "Sie haben den Text nach dieser Prüfung geändert."
@@ -19252,7 +19249,7 @@ msgstr "Es geht nicht an ChatGPT, nicht an Google und an keine andere Firma. Es 
 msgid "Nobody else can open a review, and publishing a reference on your profile never publishes its review. What a machine read into your Zeugnis is nobody's business but yours."
 msgstr "Niemand sonst kann ein Prüfergebnis öffnen. Und wenn Sie ein Zeugnis auf Ihrem Profil veröffentlichen, bleibt seine Prüfung trotzdem privat. Was eine Maschine aus Ihrem Zeugnis herausliest, geht nur Sie etwas an."
 
-#: lib/vutuv_web/templates/job_reference/view.html.heex:54
+#: lib/vutuv_web/templates/job_reference/view.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Open in a new tab"
 msgstr "In neuem Tab öffnen"
@@ -19267,8 +19264,8 @@ msgstr "Das Modell ist Open Source."
 msgid "The result is yours alone."
 msgstr "Das Ergebnis gehört Ihnen allein."
 
-#: lib/vutuv_web/templates/job_reference/view.html.heex:68
-#: lib/vutuv_web/templates/job_reference/view.html.heex:78
+#: lib/vutuv_web/templates/job_reference/view.html.heex:65
+#: lib/vutuv_web/templates/job_reference/view.html.heex:75
 #, elixir-autogen, elixir-format
 msgid "The uploaded reference"
 msgstr "Das hochgeladene Zeugnis"
@@ -19327,7 +19324,7 @@ msgstr "Zeugnisprüfungen"
 msgid "Issue date"
 msgstr "Ausstellungsdatum"
 
-#: lib/vutuv_web/live/reference_check_live.ex:299
+#: lib/vutuv_web/live/reference_check_live.ex:291
 #, elixir-autogen, elixir-format
 msgid "Reviewing your reference. This usually takes about %{duration}."
 msgstr "Ihr Zeugnis wird geprüft. Das dauert erfahrungsgemäß etwa %{duration}."
@@ -19344,7 +19341,7 @@ msgstr "Die Prüfung von „%{title}“ ist fertig."
 msgid "The review of “%{title}” is ready: %{grade}."
 msgstr "Die Prüfung von „%{title}“ ist fertig: %{grade}."
 
-#: lib/vutuv_web/live/reference_check_live.ex:284
+#: lib/vutuv_web/live/reference_check_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Usually about %{duration}."
 msgstr "Erfahrungsgemäß etwa %{duration}."
@@ -19374,13 +19371,13 @@ msgstr "Datei hierher ziehen oder eine auswählen"
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr "PDF, JPG, PNG oder WebP, bis %{limit}"
 
-#: lib/vutuv_web/components/ui.ex:4028
+#: lib/vutuv_web/components/ui.ex:4132
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
 msgstr "Diese Datei ist größer als %{limit}. Bitte laden Sie eine kleinere hoch."
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:99
+#: lib/vutuv_web/templates/job_reference/check.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "The full report"
 msgstr "Der vollständige Bericht"
@@ -19400,7 +19397,7 @@ msgstr "Ein Zeugnis gehört der Person, um die es geht. Ist es das Zeugnis einer
 msgid "This reference was issued to me."
 msgstr "Dieses Zeugnis wurde für mich ausgestellt."
 
-#: lib/vutuv_web/live/reference_check_live.ex:249
+#: lib/vutuv_web/live/reference_check_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Decode this reference"
 msgstr "Zeugnis entschlüsseln"
@@ -19410,12 +19407,12 @@ msgstr "Zeugnis entschlüsseln"
 msgid "German references are graded in code, so friendly words can carry a poor mark. We read the wording against German employment-reference law and tell you which grade is in it, what each assessing phrase really says, and what is missing, contradictory or formally wrong."
 msgstr "Deutsche Zeugnisse benoten verschlüsselt, freundliche Worte können also eine schlechte Note tragen. Wir lesen den Wortlaut nach deutschem Zeugnisrecht und sagen Ihnen, welche Note darin steckt, was jede bewertende Formulierung wirklich bedeutet und was fehlt, sich widerspricht oder formal falsch ist."
 
-#: lib/vutuv_web/live/reference_check_live.ex:258
+#: lib/vutuv_web/live/reference_check_live.ex:250
 #, elixir-autogen, elixir-format
 msgid "Only you see the result."
 msgstr "Das Ergebnis sehen nur Sie."
 
-#: lib/vutuv_web/live/reference_check_live.ex:388
+#: lib/vutuv_web/live/reference_check_live.ex:371
 #, elixir-autogen, elixir-format
 msgid "You can leave this page. The result lands in your notifications, and we email it to you if you are no longer here by then."
 msgstr "Sie können diese Seite verlassen. Das Ergebnis landet in Ihren Mitteilungen, und wir schicken es Ihnen per E-Mail, falls Sie dann nicht mehr da sind."
@@ -19512,7 +19509,7 @@ msgstr "Eine Meldung, an der Sie beteiligt sind, hat etwas an Ihrem Konto verän
 msgid "An employment reference of yours has been reviewed."
 msgstr "Eines Ihrer Arbeitszeugnisse wurde geprüft."
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:131
+#: lib/vutuv_web/templates/job_reference/check.html.heex:127
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "GitHub account @Klotzkette"
@@ -19554,7 +19551,7 @@ msgstr "Sie haben eine Rolle bei %{organization} bekommen."
 msgid "Your vutuv username is ready."
 msgstr "Ihr vutuv-Benutzername steht fest."
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:125
+#: lib/vutuv_web/templates/job_reference/check.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "by the lawyer Tom Braegelmann"
 msgstr "von Rechtsanwalt Tom Braegelmann"
@@ -19623,7 +19620,7 @@ msgstr "Ihr Zeugnis bleibt auf unseren Servern in %{country}."
 msgid "You have reached your limit of %{limit} reviews. Please try again in %{window}."
 msgstr "Sie haben Ihr Limit von %{limit} Prüfungen erreicht. Bitte versuchen Sie es in %{window} wieder."
 
-#: lib/vutuv_web/templates/page/index.html.heex:409
+#: lib/vutuv_web/templates/page/index.html.heex:408
 #, elixir-autogen, elixir-format
 msgid "Employment reference"
 msgstr "Arbeitszeugnis"
@@ -19633,7 +19630,7 @@ msgstr "Arbeitszeugnis"
 msgid "Employment references: upload them, keep them private, and have the wording read and graded on our own servers."
 msgstr "Arbeitszeugnisse hochladen, privat halten und die Formulierungen auf unseren eigenen Servern lesen und benoten lassen."
 
-#: lib/vutuv_web/templates/page/index.html.heex:386
+#: lib/vutuv_web/templates/page/index.html.heex:385
 #, elixir-autogen, elixir-format
 msgid "Job applications"
 msgstr "Bewerbungsunterlagen"
@@ -19648,7 +19645,7 @@ msgstr "Der Lebenslauf-Baukasten: eine Liste zum Abhaken mit allem, was in den L
 msgid "The finished CV ready to print: name, tagline and contact details at the top, below them the positions held with employer and period, and further down the tags and the spoken languages."
 msgstr "Der fertige Lebenslauf in der Druckansicht: oben Name, Kurzbeschreibung und Kontaktdaten, darunter die Stationen mit Arbeitgeber und Zeitraum, weiter unten die Tags und die Sprachkenntnisse."
 
-#: lib/vutuv_web/templates/page/index.html.heex:429
+#: lib/vutuv_web/templates/page/index.html.heex:428
 #, elixir-autogen, elixir-format
 msgid "The review is a text analysis, not legal advice, and it covers German employment references."
 msgstr "Die Prüfung ist eine Textanalyse, keine Rechtsberatung, und sie deckt deutsche Arbeitszeugnisse ab."
@@ -19663,22 +19660,22 @@ msgstr "Die Prüfung eines einzelnen Arbeitszeugnisses: die Gesamtnote in einem 
 msgid "The uploaded employment references, each marked private: one graded 1 (very good) on a green panel, one graded 4 to 5 (poor to unsatisfactory) on a red one, each with a link to its full report."
 msgstr "Die hochgeladenen Arbeitszeugnisse, jedes als privat gekennzeichnet: eines mit der Note 1 (sehr gut) in einem grünen Feld, eines mit der Note 4 bis 5 (mangelhaft bis ungenügend) in einem roten, jeweils mit einem Link zum vollständigen Bericht."
 
-#: lib/vutuv_web/templates/page/index.html.heex:412
+#: lib/vutuv_web/templates/page/index.html.heex:411
 #, elixir-autogen, elixir-format
 msgid "Upload your employment references and have them read sentence by sentence: a grade, a traffic light, and the explanation of how a recruiter reads that wording. It takes a few minutes, then the report is there. Nothing becomes public before you release it."
 msgstr "Laden Sie Ihre Arbeitszeugnisse hoch und lassen Sie sie Satz für Satz durchlesen: Note, Ampel und die Erklärung, wie ein Personaler die Formulierung liest. Das dauert ein paar Minuten, dann steht der Bericht da. Öffentlich wird nichts davon, bevor Sie es freigeben."
 
-#: lib/vutuv_web/templates/page/index.html.heex:410
+#: lib/vutuv_web/templates/page/index.html.heex:409
 #, elixir-autogen, elixir-format
 msgid "What your employment reference really says"
 msgstr "Was in Ihrem Arbeitszeugnis wirklich steht"
 
-#: lib/vutuv_web/templates/page/index.html.heex:389
+#: lib/vutuv_web/templates/page/index.html.heex:388
 #, elixir-autogen, elixir-format
 msgid "What your profile already says becomes a CV. You tick what should go in, then download it as PDF, Word, OpenDocument, LaTeX or JSON Resume. Anonymously as well, if you would rather show what you can do before you show who you are."
 msgstr "Was auf Ihrem Profil steht, wird auf Wunsch ein Lebenslauf. Sie haken an, was hinein soll, und laden ihn als PDF, Word, OpenDocument, LaTeX oder JSON Resume herunter. Auch anonym, wenn Sie lieber erst zeigen, was Sie können, bevor Sie zeigen, wer Sie sind."
 
-#: lib/vutuv_web/templates/page/index.html.heex:387
+#: lib/vutuv_web/templates/page/index.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "Your CV, ready to send"
 msgstr "Ihr Lebenslauf, fertig zum Verschicken"
@@ -19708,7 +19705,7 @@ msgstr ""
 "können und niemand ein gefälschtes verifiziertes Konto anlegen kann. Ein "
 "Admin kann Sie jederzeit erneut verifizieren."
 
-#: lib/vutuv_web/templates/page/index.html.heex:249
+#: lib/vutuv_web/templates/page/index.html.heex:250
 #, elixir-autogen, elixir-format
 msgid "Your public posts then also appear on {mastodon} and other independent networks, where people can follow you. Replies and reposts come back under your posts, with the account's address, and are kept for up to six months. You can switch it off at any time."
 msgstr ""
@@ -19729,14 +19726,14 @@ msgstr "6-stellige PIN"
 msgid "Enter the PIN from the email"
 msgstr "PIN aus der E-Mail eingeben"
 
-#: lib/vutuv_web/components/ui.ex:807
+#: lib/vutuv_web/components/ui.ex:831
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 "Wenn Sie Ihrem vutuv-Konto weitere Adressen hinzugefügt haben, melden Sie "
 "sich stattdessen mit einer davon an."
 
-#: lib/vutuv_web/components/ui.ex:835
+#: lib/vutuv_web/components/ui.ex:859
 #, elixir-autogen, elixir-format
 msgid "Cancel registration"
 msgstr "Registrierung abbrechen"
@@ -19754,7 +19751,7 @@ msgstr ""
 msgid "Follow other members"
 msgstr "Anderen Mitgliedern folgen"
 
-#: lib/vutuv_web/components/ui.ex:790
+#: lib/vutuv_web/components/ui.ex:814
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
@@ -19783,7 +19780,7 @@ msgstr ""
 "Anteile bezogen auf die %{answered} Mitglieder mit Angabe. %{unanswered} ohne "
 "Angabe."
 
-#: lib/vutuv_web/components/ui.ex:4670
+#: lib/vutuv_web/components/ui.ex:4778
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr "avatar profilbild portrait foto bild geburtstag geburtsdatum geschlecht über mich"
@@ -19879,7 +19876,7 @@ msgstr "Ebenfalls löschen"
 msgid "Always keep"
 msgstr "Immer behalten"
 
-#: lib/vutuv_web/components/ui.ex:4790
+#: lib/vutuv_web/components/ui.ex:4898
 #: lib/vutuv_web/controllers/settings_controller.ex:247
 #: lib/vutuv_web/controllers/settings_controller.ex:326
 #: lib/vutuv_web/controllers/settings_controller.ex:338
@@ -19976,7 +19973,7 @@ msgstr "Fotobeiträge behalten"
 msgid "Keep posts that did well"
 msgstr "Beiträge behalten, die gut liefen"
 
-#: lib/vutuv_web/components/ui.ex:4792
+#: lib/vutuv_web/components/ui.ex:4900
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr "Ihre Beiträge nach einer selbst gewählten Zeit auslaufen lassen"
@@ -20085,7 +20082,7 @@ msgstr "Sie können vorher alles herunterladen, was Sie hier haben:"
 msgid "Your rule"
 msgstr "Ihre Regel"
 
-#: lib/vutuv_web/components/ui.ex:4794
+#: lib/vutuv_web/components/ui.ex:4902
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr "löschen entfernen beiträge alter alt ablaufen verfallen automatisch aufräumen aufbewahrung"
@@ -20459,7 +20456,7 @@ msgstr "Suchen Sie so oft Sie möchten und nehmen Sie dazu, was gehört. Abkürz
 msgid "Start over"
 msgstr "Von vorn beginnen"
 
-#: lib/vutuv_web/components/post_components.ex:2985
+#: lib/vutuv_web/components/post_components.ex:3007
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr "Ein Herz oder ein Repost geht zurück in das Netzwerk, aus dem dieser Beitrag stammt. Ihr Konto nimmt derzeit nicht am Fediverse teil. Einschalten können Sie das in den {settings}."
@@ -20494,7 +20491,7 @@ msgstr "Wählen Sie mindestens eine Rolle."
 msgid "Posts jobs."
 msgstr "Schreibt Stellen aus."
 
-#: lib/vutuv_web/live/organization_live/roles.ex:274
+#: lib/vutuv_web/live/organization_live/roles.ex:269
 #, elixir-autogen, elixir-format
 msgid "Roles"
 msgstr "Rollen"
@@ -20519,22 +20516,22 @@ msgstr "Der Besitzer vergibt die Rollen der anderen Mitglieder auf der Seite und
 msgid "Nothing published yet."
 msgstr "Noch nichts veröffentlicht."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1925
+#: lib/vutuv_web/live/post_live/composer.ex:1927
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr "Als %{name} veröffentlichen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1271
+#: lib/vutuv_web/live/post_live/composer.ex:1246
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1902
+#: lib/vutuv_web/live/post_live/composer.ex:1904
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr "Ein Beitrag im Namen einer Organisation ist immer öffentlich."
 
-#: lib/vutuv_web/live/shell_live.ex:1061
+#: lib/vutuv_web/live/shell_live.ex:1057
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr "Seite öffnen"
@@ -20554,7 +20551,7 @@ msgstr "Beendet, im Namen einer Organisation zu schreiben"
 msgid "Write as %{name} for now"
 msgstr "Vorerst als %{name} schreiben"
 
-#: lib/vutuv_web/live/shell_live.ex:1071
+#: lib/vutuv_web/live/shell_live.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr "Wieder als ich selbst schreiben"
@@ -20564,7 +20561,7 @@ msgstr "Wieder als ich selbst schreiben"
 msgid "You are writing as %{name} now."
 msgstr "Sie schreiben jetzt als %{name}."
 
-#: lib/vutuv_web/live/shell_live.ex:1047
+#: lib/vutuv_web/live/shell_live.ex:1043
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr "Sie schreiben als %{name}."
@@ -20621,7 +20618,7 @@ msgstr "%{name} hat diese Seite erwähnt."
 msgid "%{name} follows"
 msgstr "%{name} folgt"
 
-#: lib/vutuv_web/live/organization_live/feed.ex:66
+#: lib/vutuv_web/live/organization_live/feed.ex:65
 #, elixir-autogen, elixir-format
 msgid "Feed – %{name}"
 msgstr "Feed – %{name}"
@@ -20636,7 +20633,7 @@ msgstr "Als %{name} folgen"
 msgid "Members and organizations"
 msgstr "Mitglieder und Organisationen"
 
-#: lib/vutuv_web/live/organization_live/feed.ex:161
+#: lib/vutuv_web/live/organization_live/feed.ex:160
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. This page does not follow anyone, or nobody it follows has published."
 msgstr "Noch nichts da. Diese Seite folgt niemandem, oder niemand, dem sie folgt, hat etwas veröffentlicht."
@@ -20667,7 +20664,7 @@ msgstr "Themen"
 msgid "Unfollow %{tag}"
 msgstr "%{tag} entfolgen"
 
-#: lib/vutuv_web/live/organization_live/feed.ex:157
+#: lib/vutuv_web/live/organization_live/feed.ex:156
 #, elixir-autogen, elixir-format
 msgid "What the members and organizations this page follows have published. Liking or saving something here is done from your own account, not the page's."
 msgstr "Was die Mitglieder und Organisationen veröffentlicht haben, denen diese Seite folgt. Wer hier etwas mag oder speichert, tut das aus dem eigenen Konto, nicht aus dem der Seite."
@@ -20771,12 +20768,12 @@ msgstr "Andere Netzwerke sprechen diese Seite als @name@%{host} an, so wie sie e
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:84
 #: lib/vutuv_web/live/organization_live/new.ex:211
-#: lib/vutuv_web/live/organization_live/show.ex:892
+#: lib/vutuv_web/live/organization_live/show.ex:887
 #, elixir-autogen, elixir-format
 msgid "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
 msgstr "Auch Menschen ohne vutuv-Konto können dieser Seite folgen und ihre Beiträge lesen, in Netzwerken wie Mastodon."
 
-#: lib/vutuv_web/live/organization_live/show.ex:906
+#: lib/vutuv_web/live/organization_live/show.ex:901
 #, elixir-autogen, elixir-format
 msgid "Set this page up for other networks"
 msgstr "Seite für andere Netzwerke einrichten"
@@ -20791,7 +20788,7 @@ msgstr "Ausschalten"
 msgid "Switch it on"
 msgstr "Einschalten"
 
-#: lib/vutuv_web/live/organization_live/show.ex:897
+#: lib/vutuv_web/live/organization_live/show.ex:892
 #, elixir-autogen, elixir-format
 msgid "The page gets an address of its own for that, written like an email address."
 msgstr "Die Seite bekommt dafür eine eigene Adresse, die wie eine E-Mail-Adresse aussieht."
@@ -20816,12 +20813,12 @@ msgstr "Diese Seite war früher auf anderen Netzwerken sichtbar. Server, die noc
 msgid "This vutuv exchanges nothing with other networks, so nothing here has any effect."
 msgstr "Dieses vutuv tauscht nichts mit anderen Netzwerken aus, hier hat also nichts eine Wirkung."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:443
+#: lib/vutuv_web/live/organization_live/edit.ex:425
 #, elixir-autogen, elixir-format
 msgid "Claim a short @name so this organization has an address of its own, like a member. Letters, numbers and underscores, %{min} to %{max} characters."
 msgstr "Reservieren Sie einen kurzen @-Namen, damit diese Organisation eine eigene Adresse bekommt, so wie ein Mitglied. Buchstaben, Zahlen und Unterstriche, %{min} bis %{max} Zeichen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:441
+#: lib/vutuv_web/live/organization_live/edit.ex:423
 #, elixir-autogen, elixir-format
 msgid "The organization's @name"
 msgstr "Der @-Name der Organisation"
@@ -20876,22 +20873,22 @@ msgstr "Neu registrieren"
 msgid "The PIN has expired."
 msgstr "Die PIN ist abgelaufen."
 
-#: lib/vutuv_web/components/ui.ex:911
+#: lib/vutuv_web/components/ui.ex:935
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr "Die PIN ist noch eine Minute gültig."
 
-#: lib/vutuv_web/components/ui.ex:913
+#: lib/vutuv_web/components/ui.ex:937
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr "Die PIN ist noch eine Sekunde gültig."
 
-#: lib/vutuv_web/components/ui.ex:912
+#: lib/vutuv_web/components/ui.ex:936
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr "Die PIN ist noch {n} Minuten gültig."
 
-#: lib/vutuv_web/components/ui.ex:914
+#: lib/vutuv_web/components/ui.ex:938
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr "Die PIN ist noch {n} Sekunden gültig."
@@ -20908,7 +20905,7 @@ msgid_plural "Your sign-up was never confirmed, so we delete it automatically in
 msgstr[0] "Ihre Registrierung wurde nicht bestätigt, deshalb löschen wir sie automatisch in rund einer Minute."
 msgstr[1] "Ihre Registrierung wurde nicht bestätigt, deshalb löschen wir sie automatisch in rund %{count} Minuten."
 
-#: lib/vutuv_web/components/fediverse_components.ex:456
+#: lib/vutuv_web/components/fediverse_components.ex:453
 #, elixir-autogen, elixir-format
 msgid "#%{tag} is a topic on this vutuv, so you now follow the tag here."
 msgstr "#%{tag} ist ein Thema auf diesem vutuv. Sie folgen dem Tag jetzt hier."
@@ -20966,12 +20963,12 @@ msgstr "Chat öffnen"
 msgid "Signal also takes its contact link (https://signal.me/#…). It names neither your phone number nor your username, and you can reset it in Signal at any time."
 msgstr "Für Signal können Sie auch Ihren Kontakt-Link angeben (https://signal.me/#…). Er nennt weder Ihre Rufnummer noch Ihren Benutzernamen, und Sie können ihn in Signal jederzeit zurücksetzen."
 
-#: lib/vutuv_web/live/search_live.ex:596
+#: lib/vutuv_web/live/search_live.ex:589
 #, elixir-autogen, elixir-format
 msgid "A post on another network"
 msgstr "Ein Beitrag aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/live/search_live.ex:620
+#: lib/vutuv_web/live/search_live.ex:613
 #, elixir-autogen, elixir-format
 msgid "Fetch this post"
 msgstr "Diesen Beitrag holen"
@@ -20981,12 +20978,12 @@ msgstr "Diesen Beitrag holen"
 msgid "Search for people, tags, posts, or paste a Fediverse address"
 msgstr "Personen, Tags, Beiträge oder eine Fediverse-Adresse"
 
-#: lib/vutuv_web/live/search_live.ex:636
+#: lib/vutuv_web/live/search_live.ex:629
 #, elixir-autogen, elixir-format
 msgid "Sign in to fetch this post"
 msgstr "Anmelden, um diesen Beitrag zu holen"
 
-#: lib/vutuv_web/live/search_live.ex:601
+#: lib/vutuv_web/live/search_live.ex:594
 #, elixir-autogen, elixir-format
 msgid "That is a link to somewhere else, not something anybody here wrote. vutuv can fetch the post behind it so you can read it, answer it, like it or repost it from here."
 msgstr "Das ist ein Link woandershin, nichts, was hier jemand geschrieben hat. vutuv kann den Beitrag dahinter holen, damit Sie ihn hier lesen, darauf antworten, ihn mögen oder teilen können."
@@ -21001,7 +20998,7 @@ msgstr "eine Adresse in einem anderen Netzwerk: vutuv bietet Ihnen an, ihr zu fo
 msgid "the address of a post out there: vutuv fetches it so you can answer it here"
 msgstr "die Adresse eines Beitrags dort draußen: vutuv holt ihn, damit Sie hier darauf antworten können"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:86
+#: lib/vutuv_web/templates/user/edit.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Fetch my picture from gravatar.com"
 msgstr "Mein Bild von gravatar.com holen"
@@ -21026,7 +21023,7 @@ msgstr "gravatar.com war nicht erreichbar. Bitte versuchen Sie es später noch e
 msgid "gravatar.com has no picture for your email address."
 msgstr "gravatar.com hat kein Bild zu Ihrer E-Mail-Adresse."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:89
+#: lib/vutuv_web/templates/user/edit.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Only when you press this: we ask gravatar.com whether there is a picture for your email address, sending a hash of the address rather than the address itself. Nothing leaves this server otherwise."
 msgstr "Nur wenn Sie hier klicken: Wir fragen bei gravatar.com nach, ob es zu Ihrer E-Mail-Adresse ein Bild gibt, und übermitteln dafür einen Hashwert der Adresse, nicht die Adresse selbst. Sonst verlässt nichts diesen Server."
@@ -21041,8 +21038,8 @@ msgstr "Die Abfrage bei gravatar.com ist auf dieser Installation abgeschaltet."
 msgid "A new entry can take a while to reach everyone. We keep checking %{domain} by ourselves and send you an email as soon as it works, so you can close this page."
 msgstr "Ein neuer Eintrag braucht manchmal eine Weile, bis er überall ankommt. Wir prüfen %{domain} von selbst weiter und schicken Ihnen eine E-Mail, sobald es klappt. Sie können diese Seite also schließen."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:336
-#: lib/vutuv_web/live/organization_live/show.ex:1094
+#: lib/vutuv_web/live/organization_live/domains.ex:331
+#: lib/vutuv_web/live/organization_live/show.ex:1090
 #, elixir-autogen, elixir-format
 msgid "Checking …"
 msgstr "Wird geprüft …"
@@ -21329,43 +21326,43 @@ msgstr "Sie haben %{used} von %{max} Tags."
 msgid "{n} of {max} free slots selected."
 msgstr "{n} von {max} freien Plätzen ausgewählt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1967
+#: lib/vutuv_web/live/post_live/composer.ex:1881
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr "Weitere Sprachen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1952
+#: lib/vutuv_web/live/post_live/composer.ex:1866
 #, elixir-autogen, elixir-format
 msgctxt "post composer"
 msgid "Language"
 msgstr "Sprache"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1957
+#: lib/vutuv_web/live/post_live/composer.ex:1871
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr "Die Sprache, in der dieser Beitrag geschrieben ist"
 
-#: lib/vutuv_web/components/post_components.ex:4682
+#: lib/vutuv_web/components/post_components.ex:4704
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Original anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:4718
+#: lib/vutuv_web/components/post_components.ex:4740
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Übersetzen"
 
-#: lib/vutuv_web/components/post_components.ex:4727
+#: lib/vutuv_web/components/post_components.ex:4749
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Übersetzt"
 
-#: lib/vutuv_web/components/post_components.ex:4730
+#: lib/vutuv_web/components/post_components.ex:4752
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Übersetzt aus %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:4707
+#: lib/vutuv_web/components/post_components.ex:4729
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Wird übersetzt …"
@@ -21375,8 +21372,8 @@ msgstr "Wird übersetzt …"
 msgid "Feed language settings reset to the site defaults."
 msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
 
-#: lib/vutuv_web/components/post_components.ex:4697
-#: lib/vutuv_web/components/ui.ex:4749
+#: lib/vutuv_web/components/post_components.ex:4719
+#: lib/vutuv_web/components/ui.ex:4857
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -21504,27 +21501,27 @@ msgstr "Wir haben den Link in Ihrem Profil noch nicht gefunden. Bitte versuchen 
 msgid "Your username, or paste the address of your profile page."
 msgstr "Ihr Benutzername – oder fügen Sie die Adresse Ihrer Profilseite ein."
 
-#: lib/vutuv_web/components/post_components.ex:4460
+#: lib/vutuv_web/components/post_components.ex:4482
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] "Unsere KI prüft es gerade. Sobald die Prüfung durch ist, erscheint das Foto von selbst."
 msgstr[1] "Unsere KI prüft sie gerade, %{done} von %{total} sind durch. Sobald die letzte durch ist, erscheinen die Fotos von selbst."
 
-#: lib/vutuv_web/components/post_components.ex:4457
+#: lib/vutuv_web/components/post_components.ex:4479
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Ihr Beitrag ist veröffentlicht, das Foto noch nicht."
 
-#: lib/vutuv_web/components/post_components.ex:2429
-#: lib/vutuv_web/components/post_components.ex:3787
+#: lib/vutuv_web/components/post_components.ex:2451
+#: lib/vutuv_web/components/post_components.ex:3809
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
 msgstr[0] "Unsere KI sieht es sich an. Es erscheint hier von selbst, sobald sie durch ist."
 msgstr[1] "Unsere KI sieht sie sich an. Sie erscheinen hier von selbst, sobald sie durch ist."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:144
+#: lib/vutuv_web/templates/user/edit.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "Recommended: %{width} × %{height} pixels (%{ratio})."
 msgstr "Empfohlen: %{width} × %{height} Pixel (%{ratio})."
@@ -21586,7 +21583,7 @@ msgstr "Damit können Sie sich von einer Mastodon-kompatiblen App aus bei diesem
 msgid "Mastodon app access changed"
 msgstr "Mastodon-App-Zugriff geändert"
 
-#: lib/vutuv_web/components/ui.ex:4838
+#: lib/vutuv_web/components/ui.ex:4946
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr "Mastodon-Apps, verbundene Apps und Zugriffstoken"
@@ -21632,7 +21629,7 @@ msgstr "Wer etwas geschrieben hat, wird weiter festgehalten, das Team kann also 
 msgid "Your account is then %{handle}."
 msgstr "Dein Konto heißt dann %{handle}."
 
-#: lib/vutuv_web/components/ui.ex:4840
+#: lib/vutuv_web/components/ui.ex:4948
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr "api token oauth entwickler verbunden drittanbieter schnittstelle mastodon app handy telefon client ivory tusky ice cubes anmelden"
@@ -21668,7 +21665,7 @@ msgstr "Bekannte aus LinkedIn finden"
 msgid "Find your LinkedIn contacts"
 msgstr "Ihre LinkedIn-Kontakte finden"
 
-#: lib/vutuv_web/components/ui.ex:4765
+#: lib/vutuv_web/components/ui.ex:4873
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format
@@ -21681,7 +21678,7 @@ msgid "Follow selected"
 msgstr "Ausgewählten folgen"
 
 #: lib/vutuv_web/live/import_connections_live.ex:504
-#: lib/vutuv_web/live/search_live.ex:548
+#: lib/vutuv_web/live/search_live.ex:541
 #, elixir-autogen, elixir-format
 msgid "Following…"
 msgstr "Wird gefolgt …"
@@ -21776,7 +21773,7 @@ msgstr "Nach Namen suchen"
 msgid "See which of them are already on vutuv"
 msgstr "Sehen Sie, wer davon schon auf vutuv ist"
 
-#: lib/vutuv_web/components/ui.ex:4767
+#: lib/vutuv_web/components/ui.ex:4875
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr "Sehen, wer aus Ihren LinkedIn-Kontakten schon auf vutuv ist"
@@ -21848,7 +21845,7 @@ msgstr "Ihre Kontakte auf vutuv"
 msgid "Your export also lists your LinkedIn contacts."
 msgstr "Ihr Export enthält auch Ihre LinkedIn-Kontakte."
 
-#: lib/vutuv_web/components/ui.ex:4769
+#: lib/vutuv_web/components/ui.ex:4877
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr "linkedin kontakte verbindungen adressbuch bekannte kollegen finden folgen zip import netzwerk"
@@ -21992,34 +21989,34 @@ msgctxt "qualification detail"
 msgid "Jobs"
 msgstr "Jobs"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:836
+#: lib/vutuv_web/live/job_posting_live/form.ex:829
 #, elixir-autogen, elixir-format
 msgid "%{formatted} country chosen."
 msgid_plural "%{formatted} countries chosen."
 msgstr[0] "%{formatted} Land ausgewählt."
 msgstr[1] "%{formatted} Länder ausgewählt."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:620
+#: lib/vutuv_web/live/job_posting_live/form.ex:619
 #, elixir-autogen, elixir-format
 msgid "No country chosen yet."
 msgstr "Noch kein Land ausgewählt."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:612
+#: lib/vutuv_web/live/job_posting_live/form.ex:611
 #, elixir-autogen, elixir-format
 msgid "No country left to add for that."
 msgstr "Dazu ist kein weiteres Land offen."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:631
+#: lib/vutuv_web/live/job_posting_live/form.ex:630
 #, elixir-autogen, elixir-format
 msgid "Remove %{country}"
 msgstr "%{country} entfernen"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:642
+#: lib/vutuv_web/live/job_posting_live/form.ex:641
 #, elixir-autogen, elixir-format
 msgid "Remove all"
 msgstr "Alle entfernen"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:591
+#: lib/vutuv_web/live/job_posting_live/form.ex:590
 #, elixir-autogen, elixir-format
 msgid "Search for a country"
 msgstr "Land suchen"
@@ -22029,7 +22026,7 @@ msgstr "Land suchen"
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr "Diese Seite folgt bereits so vielen Konten, wie hier erlaubt sind (%{max})."
 
-#: lib/vutuv_web/components/post_components.ex:2643
+#: lib/vutuv_web/components/post_components.ex:2665
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr "%{handle} nicht mehr folgen? Die Beiträge verschwinden aus Ihrem Feed."
@@ -22059,7 +22056,7 @@ msgstr "Browser-Benachrichtigungen"
 msgid "New message"
 msgstr "Neue Nachricht"
 
-#: lib/vutuv_web/live/shell_live.ex:1024
+#: lib/vutuv_web/live/shell_live.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Jetzt nicht"
@@ -22104,12 +22101,12 @@ msgstr "Wenn etwas eintrifft, während vutuv in einem Tab offen ist, den Sie ger
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr "Sie haben Browser-Benachrichtigungen eingeschaltet. Dieser Browser wurde noch nicht um Erlaubnis gebeten."
 
-#: lib/vutuv_web/components/ui.ex:4737
+#: lib/vutuv_web/components/ui.ex:4845
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr "e-mail email mail abbestellen abmelden newsletter glocke benachrichtigung weniger ruhe browser desktop popup push hinweis mitteilung"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:311
+#: lib/vutuv_web/live/tag_live/timeline.ex:307
 #, elixir-autogen, elixir-format
 msgid "%{formatted} active"
 msgstr "%{formatted} aktiv"
@@ -22155,7 +22152,7 @@ msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public po
 msgstr ""
 "Folgen Sie #%{tag} von Mastodon oder einer anderen Fediverse-App aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3337
+#: lib/vutuv_web/live/post_live/feed.ex:3334
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Andere Mitglieder begrüßen"
@@ -22165,43 +22162,43 @@ msgstr "Andere Mitglieder begrüßen"
 msgid "New here"
 msgstr "Neu dabei"
 
-#: lib/vutuv_web/components/ui.ex:1543
+#: lib/vutuv_web/components/ui.ex:1567
 #, elixir-autogen, elixir-format
 msgid "New public posts arrive in any feed reader. No account needed either."
 msgstr "Neue öffentliche Beiträge landen in jedem Feed-Reader. Auch dafür brauchen Sie kein Konto."
 
-#: lib/vutuv_web/components/ui.ex:1539
+#: lib/vutuv_web/components/ui.ex:1563
 #, elixir-autogen, elixir-format
 msgid "Or with an RSS reader"
 msgstr "Oder mit einem RSS-Reader"
 
-#: lib/vutuv_web/components/ui.ex:1419
-#: lib/vutuv_web/components/ui.ex:1488
+#: lib/vutuv_web/components/ui.ex:1443
+#: lib/vutuv_web/components/ui.ex:1512
 #, elixir-autogen, elixir-format
 msgid "Subscribe"
 msgstr "Abonnieren"
 
-#: lib/vutuv_web/components/ui.ex:1540
+#: lib/vutuv_web/components/ui.ex:1564
 #, elixir-autogen, elixir-format
 msgid "With an RSS reader"
 msgstr "Mit einem RSS-Reader"
 
-#: lib/vutuv_web/components/ui.ex:1500
+#: lib/vutuv_web/components/ui.ex:1524
 #, elixir-autogen, elixir-format
 msgid "Create a free account"
 msgstr "Kostenloses Konto erstellen"
 
-#: lib/vutuv_web/components/ui.ex:1515
+#: lib/vutuv_web/components/ui.ex:1539
 #, elixir-autogen, elixir-format
 msgid "No vutuv account? These ways work too:"
 msgstr "Kein vutuv-Konto? Das geht auch:"
 
-#: lib/vutuv_web/components/ui.ex:1493
+#: lib/vutuv_web/components/ui.ex:1517
 #, elixir-autogen, elixir-format
 msgid "The best way: follow %{name} here. New posts land in your feed, and you can reply and join in."
 msgstr "Der beste Weg: Folgen Sie %{name} hier. Neue Beiträge landen in Ihrem Feed, und Sie können antworten und mitreden."
 
-#: lib/vutuv_web/components/ui.ex:1491
+#: lib/vutuv_web/components/ui.ex:1515
 #, elixir-autogen, elixir-format
 msgid "With a vutuv account"
 msgstr "Mit einem vutuv-Konto"
@@ -22213,7 +22210,7 @@ msgstr ""
 "Ein paar der neuesten Mitglieder. Ihnen zu folgen ist eine herzliche "
 "Begrüßung."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:278
+#: lib/vutuv_web/templates/settings/preferences.html.heex:267
 #, elixir-autogen, elixir-format
 msgid "Example"
 msgstr "Beispiel"
@@ -22228,7 +22225,7 @@ msgstr "Feed-Reiter"
 msgid "Just flashed the new release, boot is under two seconds now"
 msgstr "Neue Version geflasht, der Bootvorgang liegt jetzt unter zwei Sekunden"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:288
+#: lib/vutuv_web/templates/settings/preferences.html.heex:277
 #, elixir-autogen, elixir-format
 msgid "Play the example"
 msgstr "Beispiel abspielen"
@@ -22336,26 +22333,26 @@ msgstr "Wird in Ihrem Feed ausgeblendet."
 msgid "Shown in the language it was written in."
 msgstr "Wird in der Sprache gezeigt, in der es geschrieben wurde."
 
-#: lib/vutuv_web/components/ui.ex:4750
+#: lib/vutuv_web/components/ui.ex:4858
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr "Welche Sprachen Sie erreichen und was mit dem Rest geschieht"
 
-#: lib/vutuv_web/components/ui.ex:4752
+#: lib/vutuv_web/components/ui.ex:4860
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr ""
 "sprache übersetzen übersetzung deutsch englisch original ausblenden "
 "fremdsprache reihenfolge rang feed language translate"
 
-#: lib/vutuv_web/components/ui.ex:4817
+#: lib/vutuv_web/components/ui.ex:4925
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr ""
 "Anzeigesprache, Datumsformat und Zeitzone, Karten, wie Beiträge gekürzt "
 "werden"
 
-#: lib/vutuv_web/components/ui.ex:4821
+#: lib/vutuv_web/components/ui.ex:4929
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -22392,7 +22389,7 @@ msgstr[0] "+%{formatted} weiterer Beitrag"
 msgstr[1] "+%{formatted} weitere Beiträge"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:94
-#: lib/vutuv_web/templates/settings/preferences.html.heex:254
+#: lib/vutuv_web/templates/settings/preferences.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Browser tab"
 msgstr "Browser-Tab"
@@ -22417,12 +22414,12 @@ msgstr "Nur solange Sie einen anderen Tab ansehen, und nur für ein paar Sekunde
 msgid "Tease new posts in the browser tab"
 msgstr "Neue Beiträge im Browser-Tab anreißen"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:280
+#: lib/vutuv_web/templates/settings/preferences.html.heex:269
 #, elixir-autogen, elixir-format
 msgid "Watch this tab's title, above."
 msgstr "Achten Sie oben auf den Titel dieses Tabs."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:256
+#: lib/vutuv_web/templates/settings/preferences.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "While you are reading another tab, a new post can page its first words through this tab's title, a line at a time, and then hand the title back."
 msgstr "Während Sie einen anderen Tab lesen, kann ein neuer Beitrag seine ersten Worte durch den Titel dieses Tabs blättern, Zeile für Zeile, und den Titel danach wieder freigeben."
@@ -22484,7 +22481,7 @@ msgstr "Keine bezahlten Premium-Accounts."
 msgid "Your LinkedIn profile can come along."
 msgstr "Ihr LinkedIn-Profil kann mitkommen."
 
-#: lib/vutuv_web/components/ui.ex:1111
+#: lib/vutuv_web/components/ui.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Being checked"
 msgstr "Wird geprüft"
@@ -22708,7 +22705,7 @@ msgstr "Mehr Ihrer %{formatted} Konten"
 msgid "Move %{card}"
 msgstr "%{card} verschieben"
 
-#: lib/vutuv_web/components/ui.ex:544
+#: lib/vutuv_web/components/ui.ex:401
 #: lib/vutuv_web/live/post_live/filter_band.ex:583
 #, elixir-autogen, elixir-format
 msgid "No account found."
@@ -22749,7 +22746,7 @@ msgstr "Beiträge mit einem dieser Tags werden genauso zugeklappt."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Beiträge mit einem dieser Wörter werden auf eine Zeile zugeklappt — nicht gelöscht, und mit einem Weg, sie doch zu lesen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3363
+#: lib/vutuv_web/live/post_live/feed.ex:3360
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Weggelegt:"
@@ -22826,10 +22823,10 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "und 1 weiterer"
 msgstr[1] "und %{formatted} weitere"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2996
-#: lib/vutuv_web/live/post_live/feed.ex:3013
-#: lib/vutuv_web/live/post_live/feed.ex:3411
-#: lib/vutuv_web/live/post_live/feed.ex:3416
+#: lib/vutuv_web/live/post_live/feed.ex:2993
+#: lib/vutuv_web/live/post_live/feed.ex:3010
+#: lib/vutuv_web/live/post_live/feed.ex:3408
+#: lib/vutuv_web/live/post_live/feed.ex:3413
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -22848,7 +22845,7 @@ msgid_plural "Show %{formatted} posts in the feed"
 msgstr[0] "%{formatted} Beitrag im Feed anzeigen"
 msgstr[1] "%{formatted} Beiträge im Feed anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2351
+#: lib/vutuv_web/components/post_components.ex:2373
 #, elixir-autogen, elixir-format
 msgid "Picture unavailable"
 msgstr "Bild nicht verfügbar"
@@ -22865,7 +22862,7 @@ msgstr ""
 "Ihre Organisationsseite wurde aktualisiert. Das neue Logo wird geprüft und "
 "erscheint, sobald die Prüfung durch ist."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:286
+#: lib/vutuv_web/live/organization_live/edit.ex:281
 #, elixir-autogen, elixir-format
 msgid "%{formats}, up to %{limit}"
 msgstr "%{formats}, bis %{limit}"
@@ -22877,7 +22874,7 @@ msgstr ""
 "Ihre Organisationsseite wurde aktualisiert, aber dieses Bild konnte nicht als "
 "Logo verwendet werden. Bitte wählen Sie ein anderes."
 
-#: lib/vutuv_web/components/ui.ex:4034
+#: lib/vutuv_web/components/ui.ex:4138
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -22898,7 +22895,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} Beitrag am %{day}"
 msgstr[1] "%{count} Beiträge am %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3133
+#: lib/vutuv_web/live/post_live/feed.ex:3130
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Zurück zu jetzt"
@@ -22908,7 +22905,7 @@ msgstr "Zurück zu jetzt"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Voller Monat: die Färbung zählt mindestens so viel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3179
+#: lib/vutuv_web/live/post_live/feed.ex:3176
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22930,7 +22927,7 @@ msgstr "Nächster Monat"
 msgid "Next year"
 msgstr "Nächstes Jahr"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3129
+#: lib/vutuv_web/live/post_live/feed.ex:3126
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Am %{day} ist nichts in Ihrem Feed angekommen."
@@ -23017,14 +23014,14 @@ msgstr "Neue Version bereit."
 msgid "Page management"
 msgstr "Verwaltung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2218
+#: lib/vutuv_web/live/post_live/feed.ex:2220
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
 msgstr[0] "Neu:"
 msgstr[1] "Neu (%{formatted}):"
 
-#: lib/vutuv_web/components/post_components.ex:2777
+#: lib/vutuv_web/components/post_components.ex:2799
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr "Zitierter Beitrag"
@@ -23039,17 +23036,17 @@ msgstr "Zitiert %{name}: %{url}"
 msgid "Quotes %{url}"
 msgstr "Zitiert %{url}"
 
-#: lib/vutuv_web/components/ui.ex:543
+#: lib/vutuv_web/components/ui.ex:400
 #, elixir-autogen, elixir-format
 msgid "Mention an account"
 msgstr "Ein Konto erwähnen"
 
-#: lib/vutuv_web/components/ui.ex:546
+#: lib/vutuv_web/components/ui.ex:404
 #, elixir-autogen, elixir-format
 msgid "{used} of {max} mentions"
 msgstr "{used} von {max} Erwähnungen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2384
+#: lib/vutuv_web/live/post_live/feed.ex:2386
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr "Bis hier neu"
@@ -23075,7 +23072,7 @@ msgstr "Bleibt das Account-Feld leer, gilt die Regel für alle; %{example} grenz
 msgid "Only these accounts (empty = all) …"
 msgstr "Nur diese Accounts (leer = alle) …"
 
-#: lib/vutuv_web/components/ui.ex:3159
+#: lib/vutuv_web/components/ui.ex:3261
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr "nur %{account}"
@@ -23125,33 +23122,33 @@ msgid_plural "shared this."
 msgstr[0] "hat das geteilt."
 msgstr[1] "haben das geteilt."
 
-#: lib/vutuv_web/components/ui.ex:482
+#: lib/vutuv_web/components/ui.ex:543
 #, elixir-autogen, elixir-format
 msgid "Editor view"
 msgstr "Ansicht"
 
-#: lib/vutuv_web/components/ui.ex:430
+#: lib/vutuv_web/components/ui.ex:491
 #, elixir-autogen, elixir-format
 msgid "Insert a block"
 msgstr "Block einfügen"
 
-#: lib/vutuv_web/components/ui.ex:442
+#: lib/vutuv_web/components/ui.ex:503
 #, elixir-autogen, elixir-format
 msgid "Nothing matches."
 msgstr "Nichts gefunden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1778
-#: lib/vutuv_web/live/post_live/composer.ex:2513
+#: lib/vutuv_web/live/post_live/composer.ex:1754
+#: lib/vutuv_web/live/post_live/composer.ex:2452
 #, elixir-autogen, elixir-format
 msgid "Automatic"
 msgstr "Automatisch"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1783
+#: lib/vutuv_web/live/post_live/composer.ex:1759
 #, elixir-autogen, elixir-format
 msgid "Drag one photo onto another to swap them."
 msgstr "Ein Foto auf ein anderes ziehen, um sie zu tauschen."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1730
+#: lib/vutuv_web/live/post_live/composer.ex:1706
 #, elixir-autogen, elixir-format
 msgid "Not shown in the gallery — drag one into it to swap."
 msgstr "Nicht in der Galerie zu sehen — eines hineinziehen, um zu tauschen."
@@ -23188,17 +23185,17 @@ msgstr "Zuletzt hier"
 msgid "Mute %{host}"
 msgstr "%{host} stummschalten"
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:94
+#: lib/vutuv_web/views/remote_actor_card_html.ex:132
 #, elixir-autogen, elixir-format
 msgid "Really remove?"
 msgstr "Wirklich entfernen?"
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:95
+#: lib/vutuv_web/views/remote_actor_card_html.ex:133
 #, elixir-autogen, elixir-format
 msgid "Really unfollow?"
 msgstr "Wirklich entfolgen?"
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:96
+#: lib/vutuv_web/views/remote_actor_card_html.ex:134
 #, elixir-autogen, elixir-format
 msgid "Really withdraw?"
 msgstr "Anfrage wirklich zurückziehen?"
@@ -23208,28 +23205,28 @@ msgstr "Anfrage wirklich zurückziehen?"
 msgid "Unmute %{host}"
 msgstr "%{host} wieder einschalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1538
+#: lib/vutuv_web/live/post_live/composer.ex:1514
 #, elixir-autogen, elixir-format
 msgid "Draft discarded."
 msgstr "Entwurf gelöscht."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1577
+#: lib/vutuv_web/live/post_live/composer.ex:1553
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr "Behalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1568
+#: lib/vutuv_web/live/post_live/composer.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Keep this draft for later?"
 msgstr "Diesen Entwurf für später behalten?"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:315
+#: lib/vutuv_web/live/organization_live/edit.ex:310
 #, elixir-autogen, elixir-format
 msgid "Describe the organization. Markdown is supported."
 msgstr "Beschreiben Sie die Organisation. Markdown wird unterstützt."
 
-#: lib/vutuv_web/templates/page/index.html.heex:286
-#: lib/vutuv_web/templates/settings/preferences.html.heex:205
+#: lib/vutuv_web/templates/page/index.html.heex:287
+#: lib/vutuv_web/templates/settings/preferences.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "Bandwidth"
 msgstr "Bandbreite"
@@ -23244,7 +23241,7 @@ msgstr "Einstellungen zur Bandbreite auf die Website-Vorgaben zurückgesetzt."
 msgid "Bandwidth settings saved."
 msgstr "Einstellungen zur Bandbreite gespeichert."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:207
+#: lib/vutuv_web/templates/settings/preferences.html.heex:211
 #, elixir-autogen, elixir-format
 msgid "If you are on a slow or metered connection, vutuv can leave out the parts of the page that cost the most to download."
 msgstr "Wenn Ihre Verbindung langsam ist oder Ihr Datenvolumen begrenzt, kann vutuv die Teile der Seite weglassen, die beim Laden am meisten kosten."
@@ -23258,3 +23255,8 @@ msgstr "Datensparmodus"
 #, elixir-autogen, elixir-format
 msgid "Writing a post or a message then uses a plain Markdown box instead of the formatting editor, which saves about 150 kB of download. Everything you write still looks the same to everyone who reads it."
 msgstr "Beiträge und Nachrichten schreiben Sie dann in einem einfachen Markdown-Feld statt im Editor mit Formatierung. Das spart etwa 150 kB Download. Für alle, die Ihren Text lesen, sieht er genauso aus wie sonst."
+
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:252
+#, elixir-autogen, elixir-format
+msgid "View the original on %{url}"
+msgstr "Original auf %{url} ansehen"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -11,19 +11,19 @@ msgid ""
 msgstr ""
 "Language: INSERT LANGUAGE HERE\n"
 
-#: lib/vutuv_web/controllers/page_controller.ex:250
+#: lib/vutuv_web/controllers/page_controller.ex:251
 #: lib/vutuv_web/templates/layout/app.html.heex:111
 #, elixir-autogen
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4414
-#: lib/vutuv_web/components/ui.ex:4419
+#: lib/vutuv_web/components/ui.ex:4522
+#: lib/vutuv_web/components/ui.ex:4527
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
-#: lib/vutuv_web/live/organization_live/domains.ex:272
-#: lib/vutuv_web/live/organization_live/edit.ex:431
-#: lib/vutuv_web/live/organization_live/roles.ex:214
+#: lib/vutuv_web/live/organization_live/domains.ex:267
+#: lib/vutuv_web/live/organization_live/edit.ex:414
+#: lib/vutuv_web/live/organization_live/roles.ex:210
 #, elixir-autogen
 msgid "Add"
 msgstr ""
@@ -35,7 +35,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
 #: lib/vutuv_web/live/organization_live/fediverse.ex:115
-#: lib/vutuv_web/live/organization_live/show.ex:915
+#: lib/vutuv_web/live/organization_live/show.ex:910
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -64,7 +64,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/text.ex:71
-#: lib/vutuv_web/components/ui.ex:4712
+#: lib/vutuv_web/components/ui.ex:4820
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -77,14 +77,14 @@ msgstr ""
 msgid "Addresses"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1506
-#: lib/vutuv_web/templates/page/index.html.heex:320
+#: lib/vutuv_web/components/ui.ex:1530
+#: lib/vutuv_web/templates/page/index.html.heex:319
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4209
-#: lib/vutuv_web/components/ui.ex:4303
+#: lib/vutuv_web/components/ui.ex:4313
+#: lib/vutuv_web/components/ui.ex:4412
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Avatar"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:412
+#: lib/vutuv_web/templates/user/edit.html.heex:407
 #, elixir-autogen
 msgid "Birthdate"
 msgstr ""
@@ -111,29 +111,29 @@ msgstr ""
 msgid "Birthday"
 msgstr ""
 
-#: lib/vutuv_web/components/saved_search_components.ex:114
-#: lib/vutuv_web/components/ui.ex:4203
-#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
-#: lib/vutuv_web/live/admin/user_delete_live.ex:212
-#: lib/vutuv_web/live/job_posting_live/form.ex:812
-#: lib/vutuv_web/live/organization_live/edit.ex:382
-#: lib/vutuv_web/live/organization_live/new.ex:231
-#: lib/vutuv_web/live/post_live/composer.ex:1697
+#: lib/vutuv_web/components/saved_search_components.ex:104
+#: lib/vutuv_web/components/ui.ex:4307
+#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
+#: lib/vutuv_web/live/admin/user_delete_live.ex:202
+#: lib/vutuv_web/live/job_posting_live/form.ex:806
+#: lib/vutuv_web/live/organization_live/edit.ex:369
+#: lib/vutuv_web/live/organization_live/new.ex:222
+#: lib/vutuv_web/live/post_live/composer.ex:1673
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:113
 #: lib/vutuv_web/templates/report/new.html.heex:103
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:259
-#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:26
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:255
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:53
-#: lib/vutuv_web/templates/user/edit.html.heex:138
-#: lib/vutuv_web/templates/user/edit.html.heex:467
-#: lib/vutuv_web/templates/user/edit.html.heex:516
-#: lib/vutuv_web/templates/username/confirm.html.heex:222
+#: lib/vutuv_web/templates/user/edit.html.heex:133
+#: lib/vutuv_web/templates/user/edit.html.heex:463
+#: lib/vutuv_web/templates/user/edit.html.heex:508
+#: lib/vutuv_web/templates/username/confirm.html.heex:220
 #, elixir-autogen
 msgid "Cancel"
 msgstr ""
@@ -162,24 +162,24 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3586
-#: lib/vutuv_web/components/ui.ex:4306
-#: lib/vutuv_web/live/admin/job_live.ex:489
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
-#: lib/vutuv_web/live/admin/organization_live.ex:398
-#: lib/vutuv_web/live/admin/user_delete_live.ex:172
+#: lib/vutuv_web/components/post_components.ex:3608
+#: lib/vutuv_web/components/ui.ex:4414
+#: lib/vutuv_web/live/admin/job_live.ex:486
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:657
+#: lib/vutuv_web/live/admin/organization_live.ex:399
+#: lib/vutuv_web/live/admin/user_delete_live.ex:167
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:28
 #: lib/vutuv_web/templates/dev_app/show.html.heex:135
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:59
-#: lib/vutuv_web/templates/settings/saved_searches.html.heex:75
+#: lib/vutuv_web/templates/settings/saved_searches.html.heex:70
 #, elixir-autogen
 msgid "Delete"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:686
-#: lib/vutuv_web/live/organization_live/edit.ex:301
-#: lib/vutuv_web/live/organization_live/edit.ex:314
+#: lib/vutuv_web/live/job_posting_live/form.ex:685
+#: lib/vutuv_web/live/organization_live/edit.ex:296
+#: lib/vutuv_web/live/organization_live/edit.ex:309
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
 #: lib/vutuv_web/templates/address/form_en.html.heex:11
 #: lib/vutuv_web/templates/address/form_generic.html.heex:13
@@ -202,20 +202,20 @@ msgstr ""
 msgid "Disable"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:438
-#: lib/vutuv_web/live/post_live/composer.ex:2609
+#: lib/vutuv_web/live/cv_live.ex:428
+#: lib/vutuv_web/live/post_live/composer.ex:2548
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3551
-#: lib/vutuv_web/components/ui.ex:4297
+#: lib/vutuv_web/components/post_components.ex:3573
+#: lib/vutuv_web/components/ui.ex:4405
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
-#: lib/vutuv_web/live/job_posting_live/show.ex:178
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
+#: lib/vutuv_web/live/job_posting_live/show.ex:173
 #: lib/vutuv_web/live/organization_live/show.ex:149
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
@@ -285,7 +285,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:4676
+#: lib/vutuv_web/components/ui.ex:4784
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -306,7 +306,7 @@ msgid "Fax"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:596
-#: lib/vutuv_web/templates/user/edit.html.heex:169
+#: lib/vutuv_web/templates/user/edit.html.heex:164
 #, elixir-autogen
 msgid "First Name"
 msgstr ""
@@ -325,9 +325,9 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:632
 #: lib/vutuv_web/agent_docs/text.ex:596
-#: lib/vutuv_web/components/fediverse_components.ex:400
-#: lib/vutuv_web/components/ui.ex:2705
-#: lib/vutuv_web/components/ui.ex:2740
+#: lib/vutuv_web/components/fediverse_components.ex:397
+#: lib/vutuv_web/components/ui.ex:2807
+#: lib/vutuv_web/components/ui.ex:2842
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:608
@@ -340,8 +340,8 @@ msgid "Following"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:195
-#: lib/vutuv_web/templates/page/index.html.heex:118
-#: lib/vutuv_web/templates/user/edit.html.heex:206
+#: lib/vutuv_web/templates/page/index.html.heex:123
+#: lib/vutuv_web/templates/user/edit.html.heex:201
 #: lib/vutuv_web/views/account_event_text.ex:219
 #, elixir-autogen
 msgid "Gender"
@@ -374,7 +374,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:757
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:752
 #: lib/vutuv_web/templates/language/form_content.html.heex:5
 #: lib/vutuv_web/templates/language/show.html.heex:19
 #, elixir-autogen
@@ -382,7 +382,7 @@ msgid "Language"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:598
-#: lib/vutuv_web/templates/user/edit.html.heex:174
+#: lib/vutuv_web/templates/user/edit.html.heex:169
 #, elixir-autogen
 msgid "Last Name"
 msgstr ""
@@ -411,7 +411,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:202
 #: lib/vutuv_web/cv/latex.ex:164
 #: lib/vutuv_web/cv/odt.ex:176
-#: lib/vutuv_web/live/cv_live.ex:336
+#: lib/vutuv_web/live/cv_live.ex:326
 #: lib/vutuv_web/templates/import/new.html.heex:13
 #: lib/vutuv_web/templates/url/edit.html.heex:4
 #: lib/vutuv_web/templates/url/index.html.heex:10
@@ -440,8 +440,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1369
-#: lib/vutuv_web/live/shell_live.ex:1435
+#: lib/vutuv_web/live/shell_live.ex:1361
+#: lib/vutuv_web/live/shell_live.ex:1426
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -449,7 +449,7 @@ msgid "Log in"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:597
-#: lib/vutuv_web/templates/user/edit.html.heex:179
+#: lib/vutuv_web/templates/user/edit.html.heex:174
 #, elixir-autogen
 msgid "Middle Name"
 msgstr ""
@@ -473,7 +473,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:714
+#: lib/vutuv_web/components/post_components.ex:715
 #: lib/vutuv_web/live/notification_live/index.ex:742
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -486,7 +486,7 @@ msgid "New"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:600
-#: lib/vutuv_web/templates/user/edit.html.heex:184
+#: lib/vutuv_web/templates/user/edit.html.heex:179
 #, elixir-autogen
 msgid "Nickname"
 msgstr ""
@@ -567,7 +567,7 @@ msgid "Phone number updated successfully."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:595
-#: lib/vutuv_web/templates/user/edit.html.heex:189
+#: lib/vutuv_web/templates/user/edit.html.heex:184
 #, elixir-autogen
 msgid "Prefix"
 msgstr ""
@@ -603,7 +603,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1909
+#: lib/vutuv_web/live/post_live/composer.ex:1911
 #: lib/vutuv_web/live/section_reorder_live.ex:270
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -613,9 +613,9 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4202
-#: lib/vutuv_web/live/organization_live/edit.ex:376
-#: lib/vutuv_web/live/post_live/composer.ex:1924
+#: lib/vutuv_web/components/ui.ex:4306
+#: lib/vutuv_web/live/organization_live/edit.ex:367
+#: lib/vutuv_web/live/post_live/composer.ex:1926
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -625,40 +625,39 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
 #: lib/vutuv_web/templates/settings/preferences.html.heex:157
-#: lib/vutuv_web/templates/settings/preferences.html.heex:224
-#: lib/vutuv_web/templates/settings/preferences.html.heex:273
-#: lib/vutuv_web/templates/settings/preferences.html.heex:406
+#: lib/vutuv_web/templates/settings/preferences.html.heex:262
+#: lib/vutuv_web/templates/settings/preferences.html.heex:395
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
-#: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
-#: lib/vutuv_web/templates/user/edit.html.heex:462
+#: lib/vutuv_web/templates/settings/saved_searches.html.heex:61
+#: lib/vutuv_web/templates/user/edit.html.heex:458
 #: lib/vutuv_web/views/settings_html.ex:212
 #, elixir-autogen
 msgid "Save"
 msgstr ""
 
 #: lib/vutuv_web/components/browse_table.ex:346
-#: lib/vutuv_web/controllers/page_controller.ex:226
+#: lib/vutuv_web/controllers/page_controller.ex:227
 #: lib/vutuv_web/live/account_activity_live.ex:149
 #: lib/vutuv_web/live/admin/activity_live.ex:193
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:219
 #: lib/vutuv_web/live/directory_search_live.ex:181
-#: lib/vutuv_web/live/job_board_live.ex:418
+#: lib/vutuv_web/live/job_board_live.ex:410
 #: lib/vutuv_web/live/search_live.ex:60
-#: lib/vutuv_web/live/search_live.ex:658
-#: lib/vutuv_web/live/search_live.ex:684
-#: lib/vutuv_web/live/shell_live.ex:1234
-#: lib/vutuv_web/live/shell_live.ex:1418
-#: lib/vutuv_web/live/tag_live/timeline.ex:323
+#: lib/vutuv_web/live/search_live.ex:651
+#: lib/vutuv_web/live/search_live.ex:677
+#: lib/vutuv_web/live/shell_live.ex:1230
+#: lib/vutuv_web/live/shell_live.ex:1409
+#: lib/vutuv_web/live/tag_live/timeline.ex:319
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
-#: lib/vutuv_web/templates/admin/account/index.html.heex:39
+#: lib/vutuv_web/templates/admin/account/index.html.heex:35
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
 #: lib/vutuv_web/templates/layout/app.html.heex:155
 #, elixir-autogen
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1759
+#: lib/vutuv_web/components/post_components.ex:1781
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -666,7 +665,7 @@ msgstr ""
 msgid "Show"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:299
+#: lib/vutuv_web/templates/page/index.html.heex:298
 #, elixir-autogen
 msgid "Sign up for a free account"
 msgstr ""
@@ -686,7 +685,7 @@ msgstr ""
 #: lib/vutuv_web/cv/latex.ex:179
 #: lib/vutuv_web/cv/odt.ex:185
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:760
-#: lib/vutuv_web/live/cv_live.ex:410
+#: lib/vutuv_web/live/cv_live.ex:400
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:10
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
@@ -723,12 +722,12 @@ msgstr ""
 msgid "Profile deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1019
+#: lib/vutuv_web/views/user_html.ex:1025
 #, elixir-autogen, elixir-format
 msgid "Social networks"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1026
+#: lib/vutuv_web/views/user_html.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Code & repositories"
 msgstr ""
@@ -747,7 +746,7 @@ msgid "Submit a bugreport or a feature request."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:599
-#: lib/vutuv_web/templates/user/edit.html.heex:194
+#: lib/vutuv_web/templates/user/edit.html.heex:189
 #, elixir-autogen
 msgid "Suffix"
 msgstr ""
@@ -789,15 +788,15 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4672
+#: lib/vutuv_web/components/ui.ex:4780
 #: lib/vutuv_web/controllers/username_controller.ex:428
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:832
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
 #: lib/vutuv_web/live/directory_search_live.ex:134
 #: lib/vutuv_web/live/notification_live/index.ex:1281
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
-#: lib/vutuv_web/templates/admin/account/index.html.heex:56
+#: lib/vutuv_web/templates/admin/account/index.html.heex:51
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
 #: lib/vutuv_web/templates/settings/security.html.heex:23
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:5
@@ -841,7 +840,7 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1313
+#: lib/vutuv_web/components/ui.ex:1337
 #: lib/vutuv_web/views/user_html.ex:562
 #: lib/vutuv_web/views/user_html.ex:563
 #: lib/vutuv_web/views/user_html.ex:577
@@ -849,17 +848,17 @@ msgstr ""
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4367
+#: lib/vutuv_web/components/ui.ex:4475
 #: lib/vutuv_web/templates/user/show.html.heex:973
 #: lib/vutuv_web/templates/user/show.html.heex:996
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4780
+#: lib/vutuv_web/components/ui.ex:4888
 #: lib/vutuv_web/controllers/settings_controller.ex:171
-#: lib/vutuv_web/live/job_posting_live/form.ex:768
-#: lib/vutuv_web/live/organization_live/edit.ex:335
+#: lib/vutuv_web/live/job_posting_live/form.ex:767
+#: lib/vutuv_web/live/organization_live/edit.ex:330
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:295
@@ -873,7 +872,7 @@ msgstr ""
 msgid "We can't find em' cap'n!"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:323
+#: lib/vutuv_web/templates/page/index.html.heex:322
 #, elixir-autogen
 msgid "We reserve the right to stop this service or delete your account anytime without warning."
 msgstr ""
@@ -948,12 +947,12 @@ msgstr ""
 msgid "An email has been sent to your email address with instructions on how to delete your account."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:198
+#: lib/vutuv_web/templates/page/index.html.heex:203
 #, elixir-autogen
 msgid "Allow others to view your email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:309
+#: lib/vutuv_web/templates/page/index.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "By creating an account you accept our {nutzungsbedingungen} and confirm that you have read our {datenschutz}."
 msgstr ""
@@ -1046,7 +1045,7 @@ msgstr ""
 msgid "General Info"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:346
+#: lib/vutuv_web/live/admin/user_live.ex:345
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:32
 #, elixir-autogen
 msgid "Verify"
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "Listings"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:418
+#: lib/vutuv_web/controllers/page_controller.ex:408
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1130,8 +1129,8 @@ msgstr ""
 msgid "Our search will try to match similar names to your search, so don't worry about spelling."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:737
-#: lib/vutuv_web/live/search_live.ex:762
+#: lib/vutuv_web/live/search_live.ex:730
+#: lib/vutuv_web/live/search_live.ex:755
 #, elixir-autogen
 msgid "Search Tips"
 msgstr ""
@@ -1156,15 +1155,15 @@ msgstr ""
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:127
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:638
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:637
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:688
 #: lib/vutuv_web/live/admin/organization_live.ex:189
 #: lib/vutuv_web/live/admin/screenshot_live.ex:182
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:443
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
-#: lib/vutuv_web/live/admin/user_detail_live.ex:68
+#: lib/vutuv_web/live/admin/user_detail_live.ex:63
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1341
+#: lib/vutuv_web/live/shell_live.ex:1337
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1376,7 +1375,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:522
 #: lib/vutuv_web/agent_docs/text.ex:768
-#: lib/vutuv_web/components/ui.ex:4697
+#: lib/vutuv_web/components/ui.ex:4805
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1385,11 +1384,11 @@ msgstr ""
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:444
-#: lib/vutuv_web/live/cv_live.ex:315
-#: lib/vutuv_web/live/job_board_live.ex:277
-#: lib/vutuv_web/live/job_posting_live/form.ex:717
+#: lib/vutuv_web/live/cv_live.ex:305
+#: lib/vutuv_web/live/job_board_live.ex:276
+#: lib/vutuv_web/live/job_posting_live/form.ex:716
 #: lib/vutuv_web/live/search_live.ex:344
-#: lib/vutuv_web/live/search_live.ex:822
+#: lib/vutuv_web/live/search_live.ex:815
 #: lib/vutuv_web/live/tag_new_live.ex:35
 #: lib/vutuv_web/live/tag_new_live.ex:46
 #: lib/vutuv_web/live/tag_new_live.ex:53
@@ -1399,7 +1398,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/tag/new.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:5
 #: lib/vutuv_web/templates/import/new.html.heex:12
-#: lib/vutuv_web/templates/page/index.html.heex:133
+#: lib/vutuv_web/templates/page/index.html.heex:138
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:28
 #: lib/vutuv_web/templates/tag/show.html.heex:45
@@ -1561,10 +1560,10 @@ msgstr ""
 msgid "You'll receive an email with a login link."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:776
-#: lib/vutuv_web/live/job_board_live.ex:360
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:771
+#: lib/vutuv_web/live/job_board_live.ex:356
 #: lib/vutuv_web/live/job_posting_live/form.ex:548
-#: lib/vutuv_web/live/organization_live/edit.ex:331
+#: lib/vutuv_web/live/organization_live/edit.ex:326
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
 #: lib/vutuv_web/templates/address/country_input.html.heex:5
@@ -1598,7 +1597,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1421
+#: lib/vutuv_web/live/shell_live.ex:1412
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1617,15 +1616,15 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2864
+#: lib/vutuv_web/components/ui.ex:2966
 #: lib/vutuv_web/live/admin/job_live.ex:321
-#: lib/vutuv_web/live/admin/job_live.ex:480
+#: lib/vutuv_web/live/admin/job_live.ex:477
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1553
-#: lib/vutuv_web/live/post_live/composer.ex:1655
-#: lib/vutuv_web/live/post_live/composer.ex:1656
-#: lib/vutuv_web/live/post_live/composer.ex:2486
-#: lib/vutuv_web/live/post_live/composer.ex:2752
+#: lib/vutuv_web/live/post_live/composer.ex:1529
+#: lib/vutuv_web/live/post_live/composer.ex:1631
+#: lib/vutuv_web/live/post_live/composer.ex:1632
+#: lib/vutuv_web/live/post_live/composer.ex:2425
+#: lib/vutuv_web/live/post_live/composer.ex:2691
 #: lib/vutuv_web/templates/layout/app.html.heex:188
 #: lib/vutuv_web/templates/layout/app.html.heex:194
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
@@ -1636,7 +1635,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/email/confirm.html.heex:9
 #: lib/vutuv_web/templates/username/confirm.html.heex:25
-#: lib/vutuv_web/templates/username/confirm.html.heex:165
+#: lib/vutuv_web/templates/username/confirm.html.heex:163
 #, elixir-autogen, elixir-format
 msgid "Confirm"
 msgstr ""
@@ -1646,17 +1645,17 @@ msgstr ""
 msgid "Confirm account deletion"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:254
+#: lib/vutuv_web/controllers/page_controller.ex:255
 #: lib/vutuv_web/templates/layout/app.html.heex:117
-#: lib/vutuv_web/templates/page/index.html.heex:316
+#: lib/vutuv_web/templates/page/index.html.heex:315
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:260
+#: lib/vutuv_web/controllers/page_controller.ex:261
 #: lib/vutuv_web/templates/layout/app.html.heex:118
-#: lib/vutuv_web/templates/page/index.html.heex:316
+#: lib/vutuv_web/templates/page/index.html.heex:315
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Nutzungsbedingungen"
@@ -1674,23 +1673,23 @@ msgstr ""
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2025
-#: lib/vutuv_web/components/ui.ex:2034
-#: lib/vutuv_web/components/ui.ex:2512
+#: lib/vutuv_web/components/ui.ex:2049
+#: lib/vutuv_web/components/ui.ex:2058
+#: lib/vutuv_web/components/ui.ex:2536
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:236
-#: lib/vutuv_web/components/ui.ex:2670
-#: lib/vutuv_web/components/ui.ex:2670
-#: lib/vutuv_web/components/ui.ex:2687
-#: lib/vutuv_web/components/ui.ex:2696
-#: lib/vutuv_web/components/ui.ex:2712
-#: lib/vutuv_web/components/ui.ex:2774
-#: lib/vutuv_web/live/fediverse_account_live.ex:381
+#: lib/vutuv_web/components/ui.ex:2772
+#: lib/vutuv_web/components/ui.ex:2772
+#: lib/vutuv_web/components/ui.ex:2789
+#: lib/vutuv_web/components/ui.ex:2798
+#: lib/vutuv_web/components/ui.ex:2814
+#: lib/vutuv_web/components/ui.ex:2876
+#: lib/vutuv_web/live/fediverse_account_live.ex:391
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:311
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:312
 #: lib/vutuv_web/live/organization_live/following.ex:331
 #: lib/vutuv_web/live/organization_live/following.ex:412
 #: lib/vutuv_web/live/organization_live/show.ex:569
@@ -1713,7 +1712,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1360
+#: lib/vutuv_web/live/shell_live.ex:1356
 #: lib/vutuv_web/views/settings_html.ex:299
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1727,7 +1726,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_live.ex:154
 #: lib/vutuv_web/live/message_live/index.ex:538
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:32
-#: lib/vutuv_web/templates/admin/account/index.html.heex:55
+#: lib/vutuv_web/templates/admin/account/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:28
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:24
 #, elixir-autogen, elixir-format
@@ -1742,29 +1741,29 @@ msgstr ""
 msgid "Message"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:227
+#: lib/vutuv_web/controllers/page_controller.ex:228
 #: lib/vutuv_web/live/message_live/index.ex:49
-#: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1252
-#: lib/vutuv_web/live/shell_live.ex:1420
+#: lib/vutuv_web/live/message_live/index.ex:624
+#: lib/vutuv_web/live/shell_live.ex:1248
+#: lib/vutuv_web/live/shell_live.ex:1411
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1136
+#: lib/vutuv_web/live/shell_live.ex:1132
 #: lib/vutuv_web/templates/layout/app.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:450
-#: lib/vutuv_web/components/ui.ex:4416
+#: lib/vutuv_web/components/post_components.ex:451
+#: lib/vutuv_web/components/ui.ex:4524
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
 #: lib/vutuv_web/live/admin/user_live.ex:286
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:122
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr ""
@@ -1775,18 +1774,18 @@ msgid "Nothing new yet."
 msgstr ""
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:4734
-#: lib/vutuv_web/controllers/page_controller.ex:228
+#: lib/vutuv_web/components/ui.ex:4842
+#: lib/vutuv_web/controllers/page_controller.ex:229
 #: lib/vutuv_web/live/notification_live/index.ex:146
 #: lib/vutuv_web/live/notification_live/index.ex:384
-#: lib/vutuv_web/live/shell_live.ex:1264
+#: lib/vutuv_web/live/shell_live.ex:1260
 #: lib/vutuv_web/templates/layout/app.html.heex:153
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_detail_live.ex:93
+#: lib/vutuv_web/live/admin/user_detail_live.ex:88
 #: lib/vutuv_web/live/admin/user_live.ex:322
 #: lib/vutuv_web/templates/email/confirm.html.heex:25
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:17
@@ -1801,7 +1800,7 @@ msgid "Pardon us! Something went wrong."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:912
+#: lib/vutuv_web/live/message_live/index.ex:902
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
@@ -1850,7 +1849,7 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
 #: lib/vutuv_web/templates/user/show.html.heex:209
-#: lib/vutuv_web/views/user_html.ex:1071
+#: lib/vutuv_web/views/user_html.ex:1077
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
 msgstr ""
@@ -1875,8 +1874,8 @@ msgstr ""
 msgid "Who to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:901
-#: lib/vutuv_web/live/message_live/index.ex:902
+#: lib/vutuv_web/live/message_live/index.ex:891
+#: lib/vutuv_web/live/message_live/index.ex:892
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr ""
@@ -1921,17 +1920,16 @@ msgstr ""
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3695
-#: lib/vutuv_web/components/ui.ex:3848
+#: lib/vutuv_web/components/ui.ex:3807
+#: lib/vutuv_web/components/ui.ex:3952
 #: lib/vutuv_web/live/import_connections_live.ex:638
-#: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4441
+#: lib/vutuv_web/components/ui.ex:4549
 #: lib/vutuv_web/live/organization_live/activity.ex:151
-#: lib/vutuv_web/live/organization_live/feed.ex:210
+#: lib/vutuv_web/live/organization_live/feed.ex:209
 #: lib/vutuv_web/live/organization_live/show.ex:777
 #, elixir-autogen, elixir-format
 msgid "Load more"
@@ -1942,13 +1940,13 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4212
+#: lib/vutuv_web/components/ui.ex:4316
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1706
-#: lib/vutuv_web/components/ui.ex:1716
+#: lib/vutuv_web/components/ui.ex:1730
+#: lib/vutuv_web/components/ui.ex:1740
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr ""
@@ -1987,12 +1985,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3218
+#: lib/vutuv_web/components/ui.ex:3320
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3222
+#: lib/vutuv_web/components/ui.ex:3324
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -2007,7 +2005,7 @@ msgstr ""
 msgid "Change cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:101
+#: lib/vutuv_web/templates/user/edit.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
 msgstr ""
@@ -2017,37 +2015,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3226
+#: lib/vutuv_web/components/ui.ex:3328
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3216
+#: lib/vutuv_web/components/ui.ex:3318
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3215
+#: lib/vutuv_web/components/ui.ex:3317
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3221
+#: lib/vutuv_web/components/ui.ex:3323
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3220
+#: lib/vutuv_web/components/ui.ex:3322
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3217
+#: lib/vutuv_web/components/ui.ex:3319
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3219
+#: lib/vutuv_web/components/ui.ex:3321
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2062,34 +2060,34 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3225
+#: lib/vutuv_web/components/ui.ex:3327
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3224
+#: lib/vutuv_web/components/ui.ex:3326
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3223
+#: lib/vutuv_web/components/ui.ex:3325
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
 
 #: lib/vutuv_web/templates/education/form_content.html.heex:32
-#: lib/vutuv_web/templates/user/edit.html.heex:254
+#: lib/vutuv_web/templates/user/edit.html.heex:249
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Markdown is supported: bold, italics, links and lists."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:710
+#: lib/vutuv_web/live/job_posting_live/form.ex:709
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2102
+#: lib/vutuv_web/live/post_live/composer.ex:2040
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2100,7 +2098,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1795
+#: lib/vutuv_web/live/post_live/composer.ex:1771
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2110,7 +2108,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3583
+#: lib/vutuv_web/components/post_components.ex:3605
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2124,12 +2122,12 @@ msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:265
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
-#: lib/vutuv_web/live/organization_live/feed.ex:155
+#: lib/vutuv_web/live/organization_live/feed.ex:154
 #: lib/vutuv_web/live/post_live/feed.ex:317
-#: lib/vutuv_web/live/post_live/feed.ex:2899
+#: lib/vutuv_web/live/post_live/feed.ex:2896
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1114
-#: lib/vutuv_web/live/shell_live.ex:1413
+#: lib/vutuv_web/live/shell_live.ex:1110
+#: lib/vutuv_web/live/shell_live.ex:1404
 #: lib/vutuv_web/templates/layout/app.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2145,55 +2143,55 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2078
+#: lib/vutuv_web/live/post_live/composer.ex:2016
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2006
+#: lib/vutuv_web/live/post_live/composer.ex:1944
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3537
-#: lib/vutuv_web/components/post_components.ex:3539
+#: lib/vutuv_web/components/post_components.ex:3559
+#: lib/vutuv_web/components/post_components.ex:3561
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2048
+#: lib/vutuv_web/live/post_live/composer.ex:1986
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1295
-#: lib/vutuv_web/live/post_live/composer.ex:1343
+#: lib/vutuv_web/live/post_live/composer.ex:1270
+#: lib/vutuv_web/live/post_live/composer.ex:1318
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3153
+#: lib/vutuv_web/live/post_live/feed.ex:3150
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1261
+#: lib/vutuv_web/live/post_live/composer.ex:1236
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2038
+#: lib/vutuv_web/live/post_live/composer.ex:1976
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2028
+#: lib/vutuv_web/live/post_live/composer.ex:1966
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:416
-#: lib/vutuv_web/live/post_live/composer.ex:1926
+#: lib/vutuv_web/live/post_live/composer.ex:1928
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2210,40 +2208,40 @@ msgstr ""
 #: lib/vutuv_web/controllers/user_controller.ex:76
 #: lib/vutuv_web/gettext_extraction_anchors.ex:109
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
-#: lib/vutuv_web/live/fediverse_account_live.ex:388
+#: lib/vutuv_web/live/fediverse_account_live.ex:398
 #: lib/vutuv_web/live/notification_live/index.ex:1125
 #: lib/vutuv_web/live/organization_live/show.ex:700
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:345
-#: lib/vutuv_web/live/search_live.ex:836
-#: lib/vutuv_web/templates/settings/preferences.html.heex:319
+#: lib/vutuv_web/live/search_live.ex:829
+#: lib/vutuv_web/templates/settings/preferences.html.heex:308
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3998
-#: lib/vutuv_web/components/post_components.ex:4002
+#: lib/vutuv_web/components/post_components.ex:4020
+#: lib/vutuv_web/components/post_components.ex:4024
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3999
-#: lib/vutuv_web/live/fediverse_account_live.ex:334
+#: lib/vutuv_web/components/post_components.ex:4021
+#: lib/vutuv_web/live/fediverse_account_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:429
-#: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1353
+#: lib/vutuv_web/components/fediverse_components.ex:426
+#: lib/vutuv_web/components/job_exclusion_components.ex:189
+#: lib/vutuv_web/components/post_components.ex:1354
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
-#: lib/vutuv_web/live/job_search_exclusions_live.ex:234
-#: lib/vutuv_web/live/organization_live/domains.ex:246
-#: lib/vutuv_web/live/organization_live/edit.ex:408
-#: lib/vutuv_web/live/organization_live/roles.ex:247
-#: lib/vutuv_web/live/post_live/composer.ex:2064
+#: lib/vutuv_web/live/job_search_exclusions_live.ex:229
+#: lib/vutuv_web/live/organization_live/domains.ex:245
+#: lib/vutuv_web/live/organization_live/edit.ex:395
+#: lib/vutuv_web/live/organization_live/roles.ex:242
+#: lib/vutuv_web/live/post_live/composer.ex:2002
 #: lib/vutuv_web/live/post_live/filter_band.ex:455
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
@@ -2258,12 +2256,12 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1916
+#: lib/vutuv_web/live/post_live/composer.ex:1918
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2224
+#: lib/vutuv_web/live/post_live/feed.ex:2226
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2275,12 +2273,12 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1369
+#: lib/vutuv_web/live/post_live/composer.ex:1344
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1243
+#: lib/vutuv_web/live/post_live/composer.ex:1218
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2290,18 +2288,18 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2901
+#: lib/vutuv_web/live/post_live/composer.ex:2840
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2902
+#: lib/vutuv_web/live/post_live/composer.ex:2841
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5034
-#: lib/vutuv_web/live/shell_live.ex:1307
+#: lib/vutuv_web/components/ui.ex:5142
+#: lib/vutuv_web/live/shell_live.ex:1303
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:246
@@ -2309,58 +2307,58 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2179
+#: lib/vutuv_web/live/post_live/composer.ex:2117
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2180
+#: lib/vutuv_web/live/post_live/composer.ex:2118
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3534
+#: lib/vutuv_web/components/post_components.ex:3556
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5439
+#: lib/vutuv_web/components/post_components.ex:5461
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5443
+#: lib/vutuv_web/components/post_components.ex:5465
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5441
+#: lib/vutuv_web/components/post_components.ex:5463
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5442
+#: lib/vutuv_web/components/post_components.ex:5464
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3296
+#: lib/vutuv_web/components/ui.ex:3398
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1831
+#: lib/vutuv_web/live/post_live/composer.ex:1807
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2892
+#: lib/vutuv_web/live/post_live/composer.ex:2831
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2896
+#: lib/vutuv_web/live/post_live/composer.ex:2835
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2380,9 +2378,9 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2033
-#: lib/vutuv_web/components/post_components.ex:5535
-#: lib/vutuv_web/components/ui.ex:3770
+#: lib/vutuv_web/components/post_components.ex:2055
+#: lib/vutuv_web/components/post_components.ex:5557
+#: lib/vutuv_web/components/ui.ex:3874
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2391,17 +2389,17 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1145
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:1244
-#: lib/vutuv_web/live/shell_live.ex:1312
+#: lib/vutuv_web/live/shell_live.ex:1240
+#: lib/vutuv_web/live/shell_live.ex:1308
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1986
-#: lib/vutuv_web/components/post_components.ex:5771
-#: lib/vutuv_web/components/ui.ex:3756
+#: lib/vutuv_web/components/post_components.ex:2008
+#: lib/vutuv_web/components/post_components.ex:5793
+#: lib/vutuv_web/components/ui.ex:3860
 #: lib/vutuv_web/live/notification_live/index.ex:1271
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
@@ -2409,11 +2407,11 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1144
-#: lib/vutuv_web/components/post_components.ex:5781
+#: lib/vutuv_web/components/post_components.ex:5803
 #: lib/vutuv_web/live/notification_live/index.ex:1204
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:1315
+#: lib/vutuv_web/live/shell_live.ex:1311
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2431,57 +2429,57 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5523
+#: lib/vutuv_web/components/post_components.ex:5545
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2032
-#: lib/vutuv_web/components/post_components.ex:5534
+#: lib/vutuv_web/components/post_components.ex:2054
+#: lib/vutuv_web/components/post_components.ex:5556
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2014
-#: lib/vutuv_web/components/post_components.ex:5520
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
+#: lib/vutuv_web/components/post_components.ex:2036
+#: lib/vutuv_web/components/post_components.ex:5542
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2279
-#: lib/vutuv_web/components/post_components.ex:4615
+#: lib/vutuv_web/components/post_components.ex:2301
+#: lib/vutuv_web/components/post_components.ex:4637
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2013
-#: lib/vutuv_web/components/post_components.ex:5519
+#: lib/vutuv_web/components/post_components.ex:2035
+#: lib/vutuv_web/components/post_components.ex:5541
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1985
-#: lib/vutuv_web/components/post_components.ex:5770
+#: lib/vutuv_web/components/post_components.ex:2007
+#: lib/vutuv_web/components/post_components.ex:5792
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:430
-#: lib/vutuv_web/components/post_components.ex:2648
-#: lib/vutuv_web/components/ui.ex:2665
-#: lib/vutuv_web/components/ui.ex:2665
-#: lib/vutuv_web/components/ui.ex:2741
+#: lib/vutuv_web/components/fediverse_components.ex:427
+#: lib/vutuv_web/components/post_components.ex:2670
+#: lib/vutuv_web/components/ui.ex:2767
+#: lib/vutuv_web/components/ui.ex:2767
+#: lib/vutuv_web/components/ui.ex:2843
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:611
 #: lib/vutuv_web/live/post_live/feed.ex:890
 #: lib/vutuv_web/templates/followee/index.html.heex:30
-#: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
+#: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
 #: lib/vutuv_web/views/user_html.ex:618
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2492,38 +2490,38 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5825
+#: lib/vutuv_web/components/post_components.ex:5847
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:408
+#: lib/vutuv_web/components/post_components.ex:409
 #: lib/vutuv_web/live/notification_live/index.ex:1205
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1999
-#: lib/vutuv_web/components/post_components.ex:5808
-#: lib/vutuv_web/components/post_components.ex:5809
+#: lib/vutuv_web/components/post_components.ex:2021
+#: lib/vutuv_web/components/post_components.ex:5830
+#: lib/vutuv_web/components/post_components.ex:5831
 #: lib/vutuv_web/live/notification_live/index.ex:1268
 #: lib/vutuv_web/live/post_live/reply.ex:46
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3501
+#: lib/vutuv_web/components/post_components.ex:3523
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1246
-#: lib/vutuv_web/live/post_live/composer.ex:1904
+#: lib/vutuv_web/live/post_live/composer.ex:1221
+#: lib/vutuv_web/live/post_live/composer.ex:1906
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2109
+#: lib/vutuv_web/live/post_live/composer.ex:2047
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2533,7 +2531,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3037
+#: lib/vutuv_web/components/post_components.ex:3059
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:60
@@ -2541,49 +2539,49 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3475
+#: lib/vutuv_web/components/post_components.ex:3497
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3466
-#: lib/vutuv_web/components/post_components.ex:3493
-#: lib/vutuv_web/components/post_components.ex:3496
+#: lib/vutuv_web/components/post_components.ex:3488
+#: lib/vutuv_web/components/post_components.ex:3515
+#: lib/vutuv_web/components/post_components.ex:3518
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:613
+#: lib/vutuv_web/live/message_live/index.ex:603
 #, elixir-autogen, elixir-format
 msgid "%{names} are typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:612
+#: lib/vutuv_web/live/message_live/index.ex:602
 #, elixir-autogen, elixir-format
 msgid "%{name} is typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:924
+#: lib/vutuv_web/live/message_live/index.ex:914
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:875
+#: lib/vutuv_web/live/message_live/index.ex:865
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to message you."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:596
+#: lib/vutuv_web/live/message_live/index.ex:591
 #, elixir-autogen, elixir-format
 msgid "Accept"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:738
+#: lib/vutuv_web/live/message_live/index.ex:728
 #, elixir-autogen, elixir-format
 msgid "Back to conversations"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:603
+#: lib/vutuv_web/live/message_live/index.ex:593
 #, elixir-autogen, elixir-format
 msgid "Decline"
 msgstr ""
@@ -2593,7 +2591,7 @@ msgstr ""
 msgid "Deleted account"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:784
+#: lib/vutuv_web/live/message_live/index.ex:774
 #, elixir-autogen, elixir-format
 msgid "Load older messages"
 msgstr ""
@@ -2604,23 +2602,23 @@ msgstr ""
 msgid "Member not found."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:717
+#: lib/vutuv_web/live/message_live/index.ex:707
 #, elixir-autogen, elixir-format
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2988
-#: lib/vutuv_web/live/message_live/index.ex:760
+#: lib/vutuv_web/components/ui.ex:3090
+#: lib/vutuv_web/live/message_live/index.ex:750
 #, elixir-autogen, elixir-format
 msgid "Online"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:666
+#: lib/vutuv_web/live/message_live/index.ex:656
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:933
+#: lib/vutuv_web/live/message_live/index.ex:923
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr ""
@@ -2675,7 +2673,7 @@ msgstr ""
 msgid "Founder of vutuv"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:206
+#: lib/vutuv_web/templates/page/index.html.heex:211
 #: lib/vutuv_web/templates/settings/privacy.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Allow search engines to index your profile"
@@ -2696,7 +2694,7 @@ msgstr ""
 msgid "Okay, let's start over."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:815
+#: lib/vutuv_web/components/ui.ex:839
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr ""
@@ -2707,7 +2705,7 @@ msgstr ""
 msgid "Too many PIN requests. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:836
+#: lib/vutuv_web/components/ui.ex:860
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr ""
@@ -2757,11 +2755,11 @@ msgstr ""
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3936
-#: lib/vutuv_web/components/ui.ex:4369
+#: lib/vutuv_web/components/ui.ex:4040
+#: lib/vutuv_web/components/ui.ex:4477
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
-#: lib/vutuv_web/templates/settings/organizations.html.heex:104
+#: lib/vutuv_web/templates/settings/organizations.html.heex:109
 #: lib/vutuv_web/templates/settings/preferences.html.heex:195
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
@@ -2771,8 +2769,8 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:225
-#: lib/vutuv_web/live/post_live/feed.ex:2280
+#: lib/vutuv_web/controllers/page_controller.ex:226
+#: lib/vutuv_web/live/post_live/feed.ex:2282
 #: lib/vutuv_web/templates/user/show.html.heex:499
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2810,7 +2808,7 @@ msgstr[1] ""
 msgid "Connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1304
+#: lib/vutuv_web/components/ui.ex:1328
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2820,17 +2818,17 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1320
+#: lib/vutuv_web/components/ui.ex:1344
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2018
+#: lib/vutuv_web/live/post_live/composer.ex:1956
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1305
+#: lib/vutuv_web/components/ui.ex:1329
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -2848,12 +2846,12 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5440
+#: lib/vutuv_web/components/post_components.ex:5462
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:718
+#: lib/vutuv_web/live/message_live/index.ex:708
 #, elixir-autogen, elixir-format
 msgid "Open someone's profile to message them."
 msgstr ""
@@ -2957,7 +2955,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:343
 #: lib/vutuv_web/agent_docs/text.ex:324
-#: lib/vutuv_web/controllers/page_controller.ex:90
+#: lib/vutuv_web/controllers/page_controller.ex:91
 #: lib/vutuv_web/templates/layout/app.html.heex:119
 #: lib/vutuv_web/templates/page/community.html.heex:4
 #, elixir-autogen, elixir-format
@@ -3019,7 +3017,7 @@ msgstr ""
 msgid "Hidden. You can settle this yourself - see below."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:813
+#: lib/vutuv_web/live/message_live/index.ex:803
 #, elixir-autogen, elixir-format
 msgid "Hidden: reported, under review"
 msgstr ""
@@ -3111,7 +3109,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3442
+#: lib/vutuv_web/components/post_components.ex:3464
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3160,9 +3158,9 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4666
-#: lib/vutuv_web/live/shell_live.ex:1128
-#: lib/vutuv_web/live/shell_live.ex:1425
+#: lib/vutuv_web/components/ui.ex:4774
+#: lib/vutuv_web/live/shell_live.ex:1124
+#: lib/vutuv_web/live/shell_live.ex:1416
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3186,9 +3184,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1363
-#: lib/vutuv_web/components/post_components.ex:2660
-#: lib/vutuv_web/components/post_components.ex:3606
+#: lib/vutuv_web/components/post_components.ex:1364
+#: lib/vutuv_web/components/post_components.ex:2682
+#: lib/vutuv_web/components/post_components.ex:3628
 #: lib/vutuv_web/live/organization_live/show.ex:651
 #: lib/vutuv_web/templates/user/show.html.heex:229
 #, elixir-autogen, elixir-format
@@ -3216,8 +3214,8 @@ msgstr ""
 msgid "Report this content"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:831
-#: lib/vutuv_web/live/message_live/index.ex:832
+#: lib/vutuv_web/live/message_live/index.ex:821
+#: lib/vutuv_web/live/message_live/index.ex:822
 #, elixir-autogen, elixir-format
 msgid "Report this message"
 msgstr ""
@@ -3271,7 +3269,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3645
+#: lib/vutuv_web/components/ui.ex:3747
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3322,7 +3320,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/organization_live.ex:246
 #: lib/vutuv_web/live/admin/screenshot_live.ex:414
 #: lib/vutuv_web/live/admin/user_live.ex:299
-#: lib/vutuv_web/templates/admin/account/index.html.heex:57
+#: lib/vutuv_web/templates/admin/account/index.html.heex:52
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:59
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:19
 #: lib/vutuv_web/templates/admin/newsletter/index.html.heex:50
@@ -3876,7 +3874,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:157
 #: lib/vutuv_web/agent_docs/text.ex:112
 #: lib/vutuv_web/agent_docs/text.ex:143
-#: lib/vutuv_web/live/job_posting_live/form.ex:700
+#: lib/vutuv_web/live/job_posting_live/form.ex:699
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr ""
@@ -4063,7 +4061,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
 #: lib/vutuv_web/live/job_posting_live/form.ex:542
-#: lib/vutuv_web/live/organization_live/edit.ex:327
+#: lib/vutuv_web/live/organization_live/edit.ex:322
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
 #: lib/vutuv_web/templates/address/form_en.html.heex:33
@@ -4345,12 +4343,12 @@ msgstr ""
 msgid "Bookings are open through %{last}. Next available day: %{day}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3248
+#: lib/vutuv_web/components/ui.ex:3350
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3244
+#: lib/vutuv_web/components/ui.ex:3346
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr ""
@@ -4360,27 +4358,27 @@ msgstr ""
 msgid "One ad per calendar day: pick a free day in the calendar; struck-through days are already booked."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3249
+#: lib/vutuv_web/components/ui.ex:3351
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3250
+#: lib/vutuv_web/components/ui.ex:3352
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3247
+#: lib/vutuv_web/components/ui.ex:3349
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3245
+#: lib/vutuv_web/components/ui.ex:3347
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3246
+#: lib/vutuv_web/components/ui.ex:3348
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr ""
@@ -4423,7 +4421,7 @@ msgstr ""
 msgid "by"
 msgstr ""
 
-#: lib/vutuv_web/templates/ad/preview.html.heex:83
+#: lib/vutuv_web/templates/ad/preview.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Book now (binding, by invoice)"
 msgstr ""
@@ -4433,12 +4431,12 @@ msgstr ""
 msgid "Booking is binding; payment by invoice. We review and approve every ad before it runs."
 msgstr ""
 
-#: lib/vutuv_web/templates/ad/preview.html.heex:77
+#: lib/vutuv_web/templates/ad/preview.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "Edit the ad"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1004
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:999
 #: lib/vutuv_web/live/tag_new_live.ex:78
 #: lib/vutuv_web/templates/ad/preview.html.heex:3
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:122
@@ -4512,7 +4510,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4784
+#: lib/vutuv_web/components/ui.ex:4892
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4554,12 +4552,12 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3158
+#: lib/vutuv_web/live/post_live/feed.ex:3155
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:721
+#: lib/vutuv_web/live/message_live/index.ex:711
 #, elixir-autogen, elixir-format
 msgid "Find members"
 msgstr ""
@@ -4598,12 +4596,12 @@ msgstr ""
 msgid "This area is reserved for administrators."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:884
+#: lib/vutuv_web/live/search_live.ex:877
 #, elixir-autogen, elixir-format
 msgid "No results for \"%{query}\""
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:805
+#: lib/vutuv_web/live/search_live.ex:798
 #, elixir-autogen, elixir-format
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
@@ -4615,23 +4613,23 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/show.ex:787
 #: lib/vutuv_web/live/post_live/saved.ex:523
 #: lib/vutuv_web/live/search_live.ex:343
-#: lib/vutuv_web/live/search_live.ex:778
+#: lib/vutuv_web/live/search_live.ex:771
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:719
+#: lib/vutuv_web/live/search_live.ex:712
 #, elixir-autogen, elixir-format
 msgid "Results appear once you have typed at least three letters."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:802
+#: lib/vutuv_web/live/search_live.ex:795
 #, elixir-autogen, elixir-format
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:405
-#: lib/vutuv_web/components/post_components.ex:424
+#: lib/vutuv_web/components/post_components.ex:406
+#: lib/vutuv_web/components/post_components.ex:425
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -4642,7 +4640,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:702
+#: lib/vutuv_web/live/search_live.ex:695
 #, elixir-autogen, elixir-format
 msgid "Exact matches only"
 msgstr ""
@@ -4682,7 +4680,7 @@ msgstr ""
 msgid "searches first names only (last: for last names)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:388
+#: lib/vutuv_web/live/job_board_live.ex:384
 #: lib/vutuv_web/live/tag_new_live.ex:47
 #: lib/vutuv_web/live/user_profile_live.ex:1336
 #: lib/vutuv_web/templates/user/show.html.heex:602
@@ -4733,8 +4731,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:286
 #: lib/vutuv_web/agent_docs/text.ex:270
 #: lib/vutuv_web/live/admin/job_live.ex:389
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
-#: lib/vutuv_web/live/job_posting_live/show.ex:136
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:140
+#: lib/vutuv_web/live/job_posting_live/show.ex:131
 #: lib/vutuv_web/templates/access_token/new.html.heex:42
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:45
 #: lib/vutuv_web/templates/qualification/show.html.heex:38
@@ -4918,14 +4916,14 @@ msgid "API applications"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/api_app_live.ex:98
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:180
 #: lib/vutuv_web/views/settings_html.ex:90
 #: lib/vutuv_web/views/settings_html.ex:290
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:82
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Allow access"
 msgstr ""
@@ -4987,7 +4985,7 @@ msgstr ""
 msgid "Delete \"%{name}\"? Every member authorization and every token of this application stops working immediately."
 msgstr ""
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:91
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Deny"
 msgstr ""
@@ -5262,7 +5260,7 @@ msgstr ""
 msgid "vutuv POSTs signed JSON envelopes here (see the webhooks documentation). https:// only; http://localhost is allowed for development."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:211
+#: lib/vutuv_web/templates/page/index.html.heex:216
 #: lib/vutuv_web/templates/settings/privacy.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "Allow AI agents and LLMs to use your profile"
@@ -5278,14 +5276,14 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4844
+#: lib/vutuv_web/components/ui.ex:4952
 #: lib/vutuv_web/controllers/settings_controller.ex:157
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_delete_live.ex:109
-#: lib/vutuv_web/live/admin/user_delete_live.ex:221
+#: lib/vutuv_web/live/admin/user_delete_live.ex:209
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:136
 #: lib/vutuv_web/templates/settings/delete_account.html.heex:9
 #: lib/vutuv_web/templates/settings/delete_account.html.heex:11
@@ -5293,7 +5291,7 @@ msgstr ""
 msgid "Delete account"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/delete_account.html.heex:53
+#: lib/vutuv_web/templates/settings/delete_account.html.heex:54
 #, elixir-autogen, elixir-format
 msgid "Start deleting your account? We will email you a PIN to confirm."
 msgstr ""
@@ -5314,7 +5312,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1264
+#: lib/vutuv_web/live/post_live/composer.ex:1239
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5324,7 +5322,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1294
+#: lib/vutuv_web/live/shell_live.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5346,7 +5344,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1351
+#: lib/vutuv_web/live/shell_live.ex:1347
 #: lib/vutuv_web/templates/layout/app.html.heex:183
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5357,15 +5355,15 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4941
-#: lib/vutuv_web/components/ui.ex:4946
-#: lib/vutuv_web/components/ui.ex:5025
-#: lib/vutuv_web/components/ui.ex:5089
+#: lib/vutuv_web/components/ui.ex:5049
+#: lib/vutuv_web/components/ui.ex:5054
+#: lib/vutuv_web/components/ui.ex:5133
+#: lib/vutuv_web/components/ui.ex:5197
 #: lib/vutuv_web/controllers/settings_controller.ex:64
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:276
-#: lib/vutuv_web/live/shell_live.ex:1331
+#: lib/vutuv_web/live/shell_live.ex:1327
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5419,8 +5417,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1103
-#: lib/vutuv_web/live/shell_live.ex:1397
+#: lib/vutuv_web/live/shell_live.ex:1099
+#: lib/vutuv_web/live/shell_live.ex:1388
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5430,9 +5428,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3672
-#: lib/vutuv_web/components/post_components.ex:3727
-#: lib/vutuv_web/components/post_components.ex:4135
+#: lib/vutuv_web/components/post_components.ex:3694
+#: lib/vutuv_web/components/post_components.ex:3749
+#: lib/vutuv_web/components/post_components.ex:4157
 #: lib/vutuv_web/live/notification_live/index.ex:784
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
@@ -5444,7 +5442,7 @@ msgstr ""
 msgid "Someone tried to register with your email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:139
+#: lib/vutuv_web/templates/page/index.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr ""
@@ -5458,7 +5456,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:1196
+#: lib/vutuv_web/views/user_html.ex:1202
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr ""
@@ -5468,17 +5466,17 @@ msgstr ""
 msgid "Type of Email"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:171
+#: lib/vutuv_web/templates/page/index.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "Type of email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:241
+#: lib/vutuv_web/templates/user/edit.html.heex:236
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4804
+#: lib/vutuv_web/components/ui.ex:4912
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5489,7 +5487,7 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:482
+#: lib/vutuv_web/live/organization_live/edit.ex:461
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr ""
@@ -5499,7 +5497,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4704
+#: lib/vutuv_web/components/ui.ex:4812
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5528,15 +5526,15 @@ msgstr ""
 msgid "Personal tokens for the vutuv API."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2222
+#: lib/vutuv_web/live/post_live/composer.ex:2161
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4778
+#: lib/vutuv_web/components/ui.ex:4886
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
-#: lib/vutuv_web/templates/page/index.html.heex:191
+#: lib/vutuv_web/templates/page/index.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
@@ -5556,7 +5554,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:166
+#: lib/vutuv_web/templates/user/edit.html.heex:161
 #, elixir-autogen, elixir-format
 msgid "Your name"
 msgstr ""
@@ -5614,18 +5612,18 @@ msgstr ""
 msgid "Current avatar"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:112
-#: lib/vutuv_web/templates/user/edit.html.heex:119
+#: lib/vutuv_web/templates/user/edit.html.heex:107
+#: lib/vutuv_web/templates/user/edit.html.heex:114
 #, elixir-autogen, elixir-format
 msgid "Current cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:190
+#: lib/vutuv_web/templates/user/edit.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "e.g. Dr. or Prof."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:195
+#: lib/vutuv_web/templates/user/edit.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "e.g. Jr. or PhD"
 msgstr ""
@@ -5647,7 +5645,7 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4837
+#: lib/vutuv_web/components/ui.ex:4945
 #: lib/vutuv_web/controllers/settings_controller.ex:181
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5732,7 +5730,7 @@ msgstr ""
 msgid "@handle"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:776
+#: lib/vutuv_web/live/message_live/index.ex:766
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}"
 msgstr ""
@@ -5798,7 +5796,7 @@ msgid "Name (A-Z)"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:491
-#: lib/vutuv_web/live/tag_live/timeline.ex:413
+#: lib/vutuv_web/live/tag_live/timeline.ex:409
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr ""
@@ -5824,7 +5822,7 @@ msgid "Nothing here yet. People you like show up here."
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:492
-#: lib/vutuv_web/live/tag_live/timeline.ex:414
+#: lib/vutuv_web/live/tag_live/timeline.ex:410
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr ""
@@ -5846,27 +5844,27 @@ msgid "Search saved items"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:554
-#: lib/vutuv_web/live/tag_live/timeline.ex:339
+#: lib/vutuv_web/live/tag_live/timeline.ex:335
 #, elixir-autogen, elixir-format
 msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3305
+#: lib/vutuv_web/components/ui.ex:3407
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3304
+#: lib/vutuv_web/components/ui.ex:3406
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3303
+#: lib/vutuv_web/components/ui.ex:3405
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -5893,12 +5891,12 @@ msgstr ""
 msgid "Log out all other devices"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:85
+#: lib/vutuv_web/templates/settings/security.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Log out of every device except this one?"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:296
+#: lib/vutuv_web/views/settings_html.ex:297
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr ""
@@ -5933,7 +5931,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3302
+#: lib/vutuv_web/components/ui.ex:3404
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -5959,12 +5957,12 @@ msgstr ""
 msgid "When off, no one sees the green dot on your avatar, and you never show as online."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:145
+#: lib/vutuv_web/templates/settings/security.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Add a passkey"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1109
 #: lib/vutuv_web/live/admin/screenshot_live.ex:309
 #: lib/vutuv_web/live/fediverse_following_live.ex:264
 #: lib/vutuv_web/views/settings_html.ex:331
@@ -6007,7 +6005,7 @@ msgstr ""
 msgid "Passkeys"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:342
+#: lib/vutuv_web/views/settings_html.ex:343
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr ""
@@ -6022,7 +6020,7 @@ msgstr ""
 msgid "Sign in with a passkey"
 msgstr ""
 
-#: lib/vutuv_web/templates/session/new.html.heex:19
+#: lib/vutuv_web/templates/session/new.html.heex:20
 #, elixir-autogen, elixir-format
 msgid "Sign-in failed. Please try again or use your email."
 msgstr ""
@@ -6038,7 +6036,7 @@ msgstr ""
 msgid "That passkey could not be verified."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:156
+#: lib/vutuv_web/templates/settings/security.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "This browser does not support passkeys."
 msgstr ""
@@ -6069,13 +6067,13 @@ msgid "Add a tagline"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:148
-#: lib/vutuv_web/templates/user/edit.html.heex:250
+#: lib/vutuv_web/templates/user/edit.html.heex:245
 #: lib/vutuv_web/views/account_event_text.ex:212
 #, elixir-autogen, elixir-format
 msgid "Tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:396
+#: lib/vutuv_web/components/ui.ex:457
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:907
@@ -6094,18 +6092,18 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:63
-#: lib/vutuv_web/templates/user/edit.html.heex:149
+#: lib/vutuv_web/templates/user/edit.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1527
+#: lib/vutuv_web/templates/user/show.html.heex:1526
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:51
-#: lib/vutuv_web/templates/user/edit.html.heex:136
+#: lib/vutuv_web/templates/user/edit.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Drag to move, use the slider to zoom. The framed area is what others see."
 msgstr ""
@@ -6115,12 +6113,12 @@ msgstr ""
 msgid "New avatar preview"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:154
+#: lib/vutuv_web/templates/user/edit.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "New cover photo preview"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:135
+#: lib/vutuv_web/templates/user/edit.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Position your cover photo"
 msgstr ""
@@ -6131,14 +6129,14 @@ msgid "Position your photo"
 msgstr ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:52
-#: lib/vutuv_web/templates/user/edit.html.heex:137
+#: lib/vutuv_web/templates/user/edit.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Use photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1699
+#: lib/vutuv_web/live/post_live/composer.ex:1675
 #: lib/vutuv_web/templates/user/edit.html.heex:54
-#: lib/vutuv_web/templates/user/edit.html.heex:139
+#: lib/vutuv_web/templates/user/edit.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr ""
@@ -6225,7 +6223,7 @@ msgid "Previous day"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1144
-#: lib/vutuv_web/components/post_components.ex:407
+#: lib/vutuv_web/components/post_components.ex:408
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6260,9 +6258,9 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2025
-#: lib/vutuv_web/components/ui.ex:2034
-#: lib/vutuv_web/components/ui.ex:2513
+#: lib/vutuv_web/components/ui.ex:2049
+#: lib/vutuv_web/components/ui.ex:2058
+#: lib/vutuv_web/components/ui.ex:2537
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6289,9 +6287,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1513
-#: lib/vutuv_web/templates/user/show.html.heex:1521
-#: lib/vutuv_web/templates/user/show.html.heex:1533
+#: lib/vutuv_web/templates/user/show.html.heex:1516
+#: lib/vutuv_web/templates/user/show.html.heex:1520
+#: lib/vutuv_web/templates/user/show.html.heex:1532
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6323,7 +6321,7 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2466
+#: lib/vutuv_web/components/ui.ex:2490
 #: lib/vutuv_web/live/notification_live/index.ex:684
 #: lib/vutuv_web/live/notification_live/index.ex:699
 #: lib/vutuv_web/live/notification_live/index.ex:1012
@@ -6618,10 +6616,10 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2628
-#: lib/vutuv_web/components/post_components.ex:3603
-#: lib/vutuv_web/components/ui.ex:2813
-#: lib/vutuv_web/live/fediverse_account_live.ex:375
+#: lib/vutuv_web/components/post_components.ex:2650
+#: lib/vutuv_web/components/post_components.ex:3625
+#: lib/vutuv_web/components/ui.ex:2915
+#: lib/vutuv_web/live/fediverse_account_live.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:215
@@ -6647,13 +6645,13 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3603
-#: lib/vutuv_web/components/ui.ex:2812
-#: lib/vutuv_web/live/fediverse_account_live.ex:373
+#: lib/vutuv_web/components/post_components.ex:3625
+#: lib/vutuv_web/components/ui.ex:2914
+#: lib/vutuv_web/live/fediverse_account_live.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:215
-#: lib/vutuv_web/templates/settings/filters.html.heex:110
+#: lib/vutuv_web/templates/settings/filters.html.heex:111
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
 msgid "Unmute"
@@ -6675,12 +6673,12 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1195
+#: lib/vutuv_web/views/user_html.ex:1201
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:748
+#: lib/vutuv_web/views/user_html.ex:754
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr ""
@@ -6700,7 +6698,7 @@ msgstr ""
 msgid "All statuses"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:779
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "Any country"
 msgstr ""
@@ -6720,15 +6718,15 @@ msgstr ""
 msgid "Audience deleted."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:709
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:704
 #, elixir-autogen, elixir-format
 msgid "Audience name"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:574
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:638
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:637
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:688
 #: lib/vutuv_web/templates/admin/newsletter/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Audiences"
@@ -6750,7 +6748,7 @@ msgstr ""
 msgid "Build a fixed group from filters, then send a newsletter to it. Subtract another group to do a test run, then send to the rest."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:855
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:850
 #, elixir-autogen, elixir-format
 msgid "Cap group size (optional)"
 msgstr ""
@@ -6771,7 +6769,7 @@ msgid "Created"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:619
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:659
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:655
 #, elixir-autogen, elixir-format
 msgid "Delete this audience?"
 msgstr ""
@@ -6840,7 +6838,7 @@ msgid "Filter"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:591
-#: lib/vutuv_web/live/tag_live/timeline.ex:305
+#: lib/vutuv_web/live/tag_live/timeline.ex:301
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr ""
@@ -6867,14 +6865,14 @@ msgstr ""
 msgid "Markdown is supported (headings, bold, lists, links)."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:801
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:796
 #, elixir-autogen, elixir-format
 msgid "Maximum age"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:592
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:670
-#: lib/vutuv_web/live/admin/user_detail_live.ex:69
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:665
+#: lib/vutuv_web/live/admin/user_detail_live.ex:64
 #: lib/vutuv_web/live/admin/user_live.ex:28
 #: lib/vutuv_web/live/admin/user_live.ex:164
 #: lib/vutuv_web/live/admin/user_live.ex:165
@@ -6887,12 +6885,12 @@ msgstr ""
 msgid "Members"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:941
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:936
 #, elixir-autogen, elixir-format
 msgid "Members matching"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:786
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "Minimum age"
 msgstr ""
@@ -6933,8 +6931,8 @@ msgstr ""
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:19
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:128
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:638
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:637
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:688
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/index.html.heex:2
@@ -6961,7 +6959,7 @@ msgstr ""
 msgid "No newsletters yet."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:831
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:826
 #, elixir-autogen, elixir-format
 msgid "No tag with that name."
 msgstr ""
@@ -6976,7 +6974,7 @@ msgstr ""
 msgid "Occasional vutuv news and announcements."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:880
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:875
 #, elixir-autogen, elixir-format
 msgid "Off: take the oldest members first (by join date)."
 msgstr ""
@@ -6986,7 +6984,7 @@ msgstr ""
 msgid "Open newsletters"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:878
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:873
 #, elixir-autogen, elixir-format
 msgid "Pick capped members at random"
 msgstr ""
@@ -7017,19 +7015,19 @@ msgstr ""
 msgid "Rendered with your own account data for the variables."
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:241
+#: lib/vutuv_web/live/cv_live.ex:231
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:281
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Reset"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1128
 #, elixir-autogen, elixir-format
 msgid "Save audience"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:809
+#: lib/vutuv_web/live/job_posting_live/form.ex:804
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:16
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:11
 #, elixir-autogen, elixir-format
@@ -7089,7 +7087,7 @@ msgstr ""
 msgid "Subject line (variables allowed)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:915
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:910
 #, elixir-autogen, elixir-format
 msgid "Subtract these audiences"
 msgstr ""
@@ -7104,7 +7102,7 @@ msgstr ""
 msgid "Suppressed (bounced address)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:816
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:811
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:44
 #: lib/vutuv_web/templates/settings/filters.html.heex:29
 #: lib/vutuv_web/views/settings_html.ex:60
@@ -7112,7 +7110,7 @@ msgstr ""
 msgid "Tag"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:828
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:823
 #, elixir-autogen, elixir-format
 msgid "Tag found: %{name}"
 msgstr ""
@@ -7138,12 +7136,12 @@ msgstr ""
 msgid "That audience could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:918
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:913
 #, elixir-autogen, elixir-format
 msgid "Their members are removed from this one (e.g. exclude the test group to send to \"the rest\")."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:945
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:940
 #, elixir-autogen, elixir-format
 msgid "This audience will be capped to"
 msgstr ""
@@ -7169,7 +7167,7 @@ msgstr ""
 msgid "all members"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:863
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:858
 #, elixir-autogen, elixir-format
 msgid "e.g. 100 for a test run"
 msgstr ""
@@ -7179,7 +7177,7 @@ msgstr ""
 msgid "email or @handle"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:823
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:818
 #, elixir-autogen, elixir-format
 msgid "exact tag name"
 msgstr ""
@@ -7198,7 +7196,7 @@ msgid "open the dev email inbox"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
-#: lib/vutuv_web/views/user_html.ex:747
+#: lib/vutuv_web/views/user_html.ex:753
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr ""
@@ -7213,49 +7211,49 @@ msgstr ""
 msgid "max %{count}"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:674
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "The frozen snapshot saved with this audience. Click a name to open the profile."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:677
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "This audience has no members."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:844
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:839
 #, elixir-autogen, elixir-format
 msgid "e.g. stefan* or *meyer"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:849
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:844
 #, elixir-autogen, elixir-format
 msgid "Use * as a wildcard; a plain text matches anywhere in the handle."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:890
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:885
 #, elixir-autogen, elixir-format
 msgid "Add these audiences"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:893
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:888
 #, elixir-autogen, elixir-format
 msgid "Their members are added to this one (union)."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1168
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1158
 #, elixir-autogen, elixir-format
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3708
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
+#: lib/vutuv_web/components/ui.ex:3816
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3724
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
+#: lib/vutuv_web/components/ui.ex:3828
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
@@ -7267,47 +7265,47 @@ msgid_plural "plus %{count} groups"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:956
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:951
 #, elixir-autogen, elixir-format
 msgid "Choose specific accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:959
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:954
 #, elixir-autogen, elixir-format
 msgid "Tick to include an account, untick to exclude it. Search by @handle to find anyone."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:966
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1065
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:961
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1060
 #, elixir-autogen, elixir-format
 msgid "search by @handle…"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:973
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:968
 #, elixir-autogen, elixir-format
 msgid "Removed:"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:979
-#: lib/vutuv_web/live/post_live/composer.ex:1547
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:974
+#: lib/vutuv_web/live/post_live/composer.ex:1523
 #: lib/vutuv_web/live/post_live/filter_band.ex:532
 #, elixir-autogen, elixir-format
 msgid "Undo"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1025
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1020
 #, elixir-autogen, elixir-format
 msgid "In this audience"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1005
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1098
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1000
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1093
 #, elixir-autogen, elixir-format
 msgid "Search results"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1011
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1100
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1006
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1095
 #, elixir-autogen, elixir-format
 msgid "No members."
 msgstr ""
@@ -7317,27 +7315,27 @@ msgstr ""
 msgid "accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:991
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:986
 #: lib/vutuv_web/live/post_live/filter_band.ex:509
 #: lib/vutuv_web/views/import_html.ex:230
 #, elixir-autogen, elixir-format
 msgid "Select all"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:994
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:989
 #: lib/vutuv_web/views/import_html.ex:240
 #, elixir-autogen, elixir-format
 msgid "Unselect all"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:997
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:992
 #, elixir-autogen, elixir-format
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5681
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
+#: lib/vutuv_web/components/post_components.ex:5703
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
 msgstr ""
@@ -7438,7 +7436,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3424
+#: lib/vutuv_web/live/post_live/feed.ex:3421
 #, elixir-autogen
 msgid "Done"
 msgstr ""
@@ -7451,7 +7449,7 @@ msgstr ""
 msgid "View the delivery log"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:232
+#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:226
 #, elixir-autogen
 msgid "%{sent} of %{total} emails sent"
 msgstr ""
@@ -7459,7 +7457,7 @@ msgstr ""
 msgid "The newsletter will be sent to %{count} people. This cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:218
+#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:212
 #, elixir-autogen
 msgid "Send now"
 msgstr ""
@@ -7737,57 +7735,57 @@ msgstr ""
 msgid "updates automatically"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:723
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:718
 #, elixir-autogen, elixir-format
 msgid "How to build this audience"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:736
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:731
 #, elixir-autogen, elixir-format
 msgid "From filters"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:745
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:740
 #, elixir-autogen, elixir-format
 msgid "Specific accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:749
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:744
 #, elixir-autogen, elixir-format
 msgid "Pick members from filters, or hand-pick specific accounts (e.g. a small group of testers)."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1045
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1040
 #, elixir-autogen, elixir-format
 msgid "Accounts in this audience"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1049
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1044
 #, elixir-autogen, elixir-format
 msgid "Only these accounts get the newsletter. Search for members below and add them one by one."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1058
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1053
 #, elixir-autogen, elixir-format
 msgid "Find accounts to add"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1073
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Chosen accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1076
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1071
 #, elixir-autogen, elixir-format
 msgid "No accounts yet. Search above to add some."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1087
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Remove from audience"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1123
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1118
 #, elixir-autogen, elixir-format
 msgid "Add to audience"
 msgstr ""
@@ -7897,8 +7895,8 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:189
 #: lib/vutuv_web/live/admin/activity_live.ex:231
 #: lib/vutuv_web/live/admin/user_live.ex:184
-#: lib/vutuv_web/live/job_board_live.ex:257
-#: lib/vutuv_web/live/tag_live/timeline.ex:369
+#: lib/vutuv_web/live/job_board_live.ex:256
+#: lib/vutuv_web/live/tag_live/timeline.ex:365
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr ""
@@ -7914,7 +7912,7 @@ msgstr ""
 msgid "Deactivated"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_delete_live.ex:195
+#: lib/vutuv_web/live/admin/user_delete_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Delete this account?"
 msgstr ""
@@ -7959,7 +7957,7 @@ msgid "Incorrect PIN"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_delete_live.ex:145
-#: lib/vutuv_web/live/admin/user_detail_live.ex:102
+#: lib/vutuv_web/live/admin/user_detail_live.ex:97
 #: lib/vutuv_web/live/admin/user_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Joined"
@@ -7971,7 +7969,7 @@ msgid "Mark this member's identity as verified? They will be emailed."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_delete_live.ex:136
-#: lib/vutuv_web/templates/admin/account/index.html.heex:48
+#: lib/vutuv_web/templates/admin/account/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "No accounts match your search."
 msgstr ""
@@ -8002,7 +8000,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3711
+#: lib/vutuv_web/components/ui.ex:3819
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8022,7 +8020,7 @@ msgstr ""
 msgid "Search by name, @handle or email, filter and sort. The list updates as you type, and the default shows PIN-registered members, newest first."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_delete_live.ex:198
+#: lib/vutuv_web/live/admin/user_delete_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "This permanently deletes the account and everything it owns (posts, phone numbers, email addresses, tags and more). This cannot be undone. The member is not notified; a record is emailed to the operator."
 msgstr ""
@@ -8032,7 +8030,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find the account to delete."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_detail_live.ex:93
+#: lib/vutuv_web/live/admin/user_detail_live.ex:88
 #: lib/vutuv_web/live/admin/user_live.ex:322
 #, elixir-autogen, elixir-format
 msgid "Unconfirmed"
@@ -8132,7 +8130,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:4680
+#: lib/vutuv_web/components/ui.ex:4788
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8187,7 +8185,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4825
+#: lib/vutuv_web/components/ui.ex:4933
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8216,7 +8214,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4708
+#: lib/vutuv_web/components/ui.ex:4816
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8310,7 +8308,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3988
+#: lib/vutuv_web/components/ui.ex:4092
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8318,7 +8316,7 @@ msgstr ""
 msgid "Please check the fields marked in red."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1080
+#: lib/vutuv_web/views/user_html.ex:1086
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
 msgstr ""
@@ -8385,25 +8383,25 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4668
+#: lib/vutuv_web/components/ui.ex:4776
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4815
+#: lib/vutuv_web/components/ui.ex:4923
 #: lib/vutuv_web/controllers/settings_controller.ex:125
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Language & display"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:535
+#: lib/vutuv_web/templates/user/edit.html.heex:523
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4806
+#: lib/vutuv_web/components/ui.ex:4914
 #: lib/vutuv_web/controllers/settings_controller.ex:108
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8413,7 +8411,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4829
+#: lib/vutuv_web/components/ui.ex:4937
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8522,7 +8520,7 @@ msgstr[1] ""
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1322
+#: lib/vutuv_web/components/ui.ex:1346
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -8618,8 +8616,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:586
 #: lib/vutuv_web/agent_docs/text.ex:590
 #: lib/vutuv_web/components/organization_components.ex:276
-#: lib/vutuv_web/components/ui.ex:1523
-#: lib/vutuv_web/components/ui.ex:4796
+#: lib/vutuv_web/components/ui.ex:1547
+#: lib/vutuv_web/components/ui.ex:4904
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:357
 #: lib/vutuv_web/controllers/settings_controller.ex:424
@@ -8718,7 +8716,7 @@ msgstr ""
 msgid "Volunteering & hobbies"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:694
+#: lib/vutuv_web/live/search_live.ex:687
 #, elixir-autogen, elixir-format
 msgid "Not available while the search uses a people filter."
 msgstr ""
@@ -8769,12 +8767,12 @@ msgstr ""
 msgid "This is the print view of this CV. Use your browser's print dialog (Ctrl+P or Cmd+P) and choose \"Save as PDF\" to get a PDF file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1612
+#: lib/vutuv_web/components/ui.ex:1636
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4618
+#: lib/vutuv_web/components/post_components.ex:4640
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -8786,28 +8784,28 @@ msgstr[1] ""
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:233
+#: lib/vutuv_web/live/cv_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Anonymize"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:149
-#: lib/vutuv_web/templates/page/index.html.heex:161
+#: lib/vutuv_web/templates/page/index.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:440
+#: lib/vutuv_web/live/cv_live.ex:430
 #, elixir-autogen, elixir-format
 msgid "Every download reflects the parts you selected."
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:247
+#: lib/vutuv_web/live/cv_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1622
+#: lib/vutuv_web/components/ui.ex:1646
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -8824,7 +8822,7 @@ msgstr ""
 msgid "Pick what to include. Untick single entries or whole sections, or anonymize the CV by hiding the name, photo and contact details."
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:449
+#: lib/vutuv_web/live/cv_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "Print / Save as PDF"
 msgstr ""
@@ -8839,7 +8837,7 @@ msgstr ""
 msgid "The CV is public, on your profile: a visitor's download contains only what they can see there anyway, and private email addresses appear only in your own."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1614
+#: lib/vutuv_web/components/ui.ex:1638
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -8871,12 +8869,12 @@ msgstr ""
 msgid "Other activities"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:463
+#: lib/vutuv_web/live/cv_live.ex:453
 #, elixir-autogen, elixir-format
 msgid "For a PDF, open the print view and choose \"Save as PDF\" in your browser's print dialog. Word and OpenDocument are editable; LaTeX is the typesetting source; JSON Resume is the open %{link} format."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:263
+#: lib/vutuv_web/templates/user/edit.html.heex:258
 #, elixir-autogen, elixir-format
 msgid "characters"
 msgstr ""
@@ -8993,8 +8991,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2069
-#: lib/vutuv_web/components/ui.ex:2070
+#: lib/vutuv_web/components/ui.ex:2093
+#: lib/vutuv_web/components/ui.ex:2094
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9244,7 +9242,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:185
 #: lib/vutuv_web/cv/latex.ex:149
 #: lib/vutuv_web/cv/odt.ex:163
-#: lib/vutuv_web/live/cv_live.ex:386
+#: lib/vutuv_web/live/cv_live.ex:376
 #: lib/vutuv_web/templates/language/edit.html.heex:4
 #: lib/vutuv_web/templates/language/index.html.heex:10
 #: lib/vutuv_web/templates/language/manage.html.heex:4
@@ -9454,7 +9452,7 @@ msgstr ""
 msgid "Open to offers"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:287
+#: lib/vutuv_web/templates/user/edit.html.heex:282
 #, elixir-autogen, elixir-format
 msgid "Shown as a badge next to your tagline so people can see whether you are open to opportunities."
 msgstr ""
@@ -9563,7 +9561,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:4684
+#: lib/vutuv_web/components/ui.ex:4792
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -9571,7 +9569,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:169
 #: lib/vutuv_web/cv/latex.ex:140
 #: lib/vutuv_web/cv/odt.ex:154
-#: lib/vutuv_web/live/cv_live.ex:361
+#: lib/vutuv_web/live/cv_live.ex:351
 #: lib/vutuv_web/templates/import/new.html.heex:11
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
 #: lib/vutuv_web/templates/qualification/index.html.heex:11
@@ -9608,7 +9606,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:164
 #: lib/vutuv_web/live/admin/job_live.ex:180
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:183
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:182
 #: lib/vutuv_web/templates/qualification/show.html.heex:43
 #: lib/vutuv_web/views/qualification_html.ex:398
 #, elixir-autogen, elixir-format
@@ -9713,31 +9711,31 @@ msgstr ""
 msgid "Date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:440
-#: lib/vutuv_web/templates/user/edit.html.heex:523
+#: lib/vutuv_web/templates/user/edit.html.heex:436
+#: lib/vutuv_web/templates/user/edit.html.heex:511
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:503
+#: lib/vutuv_web/templates/user/edit.html.heex:499
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:506
+#: lib/vutuv_web/templates/user/edit.html.heex:502
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
 
 #: lib/vutuv_web/live/directory_search_live.ex:132
-#: lib/vutuv_web/templates/page/index.html.heex:90
+#: lib/vutuv_web/templates/page/index.html.heex:95
 #: lib/vutuv_web/views/account_event_text.ex:210
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
 #: lib/vutuv_web/live/directory_search_live.ex:133
-#: lib/vutuv_web/templates/page/index.html.heex:95
+#: lib/vutuv_web/templates/page/index.html.heex:100
 #: lib/vutuv_web/views/account_event_text.ex:211
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -9759,13 +9757,13 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3418
+#: lib/vutuv_web/components/ui.ex:3520
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3417
-#: lib/vutuv_web/components/ui.ex:3425
+#: lib/vutuv_web/components/ui.ex:3519
+#: lib/vutuv_web/components/ui.ex:3527
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -9883,12 +9881,12 @@ msgstr ""
 msgid "Removed as spam"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:357
+#: lib/vutuv_web/live/admin/user_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Restore"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:354
+#: lib/vutuv_web/live/admin/user_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "Restore this account so the member can sign in again?"
 msgstr ""
@@ -9903,7 +9901,7 @@ msgstr ""
 msgid "Thank you for your report. Our moderators have been notified and will review this account."
 msgstr ""
 
-#: lib/vutuv_web/views/admin/account_html.ex:88
+#: lib/vutuv_web/views/admin/account_html.ex:78
 #: lib/vutuv_web/views/admin/moderation_html.ex:69
 #, elixir-autogen, elixir-format
 msgid "deactivated"
@@ -9939,17 +9937,17 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:384
+#: lib/vutuv_web/components/ui.ex:445
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:436
+#: lib/vutuv_web/components/ui.ex:497
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:439
+#: lib/vutuv_web/components/ui.ex:500
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr ""
@@ -9959,18 +9957,18 @@ msgstr ""
 msgid "Delete the list"
 msgstr ""
 
-#: lib/vutuv_web/templates/login_code/index.html.heex:60
+#: lib/vutuv_web/templates/login_code/index.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "Delete your code list? All its codes stop working immediately."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:380
+#: lib/vutuv_web/components/ui.ex:441
 #, elixir-autogen, elixir-format
 msgid "Formatting"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:503
-#: lib/vutuv_web/components/ui.ex:504
+#: lib/vutuv_web/components/ui.ex:564
+#: lib/vutuv_web/components/ui.ex:565
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr ""
@@ -9985,43 +9983,43 @@ msgstr ""
 msgid "Generate code list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:434
+#: lib/vutuv_web/components/ui.ex:495
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:435
+#: lib/vutuv_web/components/ui.ex:496
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:393
+#: lib/vutuv_web/components/ui.ex:454
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:387
+#: lib/vutuv_web/components/ui.ex:448
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:540
+#: lib/vutuv_web/components/ui.ex:397
 #, elixir-autogen, elixir-format
 msgid "Link URL"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:166
+#: lib/vutuv_web/templates/settings/security.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Login codes"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:179
+#: lib/vutuv_web/templates/settings/security.html.heex:178
 #: lib/vutuv_web/templates/settings/security.html.heex:213
 #, elixir-autogen, elixir-format
 msgid "Not set up."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:437
+#: lib/vutuv_web/components/ui.ex:498
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr ""
@@ -10036,7 +10034,7 @@ msgstr ""
 msgid "Print this page or write the codes down. Crossed-out codes have been used."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:438
+#: lib/vutuv_web/components/ui.ex:499
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr ""
@@ -10057,7 +10055,7 @@ msgstr ""
 msgid "Set up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:390
+#: lib/vutuv_web/components/ui.ex:451
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr ""
@@ -10077,7 +10075,7 @@ msgstr ""
 msgid "Turn off"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:187
+#: lib/vutuv_web/templates/settings/security.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "Turn off the authenticator app? Its codes stop working at login; the emailed PIN is unaffected."
 msgstr ""
@@ -10087,7 +10085,7 @@ msgstr ""
 msgid "Turn on"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:179
+#: lib/vutuv_web/templates/settings/security.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "Turned on."
 msgstr ""
@@ -10123,7 +10121,7 @@ msgid "A one-time code (OTP) from your authenticator app or your code list also 
 msgstr ""
 
 #: lib/vutuv_web/controllers/totp_controller.ex:90
-#: lib/vutuv_web/templates/settings/security.html.heex:176
+#: lib/vutuv_web/templates/settings/security.html.heex:175
 #: lib/vutuv_web/templates/totp/new.html.heex:2
 #: lib/vutuv_web/templates/totp/new.html.heex:6
 #, elixir-autogen, elixir-format
@@ -10138,7 +10136,7 @@ msgstr ""
 msgid "One-time code list (OTP)"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:168
+#: lib/vutuv_web/templates/settings/security.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Sign in with a one-time code (OTP) from an authenticator app or from a printed code list, typed into the normal PIN field. Your emailed PIN always keeps working."
 msgstr ""
@@ -10165,15 +10163,15 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/organization_live/show.ex:638
-#: lib/vutuv_web/views/user_html.ex:944
-#: lib/vutuv_web/views/user_html.ex:1120
+#: lib/vutuv_web/views/user_html.ex:950
+#: lib/vutuv_web/views/user_html.ex:1126
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:937
+#: lib/vutuv_web/views/user_html.ex:943
 #, elixir-autogen, elixir-format
 msgid "%{formatted} star"
 msgid_plural "%{formatted} stars"
@@ -10198,7 +10196,7 @@ msgstr ""
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:951
+#: lib/vutuv_web/views/user_html.ex:957
 #, elixir-autogen, elixir-format
 msgid "Last active %{date}"
 msgstr ""
@@ -10223,7 +10221,7 @@ msgstr ""
 msgid "since %{date}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:867
+#: lib/vutuv_web/views/user_html.ex:873
 #, elixir-autogen, elixir-format
 msgid "since %{year}"
 msgstr ""
@@ -10403,7 +10401,7 @@ msgstr ""
 msgid "vutuv is the open business network where professionals connect, share, and get found. Free to join."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:150
+#: lib/vutuv_web/templates/page/index.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "At least three tags, separated by commas. A tag may be several words long, like Ruby on Rails."
 msgstr ""
@@ -10435,46 +10433,46 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:390
+#: lib/vutuv_web/templates/settings/preferences.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:321
+#: lib/vutuv_web/templates/settings/preferences.html.heex:310
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:397
+#: lib/vutuv_web/templates/settings/preferences.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:401
+#: lib/vutuv_web/templates/settings/preferences.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:387
+#: lib/vutuv_web/templates/settings/preferences.html.heex:376
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:344
+#: lib/vutuv_web/templates/settings/preferences.html.heex:333
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:353
+#: lib/vutuv_web/templates/settings/preferences.html.heex:342
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:339
+#: lib/vutuv_web/templates/settings/preferences.html.heex:328
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
@@ -10484,7 +10482,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:336
+#: lib/vutuv_web/templates/settings/preferences.html.heex:325
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr ""
@@ -10556,7 +10554,7 @@ msgstr ""
 msgid "Preference defaults"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_detail_live.ex:155
+#: lib/vutuv_web/live/admin/user_detail_live.ex:150
 #: lib/vutuv_web/live/admin/user_live.ex:336
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:10
 #, elixir-autogen, elixir-format
@@ -10572,9 +10570,9 @@ msgstr ""
 #: lib/vutuv_web/live/feed_languages_live.ex:377
 #: lib/vutuv_web/templates/settings/preferences.html.heex:101
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
-#: lib/vutuv_web/templates/settings/preferences.html.heex:239
-#: lib/vutuv_web/templates/settings/preferences.html.heex:303
-#: lib/vutuv_web/templates/settings/preferences.html.heex:421
+#: lib/vutuv_web/templates/settings/preferences.html.heex:229
+#: lib/vutuv_web/templates/settings/preferences.html.heex:292
+#: lib/vutuv_web/templates/settings/preferences.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr ""
@@ -10650,7 +10648,7 @@ msgstr ""
 msgid "Captured screenshots"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/screenshot_live.ex:525
+#: lib/vutuv_web/live/admin/screenshot_live.ex:524
 #, elixir-autogen, elixir-format
 msgid "Capturing"
 msgstr ""
@@ -10660,14 +10658,14 @@ msgstr ""
 msgid "Every captured link screenshot, newest first. Each links to the page and its post."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/screenshot_live.ex:527
+#: lib/vutuv_web/live/admin/screenshot_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
-#: lib/vutuv_web/live/post_live/composer.ex:1778
-#: lib/vutuv_web/live/post_live/composer.ex:2480
+#: lib/vutuv_web/live/post_live/composer.ex:1754
+#: lib/vutuv_web/live/post_live/composer.ex:2419
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr ""
@@ -10703,7 +10701,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/organization_live.ex:165
 #: lib/vutuv_web/live/admin/organization_live.ex:179
 #: lib/vutuv_web/live/admin/organization_live.ex:194
-#: lib/vutuv_web/live/admin/screenshot_live.ex:524
+#: lib/vutuv_web/live/admin/screenshot_live.ex:523
 #: lib/vutuv_web/live/organization_live/domains.ex:201
 #, elixir-autogen, elixir-format
 msgid "Pending"
@@ -10720,7 +10718,7 @@ msgstr ""
 msgid "Queued"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/screenshot_live.ex:526
+#: lib/vutuv_web/live/admin/screenshot_live.ex:525
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr ""
@@ -10762,7 +10760,7 @@ msgstr ""
 msgid "Views"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:296
+#: lib/vutuv_web/templates/user/edit.html.heex:291
 #, elixir-autogen, elixir-format
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
@@ -10781,48 +10779,48 @@ msgstr ""
 
 #: lib/vutuv/accounts/user.ex:1234
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
-#: lib/vutuv_web/live/job_posting_live/form.ex:773
+#: lib/vutuv_web/live/job_posting_live/form.ex:772
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:293
+#: lib/vutuv_web/templates/user/edit.html.heex:288
 #: lib/vutuv_web/templates/welcome/show.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Who can see your availability?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:318
+#: lib/vutuv_web/templates/user/edit.html.heex:313
 #: lib/vutuv_web/templates/welcome/show.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:669
-#: lib/vutuv_web/templates/user/edit.html.heex:326
+#: lib/vutuv_web/live/job_posting_live/form.ex:668
+#: lib/vutuv_web/templates/user/edit.html.heex:321
 #: lib/vutuv_web/templates/welcome/show.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:336
+#: lib/vutuv_web/templates/user/edit.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "Hidden by default, and it still does its job while hidden. \"Signed-in members only\" adds a quiet line to your profile for members; \"Everyone\" also shows it to logged-out visitors."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:309
+#: lib/vutuv_web/templates/user/edit.html.heex:304
 #: lib/vutuv_web/templates/welcome/show.html.heex:114
 #, elixir-autogen, elixir-format
 msgid "Minimum salary expectation"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:312
+#: lib/vutuv_web/templates/user/edit.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:676
-#: lib/vutuv_web/templates/user/edit.html.heex:322
+#: lib/vutuv_web/live/job_posting_live/form.ex:675
+#: lib/vutuv_web/templates/user/edit.html.heex:317
 #: lib/vutuv_web/templates/welcome/show.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Per"
@@ -10833,7 +10831,7 @@ msgstr ""
 msgid "Salary expectation from %{amount} %{currency} per %{period}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:333
+#: lib/vutuv_web/templates/user/edit.html.heex:328
 #, elixir-autogen, elixir-format
 msgid "Who can see your salary expectation?"
 msgstr ""
@@ -10883,7 +10881,7 @@ msgid "Email domain"
 msgstr ""
 
 #: lib/vutuv_web/components/job_exclusion_components.ex:110
-#: lib/vutuv_web/components/job_exclusion_components.ex:230
+#: lib/vutuv_web/components/job_exclusion_components.ex:225
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:144
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:169
 #, elixir-autogen, elixir-format
@@ -10902,7 +10900,7 @@ msgstr ""
 msgid "Exclude an email domain"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:389
+#: lib/vutuv_web/templates/user/edit.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr ""
@@ -10913,12 +10911,12 @@ msgstr ""
 msgid "Job-search exclusion list"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:392
+#: lib/vutuv_web/templates/user/edit.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:400
+#: lib/vutuv_web/templates/user/edit.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -10963,7 +10961,7 @@ msgstr ""
 msgid "Your list is empty. Nobody is excluded yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:363
+#: lib/vutuv_web/live/organization_live/edit.ex:358
 #: lib/vutuv_web/views/account_event_text.ex:232
 #, elixir-autogen, elixir-format
 msgid "AI agents"
@@ -10974,24 +10972,24 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:225
+#: lib/vutuv_web/live/organization_live/new.ex:221
 #, elixir-autogen, elixir-format
 msgid "Continue to verification"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:265
-#: lib/vutuv_web/live/organization_live/domains.ex:305
+#: lib/vutuv_web/live/organization_live/domains.ex:264
+#: lib/vutuv_web/live/organization_live/domains.ex:299
 #: lib/vutuv_web/live/organization_live/new.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:1038
+#: lib/vutuv_web/live/organization_live/show.ex:1033
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:184
-#: lib/vutuv_web/live/organization_live/domains.ex:346
-#: lib/vutuv_web/live/organization_live/show.ex:1104
-#: lib/vutuv_web/live/organization_live/show.ex:1112
+#: lib/vutuv_web/live/organization_live/domains.ex:339
+#: lib/vutuv_web/live/organization_live/show.ex:1098
+#: lib/vutuv_web/live/organization_live/show.ex:1106
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr ""
@@ -11002,7 +11000,7 @@ msgstr ""
 msgid "Edit %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:349
+#: lib/vutuv_web/live/organization_live/edit.ex:344
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this page and include it in the sitemap."
 msgstr ""
@@ -11012,7 +11010,7 @@ msgstr ""
 msgid "Logo"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:365
+#: lib/vutuv_web/live/organization_live/edit.ex:360
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
@@ -11023,22 +11021,22 @@ msgstr ""
 msgid "Please log in first."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:1011
+#: lib/vutuv_web/live/organization_live/show.ex:1006
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:283
+#: lib/vutuv_web/live/organization_live/edit.ex:278
 #, elixir-autogen, elixir-format
 msgid "Remove logo"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:83
+#: lib/vutuv_web/live/organization_live/index.ex:81
 #, elixir-autogen, elixir-format
 msgid "Search by name or city"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:347
+#: lib/vutuv_web/live/organization_live/edit.ex:342
 #: lib/vutuv_web/views/account_event_text.ex:231
 #, elixir-autogen, elixir-format
 msgid "Search engines"
@@ -11049,35 +11047,35 @@ msgstr ""
 msgid "Select a country"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:1073
+#: lib/vutuv_web/live/organization_live/domains.ex:318
+#: lib/vutuv_web/live/organization_live/show.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:328
+#: lib/vutuv_web/live/organization_live/edit.ex:323
 #: lib/vutuv_web/live/organization_live/new.ex:139
 #, elixir-autogen, elixir-format
 msgid "State / region (optional)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4042
+#: lib/vutuv_web/components/ui.ex:4146
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4044
+#: lib/vutuv_web/components/ui.ex:4148
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:1026
+#: lib/vutuv_web/live/organization_live/show.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:937
+#: lib/vutuv_web/live/organization_live/show.ex:932
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr ""
@@ -11088,33 +11086,33 @@ msgstr ""
 msgid "Verified via"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:997
+#: lib/vutuv_web/live/organization_live/show.ex:992
 #, elixir-autogen, elixir-format
 msgid "Verified via %{domain}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:1008
+#: lib/vutuv_web/live/organization_live/show.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:340
-#: lib/vutuv_web/live/organization_live/show.ex:1098
+#: lib/vutuv_web/live/organization_live/domains.ex:333
+#: lib/vutuv_web/live/organization_live/show.ex:1092
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:262
 #: lib/vutuv_web/agent_docs/text.ex:245
-#: lib/vutuv_web/live/organization_live/edit.ex:322
+#: lib/vutuv_web/live/organization_live/edit.ex:317
 #: lib/vutuv_web/live/organization_live/new.ex:130
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:266
-#: lib/vutuv_web/live/organization_live/domains.ex:315
-#: lib/vutuv_web/live/organization_live/show.ex:1049
+#: lib/vutuv_web/live/organization_live/domains.ex:265
+#: lib/vutuv_web/live/organization_live/domains.ex:309
+#: lib/vutuv_web/live/organization_live/show.ex:1044
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11130,8 +11128,8 @@ msgstr ""
 msgid "You will publish a record or file to prove control of the domain on the next step."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:326
-#: lib/vutuv_web/live/organization_live/show.ex:1079
+#: lib/vutuv_web/live/organization_live/domains.ex:320
+#: lib/vutuv_web/live/organization_live/show.ex:1074
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11143,12 +11141,12 @@ msgid "@handle or email"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:333
-#: lib/vutuv_web/live/organization_live/edit.ex:425
+#: lib/vutuv_web/live/organization_live/edit.ex:412
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:253
+#: lib/vutuv_web/live/organization_live/domains.ex:252
 #, elixir-autogen, elixir-format
 msgid "Add a domain"
 msgstr ""
@@ -11164,7 +11162,7 @@ msgid "Added @%{handle} to the team."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:334
-#: lib/vutuv_web/live/organization_live/edit.ex:423
+#: lib/vutuv_web/live/organization_live/edit.ex:410
 #, elixir-autogen, elixir-format
 msgid "Alias"
 msgstr ""
@@ -11181,24 +11179,24 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:436
 #: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/live/organization_live/edit.ex:388
-#: lib/vutuv_web/live/organization_live/show.ex:925
+#: lib/vutuv_web/live/organization_live/edit.ex:375
+#: lib/vutuv_web/live/organization_live/show.ex:920
 #: lib/vutuv_web/templates/tag/single_card.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Also known as"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:419
+#: lib/vutuv_web/live/organization_live/edit.ex:406
 #, elixir-autogen, elixir-format
 msgid "Alternative name"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:389
+#: lib/vutuv_web/live/admin/organization_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Archive"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:386
+#: lib/vutuv_web/live/admin/organization_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Archive this page?"
 msgstr ""
@@ -11210,7 +11208,7 @@ msgid "Archived"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:332
-#: lib/vutuv_web/live/organization_live/edit.ex:424
+#: lib/vutuv_web/live/organization_live/edit.ex:411
 #, elixir-autogen, elixir-format
 msgid "Brand"
 msgstr ""
@@ -11220,12 +11218,12 @@ msgstr ""
 msgid "Claimed by"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:220
+#: lib/vutuv_web/live/organization_live/roles.ex:215
 #, elixir-autogen, elixir-format
 msgid "Current team"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:395
+#: lib/vutuv_web/live/admin/organization_live.ex:397
 #, elixir-autogen, elixir-format
 msgid "Delete this page and everything it owns? This cannot be undone."
 msgstr ""
@@ -11263,14 +11261,14 @@ msgstr ""
 msgid "Former name"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:461
-#: lib/vutuv_web/live/admin/organization_live.ex:370
-#: lib/vutuv_web/views/admin/account_html.ex:45
+#: lib/vutuv_web/live/admin/job_live.ex:460
+#: lib/vutuv_web/live/admin/organization_live.ex:373
+#: lib/vutuv_web/views/admin/account_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Freeze"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:367
+#: lib/vutuv_web/live/admin/organization_live.ex:371
 #, elixir-autogen, elixir-format
 msgid "Freeze this page? It disappears for the public but stays visible to its owner."
 msgstr ""
@@ -11281,7 +11279,7 @@ msgstr ""
 msgid "Last checked"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:247
+#: lib/vutuv_web/live/organization_live/roles.ex:242
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr ""
@@ -11296,7 +11294,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:237
+#: lib/vutuv_web/live/organization_live/domains.ex:236
 #, elixir-autogen, elixir-format
 msgid "Make primary"
 msgstr ""
@@ -11346,12 +11344,12 @@ msgstr ""
 msgid "Remove this domain?"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:242
+#: lib/vutuv_web/live/organization_live/roles.ex:238
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the team?"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:405
+#: lib/vutuv_web/live/organization_live/edit.ex:393
 #, elixir-autogen, elixir-format
 msgid "Remove this name?"
 msgstr ""
@@ -11384,9 +11382,9 @@ msgstr ""
 msgid "That member could not be added."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:470
-#: lib/vutuv_web/live/admin/organization_live.ex:379
-#: lib/vutuv_web/views/admin/account_html.ex:31
+#: lib/vutuv_web/live/admin/job_live.ex:468
+#: lib/vutuv_web/live/admin/organization_live.ex:381
+#: lib/vutuv_web/views/admin/account_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "Unfreeze"
 msgstr ""
@@ -11408,24 +11406,24 @@ msgstr ""
 msgid "verified"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:325
+#: lib/vutuv_web/live/organization_live/edit.ex:320
 #: lib/vutuv_web/live/organization_live/new.ex:136
 #, elixir-autogen, elixir-format
 msgid "Street address (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:326
+#: lib/vutuv_web/live/organization_live/edit.ex:321
 #: lib/vutuv_web/live/organization_live/new.ex:137
 #, elixir-autogen, elixir-format
 msgid "ZIP / postal code (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:482
+#: lib/vutuv_web/live/organization_live/edit.ex:461
 #, elixir-autogen, elixir-format
 msgid "Claim"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:451
+#: lib/vutuv_web/live/organization_live/edit.ex:433
 #, elixir-autogen, elixir-format
 msgid "Reachable at"
 msgstr ""
@@ -11435,12 +11433,12 @@ msgstr ""
 msgid "That handle is not available."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:488
+#: lib/vutuv_web/live/organization_live/edit.ex:467
 #, elixir-autogen, elixir-format
 msgid "Danger zone"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:499
+#: lib/vutuv_web/live/organization_live/edit.ex:479
 #, elixir-autogen, elixir-format
 msgid "Really delete %{name}? This cannot be undone."
 msgstr ""
@@ -11461,7 +11459,7 @@ msgid "Back-link (rel=me)"
 msgstr ""
 
 #: lib/vutuv_web/templates/url/verify.html.heex:25
-#: lib/vutuv_web/views/url_html.ex:71
+#: lib/vutuv_web/views/url_html.ex:65
 #, elixir-autogen, elixir-format
 msgid "Link verification is disabled on this installation."
 msgstr ""
@@ -11486,7 +11484,7 @@ msgstr ""
 msgid "The link text can be anything. A hidden <link rel=\"me\"> in the page head works too."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1038
+#: lib/vutuv_web/components/ui.ex:1062
 #: lib/vutuv_web/live/section_reorder_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -11582,7 +11580,7 @@ msgid_plural "%{count} aliases match another verified organization and are flagg
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:390
+#: lib/vutuv_web/live/organization_live/edit.ex:377
 #, elixir-autogen, elixir-format
 msgid "Alternative names, brands or abbreviations this organization is findable under. A rename keeps the old name here automatically."
 msgstr ""
@@ -11612,11 +11610,11 @@ msgstr ""
 msgid "Any signed-in member whose confirmed email is at this domain, or a subdomain of it, is excluded. This is the reliable way to hide from your whole organization."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:70
-#: lib/vutuv_web/live/organization_live/index.ex:101
+#: lib/vutuv_web/live/organization_live/index.ex:68
+#: lib/vutuv_web/live/organization_live/index.ex:99
 #: lib/vutuv_web/live/organization_live/new.ex:28
 #: lib/vutuv_web/live/organization_live/new.ex:95
-#: lib/vutuv_web/templates/settings/organizations.html.heex:118
+#: lib/vutuv_web/templates/settings/organizations.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Add your organization"
 msgstr ""
@@ -11641,28 +11639,28 @@ msgstr ""
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:1020
+#: lib/vutuv_web/live/organization_live/show.ex:1015
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:503
+#: lib/vutuv_web/live/organization_live/edit.ex:482
 #, elixir-autogen, elixir-format
 msgid "Delete this organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:490
+#: lib/vutuv_web/live/organization_live/edit.ex:469
 #, elixir-autogen, elixir-format
 msgid "Deleting this organization page is permanent. Its verified domains and its @handle are freed and can be claimed again."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:297
+#: lib/vutuv_web/live/organization_live/edit.ex:292
 #: lib/vutuv_web/live/organization_live/new.ex:126
 #, elixir-autogen, elixir-format
 msgid "Kind of organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:241
+#: lib/vutuv_web/live/organization_live/roles.ex:237
 #, elixir-autogen, elixir-format
 msgid "Leave this organization team?"
 msgstr ""
@@ -11677,12 +11675,12 @@ msgstr ""
 msgid "No organization pages match."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:92
+#: lib/vutuv_web/live/organization_live/index.ex:90
 #, elixir-autogen, elixir-format
 msgid "No organization pages yet. Be the first to add yours."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:94
+#: lib/vutuv_web/live/organization_live/index.ex:92
 #, elixir-autogen, elixir-format
 msgid "No organizations found for %{term}."
 msgstr ""
@@ -11722,7 +11720,7 @@ msgstr ""
 msgid "Organization frozen."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:296
+#: lib/vutuv_web/live/organization_live/edit.ex:291
 #: lib/vutuv_web/live/organization_live/new.ex:125
 #, elixir-autogen, elixir-format
 msgid "Organization name"
@@ -11754,12 +11752,12 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:427
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:400
-#: lib/vutuv_web/components/ui.ex:4833
+#: lib/vutuv_web/components/ui.ex:4941
 #: lib/vutuv_web/controllers/settings_controller.ex:213
-#: lib/vutuv_web/live/organization_live/index.ex:30
-#: lib/vutuv_web/live/organization_live/index.ex:61
+#: lib/vutuv_web/live/organization_live/index.ex:32
+#: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1322
+#: lib/vutuv_web/live/shell_live.ex:1318
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:79
@@ -11784,7 +11782,7 @@ msgstr ""
 msgid "Please log in to claim an organization page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:75
+#: lib/vutuv_web/live/organization_live/index.ex:73
 #, elixir-autogen, elixir-format
 msgid "Search organizations"
 msgstr ""
@@ -11871,7 +11869,7 @@ msgstr ""
 msgid "made you an owner of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:472
+#: lib/vutuv_web/live/organization_live/edit.ex:454
 #, elixir-autogen, elixir-format
 msgid "your_organization"
 msgstr ""
@@ -11912,7 +11910,7 @@ msgid "Public authority"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:371
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:138
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:136
 #, elixir-autogen, elixir-format
 msgid "%{views} views · %{clicks} apply clicks"
 msgstr ""
@@ -11922,22 +11920,22 @@ msgstr ""
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:653
+#: lib/vutuv_web/live/job_posting_live/form.ex:652
 #, elixir-autogen, elixir-format
 msgid "A pay range is required to publish (except volunteer postings)."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:750
+#: lib/vutuv_web/live/job_posting_live/form.ex:749
 #, elixir-autogen, elixir-format
 msgid "A vutuv message to me"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:748
+#: lib/vutuv_web/live/job_posting_live/form.ex:747
 #, elixir-autogen, elixir-format
 msgid "A website"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:749
+#: lib/vutuv_web/live/job_posting_live/form.ex:748
 #, elixir-autogen, elixir-format
 msgid "An e-mail address"
 msgstr ""
@@ -11947,12 +11945,12 @@ msgstr ""
 msgid "Applicants must be located in"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:754
+#: lib/vutuv_web/live/job_posting_live/form.ex:753
 #, elixir-autogen, elixir-format
 msgid "Application URL"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:760
+#: lib/vutuv_web/live/job_posting_live/form.ex:759
 #, elixir-autogen, elixir-format
 msgid "Application e-mail"
 msgstr ""
@@ -11962,17 +11960,17 @@ msgstr ""
 msgid "Application: %{title}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:746
+#: lib/vutuv_web/live/job_posting_live/form.ex:745
 #, elixir-autogen, elixir-format
 msgid "Applications go to"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:275
+#: lib/vutuv_web/live/job_posting_live/show.ex:270
 #, elixir-autogen, elixir-format
 msgid "Apply by e-mail"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:274
+#: lib/vutuv_web/live/job_posting_live/show.ex:269
 #, elixir-autogen, elixir-format
 msgid "Apply on website"
 msgstr ""
@@ -11984,7 +11982,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:163
 #: lib/vutuv_web/live/admin/job_live.ex:183
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:184
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:183
 #, elixir-autogen, elixir-format
 msgid "Closed"
 msgstr ""
@@ -11994,12 +11992,12 @@ msgstr ""
 msgid "Contract"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:693
+#: lib/vutuv_web/live/job_posting_live/form.ex:692
 #, elixir-autogen, elixir-format
 msgid "Describe the role. Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:182
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
 #, elixir-autogen, elixir-format
 msgid "Drafts"
 msgstr ""
@@ -12029,19 +12027,19 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:489
 #: lib/vutuv_web/agent_docs/text.ex:265
 #: lib/vutuv_web/agent_docs/text.ex:508
-#: lib/vutuv_web/live/job_board_live.ex:367
+#: lib/vutuv_web/live/job_board_live.ex:363
 #: lib/vutuv_web/live/job_posting_live/form.ex:474
 #, elixir-autogen, elixir-format
 msgid "Employment type"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:772
+#: lib/vutuv_web/live/job_posting_live/form.ex:771
 #, elixir-autogen, elixir-format
 msgid "Everyone (public)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:657
-#: lib/vutuv_web/live/tag_live/timeline.ex:350
+#: lib/vutuv_web/live/job_posting_live/form.ex:656
+#: lib/vutuv_web/live/tag_live/timeline.ex:346
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
 #, elixir-autogen, elixir-format
@@ -12053,12 +12051,12 @@ msgstr ""
 msgid "Full-time"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:159
+#: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
 msgid "Highlighted tags match your profile."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:744
+#: lib/vutuv_web/live/job_posting_live/form.ex:743
 #, elixir-autogen, elixir-format
 msgid "How to apply"
 msgstr ""
@@ -12074,7 +12072,7 @@ msgstr ""
 msgid "I'm interested in your posting: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:692
+#: lib/vutuv_web/live/job_posting_live/form.ex:691
 #, elixir-autogen, elixir-format
 msgid "Job description"
 msgstr ""
@@ -12089,13 +12087,13 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1144
+#: lib/vutuv_web/live/shell_live.ex:1140
 #: lib/vutuv_web/templates/layout/app.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Jobs"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:782
+#: lib/vutuv_web/live/job_posting_live/form.ex:781
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this posting."
 msgstr ""
@@ -12116,12 +12114,12 @@ msgstr ""
 msgid "Mark as filled"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:157
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:158
 #, elixir-autogen, elixir-format
 msgid "Mark this posting as filled and close it?"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:276
+#: lib/vutuv_web/live/job_posting_live/show.ex:271
 #, elixir-autogen, elixir-format
 msgid "Message the poster"
 msgstr ""
@@ -12138,7 +12136,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:25
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:101
-#: lib/vutuv_web/live/job_posting_live/show.ex:181
+#: lib/vutuv_web/live/job_posting_live/show.ex:176
 #, elixir-autogen, elixir-format
 msgid "My postings"
 msgstr ""
@@ -12148,7 +12146,7 @@ msgstr ""
 msgid "New accounts can publish after a few days."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:103
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:102
 #: lib/vutuv_web/live/job_posting_live/form.ex:114
 #, elixir-autogen, elixir-format
 msgid "New posting"
@@ -12156,8 +12154,8 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:292
 #: lib/vutuv_web/agent_docs/text.ex:275
-#: lib/vutuv_web/live/job_posting_live/form.ex:732
-#: lib/vutuv_web/live/job_posting_live/show.ex:154
+#: lib/vutuv_web/live/job_posting_live/form.ex:731
+#: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
 msgstr ""
@@ -12177,7 +12175,7 @@ msgstr ""
 msgid "Nothing here yet. Jobs you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:788
+#: lib/vutuv_web/live/job_posting_live/form.ex:787
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
@@ -12198,7 +12196,7 @@ msgstr ""
 msgid "Part-time"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:651
+#: lib/vutuv_web/live/job_posting_live/form.ex:650
 #, elixir-autogen, elixir-format
 msgid "Pay"
 msgstr ""
@@ -12243,7 +12241,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/text.ex:269
 #: lib/vutuv_web/agent_docs/text.ex:512
-#: lib/vutuv_web/live/job_posting_live/show.ex:133
+#: lib/vutuv_web/live/job_posting_live/show.ex:128
 #, elixir-autogen, elixir-format
 msgid "Posted"
 msgstr ""
@@ -12259,7 +12257,7 @@ msgstr ""
 msgid "Posting not found."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:805
+#: lib/vutuv_web/live/job_posting_live/form.ex:802
 #, elixir-autogen, elixir-format
 msgid "Publish"
 msgstr ""
@@ -12277,15 +12275,15 @@ msgstr ""
 msgid "Remote"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:169
+#: lib/vutuv_web/live/job_posting_live/show.ex:164
 #, elixir-autogen, elixir-format
 msgid "Report this posting"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:291
 #: lib/vutuv_web/agent_docs/text.ex:274
-#: lib/vutuv_web/live/job_posting_live/form.ex:722
-#: lib/vutuv_web/live/job_posting_live/show.ex:149
+#: lib/vutuv_web/live/job_posting_live/form.ex:721
+#: lib/vutuv_web/live/job_posting_live/show.ex:144
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
@@ -12324,7 +12322,7 @@ msgstr ""
 msgid "Street (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:719
+#: lib/vutuv_web/live/job_posting_live/form.ex:718
 #, elixir-autogen, elixir-format
 msgid "Tags match your posting to members. Separate them with commas; a tag may be several words long, like Ruby on Rails."
 msgstr ""
@@ -12360,7 +12358,7 @@ msgid "Tip: adding a gender marker like (m/w/d) helps your posting comply with t
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:112
-#: lib/vutuv_web/live/job_posting_live/show.ex:209
+#: lib/vutuv_web/live/job_posting_live/show.ex:204
 #, elixir-autogen, elixir-format
 msgid "Verified organization"
 msgstr ""
@@ -12376,7 +12374,7 @@ msgstr ""
 msgid "Volunteer"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:770
+#: lib/vutuv_web/live/job_posting_live/form.ex:769
 #: lib/vutuv_web/templates/email/form_content.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Who can see it"
@@ -12436,7 +12434,7 @@ msgstr ""
 msgid "Your organization page on vutuv is no longer public"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:176
+#: lib/vutuv_web/live/job_posting_live/show.ex:171
 #, elixir-autogen, elixir-format
 msgid "Your posting"
 msgstr ""
@@ -12452,7 +12450,7 @@ msgstr ""
 msgid "Yourself (personal posting)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:663
+#: lib/vutuv_web/live/job_posting_live/form.ex:662
 #, elixir-autogen, elixir-format
 msgid "up to"
 msgstr ""
@@ -12494,17 +12492,17 @@ msgid_plural "Your roles"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:113
+#: lib/vutuv_web/templates/settings/organizations.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Add an organization"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:115
+#: lib/vutuv_web/templates/settings/organizations.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Represent a company, association or other group? Add its page and verify the domain to become its owner."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:125
+#: lib/vutuv_web/templates/settings/organizations.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Browse all organizations"
 msgstr ""
@@ -12519,7 +12517,7 @@ msgstr ""
 msgid "Verification pending"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:63
+#: lib/vutuv_web/live/organization_live/index.ex:64
 #, elixir-autogen, elixir-format
 msgid "Verified pages for companies, associations, schools, public authorities and other groups, not for single people. Every page has a proven web domain, so you know it is really them."
 msgstr ""
@@ -12534,14 +12532,14 @@ msgstr ""
 msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT record cannot share a name with a CNAME. Use this name instead, with the exact same value as above:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:322
-#: lib/vutuv_web/live/organization_live/show.ex:1066
+#: lib/vutuv_web/live/organization_live/domains.ex:316
+#: lib/vutuv_web/live/organization_live/show.ex:1061
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:1057
+#: lib/vutuv_web/live/organization_live/domains.ex:314
+#: lib/vutuv_web/live/organization_live/show.ex:1052
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr ""
@@ -12580,12 +12578,12 @@ msgid_plural "%{count} weeks ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/job_board_live.ex:491
+#: lib/vutuv_web/live/job_board_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "%{km} km"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:361
+#: lib/vutuv_web/live/job_board_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "All countries"
 msgstr ""
@@ -12601,43 +12599,43 @@ msgstr ""
 msgid "All jobs with this tag: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:368
+#: lib/vutuv_web/live/job_board_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "Any employment type"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:350
+#: lib/vutuv_web/live/job_board_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "City or zip code"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:491
+#: lib/vutuv_web/live/job_board_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "Exact"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:249
+#: lib/vutuv_web/live/job_board_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "From my salary expectation"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:241
+#: lib/vutuv_web/live/job_board_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Matches my tags"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:461
+#: lib/vutuv_web/live/job_board_live.ex:452
 #, elixir-autogen, elixir-format
 msgid "Min. salary/year (%{currency})"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:410
+#: lib/vutuv_web/live/job_board_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "Minimum yearly salary"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:836
+#: lib/vutuv_web/live/job_board_live.ex:320
+#: lib/vutuv_web/live/organization_live/show.ex:831
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr ""
@@ -12652,12 +12650,12 @@ msgstr ""
 msgid "Next page: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:499
+#: lib/vutuv_web/live/job_board_live.ex:479
 #, elixir-autogen, elixir-format
 msgid "No job postings yet."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:497
+#: lib/vutuv_web/live/job_board_live.ex:477
 #, elixir-autogen, elixir-format
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
@@ -12678,22 +12676,22 @@ msgstr ""
 msgid "Open positions on vutuv, newest first."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:221
+#: lib/vutuv_web/live/job_board_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Post a job"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:306
+#: lib/vutuv_web/live/job_board_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Post the first one"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:354
+#: lib/vutuv_web/live/job_board_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "Radius"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:342
+#: lib/vutuv_web/live/job_board_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "Search jobs"
 msgstr ""
@@ -12722,13 +12720,13 @@ msgstr ""
 msgid "(no employer)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:477
+#: lib/vutuv_web/live/admin/job_live.ex:475
 #, elixir-autogen, elixir-format
 msgid "Close this posting? It ends the listing (a regular ending, not a deletion)."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:414
-#: lib/vutuv_web/live/admin/user_detail_live.ex:135
+#: lib/vutuv_web/live/admin/user_detail_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "Cold outreach"
 msgstr ""
@@ -12738,7 +12736,7 @@ msgstr ""
 msgid "Counters"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:486
+#: lib/vutuv_web/live/admin/job_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Delete this posting and everything it owns? This cannot be undone."
 msgstr ""
@@ -12771,14 +12769,14 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:30
 #: lib/vutuv_web/live/admin/job_live.ex:198
 #: lib/vutuv_web/live/admin/job_live.ex:199
-#: lib/vutuv_web/live/admin/user_detail_live.ex:163
+#: lib/vutuv_web/live/admin/user_detail_live.ex:158
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Job postings"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:402
-#: lib/vutuv_web/live/admin/user_detail_live.ex:117
+#: lib/vutuv_web/live/admin/user_detail_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Live postings"
 msgstr ""
@@ -12794,7 +12792,7 @@ msgid "Open case"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:410
-#: lib/vutuv_web/live/admin/user_detail_live.ex:129
+#: lib/vutuv_web/live/admin/user_detail_live.ex:124
 #, elixir-autogen, elixir-format
 msgid "Open job cases"
 msgstr ""
@@ -12861,7 +12859,7 @@ msgid "Title"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:406
-#: lib/vutuv_web/live/admin/user_detail_live.ex:123
+#: lib/vutuv_web/live/admin/user_detail_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "Total postings"
 msgstr ""
@@ -12903,7 +12901,7 @@ msgstr ""
 msgid "Daily email"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/saved_searches.html.heex:72
+#: lib/vutuv_web/templates/settings/saved_searches.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Delete this saved search?"
 msgstr ""
@@ -12935,7 +12933,7 @@ msgstr ""
 msgid "Manage your saved searches"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/saved_searches.html.heex:87
+#: lib/vutuv_web/templates/settings/saved_searches.html.heex:82
 #, elixir-autogen, elixir-format
 msgid "Newer"
 msgstr ""
@@ -12945,7 +12943,7 @@ msgstr ""
 msgid "No emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/saved_searches.html.heex:95
+#: lib/vutuv_web/templates/settings/saved_searches.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "Older"
 msgstr ""
@@ -12955,8 +12953,8 @@ msgstr ""
 msgid "Save a search on the job board or on the people search, then let vutuv e-mail you when a new match appears. Daily searches are checked every day; weekly ones once a week."
 msgstr ""
 
-#: lib/vutuv_web/components/saved_search_components.ex:107
-#: lib/vutuv_web/components/saved_search_components.ex:128
+#: lib/vutuv_web/components/saved_search_components.ex:103
+#: lib/vutuv_web/components/saved_search_components.ex:116
 #, elixir-autogen, elixir-format
 msgid "Save search"
 msgstr ""
@@ -12966,7 +12964,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4773
+#: lib/vutuv_web/components/ui.ex:4881
 #: lib/vutuv_web/controllers/settings_controller.ex:620
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -12985,7 +12983,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2996
+#: lib/vutuv_web/components/post_components.ex:3018
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:715
 #: lib/vutuv_web/controllers/settings_controller.ex:733
@@ -13114,7 +13112,7 @@ msgstr ""
 msgid "Hide from specific viewers"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:794
+#: lib/vutuv_web/live/job_posting_live/form.ex:793
 #, elixir-autogen, elixir-format
 msgid "Hide from specific viewers (competitors, your own staff, a person) →"
 msgstr ""
@@ -13135,7 +13133,7 @@ msgstr ""
 msgid "Job exclusions – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:797
+#: lib/vutuv_web/live/job_posting_live/form.ex:796
 #, elixir-autogen, elixir-format
 msgid "Keep this posting on the board for everyone except a chosen few."
 msgstr ""
@@ -13216,7 +13214,7 @@ msgstr ""
 msgid "This page has job postings, so it cannot be deleted. Ask an admin to archive it instead."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_detail_live.ex:114
+#: lib/vutuv_web/live/admin/user_detail_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Jobs footprint"
 msgstr ""
@@ -13232,7 +13230,7 @@ msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7
 msgstr ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:41
-#: lib/vutuv_web/templates/user/edit.html.heex:126
+#: lib/vutuv_web/templates/user/edit.html.heex:121
 #: lib/vutuv_web/templates/user/show.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "Image awaiting review, visible only to you"
@@ -13285,7 +13283,7 @@ msgstr ""
 msgid "Age only, without the date"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:451
+#: lib/vutuv_web/templates/user/edit.html.heex:447
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
@@ -13308,7 +13306,7 @@ msgstr ""
 msgid "Full date and age"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:448
+#: lib/vutuv_web/templates/user/edit.html.heex:444
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr ""
@@ -13342,44 +13340,44 @@ msgstr[1] ""
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:413
+#: lib/vutuv_web/components/ui.ex:474
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:410
+#: lib/vutuv_web/components/ui.ex:471
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:416
+#: lib/vutuv_web/components/ui.ex:477
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:407
+#: lib/vutuv_web/components/ui.ex:468
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:440
+#: lib/vutuv_web/components/ui.ex:501
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2871
+#: lib/vutuv_web/live/post_live/composer.ex:2810
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:235
 #: lib/vutuv_web/agent_docs/text.ex:218
-#: lib/vutuv_web/live/tag_live/timeline.ex:253
+#: lib/vutuv_web/live/tag_live/timeline.ex:249
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:711
+#: lib/vutuv_web/live/search_live.ex:704
 #, elixir-autogen, elixir-format
 msgid "Your search uses a people-only filter such as city: or status:, so it only finds people."
 msgstr ""
@@ -13399,22 +13397,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:447
+#: lib/vutuv_web/components/post_components.ex:448
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:449
+#: lib/vutuv_web/components/post_components.ex:450
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:448
+#: lib/vutuv_web/components/post_components.ex:449
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:406
+#: lib/vutuv_web/components/post_components.ex:407
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13424,7 +13422,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4756
+#: lib/vutuv_web/components/ui.ex:4864
 #: lib/vutuv_web/controllers/settings_controller.ex:634
 #: lib/vutuv_web/live/post_live/feed.ex:712
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13433,32 +13431,32 @@ msgstr ""
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:428
+#: lib/vutuv_web/live/job_board_live.ex:419
 #, elixir-autogen, elixir-format
 msgid "Looking for a role that goes by several titles? Separate them with a comma and we show postings that match any of them."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:424
+#: lib/vutuv_web/live/job_board_live.ex:415
 #, elixir-autogen, elixir-format
 msgid "Search tips"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:482
+#: lib/vutuv_web/live/job_board_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "any of these titles"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:484
+#: lib/vutuv_web/live/job_board_live.ex:464
 #, elixir-autogen, elixir-format
 msgid "exact wording"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:485
+#: lib/vutuv_web/live/job_board_live.ex:465
 #, elixir-autogen, elixir-format
 msgid "without internships"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:483
+#: lib/vutuv_web/live/job_board_live.ex:463
 #, elixir-autogen, elixir-format
 msgid "word start: also finds Entwickler, Entwicklung"
 msgstr ""
@@ -13499,7 +13497,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:63
-#: lib/vutuv_web/components/ui.ex:4727
+#: lib/vutuv_web/components/ui.ex:4835
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13527,14 +13525,14 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4127
+#: lib/vutuv_web/components/ui.ex:4231
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:4137
+#: lib/vutuv_web/components/ui.ex:4241
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
@@ -13584,50 +13582,50 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5289
+#: lib/vutuv_web/components/post_components.ex:5311
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1233
-#: lib/vutuv_web/components/post_components.ex:5246
+#: lib/vutuv_web/components/post_components.ex:5268
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5290
+#: lib/vutuv_web/components/post_components.ex:5312
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5292
+#: lib/vutuv_web/components/post_components.ex:5314
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5288
+#: lib/vutuv_web/components/post_components.ex:5310
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1233
-#: lib/vutuv_web/components/post_components.ex:5245
+#: lib/vutuv_web/components/post_components.ex:5267
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:443
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:250
+#: lib/vutuv_web/live/fediverse_account_live.ex:453
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5287
+#: lib/vutuv_web/components/post_components.ex:5309
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5291
+#: lib/vutuv_web/components/post_components.ex:5313
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13647,7 +13645,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5328
+#: lib/vutuv_web/components/post_components.ex:5350
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13655,27 +13653,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5358
+#: lib/vutuv_web/components/post_components.ex:5380
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5359
+#: lib/vutuv_web/components/post_components.ex:5381
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5357
+#: lib/vutuv_web/components/post_components.ex:5379
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5317
+#: lib/vutuv_web/components/post_components.ex:5339
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5364
+#: lib/vutuv_web/components/post_components.ex:5386
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13705,7 +13703,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5131
+#: lib/vutuv_web/components/post_components.ex:5153
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13753,17 +13751,17 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5122
+#: lib/vutuv_web/components/post_components.ex:5144
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2203
+#: lib/vutuv_web/components/ui.ex:2227
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2207
+#: lib/vutuv_web/components/ui.ex:2231
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -13854,7 +13852,7 @@ msgstr ""
 msgid "Remove file"
 msgstr ""
 
-#: lib/vutuv_web/templates/qualification/form_content.html.heex:106
+#: lib/vutuv_web/templates/qualification/form_content.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Remove the uploaded file? The entry itself stays."
 msgstr ""
@@ -13893,7 +13891,7 @@ msgid "proof document"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:375
+#: lib/vutuv_web/templates/settings/preferences.html.heex:364
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr ""
@@ -13903,12 +13901,12 @@ msgstr ""
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:366
+#: lib/vutuv_web/templates/settings/preferences.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:369
+#: lib/vutuv_web/templates/settings/preferences.html.heex:358
 #, elixir-autogen, elixir-format
 msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
@@ -13948,13 +13946,13 @@ msgstr ""
 msgid "Optional, and nobody else sees it. It filters postings below it out of your own job search."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:356
+#: lib/vutuv_web/templates/user/edit.html.heex:351
 #: lib/vutuv_web/templates/welcome/show.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:376
+#: lib/vutuv_web/templates/user/edit.html.heex:371
 #: lib/vutuv_web/templates/welcome/show.html.heex:162
 #, elixir-autogen, elixir-format
 msgid "Shown next to your availability, and used to match you with postings."
@@ -13976,7 +13974,7 @@ msgstr ""
 msgid "Preferred workplace"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:284
+#: lib/vutuv_web/templates/user/edit.html.heex:279
 #: lib/vutuv_web/templates/welcome/show.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Availability"
@@ -14030,13 +14028,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1251
+#: lib/vutuv_web/live/post_live/composer.ex:1226
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1254
+#: lib/vutuv_web/live/post_live/composer.ex:1229
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14125,14 +14123,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3269
+#: lib/vutuv_web/components/post_components.ex:3291
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3292
+#: lib/vutuv_web/components/post_components.ex:3314
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14154,47 +14152,47 @@ msgstr ""
 msgid "This profile is currently unavailable."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/account/index.html.heex:45
+#: lib/vutuv_web/templates/admin/account/index.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5780
+#: lib/vutuv_web/components/post_components.ex:5802
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
 
-#: lib/vutuv_web/views/admin/account_html.ex:93
+#: lib/vutuv_web/views/admin/account_html.ex:83
 #, elixir-autogen, elixir-format
 msgid "active"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/account_html.ex:109
+#: lib/vutuv_web/views/admin/account_html.ex:99
 #, elixir-autogen, elixir-format
 msgid "admin"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/account_html.ex:90
+#: lib/vutuv_web/views/admin/account_html.ex:80
 #, elixir-autogen, elixir-format
 msgid "frozen"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/account_html.ex:108
+#: lib/vutuv_web/views/admin/account_html.ex:98
 #, elixir-autogen, elixir-format
 msgid "report"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/account_html.ex:89
+#: lib/vutuv_web/views/admin/account_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "suspended"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/account_html.ex:92
+#: lib/vutuv_web/views/admin/account_html.ex:82
 #, elixir-autogen, elixir-format
 msgid "unconfirmed"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/account_html.ex:91
+#: lib/vutuv_web/views/admin/account_html.ex:81
 #, elixir-autogen, elixir-format
 msgid "unreachable"
 msgstr ""
@@ -14296,7 +14294,7 @@ msgstr ""
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:389
+#: lib/vutuv_web/live/job_board_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Filter by a tag"
 msgstr ""
@@ -14316,7 +14314,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4741
+#: lib/vutuv_web/components/ui.ex:4849
 #: lib/vutuv_web/controllers/settings_controller.ex:700
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -14405,7 +14403,7 @@ msgstr ""
 msgid "You are not allowed to change this organization's handle."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/filters.html.heex:116
+#: lib/vutuv_web/templates/settings/filters.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "You have not muted anything yet."
 msgstr ""
@@ -14599,7 +14597,7 @@ msgid "Nothing changes on vutuv itself, and you can switch it off again."
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:325
-#: lib/vutuv_web/templates/page/index.html.heex:234
+#: lib/vutuv_web/templates/page/index.html.heex:239
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "Take part in the Fediverse"
@@ -14621,7 +14619,7 @@ msgstr ""
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:321
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:322
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Related"
@@ -14690,7 +14688,7 @@ msgid "Send your Fediverse followers to another account. They are asked to follo
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:265
-#: lib/vutuv_web/live/fediverse_following_live.ex:465
+#: lib/vutuv_web/live/fediverse_following_live.ex:473
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Back to Fediverse settings"
@@ -14719,7 +14717,7 @@ msgstr ""
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:18
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:34
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:260
-#: lib/vutuv_web/templates/page/index.html.heex:119
+#: lib/vutuv_web/templates/page/index.html.heex:124
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:66
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:75
 #, elixir-autogen, elixir-format
@@ -14871,7 +14869,7 @@ msgstr ""
 msgid "ZIP or postal code"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:357
+#: lib/vutuv_web/live/tag_live/timeline.ex:353
 #: lib/vutuv_web/templates/education/form_content.html.heex:59
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:81
 #, elixir-autogen, elixir-format
@@ -14949,252 +14947,252 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4669
+#: lib/vutuv_web/components/ui.ex:4777
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4674
+#: lib/vutuv_web/components/ui.ex:4782
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4677
+#: lib/vutuv_web/components/ui.ex:4785
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4678
+#: lib/vutuv_web/components/ui.ex:4786
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4681
+#: lib/vutuv_web/components/ui.ex:4789
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4682
+#: lib/vutuv_web/components/ui.ex:4790
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4685
+#: lib/vutuv_web/components/ui.ex:4793
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4686
+#: lib/vutuv_web/components/ui.ex:4794
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4693
+#: lib/vutuv_web/components/ui.ex:4801
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4694
+#: lib/vutuv_web/components/ui.ex:4802
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4695
+#: lib/vutuv_web/components/ui.ex:4803
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4698
+#: lib/vutuv_web/components/ui.ex:4806
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4699
+#: lib/vutuv_web/components/ui.ex:4807
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4834
+#: lib/vutuv_web/components/ui.ex:4942
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4835
+#: lib/vutuv_web/components/ui.ex:4943
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4702
+#: lib/vutuv_web/components/ui.ex:4810
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4705
+#: lib/vutuv_web/components/ui.ex:4813
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4706
+#: lib/vutuv_web/components/ui.ex:4814
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4709
+#: lib/vutuv_web/components/ui.ex:4817
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4710
+#: lib/vutuv_web/components/ui.ex:4818
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4713
+#: lib/vutuv_web/components/ui.ex:4821
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4714
+#: lib/vutuv_web/components/ui.ex:4822
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4716
+#: lib/vutuv_web/components/ui.ex:4824
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4717
+#: lib/vutuv_web/components/ui.ex:4825
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4718
+#: lib/vutuv_web/components/ui.ex:4826
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4720
+#: lib/vutuv_web/components/ui.ex:4828
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4721
+#: lib/vutuv_web/components/ui.ex:4829
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4723
+#: lib/vutuv_web/components/ui.ex:4831
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4728
+#: lib/vutuv_web/components/ui.ex:4836
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4729
+#: lib/vutuv_web/components/ui.ex:4837
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4732
+#: lib/vutuv_web/components/ui.ex:4840
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4735
+#: lib/vutuv_web/components/ui.ex:4843
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4742
+#: lib/vutuv_web/components/ui.ex:4850
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4743
+#: lib/vutuv_web/components/ui.ex:4851
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4757
+#: lib/vutuv_web/components/ui.ex:4865
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4758
+#: lib/vutuv_web/components/ui.ex:4866
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4774
+#: lib/vutuv_web/components/ui.ex:4882
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4775
+#: lib/vutuv_web/components/ui.ex:4883
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4781
+#: lib/vutuv_web/components/ui.ex:4889
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4782
+#: lib/vutuv_web/components/ui.ex:4890
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4785
+#: lib/vutuv_web/components/ui.ex:4893
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4786
+#: lib/vutuv_web/components/ui.ex:4894
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4807
+#: lib/vutuv_web/components/ui.ex:4915
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4808
+#: lib/vutuv_web/components/ui.ex:4916
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4826
+#: lib/vutuv_web/components/ui.ex:4934
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4827
+#: lib/vutuv_web/components/ui.ex:4935
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4830
+#: lib/vutuv_web/components/ui.ex:4938
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4831
+#: lib/vutuv_web/components/ui.ex:4939
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4845
+#: lib/vutuv_web/components/ui.ex:4953
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4846
+#: lib/vutuv_web/components/ui.ex:4954
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15260,14 +15258,14 @@ msgstr ""
 msgid "This link always opens your profile, even after you change your username. It is built from a fixed id, so it never breaks on a rename. For everyday sharing the short address above is friendlier."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:269
-#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:35
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:261
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:29
 #, elixir-autogen, elixir-format
 msgid "I understand, switch off"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:267
-#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:33
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:259
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "I understand, take part"
 msgstr ""
@@ -15302,7 +15300,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5726
+#: lib/vutuv_web/components/post_components.ex:5748
 #: lib/vutuv_web/live/notification_live/index.ex:1352
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -15310,7 +15308,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5730
+#: lib/vutuv_web/components/post_components.ex:5752
 #: lib/vutuv_web/live/notification_live/index.ex:1350
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15318,7 +15316,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5734
+#: lib/vutuv_web/components/post_components.ex:5756
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15326,7 +15324,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1182
-#: lib/vutuv_web/components/post_components.ex:5685
+#: lib/vutuv_web/components/post_components.ex:5707
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15342,14 +15340,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1478
-#: lib/vutuv_web/components/post_components.ex:2221
-#: lib/vutuv_web/live/fediverse_account_live.ex:296
+#: lib/vutuv_web/components/post_components.ex:1479
+#: lib/vutuv_web/components/post_components.ex:2243
+#: lib/vutuv_web/live/fediverse_account_live.ex:298
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1351
+#: lib/vutuv_web/components/post_components.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15378,7 +15376,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1360
+#: lib/vutuv_web/components/post_components.ex:1361
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15388,7 +15386,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1374
+#: lib/vutuv_web/components/post_components.ex:1375
 #: lib/vutuv_web/live/notification_live/index.ex:910
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15420,10 +15418,10 @@ msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1366
-#: lib/vutuv_web/components/post_components.ex:1409
-#: lib/vutuv_web/components/post_components.ex:1609
-#: lib/vutuv_web/components/post_components.ex:2910
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:244
+#: lib/vutuv_web/components/post_components.ex:1410
+#: lib/vutuv_web/components/post_components.ex:1611
+#: lib/vutuv_web/components/post_components.ex:2932
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -15557,27 +15555,27 @@ msgstr ""
 msgid "Confirm it is you"
 msgstr ""
 
-#: lib/vutuv_web/templates/username/confirm.html.heex:148
+#: lib/vutuv_web/templates/username/confirm.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "That passkey could not be verified. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/templates/username/confirm.html.heex:151
+#: lib/vutuv_web/templates/username/confirm.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "Confirm with your passkey"
 msgstr ""
 
-#: lib/vutuv_web/templates/username/confirm.html.heex:176
+#: lib/vutuv_web/templates/username/confirm.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "This browser does not support passkeys. Use a code below instead."
 msgstr ""
 
-#: lib/vutuv_web/templates/username/confirm.html.heex:211
+#: lib/vutuv_web/templates/username/confirm.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "Enter your code"
 msgstr ""
 
-#: lib/vutuv_web/templates/username/confirm.html.heex:223
+#: lib/vutuv_web/templates/username/confirm.html.heex:221
 #, elixir-autogen, elixir-format
 msgid "Change my username"
 msgstr ""
@@ -15587,17 +15585,17 @@ msgstr ""
 msgid "Send the PIN to"
 msgstr ""
 
-#: lib/vutuv_web/views/username_html.ex:155
+#: lib/vutuv_web/views/username_html.ex:152
 #, elixir-autogen, elixir-format
 msgid "Send a new PIN"
 msgstr ""
 
-#: lib/vutuv_web/views/username_html.ex:155
+#: lib/vutuv_web/views/username_html.ex:152
 #, elixir-autogen, elixir-format
 msgid "Email me a PIN"
 msgstr ""
 
-#: lib/vutuv_web/views/username_html.ex:163
+#: lib/vutuv_web/views/username_html.ex:160
 #, elixir-autogen, elixir-format
 msgid "The PIN goes to %{email}."
 msgstr ""
@@ -15651,7 +15649,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4810
+#: lib/vutuv_web/components/ui.ex:4918
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -15866,7 +15864,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:198
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/fediverse_following_live.ex:351
-#: lib/vutuv_web/live/tag_live/timeline.ex:438
+#: lib/vutuv_web/live/tag_live/timeline.ex:434
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -15998,7 +15996,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4811
+#: lib/vutuv_web/components/ui.ex:4919
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -16034,7 +16032,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4813
+#: lib/vutuv_web/components/ui.ex:4921
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16086,22 +16084,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3454
+#: lib/vutuv_web/components/post_components.ex:3476
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3570
+#: lib/vutuv_web/components/post_components.ex:3592
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3578
+#: lib/vutuv_web/components/post_components.ex:3600
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3564
+#: lib/vutuv_web/components/post_components.ex:3586
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16128,24 +16126,24 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:560
 #: lib/vutuv_web/agent_docs/text.ex:549
-#: lib/vutuv_web/templates/user/edit.html.heex:224
+#: lib/vutuv_web/templates/user/edit.html.heex:219
 #: lib/vutuv_web/templates/user/show.html.heex:254
 #: lib/vutuv_web/views/account_event_text.ex:213
 #, elixir-autogen, elixir-format
 msgid "Name pronunciation"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:228
+#: lib/vutuv_web/templates/user/edit.html.heex:223
 #, elixir-autogen, elixir-format
 msgid "e.g. [SHTEH-fahn VIN-ter-my-er]"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:231
+#: lib/vutuv_web/templates/user/edit.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2884
+#: lib/vutuv_web/live/post_live/composer.ex:2823
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16175,123 +16173,123 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2308
+#: lib/vutuv_web/live/post_live/composer.ex:2247
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2722
+#: lib/vutuv_web/live/post_live/composer.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1294
 #: lib/vutuv_web/agent_docs/text.ex:807
-#: lib/vutuv_web/components/ui.ex:2867
+#: lib/vutuv_web/components/ui.ex:2969
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2821
+#: lib/vutuv_web/live/post_live/composer.ex:2760
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2777
+#: lib/vutuv_web/live/post_live/composer.ex:2716
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2779
+#: lib/vutuv_web/live/post_live/composer.ex:2718
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2798
+#: lib/vutuv_web/live/post_live/composer.ex:2737
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2866
+#: lib/vutuv_web/components/ui.ex:2968
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2327
+#: lib/vutuv_web/live/post_live/composer.ex:2266
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3049
+#: lib/vutuv_web/components/post_components.ex:3071
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4264
+#: lib/vutuv_web/components/post_components.ex:4286
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4412
+#: lib/vutuv_web/components/post_components.ex:4434
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2280
-#: lib/vutuv_web/live/post_live/composer.ex:2281
+#: lib/vutuv_web/live/post_live/composer.ex:2219
+#: lib/vutuv_web/live/post_live/composer.ex:2220
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1327
 #: lib/vutuv_web/agent_docs/text.ex:794
-#: lib/vutuv_web/components/post_components.ex:4494
+#: lib/vutuv_web/components/post_components.ex:4516
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2865
+#: lib/vutuv_web/components/ui.ex:2967
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2340
-#: lib/vutuv_web/live/post_live/composer.ex:2341
+#: lib/vutuv_web/live/post_live/composer.ex:2279
+#: lib/vutuv_web/live/post_live/composer.ex:2280
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2800
+#: lib/vutuv_web/live/post_live/composer.ex:2739
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2741
+#: lib/vutuv_web/live/post_live/composer.ex:2680
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3102
+#: lib/vutuv_web/components/post_components.ex:3124
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2819
+#: lib/vutuv_web/live/post_live/composer.ex:2758
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2855
+#: lib/vutuv_web/live/post_live/composer.ex:2794
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2847
+#: lib/vutuv_web/live/post_live/composer.ex:2786
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3093
+#: lib/vutuv_web/components/post_components.ex:3115
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16301,37 +16299,37 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3111
+#: lib/vutuv_web/components/post_components.ex:3133
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3045
+#: lib/vutuv_web/components/post_components.ex:3067
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2598
+#: lib/vutuv_web/live/post_live/composer.ex:2537
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1278
+#: lib/vutuv_web/live/post_live/composer.ex:1253
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3106
+#: lib/vutuv_web/components/post_components.ex:3128
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1292
+#: lib/vutuv_web/live/post_live/composer.ex:1267
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3059
+#: lib/vutuv_web/components/post_components.ex:3081
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16341,65 +16339,64 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2223
+#: lib/vutuv_web/live/post_live/composer.ex:2162
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2593
+#: lib/vutuv_web/live/post_live/composer.ex:2532
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2712
+#: lib/vutuv_web/live/post_live/composer.ex:2651
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1522
-#: lib/vutuv_web/live/post_live/composer.ex:1585
-#: lib/vutuv_web/live/post_live/composer.ex:1643
-#: lib/vutuv_web/live/post_live/composer.ex:1990
+#: lib/vutuv_web/live/post_live/composer.ex:1498
+#: lib/vutuv_web/live/post_live/composer.ex:1561
+#: lib/vutuv_web/live/post_live/composer.ex:1619
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1515
+#: lib/vutuv_web/live/post_live/composer.ex:1491
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2646
+#: lib/vutuv_web/live/post_live/composer.ex:2585
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2158
+#: lib/vutuv_web/live/post_live/composer.ex:2096
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2157
+#: lib/vutuv_web/live/post_live/composer.ex:2095
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2156
+#: lib/vutuv_web/live/post_live/composer.ex:2094
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2161
+#: lib/vutuv_web/live/post_live/composer.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2616
+#: lib/vutuv_web/live/post_live/composer.ex:2555
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2635
+#: lib/vutuv_web/live/post_live/composer.ex:2574
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -16407,13 +16404,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1200
-#: lib/vutuv_web/components/post_components.ex:5723
+#: lib/vutuv_web/components/post_components.ex:5745
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1198
-#: lib/vutuv_web/components/post_components.ex:5720
+#: lib/vutuv_web/components/post_components.ex:5742
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16423,7 +16420,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5612
+#: lib/vutuv_web/components/post_components.ex:5634
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -16509,17 +16506,17 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1779
-#: lib/vutuv_web/live/post_live/composer.ex:2480
+#: lib/vutuv_web/live/post_live/composer.ex:1755
+#: lib/vutuv_web/live/post_live/composer.ex:2419
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:449
+#: lib/vutuv_web/live/fediverse_account_live.ex:459
 #: lib/vutuv_web/live/fediverse_following_live.ex:60
 #: lib/vutuv_web/live/fediverse_following_live.ex:274
 #: lib/vutuv_web/live/fediverse_following_live.ex:287
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:330
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:331
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Accounts you follow elsewhere"
@@ -16530,22 +16527,22 @@ msgstr ""
 msgid "Address of the account"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:521
+#: lib/vutuv_web/live/search_live.ex:514
 #, elixir-autogen, elixir-format
 msgid "An account on another network"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:431
+#: lib/vutuv_web/components/fediverse_components.ex:428
 #, elixir-autogen, elixir-format
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4797
+#: lib/vutuv_web/components/ui.ex:4905
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:462
+#: lib/vutuv_web/components/fediverse_components.ex:459
 #, elixir-autogen, elixir-format
 msgid "Follow request sent to %{account}."
 msgstr ""
@@ -16555,7 +16552,7 @@ msgstr ""
 msgid "Follow somebody out there"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:551
+#: lib/vutuv_web/live/search_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "Follow this account"
 msgstr ""
@@ -16577,7 +16574,7 @@ msgstr ""
 msgid "Mastodon and the other networks work like email: an address is enough. Paste one here and vutuv asks that server to let you follow the account."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:401
+#: lib/vutuv_web/components/fediverse_components.ex:398
 #: lib/vutuv_web/live/organization_live/following.ex:442
 #, elixir-autogen, elixir-format
 msgid "Requested"
@@ -16593,12 +16590,12 @@ msgstr ""
 msgid "Search for them here"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:384
+#: lib/vutuv_web/live/fediverse_following_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Show only accounts on this server"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:559
+#: lib/vutuv_web/live/search_live.ex:552
 #, elixir-autogen, elixir-format
 msgid "Sign in to follow this account"
 msgstr ""
@@ -16613,38 +16610,38 @@ msgstr ""
 msgid "Stop following %{account}?"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:484
+#: lib/vutuv_web/components/fediverse_components.ex:481
 #, elixir-autogen, elixir-format
 msgid "That account could not be loaded from its server. Try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:536
+#: lib/vutuv_web/components/fediverse_components.ex:533
 #, elixir-autogen, elixir-format
 msgid "That did not work. Check the address and try again."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:473
+#: lib/vutuv_web/components/fediverse_components.ex:470
 #, elixir-autogen, elixir-format
 msgid "That does not look like an address on another network. They look like @name@server."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:526
+#: lib/vutuv_web/live/search_live.ex:519
 #, elixir-autogen, elixir-format
 msgid "That is an address on Mastodon or one of the other networks, so nobody here carries it. You can follow it from vutuv."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:481
+#: lib/vutuv_web/components/fediverse_components.ex:478
 #, elixir-autogen, elixir-format
 msgid "That server answered, but it has no account at that address to follow."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:478
-#: lib/vutuv_web/components/fediverse_components.ex:557
+#: lib/vutuv_web/components/fediverse_components.ex:475
+#: lib/vutuv_web/components/fediverse_components.ex:554
 #, elixir-autogen, elixir-format
 msgid "That server did not answer. Check the address, and that the server is online."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:533
+#: lib/vutuv_web/components/fediverse_components.ex:530
 #, elixir-autogen, elixir-format
 msgid "The Fediverse is switched off on this vutuv."
 msgstr ""
@@ -16654,7 +16651,7 @@ msgstr ""
 msgid "The address you brought along is kept here:"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:429
+#: lib/vutuv_web/live/fediverse_following_live.ex:437
 #, elixir-autogen, elixir-format
 msgid "The other server decides. Most accounts accept straight away; one that checks its followers by hand stays on \"Requested\" until somebody there says yes."
 msgstr ""
@@ -16664,7 +16661,7 @@ msgstr ""
 msgid "This vutuv does not exchange anything with other networks, so there is nothing to follow from here. That is an operator setting, not yours."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:487
+#: lib/vutuv_web/components/fediverse_components.ex:484
 #, elixir-autogen, elixir-format
 msgid "This vutuv does not exchange anything with that server."
 msgstr ""
@@ -16674,18 +16671,18 @@ msgstr ""
 msgid "To follow an account out there you need a Fediverse identity of your own: the request is signed in your name, so the other server knows who is asking."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:134
+#: lib/vutuv_web/live/fediverse_account_live.ex:136
 #: lib/vutuv_web/live/fediverse_following_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Unfollowed."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:426
+#: lib/vutuv_web/live/fediverse_following_live.ex:434
 #, elixir-autogen, elixir-format
 msgid "What following out there means"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:434
+#: lib/vutuv_web/live/fediverse_following_live.ex:442
 #, elixir-autogen, elixir-format
 msgid "Who you follow is yours alone. Your profile publishes how many accounts you follow out there, never which ones."
 msgstr ""
@@ -16700,17 +16697,17 @@ msgstr ""
 msgid "Withdraw your follow request to %{account}?"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:504
+#: lib/vutuv_web/components/fediverse_components.ex:501
 #, elixir-autogen, elixir-format
 msgid "You already follow that account."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:522
+#: lib/vutuv_web/components/fediverse_components.ex:519
 #, elixir-autogen, elixir-format
 msgid "You are following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:512
+#: lib/vutuv_web/components/fediverse_components.ex:509
 #, elixir-autogen, elixir-format
 msgid "You are not taking part in the Fediverse at the moment, so there is no identity to sign the request with. Open the Fediverse settings to switch it on."
 msgstr ""
@@ -16727,12 +16724,12 @@ msgid_plural "You follow %{formatted} accounts on other networks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:518
+#: lib/vutuv_web/components/fediverse_components.ex:515
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of follow requests in the last hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:528
+#: lib/vutuv_web/components/fediverse_components.ex:525
 #, elixir-autogen, elixir-format
 msgid "You redirected your Fediverse followers to another account, so this account no longer acts out there."
 msgstr ""
@@ -16743,7 +16740,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4799
+#: lib/vutuv_web/components/ui.ex:4907
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -16763,7 +16760,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2669
+#: lib/vutuv_web/components/post_components.ex:2691
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16773,7 +16770,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2909
+#: lib/vutuv_web/components/post_components.ex:2931
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16793,17 +16790,17 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1762
+#: lib/vutuv_web/components/post_components.ex:1784
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2850
+#: lib/vutuv_web/components/post_components.ex:2872
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:229
+#: lib/vutuv_web/live/fediverse_account_live.ex:231
 #: lib/vutuv_web/live/remote_post_actions.ex:71
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
@@ -16814,12 +16811,12 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2655
+#: lib/vutuv_web/components/post_components.ex:2677
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:445
+#: lib/vutuv_web/live/fediverse_following_live.ex:453
 #, elixir-autogen, elixir-format
 msgid "To show their posts we keep a copy here for up to six months. If the author deletes or edits something, ours follows; and when you stop following an account, its posts are deleted here at once."
 msgstr ""
@@ -16829,62 +16826,62 @@ msgstr ""
 msgid "You do not follow anybody out there yet. Once you do, what they post appears in your feed among everything else."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:76
+#: lib/vutuv_web/live/fediverse_account_live.ex:78
 #, elixir-autogen, elixir-format
 msgid "%{name} (another network)"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:279
+#: lib/vutuv_web/live/fediverse_account_live.ex:281
 #, elixir-autogen, elixir-format
 msgid "Account on another network"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:433
+#: lib/vutuv_web/live/fediverse_account_live.ex:443
 #, elixir-autogen, elixir-format
 msgid "Look up another account"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:363
+#: lib/vutuv_web/live/fediverse_account_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "Muted"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:254
+#: lib/vutuv_web/live/fediverse_account_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "Nothing cached yet. Their posts appear here as they publish them."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:249
+#: lib/vutuv_web/live/fediverse_account_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Nothing here. vutuv only keeps an account's posts while somebody here follows it, and this page never fetches any."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:435
+#: lib/vutuv_web/live/fediverse_account_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "Paste an address from Mastodon and friends to open its page here."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:331
+#: lib/vutuv_web/live/fediverse_account_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Show the whole description"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:418
+#: lib/vutuv_web/live/fediverse_account_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "The most recent %{count} are shown. The rest are on their own server."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:231
+#: lib/vutuv_web/live/fediverse_account_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts are back in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:428
+#: lib/vutuv_web/live/fediverse_account_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "View their full profile on %{host}"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:258
+#: lib/vutuv_web/live/fediverse_account_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Waiting for that server to accept your follow. Posts they addressed to their followers appear once it does."
 msgstr ""
@@ -16895,7 +16892,7 @@ msgid "You redirected your Fediverse followers to another account, so this one n
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:310
-#: lib/vutuv_web/components/fediverse_components.ex:623
+#: lib/vutuv_web/components/fediverse_components.ex:620
 #, elixir-autogen, elixir-format
 msgid "Your account move"
 msgstr ""
@@ -17036,27 +17033,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2380
+#: lib/vutuv_web/components/post_components.ex:2402
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2408
+#: lib/vutuv_web/components/post_components.ex:2430
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2403
+#: lib/vutuv_web/components/post_components.ex:2425
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2952
+#: lib/vutuv_web/components/post_components.ex:2974
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2958
+#: lib/vutuv_web/components/post_components.ex:2980
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr ""
@@ -17066,7 +17063,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3097
+#: lib/vutuv_web/components/post_components.ex:3119
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17081,7 +17078,7 @@ msgstr ""
 msgid "Reposted. Your followers see it now."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:399
+#: lib/vutuv_web/components/fediverse_components.ex:396
 #, elixir-autogen, elixir-format
 msgid "Moved"
 msgstr ""
@@ -17248,7 +17245,7 @@ msgstr ""
 msgid "Your username is your public identity here. It changes only once you confirm with your passkey or a valid code below."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:575
+#: lib/vutuv_web/components/ui.ex:599
 #, elixir-autogen, elixir-format
 msgid "Markdown help"
 msgstr ""
@@ -17263,45 +17260,45 @@ msgstr ""
 msgid "Read this page as Markdown"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:232
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Address of the post"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:620
+#: lib/vutuv_web/components/fediverse_components.ex:617
 #: lib/vutuv_web/live/post_live/remote_actions_component.ex:276
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:597
+#: lib/vutuv_web/components/fediverse_components.ex:594
 #, elixir-autogen, elixir-format
 msgid "Fetching a post asks its server for it in your name, signed with your own key, so there is no such thing as an anonymous lookup here."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:564
+#: lib/vutuv_web/components/fediverse_components.ex:561
 #, elixir-autogen, elixir-format
 msgid "Its author published this post to their followers alone, so vutuv does not keep a copy of it."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:460
+#: lib/vutuv_web/live/fediverse_following_live.ex:468
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Look up a post by its address"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:70
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:196
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:71
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Look up a post from another network"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:324
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Looking for an account rather than a single post?"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:199
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Paste the address of a post on Mastodon and friends. vutuv fetches it, shows it here, and you can answer, like or repost it as if it had arrived on its own."
 msgstr ""
@@ -17311,170 +17308,170 @@ msgstr ""
 msgid "Read something out there that you want to answer from here?"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:549
+#: lib/vutuv_web/components/fediverse_components.ex:546
 #, elixir-autogen, elixir-format
 msgid "That does not look like a link to a post. Copy the address of the post itself, for example https://server/@name/12345."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:554
+#: lib/vutuv_web/components/fediverse_components.ex:551
 #, elixir-autogen, elixir-format
 msgid "That is a link on this vutuv, not on another network."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:316
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:317
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:240
 #, elixir-autogen, elixir-format
 msgid "Their account page here"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:560
+#: lib/vutuv_web/components/fediverse_components.ex:557
 #, elixir-autogen, elixir-format
 msgid "There is no post to show at that address."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:591
+#: lib/vutuv_web/components/fediverse_components.ex:588
 #, elixir-autogen, elixir-format
 msgid "This account no longer acts out there"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:609
+#: lib/vutuv_web/components/fediverse_components.ex:606
 #, elixir-autogen, elixir-format
 msgid "This vutuv does not exchange anything with other networks. That is an operator setting, not yours."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:592
+#: lib/vutuv_web/components/fediverse_components.ex:589
 #, elixir-autogen, elixir-format
 msgid "This vutuv stays to itself"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:589
+#: lib/vutuv_web/components/fediverse_components.ex:586
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to look up"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:454
+#: lib/vutuv_web/live/fediverse_following_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "Want to answer one particular post rather than follow its author?"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:288
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:289
 #, elixir-autogen, elixir-format
 msgid "Who wrote this"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:569
+#: lib/vutuv_web/components/fediverse_components.ex:566
 #, elixir-autogen, elixir-format
 msgid "You have looked a lot of posts up in the last hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:603
+#: lib/vutuv_web/components/fediverse_components.ex:600
 #, elixir-autogen, elixir-format
 msgid "You redirected your Fediverse followers to another account, so nothing is fetched or sent from this one any more."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:334
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:335
 #, elixir-autogen, elixir-format
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1696
+#: lib/vutuv_web/live/post_live/composer.ex:1672
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2386
+#: lib/vutuv_web/live/post_live/composer.ex:2325
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2387
+#: lib/vutuv_web/live/post_live/composer.ex:2326
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2392
+#: lib/vutuv_web/live/post_live/composer.ex:2331
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2389
+#: lib/vutuv_web/live/post_live/composer.ex:2328
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2390
+#: lib/vutuv_web/live/post_live/composer.ex:2329
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2391
+#: lib/vutuv_web/live/post_live/composer.ex:2330
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1692
-#: lib/vutuv_web/live/post_live/composer.ex:2357
-#: lib/vutuv_web/live/post_live/composer.ex:2358
+#: lib/vutuv_web/live/post_live/composer.ex:1668
+#: lib/vutuv_web/live/post_live/composer.ex:2296
+#: lib/vutuv_web/live/post_live/composer.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2316
+#: lib/vutuv_web/live/post_live/composer.ex:2255
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1614
+#: lib/vutuv_web/live/post_live/composer.ex:1590
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2393
+#: lib/vutuv_web/live/post_live/composer.ex:2332
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2394
+#: lib/vutuv_web/live/post_live/composer.ex:2333
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1694
+#: lib/vutuv_web/live/post_live/composer.ex:1670
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2385
+#: lib/vutuv_web/live/post_live/composer.ex:2324
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2388
+#: lib/vutuv_web/live/post_live/composer.ex:2327
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:497
+#: lib/vutuv_web/live/post_live/composer.ex:493
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2834
+#: lib/vutuv_web/live/post_live/composer.ex:2773
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1698
+#: lib/vutuv_web/live/post_live/composer.ex:1674
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2583
+#: lib/vutuv_web/live/post_live/composer.ex:2522
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2567
+#: lib/vutuv_web/live/post_live/composer.ex:2506
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr ""
@@ -17509,12 +17506,12 @@ msgstr ""
 msgid "The most helpful detail in such a report is the exact time of the error. Right now it is %{time}."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:448
+#: lib/vutuv_web/components/fediverse_components.ex:445
 #, elixir-autogen, elixir-format
 msgid "@%{handle} is on this vutuv, so you now follow them here."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:493
+#: lib/vutuv_web/components/fediverse_components.ex:490
 #, elixir-autogen, elixir-format
 msgid "That address is on this vutuv, but it names no member here."
 msgstr ""
@@ -17524,7 +17521,7 @@ msgstr ""
 msgid "That address is on this vutuv. Sign in and use the Follow button on this profile."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:498
+#: lib/vutuv_web/components/fediverse_components.ex:495
 #, elixir-autogen, elixir-format
 msgid "That is your own address. You cannot follow yourself."
 msgstr ""
@@ -17686,12 +17683,12 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:439
+#: lib/vutuv_web/components/post_components.ex:440
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:436
+#: lib/vutuv_web/components/post_components.ex:437
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
@@ -17701,39 +17698,39 @@ msgstr ""
 msgid "View the conversation"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:256
+#: lib/vutuv_web/live/tag_live/timeline.ex:252
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post"
 msgid_plural "%{formatted} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:415
+#: lib/vutuv_web/live/tag_live/timeline.ex:411
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:446
+#: lib/vutuv_web/live/tag_live/timeline.ex:442
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:444
+#: lib/vutuv_web/live/tag_live/timeline.ex:440
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:441
+#: lib/vutuv_web/live/tag_live/timeline.ex:437
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:332
+#: lib/vutuv_web/live/tag_live/timeline.ex:328
 #, elixir-autogen, elixir-format
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2955
+#: lib/vutuv_web/components/post_components.ex:2977
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -17754,28 +17751,28 @@ msgstr ""
 msgid "Other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_post_live.ex:80
+#: lib/vutuv_web/live/fediverse_post_live.ex:82
 #, elixir-autogen, elixir-format
 msgid "A post by %{name} (another network)"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_post_live.ex:120
+#: lib/vutuv_web/live/fediverse_post_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "A post from another network"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_post_live.ex:146
+#: lib/vutuv_web/live/fediverse_post_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "More from %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_post_live.ex:126
+#: lib/vutuv_web/live/fediverse_post_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1374
-#: lib/vutuv_web/components/ui.ex:1375
+#: lib/vutuv_web/components/ui.ex:1398
+#: lib/vutuv_web/components/ui.ex:1399
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr ""
@@ -17785,7 +17782,7 @@ msgstr ""
 msgid "A CV with positions, education, certificates including proof, spoken languages and tags other members endorse you for."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:465
+#: lib/vutuv_web/templates/page/index.html.heex:464
 #, elixir-autogen, elixir-format
 msgid "A business network that is free, does not lock your data in, and is yours to run yourself if you want to."
 msgstr ""
@@ -17805,22 +17802,22 @@ msgstr ""
 msgid "CV download as PDF, Word, OpenDocument, LaTeX or JSON Resume, and you pick what goes in before you download it."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:518
+#: lib/vutuv_web/templates/page/index.html.heex:517
 #, elixir-autogen, elixir-format
 msgid "Developer documentation"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:478
+#: lib/vutuv_web/templates/page/index.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "Every public page here is also served as Markdown, plain text, JSON and XML under the same address. No scraping, no API key, no account."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:485
+#: lib/vutuv_web/templates/page/index.html.heex:484
 #, elixir-autogen, elixir-format
 msgid "For machines"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:475
+#: lib/vutuv_web/templates/page/index.html.heex:474
 #, elixir-autogen, elixir-format
 msgid "Open by default"
 msgstr ""
@@ -17845,12 +17842,12 @@ msgstr ""
 msgid "Posts, likes, reposts, replies and 1:1 messages, in real time."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:476
+#: lib/vutuv_web/templates/page/index.html.heex:475
 #, elixir-autogen, elixir-format
 msgid "Readable by people, by machines, and on your own server"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:501
+#: lib/vutuv_web/templates/page/index.html.heex:500
 #, elixir-autogen, elixir-format
 msgid "Run it yourself"
 msgstr ""
@@ -17860,23 +17857,23 @@ msgstr ""
 msgid "Sign in without a password, by emailed PIN, passkey, authenticator app or a printed list of codes."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:512
-#: lib/vutuv_web/templates/page/index.html.heex:599
+#: lib/vutuv_web/templates/page/index.html.heex:511
+#: lib/vutuv_web/templates/page/index.html.heex:598
 #, elixir-autogen, elixir-format
 msgid "Source code"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:347
+#: lib/vutuv_web/templates/page/index.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "This is what a vutuv profile looks like"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:463
+#: lib/vutuv_web/templates/page/index.html.heex:462
 #, elixir-autogen, elixir-format
 msgid "What vutuv can do"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:462
+#: lib/vutuv_web/templates/page/index.html.heex:461
 #, elixir-autogen, elixir-format
 msgid "What you get"
 msgstr ""
@@ -17886,12 +17883,12 @@ msgstr ""
 msgid "Your independence"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:503
+#: lib/vutuv_web/templates/page/index.html.heex:502
 #, elixir-autogen, elixir-format
 msgid "vutuv is open source under the MIT license. Run it for a company, an association or a school, on the internet or air-gapped inside your own network."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:346
+#: lib/vutuv_web/templates/page/index.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "A look inside"
 msgstr ""
@@ -17901,7 +17898,7 @@ msgstr ""
 msgid "A vutuv profile: cover picture, photo, name, tagline and job title, follower counts and the first posts, with contact details and social media profiles in a column on the right."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:368
+#: lib/vutuv_web/templates/page/index.html.heex:367
 #, elixir-autogen, elixir-format
 msgid "Browse real profiles"
 msgstr ""
@@ -17921,17 +17918,17 @@ msgstr ""
 msgid "Try it out:"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:494
+#: lib/vutuv_web/templates/page/index.html.heex:493
 #, elixir-autogen, elixir-format
 msgid "Plus a sitemap, JSON-LD and a REST API with OAuth 2 and personal access tokens."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:349
+#: lib/vutuv_web/templates/page/index.html.heex:348
 #, elixir-autogen, elixir-format
 msgid "Work experience, education, certificates, languages, links and tags others endorse you for. Anyone can read a profile, entirely without a vutuv account. Unlike LinkedIn, where you hit a login wall in short order."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:449
+#: lib/vutuv_web/templates/page/index.html.heex:448
 #, elixir-autogen, elixir-format
 msgid "Talking to people"
 msgstr ""
@@ -17951,72 +17948,72 @@ msgstr ""
 msgid "The Fediverse: let people follow you from Mastodon, and your public posts show up there. You choose at sign-up, and can change it later."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:450
+#: lib/vutuv_web/templates/page/index.html.heex:449
 #, elixir-autogen, elixir-format
 msgid "Posts, messages, and the Fediverse along with them"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:452
+#: lib/vutuv_web/templates/page/index.html.heex:451
 #, elixir-autogen, elixir-format
 msgid "Write a post, react with a heart, a repost or a reply, or message somebody privately. And you are not stuck among vutuv members: vutuv is part of the Fediverse, the union of independent networks that Mastodon belongs to as well. Follow an account over there and its posts arrive in your feed; the other way round, people there can follow you and see your public posts. Both directions, and entirely your choice: at sign-up you decide whether to use vutuv with or without the Fediverse, and you can change that at any time in the settings."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:565
+#: lib/vutuv_web/templates/page/index.html.heex:564
 #, elixir-autogen, elixir-format
 msgid "Download everything you have here at any time, in a machine-readable file. Not on request, not after a waiting period: from your settings, whenever you like."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:540
+#: lib/vutuv_web/templates/page/index.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "Fair and transparent, in plain words"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:554
+#: lib/vutuv_web/templates/page/index.html.heex:553
 #, elixir-autogen, elixir-format
 msgid "No third-party cookies"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:546
+#: lib/vutuv_web/templates/page/index.html.heex:545
 #, elixir-autogen, elixir-format
 msgid "On our own servers in %{place}, not in somebody else's cloud. We do not hand your profile to a third party, and there is no tracking network reading along."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:544
+#: lib/vutuv_web/templates/page/index.html.heex:543
 #, elixir-autogen, elixir-format
 msgid "Where your data lives"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:539
+#: lib/vutuv_web/templates/page/index.html.heex:538
 #, elixir-autogen, elixir-format
 msgid "Your data"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:556
+#: lib/vutuv_web/templates/page/index.html.heex:555
 #, elixir-autogen, elixir-format
 msgid "vutuv sets one cookie, the one that keeps you signed in. No advertising network, no analytics service, nothing loaded from anybody else's server."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:572
+#: lib/vutuv_web/templates/page/index.html.heex:571
 #, elixir-autogen, elixir-format
 msgid "Leave whenever you like"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:588
+#: lib/vutuv_web/templates/page/index.html.heex:587
 #, elixir-autogen, elixir-format
 msgid "Open source"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:590
+#: lib/vutuv_web/templates/page/index.html.heex:589
 #, elixir-autogen, elixir-format
 msgid "You can check at any time how exactly vutuv works. The whole source code is public under the MIT license, so everything said above about your data can be read rather than taken on trust."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:563
+#: lib/vutuv_web/templates/page/index.html.heex:562
 #, elixir-autogen, elixir-format
 msgid "Your data stays with you"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:579
+#: lib/vutuv_web/templates/page/index.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "Delete your account yourself, without writing to anybody. No questions asked, and you are welcome back any time."
 msgstr ""
@@ -18036,19 +18033,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4788
+#: lib/vutuv_web/components/post_components.ex:4810
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4790
+#: lib/vutuv_web/components/post_components.ex:4812
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4801
+#: lib/vutuv_web/components/post_components.ex:4823
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18099,7 +18096,7 @@ msgid "A published reference then appears next to the entry it documents."
 msgstr ""
 
 #: lib/vutuv_web/controllers/job_reference_controller.ex:252
-#: lib/vutuv_web/live/reference_check_live.ex:420
+#: lib/vutuv_web/live/reference_check_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "A review for this reference is already running."
 msgstr ""
@@ -18175,7 +18172,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:4688
+#: lib/vutuv_web/components/ui.ex:4796
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -18220,7 +18217,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3176
+#: lib/vutuv_web/live/post_live/feed.ex:3173
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -18263,7 +18260,7 @@ msgstr ""
 msgid "Review result"
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:303
+#: lib/vutuv_web/live/reference_check_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Reviewing your reference. This takes a few minutes."
 msgstr ""
@@ -18274,7 +18271,7 @@ msgid "Show this reference publicly on my profile"
 msgstr ""
 
 #: lib/vutuv_web/templates/job_reference/show.html.heex:39
-#: lib/vutuv_web/templates/job_reference/view.html.heex:89
+#: lib/vutuv_web/templates/job_reference/view.html.heex:86
 #: lib/vutuv_web/views/account_event_text.ex:227
 #, elixir-autogen, elixir-format
 msgid "Text"
@@ -18302,22 +18299,22 @@ msgid "The AI review reads German employment law and is therefore offered for Ge
 msgstr ""
 
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:55
-#: lib/vutuv_web/templates/job_reference/view.html.heex:47
+#: lib/vutuv_web/templates/job_reference/view.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "The document"
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:359
+#: lib/vutuv_web/live/reference_check_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "The review could not be completed."
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:428
+#: lib/vutuv_web/live/reference_check_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "The review could not be started."
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:426
+#: lib/vutuv_web/live/reference_check_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "The review covers German Arbeitszeugnisse only."
 msgstr ""
@@ -18338,12 +18335,12 @@ msgid "The review is not available on this installation."
 msgstr ""
 
 #: lib/vutuv_web/controllers/job_reference_controller.ex:259
-#: lib/vutuv_web/live/reference_check_live.ex:423
+#: lib/vutuv_web/live/reference_check_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "There is no text to review yet. Upload the document or paste the text."
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:366
+#: lib/vutuv_web/live/reference_check_live.ex:349
 #: lib/vutuv_web/templates/service_worker/offline.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "Try again"
@@ -18354,14 +18351,14 @@ msgstr ""
 msgid "Upload your Arbeitszeugnisse, attach them to your CV, and have them reviewed. Nothing is public until you say so."
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:272
+#: lib/vutuv_web/live/reference_check_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Waiting — %{count} review ahead of yours."
 msgid_plural "Waiting — %{count} reviews ahead of yours."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:278
+#: lib/vutuv_web/live/reference_check_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Waiting — yours is next."
 msgstr ""
@@ -18371,7 +18368,7 @@ msgstr ""
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4689
+#: lib/vutuv_web/components/ui.ex:4797
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
@@ -18382,7 +18379,7 @@ msgstr ""
 msgid "Zwischenzeugnis"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4691
+#: lib/vutuv_web/components/ui.ex:4799
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -18392,27 +18389,27 @@ msgstr ""
 msgid "e.g. Zeugnis Muster GmbH 2019–2026"
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:116
+#: lib/vutuv_web/templates/job_reference/check.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "For a binding assessment please ask a lawyer, ideally a Fachanwalt für Arbeitsrecht."
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:123
+#: lib/vutuv_web/templates/job_reference/check.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "The analysis follows the freely available Arbeitszeugnis-Prüfer prompt"
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:110
+#: lib/vutuv_web/templates/job_reference/check.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "This is not legal advice."
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:113
+#: lib/vutuv_web/templates/job_reference/check.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "We do not assess your case. What you see is an automated reading of the wording of your document, produced on our own servers by a language model."
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:139
+#: lib/vutuv_web/templates/job_reference/check.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "We wrote neither the prompt nor the model."
 msgstr ""
@@ -18427,13 +18424,13 @@ msgstr ""
 msgid "document"
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:151
+#: lib/vutuv_web/templates/job_reference/check.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Back to your employment references"
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:332
-#: lib/vutuv_web/templates/job_reference/view.html.heex:41
+#: lib/vutuv_web/live/reference_check_live.ex:321
+#: lib/vutuv_web/templates/job_reference/view.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "Read the review"
 msgstr ""
@@ -18453,18 +18450,18 @@ msgstr ""
 msgid "Reviewed on"
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:90
+#: lib/vutuv_web/templates/job_reference/check.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Check the text"
 msgstr ""
 
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:116
-#: lib/vutuv_web/templates/job_reference/view.html.heex:104
+#: lib/vutuv_web/templates/job_reference/view.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Delete this reference, its document and its review? This cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:157
+#: lib/vutuv_web/templates/job_reference/check.html.heex:153
 #, elixir-autogen, elixir-format
 msgid "Edit this reference"
 msgstr ""
@@ -18474,8 +18471,8 @@ msgstr ""
 msgid "Open the file"
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:348
-#: lib/vutuv_web/templates/job_reference/check.html.heex:72
+#: lib/vutuv_web/live/reference_check_live.ex:332
+#: lib/vutuv_web/templates/job_reference/check.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Review again"
 msgstr ""
@@ -18485,7 +18482,7 @@ msgstr ""
 msgid "Uploaded file"
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:341
+#: lib/vutuv_web/live/reference_check_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "You changed the text after this review."
 msgstr ""
@@ -18515,7 +18512,7 @@ msgstr ""
 msgid "Nobody else can open a review, and publishing a reference on your profile never publishes its review. What a machine read into your Zeugnis is nobody's business but yours."
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/view.html.heex:54
+#: lib/vutuv_web/templates/job_reference/view.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Open in a new tab"
 msgstr ""
@@ -18530,8 +18527,8 @@ msgstr ""
 msgid "The result is yours alone."
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/view.html.heex:68
-#: lib/vutuv_web/templates/job_reference/view.html.heex:78
+#: lib/vutuv_web/templates/job_reference/view.html.heex:65
+#: lib/vutuv_web/templates/job_reference/view.html.heex:75
 #, elixir-autogen, elixir-format
 msgid "The uploaded reference"
 msgstr ""
@@ -18590,7 +18587,7 @@ msgstr ""
 msgid "Issue date"
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:299
+#: lib/vutuv_web/live/reference_check_live.ex:291
 #, elixir-autogen, elixir-format
 msgid "Reviewing your reference. This usually takes about %{duration}."
 msgstr ""
@@ -18607,7 +18604,7 @@ msgstr ""
 msgid "The review of “%{title}” is ready: %{grade}."
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:284
+#: lib/vutuv_web/live/reference_check_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Usually about %{duration}."
 msgstr ""
@@ -18637,13 +18634,13 @@ msgstr ""
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4028
+#: lib/vutuv_web/components/ui.ex:4132
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:99
+#: lib/vutuv_web/templates/job_reference/check.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "The full report"
 msgstr ""
@@ -18663,7 +18660,7 @@ msgstr ""
 msgid "This reference was issued to me."
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:249
+#: lib/vutuv_web/live/reference_check_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Decode this reference"
 msgstr ""
@@ -18673,12 +18670,12 @@ msgstr ""
 msgid "German references are graded in code, so friendly words can carry a poor mark. We read the wording against German employment-reference law and tell you which grade is in it, what each assessing phrase really says, and what is missing, contradictory or formally wrong."
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:258
+#: lib/vutuv_web/live/reference_check_live.ex:250
 #, elixir-autogen, elixir-format
 msgid "Only you see the result."
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:388
+#: lib/vutuv_web/live/reference_check_live.ex:371
 #, elixir-autogen, elixir-format
 msgid "You can leave this page. The result lands in your notifications, and we email it to you if you are no longer here by then."
 msgstr ""
@@ -18775,7 +18772,7 @@ msgstr ""
 msgid "An employment reference of yours has been reviewed."
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:131
+#: lib/vutuv_web/templates/job_reference/check.html.heex:127
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "GitHub account @Klotzkette"
@@ -18817,7 +18814,7 @@ msgstr ""
 msgid "Your vutuv username is ready."
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:125
+#: lib/vutuv_web/templates/job_reference/check.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "by the lawyer Tom Braegelmann"
 msgstr ""
@@ -18886,7 +18883,7 @@ msgstr ""
 msgid "You have reached your limit of %{limit} reviews. Please try again in %{window}."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:409
+#: lib/vutuv_web/templates/page/index.html.heex:408
 #, elixir-autogen, elixir-format
 msgid "Employment reference"
 msgstr ""
@@ -18896,7 +18893,7 @@ msgstr ""
 msgid "Employment references: upload them, keep them private, and have the wording read and graded on our own servers."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:386
+#: lib/vutuv_web/templates/page/index.html.heex:385
 #, elixir-autogen, elixir-format
 msgid "Job applications"
 msgstr ""
@@ -18911,7 +18908,7 @@ msgstr ""
 msgid "The finished CV ready to print: name, tagline and contact details at the top, below them the positions held with employer and period, and further down the tags and the spoken languages."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:429
+#: lib/vutuv_web/templates/page/index.html.heex:428
 #, elixir-autogen, elixir-format
 msgid "The review is a text analysis, not legal advice, and it covers German employment references."
 msgstr ""
@@ -18926,22 +18923,22 @@ msgstr ""
 msgid "The uploaded employment references, each marked private: one graded 1 (very good) on a green panel, one graded 4 to 5 (poor to unsatisfactory) on a red one, each with a link to its full report."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:412
+#: lib/vutuv_web/templates/page/index.html.heex:411
 #, elixir-autogen, elixir-format
 msgid "Upload your employment references and have them read sentence by sentence: a grade, a traffic light, and the explanation of how a recruiter reads that wording. It takes a few minutes, then the report is there. Nothing becomes public before you release it."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:410
+#: lib/vutuv_web/templates/page/index.html.heex:409
 #, elixir-autogen, elixir-format
 msgid "What your employment reference really says"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:389
+#: lib/vutuv_web/templates/page/index.html.heex:388
 #, elixir-autogen, elixir-format
 msgid "What your profile already says becomes a CV. You tick what should go in, then download it as PDF, Word, OpenDocument, LaTeX or JSON Resume. Anonymously as well, if you would rather show what you can do before you show who you are."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:387
+#: lib/vutuv_web/templates/page/index.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "Your CV, ready to send"
 msgstr ""
@@ -18966,7 +18963,7 @@ msgstr ""
 msgid "Your verified badge was removed because you changed your name or date of birth. We re-check identity against those details so members can trust verified profiles and nobody can set up a fake verified account. An admin can verify you again anytime."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:249
+#: lib/vutuv_web/templates/page/index.html.heex:250
 #, elixir-autogen, elixir-format
 msgid "Your public posts then also appear on {mastodon} and other independent networks, where people can follow you. Replies and reposts come back under your posts, with the account's address, and are kept for up to six months. You can switch it off at any time."
 msgstr ""
@@ -18983,12 +18980,12 @@ msgstr ""
 msgid "Enter the PIN from the email"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:807
+#: lib/vutuv_web/components/ui.ex:831
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:835
+#: lib/vutuv_web/components/ui.ex:859
 #, elixir-autogen, elixir-format
 msgid "Cancel registration"
 msgstr ""
@@ -19003,7 +19000,7 @@ msgstr ""
 msgid "Follow other members"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:790
+#: lib/vutuv_web/components/ui.ex:814
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
@@ -19028,7 +19025,7 @@ msgstr ""
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4670
+#: lib/vutuv_web/components/ui.ex:4778
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
@@ -19124,7 +19121,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4790
+#: lib/vutuv_web/components/ui.ex:4898
 #: lib/vutuv_web/controllers/settings_controller.ex:247
 #: lib/vutuv_web/controllers/settings_controller.ex:326
 #: lib/vutuv_web/controllers/settings_controller.ex:338
@@ -19221,7 +19218,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4792
+#: lib/vutuv_web/components/ui.ex:4900
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -19330,7 +19327,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4794
+#: lib/vutuv_web/components/ui.ex:4902
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -19704,7 +19701,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2985
+#: lib/vutuv_web/components/post_components.ex:3007
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -19739,7 +19736,7 @@ msgstr ""
 msgid "Posts jobs."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:274
+#: lib/vutuv_web/live/organization_live/roles.ex:269
 #, elixir-autogen, elixir-format
 msgid "Roles"
 msgstr ""
@@ -19764,22 +19761,22 @@ msgstr ""
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1925
+#: lib/vutuv_web/live/post_live/composer.ex:1927
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1271
+#: lib/vutuv_web/live/post_live/composer.ex:1246
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1902
+#: lib/vutuv_web/live/post_live/composer.ex:1904
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1061
+#: lib/vutuv_web/live/shell_live.ex:1057
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr ""
@@ -19799,7 +19796,7 @@ msgstr ""
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1071
+#: lib/vutuv_web/live/shell_live.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -19809,7 +19806,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1047
+#: lib/vutuv_web/live/shell_live.ex:1043
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -19866,7 +19863,7 @@ msgstr ""
 msgid "%{name} follows"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/feed.ex:66
+#: lib/vutuv_web/live/organization_live/feed.ex:65
 #, elixir-autogen, elixir-format
 msgid "Feed – %{name}"
 msgstr ""
@@ -19881,7 +19878,7 @@ msgstr ""
 msgid "Members and organizations"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/feed.ex:161
+#: lib/vutuv_web/live/organization_live/feed.ex:160
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. This page does not follow anyone, or nobody it follows has published."
 msgstr ""
@@ -19912,7 +19909,7 @@ msgstr ""
 msgid "Unfollow %{tag}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/feed.ex:157
+#: lib/vutuv_web/live/organization_live/feed.ex:156
 #, elixir-autogen, elixir-format
 msgid "What the members and organizations this page follows have published. Liking or saving something here is done from your own account, not the page's."
 msgstr ""
@@ -20016,12 +20013,12 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:84
 #: lib/vutuv_web/live/organization_live/new.ex:211
-#: lib/vutuv_web/live/organization_live/show.ex:892
+#: lib/vutuv_web/live/organization_live/show.ex:887
 #, elixir-autogen, elixir-format
 msgid "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:906
+#: lib/vutuv_web/live/organization_live/show.ex:901
 #, elixir-autogen, elixir-format
 msgid "Set this page up for other networks"
 msgstr ""
@@ -20036,7 +20033,7 @@ msgstr ""
 msgid "Switch it on"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:897
+#: lib/vutuv_web/live/organization_live/show.ex:892
 #, elixir-autogen, elixir-format
 msgid "The page gets an address of its own for that, written like an email address."
 msgstr ""
@@ -20061,12 +20058,12 @@ msgstr ""
 msgid "This vutuv exchanges nothing with other networks, so nothing here has any effect."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:443
+#: lib/vutuv_web/live/organization_live/edit.ex:425
 #, elixir-autogen, elixir-format
 msgid "Claim a short @name so this organization has an address of its own, like a member. Letters, numbers and underscores, %{min} to %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:441
+#: lib/vutuv_web/live/organization_live/edit.ex:423
 #, elixir-autogen, elixir-format
 msgid "The organization's @name"
 msgstr ""
@@ -20121,22 +20118,22 @@ msgstr ""
 msgid "The PIN has expired."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:911
+#: lib/vutuv_web/components/ui.ex:935
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:913
+#: lib/vutuv_web/components/ui.ex:937
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:912
+#: lib/vutuv_web/components/ui.ex:936
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:914
+#: lib/vutuv_web/components/ui.ex:938
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr ""
@@ -20153,7 +20150,7 @@ msgid_plural "Your sign-up was never confirmed, so we delete it automatically in
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:456
+#: lib/vutuv_web/components/fediverse_components.ex:453
 #, elixir-autogen, elixir-format
 msgid "#%{tag} is a topic on this vutuv, so you now follow the tag here."
 msgstr ""
@@ -20209,12 +20206,12 @@ msgstr ""
 msgid "Signal also takes its contact link (https://signal.me/#…). It names neither your phone number nor your username, and you can reset it in Signal at any time."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:596
+#: lib/vutuv_web/live/search_live.ex:589
 #, elixir-autogen, elixir-format
 msgid "A post on another network"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:620
+#: lib/vutuv_web/live/search_live.ex:613
 #, elixir-autogen, elixir-format
 msgid "Fetch this post"
 msgstr ""
@@ -20224,12 +20221,12 @@ msgstr ""
 msgid "Search for people, tags, posts, or paste a Fediverse address"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:636
+#: lib/vutuv_web/live/search_live.ex:629
 #, elixir-autogen, elixir-format
 msgid "Sign in to fetch this post"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:601
+#: lib/vutuv_web/live/search_live.ex:594
 #, elixir-autogen, elixir-format
 msgid "That is a link to somewhere else, not something anybody here wrote. vutuv can fetch the post behind it so you can read it, answer it, like it or repost it from here."
 msgstr ""
@@ -20244,7 +20241,7 @@ msgstr ""
 msgid "the address of a post out there: vutuv fetches it so you can answer it here"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:86
+#: lib/vutuv_web/templates/user/edit.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Fetch my picture from gravatar.com"
 msgstr ""
@@ -20269,7 +20266,7 @@ msgstr ""
 msgid "gravatar.com has no picture for your email address."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:89
+#: lib/vutuv_web/templates/user/edit.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Only when you press this: we ask gravatar.com whether there is a picture for your email address, sending a hash of the address rather than the address itself. Nothing leaves this server otherwise."
 msgstr ""
@@ -20284,8 +20281,8 @@ msgstr ""
 msgid "A new entry can take a while to reach everyone. We keep checking %{domain} by ourselves and send you an email as soon as it works, so you can close this page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:336
-#: lib/vutuv_web/live/organization_live/show.ex:1094
+#: lib/vutuv_web/live/organization_live/domains.ex:331
+#: lib/vutuv_web/live/organization_live/show.ex:1090
 #, elixir-autogen, elixir-format
 msgid "Checking …"
 msgstr ""
@@ -20555,43 +20552,43 @@ msgstr ""
 msgid "{n} of {max} free slots selected."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1967
+#: lib/vutuv_web/live/post_live/composer.ex:1881
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1952
+#: lib/vutuv_web/live/post_live/composer.ex:1866
 #, elixir-autogen, elixir-format
 msgctxt "post composer"
 msgid "Language"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1957
+#: lib/vutuv_web/live/post_live/composer.ex:1871
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4682
+#: lib/vutuv_web/components/post_components.ex:4704
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4718
+#: lib/vutuv_web/components/post_components.ex:4740
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4727
+#: lib/vutuv_web/components/post_components.ex:4749
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4730
+#: lib/vutuv_web/components/post_components.ex:4752
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4707
+#: lib/vutuv_web/components/post_components.ex:4729
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20601,8 +20598,8 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4697
-#: lib/vutuv_web/components/ui.ex:4749
+#: lib/vutuv_web/components/post_components.ex:4719
+#: lib/vutuv_web/components/ui.ex:4857
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -20730,27 +20727,27 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4460
+#: lib/vutuv_web/components/post_components.ex:4482
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4457
+#: lib/vutuv_web/components/post_components.ex:4479
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2429
-#: lib/vutuv_web/components/post_components.ex:3787
+#: lib/vutuv_web/components/post_components.ex:2451
+#: lib/vutuv_web/components/post_components.ex:3809
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:144
+#: lib/vutuv_web/templates/user/edit.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "Recommended: %{width} × %{height} pixels (%{ratio})."
 msgstr ""
@@ -20812,7 +20809,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4838
+#: lib/vutuv_web/components/ui.ex:4946
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
@@ -20858,7 +20855,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4840
+#: lib/vutuv_web/components/ui.ex:4948
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -20894,7 +20891,7 @@ msgstr ""
 msgid "Find your LinkedIn contacts"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4765
+#: lib/vutuv_web/components/ui.ex:4873
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format
@@ -20907,7 +20904,7 @@ msgid "Follow selected"
 msgstr ""
 
 #: lib/vutuv_web/live/import_connections_live.ex:504
-#: lib/vutuv_web/live/search_live.ex:548
+#: lib/vutuv_web/live/search_live.ex:541
 #, elixir-autogen, elixir-format
 msgid "Following…"
 msgstr ""
@@ -21002,7 +20999,7 @@ msgstr ""
 msgid "See which of them are already on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4767
+#: lib/vutuv_web/components/ui.ex:4875
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr ""
@@ -21074,7 +21071,7 @@ msgstr ""
 msgid "Your export also lists your LinkedIn contacts."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4769
+#: lib/vutuv_web/components/ui.ex:4877
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr ""
@@ -21218,34 +21215,34 @@ msgctxt "qualification detail"
 msgid "Jobs"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:836
+#: lib/vutuv_web/live/job_posting_live/form.ex:829
 #, elixir-autogen, elixir-format
 msgid "%{formatted} country chosen."
 msgid_plural "%{formatted} countries chosen."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:620
+#: lib/vutuv_web/live/job_posting_live/form.ex:619
 #, elixir-autogen, elixir-format
 msgid "No country chosen yet."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:612
+#: lib/vutuv_web/live/job_posting_live/form.ex:611
 #, elixir-autogen, elixir-format
 msgid "No country left to add for that."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:631
+#: lib/vutuv_web/live/job_posting_live/form.ex:630
 #, elixir-autogen, elixir-format
 msgid "Remove %{country}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:642
+#: lib/vutuv_web/live/job_posting_live/form.ex:641
 #, elixir-autogen, elixir-format
 msgid "Remove all"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:591
+#: lib/vutuv_web/live/job_posting_live/form.ex:590
 #, elixir-autogen, elixir-format
 msgid "Search for a country"
 msgstr ""
@@ -21255,7 +21252,7 @@ msgstr ""
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2643
+#: lib/vutuv_web/components/post_components.ex:2665
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
@@ -21285,7 +21282,7 @@ msgstr ""
 msgid "New message"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1024
+#: lib/vutuv_web/live/shell_live.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
@@ -21330,12 +21327,12 @@ msgstr ""
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4737
+#: lib/vutuv_web/components/ui.ex:4845
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:311
+#: lib/vutuv_web/live/tag_live/timeline.ex:307
 #, elixir-autogen, elixir-format
 msgid "%{formatted} active"
 msgstr ""
@@ -21380,7 +21377,7 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3337
+#: lib/vutuv_web/live/post_live/feed.ex:3334
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
@@ -21390,43 +21387,43 @@ msgstr ""
 msgid "New here"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1543
+#: lib/vutuv_web/components/ui.ex:1567
 #, elixir-autogen, elixir-format
 msgid "New public posts arrive in any feed reader. No account needed either."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1539
+#: lib/vutuv_web/components/ui.ex:1563
 #, elixir-autogen, elixir-format
 msgid "Or with an RSS reader"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1419
-#: lib/vutuv_web/components/ui.ex:1488
+#: lib/vutuv_web/components/ui.ex:1443
+#: lib/vutuv_web/components/ui.ex:1512
 #, elixir-autogen, elixir-format
 msgid "Subscribe"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1540
+#: lib/vutuv_web/components/ui.ex:1564
 #, elixir-autogen, elixir-format
 msgid "With an RSS reader"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1500
+#: lib/vutuv_web/components/ui.ex:1524
 #, elixir-autogen, elixir-format
 msgid "Create a free account"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1515
+#: lib/vutuv_web/components/ui.ex:1539
 #, elixir-autogen, elixir-format
 msgid "No vutuv account? These ways work too:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1493
+#: lib/vutuv_web/components/ui.ex:1517
 #, elixir-autogen, elixir-format
 msgid "The best way: follow %{name} here. New posts land in your feed, and you can reply and join in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1491
+#: lib/vutuv_web/components/ui.ex:1515
 #, elixir-autogen, elixir-format
 msgid "With a vutuv account"
 msgstr ""
@@ -21436,7 +21433,7 @@ msgstr ""
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:278
+#: lib/vutuv_web/templates/settings/preferences.html.heex:267
 #, elixir-autogen, elixir-format
 msgid "Example"
 msgstr ""
@@ -21451,7 +21448,7 @@ msgstr ""
 msgid "Just flashed the new release, boot is under two seconds now"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:288
+#: lib/vutuv_web/templates/settings/preferences.html.heex:277
 #, elixir-autogen, elixir-format
 msgid "Play the example"
 msgstr ""
@@ -21551,22 +21548,22 @@ msgstr ""
 msgid "Shown in the language it was written in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4750
+#: lib/vutuv_web/components/ui.ex:4858
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4752
+#: lib/vutuv_web/components/ui.ex:4860
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4817
+#: lib/vutuv_web/components/ui.ex:4925
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4821
+#: lib/vutuv_web/components/ui.ex:4929
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -21599,7 +21596,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:94
-#: lib/vutuv_web/templates/settings/preferences.html.heex:254
+#: lib/vutuv_web/templates/settings/preferences.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Browser tab"
 msgstr ""
@@ -21624,12 +21621,12 @@ msgstr ""
 msgid "Tease new posts in the browser tab"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:280
+#: lib/vutuv_web/templates/settings/preferences.html.heex:269
 #, elixir-autogen, elixir-format
 msgid "Watch this tab's title, above."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:256
+#: lib/vutuv_web/templates/settings/preferences.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "While you are reading another tab, a new post can page its first words through this tab's title, a line at a time, and then hand the title back."
 msgstr ""
@@ -21684,7 +21681,7 @@ msgstr ""
 msgid "Your LinkedIn profile can come along."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1111
+#: lib/vutuv_web/components/ui.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Being checked"
 msgstr ""
@@ -21908,7 +21905,7 @@ msgstr ""
 msgid "Move %{card}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:544
+#: lib/vutuv_web/components/ui.ex:401
 #: lib/vutuv_web/live/post_live/filter_band.ex:583
 #, elixir-autogen, elixir-format
 msgid "No account found."
@@ -21949,7 +21946,7 @@ msgstr ""
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3363
+#: lib/vutuv_web/live/post_live/feed.ex:3360
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
@@ -22026,10 +22023,10 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2996
-#: lib/vutuv_web/live/post_live/feed.ex:3013
-#: lib/vutuv_web/live/post_live/feed.ex:3411
-#: lib/vutuv_web/live/post_live/feed.ex:3416
+#: lib/vutuv_web/live/post_live/feed.ex:2993
+#: lib/vutuv_web/live/post_live/feed.ex:3010
+#: lib/vutuv_web/live/post_live/feed.ex:3408
+#: lib/vutuv_web/live/post_live/feed.ex:3413
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -22048,7 +22045,7 @@ msgid_plural "Show %{formatted} posts in the feed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2351
+#: lib/vutuv_web/components/post_components.ex:2373
 #, elixir-autogen, elixir-format
 msgid "Picture unavailable"
 msgstr ""
@@ -22063,7 +22060,7 @@ msgstr ""
 msgid "Your organization page was updated. The new logo is being checked and appears once that is through."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:286
+#: lib/vutuv_web/live/organization_live/edit.ex:281
 #, elixir-autogen, elixir-format
 msgid "%{formats}, up to %{limit}"
 msgstr ""
@@ -22073,7 +22070,7 @@ msgstr ""
 msgid "Your organization page was updated, but that picture could not be used as a logo. Please pick another one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4034
+#: lib/vutuv_web/components/ui.ex:4138
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -22094,7 +22091,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3133
+#: lib/vutuv_web/live/post_live/feed.ex:3130
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr ""
@@ -22104,7 +22101,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3179
+#: lib/vutuv_web/live/post_live/feed.ex:3176
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22126,7 +22123,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3129
+#: lib/vutuv_web/live/post_live/feed.ex:3126
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -22213,14 +22210,14 @@ msgstr ""
 msgid "Page management"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2218
+#: lib/vutuv_web/live/post_live/feed.ex:2220
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2777
+#: lib/vutuv_web/components/post_components.ex:2799
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr ""
@@ -22235,17 +22232,17 @@ msgstr ""
 msgid "Quotes %{url}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:543
+#: lib/vutuv_web/components/ui.ex:400
 #, elixir-autogen, elixir-format
 msgid "Mention an account"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:546
+#: lib/vutuv_web/components/ui.ex:404
 #, elixir-autogen, elixir-format
 msgid "{used} of {max} mentions"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2384
+#: lib/vutuv_web/live/post_live/feed.ex:2386
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""
@@ -22271,7 +22268,7 @@ msgstr ""
 msgid "Only these accounts (empty = all) …"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3159
+#: lib/vutuv_web/components/ui.ex:3261
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr ""
@@ -22321,33 +22318,33 @@ msgid_plural "shared this."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:482
+#: lib/vutuv_web/components/ui.ex:543
 #, elixir-autogen, elixir-format
 msgid "Editor view"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:430
+#: lib/vutuv_web/components/ui.ex:491
 #, elixir-autogen, elixir-format
 msgid "Insert a block"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:442
+#: lib/vutuv_web/components/ui.ex:503
 #, elixir-autogen, elixir-format
 msgid "Nothing matches."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1778
-#: lib/vutuv_web/live/post_live/composer.ex:2513
+#: lib/vutuv_web/live/post_live/composer.ex:1754
+#: lib/vutuv_web/live/post_live/composer.ex:2452
 #, elixir-autogen, elixir-format
 msgid "Automatic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1783
+#: lib/vutuv_web/live/post_live/composer.ex:1759
 #, elixir-autogen, elixir-format
 msgid "Drag one photo onto another to swap them."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1730
+#: lib/vutuv_web/live/post_live/composer.ex:1706
 #, elixir-autogen, elixir-format
 msgid "Not shown in the gallery — drag one into it to swap."
 msgstr ""
@@ -22384,17 +22381,17 @@ msgstr ""
 msgid "Mute %{host}"
 msgstr ""
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:94
+#: lib/vutuv_web/views/remote_actor_card_html.ex:132
 #, elixir-autogen, elixir-format
 msgid "Really remove?"
 msgstr ""
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:95
+#: lib/vutuv_web/views/remote_actor_card_html.ex:133
 #, elixir-autogen, elixir-format
 msgid "Really unfollow?"
 msgstr ""
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:96
+#: lib/vutuv_web/views/remote_actor_card_html.ex:134
 #, elixir-autogen, elixir-format
 msgid "Really withdraw?"
 msgstr ""
@@ -22404,28 +22401,28 @@ msgstr ""
 msgid "Unmute %{host}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1538
+#: lib/vutuv_web/live/post_live/composer.ex:1514
 #, elixir-autogen, elixir-format
 msgid "Draft discarded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1577
+#: lib/vutuv_web/live/post_live/composer.ex:1553
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1568
+#: lib/vutuv_web/live/post_live/composer.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Keep this draft for later?"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:315
+#: lib/vutuv_web/live/organization_live/edit.ex:310
 #, elixir-autogen, elixir-format
 msgid "Describe the organization. Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:286
-#: lib/vutuv_web/templates/settings/preferences.html.heex:205
+#: lib/vutuv_web/templates/page/index.html.heex:287
+#: lib/vutuv_web/templates/settings/preferences.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "Bandwidth"
 msgstr ""
@@ -22440,7 +22437,7 @@ msgstr ""
 msgid "Bandwidth settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:207
+#: lib/vutuv_web/templates/settings/preferences.html.heex:211
 #, elixir-autogen, elixir-format
 msgid "If you are on a slow or metered connection, vutuv can leave out the parts of the page that cost the most to download."
 msgstr ""
@@ -22453,4 +22450,9 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:102
 #, elixir-autogen, elixir-format
 msgid "Writing a post or a message then uses a plain Markdown box instead of the formatting editor, which saves about 150 kB of download. Everything you write still looks the same to everyone who reads it."
+msgstr ""
+
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:252
+#, elixir-autogen, elixir-format
+msgid "View the original on %{url}"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -9,19 +9,19 @@
 msgid ""
 msgstr "Language: en\n"
 
-#: lib/vutuv_web/controllers/page_controller.ex:250
+#: lib/vutuv_web/controllers/page_controller.ex:251
 #: lib/vutuv_web/templates/layout/app.html.heex:111
 #, elixir-autogen
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4414
-#: lib/vutuv_web/components/ui.ex:4419
+#: lib/vutuv_web/components/ui.ex:4522
+#: lib/vutuv_web/components/ui.ex:4527
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
-#: lib/vutuv_web/live/organization_live/domains.ex:272
-#: lib/vutuv_web/live/organization_live/edit.ex:431
-#: lib/vutuv_web/live/organization_live/roles.ex:214
+#: lib/vutuv_web/live/organization_live/domains.ex:267
+#: lib/vutuv_web/live/organization_live/edit.ex:414
+#: lib/vutuv_web/live/organization_live/roles.ex:210
 #, elixir-autogen
 msgid "Add"
 msgstr ""
@@ -33,7 +33,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
 #: lib/vutuv_web/live/organization_live/fediverse.ex:115
-#: lib/vutuv_web/live/organization_live/show.ex:915
+#: lib/vutuv_web/live/organization_live/show.ex:910
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -62,7 +62,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/text.ex:71
-#: lib/vutuv_web/components/ui.ex:4712
+#: lib/vutuv_web/components/ui.ex:4820
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -75,14 +75,14 @@ msgstr ""
 msgid "Addresses"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1506
-#: lib/vutuv_web/templates/page/index.html.heex:320
+#: lib/vutuv_web/components/ui.ex:1530
+#: lib/vutuv_web/templates/page/index.html.heex:319
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4209
-#: lib/vutuv_web/components/ui.ex:4303
+#: lib/vutuv_web/components/ui.ex:4313
+#: lib/vutuv_web/components/ui.ex:4412
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -95,7 +95,7 @@ msgstr ""
 msgid "Avatar"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:412
+#: lib/vutuv_web/templates/user/edit.html.heex:407
 #, elixir-autogen
 msgid "Birthdate"
 msgstr ""
@@ -109,29 +109,29 @@ msgstr ""
 msgid "Birthday"
 msgstr ""
 
-#: lib/vutuv_web/components/saved_search_components.ex:114
-#: lib/vutuv_web/components/ui.ex:4203
-#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
-#: lib/vutuv_web/live/admin/user_delete_live.ex:212
-#: lib/vutuv_web/live/job_posting_live/form.ex:812
-#: lib/vutuv_web/live/organization_live/edit.ex:382
-#: lib/vutuv_web/live/organization_live/new.ex:231
-#: lib/vutuv_web/live/post_live/composer.ex:1697
+#: lib/vutuv_web/components/saved_search_components.ex:104
+#: lib/vutuv_web/components/ui.ex:4307
+#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
+#: lib/vutuv_web/live/admin/user_delete_live.ex:202
+#: lib/vutuv_web/live/job_posting_live/form.ex:806
+#: lib/vutuv_web/live/organization_live/edit.ex:369
+#: lib/vutuv_web/live/organization_live/new.ex:222
+#: lib/vutuv_web/live/post_live/composer.ex:1673
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:113
 #: lib/vutuv_web/templates/report/new.html.heex:103
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:259
-#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:26
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:255
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:53
-#: lib/vutuv_web/templates/user/edit.html.heex:138
-#: lib/vutuv_web/templates/user/edit.html.heex:467
-#: lib/vutuv_web/templates/user/edit.html.heex:516
-#: lib/vutuv_web/templates/username/confirm.html.heex:222
+#: lib/vutuv_web/templates/user/edit.html.heex:133
+#: lib/vutuv_web/templates/user/edit.html.heex:463
+#: lib/vutuv_web/templates/user/edit.html.heex:508
+#: lib/vutuv_web/templates/username/confirm.html.heex:220
 #, elixir-autogen
 msgid "Cancel"
 msgstr ""
@@ -160,24 +160,24 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3586
-#: lib/vutuv_web/components/ui.ex:4306
-#: lib/vutuv_web/live/admin/job_live.ex:489
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
-#: lib/vutuv_web/live/admin/organization_live.ex:398
-#: lib/vutuv_web/live/admin/user_delete_live.ex:172
+#: lib/vutuv_web/components/post_components.ex:3608
+#: lib/vutuv_web/components/ui.ex:4414
+#: lib/vutuv_web/live/admin/job_live.ex:486
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:657
+#: lib/vutuv_web/live/admin/organization_live.ex:399
+#: lib/vutuv_web/live/admin/user_delete_live.ex:167
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:28
 #: lib/vutuv_web/templates/dev_app/show.html.heex:135
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:59
-#: lib/vutuv_web/templates/settings/saved_searches.html.heex:75
+#: lib/vutuv_web/templates/settings/saved_searches.html.heex:70
 #, elixir-autogen
 msgid "Delete"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:686
-#: lib/vutuv_web/live/organization_live/edit.ex:301
-#: lib/vutuv_web/live/organization_live/edit.ex:314
+#: lib/vutuv_web/live/job_posting_live/form.ex:685
+#: lib/vutuv_web/live/organization_live/edit.ex:296
+#: lib/vutuv_web/live/organization_live/edit.ex:309
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
 #: lib/vutuv_web/templates/address/form_en.html.heex:11
 #: lib/vutuv_web/templates/address/form_generic.html.heex:13
@@ -200,20 +200,20 @@ msgstr ""
 msgid "Disable"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:438
-#: lib/vutuv_web/live/post_live/composer.ex:2609
+#: lib/vutuv_web/live/cv_live.ex:428
+#: lib/vutuv_web/live/post_live/composer.ex:2548
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3551
-#: lib/vutuv_web/components/ui.ex:4297
+#: lib/vutuv_web/components/post_components.ex:3573
+#: lib/vutuv_web/components/ui.ex:4405
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
-#: lib/vutuv_web/live/job_posting_live/show.ex:178
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
+#: lib/vutuv_web/live/job_posting_live/show.ex:173
 #: lib/vutuv_web/live/organization_live/show.ex:149
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
@@ -283,7 +283,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:4676
+#: lib/vutuv_web/components/ui.ex:4784
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -304,7 +304,7 @@ msgid "Fax"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:596
-#: lib/vutuv_web/templates/user/edit.html.heex:169
+#: lib/vutuv_web/templates/user/edit.html.heex:164
 #, elixir-autogen
 msgid "First Name"
 msgstr ""
@@ -323,9 +323,9 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:632
 #: lib/vutuv_web/agent_docs/text.ex:596
-#: lib/vutuv_web/components/fediverse_components.ex:400
-#: lib/vutuv_web/components/ui.ex:2705
-#: lib/vutuv_web/components/ui.ex:2740
+#: lib/vutuv_web/components/fediverse_components.ex:397
+#: lib/vutuv_web/components/ui.ex:2807
+#: lib/vutuv_web/components/ui.ex:2842
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:608
@@ -338,8 +338,8 @@ msgid "Following"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:195
-#: lib/vutuv_web/templates/page/index.html.heex:118
-#: lib/vutuv_web/templates/user/edit.html.heex:206
+#: lib/vutuv_web/templates/page/index.html.heex:123
+#: lib/vutuv_web/templates/user/edit.html.heex:201
 #: lib/vutuv_web/views/account_event_text.ex:219
 #, elixir-autogen
 msgid "Gender"
@@ -372,7 +372,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:757
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:752
 #: lib/vutuv_web/templates/language/form_content.html.heex:5
 #: lib/vutuv_web/templates/language/show.html.heex:19
 #, elixir-autogen
@@ -380,7 +380,7 @@ msgid "Language"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:598
-#: lib/vutuv_web/templates/user/edit.html.heex:174
+#: lib/vutuv_web/templates/user/edit.html.heex:169
 #, elixir-autogen
 msgid "Last Name"
 msgstr ""
@@ -409,7 +409,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:202
 #: lib/vutuv_web/cv/latex.ex:164
 #: lib/vutuv_web/cv/odt.ex:176
-#: lib/vutuv_web/live/cv_live.ex:336
+#: lib/vutuv_web/live/cv_live.ex:326
 #: lib/vutuv_web/templates/import/new.html.heex:13
 #: lib/vutuv_web/templates/url/edit.html.heex:4
 #: lib/vutuv_web/templates/url/index.html.heex:10
@@ -438,8 +438,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1369
-#: lib/vutuv_web/live/shell_live.ex:1435
+#: lib/vutuv_web/live/shell_live.ex:1361
+#: lib/vutuv_web/live/shell_live.ex:1426
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -447,7 +447,7 @@ msgid "Log in"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:597
-#: lib/vutuv_web/templates/user/edit.html.heex:179
+#: lib/vutuv_web/templates/user/edit.html.heex:174
 #, elixir-autogen
 msgid "Middle Name"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:714
+#: lib/vutuv_web/components/post_components.ex:715
 #: lib/vutuv_web/live/notification_live/index.ex:742
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -484,7 +484,7 @@ msgid "New"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:600
-#: lib/vutuv_web/templates/user/edit.html.heex:184
+#: lib/vutuv_web/templates/user/edit.html.heex:179
 #, elixir-autogen
 msgid "Nickname"
 msgstr ""
@@ -565,7 +565,7 @@ msgid "Phone number updated successfully."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:595
-#: lib/vutuv_web/templates/user/edit.html.heex:189
+#: lib/vutuv_web/templates/user/edit.html.heex:184
 #, elixir-autogen
 msgid "Prefix"
 msgstr ""
@@ -601,7 +601,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1909
+#: lib/vutuv_web/live/post_live/composer.ex:1911
 #: lib/vutuv_web/live/section_reorder_live.ex:270
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -611,9 +611,9 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4202
-#: lib/vutuv_web/live/organization_live/edit.ex:376
-#: lib/vutuv_web/live/post_live/composer.ex:1924
+#: lib/vutuv_web/components/ui.ex:4306
+#: lib/vutuv_web/live/organization_live/edit.ex:367
+#: lib/vutuv_web/live/post_live/composer.ex:1926
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -623,40 +623,39 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
 #: lib/vutuv_web/templates/settings/preferences.html.heex:157
-#: lib/vutuv_web/templates/settings/preferences.html.heex:224
-#: lib/vutuv_web/templates/settings/preferences.html.heex:273
-#: lib/vutuv_web/templates/settings/preferences.html.heex:406
+#: lib/vutuv_web/templates/settings/preferences.html.heex:262
+#: lib/vutuv_web/templates/settings/preferences.html.heex:395
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
-#: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
-#: lib/vutuv_web/templates/user/edit.html.heex:462
+#: lib/vutuv_web/templates/settings/saved_searches.html.heex:61
+#: lib/vutuv_web/templates/user/edit.html.heex:458
 #: lib/vutuv_web/views/settings_html.ex:212
 #, elixir-autogen
 msgid "Save"
 msgstr ""
 
 #: lib/vutuv_web/components/browse_table.ex:346
-#: lib/vutuv_web/controllers/page_controller.ex:226
+#: lib/vutuv_web/controllers/page_controller.ex:227
 #: lib/vutuv_web/live/account_activity_live.ex:149
 #: lib/vutuv_web/live/admin/activity_live.ex:193
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:219
 #: lib/vutuv_web/live/directory_search_live.ex:181
-#: lib/vutuv_web/live/job_board_live.ex:418
+#: lib/vutuv_web/live/job_board_live.ex:410
 #: lib/vutuv_web/live/search_live.ex:60
-#: lib/vutuv_web/live/search_live.ex:658
-#: lib/vutuv_web/live/search_live.ex:684
-#: lib/vutuv_web/live/shell_live.ex:1234
-#: lib/vutuv_web/live/shell_live.ex:1418
-#: lib/vutuv_web/live/tag_live/timeline.ex:323
+#: lib/vutuv_web/live/search_live.ex:651
+#: lib/vutuv_web/live/search_live.ex:677
+#: lib/vutuv_web/live/shell_live.ex:1230
+#: lib/vutuv_web/live/shell_live.ex:1409
+#: lib/vutuv_web/live/tag_live/timeline.ex:319
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
-#: lib/vutuv_web/templates/admin/account/index.html.heex:39
+#: lib/vutuv_web/templates/admin/account/index.html.heex:35
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
 #: lib/vutuv_web/templates/layout/app.html.heex:155
 #, elixir-autogen
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1759
+#: lib/vutuv_web/components/post_components.ex:1781
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -664,7 +663,7 @@ msgstr ""
 msgid "Show"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:299
+#: lib/vutuv_web/templates/page/index.html.heex:298
 #, elixir-autogen
 msgid "Sign up for a free account"
 msgstr ""
@@ -684,7 +683,7 @@ msgstr ""
 #: lib/vutuv_web/cv/latex.ex:179
 #: lib/vutuv_web/cv/odt.ex:185
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:760
-#: lib/vutuv_web/live/cv_live.ex:410
+#: lib/vutuv_web/live/cv_live.ex:400
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:10
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
@@ -721,12 +720,12 @@ msgstr ""
 msgid "Profile deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1019
+#: lib/vutuv_web/views/user_html.ex:1025
 #, elixir-autogen, elixir-format
 msgid "Social networks"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1026
+#: lib/vutuv_web/views/user_html.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Code & repositories"
 msgstr ""
@@ -745,7 +744,7 @@ msgid "Submit a bugreport or a feature request."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:599
-#: lib/vutuv_web/templates/user/edit.html.heex:194
+#: lib/vutuv_web/templates/user/edit.html.heex:189
 #, elixir-autogen
 msgid "Suffix"
 msgstr ""
@@ -787,15 +786,15 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4672
+#: lib/vutuv_web/components/ui.ex:4780
 #: lib/vutuv_web/controllers/username_controller.ex:428
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:832
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
 #: lib/vutuv_web/live/directory_search_live.ex:134
 #: lib/vutuv_web/live/notification_live/index.ex:1281
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
-#: lib/vutuv_web/templates/admin/account/index.html.heex:56
+#: lib/vutuv_web/templates/admin/account/index.html.heex:51
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
 #: lib/vutuv_web/templates/settings/security.html.heex:23
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:5
@@ -839,7 +838,7 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1313
+#: lib/vutuv_web/components/ui.ex:1337
 #: lib/vutuv_web/views/user_html.ex:562
 #: lib/vutuv_web/views/user_html.ex:563
 #: lib/vutuv_web/views/user_html.ex:577
@@ -847,17 +846,17 @@ msgstr ""
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4367
+#: lib/vutuv_web/components/ui.ex:4475
 #: lib/vutuv_web/templates/user/show.html.heex:973
 #: lib/vutuv_web/templates/user/show.html.heex:996
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4780
+#: lib/vutuv_web/components/ui.ex:4888
 #: lib/vutuv_web/controllers/settings_controller.ex:171
-#: lib/vutuv_web/live/job_posting_live/form.ex:768
-#: lib/vutuv_web/live/organization_live/edit.ex:335
+#: lib/vutuv_web/live/job_posting_live/form.ex:767
+#: lib/vutuv_web/live/organization_live/edit.ex:330
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:295
@@ -871,7 +870,7 @@ msgstr ""
 msgid "We can't find em' cap'n!"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:323
+#: lib/vutuv_web/templates/page/index.html.heex:322
 #, elixir-autogen
 msgid "We reserve the right to stop this service or delete your account anytime without warning."
 msgstr ""
@@ -946,12 +945,12 @@ msgstr ""
 msgid "An email has been sent to your email address with instructions on how to delete your account."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:198
+#: lib/vutuv_web/templates/page/index.html.heex:203
 #, elixir-autogen
 msgid "Allow others to view your email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:309
+#: lib/vutuv_web/templates/page/index.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "By creating an account you accept our {nutzungsbedingungen} and confirm that you have read our {datenschutz}."
 msgstr ""
@@ -1044,7 +1043,7 @@ msgstr ""
 msgid "General Info"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:346
+#: lib/vutuv_web/live/admin/user_live.ex:345
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:32
 #, elixir-autogen
 msgid "Verify"
@@ -1075,7 +1074,7 @@ msgstr ""
 msgid "Listings"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:418
+#: lib/vutuv_web/controllers/page_controller.ex:408
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1128,8 +1127,8 @@ msgstr ""
 msgid "Our search will try to match similar names to your search, so don't worry about spelling."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:737
-#: lib/vutuv_web/live/search_live.ex:762
+#: lib/vutuv_web/live/search_live.ex:730
+#: lib/vutuv_web/live/search_live.ex:755
 #, elixir-autogen
 msgid "Search Tips"
 msgstr ""
@@ -1154,15 +1153,15 @@ msgstr ""
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:127
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:638
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:637
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:688
 #: lib/vutuv_web/live/admin/organization_live.ex:189
 #: lib/vutuv_web/live/admin/screenshot_live.ex:182
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:443
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
-#: lib/vutuv_web/live/admin/user_detail_live.ex:68
+#: lib/vutuv_web/live/admin/user_detail_live.ex:63
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1341
+#: lib/vutuv_web/live/shell_live.ex:1337
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1374,7 +1373,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:522
 #: lib/vutuv_web/agent_docs/text.ex:768
-#: lib/vutuv_web/components/ui.ex:4697
+#: lib/vutuv_web/components/ui.ex:4805
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1383,11 +1382,11 @@ msgstr ""
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:444
-#: lib/vutuv_web/live/cv_live.ex:315
-#: lib/vutuv_web/live/job_board_live.ex:277
-#: lib/vutuv_web/live/job_posting_live/form.ex:717
+#: lib/vutuv_web/live/cv_live.ex:305
+#: lib/vutuv_web/live/job_board_live.ex:276
+#: lib/vutuv_web/live/job_posting_live/form.ex:716
 #: lib/vutuv_web/live/search_live.ex:344
-#: lib/vutuv_web/live/search_live.ex:822
+#: lib/vutuv_web/live/search_live.ex:815
 #: lib/vutuv_web/live/tag_new_live.ex:35
 #: lib/vutuv_web/live/tag_new_live.ex:46
 #: lib/vutuv_web/live/tag_new_live.ex:53
@@ -1397,7 +1396,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/tag/new.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:5
 #: lib/vutuv_web/templates/import/new.html.heex:12
-#: lib/vutuv_web/templates/page/index.html.heex:133
+#: lib/vutuv_web/templates/page/index.html.heex:138
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:28
 #: lib/vutuv_web/templates/tag/show.html.heex:45
@@ -1559,10 +1558,10 @@ msgstr ""
 msgid "You'll receive an email with a login link."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:776
-#: lib/vutuv_web/live/job_board_live.ex:360
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:771
+#: lib/vutuv_web/live/job_board_live.ex:356
 #: lib/vutuv_web/live/job_posting_live/form.ex:548
-#: lib/vutuv_web/live/organization_live/edit.ex:331
+#: lib/vutuv_web/live/organization_live/edit.ex:326
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
 #: lib/vutuv_web/templates/address/country_input.html.heex:5
@@ -1596,7 +1595,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1421
+#: lib/vutuv_web/live/shell_live.ex:1412
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1615,15 +1614,15 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2864
+#: lib/vutuv_web/components/ui.ex:2966
 #: lib/vutuv_web/live/admin/job_live.ex:321
-#: lib/vutuv_web/live/admin/job_live.ex:480
+#: lib/vutuv_web/live/admin/job_live.ex:477
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1553
-#: lib/vutuv_web/live/post_live/composer.ex:1655
-#: lib/vutuv_web/live/post_live/composer.ex:1656
-#: lib/vutuv_web/live/post_live/composer.ex:2486
-#: lib/vutuv_web/live/post_live/composer.ex:2752
+#: lib/vutuv_web/live/post_live/composer.ex:1529
+#: lib/vutuv_web/live/post_live/composer.ex:1631
+#: lib/vutuv_web/live/post_live/composer.ex:1632
+#: lib/vutuv_web/live/post_live/composer.ex:2425
+#: lib/vutuv_web/live/post_live/composer.ex:2691
 #: lib/vutuv_web/templates/layout/app.html.heex:188
 #: lib/vutuv_web/templates/layout/app.html.heex:194
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
@@ -1634,7 +1633,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/email/confirm.html.heex:9
 #: lib/vutuv_web/templates/username/confirm.html.heex:25
-#: lib/vutuv_web/templates/username/confirm.html.heex:165
+#: lib/vutuv_web/templates/username/confirm.html.heex:163
 #, elixir-autogen, elixir-format
 msgid "Confirm"
 msgstr ""
@@ -1644,17 +1643,17 @@ msgstr ""
 msgid "Confirm account deletion"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:254
+#: lib/vutuv_web/controllers/page_controller.ex:255
 #: lib/vutuv_web/templates/layout/app.html.heex:117
-#: lib/vutuv_web/templates/page/index.html.heex:316
+#: lib/vutuv_web/templates/page/index.html.heex:315
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:260
+#: lib/vutuv_web/controllers/page_controller.ex:261
 #: lib/vutuv_web/templates/layout/app.html.heex:118
-#: lib/vutuv_web/templates/page/index.html.heex:316
+#: lib/vutuv_web/templates/page/index.html.heex:315
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Nutzungsbedingungen"
@@ -1672,23 +1671,23 @@ msgstr ""
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2025
-#: lib/vutuv_web/components/ui.ex:2034
-#: lib/vutuv_web/components/ui.ex:2512
+#: lib/vutuv_web/components/ui.ex:2049
+#: lib/vutuv_web/components/ui.ex:2058
+#: lib/vutuv_web/components/ui.ex:2536
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:236
-#: lib/vutuv_web/components/ui.ex:2670
-#: lib/vutuv_web/components/ui.ex:2670
-#: lib/vutuv_web/components/ui.ex:2687
-#: lib/vutuv_web/components/ui.ex:2696
-#: lib/vutuv_web/components/ui.ex:2712
-#: lib/vutuv_web/components/ui.ex:2774
-#: lib/vutuv_web/live/fediverse_account_live.ex:381
+#: lib/vutuv_web/components/ui.ex:2772
+#: lib/vutuv_web/components/ui.ex:2772
+#: lib/vutuv_web/components/ui.ex:2789
+#: lib/vutuv_web/components/ui.ex:2798
+#: lib/vutuv_web/components/ui.ex:2814
+#: lib/vutuv_web/components/ui.ex:2876
+#: lib/vutuv_web/live/fediverse_account_live.ex:391
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:311
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:312
 #: lib/vutuv_web/live/organization_live/following.ex:331
 #: lib/vutuv_web/live/organization_live/following.ex:412
 #: lib/vutuv_web/live/organization_live/show.ex:569
@@ -1711,7 +1710,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1360
+#: lib/vutuv_web/live/shell_live.ex:1356
 #: lib/vutuv_web/views/settings_html.ex:299
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1725,7 +1724,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_live.ex:154
 #: lib/vutuv_web/live/message_live/index.ex:538
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:32
-#: lib/vutuv_web/templates/admin/account/index.html.heex:55
+#: lib/vutuv_web/templates/admin/account/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:28
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:24
 #, elixir-autogen, elixir-format
@@ -1740,29 +1739,29 @@ msgstr ""
 msgid "Message"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:227
+#: lib/vutuv_web/controllers/page_controller.ex:228
 #: lib/vutuv_web/live/message_live/index.ex:49
-#: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1252
-#: lib/vutuv_web/live/shell_live.ex:1420
+#: lib/vutuv_web/live/message_live/index.ex:624
+#: lib/vutuv_web/live/shell_live.ex:1248
+#: lib/vutuv_web/live/shell_live.ex:1411
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1136
+#: lib/vutuv_web/live/shell_live.ex:1132
 #: lib/vutuv_web/templates/layout/app.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:450
-#: lib/vutuv_web/components/ui.ex:4416
+#: lib/vutuv_web/components/post_components.ex:451
+#: lib/vutuv_web/components/ui.ex:4524
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
 #: lib/vutuv_web/live/admin/user_live.ex:286
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:122
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr ""
@@ -1773,18 +1772,18 @@ msgid "Nothing new yet."
 msgstr ""
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:4734
-#: lib/vutuv_web/controllers/page_controller.ex:228
+#: lib/vutuv_web/components/ui.ex:4842
+#: lib/vutuv_web/controllers/page_controller.ex:229
 #: lib/vutuv_web/live/notification_live/index.ex:146
 #: lib/vutuv_web/live/notification_live/index.ex:384
-#: lib/vutuv_web/live/shell_live.ex:1264
+#: lib/vutuv_web/live/shell_live.ex:1260
 #: lib/vutuv_web/templates/layout/app.html.heex:153
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_detail_live.ex:93
+#: lib/vutuv_web/live/admin/user_detail_live.ex:88
 #: lib/vutuv_web/live/admin/user_live.ex:322
 #: lib/vutuv_web/templates/email/confirm.html.heex:25
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:17
@@ -1799,7 +1798,7 @@ msgid "Pardon us! Something went wrong."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:912
+#: lib/vutuv_web/live/message_live/index.ex:902
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
@@ -1848,7 +1847,7 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
 #: lib/vutuv_web/templates/user/show.html.heex:209
-#: lib/vutuv_web/views/user_html.ex:1071
+#: lib/vutuv_web/views/user_html.ex:1077
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
 msgstr ""
@@ -1873,8 +1872,8 @@ msgstr ""
 msgid "Who to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:901
-#: lib/vutuv_web/live/message_live/index.ex:902
+#: lib/vutuv_web/live/message_live/index.ex:891
+#: lib/vutuv_web/live/message_live/index.ex:892
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr ""
@@ -1919,17 +1918,16 @@ msgstr ""
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3695
-#: lib/vutuv_web/components/ui.ex:3848
+#: lib/vutuv_web/components/ui.ex:3807
+#: lib/vutuv_web/components/ui.ex:3952
 #: lib/vutuv_web/live/import_connections_live.ex:638
-#: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4441
+#: lib/vutuv_web/components/ui.ex:4549
 #: lib/vutuv_web/live/organization_live/activity.ex:151
-#: lib/vutuv_web/live/organization_live/feed.ex:210
+#: lib/vutuv_web/live/organization_live/feed.ex:209
 #: lib/vutuv_web/live/organization_live/show.ex:777
 #, elixir-autogen, elixir-format
 msgid "Load more"
@@ -1940,13 +1938,13 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4212
+#: lib/vutuv_web/components/ui.ex:4316
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1706
-#: lib/vutuv_web/components/ui.ex:1716
+#: lib/vutuv_web/components/ui.ex:1730
+#: lib/vutuv_web/components/ui.ex:1740
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr ""
@@ -1985,12 +1983,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3218
+#: lib/vutuv_web/components/ui.ex:3320
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3222
+#: lib/vutuv_web/components/ui.ex:3324
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -2005,7 +2003,7 @@ msgstr ""
 msgid "Change cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:101
+#: lib/vutuv_web/templates/user/edit.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
 msgstr ""
@@ -2015,37 +2013,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3226
+#: lib/vutuv_web/components/ui.ex:3328
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3216
+#: lib/vutuv_web/components/ui.ex:3318
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3215
+#: lib/vutuv_web/components/ui.ex:3317
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3221
+#: lib/vutuv_web/components/ui.ex:3323
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3220
+#: lib/vutuv_web/components/ui.ex:3322
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3217
+#: lib/vutuv_web/components/ui.ex:3319
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3219
+#: lib/vutuv_web/components/ui.ex:3321
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2060,34 +2058,34 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3225
+#: lib/vutuv_web/components/ui.ex:3327
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3224
+#: lib/vutuv_web/components/ui.ex:3326
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3223
+#: lib/vutuv_web/components/ui.ex:3325
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
 
 #: lib/vutuv_web/templates/education/form_content.html.heex:32
-#: lib/vutuv_web/templates/user/edit.html.heex:254
+#: lib/vutuv_web/templates/user/edit.html.heex:249
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Markdown is supported: bold, italics, links and lists."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:710
+#: lib/vutuv_web/live/job_posting_live/form.ex:709
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2102
+#: lib/vutuv_web/live/post_live/composer.ex:2040
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2098,7 +2096,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1795
+#: lib/vutuv_web/live/post_live/composer.ex:1771
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2108,7 +2106,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3583
+#: lib/vutuv_web/components/post_components.ex:3605
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2122,12 +2120,12 @@ msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:265
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
-#: lib/vutuv_web/live/organization_live/feed.ex:155
+#: lib/vutuv_web/live/organization_live/feed.ex:154
 #: lib/vutuv_web/live/post_live/feed.ex:317
-#: lib/vutuv_web/live/post_live/feed.ex:2899
+#: lib/vutuv_web/live/post_live/feed.ex:2896
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1114
-#: lib/vutuv_web/live/shell_live.ex:1413
+#: lib/vutuv_web/live/shell_live.ex:1110
+#: lib/vutuv_web/live/shell_live.ex:1404
 #: lib/vutuv_web/templates/layout/app.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2143,55 +2141,55 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2078
+#: lib/vutuv_web/live/post_live/composer.ex:2016
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2006
+#: lib/vutuv_web/live/post_live/composer.ex:1944
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3537
-#: lib/vutuv_web/components/post_components.ex:3539
+#: lib/vutuv_web/components/post_components.ex:3559
+#: lib/vutuv_web/components/post_components.ex:3561
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2048
+#: lib/vutuv_web/live/post_live/composer.ex:1986
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1295
-#: lib/vutuv_web/live/post_live/composer.ex:1343
+#: lib/vutuv_web/live/post_live/composer.ex:1270
+#: lib/vutuv_web/live/post_live/composer.ex:1318
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3153
+#: lib/vutuv_web/live/post_live/feed.ex:3150
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1261
+#: lib/vutuv_web/live/post_live/composer.ex:1236
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2038
+#: lib/vutuv_web/live/post_live/composer.ex:1976
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2028
+#: lib/vutuv_web/live/post_live/composer.ex:1966
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:416
-#: lib/vutuv_web/live/post_live/composer.ex:1926
+#: lib/vutuv_web/live/post_live/composer.ex:1928
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2208,40 +2206,40 @@ msgstr ""
 #: lib/vutuv_web/controllers/user_controller.ex:76
 #: lib/vutuv_web/gettext_extraction_anchors.ex:109
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
-#: lib/vutuv_web/live/fediverse_account_live.ex:388
+#: lib/vutuv_web/live/fediverse_account_live.ex:398
 #: lib/vutuv_web/live/notification_live/index.ex:1125
 #: lib/vutuv_web/live/organization_live/show.ex:700
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:345
-#: lib/vutuv_web/live/search_live.ex:836
-#: lib/vutuv_web/templates/settings/preferences.html.heex:319
+#: lib/vutuv_web/live/search_live.ex:829
+#: lib/vutuv_web/templates/settings/preferences.html.heex:308
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3998
-#: lib/vutuv_web/components/post_components.ex:4002
+#: lib/vutuv_web/components/post_components.ex:4020
+#: lib/vutuv_web/components/post_components.ex:4024
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3999
-#: lib/vutuv_web/live/fediverse_account_live.ex:334
+#: lib/vutuv_web/components/post_components.ex:4021
+#: lib/vutuv_web/live/fediverse_account_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:429
-#: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1353
+#: lib/vutuv_web/components/fediverse_components.ex:426
+#: lib/vutuv_web/components/job_exclusion_components.ex:189
+#: lib/vutuv_web/components/post_components.ex:1354
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
-#: lib/vutuv_web/live/job_search_exclusions_live.ex:234
-#: lib/vutuv_web/live/organization_live/domains.ex:246
-#: lib/vutuv_web/live/organization_live/edit.ex:408
-#: lib/vutuv_web/live/organization_live/roles.ex:247
-#: lib/vutuv_web/live/post_live/composer.ex:2064
+#: lib/vutuv_web/live/job_search_exclusions_live.ex:229
+#: lib/vutuv_web/live/organization_live/domains.ex:245
+#: lib/vutuv_web/live/organization_live/edit.ex:395
+#: lib/vutuv_web/live/organization_live/roles.ex:242
+#: lib/vutuv_web/live/post_live/composer.ex:2002
 #: lib/vutuv_web/live/post_live/filter_band.ex:455
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
@@ -2256,12 +2254,12 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1916
+#: lib/vutuv_web/live/post_live/composer.ex:1918
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2224
+#: lib/vutuv_web/live/post_live/feed.ex:2226
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2273,12 +2271,12 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1369
+#: lib/vutuv_web/live/post_live/composer.ex:1344
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1243
+#: lib/vutuv_web/live/post_live/composer.ex:1218
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2288,18 +2286,18 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2901
+#: lib/vutuv_web/live/post_live/composer.ex:2840
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2902
+#: lib/vutuv_web/live/post_live/composer.ex:2841
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5034
-#: lib/vutuv_web/live/shell_live.ex:1307
+#: lib/vutuv_web/components/ui.ex:5142
+#: lib/vutuv_web/live/shell_live.ex:1303
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:246
@@ -2307,58 +2305,58 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2179
+#: lib/vutuv_web/live/post_live/composer.ex:2117
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2180
+#: lib/vutuv_web/live/post_live/composer.ex:2118
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3534
+#: lib/vutuv_web/components/post_components.ex:3556
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5439
+#: lib/vutuv_web/components/post_components.ex:5461
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5443
+#: lib/vutuv_web/components/post_components.ex:5465
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5441
+#: lib/vutuv_web/components/post_components.ex:5463
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5442
+#: lib/vutuv_web/components/post_components.ex:5464
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3296
+#: lib/vutuv_web/components/ui.ex:3398
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1831
+#: lib/vutuv_web/live/post_live/composer.ex:1807
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2892
+#: lib/vutuv_web/live/post_live/composer.ex:2831
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2896
+#: lib/vutuv_web/live/post_live/composer.ex:2835
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2378,9 +2376,9 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2033
-#: lib/vutuv_web/components/post_components.ex:5535
-#: lib/vutuv_web/components/ui.ex:3770
+#: lib/vutuv_web/components/post_components.ex:2055
+#: lib/vutuv_web/components/post_components.ex:5557
+#: lib/vutuv_web/components/ui.ex:3874
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2389,17 +2387,17 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1145
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:1244
-#: lib/vutuv_web/live/shell_live.ex:1312
+#: lib/vutuv_web/live/shell_live.ex:1240
+#: lib/vutuv_web/live/shell_live.ex:1308
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1986
-#: lib/vutuv_web/components/post_components.ex:5771
-#: lib/vutuv_web/components/ui.ex:3756
+#: lib/vutuv_web/components/post_components.ex:2008
+#: lib/vutuv_web/components/post_components.ex:5793
+#: lib/vutuv_web/components/ui.ex:3860
 #: lib/vutuv_web/live/notification_live/index.ex:1271
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
@@ -2407,11 +2405,11 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1144
-#: lib/vutuv_web/components/post_components.ex:5781
+#: lib/vutuv_web/components/post_components.ex:5803
 #: lib/vutuv_web/live/notification_live/index.ex:1204
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:1315
+#: lib/vutuv_web/live/shell_live.ex:1311
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2429,57 +2427,57 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5523
+#: lib/vutuv_web/components/post_components.ex:5545
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2032
-#: lib/vutuv_web/components/post_components.ex:5534
+#: lib/vutuv_web/components/post_components.ex:2054
+#: lib/vutuv_web/components/post_components.ex:5556
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2014
-#: lib/vutuv_web/components/post_components.ex:5520
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
+#: lib/vutuv_web/components/post_components.ex:2036
+#: lib/vutuv_web/components/post_components.ex:5542
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2279
-#: lib/vutuv_web/components/post_components.ex:4615
+#: lib/vutuv_web/components/post_components.ex:2301
+#: lib/vutuv_web/components/post_components.ex:4637
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2013
-#: lib/vutuv_web/components/post_components.ex:5519
+#: lib/vutuv_web/components/post_components.ex:2035
+#: lib/vutuv_web/components/post_components.ex:5541
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1985
-#: lib/vutuv_web/components/post_components.ex:5770
+#: lib/vutuv_web/components/post_components.ex:2007
+#: lib/vutuv_web/components/post_components.ex:5792
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:430
-#: lib/vutuv_web/components/post_components.ex:2648
-#: lib/vutuv_web/components/ui.ex:2665
-#: lib/vutuv_web/components/ui.ex:2665
-#: lib/vutuv_web/components/ui.ex:2741
+#: lib/vutuv_web/components/fediverse_components.ex:427
+#: lib/vutuv_web/components/post_components.ex:2670
+#: lib/vutuv_web/components/ui.ex:2767
+#: lib/vutuv_web/components/ui.ex:2767
+#: lib/vutuv_web/components/ui.ex:2843
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:611
 #: lib/vutuv_web/live/post_live/feed.ex:890
 #: lib/vutuv_web/templates/followee/index.html.heex:30
-#: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
+#: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
 #: lib/vutuv_web/views/user_html.ex:618
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2490,38 +2488,38 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5825
+#: lib/vutuv_web/components/post_components.ex:5847
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:408
+#: lib/vutuv_web/components/post_components.ex:409
 #: lib/vutuv_web/live/notification_live/index.ex:1205
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1999
-#: lib/vutuv_web/components/post_components.ex:5808
-#: lib/vutuv_web/components/post_components.ex:5809
+#: lib/vutuv_web/components/post_components.ex:2021
+#: lib/vutuv_web/components/post_components.ex:5830
+#: lib/vutuv_web/components/post_components.ex:5831
 #: lib/vutuv_web/live/notification_live/index.ex:1268
 #: lib/vutuv_web/live/post_live/reply.ex:46
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3501
+#: lib/vutuv_web/components/post_components.ex:3523
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1246
-#: lib/vutuv_web/live/post_live/composer.ex:1904
+#: lib/vutuv_web/live/post_live/composer.ex:1221
+#: lib/vutuv_web/live/post_live/composer.ex:1906
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2109
+#: lib/vutuv_web/live/post_live/composer.ex:2047
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2531,7 +2529,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3037
+#: lib/vutuv_web/components/post_components.ex:3059
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:60
@@ -2539,49 +2537,49 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3475
+#: lib/vutuv_web/components/post_components.ex:3497
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3466
-#: lib/vutuv_web/components/post_components.ex:3493
-#: lib/vutuv_web/components/post_components.ex:3496
+#: lib/vutuv_web/components/post_components.ex:3488
+#: lib/vutuv_web/components/post_components.ex:3515
+#: lib/vutuv_web/components/post_components.ex:3518
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:613
+#: lib/vutuv_web/live/message_live/index.ex:603
 #, elixir-autogen, elixir-format
 msgid "%{names} are typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:612
+#: lib/vutuv_web/live/message_live/index.ex:602
 #, elixir-autogen, elixir-format
 msgid "%{name} is typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:924
+#: lib/vutuv_web/live/message_live/index.ex:914
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:875
+#: lib/vutuv_web/live/message_live/index.ex:865
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to message you."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:596
+#: lib/vutuv_web/live/message_live/index.ex:591
 #, elixir-autogen, elixir-format
 msgid "Accept"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:738
+#: lib/vutuv_web/live/message_live/index.ex:728
 #, elixir-autogen, elixir-format
 msgid "Back to conversations"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:603
+#: lib/vutuv_web/live/message_live/index.ex:593
 #, elixir-autogen, elixir-format
 msgid "Decline"
 msgstr ""
@@ -2591,7 +2589,7 @@ msgstr ""
 msgid "Deleted account"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:784
+#: lib/vutuv_web/live/message_live/index.ex:774
 #, elixir-autogen, elixir-format
 msgid "Load older messages"
 msgstr ""
@@ -2602,23 +2600,23 @@ msgstr ""
 msgid "Member not found."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:717
+#: lib/vutuv_web/live/message_live/index.ex:707
 #, elixir-autogen, elixir-format
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2988
-#: lib/vutuv_web/live/message_live/index.ex:760
+#: lib/vutuv_web/components/ui.ex:3090
+#: lib/vutuv_web/live/message_live/index.ex:750
 #, elixir-autogen, elixir-format
 msgid "Online"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:666
+#: lib/vutuv_web/live/message_live/index.ex:656
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:933
+#: lib/vutuv_web/live/message_live/index.ex:923
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr ""
@@ -2673,7 +2671,7 @@ msgstr ""
 msgid "Founder of vutuv"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:206
+#: lib/vutuv_web/templates/page/index.html.heex:211
 #: lib/vutuv_web/templates/settings/privacy.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Allow search engines to index your profile"
@@ -2694,7 +2692,7 @@ msgstr ""
 msgid "Okay, let's start over."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:815
+#: lib/vutuv_web/components/ui.ex:839
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr ""
@@ -2705,7 +2703,7 @@ msgstr ""
 msgid "Too many PIN requests. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:836
+#: lib/vutuv_web/components/ui.ex:860
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr ""
@@ -2755,11 +2753,11 @@ msgstr ""
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3936
-#: lib/vutuv_web/components/ui.ex:4369
+#: lib/vutuv_web/components/ui.ex:4040
+#: lib/vutuv_web/components/ui.ex:4477
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
-#: lib/vutuv_web/templates/settings/organizations.html.heex:104
+#: lib/vutuv_web/templates/settings/organizations.html.heex:109
 #: lib/vutuv_web/templates/settings/preferences.html.heex:195
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
@@ -2769,8 +2767,8 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:225
-#: lib/vutuv_web/live/post_live/feed.ex:2280
+#: lib/vutuv_web/controllers/page_controller.ex:226
+#: lib/vutuv_web/live/post_live/feed.ex:2282
 #: lib/vutuv_web/templates/user/show.html.heex:499
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2808,7 +2806,7 @@ msgstr[1] ""
 msgid "Connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1304
+#: lib/vutuv_web/components/ui.ex:1328
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2818,17 +2816,17 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1320
+#: lib/vutuv_web/components/ui.ex:1344
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2018
+#: lib/vutuv_web/live/post_live/composer.ex:1956
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1305
+#: lib/vutuv_web/components/ui.ex:1329
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -2846,12 +2844,12 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5440
+#: lib/vutuv_web/components/post_components.ex:5462
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:718
+#: lib/vutuv_web/live/message_live/index.ex:708
 #, elixir-autogen, elixir-format
 msgid "Open someone's profile to message them."
 msgstr ""
@@ -2955,7 +2953,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:343
 #: lib/vutuv_web/agent_docs/text.ex:324
-#: lib/vutuv_web/controllers/page_controller.ex:90
+#: lib/vutuv_web/controllers/page_controller.ex:91
 #: lib/vutuv_web/templates/layout/app.html.heex:119
 #: lib/vutuv_web/templates/page/community.html.heex:4
 #, elixir-autogen, elixir-format
@@ -3017,7 +3015,7 @@ msgstr ""
 msgid "Hidden. You can settle this yourself - see below."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:813
+#: lib/vutuv_web/live/message_live/index.ex:803
 #, elixir-autogen, elixir-format
 msgid "Hidden: reported, under review"
 msgstr ""
@@ -3109,7 +3107,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3442
+#: lib/vutuv_web/components/post_components.ex:3464
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3158,9 +3156,9 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4666
-#: lib/vutuv_web/live/shell_live.ex:1128
-#: lib/vutuv_web/live/shell_live.ex:1425
+#: lib/vutuv_web/components/ui.ex:4774
+#: lib/vutuv_web/live/shell_live.ex:1124
+#: lib/vutuv_web/live/shell_live.ex:1416
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3184,9 +3182,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1363
-#: lib/vutuv_web/components/post_components.ex:2660
-#: lib/vutuv_web/components/post_components.ex:3606
+#: lib/vutuv_web/components/post_components.ex:1364
+#: lib/vutuv_web/components/post_components.ex:2682
+#: lib/vutuv_web/components/post_components.ex:3628
 #: lib/vutuv_web/live/organization_live/show.ex:651
 #: lib/vutuv_web/templates/user/show.html.heex:229
 #, elixir-autogen, elixir-format
@@ -3214,8 +3212,8 @@ msgstr ""
 msgid "Report this content"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:831
-#: lib/vutuv_web/live/message_live/index.ex:832
+#: lib/vutuv_web/live/message_live/index.ex:821
+#: lib/vutuv_web/live/message_live/index.ex:822
 #, elixir-autogen, elixir-format
 msgid "Report this message"
 msgstr ""
@@ -3269,7 +3267,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3645
+#: lib/vutuv_web/components/ui.ex:3747
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3320,7 +3318,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/organization_live.ex:246
 #: lib/vutuv_web/live/admin/screenshot_live.ex:414
 #: lib/vutuv_web/live/admin/user_live.ex:299
-#: lib/vutuv_web/templates/admin/account/index.html.heex:57
+#: lib/vutuv_web/templates/admin/account/index.html.heex:52
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:59
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:19
 #: lib/vutuv_web/templates/admin/newsletter/index.html.heex:50
@@ -3874,7 +3872,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:157
 #: lib/vutuv_web/agent_docs/text.ex:112
 #: lib/vutuv_web/agent_docs/text.ex:143
-#: lib/vutuv_web/live/job_posting_live/form.ex:700
+#: lib/vutuv_web/live/job_posting_live/form.ex:699
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr ""
@@ -4061,7 +4059,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
 #: lib/vutuv_web/live/job_posting_live/form.ex:542
-#: lib/vutuv_web/live/organization_live/edit.ex:327
+#: lib/vutuv_web/live/organization_live/edit.ex:322
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
 #: lib/vutuv_web/templates/address/form_en.html.heex:33
@@ -4343,12 +4341,12 @@ msgstr ""
 msgid "Bookings are open through %{last}. Next available day: %{day}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3248
+#: lib/vutuv_web/components/ui.ex:3350
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3244
+#: lib/vutuv_web/components/ui.ex:3346
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr ""
@@ -4358,27 +4356,27 @@ msgstr ""
 msgid "One ad per calendar day: pick a free day in the calendar; struck-through days are already booked."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3249
+#: lib/vutuv_web/components/ui.ex:3351
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3250
+#: lib/vutuv_web/components/ui.ex:3352
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3247
+#: lib/vutuv_web/components/ui.ex:3349
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3245
+#: lib/vutuv_web/components/ui.ex:3347
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3246
+#: lib/vutuv_web/components/ui.ex:3348
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr ""
@@ -4421,7 +4419,7 @@ msgstr ""
 msgid "by"
 msgstr ""
 
-#: lib/vutuv_web/templates/ad/preview.html.heex:83
+#: lib/vutuv_web/templates/ad/preview.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Book now (binding, by invoice)"
 msgstr ""
@@ -4431,12 +4429,12 @@ msgstr ""
 msgid "Booking is binding; payment by invoice. We review and approve every ad before it runs."
 msgstr ""
 
-#: lib/vutuv_web/templates/ad/preview.html.heex:77
+#: lib/vutuv_web/templates/ad/preview.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "Edit the ad"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1004
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:999
 #: lib/vutuv_web/live/tag_new_live.ex:78
 #: lib/vutuv_web/templates/ad/preview.html.heex:3
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:122
@@ -4510,7 +4508,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4784
+#: lib/vutuv_web/components/ui.ex:4892
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4552,12 +4550,12 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3158
+#: lib/vutuv_web/live/post_live/feed.ex:3155
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:721
+#: lib/vutuv_web/live/message_live/index.ex:711
 #, elixir-autogen, elixir-format
 msgid "Find members"
 msgstr ""
@@ -4596,12 +4594,12 @@ msgstr ""
 msgid "This area is reserved for administrators."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:884
+#: lib/vutuv_web/live/search_live.ex:877
 #, elixir-autogen, elixir-format
 msgid "No results for \"%{query}\""
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:805
+#: lib/vutuv_web/live/search_live.ex:798
 #, elixir-autogen, elixir-format
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
@@ -4613,23 +4611,23 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/show.ex:787
 #: lib/vutuv_web/live/post_live/saved.ex:523
 #: lib/vutuv_web/live/search_live.ex:343
-#: lib/vutuv_web/live/search_live.ex:778
+#: lib/vutuv_web/live/search_live.ex:771
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:719
+#: lib/vutuv_web/live/search_live.ex:712
 #, elixir-autogen, elixir-format
 msgid "Results appear once you have typed at least three letters."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:802
+#: lib/vutuv_web/live/search_live.ex:795
 #, elixir-autogen, elixir-format
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:405
-#: lib/vutuv_web/components/post_components.ex:424
+#: lib/vutuv_web/components/post_components.ex:406
+#: lib/vutuv_web/components/post_components.ex:425
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -4640,7 +4638,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:702
+#: lib/vutuv_web/live/search_live.ex:695
 #, elixir-autogen, elixir-format
 msgid "Exact matches only"
 msgstr ""
@@ -4680,7 +4678,7 @@ msgstr ""
 msgid "searches first names only (last: for last names)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:388
+#: lib/vutuv_web/live/job_board_live.ex:384
 #: lib/vutuv_web/live/tag_new_live.ex:47
 #: lib/vutuv_web/live/user_profile_live.ex:1336
 #: lib/vutuv_web/templates/user/show.html.heex:602
@@ -4731,8 +4729,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:286
 #: lib/vutuv_web/agent_docs/text.ex:270
 #: lib/vutuv_web/live/admin/job_live.ex:389
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
-#: lib/vutuv_web/live/job_posting_live/show.ex:136
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:140
+#: lib/vutuv_web/live/job_posting_live/show.ex:131
 #: lib/vutuv_web/templates/access_token/new.html.heex:42
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:45
 #: lib/vutuv_web/templates/qualification/show.html.heex:38
@@ -4916,14 +4914,14 @@ msgid "API applications"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/api_app_live.ex:98
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:180
 #: lib/vutuv_web/views/settings_html.ex:90
 #: lib/vutuv_web/views/settings_html.ex:290
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:82
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Allow access"
 msgstr ""
@@ -4985,7 +4983,7 @@ msgstr ""
 msgid "Delete \"%{name}\"? Every member authorization and every token of this application stops working immediately."
 msgstr ""
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:91
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Deny"
 msgstr ""
@@ -5260,7 +5258,7 @@ msgstr ""
 msgid "vutuv POSTs signed JSON envelopes here (see the webhooks documentation). https:// only; http://localhost is allowed for development."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:211
+#: lib/vutuv_web/templates/page/index.html.heex:216
 #: lib/vutuv_web/templates/settings/privacy.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "Allow AI agents and LLMs to use your profile"
@@ -5276,14 +5274,14 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4844
+#: lib/vutuv_web/components/ui.ex:4952
 #: lib/vutuv_web/controllers/settings_controller.ex:157
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_delete_live.ex:109
-#: lib/vutuv_web/live/admin/user_delete_live.ex:221
+#: lib/vutuv_web/live/admin/user_delete_live.ex:209
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:136
 #: lib/vutuv_web/templates/settings/delete_account.html.heex:9
 #: lib/vutuv_web/templates/settings/delete_account.html.heex:11
@@ -5291,7 +5289,7 @@ msgstr ""
 msgid "Delete account"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/delete_account.html.heex:53
+#: lib/vutuv_web/templates/settings/delete_account.html.heex:54
 #, elixir-autogen, elixir-format
 msgid "Start deleting your account? We will email you a PIN to confirm."
 msgstr ""
@@ -5312,7 +5310,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1264
+#: lib/vutuv_web/live/post_live/composer.ex:1239
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5322,7 +5320,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1294
+#: lib/vutuv_web/live/shell_live.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5344,7 +5342,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1351
+#: lib/vutuv_web/live/shell_live.ex:1347
 #: lib/vutuv_web/templates/layout/app.html.heex:183
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5355,15 +5353,15 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4941
-#: lib/vutuv_web/components/ui.ex:4946
-#: lib/vutuv_web/components/ui.ex:5025
-#: lib/vutuv_web/components/ui.ex:5089
+#: lib/vutuv_web/components/ui.ex:5049
+#: lib/vutuv_web/components/ui.ex:5054
+#: lib/vutuv_web/components/ui.ex:5133
+#: lib/vutuv_web/components/ui.ex:5197
 #: lib/vutuv_web/controllers/settings_controller.ex:64
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:276
-#: lib/vutuv_web/live/shell_live.ex:1331
+#: lib/vutuv_web/live/shell_live.ex:1327
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5417,8 +5415,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1103
-#: lib/vutuv_web/live/shell_live.ex:1397
+#: lib/vutuv_web/live/shell_live.ex:1099
+#: lib/vutuv_web/live/shell_live.ex:1388
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5428,9 +5426,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3672
-#: lib/vutuv_web/components/post_components.ex:3727
-#: lib/vutuv_web/components/post_components.ex:4135
+#: lib/vutuv_web/components/post_components.ex:3694
+#: lib/vutuv_web/components/post_components.ex:3749
+#: lib/vutuv_web/components/post_components.ex:4157
 #: lib/vutuv_web/live/notification_live/index.ex:784
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
@@ -5442,7 +5440,7 @@ msgstr ""
 msgid "Someone tried to register with your email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:139
+#: lib/vutuv_web/templates/page/index.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr ""
@@ -5456,7 +5454,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:1196
+#: lib/vutuv_web/views/user_html.ex:1202
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr ""
@@ -5466,17 +5464,17 @@ msgstr ""
 msgid "Type of Email"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:171
+#: lib/vutuv_web/templates/page/index.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "Type of email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:241
+#: lib/vutuv_web/templates/user/edit.html.heex:236
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4804
+#: lib/vutuv_web/components/ui.ex:4912
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5487,7 +5485,7 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:482
+#: lib/vutuv_web/live/organization_live/edit.ex:461
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr ""
@@ -5497,7 +5495,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4704
+#: lib/vutuv_web/components/ui.ex:4812
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5526,15 +5524,15 @@ msgstr ""
 msgid "Personal tokens for the vutuv API."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2222
+#: lib/vutuv_web/live/post_live/composer.ex:2161
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4778
+#: lib/vutuv_web/components/ui.ex:4886
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
-#: lib/vutuv_web/templates/page/index.html.heex:191
+#: lib/vutuv_web/templates/page/index.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
@@ -5554,7 +5552,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:166
+#: lib/vutuv_web/templates/user/edit.html.heex:161
 #, elixir-autogen, elixir-format
 msgid "Your name"
 msgstr ""
@@ -5612,18 +5610,18 @@ msgstr ""
 msgid "Current avatar"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:112
-#: lib/vutuv_web/templates/user/edit.html.heex:119
+#: lib/vutuv_web/templates/user/edit.html.heex:107
+#: lib/vutuv_web/templates/user/edit.html.heex:114
 #, elixir-autogen, elixir-format
 msgid "Current cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:190
+#: lib/vutuv_web/templates/user/edit.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "e.g. Dr. or Prof."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:195
+#: lib/vutuv_web/templates/user/edit.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "e.g. Jr. or PhD"
 msgstr ""
@@ -5645,7 +5643,7 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4837
+#: lib/vutuv_web/components/ui.ex:4945
 #: lib/vutuv_web/controllers/settings_controller.ex:181
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5730,7 +5728,7 @@ msgstr ""
 msgid "@handle"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:776
+#: lib/vutuv_web/live/message_live/index.ex:766
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}"
 msgstr ""
@@ -5796,7 +5794,7 @@ msgid "Name (A-Z)"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:491
-#: lib/vutuv_web/live/tag_live/timeline.ex:413
+#: lib/vutuv_web/live/tag_live/timeline.ex:409
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr ""
@@ -5822,7 +5820,7 @@ msgid "Nothing here yet. People you like show up here."
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:492
-#: lib/vutuv_web/live/tag_live/timeline.ex:414
+#: lib/vutuv_web/live/tag_live/timeline.ex:410
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr ""
@@ -5844,27 +5842,27 @@ msgid "Search saved items"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:554
-#: lib/vutuv_web/live/tag_live/timeline.ex:339
+#: lib/vutuv_web/live/tag_live/timeline.ex:335
 #, elixir-autogen, elixir-format
 msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3305
+#: lib/vutuv_web/components/ui.ex:3407
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3304
+#: lib/vutuv_web/components/ui.ex:3406
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3303
+#: lib/vutuv_web/components/ui.ex:3405
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -5891,12 +5889,12 @@ msgstr ""
 msgid "Log out all other devices"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:85
+#: lib/vutuv_web/templates/settings/security.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Log out of every device except this one?"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:296
+#: lib/vutuv_web/views/settings_html.ex:297
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr ""
@@ -5931,7 +5929,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3302
+#: lib/vutuv_web/components/ui.ex:3404
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -5957,12 +5955,12 @@ msgstr ""
 msgid "When off, no one sees the green dot on your avatar, and you never show as online."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:145
+#: lib/vutuv_web/templates/settings/security.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Add a passkey"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1109
 #: lib/vutuv_web/live/admin/screenshot_live.ex:309
 #: lib/vutuv_web/live/fediverse_following_live.ex:264
 #: lib/vutuv_web/views/settings_html.ex:331
@@ -6005,7 +6003,7 @@ msgstr ""
 msgid "Passkeys"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:342
+#: lib/vutuv_web/views/settings_html.ex:343
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr ""
@@ -6020,7 +6018,7 @@ msgstr ""
 msgid "Sign in with a passkey"
 msgstr ""
 
-#: lib/vutuv_web/templates/session/new.html.heex:19
+#: lib/vutuv_web/templates/session/new.html.heex:20
 #, elixir-autogen, elixir-format
 msgid "Sign-in failed. Please try again or use your email."
 msgstr ""
@@ -6036,7 +6034,7 @@ msgstr ""
 msgid "That passkey could not be verified."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:156
+#: lib/vutuv_web/templates/settings/security.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "This browser does not support passkeys."
 msgstr ""
@@ -6067,13 +6065,13 @@ msgid "Add a tagline"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:148
-#: lib/vutuv_web/templates/user/edit.html.heex:250
+#: lib/vutuv_web/templates/user/edit.html.heex:245
 #: lib/vutuv_web/views/account_event_text.ex:212
 #, elixir-autogen, elixir-format
 msgid "Tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:396
+#: lib/vutuv_web/components/ui.ex:457
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:907
@@ -6092,18 +6090,18 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:63
-#: lib/vutuv_web/templates/user/edit.html.heex:149
+#: lib/vutuv_web/templates/user/edit.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1527
+#: lib/vutuv_web/templates/user/show.html.heex:1526
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:51
-#: lib/vutuv_web/templates/user/edit.html.heex:136
+#: lib/vutuv_web/templates/user/edit.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Drag to move, use the slider to zoom. The framed area is what others see."
 msgstr ""
@@ -6113,12 +6111,12 @@ msgstr ""
 msgid "New avatar preview"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:154
+#: lib/vutuv_web/templates/user/edit.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "New cover photo preview"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:135
+#: lib/vutuv_web/templates/user/edit.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Position your cover photo"
 msgstr ""
@@ -6129,14 +6127,14 @@ msgid "Position your photo"
 msgstr ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:52
-#: lib/vutuv_web/templates/user/edit.html.heex:137
+#: lib/vutuv_web/templates/user/edit.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Use photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1699
+#: lib/vutuv_web/live/post_live/composer.ex:1675
 #: lib/vutuv_web/templates/user/edit.html.heex:54
-#: lib/vutuv_web/templates/user/edit.html.heex:139
+#: lib/vutuv_web/templates/user/edit.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr ""
@@ -6223,7 +6221,7 @@ msgid "Previous day"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1144
-#: lib/vutuv_web/components/post_components.ex:407
+#: lib/vutuv_web/components/post_components.ex:408
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6258,9 +6256,9 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2025
-#: lib/vutuv_web/components/ui.ex:2034
-#: lib/vutuv_web/components/ui.ex:2513
+#: lib/vutuv_web/components/ui.ex:2049
+#: lib/vutuv_web/components/ui.ex:2058
+#: lib/vutuv_web/components/ui.ex:2537
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6287,9 +6285,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1513
-#: lib/vutuv_web/templates/user/show.html.heex:1521
-#: lib/vutuv_web/templates/user/show.html.heex:1533
+#: lib/vutuv_web/templates/user/show.html.heex:1516
+#: lib/vutuv_web/templates/user/show.html.heex:1520
+#: lib/vutuv_web/templates/user/show.html.heex:1532
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6321,7 +6319,7 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2466
+#: lib/vutuv_web/components/ui.ex:2490
 #: lib/vutuv_web/live/notification_live/index.ex:684
 #: lib/vutuv_web/live/notification_live/index.ex:699
 #: lib/vutuv_web/live/notification_live/index.ex:1012
@@ -6616,10 +6614,10 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2628
-#: lib/vutuv_web/components/post_components.ex:3603
-#: lib/vutuv_web/components/ui.ex:2813
-#: lib/vutuv_web/live/fediverse_account_live.ex:375
+#: lib/vutuv_web/components/post_components.ex:2650
+#: lib/vutuv_web/components/post_components.ex:3625
+#: lib/vutuv_web/components/ui.ex:2915
+#: lib/vutuv_web/live/fediverse_account_live.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:215
@@ -6645,13 +6643,13 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3603
-#: lib/vutuv_web/components/ui.ex:2812
-#: lib/vutuv_web/live/fediverse_account_live.ex:373
+#: lib/vutuv_web/components/post_components.ex:3625
+#: lib/vutuv_web/components/ui.ex:2914
+#: lib/vutuv_web/live/fediverse_account_live.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:215
-#: lib/vutuv_web/templates/settings/filters.html.heex:110
+#: lib/vutuv_web/templates/settings/filters.html.heex:111
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
 msgid "Unmute"
@@ -6673,12 +6671,12 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1195
+#: lib/vutuv_web/views/user_html.ex:1201
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:748
+#: lib/vutuv_web/views/user_html.ex:754
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr ""
@@ -6698,7 +6696,7 @@ msgstr ""
 msgid "All statuses"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:779
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "Any country"
 msgstr ""
@@ -6718,15 +6716,15 @@ msgstr ""
 msgid "Audience deleted."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:709
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:704
 #, elixir-autogen, elixir-format
 msgid "Audience name"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:574
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:638
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:637
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:688
 #: lib/vutuv_web/templates/admin/newsletter/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Audiences"
@@ -6748,7 +6746,7 @@ msgstr ""
 msgid "Build a fixed group from filters, then send a newsletter to it. Subtract another group to do a test run, then send to the rest."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:855
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:850
 #, elixir-autogen, elixir-format
 msgid "Cap group size (optional)"
 msgstr ""
@@ -6769,7 +6767,7 @@ msgid "Created"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:619
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:659
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:655
 #, elixir-autogen, elixir-format
 msgid "Delete this audience?"
 msgstr ""
@@ -6838,7 +6836,7 @@ msgid "Filter"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:591
-#: lib/vutuv_web/live/tag_live/timeline.ex:305
+#: lib/vutuv_web/live/tag_live/timeline.ex:301
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr ""
@@ -6865,14 +6863,14 @@ msgstr ""
 msgid "Markdown is supported (headings, bold, lists, links)."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:801
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:796
 #, elixir-autogen, elixir-format
 msgid "Maximum age"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:592
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:670
-#: lib/vutuv_web/live/admin/user_detail_live.ex:69
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:665
+#: lib/vutuv_web/live/admin/user_detail_live.ex:64
 #: lib/vutuv_web/live/admin/user_live.ex:28
 #: lib/vutuv_web/live/admin/user_live.ex:164
 #: lib/vutuv_web/live/admin/user_live.ex:165
@@ -6885,12 +6883,12 @@ msgstr ""
 msgid "Members"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:941
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:936
 #, elixir-autogen, elixir-format
 msgid "Members matching"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:786
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "Minimum age"
 msgstr ""
@@ -6931,8 +6929,8 @@ msgstr ""
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:19
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:128
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:638
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:637
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:688
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/index.html.heex:2
@@ -6959,7 +6957,7 @@ msgstr ""
 msgid "No newsletters yet."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:831
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:826
 #, elixir-autogen, elixir-format
 msgid "No tag with that name."
 msgstr ""
@@ -6974,7 +6972,7 @@ msgstr ""
 msgid "Occasional vutuv news and announcements."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:880
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:875
 #, elixir-autogen, elixir-format
 msgid "Off: take the oldest members first (by join date)."
 msgstr ""
@@ -6984,7 +6982,7 @@ msgstr ""
 msgid "Open newsletters"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:878
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:873
 #, elixir-autogen, elixir-format
 msgid "Pick capped members at random"
 msgstr ""
@@ -7015,19 +7013,19 @@ msgstr ""
 msgid "Rendered with your own account data for the variables."
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:241
+#: lib/vutuv_web/live/cv_live.ex:231
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:281
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Reset"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1128
 #, elixir-autogen, elixir-format
 msgid "Save audience"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:809
+#: lib/vutuv_web/live/job_posting_live/form.ex:804
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:16
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:11
 #, elixir-autogen, elixir-format
@@ -7087,7 +7085,7 @@ msgstr ""
 msgid "Subject line (variables allowed)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:915
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:910
 #, elixir-autogen, elixir-format
 msgid "Subtract these audiences"
 msgstr ""
@@ -7102,7 +7100,7 @@ msgstr ""
 msgid "Suppressed (bounced address)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:816
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:811
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:44
 #: lib/vutuv_web/templates/settings/filters.html.heex:29
 #: lib/vutuv_web/views/settings_html.ex:60
@@ -7110,7 +7108,7 @@ msgstr ""
 msgid "Tag"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:828
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:823
 #, elixir-autogen, elixir-format
 msgid "Tag found: %{name}"
 msgstr ""
@@ -7136,12 +7134,12 @@ msgstr ""
 msgid "That audience could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:918
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:913
 #, elixir-autogen, elixir-format
 msgid "Their members are removed from this one (e.g. exclude the test group to send to \"the rest\")."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:945
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:940
 #, elixir-autogen, elixir-format
 msgid "This audience will be capped to"
 msgstr ""
@@ -7167,7 +7165,7 @@ msgstr ""
 msgid "all members"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:863
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:858
 #, elixir-autogen, elixir-format
 msgid "e.g. 100 for a test run"
 msgstr ""
@@ -7177,7 +7175,7 @@ msgstr ""
 msgid "email or @handle"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:823
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:818
 #, elixir-autogen, elixir-format
 msgid "exact tag name"
 msgstr ""
@@ -7196,7 +7194,7 @@ msgid "open the dev email inbox"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
-#: lib/vutuv_web/views/user_html.ex:747
+#: lib/vutuv_web/views/user_html.ex:753
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr ""
@@ -7211,49 +7209,49 @@ msgstr ""
 msgid "max %{count}"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:674
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "The frozen snapshot saved with this audience. Click a name to open the profile."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:677
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "This audience has no members."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:844
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:839
 #, elixir-autogen, elixir-format
 msgid "e.g. stefan* or *meyer"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:849
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:844
 #, elixir-autogen, elixir-format
 msgid "Use * as a wildcard; a plain text matches anywhere in the handle."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:890
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:885
 #, elixir-autogen, elixir-format
 msgid "Add these audiences"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:893
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:888
 #, elixir-autogen, elixir-format
 msgid "Their members are added to this one (union)."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1168
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1158
 #, elixir-autogen, elixir-format
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3708
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
+#: lib/vutuv_web/components/ui.ex:3816
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3724
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
+#: lib/vutuv_web/components/ui.ex:3828
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
@@ -7265,47 +7263,47 @@ msgid_plural "plus %{count} groups"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:956
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:951
 #, elixir-autogen, elixir-format
 msgid "Choose specific accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:959
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:954
 #, elixir-autogen, elixir-format
 msgid "Tick to include an account, untick to exclude it. Search by @handle to find anyone."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:966
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1065
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:961
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1060
 #, elixir-autogen, elixir-format
 msgid "search by @handle…"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:973
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:968
 #, elixir-autogen, elixir-format
 msgid "Removed:"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:979
-#: lib/vutuv_web/live/post_live/composer.ex:1547
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:974
+#: lib/vutuv_web/live/post_live/composer.ex:1523
 #: lib/vutuv_web/live/post_live/filter_band.ex:532
 #, elixir-autogen, elixir-format
 msgid "Undo"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1025
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1020
 #, elixir-autogen, elixir-format
 msgid "In this audience"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1005
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1098
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1000
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1093
 #, elixir-autogen, elixir-format
 msgid "Search results"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1011
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1100
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1006
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1095
 #, elixir-autogen, elixir-format
 msgid "No members."
 msgstr ""
@@ -7315,27 +7313,27 @@ msgstr ""
 msgid "accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:991
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:986
 #: lib/vutuv_web/live/post_live/filter_band.ex:509
 #: lib/vutuv_web/views/import_html.ex:230
 #, elixir-autogen, elixir-format
 msgid "Select all"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:994
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:989
 #: lib/vutuv_web/views/import_html.ex:240
 #, elixir-autogen, elixir-format
 msgid "Unselect all"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:997
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:992
 #, elixir-autogen, elixir-format
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5681
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
+#: lib/vutuv_web/components/post_components.ex:5703
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
 msgstr ""
@@ -7436,7 +7434,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3424
+#: lib/vutuv_web/live/post_live/feed.ex:3421
 #, elixir-autogen
 msgid "Done"
 msgstr ""
@@ -7449,7 +7447,7 @@ msgstr ""
 msgid "View the delivery log"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:232
+#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:226
 #, elixir-autogen
 msgid "%{sent} of %{total} emails sent"
 msgstr ""
@@ -7457,7 +7455,7 @@ msgstr ""
 msgid "The newsletter will be sent to %{count} people. This cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:218
+#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:212
 #, elixir-autogen
 msgid "Send now"
 msgstr ""
@@ -7735,57 +7733,57 @@ msgstr ""
 msgid "updates automatically"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:723
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:718
 #, elixir-autogen, elixir-format
 msgid "How to build this audience"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:736
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:731
 #, elixir-autogen, elixir-format
 msgid "From filters"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:745
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:740
 #, elixir-autogen, elixir-format
 msgid "Specific accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:749
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:744
 #, elixir-autogen, elixir-format
 msgid "Pick members from filters, or hand-pick specific accounts (e.g. a small group of testers)."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1045
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1040
 #, elixir-autogen, elixir-format
 msgid "Accounts in this audience"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1049
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1044
 #, elixir-autogen, elixir-format
 msgid "Only these accounts get the newsletter. Search for members below and add them one by one."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1058
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1053
 #, elixir-autogen, elixir-format
 msgid "Find accounts to add"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1073
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Chosen accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1076
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1071
 #, elixir-autogen, elixir-format
 msgid "No accounts yet. Search above to add some."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1087
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Remove from audience"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1123
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1118
 #, elixir-autogen, elixir-format
 msgid "Add to audience"
 msgstr ""
@@ -7895,8 +7893,8 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:189
 #: lib/vutuv_web/live/admin/activity_live.ex:231
 #: lib/vutuv_web/live/admin/user_live.ex:184
-#: lib/vutuv_web/live/job_board_live.ex:257
-#: lib/vutuv_web/live/tag_live/timeline.ex:369
+#: lib/vutuv_web/live/job_board_live.ex:256
+#: lib/vutuv_web/live/tag_live/timeline.ex:365
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr ""
@@ -7912,7 +7910,7 @@ msgstr ""
 msgid "Deactivated"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_delete_live.ex:195
+#: lib/vutuv_web/live/admin/user_delete_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Delete this account?"
 msgstr ""
@@ -7957,7 +7955,7 @@ msgid "Incorrect PIN"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_delete_live.ex:145
-#: lib/vutuv_web/live/admin/user_detail_live.ex:102
+#: lib/vutuv_web/live/admin/user_detail_live.ex:97
 #: lib/vutuv_web/live/admin/user_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Joined"
@@ -7969,7 +7967,7 @@ msgid "Mark this member's identity as verified? They will be emailed."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_delete_live.ex:136
-#: lib/vutuv_web/templates/admin/account/index.html.heex:48
+#: lib/vutuv_web/templates/admin/account/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "No accounts match your search."
 msgstr ""
@@ -8000,7 +7998,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3711
+#: lib/vutuv_web/components/ui.ex:3819
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8020,7 +8018,7 @@ msgstr ""
 msgid "Search by name, @handle or email, filter and sort. The list updates as you type, and the default shows PIN-registered members, newest first."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_delete_live.ex:198
+#: lib/vutuv_web/live/admin/user_delete_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "This permanently deletes the account and everything it owns (posts, phone numbers, email addresses, tags and more). This cannot be undone. The member is not notified; a record is emailed to the operator."
 msgstr ""
@@ -8030,7 +8028,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find the account to delete."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_detail_live.ex:93
+#: lib/vutuv_web/live/admin/user_detail_live.ex:88
 #: lib/vutuv_web/live/admin/user_live.ex:322
 #, elixir-autogen, elixir-format
 msgid "Unconfirmed"
@@ -8130,7 +8128,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:4680
+#: lib/vutuv_web/components/ui.ex:4788
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8185,7 +8183,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4825
+#: lib/vutuv_web/components/ui.ex:4933
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8214,7 +8212,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4708
+#: lib/vutuv_web/components/ui.ex:4816
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8308,7 +8306,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3988
+#: lib/vutuv_web/components/ui.ex:4092
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8316,7 +8314,7 @@ msgstr ""
 msgid "Please check the fields marked in red."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1080
+#: lib/vutuv_web/views/user_html.ex:1086
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
 msgstr ""
@@ -8383,25 +8381,25 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4668
+#: lib/vutuv_web/components/ui.ex:4776
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4815
+#: lib/vutuv_web/components/ui.ex:4923
 #: lib/vutuv_web/controllers/settings_controller.ex:125
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Language & display"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:535
+#: lib/vutuv_web/templates/user/edit.html.heex:523
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4806
+#: lib/vutuv_web/components/ui.ex:4914
 #: lib/vutuv_web/controllers/settings_controller.ex:108
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8411,7 +8409,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4829
+#: lib/vutuv_web/components/ui.ex:4937
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8520,7 +8518,7 @@ msgstr[1] ""
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1322
+#: lib/vutuv_web/components/ui.ex:1346
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -8616,8 +8614,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:586
 #: lib/vutuv_web/agent_docs/text.ex:590
 #: lib/vutuv_web/components/organization_components.ex:276
-#: lib/vutuv_web/components/ui.ex:1523
-#: lib/vutuv_web/components/ui.ex:4796
+#: lib/vutuv_web/components/ui.ex:1547
+#: lib/vutuv_web/components/ui.ex:4904
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:357
 #: lib/vutuv_web/controllers/settings_controller.ex:424
@@ -8716,7 +8714,7 @@ msgstr ""
 msgid "Volunteering & hobbies"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:694
+#: lib/vutuv_web/live/search_live.ex:687
 #, elixir-autogen, elixir-format
 msgid "Not available while the search uses a people filter."
 msgstr ""
@@ -8767,12 +8765,12 @@ msgstr ""
 msgid "This is the print view of this CV. Use your browser's print dialog (Ctrl+P or Cmd+P) and choose \"Save as PDF\" to get a PDF file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1612
+#: lib/vutuv_web/components/ui.ex:1636
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4618
+#: lib/vutuv_web/components/post_components.ex:4640
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -8784,28 +8782,28 @@ msgstr[1] ""
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:233
+#: lib/vutuv_web/live/cv_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Anonymize"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:149
-#: lib/vutuv_web/templates/page/index.html.heex:161
+#: lib/vutuv_web/templates/page/index.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:440
+#: lib/vutuv_web/live/cv_live.ex:430
 #, elixir-autogen, elixir-format
 msgid "Every download reflects the parts you selected."
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:247
+#: lib/vutuv_web/live/cv_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1622
+#: lib/vutuv_web/components/ui.ex:1646
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -8822,7 +8820,7 @@ msgstr ""
 msgid "Pick what to include. Untick single entries or whole sections, or anonymize the CV by hiding the name, photo and contact details."
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:449
+#: lib/vutuv_web/live/cv_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "Print / Save as PDF"
 msgstr ""
@@ -8837,7 +8835,7 @@ msgstr ""
 msgid "The CV is public, on your profile: a visitor's download contains only what they can see there anyway, and private email addresses appear only in your own."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1614
+#: lib/vutuv_web/components/ui.ex:1638
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -8869,12 +8867,12 @@ msgstr ""
 msgid "Other activities"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:463
+#: lib/vutuv_web/live/cv_live.ex:453
 #, elixir-autogen, elixir-format
 msgid "For a PDF, open the print view and choose \"Save as PDF\" in your browser's print dialog. Word and OpenDocument are editable; LaTeX is the typesetting source; JSON Resume is the open %{link} format."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:263
+#: lib/vutuv_web/templates/user/edit.html.heex:258
 #, elixir-autogen, elixir-format
 msgid "characters"
 msgstr ""
@@ -8991,8 +8989,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2069
-#: lib/vutuv_web/components/ui.ex:2070
+#: lib/vutuv_web/components/ui.ex:2093
+#: lib/vutuv_web/components/ui.ex:2094
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9242,7 +9240,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:185
 #: lib/vutuv_web/cv/latex.ex:149
 #: lib/vutuv_web/cv/odt.ex:163
-#: lib/vutuv_web/live/cv_live.ex:386
+#: lib/vutuv_web/live/cv_live.ex:376
 #: lib/vutuv_web/templates/language/edit.html.heex:4
 #: lib/vutuv_web/templates/language/index.html.heex:10
 #: lib/vutuv_web/templates/language/manage.html.heex:4
@@ -9452,7 +9450,7 @@ msgstr ""
 msgid "Open to offers"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:287
+#: lib/vutuv_web/templates/user/edit.html.heex:282
 #, elixir-autogen, elixir-format
 msgid "Shown as a badge next to your tagline so people can see whether you are open to opportunities."
 msgstr ""
@@ -9561,7 +9559,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:4684
+#: lib/vutuv_web/components/ui.ex:4792
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -9569,7 +9567,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:169
 #: lib/vutuv_web/cv/latex.ex:140
 #: lib/vutuv_web/cv/odt.ex:154
-#: lib/vutuv_web/live/cv_live.ex:361
+#: lib/vutuv_web/live/cv_live.ex:351
 #: lib/vutuv_web/templates/import/new.html.heex:11
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
 #: lib/vutuv_web/templates/qualification/index.html.heex:11
@@ -9606,7 +9604,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:164
 #: lib/vutuv_web/live/admin/job_live.ex:180
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:183
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:182
 #: lib/vutuv_web/templates/qualification/show.html.heex:43
 #: lib/vutuv_web/views/qualification_html.ex:398
 #, elixir-autogen, elixir-format
@@ -9711,31 +9709,31 @@ msgstr ""
 msgid "Date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:440
-#: lib/vutuv_web/templates/user/edit.html.heex:523
+#: lib/vutuv_web/templates/user/edit.html.heex:436
+#: lib/vutuv_web/templates/user/edit.html.heex:511
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:503
+#: lib/vutuv_web/templates/user/edit.html.heex:499
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:506
+#: lib/vutuv_web/templates/user/edit.html.heex:502
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
 
 #: lib/vutuv_web/live/directory_search_live.ex:132
-#: lib/vutuv_web/templates/page/index.html.heex:90
+#: lib/vutuv_web/templates/page/index.html.heex:95
 #: lib/vutuv_web/views/account_event_text.ex:210
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
 #: lib/vutuv_web/live/directory_search_live.ex:133
-#: lib/vutuv_web/templates/page/index.html.heex:95
+#: lib/vutuv_web/templates/page/index.html.heex:100
 #: lib/vutuv_web/views/account_event_text.ex:211
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -9757,13 +9755,13 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3418
+#: lib/vutuv_web/components/ui.ex:3520
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3417
-#: lib/vutuv_web/components/ui.ex:3425
+#: lib/vutuv_web/components/ui.ex:3519
+#: lib/vutuv_web/components/ui.ex:3527
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -9881,12 +9879,12 @@ msgstr ""
 msgid "Removed as spam"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:357
+#: lib/vutuv_web/live/admin/user_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Restore"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:354
+#: lib/vutuv_web/live/admin/user_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "Restore this account so the member can sign in again?"
 msgstr ""
@@ -9901,7 +9899,7 @@ msgstr ""
 msgid "Thank you for your report. Our moderators have been notified and will review this account."
 msgstr ""
 
-#: lib/vutuv_web/views/admin/account_html.ex:88
+#: lib/vutuv_web/views/admin/account_html.ex:78
 #: lib/vutuv_web/views/admin/moderation_html.ex:69
 #, elixir-autogen, elixir-format
 msgid "deactivated"
@@ -9937,17 +9935,17 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:384
+#: lib/vutuv_web/components/ui.ex:445
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:436
+#: lib/vutuv_web/components/ui.ex:497
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:439
+#: lib/vutuv_web/components/ui.ex:500
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr ""
@@ -9957,18 +9955,18 @@ msgstr ""
 msgid "Delete the list"
 msgstr ""
 
-#: lib/vutuv_web/templates/login_code/index.html.heex:60
+#: lib/vutuv_web/templates/login_code/index.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "Delete your code list? All its codes stop working immediately."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:380
+#: lib/vutuv_web/components/ui.ex:441
 #, elixir-autogen, elixir-format
 msgid "Formatting"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:503
-#: lib/vutuv_web/components/ui.ex:504
+#: lib/vutuv_web/components/ui.ex:564
+#: lib/vutuv_web/components/ui.ex:565
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr ""
@@ -9983,43 +9981,43 @@ msgstr ""
 msgid "Generate code list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:434
+#: lib/vutuv_web/components/ui.ex:495
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:435
+#: lib/vutuv_web/components/ui.ex:496
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:393
+#: lib/vutuv_web/components/ui.ex:454
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:387
+#: lib/vutuv_web/components/ui.ex:448
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:540
+#: lib/vutuv_web/components/ui.ex:397
 #, elixir-autogen, elixir-format
 msgid "Link URL"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:166
+#: lib/vutuv_web/templates/settings/security.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Login codes"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:179
+#: lib/vutuv_web/templates/settings/security.html.heex:178
 #: lib/vutuv_web/templates/settings/security.html.heex:213
 #, elixir-autogen, elixir-format
 msgid "Not set up."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:437
+#: lib/vutuv_web/components/ui.ex:498
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr ""
@@ -10034,7 +10032,7 @@ msgstr ""
 msgid "Print this page or write the codes down. Crossed-out codes have been used."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:438
+#: lib/vutuv_web/components/ui.ex:499
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr ""
@@ -10055,7 +10053,7 @@ msgstr ""
 msgid "Set up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:390
+#: lib/vutuv_web/components/ui.ex:451
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr ""
@@ -10075,7 +10073,7 @@ msgstr ""
 msgid "Turn off"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:187
+#: lib/vutuv_web/templates/settings/security.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "Turn off the authenticator app? Its codes stop working at login; the emailed PIN is unaffected."
 msgstr ""
@@ -10085,7 +10083,7 @@ msgstr ""
 msgid "Turn on"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:179
+#: lib/vutuv_web/templates/settings/security.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "Turned on."
 msgstr ""
@@ -10121,7 +10119,7 @@ msgid "A one-time code (OTP) from your authenticator app or your code list also 
 msgstr ""
 
 #: lib/vutuv_web/controllers/totp_controller.ex:90
-#: lib/vutuv_web/templates/settings/security.html.heex:176
+#: lib/vutuv_web/templates/settings/security.html.heex:175
 #: lib/vutuv_web/templates/totp/new.html.heex:2
 #: lib/vutuv_web/templates/totp/new.html.heex:6
 #, elixir-autogen, elixir-format
@@ -10136,7 +10134,7 @@ msgstr ""
 msgid "One-time code list (OTP)"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:168
+#: lib/vutuv_web/templates/settings/security.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Sign in with a one-time code (OTP) from an authenticator app or from a printed code list, typed into the normal PIN field. Your emailed PIN always keeps working."
 msgstr ""
@@ -10163,15 +10161,15 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/organization_live/show.ex:638
-#: lib/vutuv_web/views/user_html.ex:944
-#: lib/vutuv_web/views/user_html.ex:1120
+#: lib/vutuv_web/views/user_html.ex:950
+#: lib/vutuv_web/views/user_html.ex:1126
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:937
+#: lib/vutuv_web/views/user_html.ex:943
 #, elixir-autogen, elixir-format
 msgid "%{formatted} star"
 msgid_plural "%{formatted} stars"
@@ -10196,7 +10194,7 @@ msgstr ""
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:951
+#: lib/vutuv_web/views/user_html.ex:957
 #, elixir-autogen, elixir-format
 msgid "Last active %{date}"
 msgstr ""
@@ -10221,7 +10219,7 @@ msgstr ""
 msgid "since %{date}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:867
+#: lib/vutuv_web/views/user_html.ex:873
 #, elixir-autogen, elixir-format
 msgid "since %{year}"
 msgstr ""
@@ -10401,7 +10399,7 @@ msgstr ""
 msgid "vutuv is the open business network where professionals connect, share, and get found. Free to join."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:150
+#: lib/vutuv_web/templates/page/index.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "At least three tags, separated by commas. A tag may be several words long, like Ruby on Rails."
 msgstr ""
@@ -10433,46 +10431,46 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:390
+#: lib/vutuv_web/templates/settings/preferences.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:321
+#: lib/vutuv_web/templates/settings/preferences.html.heex:310
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:397
+#: lib/vutuv_web/templates/settings/preferences.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:401
+#: lib/vutuv_web/templates/settings/preferences.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:387
+#: lib/vutuv_web/templates/settings/preferences.html.heex:376
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:344
+#: lib/vutuv_web/templates/settings/preferences.html.heex:333
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:353
+#: lib/vutuv_web/templates/settings/preferences.html.heex:342
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:339
+#: lib/vutuv_web/templates/settings/preferences.html.heex:328
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
@@ -10482,7 +10480,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:336
+#: lib/vutuv_web/templates/settings/preferences.html.heex:325
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr ""
@@ -10554,7 +10552,7 @@ msgstr ""
 msgid "Preference defaults"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_detail_live.ex:155
+#: lib/vutuv_web/live/admin/user_detail_live.ex:150
 #: lib/vutuv_web/live/admin/user_live.ex:336
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:10
 #, elixir-autogen, elixir-format
@@ -10570,9 +10568,9 @@ msgstr ""
 #: lib/vutuv_web/live/feed_languages_live.ex:377
 #: lib/vutuv_web/templates/settings/preferences.html.heex:101
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
-#: lib/vutuv_web/templates/settings/preferences.html.heex:239
-#: lib/vutuv_web/templates/settings/preferences.html.heex:303
-#: lib/vutuv_web/templates/settings/preferences.html.heex:421
+#: lib/vutuv_web/templates/settings/preferences.html.heex:229
+#: lib/vutuv_web/templates/settings/preferences.html.heex:292
+#: lib/vutuv_web/templates/settings/preferences.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr ""
@@ -10648,7 +10646,7 @@ msgstr ""
 msgid "Captured screenshots"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/screenshot_live.ex:525
+#: lib/vutuv_web/live/admin/screenshot_live.ex:524
 #, elixir-autogen, elixir-format
 msgid "Capturing"
 msgstr ""
@@ -10658,14 +10656,14 @@ msgstr ""
 msgid "Every captured link screenshot, newest first. Each links to the page and its post."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/screenshot_live.ex:527
+#: lib/vutuv_web/live/admin/screenshot_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
-#: lib/vutuv_web/live/post_live/composer.ex:1778
-#: lib/vutuv_web/live/post_live/composer.ex:2480
+#: lib/vutuv_web/live/post_live/composer.ex:1754
+#: lib/vutuv_web/live/post_live/composer.ex:2419
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr ""
@@ -10701,7 +10699,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/organization_live.ex:165
 #: lib/vutuv_web/live/admin/organization_live.ex:179
 #: lib/vutuv_web/live/admin/organization_live.ex:194
-#: lib/vutuv_web/live/admin/screenshot_live.ex:524
+#: lib/vutuv_web/live/admin/screenshot_live.ex:523
 #: lib/vutuv_web/live/organization_live/domains.ex:201
 #, elixir-autogen, elixir-format
 msgid "Pending"
@@ -10718,7 +10716,7 @@ msgstr ""
 msgid "Queued"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/screenshot_live.ex:526
+#: lib/vutuv_web/live/admin/screenshot_live.ex:525
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr ""
@@ -10760,7 +10758,7 @@ msgstr ""
 msgid "Views"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:296
+#: lib/vutuv_web/templates/user/edit.html.heex:291
 #, elixir-autogen, elixir-format
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
@@ -10779,48 +10777,48 @@ msgstr ""
 
 #: lib/vutuv/accounts/user.ex:1234
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
-#: lib/vutuv_web/live/job_posting_live/form.ex:773
+#: lib/vutuv_web/live/job_posting_live/form.ex:772
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:293
+#: lib/vutuv_web/templates/user/edit.html.heex:288
 #: lib/vutuv_web/templates/welcome/show.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Who can see your availability?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:318
+#: lib/vutuv_web/templates/user/edit.html.heex:313
 #: lib/vutuv_web/templates/welcome/show.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:669
-#: lib/vutuv_web/templates/user/edit.html.heex:326
+#: lib/vutuv_web/live/job_posting_live/form.ex:668
+#: lib/vutuv_web/templates/user/edit.html.heex:321
 #: lib/vutuv_web/templates/welcome/show.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:336
+#: lib/vutuv_web/templates/user/edit.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "Hidden by default, and it still does its job while hidden. \"Signed-in members only\" adds a quiet line to your profile for members; \"Everyone\" also shows it to logged-out visitors."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:309
+#: lib/vutuv_web/templates/user/edit.html.heex:304
 #: lib/vutuv_web/templates/welcome/show.html.heex:114
 #, elixir-autogen, elixir-format
 msgid "Minimum salary expectation"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:312
+#: lib/vutuv_web/templates/user/edit.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:676
-#: lib/vutuv_web/templates/user/edit.html.heex:322
+#: lib/vutuv_web/live/job_posting_live/form.ex:675
+#: lib/vutuv_web/templates/user/edit.html.heex:317
 #: lib/vutuv_web/templates/welcome/show.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Per"
@@ -10831,7 +10829,7 @@ msgstr ""
 msgid "Salary expectation from %{amount} %{currency} per %{period}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:333
+#: lib/vutuv_web/templates/user/edit.html.heex:328
 #, elixir-autogen, elixir-format
 msgid "Who can see your salary expectation?"
 msgstr ""
@@ -10881,7 +10879,7 @@ msgid "Email domain"
 msgstr ""
 
 #: lib/vutuv_web/components/job_exclusion_components.ex:110
-#: lib/vutuv_web/components/job_exclusion_components.ex:230
+#: lib/vutuv_web/components/job_exclusion_components.ex:225
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:144
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:169
 #, elixir-autogen, elixir-format
@@ -10900,7 +10898,7 @@ msgstr ""
 msgid "Exclude an email domain"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:389
+#: lib/vutuv_web/templates/user/edit.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr ""
@@ -10911,12 +10909,12 @@ msgstr ""
 msgid "Job-search exclusion list"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:392
+#: lib/vutuv_web/templates/user/edit.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:400
+#: lib/vutuv_web/templates/user/edit.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -10961,7 +10959,7 @@ msgstr ""
 msgid "Your list is empty. Nobody is excluded yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:363
+#: lib/vutuv_web/live/organization_live/edit.ex:358
 #: lib/vutuv_web/views/account_event_text.ex:232
 #, elixir-autogen, elixir-format
 msgid "AI agents"
@@ -10972,24 +10970,24 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:225
+#: lib/vutuv_web/live/organization_live/new.ex:221
 #, elixir-autogen, elixir-format
 msgid "Continue to verification"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:265
-#: lib/vutuv_web/live/organization_live/domains.ex:305
+#: lib/vutuv_web/live/organization_live/domains.ex:264
+#: lib/vutuv_web/live/organization_live/domains.ex:299
 #: lib/vutuv_web/live/organization_live/new.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:1038
+#: lib/vutuv_web/live/organization_live/show.ex:1033
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:184
-#: lib/vutuv_web/live/organization_live/domains.ex:346
-#: lib/vutuv_web/live/organization_live/show.ex:1104
-#: lib/vutuv_web/live/organization_live/show.ex:1112
+#: lib/vutuv_web/live/organization_live/domains.ex:339
+#: lib/vutuv_web/live/organization_live/show.ex:1098
+#: lib/vutuv_web/live/organization_live/show.ex:1106
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr ""
@@ -11000,7 +10998,7 @@ msgstr ""
 msgid "Edit %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:349
+#: lib/vutuv_web/live/organization_live/edit.ex:344
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this page and include it in the sitemap."
 msgstr ""
@@ -11010,7 +11008,7 @@ msgstr ""
 msgid "Logo"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:365
+#: lib/vutuv_web/live/organization_live/edit.ex:360
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
@@ -11021,22 +11019,22 @@ msgstr ""
 msgid "Please log in first."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:1011
+#: lib/vutuv_web/live/organization_live/show.ex:1006
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:283
+#: lib/vutuv_web/live/organization_live/edit.ex:278
 #, elixir-autogen, elixir-format
 msgid "Remove logo"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:83
+#: lib/vutuv_web/live/organization_live/index.ex:81
 #, elixir-autogen, elixir-format
 msgid "Search by name or city"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:347
+#: lib/vutuv_web/live/organization_live/edit.ex:342
 #: lib/vutuv_web/views/account_event_text.ex:231
 #, elixir-autogen, elixir-format
 msgid "Search engines"
@@ -11047,35 +11045,35 @@ msgstr ""
 msgid "Select a country"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:1073
+#: lib/vutuv_web/live/organization_live/domains.ex:318
+#: lib/vutuv_web/live/organization_live/show.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:328
+#: lib/vutuv_web/live/organization_live/edit.ex:323
 #: lib/vutuv_web/live/organization_live/new.ex:139
 #, elixir-autogen, elixir-format
 msgid "State / region (optional)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4042
+#: lib/vutuv_web/components/ui.ex:4146
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4044
+#: lib/vutuv_web/components/ui.ex:4148
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:1026
+#: lib/vutuv_web/live/organization_live/show.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:937
+#: lib/vutuv_web/live/organization_live/show.ex:932
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr ""
@@ -11086,33 +11084,33 @@ msgstr ""
 msgid "Verified via"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:997
+#: lib/vutuv_web/live/organization_live/show.ex:992
 #, elixir-autogen, elixir-format
 msgid "Verified via %{domain}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:1008
+#: lib/vutuv_web/live/organization_live/show.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:340
-#: lib/vutuv_web/live/organization_live/show.ex:1098
+#: lib/vutuv_web/live/organization_live/domains.ex:333
+#: lib/vutuv_web/live/organization_live/show.ex:1092
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:262
 #: lib/vutuv_web/agent_docs/text.ex:245
-#: lib/vutuv_web/live/organization_live/edit.ex:322
+#: lib/vutuv_web/live/organization_live/edit.ex:317
 #: lib/vutuv_web/live/organization_live/new.ex:130
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:266
-#: lib/vutuv_web/live/organization_live/domains.ex:315
-#: lib/vutuv_web/live/organization_live/show.ex:1049
+#: lib/vutuv_web/live/organization_live/domains.ex:265
+#: lib/vutuv_web/live/organization_live/domains.ex:309
+#: lib/vutuv_web/live/organization_live/show.ex:1044
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11128,8 +11126,8 @@ msgstr ""
 msgid "You will publish a record or file to prove control of the domain on the next step."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:326
-#: lib/vutuv_web/live/organization_live/show.ex:1079
+#: lib/vutuv_web/live/organization_live/domains.ex:320
+#: lib/vutuv_web/live/organization_live/show.ex:1074
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11141,12 +11139,12 @@ msgid "@handle or email"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:333
-#: lib/vutuv_web/live/organization_live/edit.ex:425
+#: lib/vutuv_web/live/organization_live/edit.ex:412
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:253
+#: lib/vutuv_web/live/organization_live/domains.ex:252
 #, elixir-autogen, elixir-format
 msgid "Add a domain"
 msgstr ""
@@ -11162,7 +11160,7 @@ msgid "Added @%{handle} to the team."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:334
-#: lib/vutuv_web/live/organization_live/edit.ex:423
+#: lib/vutuv_web/live/organization_live/edit.ex:410
 #, elixir-autogen, elixir-format
 msgid "Alias"
 msgstr ""
@@ -11179,24 +11177,24 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:436
 #: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/live/organization_live/edit.ex:388
-#: lib/vutuv_web/live/organization_live/show.ex:925
+#: lib/vutuv_web/live/organization_live/edit.ex:375
+#: lib/vutuv_web/live/organization_live/show.ex:920
 #: lib/vutuv_web/templates/tag/single_card.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Also known as"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:419
+#: lib/vutuv_web/live/organization_live/edit.ex:406
 #, elixir-autogen, elixir-format
 msgid "Alternative name"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:389
+#: lib/vutuv_web/live/admin/organization_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Archive"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:386
+#: lib/vutuv_web/live/admin/organization_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Archive this page?"
 msgstr ""
@@ -11208,7 +11206,7 @@ msgid "Archived"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:332
-#: lib/vutuv_web/live/organization_live/edit.ex:424
+#: lib/vutuv_web/live/organization_live/edit.ex:411
 #, elixir-autogen, elixir-format
 msgid "Brand"
 msgstr ""
@@ -11218,12 +11216,12 @@ msgstr ""
 msgid "Claimed by"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:220
+#: lib/vutuv_web/live/organization_live/roles.ex:215
 #, elixir-autogen, elixir-format
 msgid "Current team"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:395
+#: lib/vutuv_web/live/admin/organization_live.ex:397
 #, elixir-autogen, elixir-format
 msgid "Delete this page and everything it owns? This cannot be undone."
 msgstr ""
@@ -11261,14 +11259,14 @@ msgstr ""
 msgid "Former name"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:461
-#: lib/vutuv_web/live/admin/organization_live.ex:370
-#: lib/vutuv_web/views/admin/account_html.ex:45
+#: lib/vutuv_web/live/admin/job_live.ex:460
+#: lib/vutuv_web/live/admin/organization_live.ex:373
+#: lib/vutuv_web/views/admin/account_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Freeze"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:367
+#: lib/vutuv_web/live/admin/organization_live.ex:371
 #, elixir-autogen, elixir-format
 msgid "Freeze this page? It disappears for the public but stays visible to its owner."
 msgstr ""
@@ -11279,7 +11277,7 @@ msgstr ""
 msgid "Last checked"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:247
+#: lib/vutuv_web/live/organization_live/roles.ex:242
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr ""
@@ -11294,7 +11292,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:237
+#: lib/vutuv_web/live/organization_live/domains.ex:236
 #, elixir-autogen, elixir-format
 msgid "Make primary"
 msgstr ""
@@ -11344,12 +11342,12 @@ msgstr ""
 msgid "Remove this domain?"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:242
+#: lib/vutuv_web/live/organization_live/roles.ex:238
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the team?"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:405
+#: lib/vutuv_web/live/organization_live/edit.ex:393
 #, elixir-autogen, elixir-format
 msgid "Remove this name?"
 msgstr ""
@@ -11382,9 +11380,9 @@ msgstr ""
 msgid "That member could not be added."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:470
-#: lib/vutuv_web/live/admin/organization_live.ex:379
-#: lib/vutuv_web/views/admin/account_html.ex:31
+#: lib/vutuv_web/live/admin/job_live.ex:468
+#: lib/vutuv_web/live/admin/organization_live.ex:381
+#: lib/vutuv_web/views/admin/account_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "Unfreeze"
 msgstr ""
@@ -11406,24 +11404,24 @@ msgstr ""
 msgid "verified"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:325
+#: lib/vutuv_web/live/organization_live/edit.ex:320
 #: lib/vutuv_web/live/organization_live/new.ex:136
 #, elixir-autogen, elixir-format
 msgid "Street address (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:326
+#: lib/vutuv_web/live/organization_live/edit.ex:321
 #: lib/vutuv_web/live/organization_live/new.ex:137
 #, elixir-autogen, elixir-format
 msgid "ZIP / postal code (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:482
+#: lib/vutuv_web/live/organization_live/edit.ex:461
 #, elixir-autogen, elixir-format
 msgid "Claim"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:451
+#: lib/vutuv_web/live/organization_live/edit.ex:433
 #, elixir-autogen, elixir-format
 msgid "Reachable at"
 msgstr ""
@@ -11433,12 +11431,12 @@ msgstr ""
 msgid "That handle is not available."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:488
+#: lib/vutuv_web/live/organization_live/edit.ex:467
 #, elixir-autogen, elixir-format
 msgid "Danger zone"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:499
+#: lib/vutuv_web/live/organization_live/edit.ex:479
 #, elixir-autogen, elixir-format
 msgid "Really delete %{name}? This cannot be undone."
 msgstr ""
@@ -11459,7 +11457,7 @@ msgid "Back-link (rel=me)"
 msgstr ""
 
 #: lib/vutuv_web/templates/url/verify.html.heex:25
-#: lib/vutuv_web/views/url_html.ex:71
+#: lib/vutuv_web/views/url_html.ex:65
 #, elixir-autogen, elixir-format
 msgid "Link verification is disabled on this installation."
 msgstr ""
@@ -11484,7 +11482,7 @@ msgstr ""
 msgid "The link text can be anything. A hidden <link rel=\"me\"> in the page head works too."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1038
+#: lib/vutuv_web/components/ui.ex:1062
 #: lib/vutuv_web/live/section_reorder_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -11580,7 +11578,7 @@ msgid_plural "%{count} aliases match another verified organization and are flagg
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:390
+#: lib/vutuv_web/live/organization_live/edit.ex:377
 #, elixir-autogen, elixir-format
 msgid "Alternative names, brands or abbreviations this organization is findable under. A rename keeps the old name here automatically."
 msgstr ""
@@ -11610,11 +11608,11 @@ msgstr ""
 msgid "Any signed-in member whose confirmed email is at this domain, or a subdomain of it, is excluded. This is the reliable way to hide from your whole organization."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:70
-#: lib/vutuv_web/live/organization_live/index.ex:101
+#: lib/vutuv_web/live/organization_live/index.ex:68
+#: lib/vutuv_web/live/organization_live/index.ex:99
 #: lib/vutuv_web/live/organization_live/new.ex:28
 #: lib/vutuv_web/live/organization_live/new.ex:95
-#: lib/vutuv_web/templates/settings/organizations.html.heex:118
+#: lib/vutuv_web/templates/settings/organizations.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Add your organization"
 msgstr ""
@@ -11639,28 +11637,28 @@ msgstr ""
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:1020
+#: lib/vutuv_web/live/organization_live/show.ex:1015
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:503
+#: lib/vutuv_web/live/organization_live/edit.ex:482
 #, elixir-autogen, elixir-format
 msgid "Delete this organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:490
+#: lib/vutuv_web/live/organization_live/edit.ex:469
 #, elixir-autogen, elixir-format
 msgid "Deleting this organization page is permanent. Its verified domains and its @handle are freed and can be claimed again."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:297
+#: lib/vutuv_web/live/organization_live/edit.ex:292
 #: lib/vutuv_web/live/organization_live/new.ex:126
 #, elixir-autogen, elixir-format
 msgid "Kind of organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:241
+#: lib/vutuv_web/live/organization_live/roles.ex:237
 #, elixir-autogen, elixir-format
 msgid "Leave this organization team?"
 msgstr ""
@@ -11675,12 +11673,12 @@ msgstr ""
 msgid "No organization pages match."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:92
+#: lib/vutuv_web/live/organization_live/index.ex:90
 #, elixir-autogen, elixir-format
 msgid "No organization pages yet. Be the first to add yours."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:94
+#: lib/vutuv_web/live/organization_live/index.ex:92
 #, elixir-autogen, elixir-format
 msgid "No organizations found for %{term}."
 msgstr ""
@@ -11720,7 +11718,7 @@ msgstr ""
 msgid "Organization frozen."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:296
+#: lib/vutuv_web/live/organization_live/edit.ex:291
 #: lib/vutuv_web/live/organization_live/new.ex:125
 #, elixir-autogen, elixir-format
 msgid "Organization name"
@@ -11752,12 +11750,12 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:427
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:400
-#: lib/vutuv_web/components/ui.ex:4833
+#: lib/vutuv_web/components/ui.ex:4941
 #: lib/vutuv_web/controllers/settings_controller.ex:213
-#: lib/vutuv_web/live/organization_live/index.ex:30
-#: lib/vutuv_web/live/organization_live/index.ex:61
+#: lib/vutuv_web/live/organization_live/index.ex:32
+#: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1322
+#: lib/vutuv_web/live/shell_live.ex:1318
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:79
@@ -11782,7 +11780,7 @@ msgstr ""
 msgid "Please log in to claim an organization page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:75
+#: lib/vutuv_web/live/organization_live/index.ex:73
 #, elixir-autogen, elixir-format
 msgid "Search organizations"
 msgstr ""
@@ -11869,7 +11867,7 @@ msgstr ""
 msgid "made you an owner of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:472
+#: lib/vutuv_web/live/organization_live/edit.ex:454
 #, elixir-autogen, elixir-format
 msgid "your_organization"
 msgstr ""
@@ -11910,7 +11908,7 @@ msgid "Public authority"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:371
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:138
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:136
 #, elixir-autogen, elixir-format
 msgid "%{views} views · %{clicks} apply clicks"
 msgstr ""
@@ -11920,22 +11918,22 @@ msgstr ""
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:653
+#: lib/vutuv_web/live/job_posting_live/form.ex:652
 #, elixir-autogen, elixir-format
 msgid "A pay range is required to publish (except volunteer postings)."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:750
+#: lib/vutuv_web/live/job_posting_live/form.ex:749
 #, elixir-autogen, elixir-format
 msgid "A vutuv message to me"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:748
+#: lib/vutuv_web/live/job_posting_live/form.ex:747
 #, elixir-autogen, elixir-format
 msgid "A website"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:749
+#: lib/vutuv_web/live/job_posting_live/form.ex:748
 #, elixir-autogen, elixir-format
 msgid "An e-mail address"
 msgstr ""
@@ -11945,12 +11943,12 @@ msgstr ""
 msgid "Applicants must be located in"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:754
+#: lib/vutuv_web/live/job_posting_live/form.ex:753
 #, elixir-autogen, elixir-format
 msgid "Application URL"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:760
+#: lib/vutuv_web/live/job_posting_live/form.ex:759
 #, elixir-autogen, elixir-format
 msgid "Application e-mail"
 msgstr ""
@@ -11960,17 +11958,17 @@ msgstr ""
 msgid "Application: %{title}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:746
+#: lib/vutuv_web/live/job_posting_live/form.ex:745
 #, elixir-autogen, elixir-format
 msgid "Applications go to"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:275
+#: lib/vutuv_web/live/job_posting_live/show.ex:270
 #, elixir-autogen, elixir-format
 msgid "Apply by e-mail"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:274
+#: lib/vutuv_web/live/job_posting_live/show.ex:269
 #, elixir-autogen, elixir-format
 msgid "Apply on website"
 msgstr ""
@@ -11982,7 +11980,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:163
 #: lib/vutuv_web/live/admin/job_live.ex:183
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:184
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:183
 #, elixir-autogen, elixir-format
 msgid "Closed"
 msgstr ""
@@ -11992,12 +11990,12 @@ msgstr ""
 msgid "Contract"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:693
+#: lib/vutuv_web/live/job_posting_live/form.ex:692
 #, elixir-autogen, elixir-format
 msgid "Describe the role. Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:182
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
 #, elixir-autogen, elixir-format
 msgid "Drafts"
 msgstr ""
@@ -12027,19 +12025,19 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:489
 #: lib/vutuv_web/agent_docs/text.ex:265
 #: lib/vutuv_web/agent_docs/text.ex:508
-#: lib/vutuv_web/live/job_board_live.ex:367
+#: lib/vutuv_web/live/job_board_live.ex:363
 #: lib/vutuv_web/live/job_posting_live/form.ex:474
 #, elixir-autogen, elixir-format
 msgid "Employment type"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:772
+#: lib/vutuv_web/live/job_posting_live/form.ex:771
 #, elixir-autogen, elixir-format
 msgid "Everyone (public)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:657
-#: lib/vutuv_web/live/tag_live/timeline.ex:350
+#: lib/vutuv_web/live/job_posting_live/form.ex:656
+#: lib/vutuv_web/live/tag_live/timeline.ex:346
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
 #, elixir-autogen, elixir-format
@@ -12051,12 +12049,12 @@ msgstr ""
 msgid "Full-time"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:159
+#: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
 msgid "Highlighted tags match your profile."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:744
+#: lib/vutuv_web/live/job_posting_live/form.ex:743
 #, elixir-autogen, elixir-format
 msgid "How to apply"
 msgstr ""
@@ -12072,7 +12070,7 @@ msgstr ""
 msgid "I'm interested in your posting: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:692
+#: lib/vutuv_web/live/job_posting_live/form.ex:691
 #, elixir-autogen, elixir-format
 msgid "Job description"
 msgstr ""
@@ -12087,13 +12085,13 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1144
+#: lib/vutuv_web/live/shell_live.ex:1140
 #: lib/vutuv_web/templates/layout/app.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Jobs"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:782
+#: lib/vutuv_web/live/job_posting_live/form.ex:781
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this posting."
 msgstr ""
@@ -12114,12 +12112,12 @@ msgstr ""
 msgid "Mark as filled"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:157
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:158
 #, elixir-autogen, elixir-format
 msgid "Mark this posting as filled and close it?"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:276
+#: lib/vutuv_web/live/job_posting_live/show.ex:271
 #, elixir-autogen, elixir-format
 msgid "Message the poster"
 msgstr ""
@@ -12136,7 +12134,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:25
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:101
-#: lib/vutuv_web/live/job_posting_live/show.ex:181
+#: lib/vutuv_web/live/job_posting_live/show.ex:176
 #, elixir-autogen, elixir-format
 msgid "My postings"
 msgstr ""
@@ -12146,7 +12144,7 @@ msgstr ""
 msgid "New accounts can publish after a few days."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:103
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:102
 #: lib/vutuv_web/live/job_posting_live/form.ex:114
 #, elixir-autogen, elixir-format
 msgid "New posting"
@@ -12154,8 +12152,8 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:292
 #: lib/vutuv_web/agent_docs/text.ex:275
-#: lib/vutuv_web/live/job_posting_live/form.ex:732
-#: lib/vutuv_web/live/job_posting_live/show.ex:154
+#: lib/vutuv_web/live/job_posting_live/form.ex:731
+#: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
 msgstr ""
@@ -12175,7 +12173,7 @@ msgstr ""
 msgid "Nothing here yet. Jobs you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:788
+#: lib/vutuv_web/live/job_posting_live/form.ex:787
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
@@ -12196,7 +12194,7 @@ msgstr ""
 msgid "Part-time"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:651
+#: lib/vutuv_web/live/job_posting_live/form.ex:650
 #, elixir-autogen, elixir-format
 msgid "Pay"
 msgstr ""
@@ -12241,7 +12239,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/text.ex:269
 #: lib/vutuv_web/agent_docs/text.ex:512
-#: lib/vutuv_web/live/job_posting_live/show.ex:133
+#: lib/vutuv_web/live/job_posting_live/show.ex:128
 #, elixir-autogen, elixir-format
 msgid "Posted"
 msgstr ""
@@ -12257,7 +12255,7 @@ msgstr ""
 msgid "Posting not found."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:805
+#: lib/vutuv_web/live/job_posting_live/form.ex:802
 #, elixir-autogen, elixir-format
 msgid "Publish"
 msgstr ""
@@ -12275,15 +12273,15 @@ msgstr ""
 msgid "Remote"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:169
+#: lib/vutuv_web/live/job_posting_live/show.ex:164
 #, elixir-autogen, elixir-format
 msgid "Report this posting"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:291
 #: lib/vutuv_web/agent_docs/text.ex:274
-#: lib/vutuv_web/live/job_posting_live/form.ex:722
-#: lib/vutuv_web/live/job_posting_live/show.ex:149
+#: lib/vutuv_web/live/job_posting_live/form.ex:721
+#: lib/vutuv_web/live/job_posting_live/show.ex:144
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
@@ -12322,7 +12320,7 @@ msgstr ""
 msgid "Street (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:719
+#: lib/vutuv_web/live/job_posting_live/form.ex:718
 #, elixir-autogen, elixir-format
 msgid "Tags match your posting to members. Separate them with commas; a tag may be several words long, like Ruby on Rails."
 msgstr ""
@@ -12358,7 +12356,7 @@ msgid "Tip: adding a gender marker like (m/w/d) helps your posting comply with t
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:112
-#: lib/vutuv_web/live/job_posting_live/show.ex:209
+#: lib/vutuv_web/live/job_posting_live/show.ex:204
 #, elixir-autogen, elixir-format
 msgid "Verified organization"
 msgstr ""
@@ -12374,7 +12372,7 @@ msgstr ""
 msgid "Volunteer"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:770
+#: lib/vutuv_web/live/job_posting_live/form.ex:769
 #: lib/vutuv_web/templates/email/form_content.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Who can see it"
@@ -12434,7 +12432,7 @@ msgstr ""
 msgid "Your organization page on vutuv is no longer public"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:176
+#: lib/vutuv_web/live/job_posting_live/show.ex:171
 #, elixir-autogen, elixir-format
 msgid "Your posting"
 msgstr ""
@@ -12450,7 +12448,7 @@ msgstr ""
 msgid "Yourself (personal posting)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:663
+#: lib/vutuv_web/live/job_posting_live/form.ex:662
 #, elixir-autogen, elixir-format
 msgid "up to"
 msgstr ""
@@ -12492,17 +12490,17 @@ msgid_plural "Your roles"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:113
+#: lib/vutuv_web/templates/settings/organizations.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Add an organization"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:115
+#: lib/vutuv_web/templates/settings/organizations.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Represent a company, association or other group? Add its page and verify the domain to become its owner."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:125
+#: lib/vutuv_web/templates/settings/organizations.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Browse all organizations"
 msgstr ""
@@ -12517,7 +12515,7 @@ msgstr ""
 msgid "Verification pending"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:63
+#: lib/vutuv_web/live/organization_live/index.ex:64
 #, elixir-autogen, elixir-format
 msgid "Verified pages for companies, associations, schools, public authorities and other groups, not for single people. Every page has a proven web domain, so you know it is really them."
 msgstr ""
@@ -12532,14 +12530,14 @@ msgstr ""
 msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT record cannot share a name with a CNAME. Use this name instead, with the exact same value as above:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:322
-#: lib/vutuv_web/live/organization_live/show.ex:1066
+#: lib/vutuv_web/live/organization_live/domains.ex:316
+#: lib/vutuv_web/live/organization_live/show.ex:1061
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:1057
+#: lib/vutuv_web/live/organization_live/domains.ex:314
+#: lib/vutuv_web/live/organization_live/show.ex:1052
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr ""
@@ -12578,12 +12576,12 @@ msgid_plural "%{count} weeks ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/job_board_live.ex:491
+#: lib/vutuv_web/live/job_board_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "%{km} km"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:361
+#: lib/vutuv_web/live/job_board_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "All countries"
 msgstr ""
@@ -12599,43 +12597,43 @@ msgstr ""
 msgid "All jobs with this tag: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:368
+#: lib/vutuv_web/live/job_board_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "Any employment type"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:350
+#: lib/vutuv_web/live/job_board_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "City or zip code"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:491
+#: lib/vutuv_web/live/job_board_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "Exact"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:249
+#: lib/vutuv_web/live/job_board_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "From my salary expectation"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:241
+#: lib/vutuv_web/live/job_board_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Matches my tags"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:461
+#: lib/vutuv_web/live/job_board_live.ex:452
 #, elixir-autogen, elixir-format
 msgid "Min. salary/year (%{currency})"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:410
+#: lib/vutuv_web/live/job_board_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "Minimum yearly salary"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:836
+#: lib/vutuv_web/live/job_board_live.ex:320
+#: lib/vutuv_web/live/organization_live/show.ex:831
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr ""
@@ -12650,12 +12648,12 @@ msgstr ""
 msgid "Next page: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:499
+#: lib/vutuv_web/live/job_board_live.ex:479
 #, elixir-autogen, elixir-format
 msgid "No job postings yet."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:497
+#: lib/vutuv_web/live/job_board_live.ex:477
 #, elixir-autogen, elixir-format
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
@@ -12676,22 +12674,22 @@ msgstr ""
 msgid "Open positions on vutuv, newest first."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:221
+#: lib/vutuv_web/live/job_board_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Post a job"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:306
+#: lib/vutuv_web/live/job_board_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Post the first one"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:354
+#: lib/vutuv_web/live/job_board_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "Radius"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:342
+#: lib/vutuv_web/live/job_board_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "Search jobs"
 msgstr ""
@@ -12720,13 +12718,13 @@ msgstr ""
 msgid "(no employer)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:477
+#: lib/vutuv_web/live/admin/job_live.ex:475
 #, elixir-autogen, elixir-format
 msgid "Close this posting? It ends the listing (a regular ending, not a deletion)."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:414
-#: lib/vutuv_web/live/admin/user_detail_live.ex:135
+#: lib/vutuv_web/live/admin/user_detail_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "Cold outreach"
 msgstr ""
@@ -12736,7 +12734,7 @@ msgstr ""
 msgid "Counters"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:486
+#: lib/vutuv_web/live/admin/job_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Delete this posting and everything it owns? This cannot be undone."
 msgstr ""
@@ -12769,14 +12767,14 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:30
 #: lib/vutuv_web/live/admin/job_live.ex:198
 #: lib/vutuv_web/live/admin/job_live.ex:199
-#: lib/vutuv_web/live/admin/user_detail_live.ex:163
+#: lib/vutuv_web/live/admin/user_detail_live.ex:158
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Job postings"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:402
-#: lib/vutuv_web/live/admin/user_detail_live.ex:117
+#: lib/vutuv_web/live/admin/user_detail_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Live postings"
 msgstr ""
@@ -12792,7 +12790,7 @@ msgid "Open case"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:410
-#: lib/vutuv_web/live/admin/user_detail_live.ex:129
+#: lib/vutuv_web/live/admin/user_detail_live.ex:124
 #, elixir-autogen, elixir-format
 msgid "Open job cases"
 msgstr ""
@@ -12859,7 +12857,7 @@ msgid "Title"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:406
-#: lib/vutuv_web/live/admin/user_detail_live.ex:123
+#: lib/vutuv_web/live/admin/user_detail_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "Total postings"
 msgstr ""
@@ -12901,7 +12899,7 @@ msgstr ""
 msgid "Daily email"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/saved_searches.html.heex:72
+#: lib/vutuv_web/templates/settings/saved_searches.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Delete this saved search?"
 msgstr ""
@@ -12933,7 +12931,7 @@ msgstr ""
 msgid "Manage your saved searches"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/saved_searches.html.heex:87
+#: lib/vutuv_web/templates/settings/saved_searches.html.heex:82
 #, elixir-autogen, elixir-format
 msgid "Newer"
 msgstr ""
@@ -12943,7 +12941,7 @@ msgstr ""
 msgid "No emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/saved_searches.html.heex:95
+#: lib/vutuv_web/templates/settings/saved_searches.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "Older"
 msgstr ""
@@ -12953,8 +12951,8 @@ msgstr ""
 msgid "Save a search on the job board or on the people search, then let vutuv e-mail you when a new match appears. Daily searches are checked every day; weekly ones once a week."
 msgstr ""
 
-#: lib/vutuv_web/components/saved_search_components.ex:107
-#: lib/vutuv_web/components/saved_search_components.ex:128
+#: lib/vutuv_web/components/saved_search_components.ex:103
+#: lib/vutuv_web/components/saved_search_components.ex:116
 #, elixir-autogen, elixir-format
 msgid "Save search"
 msgstr ""
@@ -12964,7 +12962,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4773
+#: lib/vutuv_web/components/ui.ex:4881
 #: lib/vutuv_web/controllers/settings_controller.ex:620
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -12983,7 +12981,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2996
+#: lib/vutuv_web/components/post_components.ex:3018
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:715
 #: lib/vutuv_web/controllers/settings_controller.ex:733
@@ -13112,7 +13110,7 @@ msgstr ""
 msgid "Hide from specific viewers"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:794
+#: lib/vutuv_web/live/job_posting_live/form.ex:793
 #, elixir-autogen, elixir-format
 msgid "Hide from specific viewers (competitors, your own staff, a person) →"
 msgstr ""
@@ -13133,7 +13131,7 @@ msgstr ""
 msgid "Job exclusions – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:797
+#: lib/vutuv_web/live/job_posting_live/form.ex:796
 #, elixir-autogen, elixir-format
 msgid "Keep this posting on the board for everyone except a chosen few."
 msgstr ""
@@ -13214,7 +13212,7 @@ msgstr ""
 msgid "This page has job postings, so it cannot be deleted. Ask an admin to archive it instead."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_detail_live.ex:114
+#: lib/vutuv_web/live/admin/user_detail_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Jobs footprint"
 msgstr ""
@@ -13230,7 +13228,7 @@ msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7
 msgstr ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:41
-#: lib/vutuv_web/templates/user/edit.html.heex:126
+#: lib/vutuv_web/templates/user/edit.html.heex:121
 #: lib/vutuv_web/templates/user/show.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "Image awaiting review, visible only to you"
@@ -13283,7 +13281,7 @@ msgstr ""
 msgid "Age only, without the date"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:451
+#: lib/vutuv_web/templates/user/edit.html.heex:447
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
@@ -13306,7 +13304,7 @@ msgstr ""
 msgid "Full date and age"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:448
+#: lib/vutuv_web/templates/user/edit.html.heex:444
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr ""
@@ -13340,44 +13338,44 @@ msgstr[1] ""
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:413
+#: lib/vutuv_web/components/ui.ex:474
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:410
+#: lib/vutuv_web/components/ui.ex:471
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:416
+#: lib/vutuv_web/components/ui.ex:477
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:407
+#: lib/vutuv_web/components/ui.ex:468
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:440
+#: lib/vutuv_web/components/ui.ex:501
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2871
+#: lib/vutuv_web/live/post_live/composer.ex:2810
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:235
 #: lib/vutuv_web/agent_docs/text.ex:218
-#: lib/vutuv_web/live/tag_live/timeline.ex:253
+#: lib/vutuv_web/live/tag_live/timeline.ex:249
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:711
+#: lib/vutuv_web/live/search_live.ex:704
 #, elixir-autogen, elixir-format
 msgid "Your search uses a people-only filter such as city: or status:, so it only finds people."
 msgstr ""
@@ -13397,22 +13395,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:447
+#: lib/vutuv_web/components/post_components.ex:448
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:449
+#: lib/vutuv_web/components/post_components.ex:450
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:448
+#: lib/vutuv_web/components/post_components.ex:449
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:406
+#: lib/vutuv_web/components/post_components.ex:407
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13422,7 +13420,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4756
+#: lib/vutuv_web/components/ui.ex:4864
 #: lib/vutuv_web/controllers/settings_controller.ex:634
 #: lib/vutuv_web/live/post_live/feed.ex:712
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13431,32 +13429,32 @@ msgstr ""
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:428
+#: lib/vutuv_web/live/job_board_live.ex:419
 #, elixir-autogen, elixir-format
 msgid "Looking for a role that goes by several titles? Separate them with a comma and we show postings that match any of them."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:424
+#: lib/vutuv_web/live/job_board_live.ex:415
 #, elixir-autogen, elixir-format
 msgid "Search tips"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:482
+#: lib/vutuv_web/live/job_board_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "any of these titles"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:484
+#: lib/vutuv_web/live/job_board_live.ex:464
 #, elixir-autogen, elixir-format
 msgid "exact wording"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:485
+#: lib/vutuv_web/live/job_board_live.ex:465
 #, elixir-autogen, elixir-format
 msgid "without internships"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:483
+#: lib/vutuv_web/live/job_board_live.ex:463
 #, elixir-autogen, elixir-format
 msgid "word start: also finds Entwickler, Entwicklung"
 msgstr ""
@@ -13497,7 +13495,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:63
-#: lib/vutuv_web/components/ui.ex:4727
+#: lib/vutuv_web/components/ui.ex:4835
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13525,14 +13523,14 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4127
+#: lib/vutuv_web/components/ui.ex:4231
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:4137
+#: lib/vutuv_web/components/ui.ex:4241
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
@@ -13582,50 +13580,50 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5289
+#: lib/vutuv_web/components/post_components.ex:5311
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1233
-#: lib/vutuv_web/components/post_components.ex:5246
+#: lib/vutuv_web/components/post_components.ex:5268
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5290
+#: lib/vutuv_web/components/post_components.ex:5312
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5292
+#: lib/vutuv_web/components/post_components.ex:5314
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5288
+#: lib/vutuv_web/components/post_components.ex:5310
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1233
-#: lib/vutuv_web/components/post_components.ex:5245
+#: lib/vutuv_web/components/post_components.ex:5267
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:443
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:250
+#: lib/vutuv_web/live/fediverse_account_live.ex:453
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5287
+#: lib/vutuv_web/components/post_components.ex:5309
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5291
+#: lib/vutuv_web/components/post_components.ex:5313
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13645,7 +13643,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5328
+#: lib/vutuv_web/components/post_components.ex:5350
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13653,27 +13651,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5358
+#: lib/vutuv_web/components/post_components.ex:5380
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5359
+#: lib/vutuv_web/components/post_components.ex:5381
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5357
+#: lib/vutuv_web/components/post_components.ex:5379
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5317
+#: lib/vutuv_web/components/post_components.ex:5339
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5364
+#: lib/vutuv_web/components/post_components.ex:5386
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13703,7 +13701,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5131
+#: lib/vutuv_web/components/post_components.ex:5153
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13751,17 +13749,17 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5122
+#: lib/vutuv_web/components/post_components.ex:5144
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2203
+#: lib/vutuv_web/components/ui.ex:2227
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2207
+#: lib/vutuv_web/components/ui.ex:2231
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -13852,7 +13850,7 @@ msgstr ""
 msgid "Remove file"
 msgstr ""
 
-#: lib/vutuv_web/templates/qualification/form_content.html.heex:106
+#: lib/vutuv_web/templates/qualification/form_content.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Remove the uploaded file? The entry itself stays."
 msgstr ""
@@ -13891,7 +13889,7 @@ msgid "proof document"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:375
+#: lib/vutuv_web/templates/settings/preferences.html.heex:364
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr ""
@@ -13901,12 +13899,12 @@ msgstr ""
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:366
+#: lib/vutuv_web/templates/settings/preferences.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:369
+#: lib/vutuv_web/templates/settings/preferences.html.heex:358
 #, elixir-autogen, elixir-format
 msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
@@ -13946,13 +13944,13 @@ msgstr ""
 msgid "Optional, and nobody else sees it. It filters postings below it out of your own job search."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:356
+#: lib/vutuv_web/templates/user/edit.html.heex:351
 #: lib/vutuv_web/templates/welcome/show.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:376
+#: lib/vutuv_web/templates/user/edit.html.heex:371
 #: lib/vutuv_web/templates/welcome/show.html.heex:162
 #, elixir-autogen, elixir-format
 msgid "Shown next to your availability, and used to match you with postings."
@@ -13974,7 +13972,7 @@ msgstr ""
 msgid "Preferred workplace"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:284
+#: lib/vutuv_web/templates/user/edit.html.heex:279
 #: lib/vutuv_web/templates/welcome/show.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Availability"
@@ -14028,13 +14026,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1251
+#: lib/vutuv_web/live/post_live/composer.ex:1226
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1254
+#: lib/vutuv_web/live/post_live/composer.ex:1229
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14123,14 +14121,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3269
+#: lib/vutuv_web/components/post_components.ex:3291
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3292
+#: lib/vutuv_web/components/post_components.ex:3314
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14152,47 +14150,47 @@ msgstr ""
 msgid "This profile is currently unavailable."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/account/index.html.heex:45
+#: lib/vutuv_web/templates/admin/account/index.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5780
+#: lib/vutuv_web/components/post_components.ex:5802
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
 
-#: lib/vutuv_web/views/admin/account_html.ex:93
+#: lib/vutuv_web/views/admin/account_html.ex:83
 #, elixir-autogen, elixir-format
 msgid "active"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/account_html.ex:109
+#: lib/vutuv_web/views/admin/account_html.ex:99
 #, elixir-autogen, elixir-format
 msgid "admin"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/account_html.ex:90
+#: lib/vutuv_web/views/admin/account_html.ex:80
 #, elixir-autogen, elixir-format
 msgid "frozen"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/account_html.ex:108
+#: lib/vutuv_web/views/admin/account_html.ex:98
 #, elixir-autogen, elixir-format
 msgid "report"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/account_html.ex:89
+#: lib/vutuv_web/views/admin/account_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "suspended"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/account_html.ex:92
+#: lib/vutuv_web/views/admin/account_html.ex:82
 #, elixir-autogen, elixir-format
 msgid "unconfirmed"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/account_html.ex:91
+#: lib/vutuv_web/views/admin/account_html.ex:81
 #, elixir-autogen, elixir-format
 msgid "unreachable"
 msgstr ""
@@ -14294,7 +14292,7 @@ msgstr ""
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:389
+#: lib/vutuv_web/live/job_board_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Filter by a tag"
 msgstr ""
@@ -14314,7 +14312,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4741
+#: lib/vutuv_web/components/ui.ex:4849
 #: lib/vutuv_web/controllers/settings_controller.ex:700
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -14403,7 +14401,7 @@ msgstr ""
 msgid "You are not allowed to change this organization's handle."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/filters.html.heex:116
+#: lib/vutuv_web/templates/settings/filters.html.heex:117
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You have not muted anything yet."
 msgstr ""
@@ -14597,7 +14595,7 @@ msgid "Nothing changes on vutuv itself, and you can switch it off again."
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:325
-#: lib/vutuv_web/templates/page/index.html.heex:234
+#: lib/vutuv_web/templates/page/index.html.heex:239
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "Take part in the Fediverse"
@@ -14619,7 +14617,7 @@ msgstr ""
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:321
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:322
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Related"
@@ -14688,7 +14686,7 @@ msgid "Send your Fediverse followers to another account. They are asked to follo
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:265
-#: lib/vutuv_web/live/fediverse_following_live.ex:465
+#: lib/vutuv_web/live/fediverse_following_live.ex:473
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Back to Fediverse settings"
@@ -14717,7 +14715,7 @@ msgstr ""
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:18
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:34
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:260
-#: lib/vutuv_web/templates/page/index.html.heex:119
+#: lib/vutuv_web/templates/page/index.html.heex:124
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:66
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:75
 #, elixir-autogen, elixir-format, fuzzy
@@ -14869,7 +14867,7 @@ msgstr ""
 msgid "ZIP or postal code"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:357
+#: lib/vutuv_web/live/tag_live/timeline.ex:353
 #: lib/vutuv_web/templates/education/form_content.html.heex:59
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:81
 #, elixir-autogen, elixir-format
@@ -14947,252 +14945,252 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4669
+#: lib/vutuv_web/components/ui.ex:4777
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4674
+#: lib/vutuv_web/components/ui.ex:4782
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4677
+#: lib/vutuv_web/components/ui.ex:4785
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4678
+#: lib/vutuv_web/components/ui.ex:4786
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4681
+#: lib/vutuv_web/components/ui.ex:4789
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4682
+#: lib/vutuv_web/components/ui.ex:4790
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4685
+#: lib/vutuv_web/components/ui.ex:4793
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4686
+#: lib/vutuv_web/components/ui.ex:4794
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4693
+#: lib/vutuv_web/components/ui.ex:4801
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4694
+#: lib/vutuv_web/components/ui.ex:4802
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4695
+#: lib/vutuv_web/components/ui.ex:4803
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4698
+#: lib/vutuv_web/components/ui.ex:4806
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4699
+#: lib/vutuv_web/components/ui.ex:4807
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4834
+#: lib/vutuv_web/components/ui.ex:4942
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4835
+#: lib/vutuv_web/components/ui.ex:4943
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4702
+#: lib/vutuv_web/components/ui.ex:4810
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4705
+#: lib/vutuv_web/components/ui.ex:4813
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4706
+#: lib/vutuv_web/components/ui.ex:4814
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4709
+#: lib/vutuv_web/components/ui.ex:4817
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4710
+#: lib/vutuv_web/components/ui.ex:4818
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4713
+#: lib/vutuv_web/components/ui.ex:4821
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4714
+#: lib/vutuv_web/components/ui.ex:4822
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4716
+#: lib/vutuv_web/components/ui.ex:4824
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4717
+#: lib/vutuv_web/components/ui.ex:4825
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4718
+#: lib/vutuv_web/components/ui.ex:4826
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4720
+#: lib/vutuv_web/components/ui.ex:4828
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4721
+#: lib/vutuv_web/components/ui.ex:4829
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4723
+#: lib/vutuv_web/components/ui.ex:4831
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4728
+#: lib/vutuv_web/components/ui.ex:4836
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4729
+#: lib/vutuv_web/components/ui.ex:4837
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4732
+#: lib/vutuv_web/components/ui.ex:4840
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4735
+#: lib/vutuv_web/components/ui.ex:4843
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4742
+#: lib/vutuv_web/components/ui.ex:4850
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4743
+#: lib/vutuv_web/components/ui.ex:4851
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4757
+#: lib/vutuv_web/components/ui.ex:4865
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4758
+#: lib/vutuv_web/components/ui.ex:4866
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4774
+#: lib/vutuv_web/components/ui.ex:4882
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4775
+#: lib/vutuv_web/components/ui.ex:4883
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4781
+#: lib/vutuv_web/components/ui.ex:4889
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4782
+#: lib/vutuv_web/components/ui.ex:4890
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4785
+#: lib/vutuv_web/components/ui.ex:4893
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4786
+#: lib/vutuv_web/components/ui.ex:4894
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4807
+#: lib/vutuv_web/components/ui.ex:4915
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4808
+#: lib/vutuv_web/components/ui.ex:4916
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4826
+#: lib/vutuv_web/components/ui.ex:4934
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4827
+#: lib/vutuv_web/components/ui.ex:4935
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4830
+#: lib/vutuv_web/components/ui.ex:4938
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4831
+#: lib/vutuv_web/components/ui.ex:4939
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4845
+#: lib/vutuv_web/components/ui.ex:4953
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4846
+#: lib/vutuv_web/components/ui.ex:4954
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15258,14 +15256,14 @@ msgstr ""
 msgid "This link always opens your profile, even after you change your username. It is built from a fixed id, so it never breaks on a rename. For everyday sharing the short address above is friendlier."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:269
-#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:35
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:261
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:29
 #, elixir-autogen, elixir-format
 msgid "I understand, switch off"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:267
-#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:33
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:259
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "I understand, take part"
 msgstr ""
@@ -15300,7 +15298,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5726
+#: lib/vutuv_web/components/post_components.ex:5748
 #: lib/vutuv_web/live/notification_live/index.ex:1352
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
@@ -15308,7 +15306,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5730
+#: lib/vutuv_web/components/post_components.ex:5752
 #: lib/vutuv_web/live/notification_live/index.ex:1350
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15316,7 +15314,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5734
+#: lib/vutuv_web/components/post_components.ex:5756
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15324,7 +15322,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1182
-#: lib/vutuv_web/components/post_components.ex:5685
+#: lib/vutuv_web/components/post_components.ex:5707
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15340,14 +15338,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1478
-#: lib/vutuv_web/components/post_components.ex:2221
-#: lib/vutuv_web/live/fediverse_account_live.ex:296
+#: lib/vutuv_web/components/post_components.ex:1479
+#: lib/vutuv_web/components/post_components.ex:2243
+#: lib/vutuv_web/live/fediverse_account_live.ex:298
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1351
+#: lib/vutuv_web/components/post_components.ex:1352
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15376,7 +15374,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1360
+#: lib/vutuv_web/components/post_components.ex:1361
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15386,7 +15384,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1374
+#: lib/vutuv_web/components/post_components.ex:1375
 #: lib/vutuv_web/live/notification_live/index.ex:910
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15418,10 +15416,10 @@ msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1366
-#: lib/vutuv_web/components/post_components.ex:1409
-#: lib/vutuv_web/components/post_components.ex:1609
-#: lib/vutuv_web/components/post_components.ex:2910
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:244
+#: lib/vutuv_web/components/post_components.ex:1410
+#: lib/vutuv_web/components/post_components.ex:1611
+#: lib/vutuv_web/components/post_components.ex:2932
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -15555,27 +15553,27 @@ msgstr ""
 msgid "Confirm it is you"
 msgstr ""
 
-#: lib/vutuv_web/templates/username/confirm.html.heex:148
+#: lib/vutuv_web/templates/username/confirm.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "That passkey could not be verified. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/templates/username/confirm.html.heex:151
+#: lib/vutuv_web/templates/username/confirm.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "Confirm with your passkey"
 msgstr ""
 
-#: lib/vutuv_web/templates/username/confirm.html.heex:176
+#: lib/vutuv_web/templates/username/confirm.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "This browser does not support passkeys. Use a code below instead."
 msgstr ""
 
-#: lib/vutuv_web/templates/username/confirm.html.heex:211
+#: lib/vutuv_web/templates/username/confirm.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "Enter your code"
 msgstr ""
 
-#: lib/vutuv_web/templates/username/confirm.html.heex:223
+#: lib/vutuv_web/templates/username/confirm.html.heex:221
 #, elixir-autogen, elixir-format
 msgid "Change my username"
 msgstr ""
@@ -15585,17 +15583,17 @@ msgstr ""
 msgid "Send the PIN to"
 msgstr ""
 
-#: lib/vutuv_web/views/username_html.ex:155
+#: lib/vutuv_web/views/username_html.ex:152
 #, elixir-autogen, elixir-format
 msgid "Send a new PIN"
 msgstr ""
 
-#: lib/vutuv_web/views/username_html.ex:155
+#: lib/vutuv_web/views/username_html.ex:152
 #, elixir-autogen, elixir-format
 msgid "Email me a PIN"
 msgstr ""
 
-#: lib/vutuv_web/views/username_html.ex:163
+#: lib/vutuv_web/views/username_html.ex:160
 #, elixir-autogen, elixir-format
 msgid "The PIN goes to %{email}."
 msgstr ""
@@ -15649,7 +15647,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4810
+#: lib/vutuv_web/components/ui.ex:4918
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -15864,7 +15862,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:198
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/fediverse_following_live.ex:351
-#: lib/vutuv_web/live/tag_live/timeline.ex:438
+#: lib/vutuv_web/live/tag_live/timeline.ex:434
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -15996,7 +15994,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4811
+#: lib/vutuv_web/components/ui.ex:4919
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -16032,7 +16030,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4813
+#: lib/vutuv_web/components/ui.ex:4921
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16084,22 +16082,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3454
+#: lib/vutuv_web/components/post_components.ex:3476
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3570
+#: lib/vutuv_web/components/post_components.ex:3592
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3578
+#: lib/vutuv_web/components/post_components.ex:3600
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3564
+#: lib/vutuv_web/components/post_components.ex:3586
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16126,24 +16124,24 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:560
 #: lib/vutuv_web/agent_docs/text.ex:549
-#: lib/vutuv_web/templates/user/edit.html.heex:224
+#: lib/vutuv_web/templates/user/edit.html.heex:219
 #: lib/vutuv_web/templates/user/show.html.heex:254
 #: lib/vutuv_web/views/account_event_text.ex:213
 #, elixir-autogen, elixir-format
 msgid "Name pronunciation"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:228
+#: lib/vutuv_web/templates/user/edit.html.heex:223
 #, elixir-autogen, elixir-format
 msgid "e.g. [SHTEH-fahn VIN-ter-my-er]"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:231
+#: lib/vutuv_web/templates/user/edit.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2884
+#: lib/vutuv_web/live/post_live/composer.ex:2823
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16173,123 +16171,123 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2308
+#: lib/vutuv_web/live/post_live/composer.ex:2247
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2722
+#: lib/vutuv_web/live/post_live/composer.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1294
 #: lib/vutuv_web/agent_docs/text.ex:807
-#: lib/vutuv_web/components/ui.ex:2867
+#: lib/vutuv_web/components/ui.ex:2969
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2821
+#: lib/vutuv_web/live/post_live/composer.ex:2760
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2777
+#: lib/vutuv_web/live/post_live/composer.ex:2716
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2779
+#: lib/vutuv_web/live/post_live/composer.ex:2718
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2798
+#: lib/vutuv_web/live/post_live/composer.ex:2737
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2866
+#: lib/vutuv_web/components/ui.ex:2968
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2327
+#: lib/vutuv_web/live/post_live/composer.ex:2266
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3049
+#: lib/vutuv_web/components/post_components.ex:3071
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4264
+#: lib/vutuv_web/components/post_components.ex:4286
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4412
+#: lib/vutuv_web/components/post_components.ex:4434
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2280
-#: lib/vutuv_web/live/post_live/composer.ex:2281
+#: lib/vutuv_web/live/post_live/composer.ex:2219
+#: lib/vutuv_web/live/post_live/composer.ex:2220
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1327
 #: lib/vutuv_web/agent_docs/text.ex:794
-#: lib/vutuv_web/components/post_components.ex:4494
+#: lib/vutuv_web/components/post_components.ex:4516
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2865
+#: lib/vutuv_web/components/ui.ex:2967
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2340
-#: lib/vutuv_web/live/post_live/composer.ex:2341
+#: lib/vutuv_web/live/post_live/composer.ex:2279
+#: lib/vutuv_web/live/post_live/composer.ex:2280
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2800
+#: lib/vutuv_web/live/post_live/composer.ex:2739
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2741
+#: lib/vutuv_web/live/post_live/composer.ex:2680
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3102
+#: lib/vutuv_web/components/post_components.ex:3124
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2819
+#: lib/vutuv_web/live/post_live/composer.ex:2758
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2855
+#: lib/vutuv_web/live/post_live/composer.ex:2794
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2847
+#: lib/vutuv_web/live/post_live/composer.ex:2786
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3093
+#: lib/vutuv_web/components/post_components.ex:3115
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16299,37 +16297,37 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3111
+#: lib/vutuv_web/components/post_components.ex:3133
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3045
+#: lib/vutuv_web/components/post_components.ex:3067
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2598
+#: lib/vutuv_web/live/post_live/composer.ex:2537
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1278
+#: lib/vutuv_web/live/post_live/composer.ex:1253
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3106
+#: lib/vutuv_web/components/post_components.ex:3128
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1292
+#: lib/vutuv_web/live/post_live/composer.ex:1267
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3059
+#: lib/vutuv_web/components/post_components.ex:3081
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16339,65 +16337,64 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2223
+#: lib/vutuv_web/live/post_live/composer.ex:2162
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2593
+#: lib/vutuv_web/live/post_live/composer.ex:2532
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2712
+#: lib/vutuv_web/live/post_live/composer.ex:2651
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1522
-#: lib/vutuv_web/live/post_live/composer.ex:1585
-#: lib/vutuv_web/live/post_live/composer.ex:1643
-#: lib/vutuv_web/live/post_live/composer.ex:1990
+#: lib/vutuv_web/live/post_live/composer.ex:1498
+#: lib/vutuv_web/live/post_live/composer.ex:1561
+#: lib/vutuv_web/live/post_live/composer.ex:1619
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1515
+#: lib/vutuv_web/live/post_live/composer.ex:1491
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2646
+#: lib/vutuv_web/live/post_live/composer.ex:2585
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2158
+#: lib/vutuv_web/live/post_live/composer.ex:2096
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2157
+#: lib/vutuv_web/live/post_live/composer.ex:2095
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2156
+#: lib/vutuv_web/live/post_live/composer.ex:2094
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2161
+#: lib/vutuv_web/live/post_live/composer.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2616
+#: lib/vutuv_web/live/post_live/composer.ex:2555
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2635
+#: lib/vutuv_web/live/post_live/composer.ex:2574
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -16405,13 +16402,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1200
-#: lib/vutuv_web/components/post_components.ex:5723
+#: lib/vutuv_web/components/post_components.ex:5745
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1198
-#: lib/vutuv_web/components/post_components.ex:5720
+#: lib/vutuv_web/components/post_components.ex:5742
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16421,7 +16418,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5612
+#: lib/vutuv_web/components/post_components.ex:5634
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -16507,17 +16504,17 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1779
-#: lib/vutuv_web/live/post_live/composer.ex:2480
+#: lib/vutuv_web/live/post_live/composer.ex:1755
+#: lib/vutuv_web/live/post_live/composer.ex:2419
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:449
+#: lib/vutuv_web/live/fediverse_account_live.ex:459
 #: lib/vutuv_web/live/fediverse_following_live.ex:60
 #: lib/vutuv_web/live/fediverse_following_live.ex:274
 #: lib/vutuv_web/live/fediverse_following_live.ex:287
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:330
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:331
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Accounts you follow elsewhere"
@@ -16528,22 +16525,22 @@ msgstr ""
 msgid "Address of the account"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:521
+#: lib/vutuv_web/live/search_live.ex:514
 #, elixir-autogen, elixir-format
 msgid "An account on another network"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:431
+#: lib/vutuv_web/components/fediverse_components.ex:428
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4797
+#: lib/vutuv_web/components/ui.ex:4905
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:462
+#: lib/vutuv_web/components/fediverse_components.ex:459
 #, elixir-autogen, elixir-format
 msgid "Follow request sent to %{account}."
 msgstr ""
@@ -16553,7 +16550,7 @@ msgstr ""
 msgid "Follow somebody out there"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:551
+#: lib/vutuv_web/live/search_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "Follow this account"
 msgstr ""
@@ -16575,7 +16572,7 @@ msgstr ""
 msgid "Mastodon and the other networks work like email: an address is enough. Paste one here and vutuv asks that server to let you follow the account."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:401
+#: lib/vutuv_web/components/fediverse_components.ex:398
 #: lib/vutuv_web/live/organization_live/following.ex:442
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Requested"
@@ -16591,12 +16588,12 @@ msgstr ""
 msgid "Search for them here"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:384
+#: lib/vutuv_web/live/fediverse_following_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Show only accounts on this server"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:559
+#: lib/vutuv_web/live/search_live.ex:552
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sign in to follow this account"
 msgstr ""
@@ -16611,38 +16608,38 @@ msgstr ""
 msgid "Stop following %{account}?"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:484
+#: lib/vutuv_web/components/fediverse_components.ex:481
 #, elixir-autogen, elixir-format
 msgid "That account could not be loaded from its server. Try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:536
+#: lib/vutuv_web/components/fediverse_components.ex:533
 #, elixir-autogen, elixir-format
 msgid "That did not work. Check the address and try again."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:473
+#: lib/vutuv_web/components/fediverse_components.ex:470
 #, elixir-autogen, elixir-format
 msgid "That does not look like an address on another network. They look like @name@server."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:526
+#: lib/vutuv_web/live/search_live.ex:519
 #, elixir-autogen, elixir-format
 msgid "That is an address on Mastodon or one of the other networks, so nobody here carries it. You can follow it from vutuv."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:481
+#: lib/vutuv_web/components/fediverse_components.ex:478
 #, elixir-autogen, elixir-format
 msgid "That server answered, but it has no account at that address to follow."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:478
-#: lib/vutuv_web/components/fediverse_components.ex:557
+#: lib/vutuv_web/components/fediverse_components.ex:475
+#: lib/vutuv_web/components/fediverse_components.ex:554
 #, elixir-autogen, elixir-format
 msgid "That server did not answer. Check the address, and that the server is online."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:533
+#: lib/vutuv_web/components/fediverse_components.ex:530
 #, elixir-autogen, elixir-format
 msgid "The Fediverse is switched off on this vutuv."
 msgstr ""
@@ -16652,7 +16649,7 @@ msgstr ""
 msgid "The address you brought along is kept here:"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:429
+#: lib/vutuv_web/live/fediverse_following_live.ex:437
 #, elixir-autogen, elixir-format
 msgid "The other server decides. Most accounts accept straight away; one that checks its followers by hand stays on \"Requested\" until somebody there says yes."
 msgstr ""
@@ -16662,7 +16659,7 @@ msgstr ""
 msgid "This vutuv does not exchange anything with other networks, so there is nothing to follow from here. That is an operator setting, not yours."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:487
+#: lib/vutuv_web/components/fediverse_components.ex:484
 #, elixir-autogen, elixir-format
 msgid "This vutuv does not exchange anything with that server."
 msgstr ""
@@ -16672,18 +16669,18 @@ msgstr ""
 msgid "To follow an account out there you need a Fediverse identity of your own: the request is signed in your name, so the other server knows who is asking."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:134
+#: lib/vutuv_web/live/fediverse_account_live.ex:136
 #: lib/vutuv_web/live/fediverse_following_live.ex:177
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unfollowed."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:426
+#: lib/vutuv_web/live/fediverse_following_live.ex:434
 #, elixir-autogen, elixir-format
 msgid "What following out there means"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:434
+#: lib/vutuv_web/live/fediverse_following_live.ex:442
 #, elixir-autogen, elixir-format
 msgid "Who you follow is yours alone. Your profile publishes how many accounts you follow out there, never which ones."
 msgstr ""
@@ -16698,17 +16695,17 @@ msgstr ""
 msgid "Withdraw your follow request to %{account}?"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:504
+#: lib/vutuv_web/components/fediverse_components.ex:501
 #, elixir-autogen, elixir-format
 msgid "You already follow that account."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:522
+#: lib/vutuv_web/components/fediverse_components.ex:519
 #, elixir-autogen, elixir-format
 msgid "You are following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:512
+#: lib/vutuv_web/components/fediverse_components.ex:509
 #, elixir-autogen, elixir-format
 msgid "You are not taking part in the Fediverse at the moment, so there is no identity to sign the request with. Open the Fediverse settings to switch it on."
 msgstr ""
@@ -16725,12 +16722,12 @@ msgid_plural "You follow %{formatted} accounts on other networks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:518
+#: lib/vutuv_web/components/fediverse_components.ex:515
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You have sent a lot of follow requests in the last hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:528
+#: lib/vutuv_web/components/fediverse_components.ex:525
 #, elixir-autogen, elixir-format
 msgid "You redirected your Fediverse followers to another account, so this account no longer acts out there."
 msgstr ""
@@ -16741,7 +16738,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4799
+#: lib/vutuv_web/components/ui.ex:4907
 #, elixir-autogen, elixir-format, fuzzy
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -16761,7 +16758,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2669
+#: lib/vutuv_web/components/post_components.ex:2691
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16771,7 +16768,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2909
+#: lib/vutuv_web/components/post_components.ex:2931
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16791,17 +16788,17 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1762
+#: lib/vutuv_web/components/post_components.ex:1784
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2850
+#: lib/vutuv_web/components/post_components.ex:2872
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:229
+#: lib/vutuv_web/live/fediverse_account_live.ex:231
 #: lib/vutuv_web/live/remote_post_actions.ex:71
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
@@ -16812,12 +16809,12 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2655
+#: lib/vutuv_web/components/post_components.ex:2677
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:445
+#: lib/vutuv_web/live/fediverse_following_live.ex:453
 #, elixir-autogen, elixir-format
 msgid "To show their posts we keep a copy here for up to six months. If the author deletes or edits something, ours follows; and when you stop following an account, its posts are deleted here at once."
 msgstr ""
@@ -16827,62 +16824,62 @@ msgstr ""
 msgid "You do not follow anybody out there yet. Once you do, what they post appears in your feed among everything else."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:76
+#: lib/vutuv_web/live/fediverse_account_live.ex:78
 #, elixir-autogen, elixir-format
 msgid "%{name} (another network)"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:279
+#: lib/vutuv_web/live/fediverse_account_live.ex:281
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Account on another network"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:433
+#: lib/vutuv_web/live/fediverse_account_live.ex:443
 #, elixir-autogen, elixir-format
 msgid "Look up another account"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:363
+#: lib/vutuv_web/live/fediverse_account_live.ex:312
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Muted"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:254
+#: lib/vutuv_web/live/fediverse_account_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "Nothing cached yet. Their posts appear here as they publish them."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:249
+#: lib/vutuv_web/live/fediverse_account_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Nothing here. vutuv only keeps an account's posts while somebody here follows it, and this page never fetches any."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:435
+#: lib/vutuv_web/live/fediverse_account_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "Paste an address from Mastodon and friends to open its page here."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:331
+#: lib/vutuv_web/live/fediverse_account_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Show the whole description"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:418
+#: lib/vutuv_web/live/fediverse_account_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "The most recent %{count} are shown. The rest are on their own server."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:231
+#: lib/vutuv_web/live/fediverse_account_live.ex:233
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unmuted. Their posts are back in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:428
+#: lib/vutuv_web/live/fediverse_account_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "View their full profile on %{host}"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:258
+#: lib/vutuv_web/live/fediverse_account_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Waiting for that server to accept your follow. Posts they addressed to their followers appear once it does."
 msgstr ""
@@ -16893,7 +16890,7 @@ msgid "You redirected your Fediverse followers to another account, so this one n
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:310
-#: lib/vutuv_web/components/fediverse_components.ex:623
+#: lib/vutuv_web/components/fediverse_components.ex:620
 #, elixir-autogen, elixir-format
 msgid "Your account move"
 msgstr ""
@@ -17034,27 +17031,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2380
+#: lib/vutuv_web/components/post_components.ex:2402
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2408
+#: lib/vutuv_web/components/post_components.ex:2430
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2403
+#: lib/vutuv_web/components/post_components.ex:2425
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2952
+#: lib/vutuv_web/components/post_components.ex:2974
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2958
+#: lib/vutuv_web/components/post_components.ex:2980
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is not here any more."
 msgstr ""
@@ -17064,7 +17061,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3097
+#: lib/vutuv_web/components/post_components.ex:3119
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17079,7 +17076,7 @@ msgstr ""
 msgid "Reposted. Your followers see it now."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:399
+#: lib/vutuv_web/components/fediverse_components.ex:396
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Moved"
 msgstr ""
@@ -17246,7 +17243,7 @@ msgstr ""
 msgid "Your username is your public identity here. It changes only once you confirm with your passkey or a valid code below."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:575
+#: lib/vutuv_web/components/ui.ex:599
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Markdown help"
 msgstr ""
@@ -17261,45 +17258,45 @@ msgstr ""
 msgid "Read this page as Markdown"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:232
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:233
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Address of the post"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:620
+#: lib/vutuv_web/components/fediverse_components.ex:617
 #: lib/vutuv_web/live/post_live/remote_actions_component.ex:276
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:597
+#: lib/vutuv_web/components/fediverse_components.ex:594
 #, elixir-autogen, elixir-format
 msgid "Fetching a post asks its server for it in your name, signed with your own key, so there is no such thing as an anonymous lookup here."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:564
+#: lib/vutuv_web/components/fediverse_components.ex:561
 #, elixir-autogen, elixir-format
 msgid "Its author published this post to their followers alone, so vutuv does not keep a copy of it."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:460
+#: lib/vutuv_web/live/fediverse_following_live.ex:468
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Look up a post by its address"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:70
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:196
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:71
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Look up a post from another network"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:324
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Looking for an account rather than a single post?"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:199
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Paste the address of a post on Mastodon and friends. vutuv fetches it, shows it here, and you can answer, like or repost it as if it had arrived on its own."
 msgstr ""
@@ -17309,170 +17306,170 @@ msgstr ""
 msgid "Read something out there that you want to answer from here?"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:549
+#: lib/vutuv_web/components/fediverse_components.ex:546
 #, elixir-autogen, elixir-format
 msgid "That does not look like a link to a post. Copy the address of the post itself, for example https://server/@name/12345."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:554
+#: lib/vutuv_web/components/fediverse_components.ex:551
 #, elixir-autogen, elixir-format
 msgid "That is a link on this vutuv, not on another network."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:316
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:317
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:240
 #, elixir-autogen, elixir-format
 msgid "Their account page here"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:560
+#: lib/vutuv_web/components/fediverse_components.ex:557
 #, elixir-autogen, elixir-format
 msgid "There is no post to show at that address."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:591
+#: lib/vutuv_web/components/fediverse_components.ex:588
 #, elixir-autogen, elixir-format
 msgid "This account no longer acts out there"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:609
+#: lib/vutuv_web/components/fediverse_components.ex:606
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This vutuv does not exchange anything with other networks. That is an operator setting, not yours."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:592
+#: lib/vutuv_web/components/fediverse_components.ex:589
 #, elixir-autogen, elixir-format
 msgid "This vutuv stays to itself"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:589
+#: lib/vutuv_web/components/fediverse_components.ex:586
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Turn on Fediverse participation to look up"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:454
+#: lib/vutuv_web/live/fediverse_following_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "Want to answer one particular post rather than follow its author?"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:288
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:289
 #, elixir-autogen, elixir-format
 msgid "Who wrote this"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:569
+#: lib/vutuv_web/components/fediverse_components.ex:566
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You have looked a lot of posts up in the last hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:603
+#: lib/vutuv_web/components/fediverse_components.ex:600
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You redirected your Fediverse followers to another account, so nothing is fetched or sent from this one any more."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:334
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:335
 #, elixir-autogen, elixir-format
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1696
+#: lib/vutuv_web/live/post_live/composer.ex:1672
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2386
+#: lib/vutuv_web/live/post_live/composer.ex:2325
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2387
+#: lib/vutuv_web/live/post_live/composer.ex:2326
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2392
+#: lib/vutuv_web/live/post_live/composer.ex:2331
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2389
+#: lib/vutuv_web/live/post_live/composer.ex:2328
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2390
+#: lib/vutuv_web/live/post_live/composer.ex:2329
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover on top"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2391
+#: lib/vutuv_web/live/post_live/composer.ex:2330
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1692
-#: lib/vutuv_web/live/post_live/composer.ex:2357
-#: lib/vutuv_web/live/post_live/composer.ex:2358
+#: lib/vutuv_web/live/post_live/composer.ex:1668
+#: lib/vutuv_web/live/post_live/composer.ex:2296
+#: lib/vutuv_web/live/post_live/composer.ex:2297
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Crop photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2316
+#: lib/vutuv_web/live/post_live/composer.ex:2255
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cropped"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1614
+#: lib/vutuv_web/live/post_live/composer.ex:1590
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2393
+#: lib/vutuv_web/live/post_live/composer.ex:2332
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2394
+#: lib/vutuv_web/live/post_live/composer.ex:2333
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1694
+#: lib/vutuv_web/live/post_live/composer.ex:1670
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2385
+#: lib/vutuv_web/live/post_live/composer.ex:2324
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2388
+#: lib/vutuv_web/live/post_live/composer.ex:2327
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:497
+#: lib/vutuv_web/live/post_live/composer.ex:493
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2834
+#: lib/vutuv_web/live/post_live/composer.ex:2773
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1698
+#: lib/vutuv_web/live/post_live/composer.ex:1674
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Whole photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2583
+#: lib/vutuv_web/live/post_live/composer.ex:2522
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2567
+#: lib/vutuv_web/live/post_live/composer.ex:2506
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Whole photos"
 msgstr ""
@@ -17507,12 +17504,12 @@ msgstr ""
 msgid "The most helpful detail in such a report is the exact time of the error. Right now it is %{time}."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:448
+#: lib/vutuv_web/components/fediverse_components.ex:445
 #, elixir-autogen, elixir-format
 msgid "@%{handle} is on this vutuv, so you now follow them here."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:493
+#: lib/vutuv_web/components/fediverse_components.ex:490
 #, elixir-autogen, elixir-format
 msgid "That address is on this vutuv, but it names no member here."
 msgstr ""
@@ -17522,7 +17519,7 @@ msgstr ""
 msgid "That address is on this vutuv. Sign in and use the Follow button on this profile."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:498
+#: lib/vutuv_web/components/fediverse_components.ex:495
 #, elixir-autogen, elixir-format
 msgid "That is your own address. You cannot follow yourself."
 msgstr ""
@@ -17684,12 +17681,12 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:439
+#: lib/vutuv_web/components/post_components.ex:440
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:436
+#: lib/vutuv_web/components/post_components.ex:437
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
@@ -17699,39 +17696,39 @@ msgstr ""
 msgid "View the conversation"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:256
+#: lib/vutuv_web/live/tag_live/timeline.ex:252
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post"
 msgid_plural "%{formatted} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:415
+#: lib/vutuv_web/live/tag_live/timeline.ex:411
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:446
+#: lib/vutuv_web/live/tag_live/timeline.ex:442
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:444
+#: lib/vutuv_web/live/tag_live/timeline.ex:440
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:441
+#: lib/vutuv_web/live/tag_live/timeline.ex:437
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:332
+#: lib/vutuv_web/live/tag_live/timeline.ex:328
 #, elixir-autogen, elixir-format
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2955
+#: lib/vutuv_web/components/post_components.ex:2977
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -17752,28 +17749,28 @@ msgstr ""
 msgid "Other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_post_live.ex:80
+#: lib/vutuv_web/live/fediverse_post_live.ex:82
 #, elixir-autogen, elixir-format
 msgid "A post by %{name} (another network)"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_post_live.ex:120
+#: lib/vutuv_web/live/fediverse_post_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "A post from another network"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_post_live.ex:146
+#: lib/vutuv_web/live/fediverse_post_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "More from %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_post_live.ex:126
+#: lib/vutuv_web/live/fediverse_post_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1374
-#: lib/vutuv_web/components/ui.ex:1375
+#: lib/vutuv_web/components/ui.ex:1398
+#: lib/vutuv_web/components/ui.ex:1399
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr ""
@@ -17783,7 +17780,7 @@ msgstr ""
 msgid "A CV with positions, education, certificates including proof, spoken languages and tags other members endorse you for."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:465
+#: lib/vutuv_web/templates/page/index.html.heex:464
 #, elixir-autogen, elixir-format
 msgid "A business network that is free, does not lock your data in, and is yours to run yourself if you want to."
 msgstr ""
@@ -17803,22 +17800,22 @@ msgstr ""
 msgid "CV download as PDF, Word, OpenDocument, LaTeX or JSON Resume, and you pick what goes in before you download it."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:518
+#: lib/vutuv_web/templates/page/index.html.heex:517
 #, elixir-autogen, elixir-format
 msgid "Developer documentation"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:478
+#: lib/vutuv_web/templates/page/index.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "Every public page here is also served as Markdown, plain text, JSON and XML under the same address. No scraping, no API key, no account."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:485
+#: lib/vutuv_web/templates/page/index.html.heex:484
 #, elixir-autogen, elixir-format
 msgid "For machines"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:475
+#: lib/vutuv_web/templates/page/index.html.heex:474
 #, elixir-autogen, elixir-format
 msgid "Open by default"
 msgstr ""
@@ -17843,12 +17840,12 @@ msgstr ""
 msgid "Posts, likes, reposts, replies and 1:1 messages, in real time."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:476
+#: lib/vutuv_web/templates/page/index.html.heex:475
 #, elixir-autogen, elixir-format
 msgid "Readable by people, by machines, and on your own server"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:501
+#: lib/vutuv_web/templates/page/index.html.heex:500
 #, elixir-autogen, elixir-format
 msgid "Run it yourself"
 msgstr ""
@@ -17858,23 +17855,23 @@ msgstr ""
 msgid "Sign in without a password, by emailed PIN, passkey, authenticator app or a printed list of codes."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:512
-#: lib/vutuv_web/templates/page/index.html.heex:599
+#: lib/vutuv_web/templates/page/index.html.heex:511
+#: lib/vutuv_web/templates/page/index.html.heex:598
 #, elixir-autogen, elixir-format
 msgid "Source code"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:347
+#: lib/vutuv_web/templates/page/index.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "This is what a vutuv profile looks like"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:463
+#: lib/vutuv_web/templates/page/index.html.heex:462
 #, elixir-autogen, elixir-format
 msgid "What vutuv can do"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:462
+#: lib/vutuv_web/templates/page/index.html.heex:461
 #, elixir-autogen, elixir-format
 msgid "What you get"
 msgstr ""
@@ -17884,12 +17881,12 @@ msgstr ""
 msgid "Your independence"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:503
+#: lib/vutuv_web/templates/page/index.html.heex:502
 #, elixir-autogen, elixir-format
 msgid "vutuv is open source under the MIT license. Run it for a company, an association or a school, on the internet or air-gapped inside your own network."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:346
+#: lib/vutuv_web/templates/page/index.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "A look inside"
 msgstr ""
@@ -17899,7 +17896,7 @@ msgstr ""
 msgid "A vutuv profile: cover picture, photo, name, tagline and job title, follower counts and the first posts, with contact details and social media profiles in a column on the right."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:368
+#: lib/vutuv_web/templates/page/index.html.heex:367
 #, elixir-autogen, elixir-format
 msgid "Browse real profiles"
 msgstr ""
@@ -17919,17 +17916,17 @@ msgstr ""
 msgid "Try it out:"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:494
+#: lib/vutuv_web/templates/page/index.html.heex:493
 #, elixir-autogen, elixir-format
 msgid "Plus a sitemap, JSON-LD and a REST API with OAuth 2 and personal access tokens."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:349
+#: lib/vutuv_web/templates/page/index.html.heex:348
 #, elixir-autogen, elixir-format
 msgid "Work experience, education, certificates, languages, links and tags others endorse you for. Anyone can read a profile, entirely without a vutuv account. Unlike LinkedIn, where you hit a login wall in short order."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:449
+#: lib/vutuv_web/templates/page/index.html.heex:448
 #, elixir-autogen, elixir-format
 msgid "Talking to people"
 msgstr ""
@@ -17949,72 +17946,72 @@ msgstr ""
 msgid "The Fediverse: let people follow you from Mastodon, and your public posts show up there. You choose at sign-up, and can change it later."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:450
+#: lib/vutuv_web/templates/page/index.html.heex:449
 #, elixir-autogen, elixir-format
 msgid "Posts, messages, and the Fediverse along with them"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:452
+#: lib/vutuv_web/templates/page/index.html.heex:451
 #, elixir-autogen, elixir-format
 msgid "Write a post, react with a heart, a repost or a reply, or message somebody privately. And you are not stuck among vutuv members: vutuv is part of the Fediverse, the union of independent networks that Mastodon belongs to as well. Follow an account over there and its posts arrive in your feed; the other way round, people there can follow you and see your public posts. Both directions, and entirely your choice: at sign-up you decide whether to use vutuv with or without the Fediverse, and you can change that at any time in the settings."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:565
+#: lib/vutuv_web/templates/page/index.html.heex:564
 #, elixir-autogen, elixir-format
 msgid "Download everything you have here at any time, in a machine-readable file. Not on request, not after a waiting period: from your settings, whenever you like."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:540
+#: lib/vutuv_web/templates/page/index.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "Fair and transparent, in plain words"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:554
+#: lib/vutuv_web/templates/page/index.html.heex:553
 #, elixir-autogen, elixir-format
 msgid "No third-party cookies"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:546
+#: lib/vutuv_web/templates/page/index.html.heex:545
 #, elixir-autogen, elixir-format
 msgid "On our own servers in %{place}, not in somebody else's cloud. We do not hand your profile to a third party, and there is no tracking network reading along."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:544
+#: lib/vutuv_web/templates/page/index.html.heex:543
 #, elixir-autogen, elixir-format
 msgid "Where your data lives"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:539
+#: lib/vutuv_web/templates/page/index.html.heex:538
 #, elixir-autogen, elixir-format
 msgid "Your data"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:556
+#: lib/vutuv_web/templates/page/index.html.heex:555
 #, elixir-autogen, elixir-format
 msgid "vutuv sets one cookie, the one that keeps you signed in. No advertising network, no analytics service, nothing loaded from anybody else's server."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:572
+#: lib/vutuv_web/templates/page/index.html.heex:571
 #, elixir-autogen, elixir-format
 msgid "Leave whenever you like"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:588
+#: lib/vutuv_web/templates/page/index.html.heex:587
 #, elixir-autogen, elixir-format
 msgid "Open source"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:590
+#: lib/vutuv_web/templates/page/index.html.heex:589
 #, elixir-autogen, elixir-format
 msgid "You can check at any time how exactly vutuv works. The whole source code is public under the MIT license, so everything said above about your data can be read rather than taken on trust."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:563
+#: lib/vutuv_web/templates/page/index.html.heex:562
 #, elixir-autogen, elixir-format
 msgid "Your data stays with you"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:579
+#: lib/vutuv_web/templates/page/index.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "Delete your account yourself, without writing to anybody. No questions asked, and you are welcome back any time."
 msgstr ""
@@ -18034,19 +18031,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4788
+#: lib/vutuv_web/components/post_components.ex:4810
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4790
+#: lib/vutuv_web/components/post_components.ex:4812
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4801
+#: lib/vutuv_web/components/post_components.ex:4823
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18097,7 +18094,7 @@ msgid "A published reference then appears next to the entry it documents."
 msgstr ""
 
 #: lib/vutuv_web/controllers/job_reference_controller.ex:252
-#: lib/vutuv_web/live/reference_check_live.ex:420
+#: lib/vutuv_web/live/reference_check_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "A review for this reference is already running."
 msgstr ""
@@ -18173,7 +18170,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:4688
+#: lib/vutuv_web/components/ui.ex:4796
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -18218,7 +18215,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3176
+#: lib/vutuv_web/live/post_live/feed.ex:3173
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Loading…"
@@ -18261,7 +18258,7 @@ msgstr ""
 msgid "Review result"
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:303
+#: lib/vutuv_web/live/reference_check_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Reviewing your reference. This takes a few minutes."
 msgstr ""
@@ -18272,7 +18269,7 @@ msgid "Show this reference publicly on my profile"
 msgstr ""
 
 #: lib/vutuv_web/templates/job_reference/show.html.heex:39
-#: lib/vutuv_web/templates/job_reference/view.html.heex:89
+#: lib/vutuv_web/templates/job_reference/view.html.heex:86
 #: lib/vutuv_web/views/account_event_text.ex:227
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Text"
@@ -18300,22 +18297,22 @@ msgid "The AI review reads German employment law and is therefore offered for Ge
 msgstr ""
 
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:55
-#: lib/vutuv_web/templates/job_reference/view.html.heex:47
+#: lib/vutuv_web/templates/job_reference/view.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "The document"
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:359
+#: lib/vutuv_web/live/reference_check_live.ex:342
 #, elixir-autogen, elixir-format, fuzzy
 msgid "The review could not be completed."
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:428
+#: lib/vutuv_web/live/reference_check_live.ex:411
 #, elixir-autogen, elixir-format, fuzzy
 msgid "The review could not be started."
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:426
+#: lib/vutuv_web/live/reference_check_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "The review covers German Arbeitszeugnisse only."
 msgstr ""
@@ -18336,12 +18333,12 @@ msgid "The review is not available on this installation."
 msgstr ""
 
 #: lib/vutuv_web/controllers/job_reference_controller.ex:259
-#: lib/vutuv_web/live/reference_check_live.ex:423
+#: lib/vutuv_web/live/reference_check_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "There is no text to review yet. Upload the document or paste the text."
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:366
+#: lib/vutuv_web/live/reference_check_live.ex:349
 #: lib/vutuv_web/templates/service_worker/offline.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "Try again"
@@ -18352,14 +18349,14 @@ msgstr ""
 msgid "Upload your Arbeitszeugnisse, attach them to your CV, and have them reviewed. Nothing is public until you say so."
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:272
+#: lib/vutuv_web/live/reference_check_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Waiting — %{count} review ahead of yours."
 msgid_plural "Waiting — %{count} reviews ahead of yours."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:278
+#: lib/vutuv_web/live/reference_check_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Waiting — yours is next."
 msgstr ""
@@ -18369,7 +18366,7 @@ msgstr ""
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4689
+#: lib/vutuv_web/components/ui.ex:4797
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
@@ -18380,7 +18377,7 @@ msgstr ""
 msgid "Zwischenzeugnis"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4691
+#: lib/vutuv_web/components/ui.ex:4799
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -18390,27 +18387,27 @@ msgstr ""
 msgid "e.g. Zeugnis Muster GmbH 2019–2026"
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:116
+#: lib/vutuv_web/templates/job_reference/check.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "For a binding assessment please ask a lawyer, ideally a Fachanwalt für Arbeitsrecht."
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:123
+#: lib/vutuv_web/templates/job_reference/check.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "The analysis follows the freely available Arbeitszeugnis-Prüfer prompt"
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:110
+#: lib/vutuv_web/templates/job_reference/check.html.heex:106
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This is not legal advice."
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:113
+#: lib/vutuv_web/templates/job_reference/check.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "We do not assess your case. What you see is an automated reading of the wording of your document, produced on our own servers by a language model."
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:139
+#: lib/vutuv_web/templates/job_reference/check.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "We wrote neither the prompt nor the model."
 msgstr ""
@@ -18425,13 +18422,13 @@ msgstr ""
 msgid "document"
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:151
+#: lib/vutuv_web/templates/job_reference/check.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Back to your employment references"
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:332
-#: lib/vutuv_web/templates/job_reference/view.html.heex:41
+#: lib/vutuv_web/live/reference_check_live.ex:321
+#: lib/vutuv_web/templates/job_reference/view.html.heex:38
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Read the review"
 msgstr ""
@@ -18451,18 +18448,18 @@ msgstr ""
 msgid "Reviewed on"
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:90
+#: lib/vutuv_web/templates/job_reference/check.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Check the text"
 msgstr ""
 
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:116
-#: lib/vutuv_web/templates/job_reference/view.html.heex:104
+#: lib/vutuv_web/templates/job_reference/view.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Delete this reference, its document and its review? This cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:157
+#: lib/vutuv_web/templates/job_reference/check.html.heex:153
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit this reference"
 msgstr ""
@@ -18472,8 +18469,8 @@ msgstr ""
 msgid "Open the file"
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:348
-#: lib/vutuv_web/templates/job_reference/check.html.heex:72
+#: lib/vutuv_web/live/reference_check_live.ex:332
+#: lib/vutuv_web/templates/job_reference/check.html.heex:68
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Review again"
 msgstr ""
@@ -18483,7 +18480,7 @@ msgstr ""
 msgid "Uploaded file"
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:341
+#: lib/vutuv_web/live/reference_check_live.ex:330
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You changed the text after this review."
 msgstr ""
@@ -18513,7 +18510,7 @@ msgstr ""
 msgid "Nobody else can open a review, and publishing a reference on your profile never publishes its review. What a machine read into your Zeugnis is nobody's business but yours."
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/view.html.heex:54
+#: lib/vutuv_web/templates/job_reference/view.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Open in a new tab"
 msgstr ""
@@ -18528,8 +18525,8 @@ msgstr ""
 msgid "The result is yours alone."
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/view.html.heex:68
-#: lib/vutuv_web/templates/job_reference/view.html.heex:78
+#: lib/vutuv_web/templates/job_reference/view.html.heex:65
+#: lib/vutuv_web/templates/job_reference/view.html.heex:75
 #, elixir-autogen, elixir-format
 msgid "The uploaded reference"
 msgstr ""
@@ -18588,7 +18585,7 @@ msgstr ""
 msgid "Issue date"
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:299
+#: lib/vutuv_web/live/reference_check_live.ex:291
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reviewing your reference. This usually takes about %{duration}."
 msgstr ""
@@ -18605,7 +18602,7 @@ msgstr ""
 msgid "The review of “%{title}” is ready: %{grade}."
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:284
+#: lib/vutuv_web/live/reference_check_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Usually about %{duration}."
 msgstr ""
@@ -18635,13 +18632,13 @@ msgstr ""
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4028
+#: lib/vutuv_web/components/ui.ex:4132
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:99
+#: lib/vutuv_web/templates/job_reference/check.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "The full report"
 msgstr ""
@@ -18661,7 +18658,7 @@ msgstr ""
 msgid "This reference was issued to me."
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:249
+#: lib/vutuv_web/live/reference_check_live.ex:242
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Decode this reference"
 msgstr ""
@@ -18671,12 +18668,12 @@ msgstr ""
 msgid "German references are graded in code, so friendly words can carry a poor mark. We read the wording against German employment-reference law and tell you which grade is in it, what each assessing phrase really says, and what is missing, contradictory or formally wrong."
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:258
+#: lib/vutuv_web/live/reference_check_live.ex:250
 #, elixir-autogen, elixir-format
 msgid "Only you see the result."
 msgstr ""
 
-#: lib/vutuv_web/live/reference_check_live.ex:388
+#: lib/vutuv_web/live/reference_check_live.ex:371
 #, elixir-autogen, elixir-format
 msgid "You can leave this page. The result lands in your notifications, and we email it to you if you are no longer here by then."
 msgstr ""
@@ -18773,7 +18770,7 @@ msgstr ""
 msgid "An employment reference of yours has been reviewed."
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:131
+#: lib/vutuv_web/templates/job_reference/check.html.heex:127
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "GitHub account @Klotzkette"
@@ -18815,7 +18812,7 @@ msgstr ""
 msgid "Your vutuv username is ready."
 msgstr ""
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:125
+#: lib/vutuv_web/templates/job_reference/check.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "by the lawyer Tom Braegelmann"
 msgstr ""
@@ -18884,7 +18881,7 @@ msgstr ""
 msgid "You have reached your limit of %{limit} reviews. Please try again in %{window}."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:409
+#: lib/vutuv_web/templates/page/index.html.heex:408
 #, elixir-autogen, elixir-format
 msgid "Employment reference"
 msgstr ""
@@ -18894,7 +18891,7 @@ msgstr ""
 msgid "Employment references: upload them, keep them private, and have the wording read and graded on our own servers."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:386
+#: lib/vutuv_web/templates/page/index.html.heex:385
 #, elixir-autogen, elixir-format
 msgid "Job applications"
 msgstr ""
@@ -18909,7 +18906,7 @@ msgstr ""
 msgid "The finished CV ready to print: name, tagline and contact details at the top, below them the positions held with employer and period, and further down the tags and the spoken languages."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:429
+#: lib/vutuv_web/templates/page/index.html.heex:428
 #, elixir-autogen, elixir-format
 msgid "The review is a text analysis, not legal advice, and it covers German employment references."
 msgstr ""
@@ -18924,22 +18921,22 @@ msgstr ""
 msgid "The uploaded employment references, each marked private: one graded 1 (very good) on a green panel, one graded 4 to 5 (poor to unsatisfactory) on a red one, each with a link to its full report."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:412
+#: lib/vutuv_web/templates/page/index.html.heex:411
 #, elixir-autogen, elixir-format
 msgid "Upload your employment references and have them read sentence by sentence: a grade, a traffic light, and the explanation of how a recruiter reads that wording. It takes a few minutes, then the report is there. Nothing becomes public before you release it."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:410
+#: lib/vutuv_web/templates/page/index.html.heex:409
 #, elixir-autogen, elixir-format
 msgid "What your employment reference really says"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:389
+#: lib/vutuv_web/templates/page/index.html.heex:388
 #, elixir-autogen, elixir-format
 msgid "What your profile already says becomes a CV. You tick what should go in, then download it as PDF, Word, OpenDocument, LaTeX or JSON Resume. Anonymously as well, if you would rather show what you can do before you show who you are."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:387
+#: lib/vutuv_web/templates/page/index.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "Your CV, ready to send"
 msgstr ""
@@ -18964,7 +18961,7 @@ msgstr ""
 msgid "Your verified badge was removed because you changed your name or date of birth. We re-check identity against those details so members can trust verified profiles and nobody can set up a fake verified account. An admin can verify you again anytime."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:249
+#: lib/vutuv_web/templates/page/index.html.heex:250
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Your public posts then also appear on {mastodon} and other independent networks, where people can follow you. Replies and reposts come back under your posts, with the account's address, and are kept for up to six months. You can switch it off at any time."
 msgstr ""
@@ -18981,12 +18978,12 @@ msgstr ""
 msgid "Enter the PIN from the email"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:807
+#: lib/vutuv_web/components/ui.ex:831
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:835
+#: lib/vutuv_web/components/ui.ex:859
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cancel registration"
 msgstr ""
@@ -19001,7 +18998,7 @@ msgstr ""
 msgid "Follow other members"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:790
+#: lib/vutuv_web/components/ui.ex:814
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
@@ -19026,7 +19023,7 @@ msgstr ""
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4670
+#: lib/vutuv_web/components/ui.ex:4778
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
@@ -19122,7 +19119,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4790
+#: lib/vutuv_web/components/ui.ex:4898
 #: lib/vutuv_web/controllers/settings_controller.ex:247
 #: lib/vutuv_web/controllers/settings_controller.ex:326
 #: lib/vutuv_web/controllers/settings_controller.ex:338
@@ -19219,7 +19216,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4792
+#: lib/vutuv_web/components/ui.ex:4900
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -19328,7 +19325,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4794
+#: lib/vutuv_web/components/ui.ex:4902
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -19702,7 +19699,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2985
+#: lib/vutuv_web/components/post_components.ex:3007
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -19737,7 +19734,7 @@ msgstr ""
 msgid "Posts jobs."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:274
+#: lib/vutuv_web/live/organization_live/roles.ex:269
 #, elixir-autogen, elixir-format
 msgid "Roles"
 msgstr ""
@@ -19762,22 +19759,22 @@ msgstr ""
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1925
+#: lib/vutuv_web/live/post_live/composer.ex:1927
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1271
+#: lib/vutuv_web/live/post_live/composer.ex:1246
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1902
+#: lib/vutuv_web/live/post_live/composer.ex:1904
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1061
+#: lib/vutuv_web/live/shell_live.ex:1057
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Open the page"
 msgstr ""
@@ -19797,7 +19794,7 @@ msgstr ""
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1071
+#: lib/vutuv_web/live/shell_live.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -19807,7 +19804,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1047
+#: lib/vutuv_web/live/shell_live.ex:1043
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -19864,7 +19861,7 @@ msgstr ""
 msgid "%{name} follows"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/feed.ex:66
+#: lib/vutuv_web/live/organization_live/feed.ex:65
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Feed – %{name}"
 msgstr ""
@@ -19879,7 +19876,7 @@ msgstr ""
 msgid "Members and organizations"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/feed.ex:161
+#: lib/vutuv_web/live/organization_live/feed.ex:160
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. This page does not follow anyone, or nobody it follows has published."
 msgstr ""
@@ -19910,7 +19907,7 @@ msgstr ""
 msgid "Unfollow %{tag}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/feed.ex:157
+#: lib/vutuv_web/live/organization_live/feed.ex:156
 #, elixir-autogen, elixir-format
 msgid "What the members and organizations this page follows have published. Liking or saving something here is done from your own account, not the page's."
 msgstr ""
@@ -20014,12 +20011,12 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:84
 #: lib/vutuv_web/live/organization_live/new.ex:211
-#: lib/vutuv_web/live/organization_live/show.ex:892
+#: lib/vutuv_web/live/organization_live/show.ex:887
 #, elixir-autogen, elixir-format
 msgid "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:906
+#: lib/vutuv_web/live/organization_live/show.ex:901
 #, elixir-autogen, elixir-format
 msgid "Set this page up for other networks"
 msgstr ""
@@ -20034,7 +20031,7 @@ msgstr ""
 msgid "Switch it on"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:897
+#: lib/vutuv_web/live/organization_live/show.ex:892
 #, elixir-autogen, elixir-format
 msgid "The page gets an address of its own for that, written like an email address."
 msgstr ""
@@ -20059,12 +20056,12 @@ msgstr ""
 msgid "This vutuv exchanges nothing with other networks, so nothing here has any effect."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:443
+#: lib/vutuv_web/live/organization_live/edit.ex:425
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Claim a short @name so this organization has an address of its own, like a member. Letters, numbers and underscores, %{min} to %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:441
+#: lib/vutuv_web/live/organization_live/edit.ex:423
 #, elixir-autogen, elixir-format
 msgid "The organization's @name"
 msgstr ""
@@ -20119,22 +20116,22 @@ msgstr ""
 msgid "The PIN has expired."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:911
+#: lib/vutuv_web/components/ui.ex:935
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:913
+#: lib/vutuv_web/components/ui.ex:937
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:912
+#: lib/vutuv_web/components/ui.ex:936
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:914
+#: lib/vutuv_web/components/ui.ex:938
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr ""
@@ -20151,7 +20148,7 @@ msgid_plural "Your sign-up was never confirmed, so we delete it automatically in
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:456
+#: lib/vutuv_web/components/fediverse_components.ex:453
 #, elixir-autogen, elixir-format
 msgid "#%{tag} is a topic on this vutuv, so you now follow the tag here."
 msgstr ""
@@ -20207,12 +20204,12 @@ msgstr ""
 msgid "Signal also takes its contact link (https://signal.me/#…). It names neither your phone number nor your username, and you can reset it in Signal at any time."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:596
+#: lib/vutuv_web/live/search_live.ex:589
 #, elixir-autogen, elixir-format, fuzzy
 msgid "A post on another network"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:620
+#: lib/vutuv_web/live/search_live.ex:613
 #, elixir-autogen, elixir-format
 msgid "Fetch this post"
 msgstr ""
@@ -20222,12 +20219,12 @@ msgstr ""
 msgid "Search for people, tags, posts, or paste a Fediverse address"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:636
+#: lib/vutuv_web/live/search_live.ex:629
 #, elixir-autogen, elixir-format
 msgid "Sign in to fetch this post"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:601
+#: lib/vutuv_web/live/search_live.ex:594
 #, elixir-autogen, elixir-format
 msgid "That is a link to somewhere else, not something anybody here wrote. vutuv can fetch the post behind it so you can read it, answer it, like it or repost it from here."
 msgstr ""
@@ -20242,7 +20239,7 @@ msgstr ""
 msgid "the address of a post out there: vutuv fetches it so you can answer it here"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:86
+#: lib/vutuv_web/templates/user/edit.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Fetch my picture from gravatar.com"
 msgstr ""
@@ -20267,7 +20264,7 @@ msgstr ""
 msgid "gravatar.com has no picture for your email address."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:89
+#: lib/vutuv_web/templates/user/edit.html.heex:84
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Only when you press this: we ask gravatar.com whether there is a picture for your email address, sending a hash of the address rather than the address itself. Nothing leaves this server otherwise."
 msgstr ""
@@ -20282,8 +20279,8 @@ msgstr ""
 msgid "A new entry can take a while to reach everyone. We keep checking %{domain} by ourselves and send you an email as soon as it works, so you can close this page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:336
-#: lib/vutuv_web/live/organization_live/show.ex:1094
+#: lib/vutuv_web/live/organization_live/domains.ex:331
+#: lib/vutuv_web/live/organization_live/show.ex:1090
 #, elixir-autogen, elixir-format
 msgid "Checking …"
 msgstr ""
@@ -20553,43 +20550,43 @@ msgstr ""
 msgid "{n} of {max} free slots selected."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1967
+#: lib/vutuv_web/live/post_live/composer.ex:1881
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1952
+#: lib/vutuv_web/live/post_live/composer.ex:1866
 #, elixir-autogen, elixir-format
 msgctxt "post composer"
 msgid "Language"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1957
+#: lib/vutuv_web/live/post_live/composer.ex:1871
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4682
+#: lib/vutuv_web/components/post_components.ex:4704
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4718
+#: lib/vutuv_web/components/post_components.ex:4740
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4727
+#: lib/vutuv_web/components/post_components.ex:4749
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4730
+#: lib/vutuv_web/components/post_components.ex:4752
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4707
+#: lib/vutuv_web/components/post_components.ex:4729
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20599,8 +20596,8 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4697
-#: lib/vutuv_web/components/ui.ex:4749
+#: lib/vutuv_web/components/post_components.ex:4719
+#: lib/vutuv_web/components/ui.ex:4857
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -20728,27 +20725,27 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4460
+#: lib/vutuv_web/components/post_components.ex:4482
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4457
+#: lib/vutuv_web/components/post_components.ex:4479
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2429
-#: lib/vutuv_web/components/post_components.ex:3787
+#: lib/vutuv_web/components/post_components.ex:2451
+#: lib/vutuv_web/components/post_components.ex:3809
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:144
+#: lib/vutuv_web/templates/user/edit.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "Recommended: %{width} × %{height} pixels (%{ratio})."
 msgstr ""
@@ -20810,7 +20807,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4838
+#: lib/vutuv_web/components/ui.ex:4946
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
@@ -20856,7 +20853,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4840
+#: lib/vutuv_web/components/ui.ex:4948
 #, elixir-autogen, elixir-format, fuzzy
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -20892,7 +20889,7 @@ msgstr ""
 msgid "Find your LinkedIn contacts"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4765
+#: lib/vutuv_web/components/ui.ex:4873
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format, fuzzy
@@ -20905,7 +20902,7 @@ msgid "Follow selected"
 msgstr ""
 
 #: lib/vutuv_web/live/import_connections_live.ex:504
-#: lib/vutuv_web/live/search_live.ex:548
+#: lib/vutuv_web/live/search_live.ex:541
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Following…"
 msgstr ""
@@ -21000,7 +20997,7 @@ msgstr ""
 msgid "See which of them are already on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4767
+#: lib/vutuv_web/components/ui.ex:4875
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr ""
@@ -21072,7 +21069,7 @@ msgstr ""
 msgid "Your export also lists your LinkedIn contacts."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4769
+#: lib/vutuv_web/components/ui.ex:4877
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr ""
@@ -21216,34 +21213,34 @@ msgctxt "qualification detail"
 msgid "Jobs"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:836
+#: lib/vutuv_web/live/job_posting_live/form.ex:829
 #, elixir-autogen, elixir-format
 msgid "%{formatted} country chosen."
 msgid_plural "%{formatted} countries chosen."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:620
+#: lib/vutuv_web/live/job_posting_live/form.ex:619
 #, elixir-autogen, elixir-format
 msgid "No country chosen yet."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:612
+#: lib/vutuv_web/live/job_posting_live/form.ex:611
 #, elixir-autogen, elixir-format
 msgid "No country left to add for that."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:631
+#: lib/vutuv_web/live/job_posting_live/form.ex:630
 #, elixir-autogen, elixir-format
 msgid "Remove %{country}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:642
+#: lib/vutuv_web/live/job_posting_live/form.ex:641
 #, elixir-autogen, elixir-format
 msgid "Remove all"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:591
+#: lib/vutuv_web/live/job_posting_live/form.ex:590
 #, elixir-autogen, elixir-format
 msgid "Search for a country"
 msgstr ""
@@ -21253,7 +21250,7 @@ msgstr ""
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2643
+#: lib/vutuv_web/components/post_components.ex:2665
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
@@ -21283,7 +21280,7 @@ msgstr ""
 msgid "New message"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1024
+#: lib/vutuv_web/live/shell_live.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
@@ -21328,12 +21325,12 @@ msgstr ""
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4737
+#: lib/vutuv_web/components/ui.ex:4845
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:311
+#: lib/vutuv_web/live/tag_live/timeline.ex:307
 #, elixir-autogen, elixir-format
 msgid "%{formatted} active"
 msgstr ""
@@ -21378,7 +21375,7 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3337
+#: lib/vutuv_web/live/post_live/feed.ex:3334
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
@@ -21388,43 +21385,43 @@ msgstr ""
 msgid "New here"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1543
+#: lib/vutuv_web/components/ui.ex:1567
 #, elixir-autogen, elixir-format
 msgid "New public posts arrive in any feed reader. No account needed either."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1539
+#: lib/vutuv_web/components/ui.ex:1563
 #, elixir-autogen, elixir-format
 msgid "Or with an RSS reader"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1419
-#: lib/vutuv_web/components/ui.ex:1488
+#: lib/vutuv_web/components/ui.ex:1443
+#: lib/vutuv_web/components/ui.ex:1512
 #, elixir-autogen, elixir-format
 msgid "Subscribe"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1540
+#: lib/vutuv_web/components/ui.ex:1564
 #, elixir-autogen, elixir-format
 msgid "With an RSS reader"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1500
+#: lib/vutuv_web/components/ui.ex:1524
 #, elixir-autogen, elixir-format
 msgid "Create a free account"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1515
+#: lib/vutuv_web/components/ui.ex:1539
 #, elixir-autogen, elixir-format
 msgid "No vutuv account? These ways work too:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1493
+#: lib/vutuv_web/components/ui.ex:1517
 #, elixir-autogen, elixir-format
 msgid "The best way: follow %{name} here. New posts land in your feed, and you can reply and join in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1491
+#: lib/vutuv_web/components/ui.ex:1515
 #, elixir-autogen, elixir-format
 msgid "With a vutuv account"
 msgstr ""
@@ -21434,7 +21431,7 @@ msgstr ""
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:278
+#: lib/vutuv_web/templates/settings/preferences.html.heex:267
 #, elixir-autogen, elixir-format
 msgid "Example"
 msgstr ""
@@ -21449,7 +21446,7 @@ msgstr ""
 msgid "Just flashed the new release, boot is under two seconds now"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:288
+#: lib/vutuv_web/templates/settings/preferences.html.heex:277
 #, elixir-autogen, elixir-format
 msgid "Play the example"
 msgstr ""
@@ -21549,22 +21546,22 @@ msgstr ""
 msgid "Shown in the language it was written in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4750
+#: lib/vutuv_web/components/ui.ex:4858
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4752
+#: lib/vutuv_web/components/ui.ex:4860
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4817
+#: lib/vutuv_web/components/ui.ex:4925
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4821
+#: lib/vutuv_web/components/ui.ex:4929
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -21597,7 +21594,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:94
-#: lib/vutuv_web/templates/settings/preferences.html.heex:254
+#: lib/vutuv_web/templates/settings/preferences.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Browser tab"
 msgstr ""
@@ -21622,12 +21619,12 @@ msgstr ""
 msgid "Tease new posts in the browser tab"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:280
+#: lib/vutuv_web/templates/settings/preferences.html.heex:269
 #, elixir-autogen, elixir-format
 msgid "Watch this tab's title, above."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:256
+#: lib/vutuv_web/templates/settings/preferences.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "While you are reading another tab, a new post can page its first words through this tab's title, a line at a time, and then hand the title back."
 msgstr ""
@@ -21682,7 +21679,7 @@ msgstr ""
 msgid "Your LinkedIn profile can come along."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1111
+#: lib/vutuv_web/components/ui.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Being checked"
 msgstr ""
@@ -21906,7 +21903,7 @@ msgstr ""
 msgid "Move %{card}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:544
+#: lib/vutuv_web/components/ui.ex:401
 #: lib/vutuv_web/live/post_live/filter_band.ex:583
 #, elixir-autogen, elixir-format
 msgid "No account found."
@@ -21947,7 +21944,7 @@ msgstr "Posts carrying one of these tags are folded the same way."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3363
+#: lib/vutuv_web/live/post_live/feed.ex:3360
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
@@ -22024,10 +22021,10 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2996
-#: lib/vutuv_web/live/post_live/feed.ex:3013
-#: lib/vutuv_web/live/post_live/feed.ex:3411
-#: lib/vutuv_web/live/post_live/feed.ex:3416
+#: lib/vutuv_web/live/post_live/feed.ex:2993
+#: lib/vutuv_web/live/post_live/feed.ex:3010
+#: lib/vutuv_web/live/post_live/feed.ex:3408
+#: lib/vutuv_web/live/post_live/feed.ex:3413
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -22046,7 +22043,7 @@ msgid_plural "Show %{formatted} posts in the feed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2351
+#: lib/vutuv_web/components/post_components.ex:2373
 #, elixir-autogen, elixir-format
 msgid "Picture unavailable"
 msgstr "Picture unavailable"
@@ -22061,7 +22058,7 @@ msgstr ""
 msgid "Your organization page was updated. The new logo is being checked and appears once that is through."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:286
+#: lib/vutuv_web/live/organization_live/edit.ex:281
 #, elixir-autogen, elixir-format
 msgid "%{formats}, up to %{limit}"
 msgstr ""
@@ -22071,7 +22068,7 @@ msgstr ""
 msgid "Your organization page was updated, but that picture could not be used as a logo. Please pick another one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4034
+#: lib/vutuv_web/components/ui.ex:4138
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -22092,7 +22089,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3133
+#: lib/vutuv_web/live/post_live/feed.ex:3130
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to now"
 msgstr ""
@@ -22102,7 +22099,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3179
+#: lib/vutuv_web/live/post_live/feed.ex:3176
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22124,7 +22121,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3129
+#: lib/vutuv_web/live/post_live/feed.ex:3126
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -22211,14 +22208,14 @@ msgstr ""
 msgid "Page management"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2218
+#: lib/vutuv_web/live/post_live/feed.ex:2220
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2777
+#: lib/vutuv_web/components/post_components.ex:2799
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Quoted post"
 msgstr ""
@@ -22233,17 +22230,17 @@ msgstr ""
 msgid "Quotes %{url}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:543
+#: lib/vutuv_web/components/ui.ex:400
 #, elixir-autogen, elixir-format
 msgid "Mention an account"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:546
+#: lib/vutuv_web/components/ui.ex:404
 #, elixir-autogen, elixir-format
 msgid "{used} of {max} mentions"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2384
+#: lib/vutuv_web/live/post_live/feed.ex:2386
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""
@@ -22269,7 +22266,7 @@ msgstr ""
 msgid "Only these accounts (empty = all) …"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3159
+#: lib/vutuv_web/components/ui.ex:3261
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr ""
@@ -22319,33 +22316,33 @@ msgid_plural "shared this."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:482
+#: lib/vutuv_web/components/ui.ex:543
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Editor view"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:430
+#: lib/vutuv_web/components/ui.ex:491
 #, elixir-autogen, elixir-format
 msgid "Insert a block"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:442
+#: lib/vutuv_web/components/ui.ex:503
 #, elixir-autogen, elixir-format
 msgid "Nothing matches."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1778
-#: lib/vutuv_web/live/post_live/composer.ex:2513
+#: lib/vutuv_web/live/post_live/composer.ex:1754
+#: lib/vutuv_web/live/post_live/composer.ex:2452
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Automatic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1783
+#: lib/vutuv_web/live/post_live/composer.ex:1759
 #, elixir-autogen, elixir-format
 msgid "Drag one photo onto another to swap them."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1730
+#: lib/vutuv_web/live/post_live/composer.ex:1706
 #, elixir-autogen, elixir-format
 msgid "Not shown in the gallery — drag one into it to swap."
 msgstr ""
@@ -22382,17 +22379,17 @@ msgstr ""
 msgid "Mute %{host}"
 msgstr ""
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:94
+#: lib/vutuv_web/views/remote_actor_card_html.ex:132
 #, elixir-autogen, elixir-format
 msgid "Really remove?"
 msgstr ""
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:95
+#: lib/vutuv_web/views/remote_actor_card_html.ex:133
 #, elixir-autogen, elixir-format
 msgid "Really unfollow?"
 msgstr ""
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:96
+#: lib/vutuv_web/views/remote_actor_card_html.ex:134
 #, elixir-autogen, elixir-format
 msgid "Really withdraw?"
 msgstr ""
@@ -22402,28 +22399,28 @@ msgstr ""
 msgid "Unmute %{host}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1538
+#: lib/vutuv_web/live/post_live/composer.ex:1514
 #, elixir-autogen, elixir-format
 msgid "Draft discarded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1577
+#: lib/vutuv_web/live/post_live/composer.ex:1553
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1568
+#: lib/vutuv_web/live/post_live/composer.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Keep this draft for later?"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:315
+#: lib/vutuv_web/live/organization_live/edit.ex:310
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Describe the organization. Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:286
-#: lib/vutuv_web/templates/settings/preferences.html.heex:205
+#: lib/vutuv_web/templates/page/index.html.heex:287
+#: lib/vutuv_web/templates/settings/preferences.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "Bandwidth"
 msgstr ""
@@ -22438,7 +22435,7 @@ msgstr ""
 msgid "Bandwidth settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:207
+#: lib/vutuv_web/templates/settings/preferences.html.heex:211
 #, elixir-autogen, elixir-format
 msgid "If you are on a slow or metered connection, vutuv can leave out the parts of the page that cost the most to download."
 msgstr ""
@@ -22451,4 +22448,9 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:102
 #, elixir-autogen, elixir-format
 msgid "Writing a post or a message then uses a plain Markdown box instead of the formatting editor, which saves about 150 kB of download. Everything you write still looks the same to everyone who reads it."
+msgstr ""
+
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:252
+#, elixir-autogen, elixir-format
+msgid "View the original on %{url}"
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -11,19 +11,19 @@ msgstr ""
 "Language: it\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/vutuv_web/controllers/page_controller.ex:250
+#: lib/vutuv_web/controllers/page_controller.ex:251
 #: lib/vutuv_web/templates/layout/app.html.heex:111
 #, elixir-autogen
 msgid "About us"
 msgstr "Note legali"
 
-#: lib/vutuv_web/components/ui.ex:4414
-#: lib/vutuv_web/components/ui.ex:4419
+#: lib/vutuv_web/components/ui.ex:4522
+#: lib/vutuv_web/components/ui.ex:4527
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
-#: lib/vutuv_web/live/organization_live/domains.ex:272
-#: lib/vutuv_web/live/organization_live/edit.ex:431
-#: lib/vutuv_web/live/organization_live/roles.ex:214
+#: lib/vutuv_web/live/organization_live/domains.ex:267
+#: lib/vutuv_web/live/organization_live/edit.ex:414
+#: lib/vutuv_web/live/organization_live/roles.ex:210
 #, elixir-autogen
 msgid "Add"
 msgstr "Aggiungi"
@@ -35,7 +35,7 @@ msgstr "Aggiungi"
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
 #: lib/vutuv_web/live/organization_live/fediverse.ex:115
-#: lib/vutuv_web/live/organization_live/show.ex:915
+#: lib/vutuv_web/live/organization_live/show.ex:910
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -64,7 +64,7 @@ msgstr "Indirizzo aggiornato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/text.ex:71
-#: lib/vutuv_web/components/ui.ex:4712
+#: lib/vutuv_web/components/ui.ex:4820
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -77,14 +77,14 @@ msgstr "Indirizzo aggiornato."
 msgid "Addresses"
 msgstr "Indirizzi"
 
-#: lib/vutuv_web/components/ui.ex:1506
-#: lib/vutuv_web/templates/page/index.html.heex:320
+#: lib/vutuv_web/components/ui.ex:1530
+#: lib/vutuv_web/templates/page/index.html.heex:319
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr "È già iscritto? Acceda qui."
 
-#: lib/vutuv_web/components/ui.ex:4209
-#: lib/vutuv_web/components/ui.ex:4303
+#: lib/vutuv_web/components/ui.ex:4313
+#: lib/vutuv_web/components/ui.ex:4412
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -97,7 +97,7 @@ msgstr "Confermi?"
 msgid "Avatar"
 msgstr "Immagine del profilo"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:412
+#: lib/vutuv_web/templates/user/edit.html.heex:407
 #, elixir-autogen
 msgid "Birthdate"
 msgstr "Data di nascita"
@@ -111,29 +111,29 @@ msgstr "Data di nascita"
 msgid "Birthday"
 msgstr "Compleanno"
 
-#: lib/vutuv_web/components/saved_search_components.ex:114
-#: lib/vutuv_web/components/ui.ex:4203
-#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
-#: lib/vutuv_web/live/admin/user_delete_live.ex:212
-#: lib/vutuv_web/live/job_posting_live/form.ex:812
-#: lib/vutuv_web/live/organization_live/edit.ex:382
-#: lib/vutuv_web/live/organization_live/new.ex:231
-#: lib/vutuv_web/live/post_live/composer.ex:1697
+#: lib/vutuv_web/components/saved_search_components.ex:104
+#: lib/vutuv_web/components/ui.ex:4307
+#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
+#: lib/vutuv_web/live/admin/user_delete_live.ex:202
+#: lib/vutuv_web/live/job_posting_live/form.ex:806
+#: lib/vutuv_web/live/organization_live/edit.ex:369
+#: lib/vutuv_web/live/organization_live/new.ex:222
+#: lib/vutuv_web/live/post_live/composer.ex:1673
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:113
 #: lib/vutuv_web/templates/report/new.html.heex:103
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:259
-#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:26
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:255
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:53
-#: lib/vutuv_web/templates/user/edit.html.heex:138
-#: lib/vutuv_web/templates/user/edit.html.heex:467
-#: lib/vutuv_web/templates/user/edit.html.heex:516
-#: lib/vutuv_web/templates/username/confirm.html.heex:222
+#: lib/vutuv_web/templates/user/edit.html.heex:133
+#: lib/vutuv_web/templates/user/edit.html.heex:463
+#: lib/vutuv_web/templates/user/edit.html.heex:508
+#: lib/vutuv_web/templates/username/confirm.html.heex:220
 #, elixir-autogen
 msgid "Cancel"
 msgstr "Annulla"
@@ -162,24 +162,24 @@ msgstr "Contatto"
 msgid "Couldn't follow back to %{name}."
 msgstr "Non è stato possibile ricambiare il follow a %{name}."
 
-#: lib/vutuv_web/components/post_components.ex:3586
-#: lib/vutuv_web/components/ui.ex:4306
-#: lib/vutuv_web/live/admin/job_live.ex:489
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
-#: lib/vutuv_web/live/admin/organization_live.ex:398
-#: lib/vutuv_web/live/admin/user_delete_live.ex:172
+#: lib/vutuv_web/components/post_components.ex:3608
+#: lib/vutuv_web/components/ui.ex:4414
+#: lib/vutuv_web/live/admin/job_live.ex:486
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:657
+#: lib/vutuv_web/live/admin/organization_live.ex:399
+#: lib/vutuv_web/live/admin/user_delete_live.ex:167
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:28
 #: lib/vutuv_web/templates/dev_app/show.html.heex:135
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:59
-#: lib/vutuv_web/templates/settings/saved_searches.html.heex:75
+#: lib/vutuv_web/templates/settings/saved_searches.html.heex:70
 #, elixir-autogen
 msgid "Delete"
 msgstr "Elimina"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:686
-#: lib/vutuv_web/live/organization_live/edit.ex:301
-#: lib/vutuv_web/live/organization_live/edit.ex:314
+#: lib/vutuv_web/live/job_posting_live/form.ex:685
+#: lib/vutuv_web/live/organization_live/edit.ex:296
+#: lib/vutuv_web/live/organization_live/edit.ex:309
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
 #: lib/vutuv_web/templates/address/form_en.html.heex:11
 #: lib/vutuv_web/templates/address/form_generic.html.heex:13
@@ -202,20 +202,20 @@ msgstr "Descrizione"
 msgid "Disable"
 msgstr "Disattiva"
 
-#: lib/vutuv_web/live/cv_live.ex:438
-#: lib/vutuv_web/live/post_live/composer.ex:2609
+#: lib/vutuv_web/live/cv_live.ex:428
+#: lib/vutuv_web/live/post_live/composer.ex:2548
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
 msgid "Download"
 msgstr "Scarica"
 
-#: lib/vutuv_web/components/post_components.ex:3551
-#: lib/vutuv_web/components/ui.ex:4297
+#: lib/vutuv_web/components/post_components.ex:3573
+#: lib/vutuv_web/components/ui.ex:4405
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
-#: lib/vutuv_web/live/job_posting_live/show.ex:178
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
+#: lib/vutuv_web/live/job_posting_live/show.ex:173
 #: lib/vutuv_web/live/organization_live/show.ex:149
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
@@ -285,7 +285,7 @@ msgstr "Inserisca il Suo indirizzo e-mail"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:4676
+#: lib/vutuv_web/components/ui.ex:4784
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -306,7 +306,7 @@ msgid "Fax"
 msgstr "Fax"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:596
-#: lib/vutuv_web/templates/user/edit.html.heex:169
+#: lib/vutuv_web/templates/user/edit.html.heex:164
 #, elixir-autogen
 msgid "First Name"
 msgstr "Nome"
@@ -325,9 +325,9 @@ msgstr "Follower"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:632
 #: lib/vutuv_web/agent_docs/text.ex:596
-#: lib/vutuv_web/components/fediverse_components.ex:400
-#: lib/vutuv_web/components/ui.ex:2705
-#: lib/vutuv_web/components/ui.ex:2740
+#: lib/vutuv_web/components/fediverse_components.ex:397
+#: lib/vutuv_web/components/ui.ex:2807
+#: lib/vutuv_web/components/ui.ex:2842
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:608
@@ -340,8 +340,8 @@ msgid "Following"
 msgstr "Seguiti"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:195
-#: lib/vutuv_web/templates/page/index.html.heex:118
-#: lib/vutuv_web/templates/user/edit.html.heex:206
+#: lib/vutuv_web/templates/page/index.html.heex:123
+#: lib/vutuv_web/templates/user/edit.html.heex:201
 #: lib/vutuv_web/views/account_event_text.ex:219
 #, elixir-autogen
 msgid "Gender"
@@ -376,7 +376,7 @@ msgstr ""
 msgid "Job Title"
 msgstr "Qualifica"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:757
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:752
 #: lib/vutuv_web/templates/language/form_content.html.heex:5
 #: lib/vutuv_web/templates/language/show.html.heex:19
 #, elixir-autogen
@@ -384,7 +384,7 @@ msgid "Language"
 msgstr "Lingua"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:598
-#: lib/vutuv_web/templates/user/edit.html.heex:174
+#: lib/vutuv_web/templates/user/edit.html.heex:169
 #, elixir-autogen
 msgid "Last Name"
 msgstr "Cognome"
@@ -413,7 +413,7 @@ msgstr "Link aggiornato."
 #: lib/vutuv_web/cv/html.ex:202
 #: lib/vutuv_web/cv/latex.ex:164
 #: lib/vutuv_web/cv/odt.ex:176
-#: lib/vutuv_web/live/cv_live.ex:336
+#: lib/vutuv_web/live/cv_live.ex:326
 #: lib/vutuv_web/templates/import/new.html.heex:13
 #: lib/vutuv_web/templates/url/edit.html.heex:4
 #: lib/vutuv_web/templates/url/index.html.heex:10
@@ -442,8 +442,8 @@ msgstr "Accedi"
 msgid "Log Out"
 msgstr "Esci"
 
-#: lib/vutuv_web/live/shell_live.ex:1369
-#: lib/vutuv_web/live/shell_live.ex:1435
+#: lib/vutuv_web/live/shell_live.ex:1361
+#: lib/vutuv_web/live/shell_live.ex:1426
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -451,7 +451,7 @@ msgid "Log in"
 msgstr "Accedi"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:597
-#: lib/vutuv_web/templates/user/edit.html.heex:179
+#: lib/vutuv_web/templates/user/edit.html.heex:174
 #, elixir-autogen
 msgid "Middle Name"
 msgstr "Secondo nome"
@@ -475,7 +475,7 @@ msgstr "Altro"
 msgid "Name"
 msgstr "Nome"
 
-#: lib/vutuv_web/components/post_components.ex:714
+#: lib/vutuv_web/components/post_components.ex:715
 #: lib/vutuv_web/live/notification_live/index.ex:742
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -488,7 +488,7 @@ msgid "New"
 msgstr "Nuovo"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:600
-#: lib/vutuv_web/templates/user/edit.html.heex:184
+#: lib/vutuv_web/templates/user/edit.html.heex:179
 #, elixir-autogen
 msgid "Nickname"
 msgstr "Soprannome"
@@ -569,7 +569,7 @@ msgid "Phone number updated successfully."
 msgstr "Numero di telefono aggiornato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:595
-#: lib/vutuv_web/templates/user/edit.html.heex:189
+#: lib/vutuv_web/templates/user/edit.html.heex:184
 #, elixir-autogen
 msgid "Prefix"
 msgstr "Prefisso"
@@ -605,7 +605,7 @@ msgstr "Profili di "
 msgid "Provider"
 msgstr "Piattaforma"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1909
+#: lib/vutuv_web/live/post_live/composer.ex:1911
 #: lib/vutuv_web/live/section_reorder_live.ex:270
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -615,9 +615,9 @@ msgstr "Piattaforma"
 msgid "Public"
 msgstr "Pubblico"
 
-#: lib/vutuv_web/components/ui.ex:4202
-#: lib/vutuv_web/live/organization_live/edit.ex:376
-#: lib/vutuv_web/live/post_live/composer.ex:1924
+#: lib/vutuv_web/components/ui.ex:4306
+#: lib/vutuv_web/live/organization_live/edit.ex:367
+#: lib/vutuv_web/live/post_live/composer.ex:1926
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -627,40 +627,39 @@ msgstr "Pubblico"
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
 #: lib/vutuv_web/templates/settings/preferences.html.heex:157
-#: lib/vutuv_web/templates/settings/preferences.html.heex:224
-#: lib/vutuv_web/templates/settings/preferences.html.heex:273
-#: lib/vutuv_web/templates/settings/preferences.html.heex:406
+#: lib/vutuv_web/templates/settings/preferences.html.heex:262
+#: lib/vutuv_web/templates/settings/preferences.html.heex:395
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
-#: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
-#: lib/vutuv_web/templates/user/edit.html.heex:462
+#: lib/vutuv_web/templates/settings/saved_searches.html.heex:61
+#: lib/vutuv_web/templates/user/edit.html.heex:458
 #: lib/vutuv_web/views/settings_html.ex:212
 #, elixir-autogen
 msgid "Save"
 msgstr "Salva"
 
 #: lib/vutuv_web/components/browse_table.ex:346
-#: lib/vutuv_web/controllers/page_controller.ex:226
+#: lib/vutuv_web/controllers/page_controller.ex:227
 #: lib/vutuv_web/live/account_activity_live.ex:149
 #: lib/vutuv_web/live/admin/activity_live.ex:193
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:219
 #: lib/vutuv_web/live/directory_search_live.ex:181
-#: lib/vutuv_web/live/job_board_live.ex:418
+#: lib/vutuv_web/live/job_board_live.ex:410
 #: lib/vutuv_web/live/search_live.ex:60
-#: lib/vutuv_web/live/search_live.ex:658
-#: lib/vutuv_web/live/search_live.ex:684
-#: lib/vutuv_web/live/shell_live.ex:1234
-#: lib/vutuv_web/live/shell_live.ex:1418
-#: lib/vutuv_web/live/tag_live/timeline.ex:323
+#: lib/vutuv_web/live/search_live.ex:651
+#: lib/vutuv_web/live/search_live.ex:677
+#: lib/vutuv_web/live/shell_live.ex:1230
+#: lib/vutuv_web/live/shell_live.ex:1409
+#: lib/vutuv_web/live/tag_live/timeline.ex:319
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
-#: lib/vutuv_web/templates/admin/account/index.html.heex:39
+#: lib/vutuv_web/templates/admin/account/index.html.heex:35
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
 #: lib/vutuv_web/templates/layout/app.html.heex:155
 #, elixir-autogen
 msgid "Search"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:1759
+#: lib/vutuv_web/components/post_components.ex:1781
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -668,7 +667,7 @@ msgstr "Cerca"
 msgid "Show"
 msgstr "Mostra"
 
-#: lib/vutuv_web/templates/page/index.html.heex:299
+#: lib/vutuv_web/templates/page/index.html.heex:298
 #, elixir-autogen
 msgid "Sign up for a free account"
 msgstr "Crei un account gratuito"
@@ -688,7 +687,7 @@ msgstr "Slug"
 #: lib/vutuv_web/cv/latex.ex:179
 #: lib/vutuv_web/cv/odt.ex:185
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:760
-#: lib/vutuv_web/live/cv_live.ex:410
+#: lib/vutuv_web/live/cv_live.ex:400
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:10
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
@@ -725,12 +724,12 @@ msgstr "Profilo aggiornato."
 msgid "Profile deleted successfully."
 msgstr "Profilo eliminato."
 
-#: lib/vutuv_web/views/user_html.ex:1019
+#: lib/vutuv_web/views/user_html.ex:1025
 #, elixir-autogen, elixir-format
 msgid "Social networks"
 msgstr "Social network"
 
-#: lib/vutuv_web/views/user_html.ex:1026
+#: lib/vutuv_web/views/user_html.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Code & repositories"
 msgstr "Codice e repository"
@@ -749,7 +748,7 @@ msgid "Submit a bugreport or a feature request."
 msgstr "Segnali un problema o proponga una funzione."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:599
-#: lib/vutuv_web/templates/user/edit.html.heex:194
+#: lib/vutuv_web/templates/user/edit.html.heex:189
 #, elixir-autogen
 msgid "Suffix"
 msgstr "Suffisso"
@@ -791,15 +790,15 @@ msgstr "Utente aggiornato."
 msgid "User verified successfully."
 msgstr "Utente verificato."
 
-#: lib/vutuv_web/components/ui.ex:4672
+#: lib/vutuv_web/components/ui.ex:4780
 #: lib/vutuv_web/controllers/username_controller.ex:428
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:832
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
 #: lib/vutuv_web/live/directory_search_live.ex:134
 #: lib/vutuv_web/live/notification_live/index.ex:1281
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
-#: lib/vutuv_web/templates/admin/account/index.html.heex:56
+#: lib/vutuv_web/templates/admin/account/index.html.heex:51
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
 #: lib/vutuv_web/templates/settings/security.html.heex:23
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:5
@@ -843,7 +842,7 @@ msgstr "Nome utente"
 msgid "Users"
 msgstr "Utenti"
 
-#: lib/vutuv_web/components/ui.ex:1313
+#: lib/vutuv_web/components/ui.ex:1337
 #: lib/vutuv_web/views/user_html.ex:562
 #: lib/vutuv_web/views/user_html.ex:563
 #: lib/vutuv_web/views/user_html.ex:577
@@ -851,17 +850,17 @@ msgstr "Utenti"
 msgid "vCard"
 msgstr "vCard"
 
-#: lib/vutuv_web/components/ui.ex:4367
+#: lib/vutuv_web/components/ui.ex:4475
 #: lib/vutuv_web/templates/user/show.html.heex:973
 #: lib/vutuv_web/templates/user/show.html.heex:996
 #, elixir-autogen
 msgid "View All"
 msgstr "Mostra tutti"
 
-#: lib/vutuv_web/components/ui.ex:4780
+#: lib/vutuv_web/components/ui.ex:4888
 #: lib/vutuv_web/controllers/settings_controller.ex:171
-#: lib/vutuv_web/live/job_posting_live/form.ex:768
-#: lib/vutuv_web/live/organization_live/edit.ex:335
+#: lib/vutuv_web/live/job_posting_live/form.ex:767
+#: lib/vutuv_web/live/organization_live/edit.ex:330
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:295
@@ -875,7 +874,7 @@ msgstr "Visibilità"
 msgid "We can't find em' cap'n!"
 msgstr "Niente da fare, capitano."
 
-#: lib/vutuv_web/templates/page/index.html.heex:323
+#: lib/vutuv_web/templates/page/index.html.heex:322
 #, elixir-autogen
 msgid "We reserve the right to stop this service or delete your account anytime without warning."
 msgstr ""
@@ -958,12 +957,12 @@ msgid "An email has been sent to your email address with instructions on how to 
 msgstr ""
 "Le abbiamo inviato un'e-mail con le istruzioni per eliminare il Suo account."
 
-#: lib/vutuv_web/templates/page/index.html.heex:198
+#: lib/vutuv_web/templates/page/index.html.heex:203
 #, elixir-autogen
 msgid "Allow others to view your email address"
 msgstr "Consentire ad altri di vedere il mio indirizzo e-mail"
 
-#: lib/vutuv_web/templates/page/index.html.heex:309
+#: lib/vutuv_web/templates/page/index.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "By creating an account you accept our {nutzungsbedingungen} and confirm that you have read our {datenschutz}."
 msgstr ""
@@ -1066,7 +1065,7 @@ msgstr "Si è verificato un errore"
 msgid "General Info"
 msgstr "Informazioni generali"
 
-#: lib/vutuv_web/live/admin/user_live.ex:346
+#: lib/vutuv_web/live/admin/user_live.ex:345
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:32
 #, elixir-autogen
 msgid "Verify"
@@ -1097,7 +1096,7 @@ msgstr "Accedi a vutuv"
 msgid "Listings"
 msgstr "Elenchi"
 
-#: lib/vutuv_web/controllers/page_controller.ex:418
+#: lib/vutuv_web/controllers/page_controller.ex:408
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1154,8 +1153,8 @@ msgid "Our search will try to match similar names to your search, so don't worry
 msgstr ""
 "La ricerca trova anche nomi simili, quindi non si preoccupi dell'ortografia."
 
-#: lib/vutuv_web/live/search_live.ex:737
-#: lib/vutuv_web/live/search_live.ex:762
+#: lib/vutuv_web/live/search_live.ex:730
+#: lib/vutuv_web/live/search_live.ex:755
 #, elixir-autogen
 msgid "Search Tips"
 msgstr "Consigli per la ricerca"
@@ -1180,15 +1179,15 @@ msgstr "Aggiungi localizzazione"
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:127
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:638
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:637
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:688
 #: lib/vutuv_web/live/admin/organization_live.ex:189
 #: lib/vutuv_web/live/admin/screenshot_live.ex:182
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:443
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
-#: lib/vutuv_web/live/admin/user_detail_live.ex:68
+#: lib/vutuv_web/live/admin/user_detail_live.ex:63
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1341
+#: lib/vutuv_web/live/shell_live.ex:1337
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1402,7 +1401,7 @@ msgstr "URL dei tag"
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:522
 #: lib/vutuv_web/agent_docs/text.ex:768
-#: lib/vutuv_web/components/ui.ex:4697
+#: lib/vutuv_web/components/ui.ex:4805
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1411,11 +1410,11 @@ msgstr "URL dei tag"
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:444
-#: lib/vutuv_web/live/cv_live.ex:315
-#: lib/vutuv_web/live/job_board_live.ex:277
-#: lib/vutuv_web/live/job_posting_live/form.ex:717
+#: lib/vutuv_web/live/cv_live.ex:305
+#: lib/vutuv_web/live/job_board_live.ex:276
+#: lib/vutuv_web/live/job_posting_live/form.ex:716
 #: lib/vutuv_web/live/search_live.ex:344
-#: lib/vutuv_web/live/search_live.ex:822
+#: lib/vutuv_web/live/search_live.ex:815
 #: lib/vutuv_web/live/tag_new_live.ex:35
 #: lib/vutuv_web/live/tag_new_live.ex:46
 #: lib/vutuv_web/live/tag_new_live.ex:53
@@ -1425,7 +1424,7 @@ msgstr "URL dei tag"
 #: lib/vutuv_web/templates/admin/tag/new.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:5
 #: lib/vutuv_web/templates/import/new.html.heex:12
-#: lib/vutuv_web/templates/page/index.html.heex:133
+#: lib/vutuv_web/templates/page/index.html.heex:138
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:28
 #: lib/vutuv_web/templates/tag/show.html.heex:45
@@ -1592,10 +1591,10 @@ msgstr "Account vutuv verificato"
 msgid "You'll receive an email with a login link."
 msgstr "Riceverà un'e-mail con un link di accesso."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:776
-#: lib/vutuv_web/live/job_board_live.ex:360
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:771
+#: lib/vutuv_web/live/job_board_live.ex:356
 #: lib/vutuv_web/live/job_posting_live/form.ex:548
-#: lib/vutuv_web/live/organization_live/edit.ex:331
+#: lib/vutuv_web/live/organization_live/edit.ex:326
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
 #: lib/vutuv_web/templates/address/country_input.html.heex:5
@@ -1629,7 +1628,7 @@ msgstr "Indirizzi di %{name}"
 msgid "Admin control panel"
 msgstr "Pannello di amministrazione"
 
-#: lib/vutuv_web/live/shell_live.ex:1421
+#: lib/vutuv_web/live/shell_live.ex:1412
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Avvisi"
@@ -1648,15 +1647,15 @@ msgstr "Torna alla pagina iniziale"
 msgid "Check your inbox"
 msgstr "Controlli la Sua casella di posta"
 
-#: lib/vutuv_web/components/ui.ex:2864
+#: lib/vutuv_web/components/ui.ex:2966
 #: lib/vutuv_web/live/admin/job_live.ex:321
-#: lib/vutuv_web/live/admin/job_live.ex:480
+#: lib/vutuv_web/live/admin/job_live.ex:477
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1553
-#: lib/vutuv_web/live/post_live/composer.ex:1655
-#: lib/vutuv_web/live/post_live/composer.ex:1656
-#: lib/vutuv_web/live/post_live/composer.ex:2486
-#: lib/vutuv_web/live/post_live/composer.ex:2752
+#: lib/vutuv_web/live/post_live/composer.ex:1529
+#: lib/vutuv_web/live/post_live/composer.ex:1631
+#: lib/vutuv_web/live/post_live/composer.ex:1632
+#: lib/vutuv_web/live/post_live/composer.ex:2425
+#: lib/vutuv_web/live/post_live/composer.ex:2691
 #: lib/vutuv_web/templates/layout/app.html.heex:188
 #: lib/vutuv_web/templates/layout/app.html.heex:194
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
@@ -1667,7 +1666,7 @@ msgstr "Chiudi"
 
 #: lib/vutuv_web/templates/email/confirm.html.heex:9
 #: lib/vutuv_web/templates/username/confirm.html.heex:25
-#: lib/vutuv_web/templates/username/confirm.html.heex:165
+#: lib/vutuv_web/templates/username/confirm.html.heex:163
 #, elixir-autogen, elixir-format
 msgid "Confirm"
 msgstr "Conferma"
@@ -1677,17 +1676,17 @@ msgstr "Conferma"
 msgid "Confirm account deletion"
 msgstr "Confermi l'eliminazione dell'account"
 
-#: lib/vutuv_web/controllers/page_controller.ex:254
+#: lib/vutuv_web/controllers/page_controller.ex:255
 #: lib/vutuv_web/templates/layout/app.html.heex:117
-#: lib/vutuv_web/templates/page/index.html.heex:316
+#: lib/vutuv_web/templates/page/index.html.heex:315
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
 msgstr "Informativa sulla privacy"
 
-#: lib/vutuv_web/controllers/page_controller.ex:260
+#: lib/vutuv_web/controllers/page_controller.ex:261
 #: lib/vutuv_web/templates/layout/app.html.heex:118
-#: lib/vutuv_web/templates/page/index.html.heex:316
+#: lib/vutuv_web/templates/page/index.html.heex:315
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Nutzungsbedingungen"
@@ -1705,23 +1704,23 @@ msgstr "Elimina il mio account"
 msgid "Edit profile"
 msgstr "Modifica profilo"
 
-#: lib/vutuv_web/components/ui.ex:2025
-#: lib/vutuv_web/components/ui.ex:2034
-#: lib/vutuv_web/components/ui.ex:2512
+#: lib/vutuv_web/components/ui.ex:2049
+#: lib/vutuv_web/components/ui.ex:2058
+#: lib/vutuv_web/components/ui.ex:2536
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr "Conferma"
 
 #: lib/vutuv_web/components/fediverse_components.ex:236
-#: lib/vutuv_web/components/ui.ex:2670
-#: lib/vutuv_web/components/ui.ex:2670
-#: lib/vutuv_web/components/ui.ex:2687
-#: lib/vutuv_web/components/ui.ex:2696
-#: lib/vutuv_web/components/ui.ex:2712
-#: lib/vutuv_web/components/ui.ex:2774
-#: lib/vutuv_web/live/fediverse_account_live.ex:381
+#: lib/vutuv_web/components/ui.ex:2772
+#: lib/vutuv_web/components/ui.ex:2772
+#: lib/vutuv_web/components/ui.ex:2789
+#: lib/vutuv_web/components/ui.ex:2798
+#: lib/vutuv_web/components/ui.ex:2814
+#: lib/vutuv_web/components/ui.ex:2876
+#: lib/vutuv_web/live/fediverse_account_live.ex:391
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:311
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:312
 #: lib/vutuv_web/live/organization_live/following.ex:331
 #: lib/vutuv_web/live/organization_live/following.ex:412
 #: lib/vutuv_web/live/organization_live/show.ex:569
@@ -1746,7 +1745,7 @@ msgstr ""
 "Sembra che non segua ancora nessuno. Apra il profilo di una persona che "
 "conosce o che La incuriosisce e prema il pulsante «Segui»."
 
-#: lib/vutuv_web/live/shell_live.ex:1360
+#: lib/vutuv_web/live/shell_live.ex:1356
 #: lib/vutuv_web/views/settings_html.ex:299
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1760,7 +1759,7 @@ msgstr "Esci"
 #: lib/vutuv_web/live/admin/user_live.ex:154
 #: lib/vutuv_web/live/message_live/index.ex:538
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:32
-#: lib/vutuv_web/templates/admin/account/index.html.heex:55
+#: lib/vutuv_web/templates/admin/account/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:28
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:24
 #, elixir-autogen, elixir-format
@@ -1775,29 +1774,29 @@ msgstr "Membro"
 msgid "Message"
 msgstr "Messaggio"
 
-#: lib/vutuv_web/controllers/page_controller.ex:227
+#: lib/vutuv_web/controllers/page_controller.ex:228
 #: lib/vutuv_web/live/message_live/index.ex:49
-#: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1252
-#: lib/vutuv_web/live/shell_live.ex:1420
+#: lib/vutuv_web/live/message_live/index.ex:624
+#: lib/vutuv_web/live/shell_live.ex:1248
+#: lib/vutuv_web/live/shell_live.ex:1411
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Messaggi"
 
-#: lib/vutuv_web/live/shell_live.ex:1136
+#: lib/vutuv_web/live/shell_live.ex:1132
 #: lib/vutuv_web/templates/layout/app.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr "Rete"
 
-#: lib/vutuv_web/components/post_components.ex:450
-#: lib/vutuv_web/components/ui.ex:4416
+#: lib/vutuv_web/components/post_components.ex:451
+#: lib/vutuv_web/components/ui.ex:4524
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
 #: lib/vutuv_web/live/admin/user_live.ex:286
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:122
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr "Qui non c'è ancora nulla."
@@ -1808,18 +1807,18 @@ msgid "Nothing new yet."
 msgstr "Ancora nessuna novità."
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:4734
-#: lib/vutuv_web/controllers/page_controller.ex:228
+#: lib/vutuv_web/components/ui.ex:4842
+#: lib/vutuv_web/controllers/page_controller.ex:229
 #: lib/vutuv_web/live/notification_live/index.ex:146
 #: lib/vutuv_web/live/notification_live/index.ex:384
-#: lib/vutuv_web/live/shell_live.ex:1264
+#: lib/vutuv_web/live/shell_live.ex:1260
 #: lib/vutuv_web/templates/layout/app.html.heex:153
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr "Notifiche"
 
-#: lib/vutuv_web/live/admin/user_detail_live.ex:93
+#: lib/vutuv_web/live/admin/user_detail_live.ex:88
 #: lib/vutuv_web/live/admin/user_live.ex:322
 #: lib/vutuv_web/templates/email/confirm.html.heex:25
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:17
@@ -1834,7 +1833,7 @@ msgid "Pardon us! Something went wrong."
 msgstr "Ci scusi, qualcosa è andato storto."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:912
+#: lib/vutuv_web/live/message_live/index.ex:902
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
@@ -1883,7 +1882,7 @@ msgstr "Troppi tentativi. Riprovi più tardi."
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
 #: lib/vutuv_web/templates/user/show.html.heex:209
-#: lib/vutuv_web/views/user_html.ex:1071
+#: lib/vutuv_web/views/user_html.ex:1077
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
 msgstr "Profilo verificato"
@@ -1914,8 +1913,8 @@ msgstr ""
 msgid "Who to follow"
 msgstr "Chi seguire"
 
-#: lib/vutuv_web/live/message_live/index.ex:901
-#: lib/vutuv_web/live/message_live/index.ex:902
+#: lib/vutuv_web/live/message_live/index.ex:891
+#: lib/vutuv_web/live/message_live/index.ex:892
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr "Scriva un messaggio…"
@@ -1960,17 +1959,16 @@ msgstr "ora è collegato con Lei."
 msgid "started following you."
 msgstr "ha iniziato a seguirla."
 
-#: lib/vutuv_web/components/ui.ex:3695
-#: lib/vutuv_web/components/ui.ex:3848
+#: lib/vutuv_web/components/ui.ex:3807
+#: lib/vutuv_web/components/ui.ex:3952
 #: lib/vutuv_web/live/import_connections_live.ex:638
-#: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr "Paginazione"
 
-#: lib/vutuv_web/components/ui.ex:4441
+#: lib/vutuv_web/components/ui.ex:4549
 #: lib/vutuv_web/live/organization_live/activity.ex:151
-#: lib/vutuv_web/live/organization_live/feed.ex:210
+#: lib/vutuv_web/live/organization_live/feed.ex:209
 #: lib/vutuv_web/live/organization_live/show.ex:777
 #, elixir-autogen, elixir-format
 msgid "Load more"
@@ -1983,13 +1981,13 @@ msgstr ""
 "L'indirizzo non può essere modificato. Per usarne un altro, lo aggiunga come"
 " nuovo indirizzo e-mail ed elimini questo."
 
-#: lib/vutuv_web/components/ui.ex:4212
+#: lib/vutuv_web/components/ui.ex:4316
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Elimina voce"
 
-#: lib/vutuv_web/components/ui.ex:1706
-#: lib/vutuv_web/components/ui.ex:1716
+#: lib/vutuv_web/components/ui.ex:1730
+#: lib/vutuv_web/components/ui.ex:1740
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr "Opzioni"
@@ -2028,12 +2026,12 @@ msgstr "Aggiungi un'immagine di copertina"
 msgid "Add cover photo"
 msgstr "Aggiungi immagine di copertina"
 
-#: lib/vutuv_web/components/ui.ex:3218
+#: lib/vutuv_web/components/ui.ex:3320
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr "Aprile"
 
-#: lib/vutuv_web/components/ui.ex:3222
+#: lib/vutuv_web/components/ui.ex:3324
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr "Agosto"
@@ -2048,7 +2046,7 @@ msgstr "Cambia copertina"
 msgid "Change cover photo"
 msgstr "Cambia immagine di copertina"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:101
+#: lib/vutuv_web/templates/user/edit.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
 msgstr "Immagine di copertina"
@@ -2058,37 +2056,37 @@ msgstr "Immagine di copertina"
 msgid "Cover photo of %{name}"
 msgstr "Immagine di copertina di %{name}"
 
-#: lib/vutuv_web/components/ui.ex:3226
+#: lib/vutuv_web/components/ui.ex:3328
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr "Dicembre"
 
-#: lib/vutuv_web/components/ui.ex:3216
+#: lib/vutuv_web/components/ui.ex:3318
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr "Febbraio"
 
-#: lib/vutuv_web/components/ui.ex:3215
+#: lib/vutuv_web/components/ui.ex:3317
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr "Gennaio"
 
-#: lib/vutuv_web/components/ui.ex:3221
+#: lib/vutuv_web/components/ui.ex:3323
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr "Luglio"
 
-#: lib/vutuv_web/components/ui.ex:3220
+#: lib/vutuv_web/components/ui.ex:3322
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr "Giugno"
 
-#: lib/vutuv_web/components/ui.ex:3217
+#: lib/vutuv_web/components/ui.ex:3319
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr "Marzo"
 
-#: lib/vutuv_web/components/ui.ex:3219
+#: lib/vutuv_web/components/ui.ex:3321
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr "Maggio"
@@ -2103,34 +2101,34 @@ msgstr "Membro da %{month} %{year}"
 msgid "Member since %{year}"
 msgstr "Membro dal %{year}"
 
-#: lib/vutuv_web/components/ui.ex:3225
+#: lib/vutuv_web/components/ui.ex:3327
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr "Novembre"
 
-#: lib/vutuv_web/components/ui.ex:3224
+#: lib/vutuv_web/components/ui.ex:3326
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr "Ottobre"
 
-#: lib/vutuv_web/components/ui.ex:3223
+#: lib/vutuv_web/components/ui.ex:3325
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr "Settembre"
 
 #: lib/vutuv_web/templates/education/form_content.html.heex:32
-#: lib/vutuv_web/templates/user/edit.html.heex:254
+#: lib/vutuv_web/templates/user/edit.html.heex:249
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Markdown is supported: bold, italics, links and lists."
 msgstr "Markdown è supportato: grassetto, corsivo, link ed elenchi."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:710
+#: lib/vutuv_web/live/job_posting_live/form.ex:709
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr "Aggiungi immagini"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2102
+#: lib/vutuv_web/live/post_live/composer.ex:2040
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2143,7 +2141,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr "Torna al post"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1795
+#: lib/vutuv_web/live/post_live/composer.ex:1771
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Annulla il caricamento"
@@ -2153,7 +2151,7 @@ msgstr "Annulla il caricamento"
 msgid "Delete post"
 msgstr "Elimina il post"
 
-#: lib/vutuv_web/components/post_components.ex:3583
+#: lib/vutuv_web/components/post_components.ex:3605
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2167,12 +2165,12 @@ msgstr "Modifica il post"
 
 #: lib/vutuv_web/components/organization_components.ex:265
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
-#: lib/vutuv_web/live/organization_live/feed.ex:155
+#: lib/vutuv_web/live/organization_live/feed.ex:154
 #: lib/vutuv_web/live/post_live/feed.ex:317
-#: lib/vutuv_web/live/post_live/feed.ex:2899
+#: lib/vutuv_web/live/post_live/feed.ex:2896
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1114
-#: lib/vutuv_web/live/shell_live.ex:1413
+#: lib/vutuv_web/live/shell_live.ex:1110
+#: lib/vutuv_web/live/shell_live.ex:1404
 #: lib/vutuv_web/templates/layout/app.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2188,57 +2186,57 @@ msgstr "Segua %{name} per leggerlo."
 msgid "Hidden from:"
 msgstr "Nascosto a:"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2078
+#: lib/vutuv_web/live/post_live/composer.ex:2016
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr "Nascondi a una persona specifica…"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2006
+#: lib/vutuv_web/live/post_live/composer.ex:1944
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr "Nascondi questo post a…"
 
-#: lib/vutuv_web/components/post_components.ex:3537
-#: lib/vutuv_web/components/post_components.ex:3539
+#: lib/vutuv_web/components/post_components.ex:3559
+#: lib/vutuv_web/components/post_components.ex:3561
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Pubblico limitato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2048
+#: lib/vutuv_web/live/post_live/composer.ex:1986
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr "Visitatori non connessi"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1295
-#: lib/vutuv_web/live/post_live/composer.ex:1343
+#: lib/vutuv_web/live/post_live/composer.ex:1270
+#: lib/vutuv_web/live/post_live/composer.ex:1318
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3153
+#: lib/vutuv_web/live/post_live/feed.ex:3150
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 "Qui non c'è ancora nulla. Segua altre persone per riempire il Suo feed, "
 "oppure scriva il Suo primo post."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1261
+#: lib/vutuv_web/live/post_live/composer.ex:1236
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr "Non è stato possibile allegare una delle immagini."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2038
+#: lib/vutuv_web/live/post_live/composer.ex:1976
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr "Persone che non seguo"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2028
+#: lib/vutuv_web/live/post_live/composer.ex:1966
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr "Persone che non mi seguono"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:416
-#: lib/vutuv_web/live/post_live/composer.ex:1926
+#: lib/vutuv_web/live/post_live/composer.ex:1928
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2255,40 +2253,40 @@ msgstr "Post eliminato."
 #: lib/vutuv_web/controllers/user_controller.ex:76
 #: lib/vutuv_web/gettext_extraction_anchors.ex:109
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
-#: lib/vutuv_web/live/fediverse_account_live.ex:388
+#: lib/vutuv_web/live/fediverse_account_live.ex:398
 #: lib/vutuv_web/live/notification_live/index.ex:1125
 #: lib/vutuv_web/live/organization_live/show.ex:700
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:345
-#: lib/vutuv_web/live/search_live.ex:836
-#: lib/vutuv_web/templates/settings/preferences.html.heex:319
+#: lib/vutuv_web/live/search_live.ex:829
+#: lib/vutuv_web/templates/settings/preferences.html.heex:308
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr "Post"
 
-#: lib/vutuv_web/components/post_components.ex:3998
-#: lib/vutuv_web/components/post_components.ex:4002
+#: lib/vutuv_web/components/post_components.ex:4020
+#: lib/vutuv_web/components/post_components.ex:4024
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Leggi tutto"
 
-#: lib/vutuv_web/components/post_components.ex:3999
-#: lib/vutuv_web/live/fediverse_account_live.ex:334
+#: lib/vutuv_web/components/post_components.ex:4021
+#: lib/vutuv_web/live/fediverse_account_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr "Mostra meno"
 
-#: lib/vutuv_web/components/fediverse_components.ex:429
-#: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1353
+#: lib/vutuv_web/components/fediverse_components.ex:426
+#: lib/vutuv_web/components/job_exclusion_components.ex:189
+#: lib/vutuv_web/components/post_components.ex:1354
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
-#: lib/vutuv_web/live/job_search_exclusions_live.ex:234
-#: lib/vutuv_web/live/organization_live/domains.ex:246
-#: lib/vutuv_web/live/organization_live/edit.ex:408
-#: lib/vutuv_web/live/organization_live/roles.ex:247
-#: lib/vutuv_web/live/post_live/composer.ex:2064
+#: lib/vutuv_web/live/job_search_exclusions_live.ex:229
+#: lib/vutuv_web/live/organization_live/domains.ex:245
+#: lib/vutuv_web/live/organization_live/edit.ex:395
+#: lib/vutuv_web/live/organization_live/roles.ex:242
+#: lib/vutuv_web/live/post_live/composer.ex:2002
 #: lib/vutuv_web/live/post_live/filter_band.ex:455
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
@@ -2305,12 +2303,12 @@ msgstr ""
 "I post con pubblico limitato sono nascosti anche ai visitatori non connessi "
 "e ai motori di ricerca."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1916
+#: lib/vutuv_web/live/post_live/composer.ex:1918
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr "Salvataggio…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2224
+#: lib/vutuv_web/live/post_live/feed.ex:2226
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2322,12 +2320,12 @@ msgstr[1] "Mostra %{formatted} nuovi post"
 msgid "Sorry, that page could not be found."
 msgstr "Spiacenti, la pagina non è stata trovata."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1369
+#: lib/vutuv_web/live/post_live/composer.ex:1344
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Non è stato possibile elaborare il file."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1243
+#: lib/vutuv_web/live/post_live/composer.ex:1218
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr "La selezione del pubblico non è valida."
@@ -2337,18 +2335,18 @@ msgstr "La selezione del pubblico non è valida."
 msgid "This post is for followers of %{name}"
 msgstr "Questo post è per i follower di %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2901
+#: lib/vutuv_web/live/post_live/composer.ex:2840
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Troppi file."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2902
+#: lib/vutuv_web/live/post_live/composer.ex:2841
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Caricamento non riuscito."
 
-#: lib/vutuv_web/components/ui.ex:5034
-#: lib/vutuv_web/live/shell_live.ex:1307
+#: lib/vutuv_web/components/ui.ex:5142
+#: lib/vutuv_web/live/shell_live.ex:1303
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:246
@@ -2356,58 +2354,58 @@ msgstr "Caricamento non riuscito."
 msgid "View profile"
 msgstr "Vedi il profilo"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2179
+#: lib/vutuv_web/live/post_live/composer.ex:2117
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr "Che c'è di nuovo?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2180
+#: lib/vutuv_web/live/post_live/composer.ex:2118
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr "Che c'è di nuovo? Markdown è supportato."
 
-#: lib/vutuv_web/components/post_components.ex:3534
+#: lib/vutuv_web/components/post_components.ex:3556
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "modificato"
 
-#: lib/vutuv_web/components/post_components.ex:5439
+#: lib/vutuv_web/components/post_components.ex:5461
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "tutti gli altri"
 
-#: lib/vutuv_web/components/post_components.ex:5443
+#: lib/vutuv_web/components/post_components.ex:5465
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "visitatori non connessi"
 
-#: lib/vutuv_web/components/post_components.ex:5441
+#: lib/vutuv_web/components/post_components.ex:5463
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "persone che non La seguono"
 
-#: lib/vutuv_web/components/post_components.ex:5442
+#: lib/vutuv_web/components/post_components.ex:5464
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "persone che non segue"
 
-#: lib/vutuv_web/components/ui.ex:3296
+#: lib/vutuv_web/components/ui.ex:3398
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr "sconosciuto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1831
+#: lib/vutuv_web/live/post_live/composer.ex:1807
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr "Tag separati da virgole (max. %{max})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2892
+#: lib/vutuv_web/live/post_live/composer.ex:2831
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr "Il file supera %{mb} MB."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2896
+#: lib/vutuv_web/live/post_live/composer.ex:2835
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr "Tipo di file non supportato (ammessi: %{types})."
@@ -2427,9 +2425,9 @@ msgstr "Vedi tutti i %{count} post"
 msgid "All posts"
 msgstr "Tutti i post"
 
-#: lib/vutuv_web/components/post_components.ex:2033
-#: lib/vutuv_web/components/post_components.ex:5535
-#: lib/vutuv_web/components/ui.ex:3770
+#: lib/vutuv_web/components/post_components.ex:2055
+#: lib/vutuv_web/components/post_components.ex:5557
+#: lib/vutuv_web/components/ui.ex:3874
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2438,17 +2436,17 @@ msgstr "Salva"
 #: lib/vutuv_web/agent_docs/markdown.ex:1145
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:1244
-#: lib/vutuv_web/live/shell_live.ex:1312
+#: lib/vutuv_web/live/shell_live.ex:1240
+#: lib/vutuv_web/live/shell_live.ex:1308
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr "Salvati"
 
-#: lib/vutuv_web/components/post_components.ex:1986
-#: lib/vutuv_web/components/post_components.ex:5771
-#: lib/vutuv_web/components/ui.ex:3756
+#: lib/vutuv_web/components/post_components.ex:2008
+#: lib/vutuv_web/components/post_components.ex:5793
+#: lib/vutuv_web/components/ui.ex:3860
 #: lib/vutuv_web/live/notification_live/index.ex:1271
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
@@ -2456,11 +2454,11 @@ msgid "Like"
 msgstr "Mi piace"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1144
-#: lib/vutuv_web/components/post_components.ex:5781
+#: lib/vutuv_web/components/post_components.ex:5803
 #: lib/vutuv_web/live/notification_live/index.ex:1204
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:1315
+#: lib/vutuv_web/live/shell_live.ex:1311
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2478,57 +2476,57 @@ msgstr "Qui non c'è ancora nulla. I post che salva compaiono qui."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Qui non c'è ancora nulla. I post a cui mette Mi piace compaiono qui."
 
-#: lib/vutuv_web/components/post_components.ex:5523
+#: lib/vutuv_web/components/post_components.ex:5545
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Solo i post pubblici possono essere ripubblicati."
 
-#: lib/vutuv_web/components/post_components.ex:2032
-#: lib/vutuv_web/components/post_components.ex:5534
+#: lib/vutuv_web/components/post_components.ex:2054
+#: lib/vutuv_web/components/post_components.ex:5556
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Rimuovi dai salvati"
 
-#: lib/vutuv_web/components/post_components.ex:2014
-#: lib/vutuv_web/components/post_components.ex:5520
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
+#: lib/vutuv_web/components/post_components.ex:2036
+#: lib/vutuv_web/components/post_components.ex:5542
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Ripubblica"
 
-#: lib/vutuv_web/components/post_components.ex:2279
-#: lib/vutuv_web/components/post_components.ex:4615
+#: lib/vutuv_web/components/post_components.ex:2301
+#: lib/vutuv_web/components/post_components.ex:4637
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Ripubblicato da %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:2013
-#: lib/vutuv_web/components/post_components.ex:5519
+#: lib/vutuv_web/components/post_components.ex:2035
+#: lib/vutuv_web/components/post_components.ex:5541
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Annulla la ripubblicazione"
 
-#: lib/vutuv_web/components/post_components.ex:1985
-#: lib/vutuv_web/components/post_components.ex:5770
+#: lib/vutuv_web/components/post_components.ex:2007
+#: lib/vutuv_web/components/post_components.ex:5792
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr "Togli Mi piace"
 
-#: lib/vutuv_web/components/fediverse_components.ex:430
-#: lib/vutuv_web/components/post_components.ex:2648
-#: lib/vutuv_web/components/ui.ex:2665
-#: lib/vutuv_web/components/ui.ex:2665
-#: lib/vutuv_web/components/ui.ex:2741
+#: lib/vutuv_web/components/fediverse_components.ex:427
+#: lib/vutuv_web/components/post_components.ex:2670
+#: lib/vutuv_web/components/ui.ex:2767
+#: lib/vutuv_web/components/ui.ex:2767
+#: lib/vutuv_web/components/ui.ex:2843
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:611
 #: lib/vutuv_web/live/post_live/feed.ex:890
 #: lib/vutuv_web/templates/followee/index.html.heex:30
-#: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
+#: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
 #: lib/vutuv_web/views/user_html.ex:618
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2539,40 +2537,40 @@ msgstr "Non seguire più"
 msgid "Welcome to vutuv!"
 msgstr "Benvenuto su vutuv."
 
-#: lib/vutuv_web/components/post_components.ex:5825
+#: lib/vutuv_web/components/post_components.ex:5847
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Solo ai post pubblici si può rispondere."
 
-#: lib/vutuv_web/components/post_components.ex:408
+#: lib/vutuv_web/components/post_components.ex:409
 #: lib/vutuv_web/live/notification_live/index.ex:1205
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Risposte"
 
-#: lib/vutuv_web/components/post_components.ex:1999
-#: lib/vutuv_web/components/post_components.ex:5808
-#: lib/vutuv_web/components/post_components.ex:5809
+#: lib/vutuv_web/components/post_components.ex:2021
+#: lib/vutuv_web/components/post_components.ex:5830
+#: lib/vutuv_web/components/post_components.ex:5831
 #: lib/vutuv_web/live/notification_live/index.ex:1268
 #: lib/vutuv_web/live/post_live/reply.ex:46
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Rispondi"
 
-#: lib/vutuv_web/components/post_components.ex:3501
+#: lib/vutuv_web/components/post_components.ex:3523
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Risposta a un post eliminato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1246
-#: lib/vutuv_web/live/post_live/composer.ex:1904
+#: lib/vutuv_web/live/post_live/composer.ex:1221
+#: lib/vutuv_web/live/post_live/composer.ex:1906
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 "Il pubblico non può essere limitato finché esistono ripubblicazioni o "
 "risposte."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2109
+#: lib/vutuv_web/live/post_live/composer.ex:2047
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2585,7 +2583,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr "ha risposto al Suo post."
 
-#: lib/vutuv_web/components/post_components.ex:3037
+#: lib/vutuv_web/components/post_components.ex:3059
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:60
@@ -2593,49 +2591,49 @@ msgstr "ha risposto al Suo post."
 msgid "Reply to %{handle}"
 msgstr "Rispondi a %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:3475
+#: lib/vutuv_web/components/post_components.ex:3497
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Risposta a un post di %{handle} ora eliminato"
 
-#: lib/vutuv_web/components/post_components.ex:3466
-#: lib/vutuv_web/components/post_components.ex:3493
-#: lib/vutuv_web/components/post_components.ex:3496
+#: lib/vutuv_web/components/post_components.ex:3488
+#: lib/vutuv_web/components/post_components.ex:3515
+#: lib/vutuv_web/components/post_components.ex:3518
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "In risposta a %{handle}"
 
-#: lib/vutuv_web/live/message_live/index.ex:613
+#: lib/vutuv_web/live/message_live/index.ex:603
 #, elixir-autogen, elixir-format
 msgid "%{names} are typing…"
 msgstr "%{names} stanno scrivendo…"
 
-#: lib/vutuv_web/live/message_live/index.ex:612
+#: lib/vutuv_web/live/message_live/index.ex:602
 #, elixir-autogen, elixir-format
 msgid "%{name} is typing…"
 msgstr "%{name} sta scrivendo…"
 
-#: lib/vutuv_web/live/message_live/index.ex:924
+#: lib/vutuv_web/live/message_live/index.ex:914
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr "@%{slug} non ha ancora accettato la Sua richiesta di messaggio."
 
-#: lib/vutuv_web/live/message_live/index.ex:875
+#: lib/vutuv_web/live/message_live/index.ex:865
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to message you."
 msgstr "@%{slug} Le vuole scrivere."
 
-#: lib/vutuv_web/live/message_live/index.ex:596
+#: lib/vutuv_web/live/message_live/index.ex:591
 #, elixir-autogen, elixir-format
 msgid "Accept"
 msgstr "Accetta"
 
-#: lib/vutuv_web/live/message_live/index.ex:738
+#: lib/vutuv_web/live/message_live/index.ex:728
 #, elixir-autogen, elixir-format
 msgid "Back to conversations"
 msgstr "Torna alle conversazioni"
 
-#: lib/vutuv_web/live/message_live/index.ex:603
+#: lib/vutuv_web/live/message_live/index.ex:593
 #, elixir-autogen, elixir-format
 msgid "Decline"
 msgstr "Rifiuta"
@@ -2645,7 +2643,7 @@ msgstr "Rifiuta"
 msgid "Deleted account"
 msgstr "Account eliminato"
 
-#: lib/vutuv_web/live/message_live/index.ex:784
+#: lib/vutuv_web/live/message_live/index.ex:774
 #, elixir-autogen, elixir-format
 msgid "Load older messages"
 msgstr "Carica i messaggi precedenti"
@@ -2656,23 +2654,23 @@ msgstr "Carica i messaggi precedenti"
 msgid "Member not found."
 msgstr "Membro non trovato."
 
-#: lib/vutuv_web/live/message_live/index.ex:717
+#: lib/vutuv_web/live/message_live/index.ex:707
 #, elixir-autogen, elixir-format
 msgid "No conversations yet."
 msgstr "Ancora nessuna conversazione."
 
-#: lib/vutuv_web/components/ui.ex:2988
-#: lib/vutuv_web/live/message_live/index.ex:760
+#: lib/vutuv_web/components/ui.ex:3090
+#: lib/vutuv_web/live/message_live/index.ex:750
 #, elixir-autogen, elixir-format
 msgid "Online"
 msgstr "Online"
 
-#: lib/vutuv_web/live/message_live/index.ex:666
+#: lib/vutuv_web/live/message_live/index.ex:656
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr "Richieste"
 
-#: lib/vutuv_web/live/message_live/index.ex:933
+#: lib/vutuv_web/live/message_live/index.ex:923
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr "Selezioni una conversazione."
@@ -2729,7 +2727,7 @@ msgstr "Bentornato"
 msgid "Founder of vutuv"
 msgstr "Fondatore di vutuv"
 
-#: lib/vutuv_web/templates/page/index.html.heex:206
+#: lib/vutuv_web/templates/page/index.html.heex:211
 #: lib/vutuv_web/templates/settings/privacy.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Allow search engines to index your profile"
@@ -2750,7 +2748,7 @@ msgstr "Un nuovo PIN è in arrivo nella Sua casella di posta."
 msgid "Okay, let's start over."
 msgstr "Va bene, ricominciamo."
 
-#: lib/vutuv_web/components/ui.ex:815
+#: lib/vutuv_web/components/ui.ex:839
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr "Invia di nuovo il PIN"
@@ -2761,7 +2759,7 @@ msgstr "Invia di nuovo il PIN"
 msgid "Too many PIN requests. Please try again later."
 msgstr "Troppe richieste di PIN. Riprovi più tardi."
 
-#: lib/vutuv_web/components/ui.ex:836
+#: lib/vutuv_web/components/ui.ex:860
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr "Usa un altro indirizzo e-mail"
@@ -2811,11 +2809,11 @@ msgstr "Aggiungi un'esperienza lavorativa"
 msgid "Write your first post"
 msgstr "Scriva il Suo primo post"
 
-#: lib/vutuv_web/components/ui.ex:3936
-#: lib/vutuv_web/components/ui.ex:4369
+#: lib/vutuv_web/components/ui.ex:4040
+#: lib/vutuv_web/components/ui.ex:4477
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
-#: lib/vutuv_web/templates/settings/organizations.html.heex:104
+#: lib/vutuv_web/templates/settings/organizations.html.heex:109
 #: lib/vutuv_web/templates/settings/preferences.html.heex:195
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
@@ -2825,8 +2823,8 @@ msgstr "Scriva il Suo primo post"
 msgid "Manage"
 msgstr "Gestisci"
 
-#: lib/vutuv_web/controllers/page_controller.ex:225
-#: lib/vutuv_web/live/post_live/feed.ex:2280
+#: lib/vutuv_web/controllers/page_controller.ex:226
+#: lib/vutuv_web/live/post_live/feed.ex:2282
 #: lib/vutuv_web/templates/user/show.html.heex:499
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2864,7 +2862,7 @@ msgstr[1] "+%{formatted} altri tag"
 msgid "Connections"
 msgstr "Collegamenti"
 
-#: lib/vutuv_web/components/ui.ex:1304
+#: lib/vutuv_web/components/ui.ex:1328
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr "Markdown"
@@ -2874,17 +2872,17 @@ msgstr "Markdown"
 msgid "No connections yet."
 msgstr "Ancora nessun collegamento."
 
-#: lib/vutuv_web/components/ui.ex:1320
+#: lib/vutuv_web/components/ui.ex:1344
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr "Altri formati"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2018
+#: lib/vutuv_web/live/post_live/composer.ex:1956
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr "Persone che non sono miei collegamenti"
 
-#: lib/vutuv_web/components/ui.ex:1305
+#: lib/vutuv_web/components/ui.ex:1329
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr "Solo testo"
@@ -2902,12 +2900,12 @@ msgid_plural "connections"
 msgstr[0] "collegamento"
 msgstr[1] "collegamenti"
 
-#: lib/vutuv_web/components/post_components.ex:5440
+#: lib/vutuv_web/components/post_components.ex:5462
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "persone che non sono Suoi collegamenti"
 
-#: lib/vutuv_web/live/message_live/index.ex:718
+#: lib/vutuv_web/live/message_live/index.ex:708
 #, elixir-autogen, elixir-format
 msgid "Open someone's profile to message them."
 msgstr "Apra il profilo di una persona per scriverle."
@@ -3017,7 +3015,7 @@ msgstr "Bullismo o molestie"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:343
 #: lib/vutuv_web/agent_docs/text.ex:324
-#: lib/vutuv_web/controllers/page_controller.ex:90
+#: lib/vutuv_web/controllers/page_controller.ex:91
 #: lib/vutuv_web/templates/layout/app.html.heex:119
 #: lib/vutuv_web/templates/page/community.html.heex:4
 #, elixir-autogen, elixir-format
@@ -3087,7 +3085,7 @@ msgstr ""
 msgid "Hidden. You can settle this yourself - see below."
 msgstr "Nascosto. Può risolvere da solo: veda qui sotto."
 
-#: lib/vutuv_web/live/message_live/index.ex:813
+#: lib/vutuv_web/live/message_live/index.ex:803
 #, elixir-autogen, elixir-format
 msgid "Hidden: reported, under review"
 msgstr "Nascosto: segnalato, in esame"
@@ -3186,7 +3184,7 @@ msgstr "Nudità, violenza o altri contenuti che non hanno posto su vutuv."
 msgid "Only visible to you"
 msgstr "Visibile solo a Lei"
 
-#: lib/vutuv_web/components/post_components.ex:3442
+#: lib/vutuv_web/components/post_components.ex:3464
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solo Lei può vedere questo post finché la segnalazione è in corso."
@@ -3238,9 +3236,9 @@ msgstr ""
 msgid "Private message"
 msgstr "Messaggio privato"
 
-#: lib/vutuv_web/components/ui.ex:4666
-#: lib/vutuv_web/live/shell_live.ex:1128
-#: lib/vutuv_web/live/shell_live.ex:1425
+#: lib/vutuv_web/components/ui.ex:4774
+#: lib/vutuv_web/live/shell_live.ex:1124
+#: lib/vutuv_web/live/shell_live.ex:1416
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3264,9 +3262,9 @@ msgstr "Respinta"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Lo rimuova. La segnalazione si chiude, senza altre domande."
 
-#: lib/vutuv_web/components/post_components.ex:1363
-#: lib/vutuv_web/components/post_components.ex:2660
-#: lib/vutuv_web/components/post_components.ex:3606
+#: lib/vutuv_web/components/post_components.ex:1364
+#: lib/vutuv_web/components/post_components.ex:2682
+#: lib/vutuv_web/components/post_components.ex:3628
 #: lib/vutuv_web/live/organization_live/show.ex:651
 #: lib/vutuv_web/templates/user/show.html.heex:229
 #, elixir-autogen, elixir-format
@@ -3294,8 +3292,8 @@ msgstr "Segnalazione respinta; il contenuto è di nuovo visibile."
 msgid "Report this content"
 msgstr "Segnala questo contenuto"
 
-#: lib/vutuv_web/live/message_live/index.ex:831
-#: lib/vutuv_web/live/message_live/index.ex:832
+#: lib/vutuv_web/live/message_live/index.ex:821
+#: lib/vutuv_web/live/message_live/index.ex:822
 #, elixir-autogen, elixir-format
 msgid "Report this message"
 msgstr "Segnala questo messaggio"
@@ -3353,7 +3351,7 @@ msgstr ""
 "Le segnalazioni sono anonime; non diciamo mai chi ha segnalato. Le nostre "
 "regole:"
 
-#: lib/vutuv_web/components/ui.ex:3645
+#: lib/vutuv_web/components/ui.ex:3747
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3410,7 +3408,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/organization_live.ex:246
 #: lib/vutuv_web/live/admin/screenshot_live.ex:414
 #: lib/vutuv_web/live/admin/user_live.ex:299
-#: lib/vutuv_web/templates/admin/account/index.html.heex:57
+#: lib/vutuv_web/templates/admin/account/index.html.heex:52
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:59
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:19
 #: lib/vutuv_web/templates/admin/newsletter/index.html.heex:50
@@ -4010,7 +4008,7 @@ msgstr "Follower di %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:157
 #: lib/vutuv_web/agent_docs/text.ex:112
 #: lib/vutuv_web/agent_docs/text.ex:143
-#: lib/vutuv_web/live/job_posting_live/form.ex:700
+#: lib/vutuv_web/live/job_posting_live/form.ex:699
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr "Immagini"
@@ -4199,7 +4197,7 @@ msgstr "Per prenotare serve un accesso a vutuv."
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
 #: lib/vutuv_web/live/job_posting_live/form.ex:542
-#: lib/vutuv_web/live/organization_live/edit.ex:327
+#: lib/vutuv_web/live/organization_live/edit.ex:322
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
 #: lib/vutuv_web/templates/address/form_en.html.heex:33
@@ -4505,12 +4503,12 @@ msgstr ""
 "Le prenotazioni sono aperte fino al %{last}. Prossimo giorno disponibile: "
 "%{day}"
 
-#: lib/vutuv_web/components/ui.ex:3248
+#: lib/vutuv_web/components/ui.ex:3350
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr "Ve"
 
-#: lib/vutuv_web/components/ui.ex:3244
+#: lib/vutuv_web/components/ui.ex:3346
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr "Lu"
@@ -4522,27 +4520,27 @@ msgstr ""
 "Una pubblicità al giorno: scelga un giorno libero nel calendario; i giorni "
 "barrati sono già prenotati."
 
-#: lib/vutuv_web/components/ui.ex:3249
+#: lib/vutuv_web/components/ui.ex:3351
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr "Sa"
 
-#: lib/vutuv_web/components/ui.ex:3250
+#: lib/vutuv_web/components/ui.ex:3352
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr "Do"
 
-#: lib/vutuv_web/components/ui.ex:3247
+#: lib/vutuv_web/components/ui.ex:3349
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr "Gi"
 
-#: lib/vutuv_web/components/ui.ex:3245
+#: lib/vutuv_web/components/ui.ex:3347
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr "Ma"
 
-#: lib/vutuv_web/components/ui.ex:3246
+#: lib/vutuv_web/components/ui.ex:3348
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr "Me"
@@ -4585,7 +4583,7 @@ msgstr "Anteprima (come la vedono i visitatori)"
 msgid "by"
 msgstr "di"
 
-#: lib/vutuv_web/templates/ad/preview.html.heex:83
+#: lib/vutuv_web/templates/ad/preview.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Book now (binding, by invoice)"
 msgstr "Prenoti ora (vincolante, con fattura)"
@@ -4597,12 +4595,12 @@ msgstr ""
 "La prenotazione è vincolante; pagamento tramite fattura. Verifichiamo e "
 "approviamo ogni pubblicità prima che vada online."
 
-#: lib/vutuv_web/templates/ad/preview.html.heex:77
+#: lib/vutuv_web/templates/ad/preview.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "Edit the ad"
 msgstr "Modifica la pubblicità"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1004
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:999
 #: lib/vutuv_web/live/tag_new_live.ex:78
 #: lib/vutuv_web/templates/ad/preview.html.heex:3
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:122
@@ -4685,7 +4683,7 @@ msgstr ""
 " la vostra conversazione e impedisce ogni interazione in entrambe le "
 "direzioni. Sbloccare non ripristina ciò che è stato rimosso."
 
-#: lib/vutuv_web/components/ui.ex:4784
+#: lib/vutuv_web/components/ui.ex:4892
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4732,12 +4730,12 @@ msgstr "Non ha bloccato nessuno."
 msgid "You unblocked @%{slug}."
 msgstr "Ha sbloccato @%{slug}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3158
+#: lib/vutuv_web/live/post_live/feed.ex:3155
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Scopra persone da seguire"
 
-#: lib/vutuv_web/live/message_live/index.ex:721
+#: lib/vutuv_web/live/message_live/index.ex:711
 #, elixir-autogen, elixir-format
 msgid "Find members"
 msgstr "Trova membri"
@@ -4776,12 +4774,12 @@ msgstr "Non segue ancora nessuno."
 msgid "This area is reserved for administrators."
 msgstr "Quest'area è riservata agli amministratori."
 
-#: lib/vutuv_web/live/search_live.ex:884
+#: lib/vutuv_web/live/search_live.ex:877
 #, elixir-autogen, elixir-format
 msgid "No results for \"%{query}\""
 msgstr "Nessun risultato per \"%{query}\""
 
-#: lib/vutuv_web/live/search_live.ex:805
+#: lib/vutuv_web/live/search_live.ex:798
 #, elixir-autogen, elixir-format
 msgid "Not an exact match, but sounds like your search."
 msgstr "Non è una corrispondenza esatta, ma somiglia alla Sua ricerca."
@@ -4793,23 +4791,23 @@ msgstr "Non è una corrispondenza esatta, ma somiglia alla Sua ricerca."
 #: lib/vutuv_web/live/organization_live/show.ex:787
 #: lib/vutuv_web/live/post_live/saved.ex:523
 #: lib/vutuv_web/live/search_live.ex:343
-#: lib/vutuv_web/live/search_live.ex:778
+#: lib/vutuv_web/live/search_live.ex:771
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr "Persone"
 
-#: lib/vutuv_web/live/search_live.ex:719
+#: lib/vutuv_web/live/search_live.ex:712
 #, elixir-autogen, elixir-format
 msgid "Results appear once you have typed at least three letters."
 msgstr "I risultati compaiono dopo almeno tre lettere."
 
-#: lib/vutuv_web/live/search_live.ex:802
+#: lib/vutuv_web/live/search_live.ex:795
 #, elixir-autogen, elixir-format
 msgid "Similar names"
 msgstr "Nomi simili"
 
-#: lib/vutuv_web/components/post_components.ex:405
-#: lib/vutuv_web/components/post_components.ex:424
+#: lib/vutuv_web/components/post_components.ex:406
+#: lib/vutuv_web/components/post_components.ex:425
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -4820,7 +4818,7 @@ msgstr "Nomi simili"
 msgid "All"
 msgstr "Tutti"
 
-#: lib/vutuv_web/live/search_live.ex:702
+#: lib/vutuv_web/live/search_live.ex:695
 #, elixir-autogen, elixir-format
 msgid "Exact matches only"
 msgstr "Solo corrispondenze esatte"
@@ -4860,7 +4858,7 @@ msgstr "rossi"
 msgid "searches first names only (last: for last names)"
 msgstr "cerca solo nel nome (cognome: per il cognome)"
 
-#: lib/vutuv_web/live/job_board_live.ex:388
+#: lib/vutuv_web/live/job_board_live.ex:384
 #: lib/vutuv_web/live/tag_new_live.ex:47
 #: lib/vutuv_web/live/user_profile_live.ex:1336
 #: lib/vutuv_web/templates/user/show.html.heex:602
@@ -4913,8 +4911,8 @@ msgstr "Modificare il Suo profilo e le sue sezioni"
 #: lib/vutuv_web/agent_docs/markdown.ex:286
 #: lib/vutuv_web/agent_docs/text.ex:270
 #: lib/vutuv_web/live/admin/job_live.ex:389
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
-#: lib/vutuv_web/live/job_posting_live/show.ex:136
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:140
+#: lib/vutuv_web/live/job_posting_live/show.ex:131
 #: lib/vutuv_web/templates/access_token/new.html.heex:42
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:45
 #: lib/vutuv_web/templates/qualification/show.html.heex:38
@@ -5107,14 +5105,14 @@ msgid "API applications"
 msgstr "Applicazioni API"
 
 #: lib/vutuv_web/live/admin/api_app_live.ex:98
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:180
 #: lib/vutuv_web/views/settings_html.ex:90
 #: lib/vutuv_web/views/settings_html.ex:290
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr "Attiva"
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:82
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Allow access"
 msgstr "Consenti l'accesso"
@@ -5178,7 +5176,7 @@ msgstr ""
 "Eliminare \"%{name}\"? Ogni autorizzazione dei membri e ogni token di questa"
 " applicazione smette subito di funzionare."
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:91
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Deny"
 msgstr "Nega"
@@ -5476,7 +5474,7 @@ msgstr ""
 "vutuv invia qui buste JSON firmate via POST (veda la documentazione sui "
 "webhook). Solo https://; http://localhost è ammesso in fase di sviluppo."
 
-#: lib/vutuv_web/templates/page/index.html.heex:211
+#: lib/vutuv_web/templates/page/index.html.heex:216
 #: lib/vutuv_web/templates/settings/privacy.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "Allow AI agents and LLMs to use your profile"
@@ -5492,14 +5490,14 @@ msgstr "Token API (%{date})"
 msgid "API documentation"
 msgstr "Documentazione dell'API"
 
-#: lib/vutuv_web/components/ui.ex:4844
+#: lib/vutuv_web/components/ui.ex:4952
 #: lib/vutuv_web/controllers/settings_controller.ex:157
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_delete_live.ex:109
-#: lib/vutuv_web/live/admin/user_delete_live.ex:221
+#: lib/vutuv_web/live/admin/user_delete_live.ex:209
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:136
 #: lib/vutuv_web/templates/settings/delete_account.html.heex:9
 #: lib/vutuv_web/templates/settings/delete_account.html.heex:11
@@ -5507,7 +5505,7 @@ msgstr "Documentazione dell'API"
 msgid "Delete account"
 msgstr "Elimina l'account"
 
-#: lib/vutuv_web/templates/settings/delete_account.html.heex:53
+#: lib/vutuv_web/templates/settings/delete_account.html.heex:54
 #, elixir-autogen, elixir-format
 msgid "Start deleting your account? We will email you a PIN to confirm."
 msgstr ""
@@ -5532,7 +5530,7 @@ msgstr ""
 "Questo elimina definitivamente il Suo profilo, i post, i messaggi e tutto il"
 " resto. Le inviamo un PIN per e-mail per confermare. Non si può annullare."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1264
+#: lib/vutuv_web/live/post_live/composer.ex:1239
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr "Non può più rispondere a questo post."
@@ -5542,7 +5540,7 @@ msgstr "Non può più rispondere a questo post."
 msgid "Content under review"
 msgstr "Contenuto in esame"
 
-#: lib/vutuv_web/live/shell_live.ex:1294
+#: lib/vutuv_web/live/shell_live.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Menu dell'account"
@@ -5564,7 +5562,7 @@ msgstr "Chiudi menu e finestre"
 msgid "General"
 msgstr "Generale"
 
-#: lib/vutuv_web/live/shell_live.ex:1351
+#: lib/vutuv_web/live/shell_live.ex:1347
 #: lib/vutuv_web/templates/layout/app.html.heex:183
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5575,15 +5573,15 @@ msgstr "Scorciatoie da tastiera"
 msgid "Navigation"
 msgstr "Navigazione"
 
-#: lib/vutuv_web/components/ui.ex:4941
-#: lib/vutuv_web/components/ui.ex:4946
-#: lib/vutuv_web/components/ui.ex:5025
-#: lib/vutuv_web/components/ui.ex:5089
+#: lib/vutuv_web/components/ui.ex:5049
+#: lib/vutuv_web/components/ui.ex:5054
+#: lib/vutuv_web/components/ui.ex:5133
+#: lib/vutuv_web/components/ui.ex:5197
 #: lib/vutuv_web/controllers/settings_controller.ex:64
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:276
-#: lib/vutuv_web/live/shell_live.ex:1331
+#: lib/vutuv_web/live/shell_live.ex:1327
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5637,8 +5635,8 @@ msgstr "Post successivo nel feed"
 msgid "Previous post in the feed"
 msgstr "Post precedente nel feed"
 
-#: lib/vutuv_web/live/shell_live.ex:1103
-#: lib/vutuv_web/live/shell_live.ex:1397
+#: lib/vutuv_web/live/shell_live.ex:1099
+#: lib/vutuv_web/live/shell_live.ex:1388
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Navigazione principale"
@@ -5648,9 +5646,9 @@ msgstr "Navigazione principale"
 msgid "Footer navigation"
 msgstr "Navigazione a piè di pagina"
 
-#: lib/vutuv_web/components/post_components.ex:3672
-#: lib/vutuv_web/components/post_components.ex:3727
-#: lib/vutuv_web/components/post_components.ex:4135
+#: lib/vutuv_web/components/post_components.ex:3694
+#: lib/vutuv_web/components/post_components.ex:3749
+#: lib/vutuv_web/components/post_components.ex:4157
 #: lib/vutuv_web/live/notification_live/index.ex:784
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
@@ -5662,7 +5660,7 @@ msgstr "Vedi il post"
 msgid "Someone tried to register with your email address"
 msgstr "Qualcuno ha provato a registrarsi con il Suo indirizzo e-mail"
 
-#: lib/vutuv_web/templates/page/index.html.heex:139
+#: lib/vutuv_web/templates/page/index.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr "I Suoi tag (ad esempio JavaScript, Cucina, Origami, Gatti)"
@@ -5676,7 +5674,7 @@ msgstr "Altro"
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:1196
+#: lib/vutuv_web/views/user_html.ex:1202
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr "Personale"
@@ -5686,17 +5684,17 @@ msgstr "Personale"
 msgid "Type of Email"
 msgstr "Tipo di indirizzo e-mail"
 
-#: lib/vutuv_web/templates/page/index.html.heex:171
+#: lib/vutuv_web/templates/page/index.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "Type of email address"
 msgstr "Tipo di indirizzo e-mail"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:241
+#: lib/vutuv_web/templates/user/edit.html.heex:236
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr "Su di Lei"
 
-#: lib/vutuv_web/components/ui.ex:4804
+#: lib/vutuv_web/components/ui.ex:4912
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5707,7 +5705,7 @@ msgstr "Su di Lei"
 msgid "Account"
 msgstr "Account"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:482
+#: lib/vutuv_web/live/organization_live/edit.ex:461
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr "Modifica"
@@ -5717,7 +5715,7 @@ msgstr "Modifica"
 msgid "Download everything vutuv stores about you, as one file."
 msgstr "Scarichi in un unico file tutto ciò che vutuv conserva su di Lei."
 
-#: lib/vutuv_web/components/ui.ex:4704
+#: lib/vutuv_web/components/ui.ex:4812
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5746,15 +5744,15 @@ msgstr "Persone che non possono interagire con Lei."
 msgid "Personal tokens for the vutuv API."
 msgstr "Token personali per l'API di vutuv."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2222
+#: lib/vutuv_web/live/post_live/composer.ex:2161
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
 msgstr "Foto"
 
-#: lib/vutuv_web/components/ui.ex:4778
+#: lib/vutuv_web/components/ui.ex:4886
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
-#: lib/vutuv_web/templates/page/index.html.heex:191
+#: lib/vutuv_web/templates/page/index.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr "Privacy"
@@ -5774,7 +5772,7 @@ msgstr "App di terze parti che ha autorizzato."
 msgid "View"
 msgstr "Vedi"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:166
+#: lib/vutuv_web/templates/user/edit.html.heex:161
 #, elixir-autogen, elixir-format
 msgid "Your name"
 msgstr "Il Suo nome"
@@ -5834,18 +5832,18 @@ msgstr ""
 msgid "Current avatar"
 msgstr "Immagine del profilo attuale"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:112
-#: lib/vutuv_web/templates/user/edit.html.heex:119
+#: lib/vutuv_web/templates/user/edit.html.heex:107
+#: lib/vutuv_web/templates/user/edit.html.heex:114
 #, elixir-autogen, elixir-format
 msgid "Current cover photo"
 msgstr "Immagine di copertina attuale"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:190
+#: lib/vutuv_web/templates/user/edit.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "e.g. Dr. or Prof."
 msgstr "ad esempio Dott. o Prof."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:195
+#: lib/vutuv_web/templates/user/edit.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "e.g. Jr. or PhD"
 msgstr "ad esempio Jr. o PhD"
@@ -5867,7 +5865,7 @@ msgstr "@%{slug} ha iniziato a seguirla su vutuv"
 msgid "Apps"
 msgstr "App"
 
-#: lib/vutuv_web/components/ui.ex:4837
+#: lib/vutuv_web/components/ui.ex:4945
 #: lib/vutuv_web/controllers/settings_controller.ex:181
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5954,7 +5952,7 @@ msgstr "Quando qualcuno inizia a seguirla."
 msgid "@handle"
 msgstr "@handle"
 
-#: lib/vutuv_web/live/message_live/index.ex:776
+#: lib/vutuv_web/live/message_live/index.ex:766
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}"
 msgstr "Blocca @%{slug}"
@@ -6020,7 +6018,7 @@ msgid "Name (A-Z)"
 msgstr "Nome (A-Z)"
 
 #: lib/vutuv_web/live/post_live/saved.ex:491
-#: lib/vutuv_web/live/tag_live/timeline.ex:413
+#: lib/vutuv_web/live/tag_live/timeline.ex:409
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr "Prima i più recenti"
@@ -6047,7 +6045,7 @@ msgstr ""
 "Qui non c'è ancora nulla. Le persone a cui mette Mi piace compaiono qui."
 
 #: lib/vutuv_web/live/post_live/saved.ex:492
-#: lib/vutuv_web/live/tag_live/timeline.ex:414
+#: lib/vutuv_web/live/tag_live/timeline.ex:410
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr "Prima i meno recenti"
@@ -6069,27 +6067,27 @@ msgid "Search saved items"
 msgstr "Cerchi negli elementi salvati"
 
 #: lib/vutuv_web/live/post_live/saved.ex:554
-#: lib/vutuv_web/live/tag_live/timeline.ex:339
+#: lib/vutuv_web/live/tag_live/timeline.ex:335
 #, elixir-autogen, elixir-format
 msgid "Sort"
 msgstr "Ordina"
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3305
+#: lib/vutuv_web/components/ui.ex:3407
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "%{count} giorno fa"
 msgstr[1] "%{count} giorni fa"
 
-#: lib/vutuv_web/components/ui.ex:3304
+#: lib/vutuv_web/components/ui.ex:3406
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "%{count} ora fa"
 msgstr[1] "%{count} ore fa"
 
-#: lib/vutuv_web/components/ui.ex:3303
+#: lib/vutuv_web/components/ui.ex:3405
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -6116,12 +6114,12 @@ msgstr "Ultima attività"
 msgid "Log out all other devices"
 msgstr "Disconnetti tutti gli altri dispositivi"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:85
+#: lib/vutuv_web/templates/settings/security.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Log out of every device except this one?"
 msgstr "Disconnettere ogni dispositivo tranne questo?"
 
-#: lib/vutuv_web/views/settings_html.ex:296
+#: lib/vutuv_web/views/settings_html.ex:297
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr "Disconnettere questo dispositivo dal Suo account?"
@@ -6156,7 +6154,7 @@ msgstr "Questo dispositivo"
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr "È il primo accesso che vediamo da questo dispositivo o browser."
 
-#: lib/vutuv_web/components/ui.ex:3302
+#: lib/vutuv_web/components/ui.ex:3404
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "adesso"
@@ -6186,12 +6184,12 @@ msgstr ""
 "Se disattivato, nessuno vede il pallino verde sulla Sua immagine del profilo"
 " e non risulta mai online."
 
-#: lib/vutuv_web/templates/settings/security.html.heex:145
+#: lib/vutuv_web/templates/settings/security.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Add a passkey"
 msgstr "Aggiungi una passkey"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1109
 #: lib/vutuv_web/live/admin/screenshot_live.ex:309
 #: lib/vutuv_web/live/fediverse_following_live.ex:264
 #: lib/vutuv_web/views/settings_html.ex:331
@@ -6234,7 +6232,7 @@ msgstr "Passkey rimossa."
 msgid "Passkeys"
 msgstr "Passkey"
 
-#: lib/vutuv_web/views/settings_html.ex:342
+#: lib/vutuv_web/views/settings_html.ex:343
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr "Rimuovere questa passkey?"
@@ -6252,7 +6250,7 @@ msgstr ""
 msgid "Sign in with a passkey"
 msgstr "Acceda con una passkey"
 
-#: lib/vutuv_web/templates/session/new.html.heex:19
+#: lib/vutuv_web/templates/session/new.html.heex:20
 #, elixir-autogen, elixir-format
 msgid "Sign-in failed. Please try again or use your email."
 msgstr "Accesso non riuscito. Riprovi oppure usi il Suo indirizzo e-mail."
@@ -6268,7 +6266,7 @@ msgstr "Non è stato possibile registrare questa passkey."
 msgid "That passkey could not be verified."
 msgstr "Non è stato possibile verificare questa passkey."
 
-#: lib/vutuv_web/templates/settings/security.html.heex:156
+#: lib/vutuv_web/templates/settings/security.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "This browser does not support passkeys."
 msgstr "Questo browser non supporta le passkey."
@@ -6299,13 +6297,13 @@ msgid "Add a tagline"
 msgstr "Aggiungi una descrizione breve"
 
 #: lib/vutuv_web/live/cv_live.ex:148
-#: lib/vutuv_web/templates/user/edit.html.heex:250
+#: lib/vutuv_web/templates/user/edit.html.heex:245
 #: lib/vutuv_web/views/account_event_text.ex:212
 #, elixir-autogen, elixir-format
 msgid "Tagline"
 msgstr "Descrizione breve"
 
-#: lib/vutuv_web/components/ui.ex:396
+#: lib/vutuv_web/components/ui.ex:457
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:907
@@ -6324,18 +6322,18 @@ msgstr[0] "post"
 msgstr[1] "post"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:63
-#: lib/vutuv_web/templates/user/edit.html.heex:149
+#: lib/vutuv_web/templates/user/edit.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Dopo aver scelto un file può spostarlo e ingrandirlo."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1527
+#: lib/vutuv_web/templates/user/show.html.heex:1526
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Anche su"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:51
-#: lib/vutuv_web/templates/user/edit.html.heex:136
+#: lib/vutuv_web/templates/user/edit.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Drag to move, use the slider to zoom. The framed area is what others see."
 msgstr ""
@@ -6347,12 +6345,12 @@ msgstr ""
 msgid "New avatar preview"
 msgstr "Anteprima della nuova immagine del profilo"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:154
+#: lib/vutuv_web/templates/user/edit.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "New cover photo preview"
 msgstr "Anteprima della nuova immagine di copertina"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:135
+#: lib/vutuv_web/templates/user/edit.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Position your cover photo"
 msgstr "Posizioni la Sua immagine di copertina"
@@ -6363,14 +6361,14 @@ msgid "Position your photo"
 msgstr "Posizioni la Sua foto"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:52
-#: lib/vutuv_web/templates/user/edit.html.heex:137
+#: lib/vutuv_web/templates/user/edit.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Use photo"
 msgstr "Usa questa foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1699
+#: lib/vutuv_web/live/post_live/composer.ex:1675
 #: lib/vutuv_web/templates/user/edit.html.heex:54
-#: lib/vutuv_web/templates/user/edit.html.heex:139
+#: lib/vutuv_web/templates/user/edit.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr "Ingrandimento"
@@ -6459,7 +6457,7 @@ msgid "Previous day"
 msgstr "Giorno precedente"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1144
-#: lib/vutuv_web/components/post_components.ex:407
+#: lib/vutuv_web/components/post_components.ex:408
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6496,9 +6494,9 @@ msgstr "Sposta giù"
 msgid "Move up"
 msgstr "Sposta su"
 
-#: lib/vutuv_web/components/ui.ex:2025
-#: lib/vutuv_web/components/ui.ex:2034
-#: lib/vutuv_web/components/ui.ex:2513
+#: lib/vutuv_web/components/ui.ex:2049
+#: lib/vutuv_web/components/ui.ex:2058
+#: lib/vutuv_web/components/ui.ex:2537
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr "Ritira la conferma"
@@ -6525,9 +6523,9 @@ msgstr "Servizi di mappe da mostrare"
 msgid "Maps"
 msgstr "Mappe"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1513
-#: lib/vutuv_web/templates/user/show.html.heex:1521
-#: lib/vutuv_web/templates/user/show.html.heex:1533
+#: lib/vutuv_web/templates/user/show.html.heex:1516
+#: lib/vutuv_web/templates/user/show.html.heex:1520
+#: lib/vutuv_web/templates/user/show.html.heex:1532
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "Apri in %{name}"
@@ -6563,7 +6561,7 @@ msgstr "Membri che hanno confermato %{name} per %{tag}"
 msgid "No endorsements yet."
 msgstr "Ancora nessuna conferma."
 
-#: lib/vutuv_web/components/ui.ex:2466
+#: lib/vutuv_web/components/ui.ex:2490
 #: lib/vutuv_web/live/notification_live/index.ex:684
 #: lib/vutuv_web/live/notification_live/index.ex:699
 #: lib/vutuv_web/live/notification_live/index.ex:1012
@@ -6885,10 +6883,10 @@ msgstr ""
 "Se disattiva un'opzione, la relativa esclusione viaggia con le pagine e le "
 "risposte che La riguardano. Con entrambe disattivate, ad esempio:"
 
-#: lib/vutuv_web/components/post_components.ex:2628
-#: lib/vutuv_web/components/post_components.ex:3603
-#: lib/vutuv_web/components/ui.ex:2813
-#: lib/vutuv_web/live/fediverse_account_live.ex:375
+#: lib/vutuv_web/components/post_components.ex:2650
+#: lib/vutuv_web/components/post_components.ex:3625
+#: lib/vutuv_web/components/ui.ex:2915
+#: lib/vutuv_web/live/fediverse_account_live.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:215
@@ -6914,13 +6912,13 @@ msgstr "Nuovi messaggi e nuovi collegamenti"
 msgid "Remove this connection? You will stop following them."
 msgstr "Rimuovere questo collegamento? Smetterà di seguire questa persona."
 
-#: lib/vutuv_web/components/post_components.ex:3603
-#: lib/vutuv_web/components/ui.ex:2812
-#: lib/vutuv_web/live/fediverse_account_live.ex:373
+#: lib/vutuv_web/components/post_components.ex:3625
+#: lib/vutuv_web/components/ui.ex:2914
+#: lib/vutuv_web/live/fediverse_account_live.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:215
-#: lib/vutuv_web/templates/settings/filters.html.heex:110
+#: lib/vutuv_web/templates/settings/filters.html.heex:111
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
 msgid "Unmute"
@@ -6942,12 +6940,12 @@ msgstr "Seguitevi a vicenda per collegarsi con %{name} e leggerlo."
 msgid "Go to profile to follow"
 msgstr "Vada al profilo per seguire"
 
-#: lib/vutuv_web/views/user_html.ex:1195
+#: lib/vutuv_web/views/user_html.ex:1201
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr "Professionale"
 
-#: lib/vutuv_web/views/user_html.ex:748
+#: lib/vutuv_web/views/user_html.ex:754
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr "La segue"
@@ -6967,7 +6965,7 @@ msgstr "Tutti i tipi"
 msgid "All statuses"
 msgstr "Tutti gli stati"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:779
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "Any country"
 msgstr "Qualsiasi paese"
@@ -6987,15 +6985,15 @@ msgstr "Gruppo destinatari %{stamp}"
 msgid "Audience deleted."
 msgstr "Gruppo destinatari eliminato."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:709
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:704
 #, elixir-autogen, elixir-format
 msgid "Audience name"
 msgstr "Nome del gruppo destinatari"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:574
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:638
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:637
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:688
 #: lib/vutuv_web/templates/admin/newsletter/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Audiences"
@@ -7020,7 +7018,7 @@ msgstr ""
 "newsletter. Sottragga un altro gruppo per fare una prova, poi invii al "
 "resto."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:855
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:850
 #, elixir-autogen, elixir-format
 msgid "Cap group size (optional)"
 msgstr "Limite di dimensione del gruppo (facoltativo)"
@@ -7045,7 +7043,7 @@ msgid "Created"
 msgstr "Creato"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:619
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:659
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:655
 #, elixir-autogen, elixir-format
 msgid "Delete this audience?"
 msgstr "Eliminare questo gruppo destinatari?"
@@ -7116,7 +7114,7 @@ msgid "Filter"
 msgstr "Filtro"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:591
-#: lib/vutuv_web/live/tag_live/timeline.ex:305
+#: lib/vutuv_web/live/tag_live/timeline.ex:301
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr "Filtri"
@@ -7143,14 +7141,14 @@ msgstr "Gestisci i gruppi destinatari"
 msgid "Markdown is supported (headings, bold, lists, links)."
 msgstr "Markdown è supportato (titoli, grassetto, elenchi, link)."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:801
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:796
 #, elixir-autogen, elixir-format
 msgid "Maximum age"
 msgstr "Età massima"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:592
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:670
-#: lib/vutuv_web/live/admin/user_detail_live.ex:69
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:665
+#: lib/vutuv_web/live/admin/user_detail_live.ex:64
 #: lib/vutuv_web/live/admin/user_live.ex:28
 #: lib/vutuv_web/live/admin/user_live.ex:164
 #: lib/vutuv_web/live/admin/user_live.ex:165
@@ -7163,12 +7161,12 @@ msgstr "Età massima"
 msgid "Members"
 msgstr "Membri"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:941
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:936
 #, elixir-autogen, elixir-format
 msgid "Members matching"
 msgstr "Membri corrispondenti"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:786
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "Minimum age"
 msgstr "Età minima"
@@ -7209,8 +7207,8 @@ msgstr "Newsletter eliminata."
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:19
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:128
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:638
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:637
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:688
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/index.html.heex:2
@@ -7237,7 +7235,7 @@ msgstr "Nessuna consegna corrisponde ai Suoi filtri."
 msgid "No newsletters yet."
 msgstr "Ancora nessuna newsletter."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:831
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:826
 #, elixir-autogen, elixir-format
 msgid "No tag with that name."
 msgstr "Nessun tag con questo nome."
@@ -7252,7 +7250,7 @@ msgstr "Ancora nulla di inviato."
 msgid "Occasional vutuv news and announcements."
 msgstr "Notizie e annunci di vutuv, di tanto in tanto."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:880
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:875
 #, elixir-autogen, elixir-format
 msgid "Off: take the oldest members first (by join date)."
 msgstr ""
@@ -7263,7 +7261,7 @@ msgstr ""
 msgid "Open newsletters"
 msgstr "Apri le newsletter"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:878
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:873
 #, elixir-autogen, elixir-format
 msgid "Pick capped members at random"
 msgstr "Scegli a caso i membri entro il limite"
@@ -7296,19 +7294,19 @@ msgstr "Destinatari"
 msgid "Rendered with your own account data for the variables."
 msgstr "Reso con i dati del Suo account al posto delle variabili."
 
-#: lib/vutuv_web/live/cv_live.ex:241
+#: lib/vutuv_web/live/cv_live.ex:231
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:281
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Reset"
 msgstr "Azzera"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1128
 #, elixir-autogen, elixir-format
 msgid "Save audience"
 msgstr "Salva il gruppo destinatari"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:809
+#: lib/vutuv_web/live/job_posting_live/form.ex:804
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:16
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:11
 #, elixir-autogen, elixir-format
@@ -7371,7 +7369,7 @@ msgstr "Oggetto"
 msgid "Subject line (variables allowed)"
 msgstr "Oggetto (sono ammesse le variabili)"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:915
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:910
 #, elixir-autogen, elixir-format
 msgid "Subtract these audiences"
 msgstr "Sottrai questi gruppi destinatari"
@@ -7386,7 +7384,7 @@ msgstr "Soppressa"
 msgid "Suppressed (bounced address)"
 msgstr "Soppressa (indirizzo respinto)"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:816
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:811
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:44
 #: lib/vutuv_web/templates/settings/filters.html.heex:29
 #: lib/vutuv_web/views/settings_html.ex:60
@@ -7394,7 +7392,7 @@ msgstr "Soppressa (indirizzo respinto)"
 msgid "Tag"
 msgstr "Tag"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:828
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:823
 #, elixir-autogen, elixir-format
 msgid "Tag found: %{name}"
 msgstr "Tag trovato: %{name}"
@@ -7420,14 +7418,14 @@ msgstr "E-mail di prova inviata a %{email}."
 msgid "That audience could not be found."
 msgstr "Non è stato possibile trovare questo gruppo destinatari."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:918
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:913
 #, elixir-autogen, elixir-format
 msgid "Their members are removed from this one (e.g. exclude the test group to send to \"the rest\")."
 msgstr ""
 "I loro membri vengono tolti da questo (ad esempio escluda il gruppo di prova"
 " per inviare \"al resto\")."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:945
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:940
 #, elixir-autogen, elixir-format
 msgid "This audience will be capped to"
 msgstr "Questo gruppo destinatari sarà limitato a"
@@ -7454,7 +7452,7 @@ msgstr ""
 msgid "all members"
 msgstr "tutti i membri"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:863
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:858
 #, elixir-autogen, elixir-format
 msgid "e.g. 100 for a test run"
 msgstr "ad esempio 100 per una prova"
@@ -7464,7 +7462,7 @@ msgstr "ad esempio 100 per una prova"
 msgid "email or @handle"
 msgstr "e-mail o @handle"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:823
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:818
 #, elixir-autogen, elixir-format
 msgid "exact tag name"
 msgstr "nome esatto del tag"
@@ -7483,7 +7481,7 @@ msgid "open the dev email inbox"
 msgstr "apri la casella e-mail di sviluppo"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
-#: lib/vutuv_web/views/user_html.ex:747
+#: lib/vutuv_web/views/user_html.ex:753
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr "Collegato"
@@ -7498,53 +7496,53 @@ msgstr "tag: %{name}"
 msgid "max %{count}"
 msgstr "max %{count}"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:674
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "The frozen snapshot saved with this audience. Click a name to open the profile."
 msgstr ""
 "L'istantanea congelata salvata con questo gruppo destinatari. Prema su un "
 "nome per aprire il profilo."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:677
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "This audience has no members."
 msgstr "Questo gruppo destinatari non ha membri."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:844
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:839
 #, elixir-autogen, elixir-format
 msgid "e.g. stefan* or *meyer"
 msgstr "ad esempio stefano* o *rossi"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:849
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:844
 #, elixir-autogen, elixir-format
 msgid "Use * as a wildcard; a plain text matches anywhere in the handle."
 msgstr ""
 "Usi * come jolly; un testo semplice corrisponde in qualsiasi punto "
 "dell'handle."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:890
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:885
 #, elixir-autogen, elixir-format
 msgid "Add these audiences"
 msgstr "Aggiungi questi gruppi destinatari"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:893
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:888
 #, elixir-autogen, elixir-format
 msgid "Their members are added to this one (union)."
 msgstr "I loro membri vengono aggiunti a questo (unione)."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1168
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1158
 #, elixir-autogen, elixir-format
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr "pagina %{page} di %{pages}, %{total} in totale"
 
-#: lib/vutuv_web/components/ui.ex:3708
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
+#: lib/vutuv_web/components/ui.ex:3816
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Precedente"
 
-#: lib/vutuv_web/components/ui.ex:3724
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
+#: lib/vutuv_web/components/ui.ex:3828
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr "Successivo"
@@ -7556,49 +7554,49 @@ msgid_plural "plus %{count} groups"
 msgstr[0] "più 1 gruppo"
 msgstr[1] "più %{count} gruppi"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:956
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:951
 #, elixir-autogen, elixir-format
 msgid "Choose specific accounts"
 msgstr "Scelga account specifici"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:959
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:954
 #, elixir-autogen, elixir-format
 msgid "Tick to include an account, untick to exclude it. Search by @handle to find anyone."
 msgstr ""
 "Spunti per includere un account, tolga la spunta per escluderlo. Cerchi per "
 "@handle per trovare chiunque."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:966
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1065
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:961
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1060
 #, elixir-autogen, elixir-format
 msgid "search by @handle…"
 msgstr "cerca per @handle…"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:973
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:968
 #, elixir-autogen, elixir-format
 msgid "Removed:"
 msgstr "Rimossi:"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:979
-#: lib/vutuv_web/live/post_live/composer.ex:1547
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:974
+#: lib/vutuv_web/live/post_live/composer.ex:1523
 #: lib/vutuv_web/live/post_live/filter_band.ex:532
 #, elixir-autogen, elixir-format
 msgid "Undo"
 msgstr "Annulla"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1025
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1020
 #, elixir-autogen, elixir-format
 msgid "In this audience"
 msgstr "In questo gruppo destinatari"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1005
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1098
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1000
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1093
 #, elixir-autogen, elixir-format
 msgid "Search results"
 msgstr "Risultati della ricerca"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1011
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1100
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1006
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1095
 #, elixir-autogen, elixir-format
 msgid "No members."
 msgstr "Nessun membro."
@@ -7608,27 +7606,27 @@ msgstr "Nessun membro."
 msgid "accounts"
 msgstr "account"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:991
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:986
 #: lib/vutuv_web/live/post_live/filter_band.ex:509
 #: lib/vutuv_web/views/import_html.ex:230
 #, elixir-autogen, elixir-format
 msgid "Select all"
 msgstr "Seleziona tutto"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:994
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:989
 #: lib/vutuv_web/views/import_html.ex:240
 #, elixir-autogen, elixir-format
 msgid "Unselect all"
 msgstr "Deseleziona tutto"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:997
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:992
 #, elixir-autogen, elixir-format
 msgid "applies to the whole list, not just this page"
 msgstr "vale per l'intero elenco, non solo per questa pagina"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5681
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
+#: lib/vutuv_web/components/post_components.ex:5703
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
 msgstr "+%{count} altri"
@@ -7734,7 +7732,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr "Si aggiorna da sola. Può lasciare questa pagina: l'invio prosegue."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3424
+#: lib/vutuv_web/live/post_live/feed.ex:3421
 #, elixir-autogen
 msgid "Done"
 msgstr "Fatto"
@@ -7747,7 +7745,7 @@ msgstr "Inviata a %{count} membri."
 msgid "View the delivery log"
 msgstr "Vedi il registro delle consegne"
 
-#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:232
+#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:226
 #, elixir-autogen
 msgid "%{sent} of %{total} emails sent"
 msgstr "%{sent} e-mail inviate su %{total}"
@@ -7757,7 +7755,7 @@ msgstr ""
 "La newsletter verrà inviata a %{count} persone. L'operazione non si può "
 "annullare."
 
-#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:218
+#: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:212
 #, elixir-autogen
 msgid "Send now"
 msgstr "Invia ora"
@@ -8055,61 +8053,61 @@ msgstr "Ieri"
 msgid "updates automatically"
 msgstr "si aggiorna da solo"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:723
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:718
 #, elixir-autogen, elixir-format
 msgid "How to build this audience"
 msgstr "Come costruire questo gruppo destinatari"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:736
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:731
 #, elixir-autogen, elixir-format
 msgid "From filters"
 msgstr "Dai filtri"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:745
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:740
 #, elixir-autogen, elixir-format
 msgid "Specific accounts"
 msgstr "Account specifici"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:749
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:744
 #, elixir-autogen, elixir-format
 msgid "Pick members from filters, or hand-pick specific accounts (e.g. a small group of testers)."
 msgstr ""
 "Scelga i membri con i filtri, oppure selezioni a mano account specifici (ad "
 "esempio un piccolo gruppo di tester)."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1045
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1040
 #, elixir-autogen, elixir-format
 msgid "Accounts in this audience"
 msgstr "Account in questo gruppo destinatari"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1049
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1044
 #, elixir-autogen, elixir-format
 msgid "Only these accounts get the newsletter. Search for members below and add them one by one."
 msgstr ""
 "Solo questi account ricevono la newsletter. Cerchi i membri qui sotto e li "
 "aggiunga uno per uno."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1058
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1053
 #, elixir-autogen, elixir-format
 msgid "Find accounts to add"
 msgstr "Trovi gli account da aggiungere"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1073
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Chosen accounts"
 msgstr "Account scelti"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1076
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1071
 #, elixir-autogen, elixir-format
 msgid "No accounts yet. Search above to add some."
 msgstr "Ancora nessun account. Cerchi qui sopra per aggiungerne."
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1087
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Remove from audience"
 msgstr "Togli dal gruppo destinatari"
 
-#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1123
+#: lib/vutuv_web/live/admin/newsletter_group_live.ex:1118
 #, elixir-autogen, elixir-format
 msgid "Add to audience"
 msgstr "Aggiungi al gruppo destinatari"
@@ -8230,8 +8228,8 @@ msgstr "In attesa di verifica"
 #: lib/vutuv_web/live/account_activity_live.ex:189
 #: lib/vutuv_web/live/admin/activity_live.ex:231
 #: lib/vutuv_web/live/admin/user_live.ex:184
-#: lib/vutuv_web/live/job_board_live.ex:257
-#: lib/vutuv_web/live/tag_live/timeline.ex:369
+#: lib/vutuv_web/live/job_board_live.ex:256
+#: lib/vutuv_web/live/tag_live/timeline.ex:365
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr "Azzera i filtri"
@@ -8247,7 +8245,7 @@ msgstr "Non è stato possibile verificare questo membro."
 msgid "Deactivated"
 msgstr "Disattivato"
 
-#: lib/vutuv_web/live/admin/user_delete_live.ex:195
+#: lib/vutuv_web/live/admin/user_delete_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Delete this account?"
 msgstr "Eliminare questo account?"
@@ -8299,7 +8297,7 @@ msgid "Incorrect PIN"
 msgstr "PIN errato"
 
 #: lib/vutuv_web/live/admin/user_delete_live.ex:145
-#: lib/vutuv_web/live/admin/user_detail_live.ex:102
+#: lib/vutuv_web/live/admin/user_detail_live.ex:97
 #: lib/vutuv_web/live/admin/user_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Joined"
@@ -8313,7 +8311,7 @@ msgstr ""
 "un'e-mail."
 
 #: lib/vutuv_web/live/admin/user_delete_live.ex:136
-#: lib/vutuv_web/templates/admin/account/index.html.heex:48
+#: lib/vutuv_web/templates/admin/account/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "No accounts match your search."
 msgstr "Nessun account corrisponde alla Sua ricerca."
@@ -8344,7 +8342,7 @@ msgstr "PIN scaduto"
 msgid "PIN registered"
 msgstr "Registrato con PIN"
 
-#: lib/vutuv_web/components/ui.ex:3711
+#: lib/vutuv_web/components/ui.ex:3819
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr "Pagina %{page} di %{pages}"
@@ -8367,7 +8365,7 @@ msgstr ""
 "aggiorna mentre digita e per impostazione predefinita mostra i membri "
 "registrati con PIN, dal più recente."
 
-#: lib/vutuv_web/live/admin/user_delete_live.ex:198
+#: lib/vutuv_web/live/admin/user_delete_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "This permanently deletes the account and everything it owns (posts, phone numbers, email addresses, tags and more). This cannot be undone. The member is not notified; a record is emailed to the operator."
 msgstr ""
@@ -8383,7 +8381,7 @@ msgstr ""
 "Digiti un nome, un @handle o un indirizzo e-mail per trovare l'account da "
 "eliminare."
 
-#: lib/vutuv_web/live/admin/user_detail_live.ex:93
+#: lib/vutuv_web/live/admin/user_detail_live.ex:88
 #: lib/vutuv_web/live/admin/user_live.ex:322
 #, elixir-autogen, elixir-format
 msgid "Unconfirmed"
@@ -8483,7 +8481,7 @@ msgstr "Titolo di studio"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:4680
+#: lib/vutuv_web/components/ui.ex:4788
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8542,7 +8540,7 @@ msgstr ""
 "Ecco cosa abbiamo trovato nella Sua esportazione. Tolga la spunta a ciò che "
 "non desidera. Le voci già presenti sul Suo profilo sono già senza spunta."
 
-#: lib/vutuv_web/components/ui.ex:4825
+#: lib/vutuv_web/components/ui.ex:4933
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importa"
@@ -8571,7 +8569,7 @@ msgstr "Importati: %{items}."
 msgid "Nothing new to import."
 msgstr "Nulla di nuovo da importare."
 
-#: lib/vutuv_web/components/ui.ex:4708
+#: lib/vutuv_web/components/ui.ex:4816
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8667,7 +8665,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Troppe importazioni. Riprovi tra poco."
 
-#: lib/vutuv_web/components/ui.ex:3988
+#: lib/vutuv_web/components/ui.ex:4092
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8675,7 +8673,7 @@ msgstr "Troppe importazioni. Riprovi tra poco."
 msgid "Please check the fields marked in red."
 msgstr "Controlli i campi contrassegnati in rosso."
 
-#: lib/vutuv_web/views/user_html.ex:1080
+#: lib/vutuv_web/views/user_html.ex:1086
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
 msgstr "Caricamento dei post"
@@ -8757,25 +8755,25 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr "Trascini qui il Suo file ZIP, oppure prema per sceglierne uno."
 
-#: lib/vutuv_web/components/ui.ex:4668
+#: lib/vutuv_web/components/ui.ex:4776
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr "Dati di base e foto"
 
-#: lib/vutuv_web/components/ui.ex:4815
+#: lib/vutuv_web/components/ui.ex:4923
 #: lib/vutuv_web/controllers/settings_controller.ex:125
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Language & display"
 msgstr "Lingua e visualizzazione"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:535
+#: lib/vutuv_web/templates/user/edit.html.heex:523
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr "Altre sezioni del profilo"
 
-#: lib/vutuv_web/components/ui.ex:4806
+#: lib/vutuv_web/components/ui.ex:4914
 #: lib/vutuv_web/controllers/settings_controller.ex:108
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8785,7 +8783,7 @@ msgstr "Altre sezioni del profilo"
 msgid "Sign-in & security"
 msgstr "Accesso e sicurezza"
 
-#: lib/vutuv_web/components/ui.ex:4829
+#: lib/vutuv_web/components/ui.ex:4937
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8901,7 +8899,7 @@ msgstr[1] "%{formatted} membri"
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr "La pagina %{letter} dell'elenco dei membri, ordinata per cognome."
 
-#: lib/vutuv_web/components/ui.ex:1322
+#: lib/vutuv_web/components/ui.ex:1346
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -9009,8 +9007,8 @@ msgstr "La scriva in Amministrazione › Pagine legali"
 #: lib/vutuv_web/agent_docs/text.ex:586
 #: lib/vutuv_web/agent_docs/text.ex:590
 #: lib/vutuv_web/components/organization_components.ex:276
-#: lib/vutuv_web/components/ui.ex:1523
-#: lib/vutuv_web/components/ui.ex:4796
+#: lib/vutuv_web/components/ui.ex:1547
+#: lib/vutuv_web/components/ui.ex:4904
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:357
 #: lib/vutuv_web/controllers/settings_controller.ex:424
@@ -9116,7 +9114,7 @@ msgstr "Esperienza professionale"
 msgid "Volunteering & hobbies"
 msgstr "Volontariato e hobby"
 
-#: lib/vutuv_web/live/search_live.ex:694
+#: lib/vutuv_web/live/search_live.ex:687
 #, elixir-autogen, elixir-format
 msgid "Not available while the search uses a people filter."
 msgstr "Non disponibile mentre la ricerca usa un filtro sulle persone."
@@ -9169,12 +9167,12 @@ msgstr ""
 "Questa è la versione di stampa del CV. Usi la finestra di stampa del browser"
 " (Ctrl+P o Cmd+P) e scelga \"Salva come PDF\" per ottenere un file PDF."
 
-#: lib/vutuv_web/components/ui.ex:1612
+#: lib/vutuv_web/components/ui.ex:1636
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr "Download del CV"
 
-#: lib/vutuv_web/components/post_components.ex:4618
+#: lib/vutuv_web/components/post_components.ex:4640
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9186,28 +9184,28 @@ msgstr[1] "Ripubblicato da %{name} e da altri %{formatted}"
 msgid "reposted by %{name} and %{count} more"
 msgstr "ripubblicato da %{name} e da altri %{count}"
 
-#: lib/vutuv_web/live/cv_live.ex:233
+#: lib/vutuv_web/live/cv_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Anonymize"
 msgstr "Rendi anonimo"
 
 #: lib/vutuv_web/live/cv_live.ex:149
-#: lib/vutuv_web/templates/page/index.html.heex:161
+#: lib/vutuv_web/templates/page/index.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr "Indirizzo e-mail"
 
-#: lib/vutuv_web/live/cv_live.ex:440
+#: lib/vutuv_web/live/cv_live.ex:430
 #, elixir-autogen, elixir-format
 msgid "Every download reflects the parts you selected."
 msgstr "Ogni download rispecchia le parti che ha selezionato."
 
-#: lib/vutuv_web/live/cv_live.ex:247
+#: lib/vutuv_web/live/cv_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr "Intestazione"
 
-#: lib/vutuv_web/components/ui.ex:1622
+#: lib/vutuv_web/components/ui.ex:1646
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -9226,7 +9224,7 @@ msgstr ""
 "Scelga cosa includere. Tolga la spunta a singole voci o a intere sezioni, "
 "oppure renda anonimo il CV nascondendo nome, foto e recapiti."
 
-#: lib/vutuv_web/live/cv_live.ex:449
+#: lib/vutuv_web/live/cv_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "Print / Save as PDF"
 msgstr "Stampa / Salva come PDF"
@@ -9244,7 +9242,7 @@ msgstr ""
 "solo ciò che può già vedere lì, e gli indirizzi e-mail privati compaiono "
 "solo nel Suo."
 
-#: lib/vutuv_web/components/ui.ex:1614
+#: lib/vutuv_web/components/ui.ex:1638
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -9283,7 +9281,7 @@ msgstr "Libero professionista / Lavoratore autonomo"
 msgid "Other activities"
 msgstr "Altre attività"
 
-#: lib/vutuv_web/live/cv_live.ex:463
+#: lib/vutuv_web/live/cv_live.ex:453
 #, elixir-autogen, elixir-format
 msgid "For a PDF, open the print view and choose \"Save as PDF\" in your browser's print dialog. Word and OpenDocument are editable; LaTeX is the typesetting source; JSON Resume is the open %{link} format."
 msgstr ""
@@ -9291,7 +9289,7 @@ msgstr ""
 "finestra di stampa del browser. Word e OpenDocument sono modificabili; LaTeX"
 " è il sorgente di impaginazione; JSON Resume è il formato aperto %{link}."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:263
+#: lib/vutuv_web/templates/user/edit.html.heex:258
 #, elixir-autogen, elixir-format
 msgid "characters"
 msgstr "caratteri"
@@ -9417,8 +9415,8 @@ msgstr "Questo tag può essere rimosso solo da un amministratore del sito."
 msgid "Yes"
 msgstr "Sì"
 
-#: lib/vutuv_web/components/ui.ex:2069
-#: lib/vutuv_web/components/ui.ex:2070
+#: lib/vutuv_web/components/ui.ex:2093
+#: lib/vutuv_web/components/ui.ex:2094
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9668,7 +9666,7 @@ msgstr "Lingua aggiornata."
 #: lib/vutuv_web/cv/html.ex:185
 #: lib/vutuv_web/cv/latex.ex:149
 #: lib/vutuv_web/cv/odt.ex:163
-#: lib/vutuv_web/live/cv_live.ex:386
+#: lib/vutuv_web/live/cv_live.ex:376
 #: lib/vutuv_web/templates/language/edit.html.heex:4
 #: lib/vutuv_web/templates/language/index.html.heex:10
 #: lib/vutuv_web/templates/language/manage.html.heex:4
@@ -9878,7 +9876,7 @@ msgstr "Non in cerca di lavoro"
 msgid "Open to offers"
 msgstr "Aperto a proposte"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:287
+#: lib/vutuv_web/templates/user/edit.html.heex:282
 #, elixir-autogen, elixir-format
 msgid "Shown as a badge next to your tagline so people can see whether you are open to opportunities."
 msgstr ""
@@ -9997,7 +9995,7 @@ msgstr "Certificati"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:4684
+#: lib/vutuv_web/components/ui.ex:4792
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -10005,7 +10003,7 @@ msgstr "Certificati"
 #: lib/vutuv_web/cv/html.ex:169
 #: lib/vutuv_web/cv/latex.ex:140
 #: lib/vutuv_web/cv/odt.ex:154
-#: lib/vutuv_web/live/cv_live.ex:361
+#: lib/vutuv_web/live/cv_live.ex:351
 #: lib/vutuv_web/templates/import/new.html.heex:11
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
 #: lib/vutuv_web/templates/qualification/index.html.heex:11
@@ -10042,7 +10040,7 @@ msgstr "Non scade"
 
 #: lib/vutuv_web/live/admin/job_live.ex:164
 #: lib/vutuv_web/live/admin/job_live.ex:180
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:183
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:182
 #: lib/vutuv_web/templates/qualification/show.html.heex:43
 #: lib/vutuv_web/views/qualification_html.ex:398
 #, elixir-autogen, elixir-format
@@ -10152,18 +10150,18 @@ msgstr "+%{code} è il prefisso telefonico di %{region}"
 msgid "Date of birth"
 msgstr "Data di nascita"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:440
-#: lib/vutuv_web/templates/user/edit.html.heex:523
+#: lib/vutuv_web/templates/user/edit.html.heex:436
+#: lib/vutuv_web/templates/user/edit.html.heex:511
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr "Rimuovi la data di nascita"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:503
+#: lib/vutuv_web/templates/user/edit.html.heex:499
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr "Rimuovere la Sua data di nascita?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:506
+#: lib/vutuv_web/templates/user/edit.html.heex:502
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -10171,14 +10169,14 @@ msgstr ""
 "profilo. Può reinserirla in qualsiasi momento."
 
 #: lib/vutuv_web/live/directory_search_live.ex:132
-#: lib/vutuv_web/templates/page/index.html.heex:90
+#: lib/vutuv_web/templates/page/index.html.heex:95
 #: lib/vutuv_web/views/account_event_text.ex:210
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Nome"
 
 #: lib/vutuv_web/live/directory_search_live.ex:133
-#: lib/vutuv_web/templates/page/index.html.heex:95
+#: lib/vutuv_web/templates/page/index.html.heex:100
 #: lib/vutuv_web/views/account_event_text.ex:211
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -10200,13 +10198,13 @@ msgstr "Link permanente al profilo"
 msgid "Dismiss"
 msgstr "Chiudi"
 
-#: lib/vutuv_web/components/ui.ex:3418
+#: lib/vutuv_web/components/ui.ex:3520
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Copiato"
 
-#: lib/vutuv_web/components/ui.ex:3417
-#: lib/vutuv_web/components/ui.ex:3425
+#: lib/vutuv_web/components/ui.ex:3519
+#: lib/vutuv_web/components/ui.ex:3527
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Copia"
@@ -10331,12 +10329,12 @@ msgstr ""
 msgid "Removed as spam"
 msgstr "Rimosso come spam"
 
-#: lib/vutuv_web/live/admin/user_live.ex:357
+#: lib/vutuv_web/live/admin/user_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Restore"
 msgstr "Ripristina"
 
-#: lib/vutuv_web/live/admin/user_live.ex:354
+#: lib/vutuv_web/live/admin/user_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "Restore this account so the member can sign in again?"
 msgstr "Ripristinare questo account perché il membro possa accedere di nuovo?"
@@ -10353,7 +10351,7 @@ msgstr ""
 "Grazie per la segnalazione. I nostri moderatori sono stati avvisati ed "
 "esamineranno questo account."
 
-#: lib/vutuv_web/views/admin/account_html.ex:88
+#: lib/vutuv_web/views/admin/account_html.ex:78
 #: lib/vutuv_web/views/admin/moderation_html.ex:69
 #, elixir-autogen, elixir-format
 msgid "deactivated"
@@ -10398,17 +10396,17 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr "App di autenticazione disattivata."
 
-#: lib/vutuv_web/components/ui.ex:384
+#: lib/vutuv_web/components/ui.ex:445
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr "Grassetto"
 
-#: lib/vutuv_web/components/ui.ex:436
+#: lib/vutuv_web/components/ui.ex:497
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr "Elenco puntato"
 
-#: lib/vutuv_web/components/ui.ex:439
+#: lib/vutuv_web/components/ui.ex:500
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr "Blocco di codice"
@@ -10418,20 +10416,20 @@ msgstr "Blocco di codice"
 msgid "Delete the list"
 msgstr "Elimina l'elenco"
 
-#: lib/vutuv_web/templates/login_code/index.html.heex:60
+#: lib/vutuv_web/templates/login_code/index.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "Delete your code list? All its codes stop working immediately."
 msgstr ""
 "Eliminare il Suo elenco di codici? Tutti i suoi codici smettono subito di "
 "funzionare."
 
-#: lib/vutuv_web/components/ui.ex:380
+#: lib/vutuv_web/components/ui.ex:441
 #, elixir-autogen, elixir-format
 msgid "Formatting"
 msgstr "Formattazione"
 
-#: lib/vutuv_web/components/ui.ex:503
-#: lib/vutuv_web/components/ui.ex:504
+#: lib/vutuv_web/components/ui.ex:564
+#: lib/vutuv_web/components/ui.ex:565
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr "Schermo intero"
@@ -10446,43 +10444,43 @@ msgstr "Genera un nuovo elenco"
 msgid "Generate code list"
 msgstr "Genera l'elenco dei codici"
 
-#: lib/vutuv_web/components/ui.ex:434
+#: lib/vutuv_web/components/ui.ex:495
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr "Titolo 1"
 
-#: lib/vutuv_web/components/ui.ex:435
+#: lib/vutuv_web/components/ui.ex:496
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr "Titolo 2"
 
-#: lib/vutuv_web/components/ui.ex:393
+#: lib/vutuv_web/components/ui.ex:454
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr "Codice in linea"
 
-#: lib/vutuv_web/components/ui.ex:387
+#: lib/vutuv_web/components/ui.ex:448
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr "Corsivo"
 
-#: lib/vutuv_web/components/ui.ex:540
+#: lib/vutuv_web/components/ui.ex:397
 #, elixir-autogen, elixir-format
 msgid "Link URL"
 msgstr "URL del link"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:166
+#: lib/vutuv_web/templates/settings/security.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Login codes"
 msgstr "Codici di accesso"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:179
+#: lib/vutuv_web/templates/settings/security.html.heex:178
 #: lib/vutuv_web/templates/settings/security.html.heex:213
 #, elixir-autogen, elixir-format
 msgid "Not set up."
 msgstr "Non configurata."
 
-#: lib/vutuv_web/components/ui.ex:437
+#: lib/vutuv_web/components/ui.ex:498
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr "Elenco numerato"
@@ -10499,7 +10497,7 @@ msgstr ""
 "Stampi questa pagina o annoti i codici. I codici barrati sono già stati "
 "usati."
 
-#: lib/vutuv_web/components/ui.ex:438
+#: lib/vutuv_web/components/ui.ex:499
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr "Citazione"
@@ -10525,7 +10523,7 @@ msgstr ""
 msgid "Set up"
 msgstr "Configura"
 
-#: lib/vutuv_web/components/ui.ex:390
+#: lib/vutuv_web/components/ui.ex:451
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr "Barrato"
@@ -10547,7 +10545,7 @@ msgstr "Per finire, inserisca il codice che la Sua app mostra adesso"
 msgid "Turn off"
 msgstr "Disattiva"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:187
+#: lib/vutuv_web/templates/settings/security.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "Turn off the authenticator app? Its codes stop working at login; the emailed PIN is unaffected."
 msgstr ""
@@ -10559,7 +10557,7 @@ msgstr ""
 msgid "Turn on"
 msgstr "Attiva"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:179
+#: lib/vutuv_web/templates/settings/security.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "Turned on."
 msgstr "Attivata."
@@ -10600,7 +10598,7 @@ msgstr ""
 "elenco di codici funziona qui, al posto del PIN inviato per e-mail."
 
 #: lib/vutuv_web/controllers/totp_controller.ex:90
-#: lib/vutuv_web/templates/settings/security.html.heex:176
+#: lib/vutuv_web/templates/settings/security.html.heex:175
 #: lib/vutuv_web/templates/totp/new.html.heex:2
 #: lib/vutuv_web/templates/totp/new.html.heex:6
 #, elixir-autogen, elixir-format
@@ -10615,7 +10613,7 @@ msgstr "App di autenticazione (TOTP)"
 msgid "One-time code list (OTP)"
 msgstr "Elenco di codici monouso (OTP)"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:168
+#: lib/vutuv_web/templates/settings/security.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Sign in with a one-time code (OTP) from an authenticator app or from a printed code list, typed into the normal PIN field. Your emailed PIN always keeps working."
 msgstr ""
@@ -10645,15 +10643,15 @@ msgstr[0] "%{count} stella"
 msgstr[1] "%{count} stelle"
 
 #: lib/vutuv_web/live/organization_live/show.ex:638
-#: lib/vutuv_web/views/user_html.ex:944
-#: lib/vutuv_web/views/user_html.ex:1120
+#: lib/vutuv_web/views/user_html.ex:950
+#: lib/vutuv_web/views/user_html.ex:1126
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
 msgstr[0] "%{formatted} follower"
 msgstr[1] "%{formatted} follower"
 
-#: lib/vutuv_web/views/user_html.ex:937
+#: lib/vutuv_web/views/user_html.ex:943
 #, elixir-autogen, elixir-format
 msgid "%{formatted} star"
 msgid_plural "%{formatted} stars"
@@ -10681,7 +10679,7 @@ msgstr ""
 " le statistiche pubbliche: stelle, repository, follower, linguaggi e "
 "attività recente."
 
-#: lib/vutuv_web/views/user_html.ex:951
+#: lib/vutuv_web/views/user_html.ex:957
 #, elixir-autogen, elixir-format
 msgid "Last active %{date}"
 msgstr "Ultima attività il %{date}"
@@ -10708,7 +10706,7 @@ msgstr "ultima attività il %{date}"
 msgid "since %{date}"
 msgstr "dal %{date}"
 
-#: lib/vutuv_web/views/user_html.ex:867
+#: lib/vutuv_web/views/user_html.ex:873
 #, elixir-autogen, elixir-format
 msgid "since %{year}"
 msgstr "dal %{year}"
@@ -10900,7 +10898,7 @@ msgstr ""
 "vutuv è la rete professionale aperta dove ci si collega, si condivide e ci "
 "si fa trovare. L'iscrizione è gratuita."
 
-#: lib/vutuv_web/templates/page/index.html.heex:150
+#: lib/vutuv_web/templates/page/index.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "At least three tags, separated by commas. A tag may be several words long, like Ruby on Rails."
 msgstr ""
@@ -10936,14 +10934,14 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] "Ha %{formatted} nuovo messaggio."
 msgstr[1] "Ha %{formatted} nuovi messaggi."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:390
+#: lib/vutuv_web/templates/settings/preferences.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 "Spezza le parole lunghe in corrispondenza delle sillabe, così il testo va a "
 "capo in modo uniforme. Utile nella colonna stretta del telefono."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:321
+#: lib/vutuv_web/templates/settings/preferences.html.heex:310
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
@@ -10951,35 +10949,35 @@ msgstr ""
 "le Sue preferenze di lettura personali."
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:397
+#: lib/vutuv_web/templates/settings/preferences.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr "Sillabazione su computer"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:401
+#: lib/vutuv_web/templates/settings/preferences.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr "Sillabazione su telefono"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:387
+#: lib/vutuv_web/templates/settings/preferences.html.heex:376
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr "Sillabazione"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:344
+#: lib/vutuv_web/templates/settings/preferences.html.heex:333
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr "Righe su computer"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:353
+#: lib/vutuv_web/templates/settings/preferences.html.heex:342
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr "Righe su telefono"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:339
+#: lib/vutuv_web/templates/settings/preferences.html.heex:328
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
@@ -10991,7 +10989,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr "Impostazioni di visualizzazione dei post salvate."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:336
+#: lib/vutuv_web/templates/settings/preferences.html.heex:325
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr "Accorcia un post dopo"
@@ -11077,7 +11075,7 @@ msgstr ""
 msgid "Preference defaults"
 msgstr "Valori predefiniti delle preferenze"
 
-#: lib/vutuv_web/live/admin/user_detail_live.ex:155
+#: lib/vutuv_web/live/admin/user_detail_live.ex:150
 #: lib/vutuv_web/live/admin/user_live.ex:336
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:10
 #, elixir-autogen, elixir-format
@@ -11093,9 +11091,9 @@ msgstr "Preferenze di %{name}"
 #: lib/vutuv_web/live/feed_languages_live.ex:377
 #: lib/vutuv_web/templates/settings/preferences.html.heex:101
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
-#: lib/vutuv_web/templates/settings/preferences.html.heex:239
-#: lib/vutuv_web/templates/settings/preferences.html.heex:303
-#: lib/vutuv_web/templates/settings/preferences.html.heex:421
+#: lib/vutuv_web/templates/settings/preferences.html.heex:229
+#: lib/vutuv_web/templates/settings/preferences.html.heex:292
+#: lib/vutuv_web/templates/settings/preferences.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr "Riporta ai valori predefiniti del sito"
@@ -11183,7 +11181,7 @@ msgstr ""
 msgid "Captured screenshots"
 msgstr "Screenshot acquisiti"
 
-#: lib/vutuv_web/live/admin/screenshot_live.ex:525
+#: lib/vutuv_web/live/admin/screenshot_live.ex:524
 #, elixir-autogen, elixir-format
 msgid "Capturing"
 msgstr "Acquisizione in corso"
@@ -11195,14 +11193,14 @@ msgstr ""
 "Ogni screenshot di link acquisito, dal più recente. Ciascuno rimanda alla "
 "pagina e al relativo post."
 
-#: lib/vutuv_web/live/admin/screenshot_live.ex:527
+#: lib/vutuv_web/live/admin/screenshot_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr "Non riuscito"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
-#: lib/vutuv_web/live/post_live/composer.ex:1778
-#: lib/vutuv_web/live/post_live/composer.ex:2480
+#: lib/vutuv_web/live/post_live/composer.ex:1754
+#: lib/vutuv_web/live/post_live/composer.ex:2419
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr "Galleria"
@@ -11241,7 +11239,7 @@ msgstr "Apri la coda degli screenshot"
 #: lib/vutuv_web/live/admin/organization_live.ex:165
 #: lib/vutuv_web/live/admin/organization_live.ex:179
 #: lib/vutuv_web/live/admin/organization_live.ex:194
-#: lib/vutuv_web/live/admin/screenshot_live.ex:524
+#: lib/vutuv_web/live/admin/screenshot_live.ex:523
 #: lib/vutuv_web/live/organization_live/domains.ex:201
 #, elixir-autogen, elixir-format
 msgid "Pending"
@@ -11258,7 +11256,7 @@ msgstr "Coda"
 msgid "Queued"
 msgstr "In coda"
 
-#: lib/vutuv_web/live/admin/screenshot_live.ex:526
+#: lib/vutuv_web/live/admin/screenshot_live.ex:525
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr "Pronto"
@@ -11300,7 +11298,7 @@ msgstr "Tentativi"
 msgid "Views"
 msgstr "Visualizzazioni"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:296
+#: lib/vutuv_web/templates/user/edit.html.heex:291
 #, elixir-autogen, elixir-format
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
@@ -11322,31 +11320,31 @@ msgstr "Nessuno"
 
 #: lib/vutuv/accounts/user.ex:1234
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
-#: lib/vutuv_web/live/job_posting_live/form.ex:773
+#: lib/vutuv_web/live/job_posting_live/form.ex:772
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr "Solo i membri connessi"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:293
+#: lib/vutuv_web/templates/user/edit.html.heex:288
 #: lib/vutuv_web/templates/welcome/show.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Who can see your availability?"
 msgstr "Chi può vedere la Sua disponibilità?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:318
+#: lib/vutuv_web/templates/user/edit.html.heex:313
 #: lib/vutuv_web/templates/welcome/show.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr "Importo"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:669
-#: lib/vutuv_web/templates/user/edit.html.heex:326
+#: lib/vutuv_web/live/job_posting_live/form.ex:668
+#: lib/vutuv_web/templates/user/edit.html.heex:321
 #: lib/vutuv_web/templates/welcome/show.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr "Valuta"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:336
+#: lib/vutuv_web/templates/user/edit.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "Hidden by default, and it still does its job while hidden. \"Signed-in members only\" adds a quiet line to your profile for members; \"Everyone\" also shows it to logged-out visitors."
 msgstr ""
@@ -11354,13 +11352,13 @@ msgstr ""
 " \"Solo i membri connessi\" aggiunge al Suo profilo una riga discreta per i "
 "membri; \"Tutti\" la mostra anche ai visitatori non connessi."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:309
+#: lib/vutuv_web/templates/user/edit.html.heex:304
 #: lib/vutuv_web/templates/welcome/show.html.heex:114
 #, elixir-autogen, elixir-format
 msgid "Minimum salary expectation"
 msgstr "Retribuzione minima desiderata"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:312
+#: lib/vutuv_web/templates/user/edit.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
@@ -11368,8 +11366,8 @@ msgstr ""
 "avvisi, escludendo gli annunci al di sotto. Lasci vuoto l'importo per "
 "rimuoverla."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:676
-#: lib/vutuv_web/templates/user/edit.html.heex:322
+#: lib/vutuv_web/live/job_posting_live/form.ex:675
+#: lib/vutuv_web/templates/user/edit.html.heex:317
 #: lib/vutuv_web/templates/welcome/show.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Per"
@@ -11381,7 +11379,7 @@ msgid "Salary expectation from %{amount} %{currency} per %{period}"
 msgstr ""
 "Retribuzione desiderata a partire da %{amount} %{currency} per %{period}"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:333
+#: lib/vutuv_web/templates/user/edit.html.heex:328
 #, elixir-autogen, elixir-format
 msgid "Who can see your salary expectation?"
 msgstr "Chi può vedere la Sua retribuzione desiderata?"
@@ -11431,7 +11429,7 @@ msgid "Email domain"
 msgstr "Dominio e-mail"
 
 #: lib/vutuv_web/components/job_exclusion_components.ex:110
-#: lib/vutuv_web/components/job_exclusion_components.ex:230
+#: lib/vutuv_web/components/job_exclusion_components.ex:225
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:144
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:169
 #, elixir-autogen, elixir-format
@@ -11450,7 +11448,7 @@ msgstr "Escludi un membro"
 msgid "Exclude an email domain"
 msgstr "Escludi un dominio e-mail"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:389
+#: lib/vutuv_web/templates/user/edit.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr "Nascondi a persone specifiche"
@@ -11461,7 +11459,7 @@ msgstr "Nascondi a persone specifiche"
 msgid "Job-search exclusion list"
 msgstr "Elenco di esclusioni per la ricerca di lavoro"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:392
+#: lib/vutuv_web/templates/user/edit.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
@@ -11470,7 +11468,7 @@ msgstr ""
 "specifici: non vedranno mai la Sua disponibilità né la Sua retribuzione "
 "desiderata, nemmeno con l'impostazione \"Tutti\"."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:400
+#: lib/vutuv_web/templates/user/edit.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -11520,7 +11518,7 @@ msgstr "Il Suo elenco di esclusioni è pieno (max %{count})."
 msgid "Your list is empty. Nobody is excluded yet."
 msgstr "Il Suo elenco è vuoto. Non è ancora escluso nessuno."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:363
+#: lib/vutuv_web/live/organization_live/edit.ex:358
 #: lib/vutuv_web/views/account_event_text.ex:232
 #, elixir-autogen, elixir-format
 msgid "AI agents"
@@ -11531,24 +11529,24 @@ msgstr "Agenti IA"
 msgid "About"
 msgstr "Presentazione"
 
-#: lib/vutuv_web/live/organization_live/new.ex:225
+#: lib/vutuv_web/live/organization_live/new.ex:221
 #, elixir-autogen, elixir-format
 msgid "Continue to verification"
 msgstr "Prosegui con la verifica"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:265
-#: lib/vutuv_web/live/organization_live/domains.ex:305
+#: lib/vutuv_web/live/organization_live/domains.ex:264
+#: lib/vutuv_web/live/organization_live/domains.ex:299
 #: lib/vutuv_web/live/organization_live/new.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:1038
+#: lib/vutuv_web/live/organization_live/show.ex:1033
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
 msgstr "Record DNS TXT"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:184
-#: lib/vutuv_web/live/organization_live/domains.ex:346
-#: lib/vutuv_web/live/organization_live/show.ex:1104
-#: lib/vutuv_web/live/organization_live/show.ex:1112
+#: lib/vutuv_web/live/organization_live/domains.ex:339
+#: lib/vutuv_web/live/organization_live/show.ex:1098
+#: lib/vutuv_web/live/organization_live/show.ex:1106
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr "La verifica dei domini è disattivata su questa installazione."
@@ -11559,7 +11557,7 @@ msgstr "La verifica dei domini è disattivata su questa installazione."
 msgid "Edit %{name}"
 msgstr "Modifica %{name}"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:349
+#: lib/vutuv_web/live/organization_live/edit.ex:344
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this page and include it in the sitemap."
 msgstr ""
@@ -11571,7 +11569,7 @@ msgstr ""
 msgid "Logo"
 msgstr "Logo"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:365
+#: lib/vutuv_web/live/organization_live/edit.ex:360
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
@@ -11584,22 +11582,22 @@ msgstr ""
 msgid "Please log in first."
 msgstr "Prima acceda."
 
-#: lib/vutuv_web/live/organization_live/show.ex:1011
+#: lib/vutuv_web/live/organization_live/show.ex:1006
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr "Dimostri di controllare %{domain} per pubblicare questa pagina."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:283
+#: lib/vutuv_web/live/organization_live/edit.ex:278
 #, elixir-autogen, elixir-format
 msgid "Remove logo"
 msgstr "Rimuovi il logo"
 
-#: lib/vutuv_web/live/organization_live/index.ex:83
+#: lib/vutuv_web/live/organization_live/index.ex:81
 #, elixir-autogen, elixir-format
 msgid "Search by name or city"
 msgstr "Cerchi per nome o città"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:347
+#: lib/vutuv_web/live/organization_live/edit.ex:342
 #: lib/vutuv_web/views/account_event_text.ex:231
 #, elixir-autogen, elixir-format
 msgid "Search engines"
@@ -11610,35 +11608,35 @@ msgstr "Motori di ricerca"
 msgid "Select a country"
 msgstr "Selezioni un paese"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:1073
+#: lib/vutuv_web/live/organization_live/domains.ex:318
+#: lib/vutuv_web/live/organization_live/show.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr "Pubblichi questo file all'indirizzo:"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:328
+#: lib/vutuv_web/live/organization_live/edit.ex:323
 #: lib/vutuv_web/live/organization_live/new.ex:139
 #, elixir-autogen, elixir-format
 msgid "State / region (optional)"
 msgstr "Provincia / regione (facoltativo)"
 
-#: lib/vutuv_web/components/ui.ex:4042
+#: lib/vutuv_web/components/ui.ex:4146
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr "Questo tipo di file non è ammesso."
 
-#: lib/vutuv_web/components/ui.ex:4044
+#: lib/vutuv_web/components/ui.ex:4148
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr "Il caricamento non è riuscito."
 
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:1026
+#: lib/vutuv_web/live/organization_live/show.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr "Metodo di verifica"
 
-#: lib/vutuv_web/live/organization_live/show.ex:937
+#: lib/vutuv_web/live/organization_live/show.ex:932
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr "Domini verificati"
@@ -11649,33 +11647,33 @@ msgstr "Domini verificati"
 msgid "Verified via"
 msgstr "Verificato tramite"
 
-#: lib/vutuv_web/live/organization_live/show.ex:997
+#: lib/vutuv_web/live/organization_live/show.ex:992
 #, elixir-autogen, elixir-format
 msgid "Verified via %{domain}"
 msgstr "Verificato tramite %{domain}"
 
-#: lib/vutuv_web/live/organization_live/show.ex:1008
+#: lib/vutuv_web/live/organization_live/show.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr "Verifica %{name}"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:340
-#: lib/vutuv_web/live/organization_live/show.ex:1098
+#: lib/vutuv_web/live/organization_live/domains.ex:333
+#: lib/vutuv_web/live/organization_live/show.ex:1092
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr "Verifica ora"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:262
 #: lib/vutuv_web/agent_docs/text.ex:245
-#: lib/vutuv_web/live/organization_live/edit.ex:322
+#: lib/vutuv_web/live/organization_live/edit.ex:317
 #: lib/vutuv_web/live/organization_live/new.ex:130
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr "Sito web"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:266
-#: lib/vutuv_web/live/organization_live/domains.ex:315
-#: lib/vutuv_web/live/organization_live/show.ex:1049
+#: lib/vutuv_web/live/organization_live/domains.ex:265
+#: lib/vutuv_web/live/organization_live/domains.ex:309
+#: lib/vutuv_web/live/organization_live/show.ex:1044
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11693,8 +11691,8 @@ msgstr ""
 "Nel passo successivo pubblicherà un record o un file per dimostrare di "
 "controllare il dominio."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:326
-#: lib/vutuv_web/live/organization_live/show.ex:1079
+#: lib/vutuv_web/live/organization_live/domains.ex:320
+#: lib/vutuv_web/live/organization_live/show.ex:1074
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11706,12 +11704,12 @@ msgid "@handle or email"
 msgstr "@handle o e-mail"
 
 #: lib/vutuv_web/components/organization_components.ex:333
-#: lib/vutuv_web/live/organization_live/edit.ex:425
+#: lib/vutuv_web/live/organization_live/edit.ex:412
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
 msgstr "Sigla"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:253
+#: lib/vutuv_web/live/organization_live/domains.ex:252
 #, elixir-autogen, elixir-format
 msgid "Add a domain"
 msgstr "Aggiungi un dominio"
@@ -11727,7 +11725,7 @@ msgid "Added @%{handle} to the team."
 msgstr "@%{handle} è stato aggiunto al team."
 
 #: lib/vutuv_web/components/organization_components.ex:334
-#: lib/vutuv_web/live/organization_live/edit.ex:423
+#: lib/vutuv_web/live/organization_live/edit.ex:410
 #, elixir-autogen, elixir-format
 msgid "Alias"
 msgstr "Alias"
@@ -11744,24 +11742,24 @@ msgstr "Alias rimosso."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:436
 #: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/live/organization_live/edit.ex:388
-#: lib/vutuv_web/live/organization_live/show.ex:925
+#: lib/vutuv_web/live/organization_live/edit.ex:375
+#: lib/vutuv_web/live/organization_live/show.ex:920
 #: lib/vutuv_web/templates/tag/single_card.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Also known as"
 msgstr "Noto anche come"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:419
+#: lib/vutuv_web/live/organization_live/edit.ex:406
 #, elixir-autogen, elixir-format
 msgid "Alternative name"
 msgstr "Nome alternativo"
 
-#: lib/vutuv_web/live/admin/organization_live.ex:389
+#: lib/vutuv_web/live/admin/organization_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Archive"
 msgstr "Archivia"
 
-#: lib/vutuv_web/live/admin/organization_live.ex:386
+#: lib/vutuv_web/live/admin/organization_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Archive this page?"
 msgstr "Archiviare questa pagina?"
@@ -11773,7 +11771,7 @@ msgid "Archived"
 msgstr "Archiviata"
 
 #: lib/vutuv_web/components/organization_components.ex:332
-#: lib/vutuv_web/live/organization_live/edit.ex:424
+#: lib/vutuv_web/live/organization_live/edit.ex:411
 #, elixir-autogen, elixir-format
 msgid "Brand"
 msgstr "Marchio"
@@ -11783,12 +11781,12 @@ msgstr "Marchio"
 msgid "Claimed by"
 msgstr "Rivendicata da"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:220
+#: lib/vutuv_web/live/organization_live/roles.ex:215
 #, elixir-autogen, elixir-format
 msgid "Current team"
 msgstr "Team attuale"
 
-#: lib/vutuv_web/live/admin/organization_live.ex:395
+#: lib/vutuv_web/live/admin/organization_live.ex:397
 #, elixir-autogen, elixir-format
 msgid "Delete this page and everything it owns? This cannot be undone."
 msgstr ""
@@ -11828,14 +11826,14 @@ msgstr "Domini – %{name}"
 msgid "Former name"
 msgstr "Nome precedente"
 
-#: lib/vutuv_web/live/admin/job_live.ex:461
-#: lib/vutuv_web/live/admin/organization_live.ex:370
-#: lib/vutuv_web/views/admin/account_html.ex:45
+#: lib/vutuv_web/live/admin/job_live.ex:460
+#: lib/vutuv_web/live/admin/organization_live.ex:373
+#: lib/vutuv_web/views/admin/account_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Freeze"
 msgstr "Blocca"
 
-#: lib/vutuv_web/live/admin/organization_live.ex:367
+#: lib/vutuv_web/live/admin/organization_live.ex:371
 #, elixir-autogen, elixir-format
 msgid "Freeze this page? It disappears for the public but stays visible to its owner."
 msgstr ""
@@ -11848,7 +11846,7 @@ msgstr ""
 msgid "Last checked"
 msgstr "Ultimo controllo"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:247
+#: lib/vutuv_web/live/organization_live/roles.ex:242
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr "Esci"
@@ -11863,7 +11861,7 @@ msgstr "Esci"
 msgid "Live"
 msgstr "Online"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:237
+#: lib/vutuv_web/live/organization_live/domains.ex:236
 #, elixir-autogen, elixir-format
 msgid "Make primary"
 msgstr "Rendi principale"
@@ -11913,12 +11911,12 @@ msgstr "Selezionatore"
 msgid "Remove this domain?"
 msgstr "Rimuovere questo dominio?"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:242
+#: lib/vutuv_web/live/organization_live/roles.ex:238
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the team?"
 msgstr "Rimuovere questo membro dal team?"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:405
+#: lib/vutuv_web/live/organization_live/edit.ex:393
 #, elixir-autogen, elixir-format
 msgid "Remove this name?"
 msgstr "Rimuovere questo nome?"
@@ -11951,9 +11949,9 @@ msgstr "Questo non è un dominio valido."
 msgid "That member could not be added."
 msgstr "Non è stato possibile aggiungere questo membro."
 
-#: lib/vutuv_web/live/admin/job_live.ex:470
-#: lib/vutuv_web/live/admin/organization_live.ex:379
-#: lib/vutuv_web/views/admin/account_html.ex:31
+#: lib/vutuv_web/live/admin/job_live.ex:468
+#: lib/vutuv_web/live/admin/organization_live.ex:381
+#: lib/vutuv_web/views/admin/account_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "Unfreeze"
 msgstr "Sblocca"
@@ -11975,24 +11973,24 @@ msgstr "principale"
 msgid "verified"
 msgstr "verificato"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:325
+#: lib/vutuv_web/live/organization_live/edit.ex:320
 #: lib/vutuv_web/live/organization_live/new.ex:136
 #, elixir-autogen, elixir-format
 msgid "Street address (optional)"
 msgstr "Via e numero (facoltativo)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:326
+#: lib/vutuv_web/live/organization_live/edit.ex:321
 #: lib/vutuv_web/live/organization_live/new.ex:137
 #, elixir-autogen, elixir-format
 msgid "ZIP / postal code (optional)"
 msgstr "CAP (facoltativo)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:482
+#: lib/vutuv_web/live/organization_live/edit.ex:461
 #, elixir-autogen, elixir-format
 msgid "Claim"
 msgstr "Rivendica"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:451
+#: lib/vutuv_web/live/organization_live/edit.ex:433
 #, elixir-autogen, elixir-format
 msgid "Reachable at"
 msgstr "Raggiungibile a"
@@ -12002,12 +12000,12 @@ msgstr "Raggiungibile a"
 msgid "That handle is not available."
 msgstr "Questo handle non è disponibile."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:488
+#: lib/vutuv_web/live/organization_live/edit.ex:467
 #, elixir-autogen, elixir-format
 msgid "Danger zone"
 msgstr "Zona pericolosa"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:499
+#: lib/vutuv_web/live/organization_live/edit.ex:479
 #, elixir-autogen, elixir-format
 msgid "Really delete %{name}? This cannot be undone."
 msgstr "Eliminare davvero %{name}? L'operazione non si può annullare."
@@ -12030,7 +12028,7 @@ msgid "Back-link (rel=me)"
 msgstr "Link di ritorno (rel=me)"
 
 #: lib/vutuv_web/templates/url/verify.html.heex:25
-#: lib/vutuv_web/views/url_html.ex:71
+#: lib/vutuv_web/views/url_html.ex:65
 #, elixir-autogen, elixir-format
 msgid "Link verification is disabled on this installation."
 msgstr "La verifica dei link è disattivata su questa installazione."
@@ -12059,7 +12057,7 @@ msgstr ""
 "Il testo del link può essere qualsiasi. Va bene anche un <link rel=\"me\"> "
 "nascosto nell'head della pagina."
 
-#: lib/vutuv_web/components/ui.ex:1038
+#: lib/vutuv_web/components/ui.ex:1062
 #: lib/vutuv_web/live/section_reorder_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -12164,7 +12162,7 @@ msgstr[1] ""
 "%{count} alias coincidono con un'altra organizzazione verificata e sono "
 "segnalati per la revisione. Apra un'organizzazione qui sotto per vederli."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:390
+#: lib/vutuv_web/live/organization_live/edit.ex:377
 #, elixir-autogen, elixir-format
 msgid "Alternative names, brands or abbreviations this organization is findable under. A rename keeps the old name here automatically."
 msgstr ""
@@ -12207,11 +12205,11 @@ msgstr ""
 "appartiene a questo dominio o a un suo sottodominio. È il modo affidabile "
 "per nascondersi all'intera organizzazione."
 
-#: lib/vutuv_web/live/organization_live/index.ex:70
-#: lib/vutuv_web/live/organization_live/index.ex:101
+#: lib/vutuv_web/live/organization_live/index.ex:68
+#: lib/vutuv_web/live/organization_live/index.ex:99
 #: lib/vutuv_web/live/organization_live/new.ex:28
 #: lib/vutuv_web/live/organization_live/new.ex:95
-#: lib/vutuv_web/templates/settings/organizations.html.heex:118
+#: lib/vutuv_web/templates/settings/organizations.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Add your organization"
 msgstr "Aggiunga la Sua organizzazione"
@@ -12244,7 +12242,7 @@ msgstr ""
 "successivo mostriamo le istruzioni esatte, così può semplicemente "
 "inoltrarle."
 
-#: lib/vutuv_web/live/organization_live/show.ex:1020
+#: lib/vutuv_web/live/organization_live/show.ex:1015
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
@@ -12252,12 +12250,12 @@ msgstr ""
 "o il file mostrato qui sotto e lo invii al Suo reparto IT o a chi gestisce "
 "il sito. Quando l'avranno aggiunto, torni qui e prema Verifica ora."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:503
+#: lib/vutuv_web/live/organization_live/edit.ex:482
 #, elixir-autogen, elixir-format
 msgid "Delete this organization"
 msgstr "Elimina questa organizzazione"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:490
+#: lib/vutuv_web/live/organization_live/edit.ex:469
 #, elixir-autogen, elixir-format
 msgid "Deleting this organization page is permanent. Its verified domains and its @handle are freed and can be claimed again."
 msgstr ""
@@ -12265,13 +12263,13 @@ msgstr ""
 "domini verificati e il suo @handle tornano liberi e possono essere "
 "rivendicati di nuovo."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:297
+#: lib/vutuv_web/live/organization_live/edit.ex:292
 #: lib/vutuv_web/live/organization_live/new.ex:126
 #, elixir-autogen, elixir-format
 msgid "Kind of organization"
 msgstr "Tipo di organizzazione"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:241
+#: lib/vutuv_web/live/organization_live/roles.ex:237
 #, elixir-autogen, elixir-format
 msgid "Leave this organization team?"
 msgstr "Uscire dal team di questa organizzazione?"
@@ -12286,13 +12284,13 @@ msgstr "Coincide con un'altra organizzazione verificata"
 msgid "No organization pages match."
 msgstr "Nessuna pagina di organizzazione corrisponde."
 
-#: lib/vutuv_web/live/organization_live/index.ex:92
+#: lib/vutuv_web/live/organization_live/index.ex:90
 #, elixir-autogen, elixir-format
 msgid "No organization pages yet. Be the first to add yours."
 msgstr ""
 "Ancora nessuna pagina di organizzazione. Sia il primo ad aggiungere la Sua."
 
-#: lib/vutuv_web/live/organization_live/index.ex:94
+#: lib/vutuv_web/live/organization_live/index.ex:92
 #, elixir-autogen, elixir-format
 msgid "No organizations found for %{term}."
 msgstr "Nessuna organizzazione trovata per %{term}."
@@ -12334,7 +12332,7 @@ msgstr "Organizzazione eliminata."
 msgid "Organization frozen."
 msgstr "Organizzazione bloccata."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:296
+#: lib/vutuv_web/live/organization_live/edit.ex:291
 #: lib/vutuv_web/live/organization_live/new.ex:125
 #, elixir-autogen, elixir-format
 msgid "Organization name"
@@ -12366,12 +12364,12 @@ msgstr "Organizzazione sbloccata."
 #: lib/vutuv_web/agent_docs/markdown.ex:427
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:400
-#: lib/vutuv_web/components/ui.ex:4833
+#: lib/vutuv_web/components/ui.ex:4941
 #: lib/vutuv_web/controllers/settings_controller.ex:213
-#: lib/vutuv_web/live/organization_live/index.ex:30
-#: lib/vutuv_web/live/organization_live/index.ex:61
+#: lib/vutuv_web/live/organization_live/index.ex:32
+#: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1322
+#: lib/vutuv_web/live/shell_live.ex:1318
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:79
@@ -12398,7 +12396,7 @@ msgstr ""
 msgid "Please log in to claim an organization page."
 msgstr "Acceda per rivendicare una pagina di organizzazione."
 
-#: lib/vutuv_web/live/organization_live/index.ex:75
+#: lib/vutuv_web/live/organization_live/index.ex:73
 #, elixir-autogen, elixir-format
 msgid "Search organizations"
 msgstr "Cerchi le organizzazioni"
@@ -12491,7 +12489,7 @@ msgstr "L'ha nominata amministratore di %{organization}."
 msgid "made you an owner of %{organization}."
 msgstr "L'ha nominata proprietario di %{organization}."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:472
+#: lib/vutuv_web/live/organization_live/edit.ex:454
 #, elixir-autogen, elixir-format
 msgid "your_organization"
 msgstr "la_sua_organizzazione"
@@ -12538,7 +12536,7 @@ msgid "Public authority"
 msgstr "Ente pubblico"
 
 #: lib/vutuv_web/live/admin/job_live.ex:371
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:138
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:136
 #, elixir-autogen, elixir-format
 msgid "%{views} views · %{clicks} apply clicks"
 msgstr "%{views} visualizzazioni · %{clicks} clic per candidarsi"
@@ -12548,24 +12546,24 @@ msgstr "%{views} visualizzazioni · %{clicks} clic per candidarsi"
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr "Un annuncio di lavoro falso, ingannevole o discriminatorio."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:653
+#: lib/vutuv_web/live/job_posting_live/form.ex:652
 #, elixir-autogen, elixir-format
 msgid "A pay range is required to publish (except volunteer postings)."
 msgstr ""
 "Per pubblicare serve una fascia retributiva (tranne che per gli annunci di "
 "volontariato)."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:750
+#: lib/vutuv_web/live/job_posting_live/form.ex:749
 #, elixir-autogen, elixir-format
 msgid "A vutuv message to me"
 msgstr "Un messaggio vutuv a me"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:748
+#: lib/vutuv_web/live/job_posting_live/form.ex:747
 #, elixir-autogen, elixir-format
 msgid "A website"
 msgstr "Un sito web"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:749
+#: lib/vutuv_web/live/job_posting_live/form.ex:748
 #, elixir-autogen, elixir-format
 msgid "An e-mail address"
 msgstr "Un indirizzo e-mail"
@@ -12575,12 +12573,12 @@ msgstr "Un indirizzo e-mail"
 msgid "Applicants must be located in"
 msgstr "I candidati devono trovarsi in"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:754
+#: lib/vutuv_web/live/job_posting_live/form.ex:753
 #, elixir-autogen, elixir-format
 msgid "Application URL"
 msgstr "URL per la candidatura"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:760
+#: lib/vutuv_web/live/job_posting_live/form.ex:759
 #, elixir-autogen, elixir-format
 msgid "Application e-mail"
 msgstr "Indirizzo e-mail per la candidatura"
@@ -12590,17 +12588,17 @@ msgstr "Indirizzo e-mail per la candidatura"
 msgid "Application: %{title}"
 msgstr "Candidatura: %{title}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:746
+#: lib/vutuv_web/live/job_posting_live/form.ex:745
 #, elixir-autogen, elixir-format
 msgid "Applications go to"
 msgstr "Le candidature arrivano a"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:275
+#: lib/vutuv_web/live/job_posting_live/show.ex:270
 #, elixir-autogen, elixir-format
 msgid "Apply by e-mail"
 msgstr "Si candidi per e-mail"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:274
+#: lib/vutuv_web/live/job_posting_live/show.ex:269
 #, elixir-autogen, elixir-format
 msgid "Apply on website"
 msgstr "Si candidi sul sito web"
@@ -12612,7 +12610,7 @@ msgstr "Apprendistato"
 
 #: lib/vutuv_web/live/admin/job_live.ex:163
 #: lib/vutuv_web/live/admin/job_live.ex:183
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:184
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:183
 #, elixir-autogen, elixir-format
 msgid "Closed"
 msgstr "Chiuso"
@@ -12622,12 +12620,12 @@ msgstr "Chiuso"
 msgid "Contract"
 msgstr "Collaborazione"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:693
+#: lib/vutuv_web/live/job_posting_live/form.ex:692
 #, elixir-autogen, elixir-format
 msgid "Describe the role. Markdown is supported."
 msgstr "Descriva il ruolo. Markdown è supportato."
 
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:182
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
 #, elixir-autogen, elixir-format
 msgid "Drafts"
 msgstr "Bozze"
@@ -12657,19 +12655,19 @@ msgstr "Nome del datore di lavoro (facoltativo)"
 #: lib/vutuv_web/agent_docs/markdown.ex:489
 #: lib/vutuv_web/agent_docs/text.ex:265
 #: lib/vutuv_web/agent_docs/text.ex:508
-#: lib/vutuv_web/live/job_board_live.ex:367
+#: lib/vutuv_web/live/job_board_live.ex:363
 #: lib/vutuv_web/live/job_posting_live/form.ex:474
 #, elixir-autogen, elixir-format
 msgid "Employment type"
 msgstr "Tipo di contratto"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:772
+#: lib/vutuv_web/live/job_posting_live/form.ex:771
 #, elixir-autogen, elixir-format
 msgid "Everyone (public)"
 msgstr "Tutti (pubblico)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:657
-#: lib/vutuv_web/live/tag_live/timeline.ex:350
+#: lib/vutuv_web/live/job_posting_live/form.ex:656
+#: lib/vutuv_web/live/tag_live/timeline.ex:346
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
 #, elixir-autogen, elixir-format
@@ -12681,12 +12679,12 @@ msgstr "Da"
 msgid "Full-time"
 msgstr "Tempo pieno"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:159
+#: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
 msgid "Highlighted tags match your profile."
 msgstr "I tag evidenziati corrispondono al Suo profilo."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:744
+#: lib/vutuv_web/live/job_posting_live/form.ex:743
 #, elixir-autogen, elixir-format
 msgid "How to apply"
 msgstr "Come candidarsi"
@@ -12702,7 +12700,7 @@ msgstr "Ibrido"
 msgid "I'm interested in your posting: %{url}"
 msgstr "Mi interessa il Suo annuncio: %{url}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:692
+#: lib/vutuv_web/live/job_posting_live/form.ex:691
 #, elixir-autogen, elixir-format
 msgid "Job description"
 msgstr "Descrizione della posizione"
@@ -12717,13 +12715,13 @@ msgstr "Titolo della posizione"
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1144
+#: lib/vutuv_web/live/shell_live.ex:1140
 #: lib/vutuv_web/templates/layout/app.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Jobs"
 msgstr "Lavoro"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:782
+#: lib/vutuv_web/live/job_posting_live/form.ex:781
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this posting."
 msgstr "Consenti ai motori di ricerca di indicizzare questo annuncio."
@@ -12744,12 +12742,12 @@ msgstr "Luogo"
 msgid "Mark as filled"
 msgstr "Segna come coperta"
 
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:157
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:158
 #, elixir-autogen, elixir-format
 msgid "Mark this posting as filled and close it?"
 msgstr "Segnare questo annuncio come coperto e chiuderlo?"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:276
+#: lib/vutuv_web/live/job_posting_live/show.ex:271
 #, elixir-autogen, elixir-format
 msgid "Message the poster"
 msgstr "Scriva a chi ha pubblicato"
@@ -12766,7 +12764,7 @@ msgstr "Annuncio di lavoro ingannevole"
 
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:25
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:101
-#: lib/vutuv_web/live/job_posting_live/show.ex:181
+#: lib/vutuv_web/live/job_posting_live/show.ex:176
 #, elixir-autogen, elixir-format
 msgid "My postings"
 msgstr "I miei annunci"
@@ -12776,7 +12774,7 @@ msgstr "I miei annunci"
 msgid "New accounts can publish after a few days."
 msgstr "I nuovi account possono pubblicare dopo qualche giorno."
 
-#: lib/vutuv_web/live/job_posting_live/dashboard.ex:103
+#: lib/vutuv_web/live/job_posting_live/dashboard.ex:102
 #: lib/vutuv_web/live/job_posting_live/form.ex:114
 #, elixir-autogen, elixir-format
 msgid "New posting"
@@ -12784,8 +12782,8 @@ msgstr "Nuovo annuncio"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:292
 #: lib/vutuv_web/agent_docs/text.ex:275
-#: lib/vutuv_web/live/job_posting_live/form.ex:732
-#: lib/vutuv_web/live/job_posting_live/show.ex:154
+#: lib/vutuv_web/live/job_posting_live/form.ex:731
+#: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
 msgstr "Gradito"
@@ -12806,7 +12804,7 @@ msgid "Nothing here yet. Jobs you like show up here."
 msgstr ""
 "Qui non c'è ancora nulla. Gli annunci a cui mette Mi piace compaiono qui."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:788
+#: lib/vutuv_web/live/job_posting_live/form.ex:787
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
@@ -12830,7 +12828,7 @@ msgstr ""
 msgid "Part-time"
 msgstr "Tempo parziale"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:651
+#: lib/vutuv_web/live/job_posting_live/form.ex:650
 #, elixir-autogen, elixir-format
 msgid "Pay"
 msgstr "Retribuzione"
@@ -12876,7 +12874,7 @@ msgstr "CAP"
 #: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/text.ex:269
 #: lib/vutuv_web/agent_docs/text.ex:512
-#: lib/vutuv_web/live/job_posting_live/show.ex:133
+#: lib/vutuv_web/live/job_posting_live/show.ex:128
 #, elixir-autogen, elixir-format
 msgid "Posted"
 msgstr "Pubblicato"
@@ -12892,7 +12890,7 @@ msgstr "Lingua dell'annuncio"
 msgid "Posting not found."
 msgstr "Annuncio non trovato."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:805
+#: lib/vutuv_web/live/job_posting_live/form.ex:802
 #, elixir-autogen, elixir-format
 msgid "Publish"
 msgstr "Pubblica"
@@ -12910,15 +12908,15 @@ msgstr "Pubblica"
 msgid "Remote"
 msgstr "Da remoto"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:169
+#: lib/vutuv_web/live/job_posting_live/show.ex:164
 #, elixir-autogen, elixir-format
 msgid "Report this posting"
 msgstr "Segnala questo annuncio"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:291
 #: lib/vutuv_web/agent_docs/text.ex:274
-#: lib/vutuv_web/live/job_posting_live/form.ex:722
-#: lib/vutuv_web/live/job_posting_live/show.ex:149
+#: lib/vutuv_web/live/job_posting_live/form.ex:721
+#: lib/vutuv_web/live/job_posting_live/show.ex:144
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr "Richiesto"
@@ -12957,7 +12955,7 @@ msgstr "Qualcosa è andato storto. Riprovi."
 msgid "Street (optional)"
 msgstr "Via (facoltativo)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:719
+#: lib/vutuv_web/live/job_posting_live/form.ex:718
 #, elixir-autogen, elixir-format
 msgid "Tags match your posting to members. Separate them with commas; a tag may be several words long, like Ruby on Rails."
 msgstr ""
@@ -12998,7 +12996,7 @@ msgstr ""
 "un suggerimento, non un parere legale."
 
 #: lib/vutuv_web/components/job_components.ex:112
-#: lib/vutuv_web/live/job_posting_live/show.ex:209
+#: lib/vutuv_web/live/job_posting_live/show.ex:204
 #, elixir-autogen, elixir-format
 msgid "Verified organization"
 msgstr "Organizzazione verificata"
@@ -13014,7 +13012,7 @@ msgstr "Volontariato"
 msgid "Volunteer"
 msgstr "Volontario"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:770
+#: lib/vutuv_web/live/job_posting_live/form.ex:769
 #: lib/vutuv_web/templates/email/form_content.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Who can see it"
@@ -13079,7 +13077,7 @@ msgstr "La Sua pagina di organizzazione su vutuv sta per perdere la verifica"
 msgid "Your organization page on vutuv is no longer public"
 msgstr "La Sua pagina di organizzazione su vutuv non è più pubblica"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:176
+#: lib/vutuv_web/live/job_posting_live/show.ex:171
 #, elixir-autogen, elixir-format
 msgid "Your posting"
 msgstr "Il Suo annuncio"
@@ -13095,7 +13093,7 @@ msgstr "Il Suo annuncio è online."
 msgid "Yourself (personal posting)"
 msgstr "Se stesso (annuncio personale)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:663
+#: lib/vutuv_web/live/job_posting_live/form.ex:662
 #, elixir-autogen, elixir-format
 msgid "up to"
 msgstr "fino a"
@@ -13143,19 +13141,19 @@ msgid_plural "Your roles"
 msgstr[0] "Il Suo ruolo"
 msgstr[1] "I Suoi ruoli"
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:113
+#: lib/vutuv_web/templates/settings/organizations.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Add an organization"
 msgstr "Aggiungi un'organizzazione"
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:115
+#: lib/vutuv_web/templates/settings/organizations.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Represent a company, association or other group? Add its page and verify the domain to become its owner."
 msgstr ""
 "Rappresenta un'azienda, un'associazione o un altro gruppo? Ne aggiunga la "
 "pagina e verifichi il dominio per diventarne proprietario."
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:125
+#: lib/vutuv_web/templates/settings/organizations.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Browse all organizations"
 msgstr "Sfoglia tutte le organizzazioni"
@@ -13170,7 +13168,7 @@ msgstr "In esame"
 msgid "Verification pending"
 msgstr "Verifica in attesa"
 
-#: lib/vutuv_web/live/organization_live/index.ex:63
+#: lib/vutuv_web/live/organization_live/index.ex:64
 #, elixir-autogen, elixir-format
 msgid "Verified pages for companies, associations, schools, public authorities and other groups, not for single people. Every page has a proven web domain, so you know it is really them."
 msgstr ""
@@ -13193,16 +13191,16 @@ msgstr ""
 "indirizzo? Un record TXT non può condividere il nome con un CNAME. Usi "
 "invece questo nome, con esattamente lo stesso valore di sopra:"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:322
-#: lib/vutuv_web/live/organization_live/show.ex:1066
+#: lib/vutuv_web/live/organization_live/domains.ex:316
+#: lib/vutuv_web/live/organization_live/show.ex:1061
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 "Se %{domain} è un CNAME / alias (un record TXT non può condividere il nome "
 "con un CNAME), metta il record su %{name}, con lo stesso valore."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:1057
+#: lib/vutuv_web/live/organization_live/domains.ex:314
+#: lib/vutuv_web/live/organization_live/show.ex:1052
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr ""
@@ -13246,12 +13244,12 @@ msgid_plural "%{count} weeks ago"
 msgstr[0] "%{count} settimana fa"
 msgstr[1] "%{count} settimane fa"
 
-#: lib/vutuv_web/live/job_board_live.ex:491
+#: lib/vutuv_web/live/job_board_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "%{km} km"
 msgstr "%{km} km"
 
-#: lib/vutuv_web/live/job_board_live.ex:361
+#: lib/vutuv_web/live/job_board_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "All countries"
 msgstr "Tutti i paesi"
@@ -13267,43 +13265,43 @@ msgstr "Tutti gli annunci con questo tag"
 msgid "All jobs with this tag: %{url}"
 msgstr "Tutti gli annunci con questo tag: %{url}"
 
-#: lib/vutuv_web/live/job_board_live.ex:368
+#: lib/vutuv_web/live/job_board_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "Any employment type"
 msgstr "Qualsiasi tipo di contratto"
 
-#: lib/vutuv_web/live/job_board_live.ex:350
+#: lib/vutuv_web/live/job_board_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "City or zip code"
 msgstr "Città o CAP"
 
-#: lib/vutuv_web/live/job_board_live.ex:491
+#: lib/vutuv_web/live/job_board_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "Exact"
 msgstr "Esatto"
 
-#: lib/vutuv_web/live/job_board_live.ex:249
+#: lib/vutuv_web/live/job_board_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "From my salary expectation"
 msgstr "Dalla mia retribuzione desiderata"
 
-#: lib/vutuv_web/live/job_board_live.ex:241
+#: lib/vutuv_web/live/job_board_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Matches my tags"
 msgstr "Corrisponde ai miei tag"
 
-#: lib/vutuv_web/live/job_board_live.ex:461
+#: lib/vutuv_web/live/job_board_live.ex:452
 #, elixir-autogen, elixir-format
 msgid "Min. salary/year (%{currency})"
 msgstr "Retribuzione min./anno (%{currency})"
 
-#: lib/vutuv_web/live/job_board_live.ex:410
+#: lib/vutuv_web/live/job_board_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "Minimum yearly salary"
 msgstr "Retribuzione annua minima"
 
-#: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:836
+#: lib/vutuv_web/live/job_board_live.ex:320
+#: lib/vutuv_web/live/organization_live/show.ex:831
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr "Altri annunci"
@@ -13318,12 +13316,12 @@ msgstr "Pagina successiva"
 msgid "Next page: %{url}"
 msgstr "Pagina successiva: %{url}"
 
-#: lib/vutuv_web/live/job_board_live.ex:499
+#: lib/vutuv_web/live/job_board_live.ex:479
 #, elixir-autogen, elixir-format
 msgid "No job postings yet."
 msgstr "Ancora nessun annuncio di lavoro."
 
-#: lib/vutuv_web/live/job_board_live.ex:497
+#: lib/vutuv_web/live/job_board_live.ex:477
 #, elixir-autogen, elixir-format
 msgid "No matching positions. Try adjusting the filters."
 msgstr "Nessuna posizione corrispondente. Provi a modificare i filtri."
@@ -13344,22 +13342,22 @@ msgstr "Posizioni aperte"
 msgid "Open positions on vutuv, newest first."
 msgstr "Posizioni aperte su vutuv, dalla più recente."
 
-#: lib/vutuv_web/live/job_board_live.ex:221
+#: lib/vutuv_web/live/job_board_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Post a job"
 msgstr "Pubblichi un annuncio di lavoro"
 
-#: lib/vutuv_web/live/job_board_live.ex:306
+#: lib/vutuv_web/live/job_board_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Post the first one"
 msgstr "Pubblichi il primo"
 
-#: lib/vutuv_web/live/job_board_live.ex:354
+#: lib/vutuv_web/live/job_board_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "Radius"
 msgstr "Raggio"
 
-#: lib/vutuv_web/live/job_board_live.ex:342
+#: lib/vutuv_web/live/job_board_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "Search jobs"
 msgstr "Cerchi annunci di lavoro"
@@ -13389,7 +13387,7 @@ msgstr "(testo libero, non verificato)"
 msgid "(no employer)"
 msgstr "(nessun datore di lavoro)"
 
-#: lib/vutuv_web/live/admin/job_live.ex:477
+#: lib/vutuv_web/live/admin/job_live.ex:475
 #, elixir-autogen, elixir-format
 msgid "Close this posting? It ends the listing (a regular ending, not a deletion)."
 msgstr ""
@@ -13397,7 +13395,7 @@ msgstr ""
 "non un'eliminazione)."
 
 #: lib/vutuv_web/live/admin/job_live.ex:414
-#: lib/vutuv_web/live/admin/user_detail_live.ex:135
+#: lib/vutuv_web/live/admin/user_detail_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "Cold outreach"
 msgstr "Contatto a freddo"
@@ -13407,7 +13405,7 @@ msgstr "Contatto a freddo"
 msgid "Counters"
 msgstr "Contatori"
 
-#: lib/vutuv_web/live/admin/job_live.ex:486
+#: lib/vutuv_web/live/admin/job_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Delete this posting and everything it owns? This cannot be undone."
 msgstr ""
@@ -13447,14 +13445,14 @@ msgstr "Annuncio di lavoro"
 #: lib/vutuv_web/live/admin/job_live.ex:30
 #: lib/vutuv_web/live/admin/job_live.ex:198
 #: lib/vutuv_web/live/admin/job_live.ex:199
-#: lib/vutuv_web/live/admin/user_detail_live.ex:163
+#: lib/vutuv_web/live/admin/user_detail_live.ex:158
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Job postings"
 msgstr "Annunci di lavoro"
 
 #: lib/vutuv_web/live/admin/job_live.ex:402
-#: lib/vutuv_web/live/admin/user_detail_live.ex:117
+#: lib/vutuv_web/live/admin/user_detail_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Live postings"
 msgstr "Annunci online"
@@ -13470,7 +13468,7 @@ msgid "Open case"
 msgstr "Caso aperto"
 
 #: lib/vutuv_web/live/admin/job_live.ex:410
-#: lib/vutuv_web/live/admin/user_detail_live.ex:129
+#: lib/vutuv_web/live/admin/user_detail_live.ex:124
 #, elixir-autogen, elixir-format
 msgid "Open job cases"
 msgstr "Casi aperti sugli annunci"
@@ -13537,7 +13535,7 @@ msgid "Title"
 msgstr "Titolo"
 
 #: lib/vutuv_web/live/admin/job_live.ex:406
-#: lib/vutuv_web/live/admin/user_detail_live.ex:123
+#: lib/vutuv_web/live/admin/user_detail_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "Total postings"
 msgstr "Annunci totali"
@@ -13579,7 +13577,7 @@ msgstr "Avviso aggiornato."
 msgid "Daily email"
 msgstr "E-mail giornaliera"
 
-#: lib/vutuv_web/templates/settings/saved_searches.html.heex:72
+#: lib/vutuv_web/templates/settings/saved_searches.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Delete this saved search?"
 msgstr "Eliminare questa ricerca salvata?"
@@ -13611,7 +13609,7 @@ msgstr "Tutto"
 msgid "Manage your saved searches"
 msgstr "Gestisca le Sue ricerche salvate"
 
-#: lib/vutuv_web/templates/settings/saved_searches.html.heex:87
+#: lib/vutuv_web/templates/settings/saved_searches.html.heex:82
 #, elixir-autogen, elixir-format
 msgid "Newer"
 msgstr "Più recenti"
@@ -13621,7 +13619,7 @@ msgstr "Più recenti"
 msgid "No emails"
 msgstr "Nessuna e-mail"
 
-#: lib/vutuv_web/templates/settings/saved_searches.html.heex:95
+#: lib/vutuv_web/templates/settings/saved_searches.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "Older"
 msgstr "Meno recenti"
@@ -13635,8 +13633,8 @@ msgstr ""
 "ricerche giornaliere vengono controllate ogni giorno, quelle settimanali una"
 " volta a settimana."
 
-#: lib/vutuv_web/components/saved_search_components.ex:107
-#: lib/vutuv_web/components/saved_search_components.ex:128
+#: lib/vutuv_web/components/saved_search_components.ex:103
+#: lib/vutuv_web/components/saved_search_components.ex:116
 #, elixir-autogen, elixir-format
 msgid "Save search"
 msgstr "Salva la ricerca"
@@ -13646,7 +13644,7 @@ msgstr "Salva la ricerca"
 msgid "Saved search deleted."
 msgstr "Ricerca salvata eliminata."
 
-#: lib/vutuv_web/components/ui.ex:4773
+#: lib/vutuv_web/components/ui.ex:4881
 #: lib/vutuv_web/controllers/settings_controller.ex:620
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13666,7 +13664,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "Interrompere gli avvisi via e-mail per la Sua ricerca salvata \"%{label}\"?"
 
-#: lib/vutuv_web/components/post_components.ex:2996
+#: lib/vutuv_web/components/post_components.ex:3018
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:715
 #: lib/vutuv_web/controllers/settings_controller.ex:733
@@ -13811,7 +13809,7 @@ msgstr ""
 msgid "Hide from specific viewers"
 msgstr "Nascondi a lettori specifici"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:794
+#: lib/vutuv_web/live/job_posting_live/form.ex:793
 #, elixir-autogen, elixir-format
 msgid "Hide from specific viewers (competitors, your own staff, a person) →"
 msgstr ""
@@ -13833,7 +13831,7 @@ msgstr "Esclusioni sugli annunci"
 msgid "Job exclusions – %{name}"
 msgstr "Esclusioni sugli annunci – %{name}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:797
+#: lib/vutuv_web/live/job_posting_live/form.ex:796
 #, elixir-autogen, elixir-format
 msgid "Keep this posting on the board for everyone except a chosen few."
 msgstr ""
@@ -13926,7 +13924,7 @@ msgstr ""
 "Questa pagina ha annunci di lavoro, quindi non può essere eliminata. Chieda "
 "a un amministratore di archiviarla."
 
-#: lib/vutuv_web/live/admin/user_detail_live.ex:114
+#: lib/vutuv_web/live/admin/user_detail_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Jobs footprint"
 msgstr "Attività sugli annunci"
@@ -13945,7 +13943,7 @@ msgstr ""
 "raggiungibile."
 
 #: lib/vutuv_web/templates/user/edit.html.heex:41
-#: lib/vutuv_web/templates/user/edit.html.heex:126
+#: lib/vutuv_web/templates/user/edit.html.heex:121
 #: lib/vutuv_web/templates/user/show.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "Image awaiting review, visible only to you"
@@ -14003,7 +14001,7 @@ msgstr ""
 msgid "Age only, without the date"
 msgstr "Solo l'età, senza la data"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:451
+#: lib/vutuv_web/templates/user/edit.html.heex:447
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
@@ -14029,7 +14027,7 @@ msgstr "Non mostrare il mio compleanno"
 msgid "Full date and age"
 msgstr "Data completa ed età"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:448
+#: lib/vutuv_web/templates/user/edit.html.heex:444
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr "Mostra il mio compleanno come"
@@ -14074,44 +14072,44 @@ msgstr[1] ""
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "ha cambiato il proprio handle da @%{old} a @%{new}."
 
-#: lib/vutuv_web/components/ui.ex:413
+#: lib/vutuv_web/components/ui.ex:474
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr "Al centro"
 
-#: lib/vutuv_web/components/ui.ex:410
+#: lib/vutuv_web/components/ui.ex:471
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr "Allinea a sinistra"
 
-#: lib/vutuv_web/components/ui.ex:416
+#: lib/vutuv_web/components/ui.ex:477
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr "Allinea a destra"
 
-#: lib/vutuv_web/components/ui.ex:407
+#: lib/vutuv_web/components/ui.ex:468
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr "A tutta larghezza"
 
-#: lib/vutuv_web/components/ui.ex:440
+#: lib/vutuv_web/components/ui.ex:501
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr "Inserisci un'immagine"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2871
+#: lib/vutuv_web/live/post_live/composer.ex:2810
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr "Inserisci nel testo"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:235
 #: lib/vutuv_web/agent_docs/text.ex:218
-#: lib/vutuv_web/live/tag_live/timeline.ex:253
+#: lib/vutuv_web/live/tag_live/timeline.ex:249
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
 msgstr "Post con questo tag"
 
-#: lib/vutuv_web/live/search_live.ex:711
+#: lib/vutuv_web/live/search_live.ex:704
 #, elixir-autogen, elixir-format
 msgid "Your search uses a people-only filter such as city: or status:, so it only finds people."
 msgstr ""
@@ -14133,22 +14131,22 @@ msgstr "Cellulare privato"
 msgid "Work mobile"
 msgstr "Cellulare di lavoro"
 
-#: lib/vutuv_web/components/post_components.ex:447
+#: lib/vutuv_web/components/post_components.ex:448
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr "Ancora nessun post."
 
-#: lib/vutuv_web/components/post_components.ex:449
+#: lib/vutuv_web/components/post_components.ex:450
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr "Ancora nessuna risposta."
 
-#: lib/vutuv_web/components/post_components.ex:448
+#: lib/vutuv_web/components/post_components.ex:449
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr "Ancora nessuna ripubblicazione."
 
-#: lib/vutuv_web/components/post_components.ex:406
+#: lib/vutuv_web/components/post_components.ex:407
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr "Post propri"
@@ -14161,7 +14159,7 @@ msgstr ""
 "persone note per quel tag compaiono tra i Suoi suggerimenti. Segua un tag "
 "dalla sua pagina."
 
-#: lib/vutuv_web/components/ui.ex:4756
+#: lib/vutuv_web/components/ui.ex:4864
 #: lib/vutuv_web/controllers/settings_controller.ex:634
 #: lib/vutuv_web/live/post_live/feed.ex:712
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -14170,34 +14168,34 @@ msgstr ""
 msgid "Tags you follow"
 msgstr "Tag che segue"
 
-#: lib/vutuv_web/live/job_board_live.ex:428
+#: lib/vutuv_web/live/job_board_live.ex:419
 #, elixir-autogen, elixir-format
 msgid "Looking for a role that goes by several titles? Separate them with a comma and we show postings that match any of them."
 msgstr ""
 "Cerca un ruolo che ha più titoli diversi? Li separi con una virgola e "
 "mostreremo gli annunci che corrispondono a uno qualsiasi di essi."
 
-#: lib/vutuv_web/live/job_board_live.ex:424
+#: lib/vutuv_web/live/job_board_live.ex:415
 #, elixir-autogen, elixir-format
 msgid "Search tips"
 msgstr "Consigli per la ricerca"
 
-#: lib/vutuv_web/live/job_board_live.ex:482
+#: lib/vutuv_web/live/job_board_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "any of these titles"
 msgstr "uno qualsiasi di questi titoli"
 
-#: lib/vutuv_web/live/job_board_live.ex:484
+#: lib/vutuv_web/live/job_board_live.ex:464
 #, elixir-autogen, elixir-format
 msgid "exact wording"
 msgstr "dicitura esatta"
 
-#: lib/vutuv_web/live/job_board_live.ex:485
+#: lib/vutuv_web/live/job_board_live.ex:465
 #, elixir-autogen, elixir-format
 msgid "without internships"
 msgstr "senza tirocini"
 
-#: lib/vutuv_web/live/job_board_live.ex:483
+#: lib/vutuv_web/live/job_board_live.ex:463
 #, elixir-autogen, elixir-format
 msgid "word start: also finds Entwickler, Entwicklung"
 msgstr "inizio di parola: trova anche Sviluppatore, Sviluppo"
@@ -14241,7 +14239,7 @@ msgstr "Messenger aggiornato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:63
-#: lib/vutuv_web/components/ui.ex:4727
+#: lib/vutuv_web/components/ui.ex:4835
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -14269,14 +14267,14 @@ msgstr "Messenger di %{name}"
 msgid "Select a messenger"
 msgstr "Selezioni un messenger"
 
-#: lib/vutuv_web/components/ui.ex:4127
+#: lib/vutuv_web/components/ui.ex:4231
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] "Avvisa il mio follower"
 msgstr[1] "Avvisa i miei %{formatted} follower"
 
-#: lib/vutuv_web/components/ui.ex:4137
+#: lib/vutuv_web/components/ui.ex:4241
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
@@ -14331,50 +14329,50 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr "ha aggiunto %{count} nuove voci al proprio CV:"
 
-#: lib/vutuv_web/components/post_components.ex:5289
+#: lib/vutuv_web/components/post_components.ex:5311
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Audiolibro"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1233
-#: lib/vutuv_web/components/post_components.ex:5246
+#: lib/vutuv_web/components/post_components.ex:5268
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Recensione di un libro"
 
-#: lib/vutuv_web/components/post_components.ex:5290
+#: lib/vutuv_web/components/post_components.ex:5312
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Cinema"
 
-#: lib/vutuv_web/components/post_components.ex:5292
+#: lib/vutuv_web/components/post_components.ex:5314
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:5288
+#: lib/vutuv_web/components/post_components.ex:5310
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1233
-#: lib/vutuv_web/components/post_components.ex:5245
+#: lib/vutuv_web/components/post_components.ex:5267
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Recensione di un film"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:443
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:250
+#: lib/vutuv_web/live/fediverse_account_live.ex:453
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:5287
+#: lib/vutuv_web/components/post_components.ex:5309
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Libro cartaceo"
 
-#: lib/vutuv_web/components/post_components.ex:5291
+#: lib/vutuv_web/components/post_components.ex:5313
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14394,7 +14392,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Anno"
 
-#: lib/vutuv_web/components/post_components.ex:5328
+#: lib/vutuv_web/components/post_components.ex:5350
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14402,27 +14400,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} pagina"
 msgstr[1] "%{formatted} pagine"
 
-#: lib/vutuv_web/components/post_components.ex:5358
+#: lib/vutuv_web/components/post_components.ex:5380
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} h"
 
-#: lib/vutuv_web/components/post_components.ex:5359
+#: lib/vutuv_web/components/post_components.ex:5381
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} h %{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:5357
+#: lib/vutuv_web/components/post_components.ex:5379
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:5317
+#: lib/vutuv_web/components/post_components.ex:5339
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(edizione cartacea)"
 
-#: lib/vutuv_web/components/post_components.ex:5364
+#: lib/vutuv_web/components/post_components.ex:5386
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "circa %{duration}"
@@ -14454,7 +14452,7 @@ msgstr "Con certificazione:"
 msgid "With qualification: %{name}"
 msgstr "Con certificazione: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5131
+#: lib/vutuv_web/components/post_components.ex:5153
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Editore:"
@@ -14502,17 +14500,17 @@ msgstr "ora La seguono."
 msgid "endorsed you for %{tags}."
 msgstr "L'ha confermata per %{tags}."
 
-#: lib/vutuv_web/components/post_components.ex:5122
+#: lib/vutuv_web/components/post_components.ex:5144
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "di:"
 
-#: lib/vutuv_web/components/ui.ex:2203
+#: lib/vutuv_web/components/ui.ex:2227
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr "Confermato da %{name}"
 
-#: lib/vutuv_web/components/ui.ex:2207
+#: lib/vutuv_web/components/ui.ex:2231
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -14607,7 +14605,7 @@ msgstr "Documento di prova (PDF o immagine)"
 msgid "Remove file"
 msgstr "Rimuovi il file"
 
-#: lib/vutuv_web/templates/qualification/form_content.html.heex:106
+#: lib/vutuv_web/templates/qualification/form_content.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Remove the uploaded file? The entry itself stays."
 msgstr "Rimuovere il file caricato? La voce resta."
@@ -14646,7 +14644,7 @@ msgid "proof document"
 msgstr "documento di prova"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:375
+#: lib/vutuv_web/templates/settings/preferences.html.heex:364
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr "Righe nelle notifiche"
@@ -14657,12 +14655,12 @@ msgid "How much of a post a notification quotes before it is cut off."
 msgstr ""
 "Quanta parte di un post viene citata in una notifica prima del taglio."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:366
+#: lib/vutuv_web/templates/settings/preferences.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr "Post citati nelle notifiche"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:369
+#: lib/vutuv_web/templates/settings/preferences.html.heex:358
 #, elixir-autogen, elixir-format
 msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
@@ -14710,13 +14708,13 @@ msgstr ""
 "Facoltativo, e nessun altro lo vede. Esclude dalla Sua ricerca di lavoro gli"
 " annunci al di sotto."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:356
+#: lib/vutuv_web/templates/user/edit.html.heex:351
 #: lib/vutuv_web/templates/welcome/show.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr "Come vuole lavorare?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:376
+#: lib/vutuv_web/templates/user/edit.html.heex:371
 #: lib/vutuv_web/templates/welcome/show.html.heex:162
 #, elixir-autogen, elixir-format
 msgid "Shown next to your availability, and used to match you with postings."
@@ -14739,7 +14737,7 @@ msgstr "Salta per ora"
 msgid "Preferred workplace"
 msgstr "Modalità di lavoro preferita"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:284
+#: lib/vutuv_web/templates/user/edit.html.heex:279
 #: lib/vutuv_web/templates/welcome/show.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Availability"
@@ -14796,7 +14794,7 @@ msgstr "Menzione"
 msgid "mentioned you in a post."
 msgstr "L'ha menzionata in un post."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1251
+#: lib/vutuv_web/live/post_live/composer.ex:1226
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
@@ -14804,7 +14802,7 @@ msgstr ""
 "Questo post non può più essere modificato: qualcuno gli ha messo Mi piace, "
 "lo ha ripubblicato o gli ha risposto."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1254
+#: lib/vutuv_web/live/post_live/composer.ex:1229
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14909,14 +14907,14 @@ msgstr "Cerchi un account da bloccare"
 msgid "See all frozen accounts"
 msgstr "Vedi tutti gli account bloccati"
 
-#: lib/vutuv_web/components/post_components.ex:3269
+#: lib/vutuv_web/components/post_components.ex:3291
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "Mostra %{formatted} post precedente"
 msgstr[1] "Mostra %{formatted} post precedenti"
 
-#: lib/vutuv_web/components/post_components.ex:3292
+#: lib/vutuv_web/components/post_components.ex:3314
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14938,49 +14936,49 @@ msgstr "Questo post fa parte di una conversazione con %{formatted} post."
 msgid "This profile is currently unavailable."
 msgstr "Questo profilo al momento non è disponibile."
 
-#: lib/vutuv_web/templates/admin/account/index.html.heex:45
+#: lib/vutuv_web/templates/admin/account/index.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 "Digiti un nome, un @handle o un indirizzo e-mail per trovare un account da "
 "bloccare."
 
-#: lib/vutuv_web/components/post_components.ex:5780
+#: lib/vutuv_web/components/post_components.ex:5802
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Non può mettere Mi piace al Suo stesso post."
 
-#: lib/vutuv_web/views/admin/account_html.ex:93
+#: lib/vutuv_web/views/admin/account_html.ex:83
 #, elixir-autogen, elixir-format
 msgid "active"
 msgstr "attivo"
 
-#: lib/vutuv_web/views/admin/account_html.ex:109
+#: lib/vutuv_web/views/admin/account_html.ex:99
 #, elixir-autogen, elixir-format
 msgid "admin"
 msgstr "amministratore"
 
-#: lib/vutuv_web/views/admin/account_html.ex:90
+#: lib/vutuv_web/views/admin/account_html.ex:80
 #, elixir-autogen, elixir-format
 msgid "frozen"
 msgstr "bloccato"
 
-#: lib/vutuv_web/views/admin/account_html.ex:108
+#: lib/vutuv_web/views/admin/account_html.ex:98
 #, elixir-autogen, elixir-format
 msgid "report"
 msgstr "segnalazione"
 
-#: lib/vutuv_web/views/admin/account_html.ex:89
+#: lib/vutuv_web/views/admin/account_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "suspended"
 msgstr "sospeso"
 
-#: lib/vutuv_web/views/admin/account_html.ex:92
+#: lib/vutuv_web/views/admin/account_html.ex:82
 #, elixir-autogen, elixir-format
 msgid "unconfirmed"
 msgstr "non confermato"
 
-#: lib/vutuv_web/views/admin/account_html.ex:91
+#: lib/vutuv_web/views/admin/account_html.ex:81
 #, elixir-autogen, elixir-format
 msgid "unreachable"
 msgstr "irraggiungibile"
@@ -15099,7 +15097,7 @@ msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
 "Filtro aggiunto. I post corrispondenti sono ora nascosti nel Suo feed."
 
-#: lib/vutuv_web/live/job_board_live.ex:389
+#: lib/vutuv_web/live/job_board_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Filter by a tag"
 msgstr "Filtra per tag"
@@ -15123,7 +15121,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr "Corrispondenza solo su parole intere (parola o frase)"
 
-#: lib/vutuv_web/components/ui.ex:4741
+#: lib/vutuv_web/components/ui.ex:4849
 #: lib/vutuv_web/controllers/settings_controller.ex:700
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -15221,7 +15219,7 @@ msgstr "Parola, frase o tag da silenziare"
 msgid "You are not allowed to change this organization's handle."
 msgstr "Non ha i permessi per modificare l'handle di questa organizzazione."
 
-#: lib/vutuv_web/templates/settings/filters.html.heex:116
+#: lib/vutuv_web/templates/settings/filters.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "You have not muted anything yet."
 msgstr "Non ha ancora silenziato nulla."
@@ -15438,7 +15436,7 @@ msgstr ""
 "Su vutuv non cambia nulla, e può disattivare tutto in qualsiasi momento."
 
 #: lib/vutuv_web/components/fediverse_components.ex:325
-#: lib/vutuv_web/templates/page/index.html.heex:234
+#: lib/vutuv_web/templates/page/index.html.heex:239
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "Take part in the Fediverse"
@@ -15467,7 +15465,7 @@ msgstr ""
 "Ancora nessuno. Pubblichi il Suo handle dove le persone possono vederlo, e i"
 " primi follow compariranno qui."
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:321
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:322
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Related"
@@ -15553,7 +15551,7 @@ msgstr ""
 "profilo vutuv resta esattamente com'è e non viene eliminato nulla."
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:265
-#: lib/vutuv_web/live/fediverse_following_live.ex:465
+#: lib/vutuv_web/live/fediverse_following_live.ex:473
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Back to Fediverse settings"
@@ -15582,7 +15580,7 @@ msgstr "(lasci vuoto se è ancora in corso)"
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:18
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:34
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:260
-#: lib/vutuv_web/templates/page/index.html.heex:119
+#: lib/vutuv_web/templates/page/index.html.heex:124
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:66
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:75
 #, elixir-autogen, elixir-format
@@ -15738,7 +15736,7 @@ msgstr "Inviamo lì un PIN per confermare che l'indirizzo è Suo."
 msgid "ZIP or postal code"
 msgstr "CAP"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:357
+#: lib/vutuv_web/live/tag_live/timeline.ex:353
 #: lib/vutuv_web/templates/education/form_content.html.heex:59
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:81
 #, elixir-autogen, elixir-format
@@ -15827,259 +15825,259 @@ msgstr "Il Suo server"
 msgid "moved to %{address}"
 msgstr "spostato a %{address}"
 
-#: lib/vutuv_web/components/ui.ex:4669
+#: lib/vutuv_web/components/ui.ex:4777
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr "Nome, foto, immagine di copertina, descrizione breve"
 
-#: lib/vutuv_web/components/ui.ex:4674
+#: lib/vutuv_web/components/ui.ex:4782
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr "handle soprannome rinomina slug profilo indirizzo url menzione"
 
-#: lib/vutuv_web/components/ui.ex:4677
+#: lib/vutuv_web/components/ui.ex:4785
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr "Gli impieghi e i ruoli nel Suo CV"
 
-#: lib/vutuv_web/components/ui.ex:4678
+#: lib/vutuv_web/components/ui.ex:4786
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr "cv curriculum carriera datore di lavoro posizione qualifica azienda"
 
-#: lib/vutuv_web/components/ui.ex:4681
+#: lib/vutuv_web/components/ui.ex:4789
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr "Scuole, università, titoli di studio"
 
-#: lib/vutuv_web/components/ui.ex:4682
+#: lib/vutuv_web/components/ui.ex:4790
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr "cv curriculum studio studi scuola università laurea titolo"
 
-#: lib/vutuv_web/components/ui.ex:4685
+#: lib/vutuv_web/components/ui.ex:4793
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr "Credenziali, con documenti di prova"
 
-#: lib/vutuv_web/components/ui.ex:4686
+#: lib/vutuv_web/components/ui.ex:4794
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 "certificato abilitazione diploma credenziale riconoscimento prova documento"
 
-#: lib/vutuv_web/components/ui.ex:4693
+#: lib/vutuv_web/components/ui.ex:4801
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr "Competenze linguistiche"
 
-#: lib/vutuv_web/components/ui.ex:4694
+#: lib/vutuv_web/components/ui.ex:4802
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr "Le lingue che parla"
 
-#: lib/vutuv_web/components/ui.ex:4695
+#: lib/vutuv_web/components/ui.ex:4803
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr "lingua parlare parlata fluente madrelingua"
 
-#: lib/vutuv_web/components/ui.ex:4698
+#: lib/vutuv_web/components/ui.ex:4806
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr "Gli argomenti per cui è conosciuto"
 
-#: lib/vutuv_web/components/ui.ex:4699
+#: lib/vutuv_web/components/ui.ex:4807
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr "competenza argomento parola chiave esperienza conferma"
 
-#: lib/vutuv_web/components/ui.ex:4834
+#: lib/vutuv_web/components/ui.ex:4942
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr "Pagine aziendali che gestisce"
 
-#: lib/vutuv_web/components/ui.ex:4835
+#: lib/vutuv_web/components/ui.ex:4943
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr "azienda datore di lavoro impresa attività organizzazione pagina"
 
-#: lib/vutuv_web/components/ui.ex:4702
+#: lib/vutuv_web/components/ui.ex:4810
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr "Recapiti"
 
-#: lib/vutuv_web/components/ui.ex:4705
+#: lib/vutuv_web/components/ui.ex:4813
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr "Dove La raggiungiamo, e quale indirizzo è pubblico"
 
-#: lib/vutuv_web/components/ui.ex:4706
+#: lib/vutuv_web/components/ui.ex:4814
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr "posta e-mail indirizzo principale"
 
-#: lib/vutuv_web/components/ui.ex:4709
+#: lib/vutuv_web/components/ui.ex:4817
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr "Fisso, cellulare, fax"
 
-#: lib/vutuv_web/components/ui.ex:4710
+#: lib/vutuv_web/components/ui.ex:4818
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr "telefono cellulare fax numero"
 
-#: lib/vutuv_web/components/ui.ex:4713
+#: lib/vutuv_web/components/ui.ex:4821
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr "Indirizzi postali sul Suo profilo"
 
-#: lib/vutuv_web/components/ui.ex:4714
+#: lib/vutuv_web/components/ui.ex:4822
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr "via città cap paese posta mappa"
 
-#: lib/vutuv_web/components/ui.ex:4716
+#: lib/vutuv_web/components/ui.ex:4824
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr "Siti web e link"
 
-#: lib/vutuv_web/components/ui.ex:4717
+#: lib/vutuv_web/components/ui.ex:4825
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr "Il Suo sito e gli altri link"
 
-#: lib/vutuv_web/components/ui.ex:4718
+#: lib/vutuv_web/components/ui.ex:4826
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr "url sito web homepage blog link verifica rel=me"
 
-#: lib/vutuv_web/components/ui.ex:4720
+#: lib/vutuv_web/components/ui.ex:4828
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr "Profili sui social"
 
-#: lib/vutuv_web/components/ui.ex:4721
+#: lib/vutuv_web/components/ui.ex:4829
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr "Mastodon, Bluesky, GitHub e gli altri"
 
-#: lib/vutuv_web/components/ui.ex:4723
+#: lib/vutuv_web/components/ui.ex:4831
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 
-#: lib/vutuv_web/components/ui.ex:4728
+#: lib/vutuv_web/components/ui.ex:4836
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr "Signal, Threema, Matrix e gli altri"
 
-#: lib/vutuv_web/components/ui.ex:4729
+#: lib/vutuv_web/components/ui.ex:4837
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr "signal threema matrix xmpp telegram whatsapp chat messenger"
 
-#: lib/vutuv_web/components/ui.ex:4732
+#: lib/vutuv_web/components/ui.ex:4840
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr "Notifiche e feed"
 
-#: lib/vutuv_web/components/ui.ex:4735
+#: lib/vutuv_web/components/ui.ex:4843
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr "Quali e-mail inviamo, e cosa Le dice la campanella"
 
-#: lib/vutuv_web/components/ui.ex:4742
+#: lib/vutuv_web/components/ui.ex:4850
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr "Tenga dei post fuori dal Suo feed"
 
-#: lib/vutuv_web/components/ui.ex:4743
+#: lib/vutuv_web/components/ui.ex:4851
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr "silenzia blocca nascondi filtro parola chiave parola tag feed"
 
-#: lib/vutuv_web/components/ui.ex:4757
+#: lib/vutuv_web/components/ui.ex:4865
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr "Argomenti i cui post arrivano nel Suo feed"
 
-#: lib/vutuv_web/components/ui.ex:4758
+#: lib/vutuv_web/components/ui.ex:4866
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr "tag argomento iscriviti segui feed"
 
-#: lib/vutuv_web/components/ui.ex:4774
+#: lib/vutuv_web/components/ui.ex:4882
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 "Ricerche di lavoro e di persone che Le inviano per e-mail le nuove "
 "corrispondenze"
 
-#: lib/vutuv_web/components/ui.ex:4775
+#: lib/vutuv_web/components/ui.ex:4883
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr "lavoro avviso ricerca agente osservati"
 
-#: lib/vutuv_web/components/ui.ex:4781
+#: lib/vutuv_web/components/ui.ex:4889
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr "Motori di ricerca, IA, stato online"
 
-#: lib/vutuv_web/components/ui.ex:4782
+#: lib/vutuv_web/components/ui.ex:4890
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 "privacy google motore di ricerca ia llm crawler noindex online pallino "
 "pubblico"
 
-#: lib/vutuv_web/components/ui.ex:4785
+#: lib/vutuv_web/components/ui.ex:4893
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr "Persone che non possono interagire con Lei"
 
-#: lib/vutuv_web/components/ui.ex:4786
+#: lib/vutuv_web/components/ui.ex:4894
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr "blocca bandisci silenzia segnala abuso molestie stalker"
 
-#: lib/vutuv_web/components/ui.ex:4807
+#: lib/vutuv_web/components/ui.ex:4915
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr "Passkey, dispositivi connessi, codici di accesso"
 
-#: lib/vutuv_web/components/ui.ex:4808
+#: lib/vutuv_web/components/ui.ex:4916
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 "password accesso entrare uscire sessione dispositivo passkey totp 2fa pin"
 
-#: lib/vutuv_web/components/ui.ex:4826
+#: lib/vutuv_web/components/ui.ex:4934
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr "Porti i Suoi dati da LinkedIn"
 
-#: lib/vutuv_web/components/ui.ex:4827
+#: lib/vutuv_web/components/ui.ex:4935
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr "linkedin caricamento zip migrazione trasferimento"
 
-#: lib/vutuv_web/components/ui.ex:4830
+#: lib/vutuv_web/components/ui.ex:4938
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr "Scarichi tutto ciò che conserviamo su di Lei"
 
-#: lib/vutuv_web/components/ui.ex:4831
+#: lib/vutuv_web/components/ui.ex:4939
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr "download gdpr rgpd dati backup json cv"
 
-#: lib/vutuv_web/components/ui.ex:4845
+#: lib/vutuv_web/components/ui.ex:4953
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr "Rimuova il Suo account e tutto ciò che contiene"
 
-#: lib/vutuv_web/components/ui.ex:4846
+#: lib/vutuv_web/components/ui.ex:4954
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr "elimina rimuovi chiudi esci cancella abbandona"
@@ -16153,14 +16151,14 @@ msgstr ""
 " nome. Per condividerlo tutti i giorni, l'indirizzo breve qui sopra è più "
 "comodo."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:269
-#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:35
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:261
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:29
 #, elixir-autogen, elixir-format
 msgid "I understand, switch off"
 msgstr "Ho capito, disattiva"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:267
-#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:33
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:259
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "I understand, take part"
 msgstr "Ho capito, partecipa"
@@ -16209,7 +16207,7 @@ msgstr ""
 " vedere dove va a finire. Modificare o eliminare un post su vutuv è solo una"
 " richiesta rivolta a quei server, e non tutti la rispettano."
 
-#: lib/vutuv_web/components/post_components.ex:5726
+#: lib/vutuv_web/components/post_components.ex:5748
 #: lib/vutuv_web/live/notification_live/index.ex:1352
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -16217,7 +16215,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} risposta"
 msgstr[1] "%{formatted} risposte"
 
-#: lib/vutuv_web/components/post_components.ex:5730
+#: lib/vutuv_web/components/post_components.ex:5752
 #: lib/vutuv_web/live/notification_live/index.ex:1350
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -16225,7 +16223,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Mi piace"
 msgstr[1] "%{formatted} Mi piace"
 
-#: lib/vutuv_web/components/post_components.ex:5734
+#: lib/vutuv_web/components/post_components.ex:5756
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16233,7 +16231,7 @@ msgstr[0] "%{formatted} ripubblicazione"
 msgstr[1] "%{formatted} ripubblicazioni"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1182
-#: lib/vutuv_web/components/post_components.ex:5685
+#: lib/vutuv_web/components/post_components.ex:5707
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Già conteggiate nei numeri qui sopra."
@@ -16254,14 +16252,14 @@ msgstr ""
 msgid "Content warning"
 msgstr "Avviso sul contenuto"
 
-#: lib/vutuv_web/components/post_components.ex:1478
-#: lib/vutuv_web/components/post_components.ex:2221
-#: lib/vutuv_web/live/fediverse_account_live.ex:296
+#: lib/vutuv_web/components/post_components.ex:1479
+#: lib/vutuv_web/components/post_components.ex:2243
+#: lib/vutuv_web/live/fediverse_account_live.ex:298
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Da un'altra rete"
 
-#: lib/vutuv_web/components/post_components.ex:1351
+#: lib/vutuv_web/components/post_components.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Rimuovere questa risposta dal Suo post?"
@@ -16290,7 +16288,7 @@ msgstr "Risposta da un'altra rete"
 msgid "Reply removed."
 msgstr "Risposta rimossa."
 
-#: lib/vutuv_web/components/post_components.ex:1360
+#: lib/vutuv_web/components/post_components.ex:1361
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -16301,7 +16299,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr "Segnalata come non appropriata"
 
-#: lib/vutuv_web/components/post_components.ex:1374
+#: lib/vutuv_web/components/post_components.ex:1375
 #: lib/vutuv_web/live/notification_live/index.ex:910
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -16333,10 +16331,10 @@ msgid "That reply is not yours to remove."
 msgstr "Questa risposta non spetta a Lei rimuoverla."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1366
-#: lib/vutuv_web/components/post_components.ex:1409
-#: lib/vutuv_web/components/post_components.ex:1609
-#: lib/vutuv_web/components/post_components.ex:2910
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:244
+#: lib/vutuv_web/components/post_components.ex:1410
+#: lib/vutuv_web/components/post_components.ex:1611
+#: lib/vutuv_web/components/post_components.ex:2932
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Vedi l'originale"
@@ -16482,28 +16480,28 @@ msgstr "Scelga un altro nome utente"
 msgid "Confirm it is you"
 msgstr "Confermi che è Lei"
 
-#: lib/vutuv_web/templates/username/confirm.html.heex:148
+#: lib/vutuv_web/templates/username/confirm.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "That passkey could not be verified. Please try again."
 msgstr "Non è stato possibile verificare questa passkey. Riprovi."
 
-#: lib/vutuv_web/templates/username/confirm.html.heex:151
+#: lib/vutuv_web/templates/username/confirm.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "Confirm with your passkey"
 msgstr "Confermi con la Sua passkey"
 
-#: lib/vutuv_web/templates/username/confirm.html.heex:176
+#: lib/vutuv_web/templates/username/confirm.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "This browser does not support passkeys. Use a code below instead."
 msgstr ""
 "Questo browser non supporta le passkey. Usi invece un codice qui sotto."
 
-#: lib/vutuv_web/templates/username/confirm.html.heex:211
+#: lib/vutuv_web/templates/username/confirm.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "Enter your code"
 msgstr "Inserisca il Suo codice"
 
-#: lib/vutuv_web/templates/username/confirm.html.heex:223
+#: lib/vutuv_web/templates/username/confirm.html.heex:221
 #, elixir-autogen, elixir-format
 msgid "Change my username"
 msgstr "Cambia il mio nome utente"
@@ -16513,17 +16511,17 @@ msgstr "Cambia il mio nome utente"
 msgid "Send the PIN to"
 msgstr "Invia il PIN a"
 
-#: lib/vutuv_web/views/username_html.ex:155
+#: lib/vutuv_web/views/username_html.ex:152
 #, elixir-autogen, elixir-format
 msgid "Send a new PIN"
 msgstr "Invia un nuovo PIN"
 
-#: lib/vutuv_web/views/username_html.ex:155
+#: lib/vutuv_web/views/username_html.ex:152
 #, elixir-autogen, elixir-format
 msgid "Email me a PIN"
 msgstr "Inviami un PIN per e-mail"
 
-#: lib/vutuv_web/views/username_html.ex:163
+#: lib/vutuv_web/views/username_html.ex:160
 #, elixir-autogen, elixir-format
 msgid "The PIN goes to %{email}."
 msgstr "Il PIN viene inviato a %{email}."
@@ -16577,7 +16575,7 @@ msgstr "Token di accesso creato"
 msgid "Access token revoked"
 msgstr "Token di accesso revocato"
 
-#: lib/vutuv_web/components/ui.ex:4810
+#: lib/vutuv_web/components/ui.ex:4918
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16799,7 +16797,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:198
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/fediverse_following_live.ex:351
-#: lib/vutuv_web/live/tag_live/timeline.ex:438
+#: lib/vutuv_web/live/tag_live/timeline.ex:434
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -16938,7 +16936,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr "Cosa è cambiato sul Suo account, ed esattamente quando."
 
-#: lib/vutuv_web/components/ui.ex:4811
+#: lib/vutuv_web/components/ui.ex:4919
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr "Cosa è cambiato sul Suo account, e quando"
@@ -16974,7 +16972,7 @@ msgstr "da chi gestisce il sito"
 msgid "from a signed-in session"
 msgstr "da una sessione connessa"
 
-#: lib/vutuv_web/components/ui.ex:4813
+#: lib/vutuv_web/components/ui.ex:4921
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -17031,22 +17029,22 @@ msgstr ""
 msgid "device or detail"
 msgstr "dispositivo o dettaglio"
 
-#: lib/vutuv_web/components/post_components.ex:3454
+#: lib/vutuv_web/components/post_components.ex:3476
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Post fissato"
 
-#: lib/vutuv_web/components/post_components.ex:3570
+#: lib/vutuv_web/components/post_components.ex:3592
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "Fissa sul profilo"
 
-#: lib/vutuv_web/components/post_components.ex:3578
+#: lib/vutuv_web/components/post_components.ex:3600
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Togli dal profilo"
 
-#: lib/vutuv_web/components/post_components.ex:3564
+#: lib/vutuv_web/components/post_components.ex:3586
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -17076,19 +17074,19 @@ msgstr "post fissato"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:560
 #: lib/vutuv_web/agent_docs/text.ex:549
-#: lib/vutuv_web/templates/user/edit.html.heex:224
+#: lib/vutuv_web/templates/user/edit.html.heex:219
 #: lib/vutuv_web/templates/user/show.html.heex:254
 #: lib/vutuv_web/views/account_event_text.ex:213
 #, elixir-autogen, elixir-format
 msgid "Name pronunciation"
 msgstr "Pronuncia del nome"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:228
+#: lib/vutuv_web/templates/user/edit.html.heex:223
 #, elixir-autogen, elixir-format
 msgid "e.g. [SHTEH-fahn VIN-ter-my-er]"
 msgstr "ad esempio [STÈ-fan VÌN-ter-mai-er]"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:231
+#: lib/vutuv_web/templates/user/edit.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
@@ -17097,7 +17095,7 @@ msgstr ""
 "profilo, come si scrive una trascrizione, e le parentesi le aggiungiamo noi."
 " Se lo lascia vuoto non viene mostrato nulla."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2884
+#: lib/vutuv_web/live/post_live/composer.ex:2823
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr "Applica queste impostazioni a tutte le foto"
@@ -17127,133 +17125,133 @@ msgstr "CC BY-SA 4.0 (attribuzione, stessa licenza)"
 msgid "CC0 1.0 (no rights reserved)"
 msgstr "CC0 1.0 (nessun diritto riservato)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2308
+#: lib/vutuv_web/live/post_live/composer.ex:2247
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Copertina"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2722
+#: lib/vutuv_web/live/post_live/composer.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr "Descriva la foto per chi non può vederla"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1294
 #: lib/vutuv_web/agent_docs/text.ex:807
-#: lib/vutuv_web/components/ui.ex:2867
+#: lib/vutuv_web/components/ui.ex:2969
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Scarica l'originale"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2821
+#: lib/vutuv_web/live/post_live/composer.ex:2760
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 "Tutti i campi di metadati conservati, compreso ciò che ha scritto la Sua "
 "fotocamera."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2777
+#: lib/vutuv_web/live/post_live/composer.ex:2716
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr "Chiunque può scaricare questa foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2779
+#: lib/vutuv_web/live/post_live/composer.ex:2718
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr "Risoluzione piena, direttamente dal post."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2798
+#: lib/vutuv_web/live/post_live/composer.ex:2737
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr "Solo l'immagine"
 
-#: lib/vutuv_web/components/ui.ex:2866
+#: lib/vutuv_web/components/ui.ex:2968
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Foto successiva"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2327
+#: lib/vutuv_web/live/post_live/composer.ex:2266
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr "Ancora nessuna descrizione dell'immagine"
 
-#: lib/vutuv_web/components/post_components.ex:3049
+#: lib/vutuv_web/components/post_components.ex:3071
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Apri le impostazioni del Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:4264
+#: lib/vutuv_web/components/post_components.ex:4286
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} di %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:4412
+#: lib/vutuv_web/components/post_components.ex:4434
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "La foto è in fase di controllo"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2280
-#: lib/vutuv_web/live/post_live/composer.ex:2281
+#: lib/vutuv_web/live/post_live/composer.ex:2219
+#: lib/vutuv_web/live/post_live/composer.ex:2220
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr "Opzioni della foto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1327
 #: lib/vutuv_web/agent_docs/text.ex:794
-#: lib/vutuv_web/components/post_components.ex:4494
+#: lib/vutuv_web/components/post_components.ex:4516
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Foto:"
 
-#: lib/vutuv_web/components/ui.ex:2865
+#: lib/vutuv_web/components/ui.ex:2967
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Foto precedente"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2340
-#: lib/vutuv_web/live/post_live/composer.ex:2341
+#: lib/vutuv_web/live/post_live/composer.ex:2279
+#: lib/vutuv_web/live/post_live/composer.ex:2280
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr "Rimuovi la foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2800
+#: lib/vutuv_web/live/post_live/composer.ex:2739
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 "Gli stessi pixel e nient'altro: posizione e numeri di serie rimossi, qualità"
 " intatta."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2741
+#: lib/vutuv_web/live/post_live/composer.ex:2680
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr "Mostra le impostazioni della fotocamera"
 
-#: lib/vutuv_web/components/post_components.ex:3102
+#: lib/vutuv_web/components/post_components.ex:3124
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 "Quel server è bloccato su questo sito, quindi non gli si può inviare alcuna "
 "risposta."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2819
+#: lib/vutuv_web/live/post_live/composer.ex:2758
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr "Il file esattamente come l'ho caricato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2855
+#: lib/vutuv_web/live/post_live/composer.ex:2794
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 "Questo formato di file può essere consegnato solo così com'è. Rimuova la "
 "foto se non è ciò che desidera."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2847
+#: lib/vutuv_web/live/post_live/composer.ex:2786
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 "Questa foto porta con sé il luogo in cui è stata scattata. Chiunque scarichi"
 " il file esatto può leggerlo."
 
-#: lib/vutuv_web/components/post_components.ex:3093
+#: lib/vutuv_web/components/post_components.ex:3115
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -17268,42 +17266,42 @@ msgstr ""
 "inviare le Sue parole a quella rete, cosa che vutuv fa solo per i membri che"
 " hanno attivato la partecipazione al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:3111
+#: lib/vutuv_web/components/post_components.ex:3133
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Questo sito non partecipa al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:3045
+#: lib/vutuv_web/components/post_components.ex:3067
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Attivi la partecipazione al Fediverso per rispondere"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2598
+#: lib/vutuv_web/live/post_live/composer.ex:2537
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr "Chi può riutilizzare queste foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1278
+#: lib/vutuv_web/live/post_live/composer.ex:1253
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 "Nell'ultima ora ha inviato molte risposte ad altre reti. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:3106
+#: lib/vutuv_web/components/post_components.ex:3128
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 "Ha spostato il Suo account del Fediverso su un altro server, quindi da qui "
 "non vengono più inviate risposte."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1292
+#: lib/vutuv_web/live/post_live/composer.ex:1267
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 "Al momento le Sue impostazioni del Fediverso non consentono di inviare una "
 "risposta."
 
-#: lib/vutuv_web/components/post_components.ex:3059
+#: lib/vutuv_web/components/post_components.ex:3081
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -17315,67 +17313,66 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr "© Tutti i diritti riservati"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2223
+#: lib/vutuv_web/live/post_live/composer.ex:2162
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr "Aggiungi foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2593
+#: lib/vutuv_web/live/post_live/composer.ex:2532
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr "Licenza"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2712
+#: lib/vutuv_web/live/post_live/composer.ex:2651
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr "Didascalia (facoltativa)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1522
-#: lib/vutuv_web/live/post_live/composer.ex:1585
-#: lib/vutuv_web/live/post_live/composer.ex:1643
-#: lib/vutuv_web/live/post_live/composer.ex:1990
+#: lib/vutuv_web/live/post_live/composer.ex:1498
+#: lib/vutuv_web/live/post_live/composer.ex:1561
+#: lib/vutuv_web/live/post_live/composer.ex:1619
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr "Scarta la bozza"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1515
+#: lib/vutuv_web/live/post_live/composer.ex:1491
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr "Ripreso da dove aveva lasciato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2646
+#: lib/vutuv_web/live/post_live/composer.ex:2585
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 "Un file il cui formato non può essere ripulito viene consegnato esattamente "
 "come caricato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2158
+#: lib/vutuv_web/live/post_live/composer.ex:2096
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr "Diverso per ogni foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2157
+#: lib/vutuv_web/live/post_live/composer.ex:2095
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr "Originale, esattamente come caricato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2156
+#: lib/vutuv_web/live/post_live/composer.ex:2094
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr "Originale, senza metadati"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2161
+#: lib/vutuv_web/live/post_live/composer.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr "Solo versioni per il web (%{format})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2616
+#: lib/vutuv_web/live/post_live/composer.ex:2555
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr "Cosa può salvare un visitatore"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2635
+#: lib/vutuv_web/live/post_live/composer.ex:2574
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -17387,13 +17384,13 @@ msgstr[1] ""
 "il file esatto lo rivela."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1200
-#: lib/vutuv_web/components/post_components.ex:5723
+#: lib/vutuv_web/components/post_components.ex:5745
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "A %{handle} è piaciuto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1198
-#: lib/vutuv_web/components/post_components.ex:5720
+#: lib/vutuv_web/components/post_components.ex:5742
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} lo ha condiviso"
@@ -17403,7 +17400,7 @@ msgstr "%{handle} lo ha condiviso"
 msgid "Fediverse reactions"
 msgstr "Reazioni dal Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:5612
+#: lib/vutuv_web/components/post_components.ex:5634
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Da altre reti"
@@ -17498,17 +17495,17 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr "Richiesta di ritiro"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1779
-#: lib/vutuv_web/live/post_live/composer.ex:2480
+#: lib/vutuv_web/live/post_live/composer.ex:1755
+#: lib/vutuv_web/live/post_live/composer.ex:2419
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr "Dettagli della foto"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:449
+#: lib/vutuv_web/live/fediverse_account_live.ex:459
 #: lib/vutuv_web/live/fediverse_following_live.ex:60
 #: lib/vutuv_web/live/fediverse_following_live.ex:274
 #: lib/vutuv_web/live/fediverse_following_live.ex:287
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:330
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:331
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Accounts you follow elsewhere"
@@ -17519,22 +17516,22 @@ msgstr "Account che segue altrove"
 msgid "Address of the account"
 msgstr "Indirizzo dell'account"
 
-#: lib/vutuv_web/live/search_live.ex:521
+#: lib/vutuv_web/live/search_live.ex:514
 #, elixir-autogen, elixir-format
 msgid "An account on another network"
 msgstr "Un account su un'altra rete"
 
-#: lib/vutuv_web/components/fediverse_components.ex:431
+#: lib/vutuv_web/components/fediverse_components.ex:428
 #, elixir-autogen, elixir-format
 msgid "Cancel request"
 msgstr "Annulla la richiesta"
 
-#: lib/vutuv_web/components/ui.ex:4797
+#: lib/vutuv_web/components/ui.ex:4905
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Segua account su Mastodon, e si faccia seguire da lì"
 
-#: lib/vutuv_web/components/fediverse_components.ex:462
+#: lib/vutuv_web/components/fediverse_components.ex:459
 #, elixir-autogen, elixir-format
 msgid "Follow request sent to %{account}."
 msgstr "Richiesta di follow inviata a %{account}."
@@ -17544,7 +17541,7 @@ msgstr "Richiesta di follow inviata a %{account}."
 msgid "Follow somebody out there"
 msgstr "Segua qualcuno là fuori"
 
-#: lib/vutuv_web/live/search_live.ex:551
+#: lib/vutuv_web/live/search_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "Follow this account"
 msgstr "Segui questo account"
@@ -17571,7 +17568,7 @@ msgstr ""
 "indirizzo. Ne incolli uno qui e vutuv chiederà a quel server di lasciarLe "
 "seguire l'account."
 
-#: lib/vutuv_web/components/fediverse_components.ex:401
+#: lib/vutuv_web/components/fediverse_components.ex:398
 #: lib/vutuv_web/live/organization_live/following.ex:442
 #, elixir-autogen, elixir-format
 msgid "Requested"
@@ -17587,12 +17584,12 @@ msgstr "Azzera l'ordinamento"
 msgid "Search for them here"
 msgstr "Li cerchi qui"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:384
+#: lib/vutuv_web/live/fediverse_following_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Show only accounts on this server"
 msgstr "Mostra solo gli account su questo server"
 
-#: lib/vutuv_web/live/search_live.ex:559
+#: lib/vutuv_web/live/search_live.ex:552
 #, elixir-autogen, elixir-format
 msgid "Sign in to follow this account"
 msgstr "Acceda per seguire questo account"
@@ -17607,48 +17604,48 @@ msgstr "Stato"
 msgid "Stop following %{account}?"
 msgstr "Smettere di seguire %{account}?"
 
-#: lib/vutuv_web/components/fediverse_components.ex:484
+#: lib/vutuv_web/components/fediverse_components.ex:481
 #, elixir-autogen, elixir-format
 msgid "That account could not be loaded from its server. Try again in a little while."
 msgstr ""
 "Non è stato possibile caricare quell'account dal suo server. Riprovi tra "
 "poco."
 
-#: lib/vutuv_web/components/fediverse_components.ex:536
+#: lib/vutuv_web/components/fediverse_components.ex:533
 #, elixir-autogen, elixir-format
 msgid "That did not work. Check the address and try again."
 msgstr "Non ha funzionato. Controlli l'indirizzo e riprovi."
 
-#: lib/vutuv_web/components/fediverse_components.ex:473
+#: lib/vutuv_web/components/fediverse_components.ex:470
 #, elixir-autogen, elixir-format
 msgid "That does not look like an address on another network. They look like @name@server."
 msgstr ""
 "Questo non sembra un indirizzo su un'altra rete. Hanno la forma "
 "@nome@server."
 
-#: lib/vutuv_web/live/search_live.ex:526
+#: lib/vutuv_web/live/search_live.ex:519
 #, elixir-autogen, elixir-format
 msgid "That is an address on Mastodon or one of the other networks, so nobody here carries it. You can follow it from vutuv."
 msgstr ""
 "Questo è un indirizzo su Mastodon o su una delle altre reti, quindi qui non "
 "lo ha nessuno. Può seguirlo da vutuv."
 
-#: lib/vutuv_web/components/fediverse_components.ex:481
+#: lib/vutuv_web/components/fediverse_components.ex:478
 #, elixir-autogen, elixir-format
 msgid "That server answered, but it has no account at that address to follow."
 msgstr ""
 "Quel server ha risposto, ma non ha alcun account da seguire a "
 "quell'indirizzo."
 
-#: lib/vutuv_web/components/fediverse_components.ex:478
-#: lib/vutuv_web/components/fediverse_components.ex:557
+#: lib/vutuv_web/components/fediverse_components.ex:475
+#: lib/vutuv_web/components/fediverse_components.ex:554
 #, elixir-autogen, elixir-format
 msgid "That server did not answer. Check the address, and that the server is online."
 msgstr ""
 "Quel server non ha risposto. Controlli l'indirizzo e che il server sia "
 "online."
 
-#: lib/vutuv_web/components/fediverse_components.ex:533
+#: lib/vutuv_web/components/fediverse_components.ex:530
 #, elixir-autogen, elixir-format
 msgid "The Fediverse is switched off on this vutuv."
 msgstr "Su questo vutuv il Fediverso è disattivato."
@@ -17658,7 +17655,7 @@ msgstr "Su questo vutuv il Fediverso è disattivato."
 msgid "The address you brought along is kept here:"
 msgstr "L'indirizzo che si è portato dietro è conservato qui:"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:429
+#: lib/vutuv_web/live/fediverse_following_live.ex:437
 #, elixir-autogen, elixir-format
 msgid "The other server decides. Most accounts accept straight away; one that checks its followers by hand stays on \"Requested\" until somebody there says yes."
 msgstr ""
@@ -17673,7 +17670,7 @@ msgstr ""
 "Questo vutuv non scambia nulla con altre reti, quindi da qui non c'è nulla "
 "da seguire. È un'impostazione di chi gestisce il sito, non Sua."
 
-#: lib/vutuv_web/components/fediverse_components.ex:487
+#: lib/vutuv_web/components/fediverse_components.ex:484
 #, elixir-autogen, elixir-format
 msgid "This vutuv does not exchange anything with that server."
 msgstr "Questo vutuv non scambia nulla con quel server."
@@ -17686,18 +17683,18 @@ msgstr ""
 "richiesta viene firmata a Suo nome, così l'altro server sa chi la sta "
 "facendo."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:134
+#: lib/vutuv_web/live/fediverse_account_live.ex:136
 #: lib/vutuv_web/live/fediverse_following_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Unfollowed."
 msgstr "Non lo segue più."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:426
+#: lib/vutuv_web/live/fediverse_following_live.ex:434
 #, elixir-autogen, elixir-format
 msgid "What following out there means"
 msgstr "Cosa significa seguire là fuori"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:434
+#: lib/vutuv_web/live/fediverse_following_live.ex:442
 #, elixir-autogen, elixir-format
 msgid "Who you follow is yours alone. Your profile publishes how many accounts you follow out there, never which ones."
 msgstr ""
@@ -17714,17 +17711,17 @@ msgstr "Perché il mio account è sospeso?"
 msgid "Withdraw your follow request to %{account}?"
 msgstr "Ritirare la Sua richiesta di follow a %{account}?"
 
-#: lib/vutuv_web/components/fediverse_components.ex:504
+#: lib/vutuv_web/components/fediverse_components.ex:501
 #, elixir-autogen, elixir-format
 msgid "You already follow that account."
 msgstr "Segue già quell'account."
 
-#: lib/vutuv_web/components/fediverse_components.ex:522
+#: lib/vutuv_web/components/fediverse_components.ex:519
 #, elixir-autogen, elixir-format
 msgid "You are following the most accounts we allow (%{max})."
 msgstr "Sta seguendo il numero massimo di account che consentiamo (%{max})."
 
-#: lib/vutuv_web/components/fediverse_components.ex:512
+#: lib/vutuv_web/components/fediverse_components.ex:509
 #, elixir-autogen, elixir-format
 msgid "You are not taking part in the Fediverse at the moment, so there is no identity to sign the request with. Open the Fediverse settings to switch it on."
 msgstr ""
@@ -17743,13 +17740,13 @@ msgid_plural "You follow %{formatted} accounts on other networks"
 msgstr[0] "Segue %{formatted} account su un'altra rete"
 msgstr[1] "Segue %{formatted} account su altre reti"
 
-#: lib/vutuv_web/components/fediverse_components.ex:518
+#: lib/vutuv_web/components/fediverse_components.ex:515
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of follow requests in the last hour. Please try again later."
 msgstr ""
 "Nell'ultima ora ha inviato molte richieste di follow. Riprovi più tardi."
 
-#: lib/vutuv_web/components/fediverse_components.ex:528
+#: lib/vutuv_web/components/fediverse_components.ex:525
 #, elixir-autogen, elixir-format
 msgid "You redirected your Fediverse followers to another account, so this account no longer acts out there."
 msgstr ""
@@ -17765,7 +17762,7 @@ msgstr ""
 "reti e non può seguire nessuno lì. La sospensione decade da sé quando "
 "termina."
 
-#: lib/vutuv_web/components/ui.ex:4799
+#: lib/vutuv_web/components/ui.ex:4907
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -17789,7 +17786,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr "Post in cache"
 
-#: lib/vutuv_web/components/post_components.ex:2669
+#: lib/vutuv_web/components/post_components.ex:2691
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Solo per i follower di questo account"
@@ -17799,7 +17796,7 @@ msgstr "Solo per i follower di questo account"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Grazie. La nostra copia è stata eliminata subito."
 
-#: lib/vutuv_web/components/post_components.ex:2909
+#: lib/vutuv_web/components/post_components.ex:2931
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Vota sull'originale"
@@ -17825,17 +17822,17 @@ msgstr "Post in cache segnalato, rimosso per tutti qui"
 msgid "Content from other networks taken down by members"
 msgstr "Contenuti da altre reti rimossi dai membri"
 
-#: lib/vutuv_web/components/post_components.ex:1762
+#: lib/vutuv_web/components/post_components.ex:1784
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Nascondi"
 
-#: lib/vutuv_web/components/post_components.ex:2850
+#: lib/vutuv_web/components/post_components.ex:2872
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Contrassegnato come sensibile dal suo autore"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:229
+#: lib/vutuv_web/live/fediverse_account_live.ex:231
 #: lib/vutuv_web/live/remote_post_actions.ex:71
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
@@ -17846,14 +17843,14 @@ msgstr "Silenziato. Continua a seguirlo; i suoi post spariscono dal Suo feed."
 msgid "Nobody has removed or reported anything yet."
 msgstr "Nessuno ha ancora rimosso o segnalato nulla."
 
-#: lib/vutuv_web/components/post_components.ex:2655
+#: lib/vutuv_web/components/post_components.ex:2677
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
 "Segnalare questo post come non appropriato? La nostra copia viene eliminata "
 "subito per tutti su questo vutuv."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:445
+#: lib/vutuv_web/live/fediverse_following_live.ex:453
 #, elixir-autogen, elixir-format
 msgid "To show their posts we keep a copy here for up to six months. If the author deletes or edits something, ours follows; and when you stop following an account, its posts are deleted here at once."
 msgstr ""
@@ -17869,65 +17866,65 @@ msgstr ""
 "Non segue ancora nessuno là fuori. Quando lo farà, ciò che pubblicano "
 "comparirà nel Suo feed insieme a tutto il resto."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:76
+#: lib/vutuv_web/live/fediverse_account_live.ex:78
 #, elixir-autogen, elixir-format
 msgid "%{name} (another network)"
 msgstr "%{name} (altra rete)"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:279
+#: lib/vutuv_web/live/fediverse_account_live.ex:281
 #, elixir-autogen, elixir-format
 msgid "Account on another network"
 msgstr "Account su un'altra rete"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:433
+#: lib/vutuv_web/live/fediverse_account_live.ex:443
 #, elixir-autogen, elixir-format
 msgid "Look up another account"
 msgstr "Cerca un altro account"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:363
+#: lib/vutuv_web/live/fediverse_account_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "Muted"
 msgstr "Silenziato"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:254
+#: lib/vutuv_web/live/fediverse_account_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "Nothing cached yet. Their posts appear here as they publish them."
 msgstr ""
 "Ancora nulla in cache. I loro post compaiono qui man mano che li pubblicano."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:249
+#: lib/vutuv_web/live/fediverse_account_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Nothing here. vutuv only keeps an account's posts while somebody here follows it, and this page never fetches any."
 msgstr ""
 "Qui non c'è nulla. vutuv conserva i post di un account solo finché qualcuno "
 "qui lo segue, e questa pagina non ne scarica mai."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:435
+#: lib/vutuv_web/live/fediverse_account_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "Paste an address from Mastodon and friends to open its page here."
 msgstr "Incolli un indirizzo da Mastodon e affini per aprirne qui la pagina."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:331
+#: lib/vutuv_web/live/fediverse_account_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Show the whole description"
 msgstr "Mostra tutta la descrizione"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:418
+#: lib/vutuv_web/live/fediverse_account_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "The most recent %{count} are shown. The rest are on their own server."
 msgstr "Sono mostrati i %{count} più recenti. Gli altri sono sul loro server."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:231
+#: lib/vutuv_web/live/fediverse_account_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts are back in your feed."
 msgstr "Riattivato. I suoi post sono tornati nel Suo feed."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:428
+#: lib/vutuv_web/live/fediverse_account_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "View their full profile on %{host}"
 msgstr "Veda il suo profilo completo su %{host}"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:258
+#: lib/vutuv_web/live/fediverse_account_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Waiting for that server to accept your follow. Posts they addressed to their followers appear once it does."
 msgstr ""
@@ -17942,7 +17939,7 @@ msgstr ""
 "questo non segue più nessuno là fuori."
 
 #: lib/vutuv_web/components/fediverse_components.ex:310
-#: lib/vutuv_web/components/fediverse_components.ex:623
+#: lib/vutuv_web/components/fediverse_components.ex:620
 #, elixir-autogen, elixir-format
 msgid "Your account move"
 msgstr "Lo spostamento del Suo account"
@@ -18108,27 +18105,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(un'immagine)"
 msgstr[1] "(%{count} immagini)"
 
-#: lib/vutuv_web/components/post_components.ex:2380
+#: lib/vutuv_web/components/post_components.ex:2402
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr "L'immagine è in fase di controllo"
 
-#: lib/vutuv_web/components/post_components.ex:2408
+#: lib/vutuv_web/components/post_components.ex:2430
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Coprila di nuovo"
 
-#: lib/vutuv_web/components/post_components.ex:2403
+#: lib/vutuv_web/components/post_components.ex:2425
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Contenuto sensibile. Mostra l'immagine."
 
-#: lib/vutuv_web/components/post_components.ex:2952
+#: lib/vutuv_web/components/post_components.ex:2974
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Sono molti Mi piace in un'ora. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:2958
+#: lib/vutuv_web/components/post_components.ex:2980
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Quel post non è più qui."
@@ -18138,7 +18135,7 @@ msgstr "Quel post non è più qui."
 msgid "Back to the feed"
 msgstr "Torna al feed"
 
-#: lib/vutuv_web/components/post_components.ex:3097
+#: lib/vutuv_web/components/post_components.ex:3119
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18158,7 +18155,7 @@ msgstr ""
 msgid "Reposted. Your followers see it now."
 msgstr "Ripubblicato. Ora i Suoi follower lo vedono."
 
-#: lib/vutuv_web/components/fediverse_components.ex:399
+#: lib/vutuv_web/components/fediverse_components.ex:396
 #, elixir-autogen, elixir-format
 msgid "Moved"
 msgstr "Spostato"
@@ -18347,7 +18344,7 @@ msgstr ""
 "Il Suo nome utente è la Sua identità pubblica qui. Cambia solo dopo che avrà"
 " confermato con la Sua passkey o con un codice valido qui sotto."
 
-#: lib/vutuv_web/components/ui.ex:575
+#: lib/vutuv_web/components/ui.ex:599
 #, elixir-autogen, elixir-format
 msgid "Markdown help"
 msgstr "Guida a Markdown"
@@ -18362,49 +18359,49 @@ msgstr "In questa pagina"
 msgid "Read this page as Markdown"
 msgstr "Legga questa pagina in Markdown"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:232
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Address of the post"
 msgstr "Indirizzo del post"
 
-#: lib/vutuv_web/components/fediverse_components.ex:620
+#: lib/vutuv_web/components/fediverse_components.ex:617
 #: lib/vutuv_web/live/post_live/remote_actions_component.ex:276
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings"
 msgstr "Impostazioni del Fediverso"
 
-#: lib/vutuv_web/components/fediverse_components.ex:597
+#: lib/vutuv_web/components/fediverse_components.ex:594
 #, elixir-autogen, elixir-format
 msgid "Fetching a post asks its server for it in your name, signed with your own key, so there is no such thing as an anonymous lookup here."
 msgstr ""
 "Scaricare un post significa chiederlo al suo server a Suo nome, firmato con "
 "la Sua chiave: qui una ricerca anonima non esiste."
 
-#: lib/vutuv_web/components/fediverse_components.ex:564
+#: lib/vutuv_web/components/fediverse_components.ex:561
 #, elixir-autogen, elixir-format
 msgid "Its author published this post to their followers alone, so vutuv does not keep a copy of it."
 msgstr ""
 "Il suo autore ha pubblicato questo post solo per i propri follower, quindi "
 "vutuv non ne conserva una copia."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:460
+#: lib/vutuv_web/live/fediverse_following_live.ex:468
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Look up a post by its address"
 msgstr "Cerchi un post dal suo indirizzo"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:70
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:196
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:71
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Look up a post from another network"
 msgstr "Cerchi un post da un'altra rete"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:324
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Looking for an account rather than a single post?"
 msgstr "Cerca un account invece di un singolo post?"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:199
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Paste the address of a post on Mastodon and friends. vutuv fetches it, shows it here, and you can answer, like or repost it as if it had arrived on its own."
 msgstr ""
@@ -18417,74 +18414,74 @@ msgstr ""
 msgid "Read something out there that you want to answer from here?"
 msgstr "Ha letto qualcosa là fuori a cui vuole rispondere da qui?"
 
-#: lib/vutuv_web/components/fediverse_components.ex:549
+#: lib/vutuv_web/components/fediverse_components.ex:546
 #, elixir-autogen, elixir-format
 msgid "That does not look like a link to a post. Copy the address of the post itself, for example https://server/@name/12345."
 msgstr ""
 "Questo non sembra un link a un post. Copi l'indirizzo del post stesso, ad "
 "esempio https://server/@nome/12345."
 
-#: lib/vutuv_web/components/fediverse_components.ex:554
+#: lib/vutuv_web/components/fediverse_components.ex:551
 #, elixir-autogen, elixir-format
 msgid "That is a link on this vutuv, not on another network."
 msgstr "Questo è un link su questo vutuv, non su un'altra rete."
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:316
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:317
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:240
 #, elixir-autogen, elixir-format
 msgid "Their account page here"
 msgstr "La sua pagina account qui"
 
-#: lib/vutuv_web/components/fediverse_components.ex:560
+#: lib/vutuv_web/components/fediverse_components.ex:557
 #, elixir-autogen, elixir-format
 msgid "There is no post to show at that address."
 msgstr "A quell'indirizzo non c'è alcun post da mostrare."
 
-#: lib/vutuv_web/components/fediverse_components.ex:591
+#: lib/vutuv_web/components/fediverse_components.ex:588
 #, elixir-autogen, elixir-format
 msgid "This account no longer acts out there"
 msgstr "Questo account non agisce più là fuori"
 
-#: lib/vutuv_web/components/fediverse_components.ex:609
+#: lib/vutuv_web/components/fediverse_components.ex:606
 #, elixir-autogen, elixir-format
 msgid "This vutuv does not exchange anything with other networks. That is an operator setting, not yours."
 msgstr ""
 "Questo vutuv non scambia nulla con altre reti. È un'impostazione di chi "
 "gestisce il sito, non Sua."
 
-#: lib/vutuv_web/components/fediverse_components.ex:592
+#: lib/vutuv_web/components/fediverse_components.ex:589
 #, elixir-autogen, elixir-format
 msgid "This vutuv stays to itself"
 msgstr "Questo vutuv resta per conto proprio"
 
-#: lib/vutuv_web/components/fediverse_components.ex:589
+#: lib/vutuv_web/components/fediverse_components.ex:586
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to look up"
 msgstr "Attivi la partecipazione al Fediverso per fare ricerche"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:454
+#: lib/vutuv_web/live/fediverse_following_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "Want to answer one particular post rather than follow its author?"
 msgstr "Vuole rispondere a un post preciso invece di seguirne l'autore?"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:288
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:289
 #, elixir-autogen, elixir-format
 msgid "Who wrote this"
 msgstr "Chi lo ha scritto"
 
-#: lib/vutuv_web/components/fediverse_components.ex:569
+#: lib/vutuv_web/components/fediverse_components.ex:566
 #, elixir-autogen, elixir-format
 msgid "You have looked a lot of posts up in the last hour. Please try again later."
 msgstr "Nell'ultima ora ha cercato molti post. Riprovi più tardi."
 
-#: lib/vutuv_web/components/fediverse_components.ex:603
+#: lib/vutuv_web/components/fediverse_components.ex:600
 #, elixir-autogen, elixir-format
 msgid "You redirected your Fediverse followers to another account, so nothing is fetched or sent from this one any more."
 msgstr ""
 "Ha reindirizzato i Suoi follower del Fediverso a un altro account, quindi da"
 " questo non viene più scaricato né inviato nulla."
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:334
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:335
 #, elixir-autogen, elixir-format
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
@@ -18492,108 +18489,108 @@ msgstr ""
 "previsti per ogni altro post da un'altra rete, e al server del suo autore "
 "non viene chiesto nient'altro."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1696
+#: lib/vutuv_web/live/post_live/composer.ex:1672
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr "Applica il ritaglio"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2386
+#: lib/vutuv_web/live/post_live/composer.ex:2325
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr "Foto grande a sinistra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2387
+#: lib/vutuv_web/live/post_live/composer.ex:2326
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr "Foto grande a destra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2392
+#: lib/vutuv_web/live/post_live/composer.ex:2331
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr "Colonne"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2389
+#: lib/vutuv_web/live/post_live/composer.ex:2328
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr "Copertina a sinistra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2390
+#: lib/vutuv_web/live/post_live/composer.ex:2329
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr "Copertina in alto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2391
+#: lib/vutuv_web/live/post_live/composer.ex:2330
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr "Copertina a destra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1692
-#: lib/vutuv_web/live/post_live/composer.ex:2357
-#: lib/vutuv_web/live/post_live/composer.ex:2358
+#: lib/vutuv_web/live/post_live/composer.ex:1668
+#: lib/vutuv_web/live/post_live/composer.ex:2296
+#: lib/vutuv_web/live/post_live/composer.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr "Ritaglia la foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2316
+#: lib/vutuv_web/live/post_live/composer.ex:2255
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr "Ritagliata"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1614
+#: lib/vutuv_web/live/post_live/composer.ex:1590
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr "Trascini qui le foto per aggiungerle"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2393
+#: lib/vutuv_web/live/post_live/composer.ex:2332
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr "Griglia"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2394
+#: lib/vutuv_web/live/post_live/composer.ex:2333
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr "Mosaico"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1694
+#: lib/vutuv_web/live/post_live/composer.ex:1670
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 "Scelga una forma, poi trascini e ingrandisca. La parte nel riquadro è quella"
 " che il post mostra."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2385
+#: lib/vutuv_web/live/post_live/composer.ex:2324
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr "Affiancate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2388
+#: lib/vutuv_web/live/post_live/composer.ex:2327
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr "Impilate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:497
+#: lib/vutuv_web/live/post_live/composer.ex:493
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr "Non è stato possibile ritagliare la foto."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2834
+#: lib/vutuv_web/live/post_live/composer.ex:2773
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 "Questa foto è ritagliata: i download consegnano l'immagine ritagliata, e il "
 "caricamento intatto resta privato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1698
+#: lib/vutuv_web/live/post_live/composer.ex:1674
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr "Foto intera"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2583
+#: lib/vutuv_web/live/post_live/composer.ex:2522
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr "Riempi le caselle"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2567
+#: lib/vutuv_web/live/post_live/composer.ex:2506
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr "Foto intere"
@@ -18634,12 +18631,12 @@ msgstr ""
 "Il dettaglio più utile in una segnalazione del genere è l'ora esatta "
 "dell'errore. In questo momento sono le %{time}."
 
-#: lib/vutuv_web/components/fediverse_components.ex:448
+#: lib/vutuv_web/components/fediverse_components.ex:445
 #, elixir-autogen, elixir-format
 msgid "@%{handle} is on this vutuv, so you now follow them here."
 msgstr "@%{handle} è su questo vutuv, quindi ora lo segue qui."
 
-#: lib/vutuv_web/components/fediverse_components.ex:493
+#: lib/vutuv_web/components/fediverse_components.ex:490
 #, elixir-autogen, elixir-format
 msgid "That address is on this vutuv, but it names no member here."
 msgstr "Quell'indirizzo è su questo vutuv, ma non indica alcun membro qui."
@@ -18651,7 +18648,7 @@ msgstr ""
 "Quell'indirizzo è su questo vutuv. Acceda e usi il pulsante Segui su questo "
 "profilo."
 
-#: lib/vutuv_web/components/fediverse_components.ex:498
+#: lib/vutuv_web/components/fediverse_components.ex:495
 #, elixir-autogen, elixir-format
 msgid "That is your own address. You cannot follow yourself."
 msgstr "Questo è il Suo indirizzo. Non può seguire sé stesso."
@@ -18827,14 +18824,14 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr "Elenco dei bloccati per gli screenshot"
 
-#: lib/vutuv_web/components/post_components.ex:439
+#: lib/vutuv_web/components/post_components.ex:440
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 "Ancora nulla dal Fediverso. Segua account là fuori per riempire questa "
 "scheda."
 
-#: lib/vutuv_web/components/post_components.ex:436
+#: lib/vutuv_web/components/post_components.ex:437
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr "Ancora nulla da vutuv. Segua persone qui per riempire questa scheda."
@@ -18844,39 +18841,39 @@ msgstr "Ancora nulla da vutuv. Segua persone qui per riempire questa scheda."
 msgid "View the conversation"
 msgstr "Vedi la conversazione"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:256
+#: lib/vutuv_web/live/tag_live/timeline.ex:252
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post"
 msgid_plural "%{formatted} posts"
 msgstr[0] "%{formatted} post"
 msgstr[1] "%{formatted} post"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:415
+#: lib/vutuv_web/live/tag_live/timeline.ex:411
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr "Più apprezzati"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:446
+#: lib/vutuv_web/live/tag_live/timeline.ex:442
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr "Nessun post porta ancora questo tag."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:444
+#: lib/vutuv_web/live/tag_live/timeline.ex:440
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr "Nessun post da altre reti porta ancora questo tag."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:441
+#: lib/vutuv_web/live/tag_live/timeline.ex:437
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr "Nessun post su vutuv porta ancora questo tag."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:332
+#: lib/vutuv_web/live/tag_live/timeline.ex:328
 #, elixir-autogen, elixir-format
 msgid "word in a post"
 msgstr "parola in un post"
 
-#: lib/vutuv_web/components/post_components.ex:2955
+#: lib/vutuv_web/components/post_components.ex:2977
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Quella risposta non è più qui."
@@ -18899,30 +18896,30 @@ msgstr ""
 msgid "Other networks"
 msgstr "Altre reti"
 
-#: lib/vutuv_web/live/fediverse_post_live.ex:80
+#: lib/vutuv_web/live/fediverse_post_live.ex:82
 #, elixir-autogen, elixir-format
 msgid "A post by %{name} (another network)"
 msgstr "Un post di %{name} (altra rete)"
 
-#: lib/vutuv_web/live/fediverse_post_live.ex:120
+#: lib/vutuv_web/live/fediverse_post_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "A post from another network"
 msgstr "Un post da un'altra rete"
 
-#: lib/vutuv_web/live/fediverse_post_live.ex:146
+#: lib/vutuv_web/live/fediverse_post_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "More from %{name}"
 msgstr "Altro da %{name}"
 
-#: lib/vutuv_web/live/fediverse_post_live.ex:126
+#: lib/vutuv_web/live/fediverse_post_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr ""
 "Questa è la copia vutuv di un post pubblicato su %{host}. Viene conservata "
 "finché qualcuno qui segue il suo autore."
 
-#: lib/vutuv_web/components/ui.ex:1374
-#: lib/vutuv_web/components/ui.ex:1375
+#: lib/vutuv_web/components/ui.ex:1398
+#: lib/vutuv_web/components/ui.ex:1399
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr "Si iscriva a questo feed nel Suo lettore RSS"
@@ -18934,7 +18931,7 @@ msgstr ""
 "Un CV con posizioni, formazione, certificati con tanto di prova, lingue "
 "parlate e tag per cui altri membri La confermano."
 
-#: lib/vutuv_web/templates/page/index.html.heex:465
+#: lib/vutuv_web/templates/page/index.html.heex:464
 #, elixir-autogen, elixir-format
 msgid "A business network that is free, does not lock your data in, and is yours to run yourself if you want to."
 msgstr ""
@@ -18962,12 +18959,12 @@ msgstr ""
 "Download del CV in PDF, Word, OpenDocument, LaTeX o JSON Resume, e sceglie "
 "Lei cosa includere prima di scaricarlo."
 
-#: lib/vutuv_web/templates/page/index.html.heex:518
+#: lib/vutuv_web/templates/page/index.html.heex:517
 #, elixir-autogen, elixir-format
 msgid "Developer documentation"
 msgstr "Documentazione per sviluppatori"
 
-#: lib/vutuv_web/templates/page/index.html.heex:478
+#: lib/vutuv_web/templates/page/index.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "Every public page here is also served as Markdown, plain text, JSON and XML under the same address. No scraping, no API key, no account."
 msgstr ""
@@ -18975,12 +18972,12 @@ msgstr ""
 " XML allo stesso indirizzo. Niente scraping, niente chiave API, niente "
 "account."
 
-#: lib/vutuv_web/templates/page/index.html.heex:485
+#: lib/vutuv_web/templates/page/index.html.heex:484
 #, elixir-autogen, elixir-format
 msgid "For machines"
 msgstr "Per le macchine"
 
-#: lib/vutuv_web/templates/page/index.html.heex:475
+#: lib/vutuv_web/templates/page/index.html.heex:474
 #, elixir-autogen, elixir-format
 msgid "Open by default"
 msgstr "Aperto per impostazione predefinita"
@@ -19011,12 +19008,12 @@ msgstr ""
 "Post, Mi piace, ripubblicazioni, risposte e messaggi uno a uno, in tempo "
 "reale."
 
-#: lib/vutuv_web/templates/page/index.html.heex:476
+#: lib/vutuv_web/templates/page/index.html.heex:475
 #, elixir-autogen, elixir-format
 msgid "Readable by people, by machines, and on your own server"
 msgstr "Leggibile dalle persone, dalle macchine e sul Suo server"
 
-#: lib/vutuv_web/templates/page/index.html.heex:501
+#: lib/vutuv_web/templates/page/index.html.heex:500
 #, elixir-autogen, elixir-format
 msgid "Run it yourself"
 msgstr "Lo gestisca Lei"
@@ -19028,23 +19025,23 @@ msgstr ""
 "Acceda senza password, con un PIN via e-mail, una passkey, un'app di "
 "autenticazione o un elenco di codici stampato."
 
-#: lib/vutuv_web/templates/page/index.html.heex:512
-#: lib/vutuv_web/templates/page/index.html.heex:599
+#: lib/vutuv_web/templates/page/index.html.heex:511
+#: lib/vutuv_web/templates/page/index.html.heex:598
 #, elixir-autogen, elixir-format
 msgid "Source code"
 msgstr "Codice sorgente"
 
-#: lib/vutuv_web/templates/page/index.html.heex:347
+#: lib/vutuv_web/templates/page/index.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "This is what a vutuv profile looks like"
 msgstr "Ecco come si presenta un profilo vutuv"
 
-#: lib/vutuv_web/templates/page/index.html.heex:463
+#: lib/vutuv_web/templates/page/index.html.heex:462
 #, elixir-autogen, elixir-format
 msgid "What vutuv can do"
 msgstr "Cosa sa fare vutuv"
 
-#: lib/vutuv_web/templates/page/index.html.heex:462
+#: lib/vutuv_web/templates/page/index.html.heex:461
 #, elixir-autogen, elixir-format
 msgid "What you get"
 msgstr "Cosa ottiene"
@@ -19054,14 +19051,14 @@ msgstr "Cosa ottiene"
 msgid "Your independence"
 msgstr "La Sua indipendenza"
 
-#: lib/vutuv_web/templates/page/index.html.heex:503
+#: lib/vutuv_web/templates/page/index.html.heex:502
 #, elixir-autogen, elixir-format
 msgid "vutuv is open source under the MIT license. Run it for a company, an association or a school, on the internet or air-gapped inside your own network."
 msgstr ""
 "vutuv è open source con licenza MIT. Lo faccia girare per un'azienda, "
 "un'associazione o una scuola, su internet o isolato dentro la Sua rete."
 
-#: lib/vutuv_web/templates/page/index.html.heex:346
+#: lib/vutuv_web/templates/page/index.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "A look inside"
 msgstr "Uno sguardo dentro"
@@ -19074,7 +19071,7 @@ msgstr ""
 "qualifica, numero di follower e i primi post, con recapiti e profili social "
 "in una colonna a destra."
 
-#: lib/vutuv_web/templates/page/index.html.heex:368
+#: lib/vutuv_web/templates/page/index.html.heex:367
 #, elixir-autogen, elixir-format
 msgid "Browse real profiles"
 msgstr "Sfogli profili veri"
@@ -19100,14 +19097,14 @@ msgstr ""
 msgid "Try it out:"
 msgstr "Lo provi:"
 
-#: lib/vutuv_web/templates/page/index.html.heex:494
+#: lib/vutuv_web/templates/page/index.html.heex:493
 #, elixir-autogen, elixir-format
 msgid "Plus a sitemap, JSON-LD and a REST API with OAuth 2 and personal access tokens."
 msgstr ""
 "In più una sitemap, JSON-LD e un'API REST con OAuth 2 e token di accesso "
 "personali."
 
-#: lib/vutuv_web/templates/page/index.html.heex:349
+#: lib/vutuv_web/templates/page/index.html.heex:348
 #, elixir-autogen, elixir-format
 msgid "Work experience, education, certificates, languages, links and tags others endorse you for. Anyone can read a profile, entirely without a vutuv account. Unlike LinkedIn, where you hit a login wall in short order."
 msgstr ""
@@ -19116,7 +19113,7 @@ msgstr ""
 "vutuv. A differenza di LinkedIn, dove in poco tempo si sbatte contro una "
 "richiesta di accesso."
 
-#: lib/vutuv_web/templates/page/index.html.heex:449
+#: lib/vutuv_web/templates/page/index.html.heex:448
 #, elixir-autogen, elixir-format
 msgid "Talking to people"
 msgstr "Parlare con le persone"
@@ -19145,12 +19142,12 @@ msgstr ""
 "compariranno lì. Sceglie al momento dell'iscrizione, e può cambiare idea in "
 "seguito."
 
-#: lib/vutuv_web/templates/page/index.html.heex:450
+#: lib/vutuv_web/templates/page/index.html.heex:449
 #, elixir-autogen, elixir-format
 msgid "Posts, messages, and the Fediverse along with them"
 msgstr "Post, messaggi e con essi il Fediverso"
 
-#: lib/vutuv_web/templates/page/index.html.heex:452
+#: lib/vutuv_web/templates/page/index.html.heex:451
 #, elixir-autogen, elixir-format
 msgid "Write a post, react with a heart, a repost or a reply, or message somebody privately. And you are not stuck among vutuv members: vutuv is part of the Fediverse, the union of independent networks that Mastodon belongs to as well. Follow an account over there and its posts arrive in your feed; the other way round, people there can follow you and see your public posts. Both directions, and entirely your choice: at sign-up you decide whether to use vutuv with or without the Fediverse, and you can change that at any time in the settings."
 msgstr ""
@@ -19163,7 +19160,7 @@ msgstr ""
 "tutto Sua: al momento dell'iscrizione decide se usare vutuv con o senza il "
 "Fediverso, e può cambiare in qualsiasi momento dalle impostazioni."
 
-#: lib/vutuv_web/templates/page/index.html.heex:565
+#: lib/vutuv_web/templates/page/index.html.heex:564
 #, elixir-autogen, elixir-format
 msgid "Download everything you have here at any time, in a machine-readable file. Not on request, not after a waiting period: from your settings, whenever you like."
 msgstr ""
@@ -19171,17 +19168,17 @@ msgstr ""
 "dalle macchine. Non su richiesta, non dopo un periodo di attesa: dalle Sue "
 "impostazioni, quando vuole."
 
-#: lib/vutuv_web/templates/page/index.html.heex:540
+#: lib/vutuv_web/templates/page/index.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "Fair and transparent, in plain words"
 msgstr "Corretto e trasparente, detto in parole semplici"
 
-#: lib/vutuv_web/templates/page/index.html.heex:554
+#: lib/vutuv_web/templates/page/index.html.heex:553
 #, elixir-autogen, elixir-format
 msgid "No third-party cookies"
 msgstr "Nessun cookie di terze parti"
 
-#: lib/vutuv_web/templates/page/index.html.heex:546
+#: lib/vutuv_web/templates/page/index.html.heex:545
 #, elixir-autogen, elixir-format
 msgid "On our own servers in %{place}, not in somebody else's cloud. We do not hand your profile to a third party, and there is no tracking network reading along."
 msgstr ""
@@ -19189,17 +19186,17 @@ msgstr ""
 "consegniamo il Suo profilo a terzi, e non c'è alcuna rete di tracciamento "
 "che legge insieme a noi."
 
-#: lib/vutuv_web/templates/page/index.html.heex:544
+#: lib/vutuv_web/templates/page/index.html.heex:543
 #, elixir-autogen, elixir-format
 msgid "Where your data lives"
 msgstr "Dove stanno i Suoi dati"
 
-#: lib/vutuv_web/templates/page/index.html.heex:539
+#: lib/vutuv_web/templates/page/index.html.heex:538
 #, elixir-autogen, elixir-format
 msgid "Your data"
 msgstr "I Suoi dati"
 
-#: lib/vutuv_web/templates/page/index.html.heex:556
+#: lib/vutuv_web/templates/page/index.html.heex:555
 #, elixir-autogen, elixir-format
 msgid "vutuv sets one cookie, the one that keeps you signed in. No advertising network, no analytics service, nothing loaded from anybody else's server."
 msgstr ""
@@ -19207,17 +19204,17 @@ msgstr ""
 "pubblicitaria, nessun servizio di statistiche, nulla caricato dal server di "
 "qualcun altro."
 
-#: lib/vutuv_web/templates/page/index.html.heex:572
+#: lib/vutuv_web/templates/page/index.html.heex:571
 #, elixir-autogen, elixir-format
 msgid "Leave whenever you like"
 msgstr "Se ne vada quando vuole"
 
-#: lib/vutuv_web/templates/page/index.html.heex:588
+#: lib/vutuv_web/templates/page/index.html.heex:587
 #, elixir-autogen, elixir-format
 msgid "Open source"
 msgstr "Open source"
 
-#: lib/vutuv_web/templates/page/index.html.heex:590
+#: lib/vutuv_web/templates/page/index.html.heex:589
 #, elixir-autogen, elixir-format
 msgid "You can check at any time how exactly vutuv works. The whole source code is public under the MIT license, so everything said above about your data can be read rather than taken on trust."
 msgstr ""
@@ -19226,12 +19223,12 @@ msgstr ""
 " è stato detto qui sopra sui Suoi dati si può leggere invece che credere "
 "sulla parola."
 
-#: lib/vutuv_web/templates/page/index.html.heex:563
+#: lib/vutuv_web/templates/page/index.html.heex:562
 #, elixir-autogen, elixir-format
 msgid "Your data stays with you"
 msgstr "I Suoi dati restano Suoi"
 
-#: lib/vutuv_web/templates/page/index.html.heex:579
+#: lib/vutuv_web/templates/page/index.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "Delete your account yourself, without writing to anybody. No questions asked, and you are welcome back any time."
 msgstr ""
@@ -19255,19 +19252,19 @@ msgstr ""
 msgid "Liked by"
 msgstr "Piace a"
 
-#: lib/vutuv_web/components/post_components.ex:4788
+#: lib/vutuv_web/components/post_components.ex:4810
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Piace a %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4790
+#: lib/vutuv_web/components/post_components.ex:4812
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Piace a %{name} e a %{formatted} altro"
 msgstr[1] "Piace a %{name} e ad altri %{formatted}"
 
-#: lib/vutuv_web/components/post_components.ex:4801
+#: lib/vutuv_web/components/post_components.ex:4823
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -19324,7 +19321,7 @@ msgid "A published reference then appears next to the entry it documents."
 msgstr "Un attestato pubblicato compare poi accanto alla voce che documenta."
 
 #: lib/vutuv_web/controllers/job_reference_controller.ex:252
-#: lib/vutuv_web/live/reference_check_live.ex:420
+#: lib/vutuv_web/live/reference_check_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "A review for this reference is already running."
 msgstr "Per questo attestato è già in corso un'analisi."
@@ -19403,7 +19400,7 @@ msgstr "Attestato di lavoro aggiornato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:4688
+#: lib/vutuv_web/components/ui.ex:4796
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -19448,7 +19445,7 @@ msgstr "Rilasciato il"
 msgid "Label"
 msgstr "Etichetta"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3176
+#: lib/vutuv_web/live/post_live/feed.ex:3173
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -19492,7 +19489,7 @@ msgstr "Attestato"
 msgid "Review result"
 msgstr "Esito dell'analisi"
 
-#: lib/vutuv_web/live/reference_check_live.ex:303
+#: lib/vutuv_web/live/reference_check_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Reviewing your reference. This takes a few minutes."
 msgstr "Analisi del Suo attestato in corso. Ci vogliono alcuni minuti."
@@ -19503,7 +19500,7 @@ msgid "Show this reference publicly on my profile"
 msgstr "Mostra pubblicamente questo attestato sul mio profilo"
 
 #: lib/vutuv_web/templates/job_reference/show.html.heex:39
-#: lib/vutuv_web/templates/job_reference/view.html.heex:89
+#: lib/vutuv_web/templates/job_reference/view.html.heex:86
 #: lib/vutuv_web/views/account_event_text.ex:227
 #, elixir-autogen, elixir-format
 msgid "Text"
@@ -19533,22 +19530,22 @@ msgstr ""
 "offerta solo per gli Arbeitszeugnisse tedeschi."
 
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:55
-#: lib/vutuv_web/templates/job_reference/view.html.heex:47
+#: lib/vutuv_web/templates/job_reference/view.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "The document"
 msgstr "Il documento"
 
-#: lib/vutuv_web/live/reference_check_live.ex:359
+#: lib/vutuv_web/live/reference_check_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "The review could not be completed."
 msgstr "Non è stato possibile completare l'analisi."
 
-#: lib/vutuv_web/live/reference_check_live.ex:428
+#: lib/vutuv_web/live/reference_check_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "The review could not be started."
 msgstr "Non è stato possibile avviare l'analisi."
 
-#: lib/vutuv_web/live/reference_check_live.ex:426
+#: lib/vutuv_web/live/reference_check_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "The review covers German Arbeitszeugnisse only."
 msgstr "L'analisi riguarda solo gli Arbeitszeugnisse tedeschi."
@@ -19569,14 +19566,14 @@ msgid "The review is not available on this installation."
 msgstr "L'analisi non è disponibile su questa installazione."
 
 #: lib/vutuv_web/controllers/job_reference_controller.ex:259
-#: lib/vutuv_web/live/reference_check_live.ex:423
+#: lib/vutuv_web/live/reference_check_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "There is no text to review yet. Upload the document or paste the text."
 msgstr ""
 "Non c'è ancora alcun testo da analizzare. Carichi il documento o incolli il "
 "testo."
 
-#: lib/vutuv_web/live/reference_check_live.ex:366
+#: lib/vutuv_web/live/reference_check_live.ex:349
 #: lib/vutuv_web/templates/service_worker/offline.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "Try again"
@@ -19589,14 +19586,14 @@ msgstr ""
 "Carichi i Suoi Arbeitszeugnisse, li alleghi al Suo CV e li faccia "
 "analizzare. Nulla è pubblico finché non lo decide Lei."
 
-#: lib/vutuv_web/live/reference_check_live.ex:272
+#: lib/vutuv_web/live/reference_check_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Waiting — %{count} review ahead of yours."
 msgid_plural "Waiting — %{count} reviews ahead of yours."
 msgstr[0] "In attesa: %{count} analisi prima della Sua."
 msgstr[1] "In attesa: %{count} analisi prima della Sua."
 
-#: lib/vutuv_web/live/reference_check_live.ex:278
+#: lib/vutuv_web/live/reference_check_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Waiting — yours is next."
 msgstr "In attesa: la Sua è la prossima."
@@ -19608,7 +19605,7 @@ msgstr ""
 "Ha modificato il testo dopo questa analisi. L'analisi descrive la versione "
 "precedente."
 
-#: lib/vutuv_web/components/ui.ex:4689
+#: lib/vutuv_web/components/ui.ex:4797
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr "I Suoi Arbeitszeugnisse, privati finché non li pubblica"
@@ -19619,7 +19616,7 @@ msgstr "I Suoi Arbeitszeugnisse, privati finché non li pubblica"
 msgid "Zwischenzeugnis"
 msgstr "Zwischenzeugnis"
 
-#: lib/vutuv_web/components/ui.ex:4691
+#: lib/vutuv_web/components/ui.ex:4799
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -19631,25 +19628,25 @@ msgstr ""
 msgid "e.g. Zeugnis Muster GmbH 2019–2026"
 msgstr "ad esempio Zeugnis Muster GmbH 2019–2026"
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:116
+#: lib/vutuv_web/templates/job_reference/check.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "For a binding assessment please ask a lawyer, ideally a Fachanwalt für Arbeitsrecht."
 msgstr ""
 "Per una valutazione vincolante si rivolga a un avvocato, preferibilmente un "
 "Fachanwalt für Arbeitsrecht (specialista in diritto del lavoro tedesco)."
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:123
+#: lib/vutuv_web/templates/job_reference/check.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "The analysis follows the freely available Arbeitszeugnis-Prüfer prompt"
 msgstr ""
 "L'analisi segue il prompt Arbeitszeugnis-Prüfer, liberamente disponibile"
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:110
+#: lib/vutuv_web/templates/job_reference/check.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "This is not legal advice."
 msgstr "Questo non è un parere legale."
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:113
+#: lib/vutuv_web/templates/job_reference/check.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "We do not assess your case. What you see is an automated reading of the wording of your document, produced on our own servers by a language model."
 msgstr ""
@@ -19657,7 +19654,7 @@ msgstr ""
 "testo del Suo documento, prodotta sui nostri server da un modello "
 "linguistico."
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:139
+#: lib/vutuv_web/templates/job_reference/check.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "We wrote neither the prompt nor the model."
 msgstr "Non abbiamo scritto né il prompt né il modello."
@@ -19672,13 +19669,13 @@ msgstr "Attestati di lavoro di %{name}"
 msgid "document"
 msgstr "documento"
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:151
+#: lib/vutuv_web/templates/job_reference/check.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Back to your employment references"
 msgstr "Torna ai Suoi attestati di lavoro"
 
-#: lib/vutuv_web/live/reference_check_live.ex:332
-#: lib/vutuv_web/templates/job_reference/view.html.heex:41
+#: lib/vutuv_web/live/reference_check_live.ex:321
+#: lib/vutuv_web/templates/job_reference/view.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "Read the review"
 msgstr "Legga l'analisi"
@@ -19698,20 +19695,20 @@ msgstr "Voto complessivo"
 msgid "Reviewed on"
 msgstr "Analizzato il"
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:90
+#: lib/vutuv_web/templates/job_reference/check.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Check the text"
 msgstr "Controlli il testo"
 
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:116
-#: lib/vutuv_web/templates/job_reference/view.html.heex:104
+#: lib/vutuv_web/templates/job_reference/view.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Delete this reference, its document and its review? This cannot be undone."
 msgstr ""
 "Eliminare questo attestato, il suo documento e la sua analisi? L'operazione "
 "non si può annullare."
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:157
+#: lib/vutuv_web/templates/job_reference/check.html.heex:153
 #, elixir-autogen, elixir-format
 msgid "Edit this reference"
 msgstr "Modifica questo attestato"
@@ -19721,8 +19718,8 @@ msgstr "Modifica questo attestato"
 msgid "Open the file"
 msgstr "Apri il file"
 
-#: lib/vutuv_web/live/reference_check_live.ex:348
-#: lib/vutuv_web/templates/job_reference/check.html.heex:72
+#: lib/vutuv_web/live/reference_check_live.ex:332
+#: lib/vutuv_web/templates/job_reference/check.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Review again"
 msgstr "Analizza di nuovo"
@@ -19732,7 +19729,7 @@ msgstr "Analizza di nuovo"
 msgid "Uploaded file"
 msgstr "File caricato"
 
-#: lib/vutuv_web/live/reference_check_live.ex:341
+#: lib/vutuv_web/live/reference_check_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "You changed the text after this review."
 msgstr "Ha modificato il testo dopo questa analisi."
@@ -19770,7 +19767,7 @@ msgstr ""
 "profilo non ne pubblica mai l'analisi. Quello che una macchina ha letto nel "
 "Suo Zeugnis riguarda soltanto Lei."
 
-#: lib/vutuv_web/templates/job_reference/view.html.heex:54
+#: lib/vutuv_web/templates/job_reference/view.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Open in a new tab"
 msgstr "Apri in una nuova scheda"
@@ -19785,8 +19782,8 @@ msgstr "Il modello è open source."
 msgid "The result is yours alone."
 msgstr "L'esito è solo Suo."
 
-#: lib/vutuv_web/templates/job_reference/view.html.heex:68
-#: lib/vutuv_web/templates/job_reference/view.html.heex:78
+#: lib/vutuv_web/templates/job_reference/view.html.heex:65
+#: lib/vutuv_web/templates/job_reference/view.html.heex:75
 #, elixir-autogen, elixir-format
 msgid "The uploaded reference"
 msgstr "L'attestato caricato"
@@ -19845,7 +19842,7 @@ msgstr "Analisi degli attestati di lavoro"
 msgid "Issue date"
 msgstr "Data di rilascio"
 
-#: lib/vutuv_web/live/reference_check_live.ex:299
+#: lib/vutuv_web/live/reference_check_live.ex:291
 #, elixir-autogen, elixir-format
 msgid "Reviewing your reference. This usually takes about %{duration}."
 msgstr ""
@@ -19863,7 +19860,7 @@ msgstr "L'analisi di “%{title}” è pronta."
 msgid "The review of “%{title}” is ready: %{grade}."
 msgstr "L'analisi di “%{title}” è pronta: %{grade}."
 
-#: lib/vutuv_web/live/reference_check_live.ex:284
+#: lib/vutuv_web/live/reference_check_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Usually about %{duration}."
 msgstr "Di solito circa %{duration}."
@@ -19895,13 +19892,13 @@ msgstr "Trascini qui il file, oppure ne scelga uno"
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr "PDF, JPG, PNG o WebP, fino a %{limit}"
 
-#: lib/vutuv_web/components/ui.ex:4028
+#: lib/vutuv_web/components/ui.ex:4132
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
 msgstr "Il file supera %{limit}. Ne carichi uno più piccolo."
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:99
+#: lib/vutuv_web/templates/job_reference/check.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "The full report"
 msgstr "Il rapporto completo"
@@ -19927,7 +19924,7 @@ msgstr ""
 msgid "This reference was issued to me."
 msgstr "Questo attestato è stato rilasciato a me."
 
-#: lib/vutuv_web/live/reference_check_live.ex:249
+#: lib/vutuv_web/live/reference_check_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Decode this reference"
 msgstr "Decifri questo attestato"
@@ -19942,12 +19939,12 @@ msgstr ""
 "dice davvero ogni formula di giudizio e cosa manca, si contraddice o è "
 "formalmente sbagliato."
 
-#: lib/vutuv_web/live/reference_check_live.ex:258
+#: lib/vutuv_web/live/reference_check_live.ex:250
 #, elixir-autogen, elixir-format
 msgid "Only you see the result."
 msgstr "L'esito lo vede solo Lei."
 
-#: lib/vutuv_web/live/reference_check_live.ex:388
+#: lib/vutuv_web/live/reference_check_live.ex:371
 #, elixir-autogen, elixir-format
 msgid "You can leave this page. The result lands in your notifications, and we email it to you if you are no longer here by then."
 msgstr ""
@@ -20049,7 +20046,7 @@ msgstr ""
 msgid "An employment reference of yours has been reviewed."
 msgstr "Un Suo attestato di lavoro è stato analizzato."
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:131
+#: lib/vutuv_web/templates/job_reference/check.html.heex:127
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "GitHub account @Klotzkette"
@@ -20095,7 +20092,7 @@ msgstr "Le è stato assegnato un ruolo in %{organization}."
 msgid "Your vutuv username is ready."
 msgstr "Il Suo nome utente vutuv è pronto."
 
-#: lib/vutuv_web/templates/job_reference/check.html.heex:125
+#: lib/vutuv_web/templates/job_reference/check.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "by the lawyer Tom Braegelmann"
 msgstr "dall'avvocato Tom Braegelmann"
@@ -20169,7 +20166,7 @@ msgid "You have reached your limit of %{limit} reviews. Please try again in %{wi
 msgstr ""
 "Ha raggiunto il Suo limite di %{limit} analisi. Riprovi fra %{window}."
 
-#: lib/vutuv_web/templates/page/index.html.heex:409
+#: lib/vutuv_web/templates/page/index.html.heex:408
 #, elixir-autogen, elixir-format
 msgid "Employment reference"
 msgstr "Attestato di lavoro"
@@ -20181,7 +20178,7 @@ msgstr ""
 "Attestati di lavoro: li carichi, li tenga privati e faccia leggere e "
 "valutare il loro testo sui nostri server."
 
-#: lib/vutuv_web/templates/page/index.html.heex:386
+#: lib/vutuv_web/templates/page/index.html.heex:385
 #, elixir-autogen, elixir-format
 msgid "Job applications"
 msgstr "Candidature"
@@ -20202,7 +20199,7 @@ msgstr ""
 "recapiti, sotto le posizioni ricoperte con datore di lavoro e periodo, e più"
 " in basso i tag e le lingue parlate."
 
-#: lib/vutuv_web/templates/page/index.html.heex:429
+#: lib/vutuv_web/templates/page/index.html.heex:428
 #, elixir-autogen, elixir-format
 msgid "The review is a text analysis, not legal advice, and it covers German employment references."
 msgstr ""
@@ -20225,7 +20222,7 @@ msgstr ""
 "con voto 1 (ottimo) su un riquadro verde, uno con voto da 4 a 5 (scarso o "
 "insufficiente) su uno rosso, ciascuno con un link al rapporto completo."
 
-#: lib/vutuv_web/templates/page/index.html.heex:412
+#: lib/vutuv_web/templates/page/index.html.heex:411
 #, elixir-autogen, elixir-format
 msgid "Upload your employment references and have them read sentence by sentence: a grade, a traffic light, and the explanation of how a recruiter reads that wording. It takes a few minutes, then the report is there. Nothing becomes public before you release it."
 msgstr ""
@@ -20234,12 +20231,12 @@ msgstr ""
 "formulazione. Ci vogliono pochi minuti, poi il rapporto è pronto. Nulla "
 "diventa pubblico prima che lo autorizzi Lei."
 
-#: lib/vutuv_web/templates/page/index.html.heex:410
+#: lib/vutuv_web/templates/page/index.html.heex:409
 #, elixir-autogen, elixir-format
 msgid "What your employment reference really says"
 msgstr "Cosa dice davvero il Suo attestato di lavoro"
 
-#: lib/vutuv_web/templates/page/index.html.heex:389
+#: lib/vutuv_web/templates/page/index.html.heex:388
 #, elixir-autogen, elixir-format
 msgid "What your profile already says becomes a CV. You tick what should go in, then download it as PDF, Word, OpenDocument, LaTeX or JSON Resume. Anonymously as well, if you would rather show what you can do before you show who you are."
 msgstr ""
@@ -20247,7 +20244,7 @@ msgstr ""
 "poi lo scarica in PDF, Word, OpenDocument, LaTeX o JSON Resume. Anche in "
 "forma anonima, se preferisce mostrare cosa sa fare prima di mostrare chi è."
 
-#: lib/vutuv_web/templates/page/index.html.heex:387
+#: lib/vutuv_web/templates/page/index.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "Your CV, ready to send"
 msgstr "Il Suo CV, pronto da inviare"
@@ -20277,7 +20274,7 @@ msgstr ""
 "falso account verificato. Un amministratore può verificarla di nuovo in "
 "qualsiasi momento."
 
-#: lib/vutuv_web/templates/page/index.html.heex:249
+#: lib/vutuv_web/templates/page/index.html.heex:250
 #, elixir-autogen, elixir-format
 msgid "Your public posts then also appear on {mastodon} and other independent networks, where people can follow you. Replies and reposts come back under your posts, with the account's address, and are kept for up to six months. You can switch it off at any time."
 msgstr ""
@@ -20299,14 +20296,14 @@ msgstr "PIN di 6 cifre"
 msgid "Enter the PIN from the email"
 msgstr "Inserisca il PIN che trova nell'e-mail"
 
-#: lib/vutuv_web/components/ui.ex:807
+#: lib/vutuv_web/components/ui.ex:831
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 "Se ha aggiunto altri indirizzi al Suo account vutuv, provi ad accedere con "
 "uno di quelli."
 
-#: lib/vutuv_web/components/ui.ex:835
+#: lib/vutuv_web/components/ui.ex:859
 #, elixir-autogen, elixir-format
 msgid "Cancel registration"
 msgstr "Annulla la registrazione"
@@ -20323,7 +20320,7 @@ msgstr ""
 msgid "Follow other members"
 msgstr "Segua altri membri"
 
-#: lib/vutuv_web/components/ui.ex:790
+#: lib/vutuv_web/components/ui.ex:814
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
@@ -20352,7 +20349,7 @@ msgstr ""
 "Le percentuali si riferiscono ai %{answered} membri che hanno risposto. "
 "%{unanswered} non hanno risposto."
 
-#: lib/vutuv_web/components/ui.ex:4670
+#: lib/vutuv_web/components/ui.ex:4778
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr "immagine profilo ritratto foto compleanno genere su di me"
@@ -20454,7 +20451,7 @@ msgstr "Elimina anche"
 msgid "Always keep"
 msgstr "Conserva sempre"
 
-#: lib/vutuv_web/components/ui.ex:4790
+#: lib/vutuv_web/components/ui.ex:4898
 #: lib/vutuv_web/controllers/settings_controller.ex:247
 #: lib/vutuv_web/controllers/settings_controller.ex:326
 #: lib/vutuv_web/controllers/settings_controller.ex:338
@@ -20564,7 +20561,7 @@ msgstr "Conserva i post con foto"
 msgid "Keep posts that did well"
 msgstr "Conserva i post andati bene"
 
-#: lib/vutuv_web/components/ui.ex:4792
+#: lib/vutuv_web/components/ui.ex:4900
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr "Lasci scadere i Suoi post dopo un tempo che decide Lei"
@@ -20688,7 +20685,7 @@ msgstr "Prima può scaricare tutto ciò che ha qui:"
 msgid "Your rule"
 msgstr "La Sua regola"
 
-#: lib/vutuv_web/components/ui.ex:4794
+#: lib/vutuv_web/components/ui.ex:4902
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -21100,7 +21097,7 @@ msgstr ""
 msgid "Start over"
 msgstr "Ricomincia"
 
-#: lib/vutuv_web/components/post_components.ex:2985
+#: lib/vutuv_web/components/post_components.ex:3007
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -21140,7 +21137,7 @@ msgstr "Scelga almeno un ruolo."
 msgid "Posts jobs."
 msgstr "Pubblica annunci di lavoro."
 
-#: lib/vutuv_web/live/organization_live/roles.ex:274
+#: lib/vutuv_web/live/organization_live/roles.ex:269
 #, elixir-autogen, elixir-format
 msgid "Roles"
 msgstr "Ruoli"
@@ -21169,22 +21166,22 @@ msgstr ""
 msgid "Nothing published yet."
 msgstr "Ancora nulla di pubblicato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1925
+#: lib/vutuv_web/live/post_live/composer.ex:1927
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr "Pubblica come %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1271
+#: lib/vutuv_web/live/post_live/composer.ex:1246
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr "Non può più scrivere a nome di questa organizzazione."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1902
+#: lib/vutuv_web/live/post_live/composer.ex:1904
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr "Un post a nome di un'organizzazione è sempre pubblico."
 
-#: lib/vutuv_web/live/shell_live.ex:1061
+#: lib/vutuv_web/live/shell_live.ex:1057
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr "Apri la pagina"
@@ -21204,7 +21201,7 @@ msgstr "Ha smesso di scrivere come organizzazione"
 msgid "Write as %{name} for now"
 msgstr "Scrivi come %{name} per ora"
 
-#: lib/vutuv_web/live/shell_live.ex:1071
+#: lib/vutuv_web/live/shell_live.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr "Torna a scrivere come me stesso"
@@ -21214,7 +21211,7 @@ msgstr "Torna a scrivere come me stesso"
 msgid "You are writing as %{name} now."
 msgstr "Ora sta scrivendo come %{name}."
 
-#: lib/vutuv_web/live/shell_live.ex:1047
+#: lib/vutuv_web/live/shell_live.ex:1043
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr "Sta scrivendo come %{name}."
@@ -21273,7 +21270,7 @@ msgstr "%{name} ha menzionato questa pagina."
 msgid "%{name} follows"
 msgstr "%{name} segue"
 
-#: lib/vutuv_web/live/organization_live/feed.ex:66
+#: lib/vutuv_web/live/organization_live/feed.ex:65
 #, elixir-autogen, elixir-format
 msgid "Feed – %{name}"
 msgstr "Feed – %{name}"
@@ -21288,7 +21285,7 @@ msgstr "Segui come %{name}"
 msgid "Members and organizations"
 msgstr "Membri e organizzazioni"
 
-#: lib/vutuv_web/live/organization_live/feed.ex:161
+#: lib/vutuv_web/live/organization_live/feed.ex:160
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. This page does not follow anyone, or nobody it follows has published."
 msgstr ""
@@ -21323,7 +21320,7 @@ msgstr "Argomenti"
 msgid "Unfollow %{tag}"
 msgstr "Smetti di seguire %{tag}"
 
-#: lib/vutuv_web/live/organization_live/feed.ex:157
+#: lib/vutuv_web/live/organization_live/feed.ex:156
 #, elixir-autogen, elixir-format
 msgid "What the members and organizations this page follows have published. Liking or saving something here is done from your own account, not the page's."
 msgstr ""
@@ -21439,14 +21436,14 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:84
 #: lib/vutuv_web/live/organization_live/new.ex:211
-#: lib/vutuv_web/live/organization_live/show.ex:892
+#: lib/vutuv_web/live/organization_live/show.ex:887
 #, elixir-autogen, elixir-format
 msgid "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
 msgstr ""
 "Le persone che non hanno un account vutuv possono seguire questa pagina e "
 "leggerne i post, su reti come Mastodon."
 
-#: lib/vutuv_web/live/organization_live/show.ex:906
+#: lib/vutuv_web/live/organization_live/show.ex:901
 #, elixir-autogen, elixir-format
 msgid "Set this page up for other networks"
 msgstr "Prepari questa pagina per le altre reti"
@@ -21461,7 +21458,7 @@ msgstr "Disattivalo"
 msgid "Switch it on"
 msgstr "Attivalo"
 
-#: lib/vutuv_web/live/organization_live/show.ex:897
+#: lib/vutuv_web/live/organization_live/show.ex:892
 #, elixir-autogen, elixir-format
 msgid "The page gets an address of its own for that, written like an email address."
 msgstr ""
@@ -21494,7 +21491,7 @@ msgid "This vutuv exchanges nothing with other networks, so nothing here has any
 msgstr ""
 "Questo vutuv non scambia nulla con altre reti, quindi qui nulla ha effetto."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:443
+#: lib/vutuv_web/live/organization_live/edit.ex:425
 #, elixir-autogen, elixir-format
 msgid "Claim a short @name so this organization has an address of its own, like a member. Letters, numbers and underscores, %{min} to %{max} characters."
 msgstr ""
@@ -21502,7 +21499,7 @@ msgstr ""
 "suo, come un membro. Lettere, numeri e trattini bassi, da %{min} a %{max} "
 "caratteri."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:441
+#: lib/vutuv_web/live/organization_live/edit.ex:423
 #, elixir-autogen, elixir-format
 msgid "The organization's @name"
 msgstr "L'@nome dell'organizzazione"
@@ -21567,22 +21564,22 @@ msgstr "Si registri di nuovo"
 msgid "The PIN has expired."
 msgstr "Il PIN è scaduto."
 
-#: lib/vutuv_web/components/ui.ex:911
+#: lib/vutuv_web/components/ui.ex:935
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr "Il PIN è valido per un altro minuto."
 
-#: lib/vutuv_web/components/ui.ex:913
+#: lib/vutuv_web/components/ui.ex:937
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr "Il PIN è valido per un altro secondo."
 
-#: lib/vutuv_web/components/ui.ex:912
+#: lib/vutuv_web/components/ui.ex:936
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr "Il PIN è valido per altri {n} minuti."
 
-#: lib/vutuv_web/components/ui.ex:914
+#: lib/vutuv_web/components/ui.ex:938
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr "Il PIN è valido per altri {n} secondi."
@@ -21605,7 +21602,7 @@ msgstr[1] ""
 "La Sua iscrizione non è mai stata confermata, quindi la eliminiamo "
 "automaticamente fra circa %{count} minuti."
 
-#: lib/vutuv_web/components/fediverse_components.ex:456
+#: lib/vutuv_web/components/fediverse_components.ex:453
 #, elixir-autogen, elixir-format
 msgid "#%{tag} is a topic on this vutuv, so you now follow the tag here."
 msgstr "#%{tag} è un argomento su questo vutuv, quindi ora segue il tag qui."
@@ -21667,12 +21664,12 @@ msgstr ""
 " indica né il Suo numero di telefono né il Suo nome utente, e può azzerarlo "
 "in Signal in qualsiasi momento."
 
-#: lib/vutuv_web/live/search_live.ex:596
+#: lib/vutuv_web/live/search_live.ex:589
 #, elixir-autogen, elixir-format
 msgid "A post on another network"
 msgstr "Un post su un'altra rete"
 
-#: lib/vutuv_web/live/search_live.ex:620
+#: lib/vutuv_web/live/search_live.ex:613
 #, elixir-autogen, elixir-format
 msgid "Fetch this post"
 msgstr "Scarica questo post"
@@ -21682,12 +21679,12 @@ msgstr "Scarica questo post"
 msgid "Search for people, tags, posts, or paste a Fediverse address"
 msgstr "Cerchi persone, tag, post, oppure incolli un indirizzo del Fediverso"
 
-#: lib/vutuv_web/live/search_live.ex:636
+#: lib/vutuv_web/live/search_live.ex:629
 #, elixir-autogen, elixir-format
 msgid "Sign in to fetch this post"
 msgstr "Acceda per scaricare questo post"
 
-#: lib/vutuv_web/live/search_live.ex:601
+#: lib/vutuv_web/live/search_live.ex:594
 #, elixir-autogen, elixir-format
 msgid "That is a link to somewhere else, not something anybody here wrote. vutuv can fetch the post behind it so you can read it, answer it, like it or repost it from here."
 msgstr ""
@@ -21707,7 +21704,7 @@ msgstr ""
 "l'indirizzo di un post là fuori: vutuv lo scarica così può rispondergli da "
 "qui"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:86
+#: lib/vutuv_web/templates/user/edit.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Fetch my picture from gravatar.com"
 msgstr "Prendi la mia immagine da gravatar.com"
@@ -21732,7 +21729,7 @@ msgstr "Non è stato possibile raggiungere gravatar.com. Riprovi più tardi."
 msgid "gravatar.com has no picture for your email address."
 msgstr "gravatar.com non ha alcuna immagine per il Suo indirizzo e-mail."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:89
+#: lib/vutuv_web/templates/user/edit.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Only when you press this: we ask gravatar.com whether there is a picture for your email address, sending a hash of the address rather than the address itself. Nothing leaves this server otherwise."
 msgstr ""
@@ -21753,8 +21750,8 @@ msgstr ""
 "controllare %{domain} da soli e Le inviamo un'e-mail non appena funziona, "
 "così può chiudere questa pagina."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:336
-#: lib/vutuv_web/live/organization_live/show.ex:1094
+#: lib/vutuv_web/live/organization_live/domains.ex:331
+#: lib/vutuv_web/live/organization_live/show.ex:1090
 #, elixir-autogen, elixir-format
 msgid "Checking …"
 msgstr "Controllo in corso…"
@@ -22045,43 +22042,43 @@ msgstr "Ha %{used} tag su %{max}."
 msgid "{n} of {max} free slots selected."
 msgstr "Selezionati {n} posti liberi su {max}."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1967
+#: lib/vutuv_web/live/post_live/composer.ex:1881
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr "Altre lingue"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1952
+#: lib/vutuv_web/live/post_live/composer.ex:1866
 #, elixir-autogen, elixir-format
 msgctxt "post composer"
 msgid "Language"
 msgstr "Lingua"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1957
+#: lib/vutuv_web/live/post_live/composer.ex:1871
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr "La lingua in cui è scritto questo post"
 
-#: lib/vutuv_web/components/post_components.ex:4682
+#: lib/vutuv_web/components/post_components.ex:4704
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Mostra l'originale"
 
-#: lib/vutuv_web/components/post_components.ex:4718
+#: lib/vutuv_web/components/post_components.ex:4740
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Traduci"
 
-#: lib/vutuv_web/components/post_components.ex:4727
+#: lib/vutuv_web/components/post_components.ex:4749
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Tradotto"
 
-#: lib/vutuv_web/components/post_components.ex:4730
+#: lib/vutuv_web/components/post_components.ex:4752
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Tradotto da %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:4707
+#: lib/vutuv_web/components/post_components.ex:4729
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Traduzione in corso…"
@@ -22092,8 +22089,8 @@ msgid "Feed language settings reset to the site defaults."
 msgstr ""
 "Impostazioni delle lingue del feed riportate ai valori predefiniti del sito."
 
-#: lib/vutuv_web/components/post_components.ex:4697
-#: lib/vutuv_web/components/ui.ex:4749
+#: lib/vutuv_web/components/post_components.ex:4719
+#: lib/vutuv_web/components/ui.ex:4857
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -22235,7 +22232,7 @@ msgid "Your username, or paste the address of your profile page."
 msgstr ""
 "Il Suo nome utente, oppure incolli l'indirizzo della Sua pagina di profilo."
 
-#: lib/vutuv_web/components/post_components.ex:4460
+#: lib/vutuv_web/components/post_components.ex:4482
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
@@ -22246,13 +22243,13 @@ msgstr[1] ""
 "La nostra IA le sta ancora controllando, %{done} su %{total} fatte. Appena "
 "avrà finito con l'ultima, le foto compariranno da sé."
 
-#: lib/vutuv_web/components/post_components.ex:4457
+#: lib/vutuv_web/components/post_components.ex:4479
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Il Suo post è pubblicato, la foto non c'è ancora."
 
-#: lib/vutuv_web/components/post_components.ex:2429
-#: lib/vutuv_web/components/post_components.ex:3787
+#: lib/vutuv_web/components/post_components.ex:2451
+#: lib/vutuv_web/components/post_components.ex:3809
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -22261,7 +22258,7 @@ msgstr[0] ""
 msgstr[1] ""
 "La nostra IA le sta esaminando. Compariranno qui da sé quando avrà finito."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:144
+#: lib/vutuv_web/templates/user/edit.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "Recommended: %{width} × %{height} pixels (%{ratio})."
 msgstr "Consigliato: %{width} × %{height} pixel (%{ratio})."
@@ -22334,7 +22331,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr "Accesso delle app Mastodon modificato"
 
-#: lib/vutuv_web/components/ui.ex:4838
+#: lib/vutuv_web/components/ui.ex:4946
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr "App Mastodon, app collegate e token di accesso"
@@ -22390,7 +22387,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr "Il Suo account è allora %{handle}."
 
-#: lib/vutuv_web/components/ui.ex:4840
+#: lib/vutuv_web/components/ui.ex:4948
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -22428,7 +22425,7 @@ msgstr "Trovi le persone che conosce da LinkedIn"
 msgid "Find your LinkedIn contacts"
 msgstr "Trovi i Suoi contatti LinkedIn"
 
-#: lib/vutuv_web/components/ui.ex:4765
+#: lib/vutuv_web/components/ui.ex:4873
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format
@@ -22441,7 +22438,7 @@ msgid "Follow selected"
 msgstr "Segui i selezionati"
 
 #: lib/vutuv_web/live/import_connections_live.ex:504
-#: lib/vutuv_web/live/search_live.ex:548
+#: lib/vutuv_web/live/search_live.ex:541
 #, elixir-autogen, elixir-format
 msgid "Following…"
 msgstr "In corso…"
@@ -22542,7 +22539,7 @@ msgstr "Cerchi per nome"
 msgid "See which of them are already on vutuv"
 msgstr "Veda quali di loro sono già su vutuv"
 
-#: lib/vutuv_web/components/ui.ex:4767
+#: lib/vutuv_web/components/ui.ex:4875
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr "Veda quali dei Suoi contatti LinkedIn sono già su vutuv"
@@ -22626,7 +22623,7 @@ msgstr "I Suoi contatti su vutuv"
 msgid "Your export also lists your LinkedIn contacts."
 msgstr "La Sua esportazione elenca anche i Suoi contatti LinkedIn."
 
-#: lib/vutuv_web/components/ui.ex:4769
+#: lib/vutuv_web/components/ui.ex:4877
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr ""
@@ -22785,34 +22782,34 @@ msgctxt "qualification detail"
 msgid "Jobs"
 msgstr "Impieghi"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:836
+#: lib/vutuv_web/live/job_posting_live/form.ex:829
 #, elixir-autogen, elixir-format
 msgid "%{formatted} country chosen."
 msgid_plural "%{formatted} countries chosen."
 msgstr[0] "%{formatted} paese scelto."
 msgstr[1] "%{formatted} paesi scelti."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:620
+#: lib/vutuv_web/live/job_posting_live/form.ex:619
 #, elixir-autogen, elixir-format
 msgid "No country chosen yet."
 msgstr "Ancora nessun paese scelto."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:612
+#: lib/vutuv_web/live/job_posting_live/form.ex:611
 #, elixir-autogen, elixir-format
 msgid "No country left to add for that."
 msgstr "Non resta alcun paese da aggiungere per questo."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:631
+#: lib/vutuv_web/live/job_posting_live/form.ex:630
 #, elixir-autogen, elixir-format
 msgid "Remove %{country}"
 msgstr "Rimuovi %{country}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:642
+#: lib/vutuv_web/live/job_posting_live/form.ex:641
 #, elixir-autogen, elixir-format
 msgid "Remove all"
 msgstr "Rimuovi tutti"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:591
+#: lib/vutuv_web/live/job_posting_live/form.ex:590
 #, elixir-autogen, elixir-format
 msgid "Search for a country"
 msgstr "Cerchi un paese"
@@ -22824,7 +22821,7 @@ msgstr ""
 "Questa pagina sta seguendo il numero massimo di account che consentiamo "
 "(%{max})."
 
-#: lib/vutuv_web/components/post_components.ex:2643
+#: lib/vutuv_web/components/post_components.ex:2665
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr "Smettere di seguire %{handle}? I suoi post spariscono dal Suo feed."
@@ -22854,7 +22851,7 @@ msgstr "Notifiche del browser"
 msgid "New message"
 msgstr "Nuovo messaggio"
 
-#: lib/vutuv_web/live/shell_live.ex:1024
+#: lib/vutuv_web/live/shell_live.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Non ora"
@@ -22911,14 +22908,14 @@ msgstr ""
 "Ha attivato le notifiche del browser. A questo browser non è ancora stato "
 "chiesto il permesso."
 
-#: lib/vutuv_web/components/ui.ex:4737
+#: lib/vutuv_web/components/ui.ex:4845
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
 "e-mail posta disiscrizione newsletter campanella avviso silenzio meno "
 "browser desktop popup push notifica"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:311
+#: lib/vutuv_web/live/tag_live/timeline.ex:307
 #, elixir-autogen, elixir-format
 msgid "%{formatted} active"
 msgstr "%{formatted} attivi"
@@ -22967,7 +22964,7 @@ msgstr ""
 "Segua #%{tag} da Mastodon o da qualsiasi altra app del Fediverso e i suoi "
 "post pubblici arriveranno nella Sua cronologia. Non serve un account vutuv."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3337
+#: lib/vutuv_web/live/post_live/feed.ex:3334
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Saluti gli altri membri"
@@ -22977,47 +22974,47 @@ msgstr "Saluti gli altri membri"
 msgid "New here"
 msgstr "Nuovi qui"
 
-#: lib/vutuv_web/components/ui.ex:1543
+#: lib/vutuv_web/components/ui.ex:1567
 #, elixir-autogen, elixir-format
 msgid "New public posts arrive in any feed reader. No account needed either."
 msgstr ""
 "I nuovi post pubblici arrivano in qualsiasi lettore di feed. Anche qui non "
 "serve un account."
 
-#: lib/vutuv_web/components/ui.ex:1539
+#: lib/vutuv_web/components/ui.ex:1563
 #, elixir-autogen, elixir-format
 msgid "Or with an RSS reader"
 msgstr "Oppure con un lettore RSS"
 
-#: lib/vutuv_web/components/ui.ex:1419
-#: lib/vutuv_web/components/ui.ex:1488
+#: lib/vutuv_web/components/ui.ex:1443
+#: lib/vutuv_web/components/ui.ex:1512
 #, elixir-autogen, elixir-format
 msgid "Subscribe"
 msgstr "Iscriviti"
 
-#: lib/vutuv_web/components/ui.ex:1540
+#: lib/vutuv_web/components/ui.ex:1564
 #, elixir-autogen, elixir-format
 msgid "With an RSS reader"
 msgstr "Con un lettore RSS"
 
-#: lib/vutuv_web/components/ui.ex:1500
+#: lib/vutuv_web/components/ui.ex:1524
 #, elixir-autogen, elixir-format
 msgid "Create a free account"
 msgstr "Crei un account gratuito"
 
-#: lib/vutuv_web/components/ui.ex:1515
+#: lib/vutuv_web/components/ui.ex:1539
 #, elixir-autogen, elixir-format
 msgid "No vutuv account? These ways work too:"
 msgstr "Non ha un account vutuv? Funzionano anche questi modi:"
 
-#: lib/vutuv_web/components/ui.ex:1493
+#: lib/vutuv_web/components/ui.ex:1517
 #, elixir-autogen, elixir-format
 msgid "The best way: follow %{name} here. New posts land in your feed, and you can reply and join in."
 msgstr ""
 "Il modo migliore: segua %{name} qui. I nuovi post arrivano nel Suo feed, e "
 "può rispondere e partecipare."
 
-#: lib/vutuv_web/components/ui.ex:1491
+#: lib/vutuv_web/components/ui.ex:1515
 #, elixir-autogen, elixir-format
 msgid "With a vutuv account"
 msgstr "Con un account vutuv"
@@ -23027,7 +23024,7 @@ msgstr "Con un account vutuv"
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr "Alcuni fra i membri più recenti. Seguirli è un bel benvenuto."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:278
+#: lib/vutuv_web/templates/settings/preferences.html.heex:267
 #, elixir-autogen, elixir-format
 msgid "Example"
 msgstr "Esempio"
@@ -23043,7 +23040,7 @@ msgid "Just flashed the new release, boot is under two seconds now"
 msgstr ""
 "Appena installata la nuova versione, l'avvio ora sta sotto i due secondi"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:288
+#: lib/vutuv_web/templates/settings/preferences.html.heex:277
 #, elixir-autogen, elixir-format
 msgid "Play the example"
 msgstr "Riproduci l'esempio"
@@ -23145,22 +23142,22 @@ msgstr "Vengono nascosti dal Suo feed."
 msgid "Shown in the language it was written in."
 msgstr "Vengono mostrati nella lingua in cui sono stati scritti."
 
-#: lib/vutuv_web/components/ui.ex:4750
+#: lib/vutuv_web/components/ui.ex:4858
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr "Quali lingue arrivano fino a Lei e cosa succede al resto"
 
-#: lib/vutuv_web/components/ui.ex:4752
+#: lib/vutuv_web/components/ui.ex:4860
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr "lingua tradurre traduzione italiano tedesco inglese originale nascondere lingua straniera ordine priorità feed language translate sprache"
 
-#: lib/vutuv_web/components/ui.ex:4817
+#: lib/vutuv_web/components/ui.ex:4925
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr "Lingua dell'interfaccia, formato della data e fuso orario, mappe, come vengono accorciati i post"
 
-#: lib/vutuv_web/components/ui.ex:4821
+#: lib/vutuv_web/components/ui.ex:4929
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr "italiano tedesco inglese lingua mappa carattere lunghezza sillabazione fuso orario timezone utc data ora orologio 24 ore formato della data"
@@ -23193,7 +23190,7 @@ msgstr[0] "+%{formatted} altro post"
 msgstr[1] "+%{formatted} altri post"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:94
-#: lib/vutuv_web/templates/settings/preferences.html.heex:254
+#: lib/vutuv_web/templates/settings/preferences.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Browser tab"
 msgstr "Scheda del browser"
@@ -23218,12 +23215,12 @@ msgstr "Solo mentre sta guardando un'altra scheda, e solo per qualche secondo. I
 msgid "Tease new posts in the browser tab"
 msgstr "Anticipa i nuovi post nella scheda del browser"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:280
+#: lib/vutuv_web/templates/settings/preferences.html.heex:269
 #, elixir-autogen, elixir-format
 msgid "Watch this tab's title, above."
 msgstr "Guardi il titolo di questa scheda, qui sopra."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:256
+#: lib/vutuv_web/templates/settings/preferences.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "While you are reading another tab, a new post can page its first words through this tab's title, a line at a time, and then hand the title back."
 msgstr "Mentre sta leggendo un'altra scheda, un nuovo post può far scorrere le sue prime parole nel titolo di questa scheda, una riga alla volta, per poi restituire il titolo."
@@ -23284,7 +23281,7 @@ msgstr "Nessun account premium a pagamento."
 msgid "Your LinkedIn profile can come along."
 msgstr "Il suo profilo LinkedIn può venire con lei."
 
-#: lib/vutuv_web/components/ui.ex:1111
+#: lib/vutuv_web/components/ui.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Being checked"
 msgstr "In verifica"
@@ -23508,7 +23505,7 @@ msgstr "Altri dei tuoi %{formatted} account"
 msgid "Move %{card}"
 msgstr "Sposta %{card}"
 
-#: lib/vutuv_web/components/ui.ex:544
+#: lib/vutuv_web/components/ui.ex:401
 #: lib/vutuv_web/live/post_live/filter_band.ex:583
 #, elixir-autogen, elixir-format
 msgid "No account found."
@@ -23549,7 +23546,7 @@ msgstr "I post con uno di questi tag vengono ridotti allo stesso modo."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "I post che contengono una di queste parole vengono ridotti a una riga — non eliminati, e con un modo per aprirli comunque."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3363
+#: lib/vutuv_web/live/post_live/feed.ex:3360
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Messe da parte:"
@@ -23626,10 +23623,10 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "e 1 altro"
 msgstr[1] "e altri %{formatted}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2996
-#: lib/vutuv_web/live/post_live/feed.ex:3013
-#: lib/vutuv_web/live/post_live/feed.ex:3411
-#: lib/vutuv_web/live/post_live/feed.ex:3416
+#: lib/vutuv_web/live/post_live/feed.ex:2993
+#: lib/vutuv_web/live/post_live/feed.ex:3010
+#: lib/vutuv_web/live/post_live/feed.ex:3408
+#: lib/vutuv_web/live/post_live/feed.ex:3413
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -23648,7 +23645,7 @@ msgid_plural "Show %{formatted} posts in the feed"
 msgstr[0] "Mostra %{formatted} post nel feed"
 msgstr[1] "Mostra %{formatted} post nel feed"
 
-#: lib/vutuv_web/components/post_components.ex:2351
+#: lib/vutuv_web/components/post_components.ex:2373
 #, elixir-autogen, elixir-format
 msgid "Picture unavailable"
 msgstr "Immagine non disponibile"
@@ -23665,7 +23662,7 @@ msgstr ""
 "La pagina della Sua organizzazione è stata aggiornata. Il nuovo logo è in "
 "verifica e comparirà al termine del controllo."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:286
+#: lib/vutuv_web/live/organization_live/edit.ex:281
 #, elixir-autogen, elixir-format
 msgid "%{formats}, up to %{limit}"
 msgstr "%{formats}, fino a %{limit}"
@@ -23677,7 +23674,7 @@ msgstr ""
 "La pagina della Sua organizzazione è stata aggiornata, ma non è stato "
 "possibile usare quell'immagine come logo. Ne scelga un'altra."
 
-#: lib/vutuv_web/components/ui.ex:4034
+#: lib/vutuv_web/components/ui.ex:4138
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -23698,7 +23695,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} post il %{day}"
 msgstr[1] "%{count} post il %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3133
+#: lib/vutuv_web/live/post_live/feed.ex:3130
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Torna al presente"
@@ -23708,7 +23705,7 @@ msgstr "Torna al presente"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Mese intenso: la tonalità indica almeno questo valore."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3179
+#: lib/vutuv_web/live/post_live/feed.ex:3176
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -23730,7 +23727,7 @@ msgstr "Mese successivo"
 msgid "Next year"
 msgstr "Anno successivo"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3129
+#: lib/vutuv_web/live/post_live/feed.ex:3126
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Il %{day} non è arrivato nulla nel Suo feed."
@@ -23817,14 +23814,14 @@ msgstr "È pronta una nuova versione."
 msgid "Page management"
 msgstr "Gestione"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2218
+#: lib/vutuv_web/live/post_live/feed.ex:2220
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
 msgstr[0] "Nuovo:"
 msgstr[1] "Nuovi (%{formatted}):"
 
-#: lib/vutuv_web/components/post_components.ex:2777
+#: lib/vutuv_web/components/post_components.ex:2799
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr "Post citato"
@@ -23839,17 +23836,17 @@ msgstr "Cita %{name}: %{url}"
 msgid "Quotes %{url}"
 msgstr "Cita %{url}"
 
-#: lib/vutuv_web/components/ui.ex:543
+#: lib/vutuv_web/components/ui.ex:400
 #, elixir-autogen, elixir-format
 msgid "Mention an account"
 msgstr "Menziona un account"
 
-#: lib/vutuv_web/components/ui.ex:546
+#: lib/vutuv_web/components/ui.ex:404
 #, elixir-autogen, elixir-format
 msgid "{used} of {max} mentions"
 msgstr "{used} di {max} menzioni"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2384
+#: lib/vutuv_web/live/post_live/feed.ex:2386
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""
@@ -23875,7 +23872,7 @@ msgstr "Lascia vuoto il campo degli account e la regola vale per tutti; %{exampl
 msgid "Only these accounts (empty = all) …"
 msgstr "Solo questi account (vuoto = tutti) …"
 
-#: lib/vutuv_web/components/ui.ex:3159
+#: lib/vutuv_web/components/ui.ex:3261
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr "solo %{account}"
@@ -23925,33 +23922,33 @@ msgid_plural "shared this."
 msgstr[0] "lo ha condiviso."
 msgstr[1] "lo hanno condiviso."
 
-#: lib/vutuv_web/components/ui.ex:482
+#: lib/vutuv_web/components/ui.ex:543
 #, elixir-autogen, elixir-format
 msgid "Editor view"
 msgstr "Vista"
 
-#: lib/vutuv_web/components/ui.ex:430
+#: lib/vutuv_web/components/ui.ex:491
 #, elixir-autogen, elixir-format
 msgid "Insert a block"
 msgstr "Inserisci un blocco"
 
-#: lib/vutuv_web/components/ui.ex:442
+#: lib/vutuv_web/components/ui.ex:503
 #, elixir-autogen, elixir-format
 msgid "Nothing matches."
 msgstr "Nessun risultato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1778
-#: lib/vutuv_web/live/post_live/composer.ex:2513
+#: lib/vutuv_web/live/post_live/composer.ex:1754
+#: lib/vutuv_web/live/post_live/composer.ex:2452
 #, elixir-autogen, elixir-format
 msgid "Automatic"
 msgstr "Automatico"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1783
+#: lib/vutuv_web/live/post_live/composer.ex:1759
 #, elixir-autogen, elixir-format
 msgid "Drag one photo onto another to swap them."
 msgstr "Trascina una foto su un'altra per scambiarle."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1730
+#: lib/vutuv_web/live/post_live/composer.ex:1706
 #, elixir-autogen, elixir-format
 msgid "Not shown in the gallery — drag one into it to swap."
 msgstr "Non nella galleria — trascinane una dentro per scambiarla."
@@ -23988,17 +23985,17 @@ msgstr "Ultimo qui"
 msgid "Mute %{host}"
 msgstr "Silenzia %{host}"
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:94
+#: lib/vutuv_web/views/remote_actor_card_html.ex:132
 #, elixir-autogen, elixir-format
 msgid "Really remove?"
 msgstr "Rimuovere davvero?"
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:95
+#: lib/vutuv_web/views/remote_actor_card_html.ex:133
 #, elixir-autogen, elixir-format
 msgid "Really unfollow?"
 msgstr "Smettere davvero di seguire?"
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:96
+#: lib/vutuv_web/views/remote_actor_card_html.ex:134
 #, elixir-autogen, elixir-format
 msgid "Really withdraw?"
 msgstr "Ritirare davvero la richiesta?"
@@ -24008,28 +24005,28 @@ msgstr "Ritirare davvero la richiesta?"
 msgid "Unmute %{host}"
 msgstr "Riattiva %{host}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1538
+#: lib/vutuv_web/live/post_live/composer.ex:1514
 #, elixir-autogen, elixir-format
 msgid "Draft discarded."
 msgstr "Bozza eliminata."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1577
+#: lib/vutuv_web/live/post_live/composer.ex:1553
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr "Conserva"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1568
+#: lib/vutuv_web/live/post_live/composer.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Keep this draft for later?"
 msgstr "Conservare questa bozza per dopo?"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:315
+#: lib/vutuv_web/live/organization_live/edit.ex:310
 #, elixir-autogen, elixir-format
 msgid "Describe the organization. Markdown is supported."
 msgstr "Descriva l'organizzazione. Markdown è supportato."
 
-#: lib/vutuv_web/templates/page/index.html.heex:286
-#: lib/vutuv_web/templates/settings/preferences.html.heex:205
+#: lib/vutuv_web/templates/page/index.html.heex:287
+#: lib/vutuv_web/templates/settings/preferences.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "Bandwidth"
 msgstr "Larghezza di banda"
@@ -24044,7 +24041,7 @@ msgstr "Impostazioni della larghezza di banda ripristinate ai valori predefiniti
 msgid "Bandwidth settings saved."
 msgstr "Impostazioni della larghezza di banda salvate."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:207
+#: lib/vutuv_web/templates/settings/preferences.html.heex:211
 #, elixir-autogen, elixir-format
 msgid "If you are on a slow or metered connection, vutuv can leave out the parts of the page that cost the most to download."
 msgstr "Se la Sua connessione è lenta o a consumo, vutuv può tralasciare le parti della pagina che pesano di più da scaricare."
@@ -24058,3 +24055,8 @@ msgstr "Modalità risparmio dati"
 #, elixir-autogen, elixir-format
 msgid "Writing a post or a message then uses a plain Markdown box instead of the formatting editor, which saves about 150 kB of download. Everything you write still looks the same to everyone who reads it."
 msgstr "Per scrivere un post o un messaggio userà un semplice campo Markdown invece dell'editor con formattazione, il che risparmia circa 150 kB di download. Per chi legge, il testo resta identico."
+
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:252
+#, elixir-autogen, elixir-format
+msgid "View the original on %{url}"
+msgstr "Vedi l'originale su %{url}"

--- a/test/vutuv_web/controllers/remote_actor_card_test.exs
+++ b/test/vutuv_web/controllers/remote_actor_card_test.exs
@@ -14,6 +14,7 @@ defmodule VutuvWeb.RemoteActorCardTest do
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Follow
   alias Vutuv.Fediverse.RemoteAccount
+  alias VutuvWeb.RemoteActorCardHTML
 
   @actor "https://social.example/users/them"
   @address "them@social.example"
@@ -151,7 +152,54 @@ defmodule VutuvWeb.RemoteActorCardTest do
     assert html =~ "Anderes Netzwerk"
     assert html =~ "Folgen"
     assert html =~ "Die Seite dieses Kontos hier"
-    assert html =~ "Original ansehen"
+    assert html =~ "Original auf social.example/users/them ansehen"
+  end
+
+  # The one way off this site, and it used to say only that it was one. A reader
+  # about to leave for somebody else's server reads the address first, the way
+  # they would read a browser's status bar — and here that address is not
+  # guessable from the card, since an actor URI need not be spelled like the
+  # `@user@host` above it (`/users/them`, `/u/them`, `/profile/them`).
+  test "the way out names where it goes", %{conn: conn} do
+    {conn, _user} = federating(conn)
+    account()
+
+    html = post(conn, ~p"/system/fediverse/actor_card", address: @address) |> html_response(200)
+
+    assert html =~ "View the original on social.example/users/them"
+    # And the label is only ever a label: the href stays the whole URL.
+    assert html =~ @actor
+  end
+
+  # A scheme and a `www.` are noise every reader already knows, and dropping them
+  # buys the characters the account name needs. The cap was 32 for one afternoon,
+  # which is one character short of `social.heise.de/users/heiseonline` — so the
+  # part the reader is checking, the account's name, lost its last two letters on
+  # a card that had room for them. An ordinary actor URI reaches the whole way.
+  #
+  # `HTTPS://` is not a curiosity here: this string is a remote server's, not
+  # ours, and a scheme left standing would spend eight characters saying that a
+  # link is a link.
+  test "an ordinary actor address reaches the card whole, without scheme or www" do
+    assert RemoteActorCardHTML.origin_address("https://social.heise.de/users/heiseonline") ==
+             "social.heise.de/users/heiseonline"
+
+    assert RemoteActorCardHTML.origin_address("HTTPS://www.chaos.social/@feed/") ==
+             "chaos.social/@feed"
+  end
+
+  # Cut from the end and never from the front: the host leads the string and is
+  # the fact it is carrying, so it is the one part that may not be what goes.
+  # `…` says there is more behind the click.
+  test "an address too long for the card is cut, not wrapped across it" do
+    address =
+      RemoteActorCardHTML.origin_address(
+        "https://www.example.social/users/a-very-long-handle-indeed"
+      )
+
+    assert String.starts_with?(address, "example.social/users/")
+    assert String.ends_with?(address, "…")
+    assert String.length(address) == 40
   end
 
   test "a member without a Fediverse identity is told why, not shown a dead button", %{conn: conn} do

--- a/test/vutuv_web/live/feed_remote_posts_test.exs
+++ b/test/vutuv_web/live/feed_remote_posts_test.exs
@@ -574,6 +574,25 @@ defmodule VutuvWeb.FeedRemotePostsTest do
     assert opening_tag =~ "gap-y-"
   end
 
+  # The handle in the header asks "who is this", and until now the answer was a
+  # page the reader had to come back from. `data-remote-actor` is what
+  # `assets/js/mention_card.js` binds to, so a plain click opens the same card a
+  # `@user@host` written inside a post body already opens — one answer to one
+  # question, wherever the handle is read. The `href` stays the whole truth of
+  # the anchor: a middle click, a copied link and a page whose JavaScript never
+  # arrived all still land on the account page here.
+  test "the handle in the header opens the account card", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    cached_post(user)
+
+    {:ok, view, _html} = live(conn, ~p"/feed")
+
+    assert has_element?(view, "[data-remote-handle][data-remote-actor='them@social.example']")
+
+    assert view |> element("[data-remote-handle]") |> render() =~
+             "/system/fediverse/account/"
+  end
+
   test "muting the account takes its posts out of the feed and keeps the follow", %{conn: conn} do
     {conn, user} = create_and_login_user(conn)
     post = cached_post(user)

--- a/test/vutuv_web/live/post_actions_live_test.exs
+++ b/test/vutuv_web/live/post_actions_live_test.exs
@@ -480,6 +480,12 @@ defmodule VutuvWeb.PostActionsLiveTest do
       assert html =~ ~s(data-fediverse-reactions="1")
       assert html =~ "@alice@social.example"
       assert html =~ ~s(data-fediverse-reaction="announce")
+
+      # A chip is the same handle as the header above it, so a press opens the
+      # same account card (`remote_actor_link/3` writes the hook for both — the
+      # chip answering "who is this" differently from the card it sits under is
+      # the thing that one function exists to prevent).
+      assert html =~ ~s(data-remote-actor="alice@social.example")
     end
   end
 


### PR DESCRIPTION
A `@user@host` in a post body opens the account card; the same handle in the
header above it sent the reader to a page they had to come back from. Both ask
"who is this", so both answer alike now.

`PostComponents.remote_actor_link/3` owns where a remote handle leads *and*
what a press does, writing the card hook for the header and the reaction chips
from one place. The `href` is untouched, so middle click, copied link,
logged-out reader and no-JS keep today's destination. One trap: these are
`<.link navigate>`, and LiveView's nav listener on `window` never reads
`defaultPrevented`, so the click also stops the bubble.

The card's way out now names it: "View the original on
social.heise.de/users/heiseonline". 40 characters, measured on the 20rem
popover; 32 cut `heiseonline` two letters short.

Where to look: `/feed`, any post from another network.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01R5veyj3cgHTansrP5aNy9M
