### PR TITLE
Cap what the search box and the sign-up form accept

### DIFF
--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -1028,16 +1028,48 @@ defmodule Vutuv.Accounts.User do
     |> Mentions.validate_handle_available(:username)
   end
 
+  # Kept byte-identical to its anchor in
+  # `VutuvWeb.ErrorHelpers.__error_message_extraction_anchors__/0`, which is what
+  # gets it into errors.pot and translated.
+  @one_email_message "Only one email address can be given at sign-up."
+
   # Registration is the one place where an email address may ride along with
   # the user: the address is verified right afterwards by the login PIN. It is
   # also the one place that enforces the tag minimum — tags are how members
   # are found, so an account may not start without at least three distinct
   # ones (an existing member is never forced to keep three).
   def registration_changeset(model, params \\ %{}) do
-    model
-    |> changeset(params)
-    |> validate_tag_list()
-    |> cast_assoc(:emails)
+    changeset = model |> changeset(params) |> validate_tag_list()
+
+    if several_emails?(params) do
+      # Refused without casting. `cast_assoc/3` builds a nested changeset per
+      # entry before anything can reject the list, so a 10,000-address POST to
+      # this unauthenticated endpoint costs 5.5M reductions to say no; this
+      # costs five.
+      add_error(changeset, :emails, @one_email_message)
+    else
+      cast_assoc(changeset, :emails)
+    end
+  end
+
+  # Exactly one address may ride along, because exactly one is proven: the login
+  # PIN goes to `emails["0"]` and nothing checks the rest. `POST
+  # /new_registration` is unauthenticated and takes whatever is posted, so a
+  # second entry used to be stored as a login identity for the new account —
+  # `Accounts.user_by_email/1` resolves any stored address to its user, so the
+  # address's real owner could no longer register it, and their next login would
+  # mail them a valid PIN into somebody else's account. Additional addresses go
+  # through the PIN-verified flow in `VutuvWeb.EmailController` instead.
+  #
+  # Both key spellings are read: the web params arrive with string keys, and an
+  # atom-keyed caller would otherwise walk past the check into `cast_assoc/3`,
+  # which accepts either.
+  defp several_emails?(params) do
+    case Map.get(params, "emails") || Map.get(params, :emails) do
+      [_, _ | _] -> true
+      emails when is_map(emails) -> map_size(emails) > 1
+      _ -> false
+    end
   end
 
   # The three tag rules share one resolved list: `distinct_tag_names/1` asks the

--- a/lib/vutuv/cologne_phonetics.ex
+++ b/lib/vutuv/cologne_phonetics.ex
@@ -73,6 +73,13 @@ defmodule Vutuv.ColognePhonetics do
       {?c, ~c"8"}
     ]
 
+  # This encodes names, and the longest name any column here holds is 50
+  # characters. Both callers can be handed more than that by a stranger —
+  # `Vutuv.Search` from the public query box, `Vutuv.Accounts.SearchTerm` from
+  # the raw sign-up params, before any length validation runs — so the word is
+  # cut here rather than at each of them.
+  @max_chars 100
+
   def to_cologne(""), do: ""
 
   def to_cologne(nil), do: nil
@@ -80,7 +87,10 @@ defmodule Vutuv.ColognePhonetics do
   # The three steps of the cologne phonetics algorithm.
   def to_cologne(string) do
     # Downcase to prevent unwanted behavior
-    String.downcase(string)
+    string
+    |> String.byte_slice(0, @max_chars * 4)
+    |> String.slice(0, @max_chars)
+    |> String.downcase()
     # Normalizes special characters
     |> normalize
     # Converts the string to representative coded numbers in a char list
@@ -101,17 +111,24 @@ defmodule Vutuv.ColognePhonetics do
     encode_string(~c"", nil, nil, head, tail)
   end
 
+  # The accumulator collects the codes reversed and flat, and the last clause
+  # turns it around once. Appending instead (`encoded ++ encode(…)`) copies the
+  # whole accumulator per character, which is quadratic in the length of the
+  # word — and this encoder is reachable with a word an unauthenticated visitor
+  # chooses, both from the `/search` box and from a sign-up's raw `first_name`
+  # (`Vutuv.Accounts.SearchTerm.create_search_terms/1`, which runs before the
+  # changeset's length validation). See the work bound in
+  # `test/vutuv/cologne_phonetics_test.exs`.
   defp encode_string(encoded, prev, char, next, [head | tail]) do
     # As long as the char list is not empty, recurse
-    (encoded ++ encode(prev, char, next))
+    encode(prev, char, next)
+    |> Enum.reverse(encoded)
     |> encode_string(char, next, head, tail)
   end
 
   defp encode_string(encoded, prev, char, next, []) do
     # If the char list is empty, the operation  is finished, encode the last two letters.
-    encoded ++
-      encode(prev, char, next) ++
-      encode(char, next, nil)
+    Enum.reverse(encoded, encode(prev, char, next) ++ encode(char, next, nil))
   end
 
   # This function block defines pattern matchable functions for every possible replacement.

--- a/lib/vutuv/directory.ex
+++ b/lib/vutuv/directory.ex
@@ -26,7 +26,7 @@ defmodule Vutuv.Directory do
 
   import Ecto.Query
   import Vutuv.Moderation.Query
-  import Vutuv.SearchText, only: [contains: 1, normalize_search: 1]
+  import Vutuv.SearchText, only: [cap: 1, contains: 1, normalize_search: 1]
 
   alias Vutuv.Accounts.User
   alias Vutuv.Pages
@@ -249,7 +249,10 @@ defmodule Vutuv.Directory do
   33 ms against 67 ms on a 100k-row copy).
   """
   def search(query, fields \\ @search_fields, limit \\ @results_step) do
-    with needle when is_binary(needle) <- normalize_search(query),
+    # `/system/members?q=` is open to visitors and `field_match/2` emits one
+    # leading-wildcard `ILIKE` per word per selected column, so the query is cut
+    # to `SearchText.max_chars/0` before any of that is built.
+    with needle when is_binary(needle) <- query |> cap() |> normalize_search(),
          true <- String.length(needle) >= @min_query_chars do
       listed_users()
       |> where(^field_match(parse_search_fields(fields), needle))

--- a/lib/vutuv/jobs.ex
+++ b/lib/vutuv/jobs.ex
@@ -29,7 +29,7 @@ defmodule Vutuv.Jobs do
   """
 
   import Ecto.Query
-  import Vutuv.SearchText, only: [contains: 1, escape_like: 1, normalize_search: 1]
+  import Vutuv.SearchText, only: [cap: 1, contains: 1, escape_like: 1, normalize_search: 1]
 
   alias Vutuv.Accounts.User
   alias Vutuv.BerlinTime
@@ -957,12 +957,14 @@ defmodule Vutuv.Jobs do
   other value is validated (radius/country/enums) or dropped.
   """
   def board_filters(raw, viewer) when is_map(raw) do
+    # The board is public and `q` is split into one `ILIKE` group per token
+    # (`Vutuv.Jobs.SearchQuery`), so both free-text fields are cut first.
     %{
-      q: normalize_search(raw["q"]),
+      q: raw["q"] |> cap() |> normalize_search(),
       tags: parse_board_tags(raw["tag"]),
       workplace: parse_workplace(raw["workplace"]),
       employment: parse_employment(raw["employment"]),
-      near: normalize_search(raw["near"]),
+      near: raw["near"] |> cap() |> normalize_search(),
       radius: parse_radius(raw["radius"]),
       country: parse_country(raw["country"]),
       my_tags?: raw["my_tags"] in ["1", "true", "on"]

--- a/lib/vutuv/search.ex
+++ b/lib/vutuv/search.ex
@@ -19,6 +19,7 @@ defmodule Vutuv.Search do
   alias Vutuv.Accounts.SearchTerm
   alias Vutuv.Accounts.User
   alias Vutuv.Repo
+  alias Vutuv.SearchText
   alias Vutuv.Tags.Tag
 
   @min_chars 3
@@ -83,7 +84,8 @@ defmodule Vutuv.Search do
   (the UI toggle, OR-ed with the quotes).
   """
   def parse(value, opts \\ []) when is_binary(value) do
-    raw = value |> String.trim() |> String.downcase()
+    # Cut first, so nothing this function reaches walks more than the cap.
+    raw = value |> SearchText.cap() |> String.trim() |> String.downcase()
     {quoted?, unquoted} = strip_quotes(raw)
 
     {fields, words} =

--- a/lib/vutuv/search_text.ex
+++ b/lib/vutuv/search_text.ex
@@ -4,13 +4,45 @@ defmodule Vutuv.SearchText do
   `Vutuv.Posts`, `Vutuv.Social` and `Vutuv.Search` contexts.
 
   Kept in one place so the wildcard-escaping rule (a security-relevant string
-  escape) and the blank-to-nil normalization each have a single definition
-  instead of a copy per context.
+  escape), the query-length cap and the blank-to-nil normalization each have a
+  single definition instead of a copy per context.
   """
+
+  # The longest search string a query box accepts. Nobody searches for a name,
+  # tag or city this long, and several of these boxes are open to visitors
+  # (`/search`, the member directory at `/system/members`, the job board), where
+  # an uncapped value becomes a megabyte `ILIKE '%…%'` pattern, a megabyte
+  # `websearch_to_tsquery`, and a megabyte handed to the phonetic encoders.
+  @max_chars 200
+
+  @doc "The longest search string `cap/1` and `normalize_search/1` let through."
+  def max_chars, do: @max_chars
+
+  @doc """
+  Cuts a search string to `max_chars/0`.
+
+  Bytes first, graphemes second: `String.slice/3` alone walks the *whole* input
+  to find its cut point (131_093 reductions on a megabyte, against 961 for the
+  entire `Vutuv.Search.parse/2` it protects), so the byte cut bounds the work
+  first and the grapheme cut then lands on a character boundary. Four bytes per
+  grapheme is UTF-8's ceiling, so nothing under the cap is ever shortened.
+  """
+  def cap(value) when is_binary(value) do
+    value |> String.byte_slice(0, @max_chars * 4) |> String.slice(0, @max_chars)
+  end
+
+  def cap(value), do: value
 
   @doc """
   Trims a search string, collapsing a blank (or non-binary) value to `nil` so a
   caller can pattern-match "no search" in one spot.
+
+  Deliberately does **not** cap: despite the name this is the tree's general
+  "trim, blank to nil" normalizer, and `Vutuv.Fediverse` runs remote URIs
+  (`object["id"]`, `object["url"]`, `quoteAuthorization`) and `Vutuv.Moderation`
+  a report reason through it. Capping here silently shortened a 2 KB quote URI
+  to 200 characters and slipped it past the length check that was supposed to
+  drop it. Search entry points call `cap/1` themselves.
   """
   def normalize_search(value) when is_binary(value) do
     case String.trim(value) do

--- a/lib/vutuv/soundex.ex
+++ b/lib/vutuv/soundex.ex
@@ -47,13 +47,20 @@ defmodule Vutuv.Soundex do
       ?w
     ]
 
+  # Same bound and same reason as `Vutuv.ColognePhonetics`: a name, handed over
+  # by a stranger from the public search box or from raw sign-up params.
+  @max_chars 100
+
   def to_soundex(""), do: ""
 
   def to_soundex(nil), do: nil
 
   def to_soundex(string) do
     # Downcase to prevent unwanted behavior
-    String.downcase(string)
+    string
+    |> String.byte_slice(0, @max_chars * 4)
+    |> String.slice(0, @max_chars)
+    |> String.downcase()
     # Normalizes special characters
     |> normalize
     # Converts the string into a char list
@@ -88,11 +95,16 @@ defmodule Vutuv.Soundex do
 
   defp encode_list(tail, ~c"", head), do: encode_list([head | tail], ~c"")
 
-  defp encode_list(~c"", encoded), do: encoded
+  # The accumulator collects the replacements in reverse and is turned around
+  # once at the end. Appending per character (`encoded ++ [replace(head)]`)
+  # copies the whole accumulator every time, which is quadratic in the length of
+  # the word — and the word comes from the public `/search` box (see the work
+  # bound in `test/vutuv/soundex_test.exs`).
+  defp encode_list(~c"", encoded), do: Enum.reverse(encoded)
 
   # Recurses the char list and applies the apropriate replacements until it has replaced each letter
   defp encode_list([head | tail], encoded) do
-    encode_list(tail, encoded ++ [replace(head)])
+    encode_list(tail, [replace(head) | encoded])
   end
 
   # Generates non-breaking drops

--- a/lib/vutuv_web/live/search_live.ex
+++ b/lib/vutuv_web/live/search_live.ex
@@ -47,6 +47,7 @@ defmodule VutuvWeb.SearchLive do
   alias Vutuv.Fediverse.RemoteFollow
   alias Vutuv.Posts
   alias Vutuv.Search
+  alias Vutuv.SearchText
   alias VutuvWeb.PostTeaser
   alias VutuvWeb.UserHelpers
   alias VutuvWeb.UserHTML
@@ -189,7 +190,8 @@ defmodule VutuvWeb.SearchLive do
   end
 
   @impl true
-  def handle_event("search", %{"q" => q}, socket), do: {:noreply, patch_search(socket, q)}
+  def handle_event("search", %{"q" => q}, socket),
+    do: {:noreply, patch_search(socket, SearchText.cap(q))}
 
   # Enter on a pasted post address means "get me that post", which is the one
   # thing a text search can never do with it, so a submit takes the lookup where
@@ -197,6 +199,7 @@ defmodule VutuvWeb.SearchLive do
   # than read off the assign: `phx-debounce` holds the change event back, so a
   # paste followed straight away by Enter arrives here first.
   def handle_event("submit-search", %{"q" => q}, socket) do
+    q = SearchText.cap(q)
     socket = socket |> assign(:q, q) |> assign(:remote_post_url, remote_post_url(q))
 
     if lookup_offered?(socket),

--- a/lib/vutuv_web/templates/page/index.html.heex
+++ b/lib/vutuv_web/templates/page/index.html.heex
@@ -161,6 +161,12 @@
           form's hidden `_persistent_id` field twice under one name. `f` is still
           in scope in here, so the three user-level checkboxes below cost
           nothing for sitting in this block. --%>
+    <%!-- The association's own error, as opposed to the nested field's: the
+          only one that can land here is the "one address at sign-up" rule, and
+          without this the form would fail silently, because a refused list is
+          never cast and so has no nested form to carry the message. --%>
+    <%= error_tag f, :emails %>
+
     <.inputs_for :let={ef} field={f[:emails]}>
       <div>
         <label for={ef[:value].id} class={label_class}>{gettext("Email address")}</label>

--- a/lib/vutuv_web/views/error_helpers.ex
+++ b/lib/vutuv_web/views/error_helpers.ex
@@ -101,6 +101,8 @@ defmodule VutuvWeb.ErrorHelpers do
         "PDF uploads are not available on this installation. Please upload an image instead."
       ),
       dgettext_noop("errors", "could not be read. Please upload a PDF, JPG, PNG or WebP file."),
+      # Vutuv.Accounts.User, sign-up: only the address the PIN goes to.
+      dgettext_noop("errors", "Only one email address can be given at sign-up."),
       # Vutuv.Tags.Tag / Vutuv.Accounts.User, the "this field is not a
       # billboard" rule (Vutuv.WebAddress).
       dgettext_noop("errors", "must not be a web or email address"),

--- a/priv/gettext/de/LC_MESSAGES/errors.po
+++ b/priv/gettext/de/LC_MESSAGES/errors.po
@@ -207,114 +207,119 @@ msgstr "konnte nicht gelesen werden. Bitte laden Sie eine PDF-, JPG-, PNG- oder 
 msgid "is larger than 10 MB. Please upload a smaller file."
 msgstr "ist größer als 10 MB. Bitte laden Sie eine kleinere Datei hoch."
 
-#: lib/vutuv_web/views/error_helpers.ex:106
+#: lib/vutuv_web/views/error_helpers.ex:108
 #, elixir-autogen, elixir-format
 msgid "must not be a web or email address"
 msgstr "darf keine Web- oder E-Mail-Adresse sein"
 
-#: lib/vutuv_web/views/error_helpers.ex:107
+#: lib/vutuv_web/views/error_helpers.ex:109
 #, elixir-autogen, elixir-format
 msgid "can't be only a link. Please describe yourself in a few words."
 msgstr "darf nicht nur ein Link sein. Bitte beschreiben Sie sich in ein paar Worten."
 
-#: lib/vutuv_web/views/error_helpers.ex:111
+#: lib/vutuv_web/views/error_helpers.ex:113
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is a web address, not a tag. Please describe yourself with words."
 msgstr "„%{tag}“ ist eine Web-Adresse, kein Tag. Bitte beschreiben Sie sich mit Worten."
 
-#: lib/vutuv_web/views/error_helpers.ex:118
+#: lib/vutuv_web/views/error_helpers.ex:120
 #, elixir-autogen, elixir-format
 msgid "must not be only punctuation"
 msgstr "darf nicht nur aus Satzzeichen bestehen"
 
-#: lib/vutuv_web/views/error_helpers.ex:119
+#: lib/vutuv_web/views/error_helpers.ex:121
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr "„%{tag}“ besteht nur aus Satzzeichen und ist kein Tag."
 
-#: lib/vutuv_web/views/error_helpers.ex:129
+#: lib/vutuv_web/views/error_helpers.ex:131
 #, elixir-autogen, elixir-format
 msgid "\"%{uri}\" is not a valid https account address."
 msgstr "„%{uri}“ ist keine gültige https-Kontoadresse."
 
-#: lib/vutuv_web/views/error_helpers.ex:128
+#: lib/vutuv_web/views/error_helpers.ex:130
 #, elixir-autogen, elixir-format
 msgid "Please list at most %{max} accounts."
 msgstr "Bitte geben Sie höchstens %{max} Konten an."
 
-#: lib/vutuv_web/views/error_helpers.ex:116
+#: lib/vutuv_web/views/error_helpers.ex:118
 #, elixir-autogen, elixir-format
 msgid "must spell out how the name sounds"
 msgstr "muss beschreiben, wie der Name klingt"
 
-#: lib/vutuv_web/views/error_helpers.ex:121
+#: lib/vutuv_web/views/error_helpers.ex:123
 #, elixir-autogen, elixir-format
 msgid "Please use at most %{max} tags."
 msgstr "Bitte verwenden Sie höchstens %{max} Tags."
 
-#: lib/vutuv_web/views/error_helpers.ex:131
+#: lib/vutuv_web/views/error_helpers.ex:133
 #, elixir-autogen, elixir-format
 msgid "Enter your Signal link, it starts with https://signal.me/#"
 msgstr "Bitte geben Sie Ihren Signal-Link ein, er beginnt mit https://signal.me/#"
 
-#: lib/vutuv_web/views/error_helpers.ex:123
+#: lib/vutuv_web/views/error_helpers.ex:125
 #, elixir-autogen, elixir-format
 msgid "We allow at most %{max} accounts per post. Please remove some mentions."
 msgstr ""
 "Wir erlauben höchstens %{max} Konten pro Beitrag. Bitte entfernen Sie einige "
 "Erwähnungen."
 
-#: lib/vutuv_web/views/error_helpers.ex:134
+#: lib/vutuv_web/views/error_helpers.ex:136
 #, elixir-autogen, elixir-format
 msgid "Enter your Bluesky handle, e.g. name.bsky.social"
 msgstr "Geben Sie Ihr Bluesky-Handle an, z. B. name.bsky.social"
 
-#: lib/vutuv_web/views/error_helpers.ex:147
+#: lib/vutuv_web/views/error_helpers.ex:149
 #, elixir-autogen, elixir-format
 msgid "Enter your Codeberg username, not a full URL with extra path segments"
 msgstr "Geben Sie Ihren Codeberg-Benutzernamen an, keine vollständige URL mit weiteren Pfadangaben"
 
-#: lib/vutuv_web/views/error_helpers.ex:143
+#: lib/vutuv_web/views/error_helpers.ex:145
 #, elixir-autogen, elixir-format
 msgid "Enter your GitHub username, not a full URL with extra path segments"
 msgstr "Geben Sie Ihren GitHub-Benutzernamen an, keine vollständige URL mit weiteren Pfadangaben"
 
-#: lib/vutuv_web/views/error_helpers.ex:139
+#: lib/vutuv_web/views/error_helpers.ex:141
 #, elixir-autogen, elixir-format
 msgid "Enter your GitLab username, e.g. gitlab.com/username (not a /-/u/ ID link)"
 msgstr "Geben Sie Ihren GitLab-Benutzernamen an, z. B. gitlab.com/benutzername (keinen ID-Link mit /-/u/)"
 
-#: lib/vutuv_web/views/error_helpers.ex:133
+#: lib/vutuv_web/views/error_helpers.ex:135
 #, elixir-autogen, elixir-format
 msgid "Enter your full Mastodon handle, e.g. @user@instance.social"
 msgstr "Geben Sie Ihr vollständiges Mastodon-Handle an, z. B. @name@instanz.social"
 
-#: lib/vutuv_web/views/error_helpers.ex:135
+#: lib/vutuv_web/views/error_helpers.ex:137
 #, elixir-autogen, elixir-format
 msgid "Enter your username and your instance, e.g. name@git.example.com"
 msgstr "Geben Sie Ihren Benutzernamen und Ihre Instanz an, z. B. name@git.example.com"
 
-#: lib/vutuv_web/views/error_helpers.ex:151
+#: lib/vutuv_web/views/error_helpers.ex:153
 #, elixir-autogen, elixir-format
 msgid "Invalid account name"
 msgstr "Ungültiger Kontoname"
 
-#: lib/vutuv_web/views/error_helpers.ex:152
+#: lib/vutuv_web/views/error_helpers.ex:154
 #, elixir-autogen, elixir-format
 msgid "Someone has already claimed this account"
 msgstr "Dieses Konto hat bereits jemand für sich beansprucht"
 
-#: lib/vutuv_web/views/error_helpers.ex:159
+#: lib/vutuv_web/views/error_helpers.ex:161
 #, elixir-autogen, elixir-format
 msgid "That instance did not answer. Please try again in a moment."
 msgstr "Diese Instanz hat nicht geantwortet. Bitte versuchen Sie es gleich noch einmal."
 
-#: lib/vutuv_web/views/error_helpers.ex:160
+#: lib/vutuv_web/views/error_helpers.ex:162
 #, elixir-autogen, elixir-format
 msgid "Too many checks for now. Please try again later."
 msgstr "Vorerst zu viele Prüfungen. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/views/error_helpers.ex:155
+#: lib/vutuv_web/views/error_helpers.ex:157
 #, elixir-autogen, elixir-format
 msgid "We could not find this account on that instance. Please check the address."
 msgstr "Wir konnten dieses Konto auf dieser Instanz nicht finden. Bitte prüfen Sie die Adresse."
+
+#: lib/vutuv_web/views/error_helpers.ex:105
+#, elixir-autogen, elixir-format
+msgid "Only one email address can be given at sign-up."
+msgstr "Bei der Anmeldung kann nur eine E-Mail-Adresse angegeben werden."

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -205,112 +205,117 @@ msgstr ""
 msgid "is larger than 10 MB. Please upload a smaller file."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:106
+#: lib/vutuv_web/views/error_helpers.ex:108
 #, elixir-autogen, elixir-format
 msgid "must not be a web or email address"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:107
+#: lib/vutuv_web/views/error_helpers.ex:109
 #, elixir-autogen, elixir-format
 msgid "can't be only a link. Please describe yourself in a few words."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:111
+#: lib/vutuv_web/views/error_helpers.ex:113
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is a web address, not a tag. Please describe yourself with words."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:118
+#: lib/vutuv_web/views/error_helpers.ex:120
 #, elixir-autogen, elixir-format
 msgid "must not be only punctuation"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:119
+#: lib/vutuv_web/views/error_helpers.ex:121
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:129
+#: lib/vutuv_web/views/error_helpers.ex:131
 #, elixir-autogen, elixir-format
 msgid "\"%{uri}\" is not a valid https account address."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:128
+#: lib/vutuv_web/views/error_helpers.ex:130
 #, elixir-autogen, elixir-format
 msgid "Please list at most %{max} accounts."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:116
+#: lib/vutuv_web/views/error_helpers.ex:118
 #, elixir-autogen, elixir-format
 msgid "must spell out how the name sounds"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:121
+#: lib/vutuv_web/views/error_helpers.ex:123
 #, elixir-autogen, elixir-format
 msgid "Please use at most %{max} tags."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:131
+#: lib/vutuv_web/views/error_helpers.ex:133
 #, elixir-autogen, elixir-format
 msgid "Enter your Signal link, it starts with https://signal.me/#"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:123
+#: lib/vutuv_web/views/error_helpers.ex:125
 #, elixir-autogen, elixir-format
 msgid "We allow at most %{max} accounts per post. Please remove some mentions."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:134
+#: lib/vutuv_web/views/error_helpers.ex:136
 #, elixir-autogen, elixir-format
 msgid "Enter your Bluesky handle, e.g. name.bsky.social"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:147
+#: lib/vutuv_web/views/error_helpers.ex:149
 #, elixir-autogen, elixir-format
 msgid "Enter your Codeberg username, not a full URL with extra path segments"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:143
+#: lib/vutuv_web/views/error_helpers.ex:145
 #, elixir-autogen, elixir-format
 msgid "Enter your GitHub username, not a full URL with extra path segments"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:139
+#: lib/vutuv_web/views/error_helpers.ex:141
 #, elixir-autogen, elixir-format
 msgid "Enter your GitLab username, e.g. gitlab.com/username (not a /-/u/ ID link)"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:133
+#: lib/vutuv_web/views/error_helpers.ex:135
 #, elixir-autogen, elixir-format
 msgid "Enter your full Mastodon handle, e.g. @user@instance.social"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:135
+#: lib/vutuv_web/views/error_helpers.ex:137
 #, elixir-autogen, elixir-format
 msgid "Enter your username and your instance, e.g. name@git.example.com"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:151
+#: lib/vutuv_web/views/error_helpers.ex:153
 #, elixir-autogen, elixir-format
 msgid "Invalid account name"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:152
+#: lib/vutuv_web/views/error_helpers.ex:154
 #, elixir-autogen, elixir-format
 msgid "Someone has already claimed this account"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:159
+#: lib/vutuv_web/views/error_helpers.ex:161
 #, elixir-autogen, elixir-format
 msgid "That instance did not answer. Please try again in a moment."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:160
+#: lib/vutuv_web/views/error_helpers.ex:162
 #, elixir-autogen, elixir-format
 msgid "Too many checks for now. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:155
+#: lib/vutuv_web/views/error_helpers.ex:157
 #, elixir-autogen, elixir-format
 msgid "We could not find this account on that instance. Please check the address."
 msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:105
+#, elixir-autogen, elixir-format
+msgid "Only one email address can be given at sign-up."
+msgstr "Only one email address can be given at sign-up."

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -208,112 +208,117 @@ msgstr ""
 msgid "is larger than 10 MB. Please upload a smaller file."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:106
+#: lib/vutuv_web/views/error_helpers.ex:108
 #, elixir-autogen, elixir-format
 msgid "must not be a web or email address"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:107
+#: lib/vutuv_web/views/error_helpers.ex:109
 #, elixir-autogen, elixir-format
 msgid "can't be only a link. Please describe yourself in a few words."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:111
+#: lib/vutuv_web/views/error_helpers.ex:113
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is a web address, not a tag. Please describe yourself with words."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:118
+#: lib/vutuv_web/views/error_helpers.ex:120
 #, elixir-autogen, elixir-format
 msgid "must not be only punctuation"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:119
+#: lib/vutuv_web/views/error_helpers.ex:121
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:129
+#: lib/vutuv_web/views/error_helpers.ex:131
 #, elixir-autogen, elixir-format
 msgid "\"%{uri}\" is not a valid https account address."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:128
+#: lib/vutuv_web/views/error_helpers.ex:130
 #, elixir-autogen, elixir-format
 msgid "Please list at most %{max} accounts."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:116
+#: lib/vutuv_web/views/error_helpers.ex:118
 #, elixir-autogen, elixir-format
 msgid "must spell out how the name sounds"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:121
+#: lib/vutuv_web/views/error_helpers.ex:123
 #, elixir-autogen, elixir-format
 msgid "Please use at most %{max} tags."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:131
+#: lib/vutuv_web/views/error_helpers.ex:133
 #, elixir-autogen, elixir-format
 msgid "Enter your Signal link, it starts with https://signal.me/#"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:123
+#: lib/vutuv_web/views/error_helpers.ex:125
 #, elixir-autogen, elixir-format
 msgid "We allow at most %{max} accounts per post. Please remove some mentions."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:134
+#: lib/vutuv_web/views/error_helpers.ex:136
 #, elixir-autogen, elixir-format
 msgid "Enter your Bluesky handle, e.g. name.bsky.social"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:147
+#: lib/vutuv_web/views/error_helpers.ex:149
 #, elixir-autogen, elixir-format
 msgid "Enter your Codeberg username, not a full URL with extra path segments"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:143
+#: lib/vutuv_web/views/error_helpers.ex:145
 #, elixir-autogen, elixir-format
 msgid "Enter your GitHub username, not a full URL with extra path segments"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:139
+#: lib/vutuv_web/views/error_helpers.ex:141
 #, elixir-autogen, elixir-format
 msgid "Enter your GitLab username, e.g. gitlab.com/username (not a /-/u/ ID link)"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:133
+#: lib/vutuv_web/views/error_helpers.ex:135
 #, elixir-autogen, elixir-format
 msgid "Enter your full Mastodon handle, e.g. @user@instance.social"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:135
+#: lib/vutuv_web/views/error_helpers.ex:137
 #, elixir-autogen, elixir-format
 msgid "Enter your username and your instance, e.g. name@git.example.com"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:151
+#: lib/vutuv_web/views/error_helpers.ex:153
 #, elixir-autogen, elixir-format
 msgid "Invalid account name"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:152
+#: lib/vutuv_web/views/error_helpers.ex:154
 #, elixir-autogen, elixir-format
 msgid "Someone has already claimed this account"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:159
+#: lib/vutuv_web/views/error_helpers.ex:161
 #, elixir-autogen, elixir-format
 msgid "That instance did not answer. Please try again in a moment."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:160
+#: lib/vutuv_web/views/error_helpers.ex:162
 #, elixir-autogen, elixir-format
 msgid "Too many checks for now. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:155
+#: lib/vutuv_web/views/error_helpers.ex:157
 #, elixir-autogen, elixir-format
 msgid "We could not find this account on that instance. Please check the address."
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:105
+#, elixir-autogen, elixir-format
+msgid "Only one email address can be given at sign-up."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/errors.po
+++ b/priv/gettext/it/LC_MESSAGES/errors.po
@@ -196,123 +196,128 @@ msgstr "Non è stato possibile leggerlo. Carichi un file PDF, JPG, PNG o WebP."
 msgid "is larger than 10 MB. Please upload a smaller file."
 msgstr "Supera i 10 MB. Carichi un file più piccolo."
 
-#: lib/vutuv_web/views/error_helpers.ex:106
+#: lib/vutuv_web/views/error_helpers.ex:108
 #, elixir-autogen, elixir-format
 msgid "must not be a web or email address"
 msgstr "Non può essere un indirizzo web o e-mail"
 
-#: lib/vutuv_web/views/error_helpers.ex:107
+#: lib/vutuv_web/views/error_helpers.ex:109
 #, elixir-autogen, elixir-format
 msgid "can't be only a link. Please describe yourself in a few words."
 msgstr "Non può essere solo un link. Si descriva in poche parole."
 
-#: lib/vutuv_web/views/error_helpers.ex:111
+#: lib/vutuv_web/views/error_helpers.ex:113
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is a web address, not a tag. Please describe yourself with words."
 msgstr "\"%{tag}\" è un indirizzo web, non un tag. Si descriva a parole."
 
-#: lib/vutuv_web/views/error_helpers.ex:118
+#: lib/vutuv_web/views/error_helpers.ex:120
 #, elixir-autogen, elixir-format
 msgid "must not be only punctuation"
 msgstr "Non può essere composto solo da segni di punteggiatura"
 
-#: lib/vutuv_web/views/error_helpers.ex:119
+#: lib/vutuv_web/views/error_helpers.ex:121
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr "\"%{tag}\" è solo punteggiatura, non un tag."
 
-#: lib/vutuv_web/views/error_helpers.ex:129
+#: lib/vutuv_web/views/error_helpers.ex:131
 #, elixir-autogen, elixir-format
 msgid "\"%{uri}\" is not a valid https account address."
 msgstr "\"%{uri}\" non è un indirizzo https valido per un account."
 
-#: lib/vutuv_web/views/error_helpers.ex:128
+#: lib/vutuv_web/views/error_helpers.ex:130
 #, elixir-autogen, elixir-format
 msgid "Please list at most %{max} accounts."
 msgstr "Indichi al massimo %{max} account."
 
-#: lib/vutuv_web/views/error_helpers.ex:116
+#: lib/vutuv_web/views/error_helpers.ex:118
 #, elixir-autogen, elixir-format
 msgid "must spell out how the name sounds"
 msgstr "Deve indicare come si pronuncia il nome"
 
-#: lib/vutuv_web/views/error_helpers.ex:121
+#: lib/vutuv_web/views/error_helpers.ex:123
 #, elixir-autogen, elixir-format
 msgid "Please use at most %{max} tags."
 msgstr "Usi al massimo %{max} tag."
 
-#: lib/vutuv_web/views/error_helpers.ex:131
+#: lib/vutuv_web/views/error_helpers.ex:133
 #, elixir-autogen, elixir-format
 msgid "Enter your Signal link, it starts with https://signal.me/#"
 msgstr "Inserisca il Suo link Signal: inizia con https://signal.me/#"
 
-#: lib/vutuv_web/views/error_helpers.ex:123
+#: lib/vutuv_web/views/error_helpers.ex:125
 #, elixir-autogen, elixir-format
 msgid "We allow at most %{max} accounts per post. Please remove some mentions."
 msgstr ""
 "Sono ammessi al massimo %{max} account per post. Rimuova qualche menzione."
 
-#: lib/vutuv_web/views/error_helpers.ex:134
+#: lib/vutuv_web/views/error_helpers.ex:136
 #, elixir-autogen, elixir-format
 msgid "Enter your Bluesky handle, e.g. name.bsky.social"
 msgstr "Inserisca il Suo handle Bluesky, ad esempio nome.bsky.social"
 
-#: lib/vutuv_web/views/error_helpers.ex:147
+#: lib/vutuv_web/views/error_helpers.ex:149
 #, elixir-autogen, elixir-format
 msgid "Enter your Codeberg username, not a full URL with extra path segments"
 msgstr ""
 "Inserisca il Suo nome utente Codeberg, non un URL completo con altri "
 "segmenti di percorso"
 
-#: lib/vutuv_web/views/error_helpers.ex:143
+#: lib/vutuv_web/views/error_helpers.ex:145
 #, elixir-autogen, elixir-format
 msgid "Enter your GitHub username, not a full URL with extra path segments"
 msgstr ""
 "Inserisca il Suo nome utente GitHub, non un URL completo con altri segmenti "
 "di percorso"
 
-#: lib/vutuv_web/views/error_helpers.ex:139
+#: lib/vutuv_web/views/error_helpers.ex:141
 #, elixir-autogen, elixir-format
 msgid "Enter your GitLab username, e.g. gitlab.com/username (not a /-/u/ ID link)"
 msgstr ""
 "Inserisca il Suo nome utente GitLab, ad esempio gitlab.com/nomeutente (non "
 "un link ID /-/u/)"
 
-#: lib/vutuv_web/views/error_helpers.ex:133
+#: lib/vutuv_web/views/error_helpers.ex:135
 #, elixir-autogen, elixir-format
 msgid "Enter your full Mastodon handle, e.g. @user@instance.social"
 msgstr ""
 "Inserisca l'handle Mastodon completo, ad esempio @utente@istanza.social"
 
-#: lib/vutuv_web/views/error_helpers.ex:135
+#: lib/vutuv_web/views/error_helpers.ex:137
 #, elixir-autogen, elixir-format
 msgid "Enter your username and your instance, e.g. name@git.example.com"
 msgstr ""
 "Inserisca il Suo nome utente e la Sua istanza, ad esempio "
 "nome@git.esempio.com"
 
-#: lib/vutuv_web/views/error_helpers.ex:151
+#: lib/vutuv_web/views/error_helpers.ex:153
 #, elixir-autogen, elixir-format
 msgid "Invalid account name"
 msgstr "Nome account non valido"
 
-#: lib/vutuv_web/views/error_helpers.ex:152
+#: lib/vutuv_web/views/error_helpers.ex:154
 #, elixir-autogen, elixir-format
 msgid "Someone has already claimed this account"
 msgstr "Questo account è già stato rivendicato da qualcun altro"
 
-#: lib/vutuv_web/views/error_helpers.ex:159
+#: lib/vutuv_web/views/error_helpers.ex:161
 #, elixir-autogen, elixir-format
 msgid "That instance did not answer. Please try again in a moment."
 msgstr "L'istanza non ha risposto. Riprovi tra poco."
 
-#: lib/vutuv_web/views/error_helpers.ex:160
+#: lib/vutuv_web/views/error_helpers.ex:162
 #, elixir-autogen, elixir-format
 msgid "Too many checks for now. Please try again later."
 msgstr "Per ora troppi controlli. Riprovi più tardi."
 
-#: lib/vutuv_web/views/error_helpers.ex:155
+#: lib/vutuv_web/views/error_helpers.ex:157
 #, elixir-autogen, elixir-format
 msgid "We could not find this account on that instance. Please check the address."
 msgstr ""
 "Non abbiamo trovato questo account su quell'istanza. Controlli l'indirizzo."
+
+#: lib/vutuv_web/views/error_helpers.ex:105
+#, elixir-autogen, elixir-format
+msgid "Only one email address can be given at sign-up."
+msgstr "Alla registrazione può indicare un solo indirizzo email."

--- a/test/vutuv/accounts/user_test.exs
+++ b/test/vutuv/accounts/user_test.exs
@@ -24,6 +24,40 @@ defmodule Vutuv.Accounts.UserTest do
     refute changeset.valid?
   end
 
+  # Sign-up proves exactly one address, the one the PIN is mailed to. A second
+  # entry in the same POST would be stored as an unverified login identity for
+  # this account: its real owner could then never register it, and their own
+  # login would resolve here. Every further address goes through the
+  # PIN-verified /settings/emails flow instead.
+  test "registration_changeset refuses a second email address" do
+    changeset =
+      User.registration_changeset(%User{}, %{
+        "first_name" => "first_name",
+        "tag_list" => "elixir, phoenix, ecto",
+        "emails" => %{
+          "0" => %{"value" => "mine@example.com"},
+          "1" => %{"value" => "someone.else@example.com"}
+        }
+      })
+
+    refute changeset.valid?
+    assert %{emails: [_]} = errors_on(changeset)
+  end
+
+  # The same shape as a list, which is what Ecto hands `cast_assoc/3` once the
+  # index-keyed map has been normalized — and what a JSON client would send.
+  test "registration_changeset refuses a second email given as a list" do
+    changeset =
+      User.registration_changeset(%User{}, %{
+        "first_name" => "first_name",
+        "tag_list" => "elixir, phoenix, ecto",
+        "emails" => [%{"value" => "mine@example.com"}, %{"value" => "other@example.com"}]
+      })
+
+    refute changeset.valid?
+    assert %{emails: [_]} = errors_on(changeset)
+  end
+
   test "rejects a locale longer than its varchar(255) column" do
     changeset =
       User.changeset(%User{}, %{

--- a/test/vutuv/cologne_phonetics_test.exs
+++ b/test/vutuv/cologne_phonetics_test.exs
@@ -1,6 +1,8 @@
 defmodule Vutuv.ColognePhoneticsTest do
   use ExUnit.Case, async: true
 
+  import Vutuv.WorkCounter
+
   alias Vutuv.Accounts.SearchTerm
   alias Vutuv.ColognePhonetics
 
@@ -30,6 +32,29 @@ defmodule Vutuv.ColognePhoneticsTest do
       assert ColognePhonetics.to_cologne("Wikipedia") == "3412"
       assert ColognePhonetics.to_cologne("Meyer") == "67"
       assert ColognePhonetics.to_cologne("Breschnew") == "17863"
+    end
+  end
+
+  describe "to_cologne/1 on a long word" do
+    # Bounds `encode_string/5` against the quadratic append it used to do (see
+    # the comment there). Calibrated on this word: 9_596_862 reductions with the
+    # append, 336_584 without — with the input cap now in front of it, an
+    # over-long word costs even less. An order of magnitude of headroom each way.
+    test "stays linear in the length of the word" do
+      word = String.duplicate("a", 20_000)
+
+      {work, encoded} = count_reductions(fn -> ColognePhonetics.to_cologne(word) end)
+
+      assert encoded == "0"
+      assert work < 1_000_000
+    end
+
+    # The encoder takes a name, and both callers can be handed more than a name
+    # by a stranger — the public search box, and a sign-up's raw `first_name`,
+    # which reaches `Vutuv.Accounts.SearchTerm` before any length validation.
+    test "cuts the word to 100 characters before encoding" do
+      assert ColognePhonetics.to_cologne(String.duplicate("ab", 500)) ==
+               ColognePhonetics.to_cologne(String.duplicate("ab", 50))
     end
   end
 

--- a/test/vutuv/search_test.exs
+++ b/test/vutuv/search_test.exs
@@ -218,6 +218,22 @@ defmodule Vutuv.SearchTest do
     test "an unknown status value degrades to plain text" do
       assert %{status: nil, text: "status:employed"} = Search.parse("status:employed")
     end
+
+    # The cap lives in `Vutuv.SearchText` (see its moduledoc for why); this
+    # asserts that `parse/2` really applies it, against the literal rather than
+    # against the accessor, so raising the cap cannot keep the test green.
+    test "cuts an over-long query to 200 characters" do
+      parsed = Search.parse(String.duplicate("a", 5_000))
+
+      assert String.length(parsed.raw) == 200
+      assert String.length(parsed.text) == 200
+    end
+
+    test "a query at the cap is left alone" do
+      name = String.duplicate("a", 200)
+
+      assert %{raw: ^name} = Search.parse(name)
+    end
   end
 
   describe "status operator matching" do

--- a/test/vutuv/search_text_test.exs
+++ b/test/vutuv/search_text_test.exs
@@ -1,0 +1,51 @@
+defmodule Vutuv.SearchTextTest do
+  @moduledoc """
+  The two halves of `Vutuv.SearchText` that are easy to confuse.
+
+  `cap/1` bounds a query box. `normalize_search/1` only trims — despite its name
+  it is the tree's general "trim, blank to nil" helper, and `Vutuv.Fediverse`
+  runs remote URIs through it. Putting the cap inside it once shortened a 2 KB
+  quote URI to 200 characters and slipped it past the length check meant to drop
+  it, so the last test here holds those two apart.
+  """
+  use ExUnit.Case, async: true
+
+  alias Vutuv.SearchText
+
+  describe "cap/1" do
+    test "cuts to max_chars/0 and leaves anything shorter alone" do
+      assert String.length(SearchText.cap(String.duplicate("a", 5_000))) ==
+               SearchText.max_chars()
+
+      assert SearchText.cap("müller") == "müller"
+    end
+
+    test "cuts on a character boundary, never mid-codepoint" do
+      capped = SearchText.cap(String.duplicate("ä", 5_000))
+
+      assert String.valid?(capped)
+      assert String.length(capped) == SearchText.max_chars()
+    end
+
+    test "passes a non-binary through untouched" do
+      assert SearchText.cap(nil) == nil
+    end
+  end
+
+  describe "normalize_search/1" do
+    test "trims, and collapses blank or non-binary to nil" do
+      assert SearchText.normalize_search("  meier ") == "meier"
+      assert SearchText.normalize_search("   ") == nil
+      assert SearchText.normalize_search(nil) == nil
+    end
+
+    # The regression: capping here truncates the remote URIs and report reasons
+    # that also pass through, which hides an over-long value from the validation
+    # that exists to reject it.
+    test "does not cap — an over-long value comes back whole" do
+      uri = "https://third.example/notes/" <> String.duplicate("a", 2_048)
+
+      assert SearchText.normalize_search(uri) == uri
+    end
+  end
+end

--- a/test/vutuv/soundex_test.exs
+++ b/test/vutuv/soundex_test.exs
@@ -1,0 +1,59 @@
+defmodule Vutuv.SoundexTest do
+  @moduledoc """
+  The Soundex half of name search. `Vutuv.Search` runs both encoders over every
+  free-text query section, and `Vutuv.Accounts.SearchTerm` runs them over stored
+  names, so the two have to agree on a word forever: a change in either one
+  makes every stored term unfindable until they are regenerated.
+
+  The reference encodings below are that pin. The work bound is the other half —
+  see the comment on it.
+  """
+  use ExUnit.Case, async: true
+
+  import Vutuv.WorkCounter
+
+  alias Vutuv.Soundex
+
+  describe "to_soundex/1" do
+    test "returns \"\" for an empty string and nil for nil" do
+      assert Soundex.to_soundex("") == ""
+      assert Soundex.to_soundex(nil) == nil
+    end
+
+    # The canonical Soundex examples, and what this implementation makes of
+    # them today. They are here to catch an encoding change, not to bless one
+    # reading of the algorithm.
+    test "encodes the reference words" do
+      assert Soundex.to_soundex("Robert") == "R163"
+      assert Soundex.to_soundex("Rupert") == "R163"
+      assert Soundex.to_soundex("Ashcraft") == "A261"
+      assert Soundex.to_soundex("Tymczak") == "T522"
+      assert Soundex.to_soundex("Pfister") == "P236"
+      assert Soundex.to_soundex("Honeyman") == "H555"
+    end
+
+    test "pads and truncates to four characters" do
+      assert Soundex.to_soundex("Meyer") == "M600"
+      assert Soundex.to_soundex("Wikipedia") == "W213"
+    end
+  end
+
+  describe "to_soundex/1 on a long word" do
+    # Same defect and same fix as `Vutuv.ColognePhonetics` — see the comment on
+    # `encode_list/2`. Calibrated on this word: 9_657_196 reductions with the
+    # append, 304_353 without.
+    test "stays linear in the length of the word" do
+      word = String.duplicate("a", 20_000)
+
+      {work, encoded} = count_reductions(fn -> Soundex.to_soundex(word) end)
+
+      assert encoded == "A000"
+      assert work < 1_000_000
+    end
+
+    test "cuts the word to 100 characters before encoding" do
+      assert Soundex.to_soundex(String.duplicate("ab", 500)) ==
+               Soundex.to_soundex(String.duplicate("ab", 50))
+    end
+  end
+end

--- a/test/vutuv_web/controllers/registration_email_binding_test.exs
+++ b/test/vutuv_web/controllers/registration_email_binding_test.exs
@@ -1,0 +1,68 @@
+defmodule VutuvWeb.RegistrationEmailBindingTest do
+  @moduledoc """
+  What `POST /new_registration` may bind to a brand-new account.
+
+  Exactly one address, the one the login PIN is mailed to. The form only ever
+  submits `emails[0]`, but the endpoint is unauthenticated and takes whatever is
+  posted, and a bare `cast_assoc(:emails)` used to persist every further entry
+  as a login identity for the new account. That is an account-takeover primitive
+  rather than an untidy row: `Accounts.user_by_email/1` resolves any stored
+  address to its user, so the address's real owner could no longer register, and
+  their next login would mail them a valid PIN into somebody else's account.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  alias Vutuv.Accounts.Email
+  alias Vutuv.Repo
+
+  test "a second address in the sign-up POST creates no account", %{conn: conn} do
+    attrs = registration_attrs("binding")
+    mine = attrs["emails"]["0"]["value"]
+    theirs = "victim#{System.unique_integer([:positive])}@example.com"
+
+    attrs = put_in(attrs, ["emails", "1"], %{"value" => theirs})
+
+    post(conn, ~p"/new_registration", user: attrs)
+
+    refute Repo.get_by(Email, value: theirs)
+    refute Repo.get_by(Email, value: mine)
+  end
+
+  # The address the attacker does not own must stay registerable by its owner,
+  # which is the harm that outlives the failed sign-up.
+  test "the third-party address is still free afterwards", %{conn: conn} do
+    attrs = registration_attrs("binding")
+    theirs = "victim#{System.unique_integer([:positive])}@example.com"
+
+    post(conn, ~p"/new_registration", user: put_in(attrs, ["emails", "1"], %{"value" => theirs}))
+
+    own = registration_attrs("victim") |> put_in(["emails", "0", "value"], theirs)
+
+    assert {:ok, _user} = Vutuv.Accounts.register_user(conn, own)
+    assert Repo.get_by(Email, value: theirs)
+  end
+
+  # vutuv is a German site, so the refusal has to read as German. The msgid is
+  # new, and a new one-line msgid is exactly what `gettext.extract --merge`
+  # likes to fuzzy-fill with somebody else's sentence.
+  test "the refusal is shown, in German", %{conn: conn} do
+    attrs = registration_attrs("binding")
+    theirs = "victim#{System.unique_integer([:positive])}@example.com"
+
+    body =
+      conn
+      |> put_req_header("accept-language", "de-DE,de")
+      |> post(~p"/new_registration", user: put_in(attrs, ["emails", "1"], %{"value" => theirs}))
+      |> html_response(422)
+
+    assert body =~ "Bei der Anmeldung kann nur eine E-Mail-Adresse angegeben werden."
+  end
+
+  test "the ordinary one-address sign-up still works", %{conn: conn} do
+    attrs = registration_attrs("binding")
+
+    post(conn, ~p"/new_registration", user: attrs)
+
+    assert Repo.get_by(Email, value: attrs["emails"]["0"]["value"])
+  end
+end


### PR DESCRIPTION
`/search` is open to visitors and its LiveView socket takes 1 MB frames. The
query reached two phonetic encoders that copied their accumulator once per
character, so a single frame could pin a scheduler (9.6M reductions on a 20k
word). The same encoders are also reached from raw sign-up params, before any
length validation runs. Separately, `POST /new_registration` stored every
`emails[…]` entry it was sent while the PIN proves only the first — enough to
bind a stranger's address to your own account, block them from ever registering
it, and take their next login.

`Vutuv.SearchText.cap/1` is now the single definition of the 200-character cap,
applied at `/search`, `/system/members` and the job board. Both encoders are
linear and bound their own input. Sign-up takes one address and refuses the rest
without casting the list.

Work bounds are calibrated against the unfixed code; 50,021 words prove the
linear encoders encode identically, so stored search terms stay valid.

Found by a Claude Security scan of `lib/`.

https://claude.ai/code/session_01HpEBfNDHjPRmJ1Joe2923o
