### PR TITLE
Capture a profile link's screenshot even when no form asked

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -75,6 +75,10 @@ config :vutuv, Vutuv.Repo,
 # Vutuv.TaskSupervisor; the flags let tests disable them so the SQL Sandbox
 # connection is never used by a process that does not own it (and so the test
 # suite makes no live HTTP request / Chromium launch).
+# :generate_screenshots also starts Vutuv.PageScreenshot.Sweeper, the standing
+# retry that captures the links still waiting for a picture — one a deploy
+# killed mid-capture, or one created without a form behind it (the LinkedIn
+# import). Off, there are no captures at all, so there is nothing to sweep.
 config :vutuv, :generate_screenshots, true
 config :vutuv, :fetch_gravatar, true
 

--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -158,7 +158,7 @@ window frame (`Vutuv.BrowserFrame`); see `Vutuv.PageScreenshot`. Needs a
 
 Three surfaces ask for one, all storing through `Vutuv.Screenshot` and gated by
 `:generate_screenshots`: a member's **profile link** (`urls.screenshot`, captured
-on save), a **post's single link** (`post_screenshots`, a durable queue, see
+on save and swept, below), a **post's single link** (`post_screenshots`, a durable queue, see
 [posts-and-feed.md](posts-and-feed.md)) and an **organization's homepage**
 (`organization_screenshots`, the same queue shape, see
 [organizations.md](organizations.md)). They differ in one preflight: the link and
@@ -167,6 +167,34 @@ homepage paths **follow** redirects to their destination
 redirecting to `www.` is the normal shape of a homepage; the post path insists on
 a plain HTTP 200 (`Vutuv.Posts.Screenshots.ensure_http_ok/1`), because there a
 redirect usually means a shortener or a login wall.
+
+### The profile link's standing retry
+
+The link form's capture is fire-and-forget (`PageScreenshot.generate_async/1`),
+which is the fast path and never the guarantee: a blue/green deploy stops the
+slot mid-capture without a word, and a link created by any other path — the
+LinkedIn import inserts them straight through `Repo` — had nothing capturing it
+at all. Both left the member a grey camera tile for good; 15 of the 1,938 links
+on vutuv.de sat like that, most in same-second batches an import left behind.
+
+So the row is the record of unfinished work and `Vutuv.PageScreenshot.Sweeper`
+acts on it: every five minutes it captures `PageScreenshot.due/1`, up to five
+links, least recently attempted first. `urls.screenshot_attempted_at` is
+stamped before each capture and on every outcome — that is the sweeper's clock,
+not a claim that anything was captured, and without it the one link that can
+never be shot sorts to the front and spends every batch (the deadlock that
+stalled `Vutuv.Fediverse.refresh_counts/1`, #1316). It rides `:generate_screenshots`
+like the captures themselves, so an air-gapped installation runs no sweeper.
+
+Three things keep a link out of that query for good: `broken?` (an SSRF-refused
+target), a `screenshot_moderation` of `"rejected"` (the AI scan threw the
+picture out, and re-shooting it every six hours would be a treadmill), and
+simply having a screenshot. Which is why **editing a link's URL clears it**
+(`Url.changeset/2`): otherwise the row keeps a photograph of a different page
+and, having one, is never captured again. The LinkedIn import nudges the
+member's own waiting links after its transaction commits
+(`capture_missing_async/1`, one task for the batch), so the pictures arrive
+while they are still looking at their fresh profile.
 
 ### How the browser is driven
 

--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -189,7 +189,16 @@ like the captures themselves, so an air-gapped installation runs no sweeper.
 Three things keep a link out of that query for good: `broken?` (an SSRF-refused
 target), a `screenshot_moderation` of `"rejected"` (the AI scan threw the
 picture out, and re-shooting it every six hours would be a treadmill), and
-simply having a screenshot. Which is why **editing a link's URL clears it**
+simply having a screenshot.
+
+`broken?` had to be cleaned up before it could carry that weight. Until v5 the
+pipeline flagged **every** failure with it — a missing Chromium binary, a
+timeout, a site down that afternoon — and nothing ever cleared it, so vutuv.de
+carried 45 links flagged between 2016-12 and 2018-03, none of which resolves to
+an internal address today. They are ordinary member homepages that a rule which
+no longer exists poisoned, and the sweeper would have stepped over them forever;
+`clear_stale_broken_flag_on_urls` sets them back to NULL. A link that really is
+an internal target costs one DNS lookup on the next sweep and is flagged again. Which is why **editing a link's URL clears it**
 (`Url.changeset/2`): otherwise the row keeps a photograph of a different page
 and, having one, is never captured again. The LinkedIn import nudges the
 member's own waiting links after its transaction commits

--- a/lib/mix/tasks/urls.create_screenshots.ex
+++ b/lib/mix/tasks/urls.create_screenshots.ex
@@ -2,36 +2,26 @@ defmodule Mix.Tasks.Urls.CreateScreenshots do
   @moduledoc false
 
   use Mix.Task
-  import Ecto.Query
-  alias Vutuv.Accounts.User
-  alias Vutuv.Repo
 
-  @shortdoc "Creates screenshots for all Urls."
+  alias Vutuv.PageScreenshot
 
+  @shortdoc "Captures every profile link still waiting for a screenshot."
+
+  # The manual version of Vutuv.PageScreenshot.Sweeper: same batch, drained in
+  # one go instead of one batch per five minutes. It walks `due/1` rather than
+  # its own filter, so "which link still needs a picture" — and the retry clock
+  # that keeps an unshootable page from being tried on every pass — is decided
+  # in one place. The drain terminates because each pass stamps its batch,
+  # which takes those links out of the next one.
   def run(_args) do
     Mix.Task.run("app.start", [])
-    users = Repo.all(from(u in User))
-
-    for user <- users do
-      user = Vutuv.Repo.preload(user, :urls)
-      process_user_urls(user)
-    end
+    drain(0)
   end
 
-  defp process_user_urls(%{urls: []}), do: :ok
-
-  defp process_user_urls(user) do
-    IO.puts("#{user.first_name} #{user.last_name}")
-
-    # A blocklisted page is skipped outright rather than walked past a Chromium
-    # run that would refuse it anyway (Vutuv.ScreenshotBlocklist).
-    for url <- user.urls,
-        !url.screenshot,
-        !url.broken?,
-        !Vutuv.ScreenshotBlocklist.blocked?(url.value) do
-      IO.puts("-> #{url.value}")
-      Vutuv.PageScreenshot.generate_screenshot(url)
-      :timer.sleep(500)
+  defp drain(done) do
+    case PageScreenshot.capture_due() do
+      0 -> Mix.shell().info("#{done} link(s) attempted")
+      count -> drain(done + count)
     end
   end
 end

--- a/lib/vutuv/application.ex
+++ b/lib/vutuv/application.ex
@@ -156,6 +156,7 @@ defmodule Vutuv.Application do
           Vutuv.Organizations.PendingDomainSweeper
         ) ++
         optional_child(:recheck_user_links, Vutuv.Profiles.LinkRecheckSweeper) ++
+        optional_child(:generate_screenshots, Vutuv.PageScreenshot.Sweeper) ++
         optional_child(
           :recheck_social_accounts,
           Vutuv.Profiles.SocialAccountRecheckSweeper

--- a/lib/vutuv/imports/linked_in.ex
+++ b/lib/vutuv/imports/linked_in.ex
@@ -29,6 +29,7 @@ defmodule Vutuv.Imports.LinkedIn do
   alias Vutuv.Accounts
   alias Vutuv.Accounts.User
   alias Vutuv.Mentions
+  alias Vutuv.PageScreenshot
   alias Vutuv.Profiles.Education
   alias Vutuv.Profiles.PhoneNumber
   alias Vutuv.Profiles.Qualification
@@ -1145,7 +1146,17 @@ defmodule Vutuv.Imports.LinkedIn do
     # relax the mention-existence check for this whole transaction — otherwise a
     # stray `@token` would silently drop the row. A rename still rewrites these
     # bodies later, and only posts are scanned for handle availability.
-    Mentions.without_existence_check(fn -> do_apply_selection(user, selection) end)
+    result = Mentions.without_existence_check(fn -> do_apply_selection(user, selection) end)
+
+    # Links land here through `Repo.insert` rather than through the link form,
+    # so nothing queues their screenshot. The sweeper would find them within
+    # five minutes either way; this is only so the member watching their fresh
+    # profile sees the pictures arrive. After the transaction, never inside it:
+    # a task started in there reads on another connection and finds no row yet.
+    with {:ok, %{created: %{urls: created}}} when created > 0 <- result,
+         do: PageScreenshot.capture_missing_async(user.id)
+
+    result
   end
 
   defp do_apply_selection(user, selection) do

--- a/lib/vutuv/moderation/image_subjects.ex
+++ b/lib/vutuv/moderation/image_subjects.ex
@@ -568,7 +568,12 @@ defmodule Vutuv.Moderation.ImageSubjects do
   def apply_rejected(%ImageScan{kind: "url_screenshot"} = scan) do
     cleared =
       from(u in Url, where: u.id == ^scan.subject_id and u.screenshot == ^scan.fingerprint)
-      |> Repo.update_all(set: [screenshot: nil, screenshot_moderation: nil])
+      # "rejected", not nil, the way the post branch below records it: the row
+      # is the only memory of the verdict, and `Vutuv.PageScreenshot.due/1`
+      # reads it to leave the link alone. Clearing it would put the page back
+      # in the capture queue and have the sweeper shoot, store and re-scan the
+      # same rejected picture every retry window, forever.
+      |> Repo.update_all(set: [screenshot: nil, screenshot_moderation: "rejected"])
 
     case cleared do
       {1, _} ->

--- a/lib/vutuv/page_screenshot.ex
+++ b/lib/vutuv/page_screenshot.ex
@@ -56,6 +56,10 @@ defmodule Vutuv.PageScreenshot do
 
   A blocklisted page (`Vutuv.ScreenshotBlocklist`) never gets a task at all —
   the check is a cached string comparison, cheaper than the process it saves.
+
+  This is the fast path only, never the guarantee: the task dies with the slot a
+  deploy stops, and a link created anywhere else never gets one at all. What
+  makes a screenshot actually happen is `due/1` and the sweeper behind it.
   """
   def generate_async(%Url{} = url) do
     if Application.get_env(:vutuv, :generate_screenshots, true) and
@@ -64,6 +68,85 @@ defmodule Vutuv.PageScreenshot do
     end
 
     :ok
+  end
+
+  @doc """
+  Works through `user_id`'s waiting links in one background task, so a member
+  who just imported an archive sees the pictures arrive instead of waiting for
+  the next sweep. One task for the batch, not one per link: each capture is a
+  headless Chromium of its own, and five at once is not a nudge.
+
+  Fire it **after** the import's transaction commits — a task started inside it
+  reads on another connection and finds no row yet.
+  """
+  def capture_missing_async(user_id) do
+    if Application.get_env(:vutuv, :generate_screenshots, true) do
+      Task.Supervisor.start_child(Vutuv.TaskSupervisor, fn ->
+        capture_due(user_id: user_id)
+      end)
+    end
+
+    :ok
+  end
+
+  # How long before a link whose capture produced no screenshot is tried again.
+  @retry_after_hours 6
+  # How many links one pass captures. Each one costs a Chromium run of up to
+  # `Cdp.capture_seconds/0` + 10 s, and they run one after the other.
+  @batch 5
+
+  @doc """
+  The profile links still waiting for a screenshot, least-recently-attempted
+  first: never captured, not permanently refused (`broken?`), not moderated
+  away (`screenshot_moderation`), and either never attempted or last attempted
+  more than #{@retry_after_hours} hours ago. Capped at #{@batch}; `user_id:`
+  narrows it to one member's links (what an import nudges, so a member with
+  more than #{@batch} fresh links gets the rest from the next sweep).
+
+  There is deliberately no attempt ceiling, unlike the post and organization
+  queues: a link is a page somebody chose to show, so a site that is down today
+  is worth another look tomorrow, and one run every #{@retry_after_hours} hours
+  is cheap enough to keep offering that indefinitely.
+
+  This is what makes a screenshot happen. `generate_async/1` is the fast path
+  from the link form, and it was the only one: a task the deploy killed
+  mid-capture was never retried, and a link created by any other path (the
+  LinkedIn import inserts them straight through `Repo`) was never captured at
+  all — 15 of the 1,938 links on vutuv.de sat like that, most of them in
+  same-second batches an import left behind. So the *row* is the record of
+  unfinished work, and `Vutuv.PageScreenshot.Sweeper` acts on it.
+
+  Both nullable columns are asked twice (`is_nil(x) or x != …`): a bare
+  inequality is NULL rather than true for a row that was never flagged, which
+  is almost all of them, so it would silently return nothing.
+  """
+  def due(opts \\ []) do
+    cutoff = NaiveDateTime.add(NaiveDateTime.utc_now(:second), -@retry_after_hours, :hour)
+
+    from(u in Url,
+      where: is_nil(u.screenshot),
+      where: is_nil(u.broken?) or u.broken? == false,
+      where: is_nil(u.screenshot_moderation) or u.screenshot_moderation != "rejected",
+      where: is_nil(u.screenshot_attempted_at) or u.screenshot_attempted_at <= ^cutoff,
+      order_by: [asc_nulls_first: u.screenshot_attempted_at],
+      limit: @batch
+    )
+    |> scope_to_user(Keyword.get(opts, :user_id))
+    |> Repo.all()
+  end
+
+  defp scope_to_user(query, nil), do: query
+  defp scope_to_user(query, user_id), do: from(u in query, where: u.user_id == ^user_id)
+
+  @doc """
+  Captures the due links one after the other and returns how many it worked
+  through — attempts, not successes, since a blocklisted page is neither. What
+  `Vutuv.PageScreenshot.Sweeper` runs; `opts` are `due/1`'s.
+  """
+  def capture_due(opts \\ []) do
+    urls = due(opts)
+    Enum.each(urls, &generate_screenshot/1)
+    length(urls)
   end
 
   @doc """
@@ -98,10 +181,16 @@ defmodule Vutuv.PageScreenshot do
   end
 
   defp capture_store_and_flag(url) do
+    # Before the capture, not after, and on every outcome: this is `due/1`'s
+    # clock, not a claim that anything was captured. A run that dies mid-way —
+    # a Chromium crash, a deploy stopping the slot — must still move the link
+    # off the front of the next batch, or the one link that can never be shot
+    # sorts oldest-first and spends every batch on itself forever.
+    stamp_attempt(url)
+
     case capture_and_frame(url) do
       {:ok, framed_path} ->
         store(url, framed_path)
-        set_broken(url, false)
         File.rm(framed_path)
         :ok
 
@@ -345,7 +434,9 @@ defmodule Vutuv.PageScreenshot do
 
     result =
       url
-      |> Url.changeset(%{screenshot: upload})
+      # `broken?: false` rides along rather than following as a second update
+      # of the same row: a page we just photographed is by definition reachable.
+      |> Url.changeset(%{screenshot: upload, broken?: false})
       |> Repo.update()
 
     # The fresh capture waits in AI-moderation limbo until the scan releases
@@ -362,6 +453,14 @@ defmodule Vutuv.PageScreenshot do
     url
     |> Url.changeset(%{broken?: value})
     |> Repo.update()
+  end
+
+  # One targeted write rather than a changeset round trip: nothing downstream
+  # reads the stamp, and leaving `updated_at` alone keeps this out of the
+  # row's own history.
+  defp stamp_attempt(%Url{id: id}) do
+    from(u in Url, where: u.id == ^id)
+    |> Repo.update_all(set: [screenshot_attempted_at: NaiveDateTime.utc_now(:second)])
   end
 
   @doc """

--- a/lib/vutuv/page_screenshot/sweeper.ex
+++ b/lib/vutuv/page_screenshot/sweeper.ex
@@ -1,0 +1,59 @@
+defmodule Vutuv.PageScreenshot.Sweeper do
+  @moduledoc """
+  Captures the profile links that are still waiting for a screenshot
+  (`Vutuv.PageScreenshot.due/1`), a small batch at a time.
+
+  The link form fires its capture off the request path and forgets it, which is
+  fine right up to the moment the task does not finish: a blue/green deploy
+  stops the slot mid-capture and nobody hears about it. And a link the form
+  never saw — the LinkedIn import inserts them straight through `Repo` — had
+  nothing capturing it in the first place. Either way the member kept a grey
+  camera tile forever, because nothing ever looked at the link again.
+
+  So the unfinished work is recorded where the dying process does not own it,
+  in the row itself, and this is the standing job that finds it and runs it
+  again. A capture is idempotent and cheap, so it repeats the whole thing
+  rather than resuming anything.
+
+  Behind `:generate_screenshots`, the same flag the captures themselves ride
+  on: an installation that takes no screenshots needs no sweeper, and the test
+  suite (where it is off) drives `capture_due/1` directly.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Vutuv.PageScreenshot
+
+  @interval :timer.minutes(5)
+
+  def start_link(_opts), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+
+  @impl GenServer
+  def init(:ok) do
+    schedule()
+    {:ok, %{}}
+  end
+
+  @impl GenServer
+  def handle_info(:sweep, state) do
+    sweep()
+    schedule()
+    {:noreply, state}
+  end
+
+  # A DB hiccup must not take the sweeper down with it — the next tick tries
+  # again. Scheduled after the sweep, so a batch of slow captures spaces the
+  # next one out instead of queueing back to back.
+  defp sweep do
+    case PageScreenshot.capture_due() do
+      0 -> :ok
+      count -> Logger.info("Link screenshot sweep: #{count} link(s)")
+    end
+  rescue
+    error -> Logger.error("Link screenshot sweep failed: #{inspect(error)}")
+  end
+
+  defp schedule, do: Process.send_after(self(), :sweep, @interval)
+end

--- a/lib/vutuv/profiles/url.ex
+++ b/lib/vutuv/profiles/url.ex
@@ -15,6 +15,10 @@ defmodule Vutuv.Profiles.Url do
     # nil = none/grandfathered, "pending" = limbo, "approved" = released. Set
     # programmatically with the screenshot, never cast from params.
     field(:screenshot_moderation, :string)
+    # When the screenshot pipeline last ran for this link, whatever came of it:
+    # the clock Vutuv.PageScreenshot.due/1 orders its retry batch by. Set
+    # programmatically, never cast from params.
+    field(:screenshot_attempted_at, :naive_datetime)
     field(:broken?, :boolean)
     # The owner's chosen display order. Set programmatically (on create and via
     # the reorder/move actions), never cast from user params. NULLs sort last so
@@ -64,6 +68,24 @@ defmodule Vutuv.Profiles.Url do
     |> ensure_http_prefix
     |> validate_url
     |> reset_verification_on_value_change()
+    |> drop_screenshot_on_value_change()
+  end
+
+  # Pointing the row at another address makes the stored capture a picture of
+  # somebody else's page, so it goes with the URL it was taken of. Dropping the
+  # column is also what puts the row back in front of
+  # `Vutuv.PageScreenshot.due/1`, which asks for links with no screenshot — a
+  # row that kept the old one would never be captured again if the edit's
+  # fire-and-forget task died, and would show the wrong page indefinitely
+  # rather than none.
+  defp drop_screenshot_on_value_change(changeset) do
+    if get_change(changeset, :value) && get_field(changeset, :screenshot) do
+      changeset
+      |> put_change(:screenshot, nil)
+      |> put_change(:screenshot_moderation, nil)
+    else
+      changeset
+    end
   end
 
   # Editing the link to a different URL invalidates any existing proof (the

--- a/priv/repo/migrations/20260902101359_add_screenshot_attempted_at_to_urls.exs
+++ b/priv/repo/migrations/20260902101359_add_screenshot_attempted_at_to_urls.exs
@@ -1,0 +1,22 @@
+defmodule Vutuv.Repo.Migrations.AddScreenshotAttemptedAtToUrls do
+  use Ecto.Migration
+
+  # The clock `Vutuv.PageScreenshot.due/1` orders its batch by. Every attempt
+  # stamps it, the ones that captured nothing included, so a page that can
+  # never be shot leaves the front of the retry batch instead of holding it.
+  #
+  # No index: measured on this table's shape (1,937 rows, 43 heap pages) the
+  # due query is a 0.086 ms sequential scan, and an index on the one column
+  # every capture writes would cost each stamp its HOT update. Worth revisiting
+  # at two orders of magnitude more links — and then as
+  # `["screenshot_attempted_at ASC NULLS FIRST"]`, since a default btree cannot
+  # serve that ordering and the planner falls back to a full sort anyway.
+  #
+  # A plain nullable column: N-1 compatible, the previous release neither reads
+  # nor writes it.
+  def change do
+    alter table(:urls) do
+      add(:screenshot_attempted_at, :naive_datetime)
+    end
+  end
+end

--- a/priv/repo/migrations/20260902115719_clear_stale_broken_flag_on_urls.exs
+++ b/priv/repo/migrations/20260902115719_clear_stale_broken_flag_on_urls.exs
@@ -1,0 +1,36 @@
+defmodule Vutuv.Repo.Migrations.ClearStaleBrokenFlagOnUrls do
+  use Ecto.Migration
+
+  # `urls.broken?` today means one thing: the capture was refused because the
+  # host resolves to an internal address (issue #777). It did not always. Until
+  # v5 the pipeline flagged **every** failure — a missing Chromium binary, a
+  # timeout, a site that was down that afternoon — and that flag is permanent,
+  # because nothing ever clears it.
+  #
+  # On vutuv.de that left 45 links flagged, every one of them stamped between
+  # 2016-12 and 2018-03, and not one of them resolving to an internal address
+  # today: measured, all 45 answer with a public IP. They are members' ordinary
+  # homepages, poisoned by a rule that no longer exists — and now that
+  # `Vutuv.PageScreenshot.due/1` reads the flag to decide what to retry, they
+  # are the rows the new sweeper would step over forever.
+  #
+  # So this clears the flag rather than the screenshots: NULL, not false, because
+  # "never determined" is what these rows are. A link that really is an internal
+  # target costs one DNS lookup on the next sweep and is flagged again — the
+  # answer is cheap and the current code is the one that decides it.
+  #
+  # What this deliberately does **not** do is capture anything. A migration runs
+  # before the app is started, so `Vutuv.Ssrf.SocksProxy` is not up and every
+  # capture from here fails closed with `:proxy_unavailable` (verified against
+  # production's own release). The pictures are the sweeper's job, and the row
+  # state above is all it needs to find them.
+  def up do
+    execute("""
+    UPDATE urls SET "broken?" = NULL WHERE "broken?" = true
+    """)
+  end
+
+  # Not reversible in any useful sense: which rows carried the flag is exactly
+  # what this drops, and restoring it would re-poison links that are fine.
+  def down, do: :ok
+end

--- a/test/vutuv/imports/linked_in_apply_test.exs
+++ b/test/vutuv/imports/linked_in_apply_test.exs
@@ -9,8 +9,10 @@ defmodule Vutuv.Imports.LinkedInApplyTest do
   import Vutuv.Factory
 
   alias Vutuv.Imports.LinkedIn
+  alias Vutuv.PageScreenshot
   alias Vutuv.Profiles.Education
   alias Vutuv.Profiles.Qualification
+  alias Vutuv.Profiles.Url
   alias Vutuv.Profiles.WorkExperience
   alias Vutuv.Tags
   alias Vutuv.Tags.UserTag
@@ -284,6 +286,25 @@ defmodule Vutuv.Imports.LinkedInApplyTest do
     assert summary.blocked.positions == 1
     assert Repo.get_by(WorkExperience, user_id: user.id, organization: "Beta")
     refute Repo.get_by(WorkExperience, user_id: user.id, organization: "Acme")
+  end
+
+  test "an imported link is waiting for its screenshot like a hand-added one" do
+    # The import writes links straight through `Repo`, so the link form's
+    # fire-and-forget capture never sees them. Until they joined the capture
+    # queue, an imported link showed the grey camera tile for good — 15 links
+    # on vutuv.de sat like that, most in same-second batches an import left.
+    user = insert(:user)
+
+    profile_csv =
+      "First Name,Last Name,Maiden Name,Address,Birth Date,Headline,Summary,Industry,Zip Code,Geo Location,Twitter Handles,Websites,Instant Messengers\n" <>
+        "Stefan,Wintermeyer,,,,,,,,,,[PORTFOLIO:https://andreashechler.example],\n"
+
+    {:ok, parsed} = LinkedIn.parse(zip([{"Profile.csv", profile_csv}]))
+    {:ok, summary} = LinkedIn.apply_selection(user, parsed)
+
+    assert summary.created.urls == 1
+    imported = Repo.get_by!(Url, user_id: user.id)
+    assert imported.id in Enum.map(PageScreenshot.due(user_id: user.id), & &1.id)
   end
 
   test "an overlong website URL is skipped, not crashed" do

--- a/test/vutuv/moderation/image_scans_test.exs
+++ b/test/vutuv/moderation/image_scans_test.exs
@@ -17,6 +17,7 @@ defmodule Vutuv.Moderation.ImageScansTest do
   alias Vutuv.Accounts
   alias Vutuv.Moderation.ImageScan
   alias Vutuv.Moderation.ImageScans
+  alias Vutuv.Moderation.ImageSubjects
   alias Vutuv.Posts
   alias Vutuv.Posts.Screenshots
   alias Vutuv.Profiles.Url
@@ -514,6 +515,32 @@ defmodule Vutuv.Moderation.ImageScansTest do
 
       assert url.screenshot_moderation == "pending"
       assert Vutuv.Screenshot.url({url.screenshot, url}, :thumb) == "/images/screenshot.png"
+    end
+
+    test "a rejected link screenshot is remembered, not just removed", %{user: user} do
+      # The row is the only memory of the verdict. Clearing the column would
+      # put the page straight back in front of Vutuv.PageScreenshot.due/1, and
+      # the sweeper would shoot, store and re-scan the same rejected picture
+      # every six hours for good.
+      {:ok, url} =
+        user
+        |> Ecto.build_assoc(:urls)
+        |> Url.changeset(%{"value" => "https://example.com"})
+        |> Repo.insert()
+
+      {:ok, url} = url |> Url.changeset(%{screenshot: jpeg_upload()}) |> Repo.update()
+
+      assert :ok =
+               ImageSubjects.apply_rejected(%ImageScan{
+                 kind: "url_screenshot",
+                 subject_id: url.id,
+                 fingerprint: url.screenshot
+               })
+
+      judged = Repo.reload!(url)
+      assert is_nil(judged.screenshot)
+      assert judged.screenshot_moderation == "rejected"
+      refute judged.id in Enum.map(Vutuv.PageScreenshot.due(), & &1.id)
     end
   end
 

--- a/test/vutuv/page_screenshot_test.exs
+++ b/test/vutuv/page_screenshot_test.exs
@@ -12,6 +12,7 @@ defmodule Vutuv.PageScreenshotTest do
   import ExUnit.CaptureLog
   import Vutuv.Factory
 
+  alias Vutuv.Profiles.Url
   alias Vutuv.SocialFeed.Http
 
   setup do
@@ -172,7 +173,7 @@ defmodule Vutuv.PageScreenshotTest do
       # the wrong reason.
       assert :ok = Vutuv.PageScreenshot.generate_screenshot(url)
 
-      reloaded = Vutuv.Repo.get!(Vutuv.Profiles.Url, url.id)
+      reloaded = Vutuv.Repo.get!(Url, url.id)
       assert is_nil(reloaded.screenshot)
       assert is_nil(reloaded.broken?)
     end
@@ -189,8 +190,8 @@ defmodule Vutuv.PageScreenshotTest do
 
     assert Vutuv.PageScreenshot.purge_blocklisted() == 1
 
-    assert is_nil(Vutuv.Repo.get!(Vutuv.Profiles.Url, blocked.id).screenshot)
-    assert Vutuv.Repo.get!(Vutuv.Profiles.Url, kept.id).screenshot == "b0efec47a6e9.webp"
+    assert is_nil(Vutuv.Repo.get!(Url, blocked.id).screenshot)
+    assert Vutuv.Repo.get!(Url, kept.id).screenshot == "b0efec47a6e9.webp"
   end
 
   test "capture_framed refuses a host that resolves to an internal IP before launching Chromium" do
@@ -232,7 +233,7 @@ defmodule Vutuv.PageScreenshotTest do
       end)
 
     assert log =~ "internal_target"
-    assert Repo.get!(Vutuv.Profiles.Url, url.id).broken? == true
+    assert Repo.get!(Url, url.id).broken? == true
   end
 
   test "refuses a profile URL that 3xx-redirects to an internal address" do
@@ -259,7 +260,7 @@ defmodule Vutuv.PageScreenshotTest do
       end)
 
     assert log =~ "internal_target"
-    assert Repo.get!(Vutuv.Profiles.Url, url.id).broken? == true
+    assert Repo.get!(Url, url.id).broken? == true
   end
 
   test "an environment failure is logged but does not poison the URL, so it is retried later" do
@@ -286,8 +287,128 @@ defmodule Vutuv.PageScreenshotTest do
     # Logged at :error so a broken capture pipeline is visible under prod's
     # :error Logger level, instead of failing silently ...
     assert log =~ "screenshot generation failed"
-    # ... and the row is left un-poisoned, so the bulk urls.create_screenshots
-    # task retries it once capture works again.
-    refute Repo.get!(Vutuv.Profiles.Url, url.id).broken?
+    # ... and the row is left un-poisoned, so the sweeper retries it once
+    # capture works again.
+    refute Repo.get!(Url, url.id).broken?
+  end
+
+  describe "due/1, the standing retry" do
+    setup do
+      %{user: insert_activated_user()}
+    end
+
+    defp due_ids, do: Enum.map(Vutuv.PageScreenshot.due(), & &1.id)
+
+    test "hands over the waiting links, never-attempted first", %{user: user} do
+      # A link with nothing but a URL is the shape the LinkedIn import leaves
+      # behind — it writes rows straight through `Repo`, so the link form's
+      # fire-and-forget capture never sees them. Before this query nothing ever
+      # looked at such a link again, and 15 of the 1,938 links on vutuv.de sat
+      # without a picture for good.
+      never = insert(:url, user: user, value: "https://never.example")
+
+      older =
+        insert(:url,
+          user: user,
+          value: "https://older.example",
+          screenshot_attempted_at: hours_ago(48)
+        )
+
+      newer =
+        insert(:url,
+          user: user,
+          value: "https://newer.example",
+          screenshot_attempted_at: hours_ago(24)
+        )
+
+      assert due_ids() == [never.id, older.id, newer.id]
+    end
+
+    test "leaves out what has a picture, cannot have one, or was just tried", %{user: user} do
+      shot = insert(:url, user: user, value: "https://a.example", screenshot: "abc123.webp")
+      broken = insert(:url, user: user, value: "https://b.example", broken?: true)
+      # A capture the AI moderation threw out. Without this the sweeper would
+      # shoot, store and re-scan the same rejected picture every six hours.
+      rejected =
+        insert(:url, user: user, value: "https://c.example", screenshot_moderation: "rejected")
+
+      just_tried =
+        insert(:url,
+          user: user,
+          value: "https://d.example",
+          screenshot_attempted_at: hours_ago(1)
+        )
+
+      due = due_ids()
+      refute shot.id in due
+      refute broken.id in due
+      refute rejected.id in due
+      refute just_tried.id in due
+    end
+
+    test "narrows to one member's links (what an import nudges)", %{user: user} do
+      other = insert_activated_user()
+      insert(:url, user: user, value: "https://mine.example")
+      theirs = insert(:url, user: other, value: "https://theirs.example")
+
+      assert Enum.map(Vutuv.PageScreenshot.due(user_id: other.id), & &1.id) == [theirs.id]
+    end
+
+    defp hours_ago(hours),
+      do: NaiveDateTime.add(NaiveDateTime.utc_now(:second), -hours, :hour)
+  end
+
+  describe "capture_due/1" do
+    test "a link it could not capture stops being due" do
+      # The deadlock this guards: an unshootable link is due again on the next
+      # sweep and, ordered oldest-first, spends the whole batch — so the links
+      # behind it are never reached. Calibrated by dropping the stamp in
+      # capture_store_and_flag/1: this link comes back and the test goes red.
+      user = insert_activated_user()
+      url = insert(:url, user: user, value: "https://unshootable.example")
+
+      args_file =
+        Path.join(System.tmp_dir!(), "chromium-args-#{System.unique_integer([:positive])}")
+
+      on_exit(fn -> File.rm(args_file) end)
+      Application.put_env(:vutuv, :chromium_path, fake_chromium(args_file))
+
+      capture_log(fn -> assert Vutuv.PageScreenshot.capture_due() == 1 end)
+
+      reloaded = Repo.get!(Url, url.id)
+      assert is_nil(reloaded.screenshot)
+      refute is_nil(reloaded.screenshot_attempted_at)
+      refute url.id in Enum.map(Vutuv.PageScreenshot.due(), & &1.id)
+    end
+
+    test "a blocklisted link is stamped too, so it never holds up the batch" do
+      # Nothing is captured here by design — a blocklisted page is one this
+      # installation never shoots, which is no failure and leaves no log. It
+      # still has to leave the batch, or the one link that will never have a
+      # picture is the only one the sweeper ever looks at.
+      user = insert_activated_user()
+      # The seeded blocklist ships heise.de (see Vutuv.ScreenshotBlocklist).
+      url = insert(:url, user: user, value: "https://www.heise.de/newsticker/meldung-1.html")
+
+      assert capture_log(fn -> assert Vutuv.PageScreenshot.capture_due() == 1 end) == ""
+
+      refute is_nil(Repo.get!(Url, url.id).screenshot_attempted_at)
+      refute url.id in Enum.map(Vutuv.PageScreenshot.due(), & &1.id)
+    end
+  end
+
+  test "editing a link to another address drops the picture of the old one" do
+    # Otherwise the profile shows a photograph of somebody else's page under
+    # the new address — and because the retry query asks for links with *no*
+    # screenshot, that row would never be captured again if the edit's own
+    # fire-and-forget task died. Wrong content instead of none, forever.
+    user = insert_activated_user()
+    url = insert(:url, user: user, value: "https://old.example", screenshot: "abc123.webp")
+
+    {:ok, moved} =
+      url |> Url.changeset(%{"value" => "https://new.example"}) |> Repo.update()
+
+    assert is_nil(moved.screenshot)
+    assert moved.id in Enum.map(Vutuv.PageScreenshot.due(), & &1.id)
   end
 end


### PR DESCRIPTION
A profile link's screenshot tile stays a grey camera forever — on vutuv.de for 60 of 1,938 links, among them https://vutuv.de/andreas_hechler.

Only the link form ever queued a capture, fire-and-forget. Links written by the LinkedIn import (`Vutuv.Imports.LinkedIn.apply_selection/2`) never got one, and a capture a deploy killed mid-run was never retried.

The row is now the record of unfinished work: `Vutuv.PageScreenshot.due/1` plus a sweeper, five links every five minutes, least recently attempted first. Each attempt stamps `screenshot_attempted_at` before capturing and on every outcome, so a link that can never be shot cannot hold the batch.

Three things the same state exposed: editing a link's URL now drops the picture of the old page, an AI-rejected capture is remembered instead of re-shot, and a migration clears 45 `broken?` flags a pre-v5 rule set on any failure — none resolves internally today.

Measured against a production copy: 58 of 59 waiting links capture cleanly in 8 minutes.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_014hMNXh4kh99Gsqer4E4eVG
