### PR TITLE
Every remote account opens its card

### DIFF
--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -309,17 +309,23 @@ LiveView can sit on either style.
   in `components.css`, `assets/js/mention_card.js`). Every remote handle keeps
   its own link; a plain left click by a signed-in member opens a small card
   under it instead. Two surfaces write the `a[data-remote-actor]` hook the JS
-  binds to: a `@user@host` in rendered text (`VutuvWeb.Markdown`, which leaves
-  for that server) and every remote handle a post card draws — its header and
-  its reaction chips alike — through the one function that owns where such a
-  handle leads and what a press does, `PostComponents.remote_actor_link/3`
-  (which leads to that account's page here). Both from that one place, because a
-  chip answering "who is this" differently from the card it sits under is what
-  that function exists to prevent. Those anchors are `<.link navigate>`, so the
-  JS stops the click's bubble as well as its default: LiveView's nav listener on
-  `window` reads `data-phx-link` without asking whether the default was
-  prevented — which also swallows `phx-click-away`, dispatched from the same
-  listener and used nowhere in the app today. It answers three questions in that order:
+  binds to. A `@user@host` in rendered text (`VutuvWeb.Markdown`, which leaves
+  for that server), which reaches further than posts — a chat message and a
+  work-experience description run through the same renderer. And **every other
+  remote account the app draws**, through the one function that owns where such
+  a handle leads and what a press does,
+  `FediverseComponents.remote_actor_link/3`, whose docstring holds the list of
+  its callers — the only copy of that list, so do not repeat it here. A chip
+  answering "who is this" differently from the card it sits under is what that
+  function exists to prevent, and a surface that answered it with a trip to
+  somebody else's server was not offering less, it was offering a different app.
+  It lives in `FediverseComponents` rather than beside the post card that first
+  needed it because most of its callers hold no post. Those anchors
+  are `<.link navigate>`, so the JS stops the click's bubble as well as its
+  default: LiveView's nav listener on `window` reads `data-phx-link` without
+  asking whether the default was prevented — which also swallows
+  `phx-click-away`, dispatched from the same listener and used nowhere in the
+  app today. It answers three questions in that order:
   **who is this** (a `.actor-card__chip` carrying the globe and the host, then
   name, address and a two-line self-description), **is it worth it**
   (`.actor-card__stats` — how many of their posts we hold for *this* reader and

--- a/assets/js/mention_card.js
+++ b/assets/js/mention_card.js
@@ -11,11 +11,13 @@
 // It binds to `a[data-remote-actor]`, wherever that is written. Two places
 // write it. A `@user@host` inside rendered text (`VutuvWeb.Markdown`), which is
 // more than posts — a chat message and a work-experience description run
-// through the same renderer. And the handle in the header of a card from
-// another network (`VutuvWeb.PostComponents`), where the reader is asking the
-// same question about the same account and until now got a page they had to
-// come back from. The two anchors lead different places when the card cannot
-// open, which is why `followTheLink` reads the target rather than assuming one.
+// through the same renderer. And every other remote account the app draws,
+// through `VutuvWeb.FediverseComponents.remote_actor_link/3`, whose docstring
+// names its callers. Wherever a reader meets somebody from another network they
+// are asking the same question about the same account, and until this they got
+// either a trip to a server they have no account on or a page they had to come
+// back from. The two writers lead different places when the card cannot open,
+// which is why `followTheLink` reads the target rather than assuming one.
 //
 // The card's markup comes from the server on every act
 // (`VutuvWeb.RemoteActorCardController`), so no sentence about a follow, a

--- a/docs/architecture/mentions.md
+++ b/docs/architecture/mentions.md
@@ -162,6 +162,49 @@ Every field whose stored `@handle` linkifies is one `{schema, field}` entry in
 | `job_postings` | `description` |
 | `ads` | `content` |
 
+## The account card behind a remote handle
+
+An account on another network has no profile here, so every place that named one
+had to answer "who is this" by sending the reader somewhere — that server, or
+the cached account page at `/system/fediverse/account/:id`, which they then had
+to come back from. A plain left click by a signed-in member now opens a small
+card over the handle instead: name, address, self-description, how much of them
+we hold, one Follow button, both mutes, and the two ways onward.
+
+The card's markup is a server-rendered fragment
+(`VutuvWeb.RemoteActorCardController`, POST only — resolving an unknown address
+is an outbound request, so it may not be reachable by a link or a crawler), and
+`assets/js/mention_card.js` positions a box and swaps the HTML in. It binds to
+`a[data-remote-actor]` and two places write that hook:
+
+| Writer | Anchors |
+|---|---|
+| `VutuvWeb.Markdown` | a `@user@host` inside any rendered body — a post, a **chat message**, a work-experience description |
+| `VutuvWeb.FediverseComponents.remote_actor_link/3` | every other remote account the app draws |
+
+The second is the chokepoint. It owns **both** halves of the answer — where the
+anchor leads and what a press does — and its ten callers are the post card's
+header and its reaction chips, the boost banner, the "Replying to" line, a
+notification row, the followers and following tables (a member's own and an
+organization's), the feed's filter band, and a member's forwarding address after
+they moved. A handle that is not a full `user@host` (the actor document carried
+no username, so `Handle.display/2` fell back to `@name` or a bare `@host`) gets
+no hook and keeps its plain link: the card is addressed by the address.
+
+Nothing else about the anchor changes, so the `href` stays its whole truth — a
+middle click, a copied link, a logged-out visitor and a page whose JavaScript
+never arrived all still go to the destination. Those anchors are often
+`<.link navigate>`, which is why the JS stops the click's bubble as well as its
+default: LiveView's nav listener on `window` reads `data-phx-link` without
+asking whether the default was prevented, so the card would open and the page
+would leave underneath it in one gesture.
+
+Three surfaces deliberately stay out. The quoted-post card is one big link to
+the original, and an anchor inside an anchor is not markup. `/settings/fediverse/move`
+shows the member their *own* forwarding address, where a Follow button is the
+wrong offer. And the admin queues name a handle as a row label, not as somebody
+to meet.
+
 ## Existence validation (anti-reservation)
 
 Every one of those changesets runs `Mentions.validate_mentions_exist/2`: a saved
@@ -328,6 +371,11 @@ posts (the newest five, plus an "and N more" count).
 - `lib/vutuv/accounts/handle_change_notification.ex` — the durable row.
 - `lib/vutuv_web/live/notification_live/index.ex` — the `mention` and
   `handle_change` renderings.
+- `lib/vutuv_web/components/fediverse_components.ex` — `remote_actor_link/3`,
+  the one owner of where a remote handle leads and what a press does;
+  `lib/vutuv_web/controllers/remote_actor_card_controller.ex` +
+  `templates/remote_actor_card/card.html.heex` render the card,
+  `assets/js/mention_card.js` positions it.
 - `test/vutuv/mentions_test.exs`, `mentions_local_address_test.exs`,
   `vutuv_web/markdown_local_address_test.exs`, `vutuv_web/mention_form_test.exs`,
   `mention_existence_test.exs`, `mention_suggest_test.exs`,
@@ -336,4 +384,6 @@ posts (the newest five, plus an "and N more" count).
   `mention_limit_test.exs`,
   `mention_notifications_test.exs`, `handle_availability_test.exs`,
   `accounts/handle_change_propagation_test.exs`,
-  `vutuv_web/live/handle_change_notification_test.exs`.
+  `vutuv_web/live/handle_change_notification_test.exs`,
+  `vutuv_web/components/remote_actor_link_test.exs`,
+  `vutuv_web/controllers/remote_actor_card_test.exs`.

--- a/lib/vutuv/fediverse/handle.ex
+++ b/lib/vutuv/fediverse/handle.ex
@@ -63,9 +63,15 @@ defmodule Vutuv.Fediverse.Handle do
 
   Falls back to the URI's last path segment, then to `@host` alone, and finally
   — for a URI we cannot even parse a host out of — to the stored handle or nil.
+
+  Pass `known_host` where the caller already holds the server as a column
+  (`RemoteAccount.host`, `Follower.host/1`) and the `URI.parse/1` this would
+  otherwise do is pure repetition. It is not a rounding error: parsing dominates
+  this function at ~5 µs against ~0.01 µs for composing the string, and a single
+  remote post card asks for the address six times.
   """
-  def display(handle, actor_uri) do
-    case {SearchText.normalize_search(handle) || derive(actor_uri), host(actor_uri)} do
+  def display(handle, actor_uri, known_host \\ nil) do
+    case {SearchText.normalize_search(handle) || derive(actor_uri), known_host || host(actor_uri)} do
       {nil, nil} -> nil
       {name, nil} -> "@" <> name
       {nil, host} -> "@" <> host

--- a/lib/vutuv/fediverse/remote_account.ex
+++ b/lib/vutuv/fediverse/remote_account.ex
@@ -111,7 +111,7 @@ defmodule Vutuv.Fediverse.RemoteAccount do
   reaction never write the same person two different ways on one page.
   """
   def display_handle(%__MODULE__{} = account),
-    do: Handle.display(account.handle, account.actor_uri)
+    do: Handle.display(account.handle, account.actor_uri, account.host)
 
   @doc """
   Whether this account's cached picture may be shown: we have one and the AI

--- a/lib/vutuv/feed_band.ex
+++ b/lib/vutuv/feed_band.ex
@@ -386,14 +386,27 @@ defmodule Vutuv.FeedBand do
     accounts =
       rows
       |> Enum.map(fn agg ->
+        # Both spellings of the address come from the one chokepoint, not from
+        # the raw column: `handle` stores the bare username, so `Handle.short/1`
+        # on it had nothing to strip and the row read `them` where a member's
+        # row reads `@stefan`. `address` is the whole `@user@host` the account
+        # card is addressed by; `handle` is the short form the row shows,
+        # because the server it names is the heading this row already sits
+        # under.
+        address = RemoteAccount.display_handle(agg.account)
+
         %{
           key: "remote:" <> agg.account.id,
           kind: :remote,
           id: agg.account.id,
           host: agg.account.host,
-          name: agg.account.name || agg.account.handle,
-          handle: Fediverse.Handle.short(agg.account.handle),
-          path: "/system/fediverse/account/" <> agg.account.id,
+          name: RemoteAccount.label(agg.account),
+          handle: Fediverse.Handle.short(address),
+          address: address,
+          # No `path`, unlike a member's or a page's row: where this one leads
+          # is the same question as what a press on it does, and
+          # `remote_actor_link/3` answers both from the id. A second spelling of
+          # the account URL here is how the two drift apart.
           posts: agg.posts,
           last_at: agg.last_at,
           muted?: agg.muted

--- a/lib/vutuv_web/components/browse_table.ex
+++ b/lib/vutuv_web/components/browse_table.ex
@@ -23,6 +23,7 @@ defmodule VutuvWeb.BrowseTable do
   use Gettext, backend: VutuvWeb.Gettext
 
   import Phoenix.LiveView, only: [push_patch: 2]
+  import VutuvWeb.FediverseComponents, only: [remote_actor_link: 3]
   import VutuvWeb.UI
 
   alias Vutuv.Fediverse
@@ -403,13 +404,31 @@ defmodule VutuvWeb.BrowseTable do
   attr(:name, :string, default: nil)
   attr(:handle, :string, required: true)
 
+  attr(:account_id, :any,
+    default: nil,
+    doc:
+      "the stored account's **id**, when we hold a row for it: the cell then leads to its page here rather than out. A follower is not a stored account (`fediverse_followers` is its own table), so the two follower tables pass none."
+  )
+
   @doc """
-  The Account cell's content: the display name over the `@user@server` handle,
-  both linking out to the account on its own server.
+  The Account cell's content: the display name over the `@user@server` handle.
+
+  A press opens the account card over the row (`remote_actor_link/3`), the same
+  card the handle opens on a post and inside a post body — because a table of
+  people the member follows, or who follow them, is exactly where "who is this
+  again, and do I follow them back" gets asked, and answering it used to mean
+  leaving for a server the member has no account on and finding their way home
+  again. Ten thousand rows and one of them is somebody worth a second look.
+
+  Where the card cannot open, `@uri` is still where the cell goes — which is why
+  it stays required even though `@account_id` outranks it.
   """
   def account_link(assigns) do
     ~H"""
-    <a href={@uri} target="_blank" rel="nofollow noopener noreferrer" class="group block min-w-0">
+    <.link
+      {remote_actor_link(@account_id, @uri, @handle)}
+      class="group block min-w-0"
+    >
       <span
         :if={@name}
         class="breakwrap block font-medium text-slate-800 group-hover:text-brand-700 dark:text-slate-100 dark:group-hover:text-brand-300"
@@ -423,7 +442,7 @@ defmodule VutuvWeb.BrowseTable do
       <span class="block break-all text-slate-600 group-hover:text-brand-600 dark:text-slate-400 dark:group-hover:text-brand-300 sm:break-normal">
         {@handle}
       </span>
-    </a>
+    </.link>
     """
   end
 

--- a/lib/vutuv_web/components/fediverse_components.ex
+++ b/lib/vutuv_web/components/fediverse_components.ex
@@ -30,6 +30,13 @@ defmodule VutuvWeb.FediverseComponents do
   this subsystem offers a member — fetching one post by its address — which has
   likewise grown a second surface: the lookup page and, since a URL means
   nothing to a text search, the search box itself (issue #1211).
+
+  `remote_actor_link/3` is the same idea one step earlier: before a member can
+  follow somebody out there they have to be able to *reach* them, and a remote
+  account is named on a dozen surfaces here. That function owns where each of
+  those names leads and what a press on it does, so the answer cannot differ
+  between a post card and a notification about the same account. Its docstring
+  holds the list of callers.
   """
 
   use Phoenix.Component
@@ -44,6 +51,7 @@ defmodule VutuvWeb.FediverseComponents do
 
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.Handle
   alias Vutuv.Fediverse.RemoteAccount
 
   attr(:id, :string,
@@ -355,6 +363,69 @@ defmodule VutuvWeb.FediverseComponents do
   def follow_refusal_sentence(:disabled), do: refusal_message(:fediverse_disabled)
   def follow_refusal_sentence(:moved), do: refusal_message(:moved)
   def follow_refusal_sentence(_opted_out), do: refusal_message(:not_federating)
+
+  @doc """
+  Where a remote handle leads and what a press on it does, as the attributes to
+  splat onto a `<.link>`.
+
+  Inward when we know the account (issue #1162): the handle is the thing a
+  reader taps to ask "who is this", and the answer to that is a page here where
+  they can see what the account posts and follow it — not a trip off the site to
+  somebody else's server. The link out is still one click away, in the footer.
+  Straight out when we do not know them, since there would be nothing to show.
+
+  And a plain left click answers that question without going anywhere at all:
+  `data-remote-actor` is what `assets/js/mention_card.js` binds to, so it opens
+  the account card over the handle — who this is, one Follow button, both ways
+  onward — the same card a `@user@host` written inside a post body already
+  opens. Everything else about the anchor is untouched, so a middle click, a
+  copied link, a reader who is not signed in and a page whose JavaScript never
+  arrived all still land on the destination above.
+
+  **This is where every remote account the app draws becomes clickable**, which
+  is why it lives here rather than beside the post card that first needed it.
+  The callers, and the only list of them worth keeping current:
+
+    * a post card's header and its reaction chips (`PostComponents`),
+    * the boost banner and the "Replying to" line above a reply,
+    * a notification row (`NotificationLive.Index`),
+    * the three account tables — a member's followers and following, and an
+      organization's follows,
+    * the feed's filter band (`PostLive.FilterBand`),
+    * a member's forwarding address after they moved (`user/show.html.heex`).
+
+  Every one is the same reader asking the same question about the same account,
+  and a surface that answered it with a trip to somebody else's server was not
+  offering less, it was offering a different app.
+
+  The **one** remote handle that does not come through here is a `@user@host`
+  written inside a body, which `VutuvWeb.Markdown` links at render time and
+  which writes the same `data-remote-actor` hook by hand. That one always leads
+  out: it is a string mapping with no database lookup, so it works on an
+  air-gapped install and never tells us whether we hold the account.
+
+  Takes the handle rather than reading it off a record, because the callers hold
+  eight different record shapes and only some of them have one.
+  """
+  def remote_actor_link(account_id, actor_uri, handle),
+    do: remote_actor_destination(account_id, actor_uri) ++ card_hook(handle)
+
+  defp remote_actor_destination(nil, actor_uri),
+    do: [href: actor_uri, target: "_blank", rel: "nofollow noopener noreferrer"]
+
+  defp remote_actor_destination(account_id, _actor_uri),
+    do: [navigate: ~p"/system/fediverse/account/#{account_id}"]
+
+  # Nothing, for a handle that is not an address: `Handle.display/2` falls back
+  # to `@name` and to a bare `@host` when the actor document carried no
+  # username, and the card cannot resolve either. Such a handle keeps today's
+  # behaviour rather than opening a card that can only say it failed.
+  defp card_hook(handle) do
+    case Handle.address(handle) do
+      nil -> []
+      address -> ["data-remote-actor": address]
+    end
+  end
 
   attr(:follow, :map, required: true, doc: "a `Vutuv.Fediverse.Follow`")
   attr(:class, :string, default: nil)

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -23,6 +23,7 @@ defmodule VutuvWeb.PostComponents do
     router: VutuvWeb.Router,
     statics: ~w(assets fonts images favicon.ico)
 
+  import VutuvWeb.FediverseComponents, only: [remote_actor_link: 3]
   import VutuvWeb.UI
   import VutuvWeb.UserHelpers, only: [full_name: 1]
 
@@ -1324,7 +1325,7 @@ defmodule VutuvWeb.PostComponents do
       <.reshare_line
         :if={@reposted_by}
         name={full_name(@reposted_by)}
-        navigate={~p"/#{@reposted_by.username}"}
+        link={[navigate: ~p"/#{@reposted_by.username}"]}
         data-reshared-reply
       />
       <div class="flex items-start gap-3">
@@ -1633,49 +1634,6 @@ defmodule VutuvWeb.PostComponents do
   """
   def network_chip_class do
     "inline-flex max-w-full items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300"
-  end
-
-  # Where a remote handle leads and what a press on it does, as the attributes
-  # to splat onto a `<.link>`.
-  #
-  # Inward when we know the account (issue #1162): the handle is the thing a
-  # reader taps to ask "who is this", and the answer to that is a page here
-  # where they can see what the account posts and follow it — not a trip off
-  # the site to somebody else's server. The link out is still one click away,
-  # in the footer. Straight out when we do not know them, since there would be
-  # nothing to show.
-  #
-  # And a plain left click answers that question without going anywhere at all:
-  # `data-remote-actor` is what `assets/js/mention_card.js` binds to, so it opens
-  # the account card over the handle — who this is, one Follow button, both ways
-  # onward — the same card a `@user@host` written inside a post body already
-  # opens. Everything else about the anchor is untouched, so a middle click, a
-  # copied link, a reader who is not signed in and a page whose JavaScript never
-  # arrived all still land on the destination above.
-  #
-  # One definition, because the header of every remote card and the reaction
-  # chips ask the same question, and a chip that answered it differently from
-  # the card above it would be the same handle leading two places. The hook
-  # therefore lives here rather than at either call site — which is also why
-  # this takes the handle: nothing else on the way in carries the address.
-  defp remote_actor_link(account_id, actor_uri, handle),
-    do: remote_actor_destination(account_id, actor_uri) ++ card_hook(handle)
-
-  defp remote_actor_destination(nil, actor_uri),
-    do: [href: actor_uri, target: "_blank", rel: "nofollow noopener noreferrer"]
-
-  defp remote_actor_destination(account_id, _actor_uri),
-    do: [navigate: ~p"/system/fediverse/account/#{account_id}"]
-
-  # Nothing, for a handle that is not an address: `Handle.display/2` falls back
-  # to `@name` and to a bare `@host` when the actor document carried no
-  # username, and the card cannot resolve either. Such a handle keeps today's
-  # behaviour rather than opening a card that can only say it failed.
-  defp card_hook(handle) do
-    case Handle.address(handle) do
-      nil -> []
-      address -> ["data-remote-actor": address]
-    end
   end
 
   # The lock line. The same glyph a restricted vutuv post wears, so "not
@@ -2269,6 +2227,11 @@ defmodule VutuvWeb.PostComponents do
   line names the messenger, never the writer.
   """
   def boosted_banner(assigns) do
+    # Once, not three times: the line names the handle, the link is addressed by
+    # it, and `label/1` falls back to it — and composing it is the cheap half of
+    # `display_handle/1`, not the whole of it.
+    assigns = assign(assigns, :handle, RemoteAccount.display_handle(assigns.account))
+
     ~H"""
     <%!-- Name **and** handle, unlike the local line beside it. A display name
     on a remote account is whatever that server lets somebody type, and this
@@ -2277,22 +2240,30 @@ defmodule VutuvWeb.PostComponents do
     read as the member of that name. Every other surface pairs the two for the
     same reason. --%>
     <.reshare_line
-      name={"#{RemoteAccount.label(@account)} (#{RemoteAccount.display_handle(@account)})"}
-      navigate={~p"/system/fediverse/account/#{@account.id}"}
+      name={"#{RemoteAccount.label(@account)} (#{@handle})"}
+      link={remote_actor_link(@account.id, @account.actor_uri, @handle)}
       data-boosted-by={@account.id}
     />
     """
   end
 
   attr(:name, :string, required: true)
-  attr(:navigate, :any, default: nil, doc: "in-app destination (a remote account page)")
-  attr(:href, :any, default: nil, doc: "full-navigation destination (a member's profile)")
+
+  attr(:link, :list,
+    required: true,
+    doc:
+      "the anchor's attributes, splatted: `[navigate: ...]` / `[href: ...]` for a member here, `remote_actor_link/3` for an account out there"
+  )
+
   attr(:rest, :global)
 
   # "Reposted by NAME" over the post it carries: the one markup for both worlds,
   # a member here resharing a cached post (issue #1166) and an account the
-  # reader follows out there boosting one (issue #1167). Pass whichever of
-  # `navigate` / `href` the destination needs.
+  # reader follows out there boosting one (issue #1167). The destination arrives
+  # as attributes rather than as a `navigate` / `href` pair, because the remote
+  # half of it is not a destination alone: a press on the account that boosted
+  # this opens its card, exactly as a press on the handle in the header below
+  # does, and only the one function that owns both may say so.
   defp reshare_line(assigns) do
     ~H"""
     <p
@@ -2300,7 +2271,7 @@ defmodule VutuvWeb.PostComponents do
       {@rest}
     >
       <.icon_repost class="h-4 w-4 shrink-0" />
-      <.link navigate={@navigate} href={@href} class="min-w-0 truncate hover:text-brand-700 dark:hover:text-brand-300">
+      <.link {@link} class="min-w-0 truncate hover:text-brand-700 dark:hover:text-brand-300">
         {gettext("Reposted by %{name}", name: @name)}
       </.link>
     </p>
@@ -2596,7 +2567,7 @@ defmodule VutuvWeb.PostComponents do
       <.reshare_line
         :if={@reposted_by}
         name={full_name(@reposted_by)}
-        href={~p"/#{@reposted_by}"}
+        link={[href: ~p"/#{@reposted_by}"]}
         data-remote-reposted-by={@reposted_by.id}
       />
 
@@ -3503,16 +3474,18 @@ defmodule VutuvWeb.PostComponents do
             </.link>
           </.reply_banner_line>
         <% {:remote, remote_handle, remote_account_id} -> %>
-          <%!-- Answering a post on another network (issue #1165). The link goes
-          to that account's page *here* rather than out to their server: the
-          reader is one click from the same context the answer's author had,
+          <%!-- Answering a post on another network (issue #1165). A press opens
+          that account's card, exactly as a press on the same handle in the
+          header below does (`remote_actor_link/3`); where the card cannot open,
+          the link goes to their page *here* rather than out to their server, so
+          the reader is one click from the context the answer's author had
           without leaving the site and without an outbound request. It degrades
           to plain text once our copy of the post has expired, since the account
           is reached through the post. --%>
           <.reply_banner_line variant="remote">
             <.link
               :if={remote_account_id}
-              navigate={~p"/system/fediverse/account/#{remote_account_id}"}
+              {remote_actor_link(remote_account_id, nil, remote_handle)}
               class="hover:text-brand-700 dark:hover:text-brand-300"
             >
               {gettext("Replying to %{handle}", handle: remote_handle)}

--- a/lib/vutuv_web/live/fediverse_following_live.ex
+++ b/lib/vutuv_web/live/fediverse_following_live.ex
@@ -377,7 +377,12 @@ defmodule VutuvWeb.FediverseFollowingLive do
                     data-row-changed={row_changed?(@changed_ids, follow.id)}
                   >
                     <td>
+                      <%!-- The row names an account we hold, so where the card
+                      cannot open it leads to that account's page here rather
+                      than out to their server — the same destination its handle
+                      has on a post card. --%>
                       <.account_link
+                        account_id={follow.remote_account.id}
                         uri={follow.remote_account.actor_uri}
                         name={RemoteAccount.display_name(follow.remote_account)}
                         handle={RemoteAccount.display_handle(follow.remote_account)}

--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -56,6 +56,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   """
   use VutuvWeb, :live_view
 
+  import VutuvWeb.FediverseComponents, only: [remote_actor_link: 3]
   import VutuvWeb.UserHTML, only: [user_row: 1]
 
   # What a notification says and where it leads, shared with the browser
@@ -1033,14 +1034,18 @@ defmodule VutuvWeb.NotificationLive.Index do
         >{@actor.name}</.link>
       <% @actor[:url] -> %>
         <%!-- Somebody on another network (issue #1069). There is no vutuv
-        profile behind the name, so it links out to their account and the
-        `@handle@host` beside it says which network answered. --%>
-        <a
-          href={@actor.url}
-          target="_blank"
-          rel="nofollow noopener noreferrer"
+        profile behind the name, so a press opens the account card over it —
+        who they are, one Follow button, both mutes — the same card their
+        handle opens on a post card and inside a post body
+        (`remote_actor_link/3`). This row is where a member most often meets a
+        stranger for the first time, and until now it was the one place that
+        answered "who just boosted me" by handing them to a server they have no
+        account on. The `@handle@host` beside the name still says which network
+        answered, and the `href` out there is still what a middle click takes. --%>
+        <.link
+          {remote_actor_link(nil, @actor.url, @actor[:handle])}
           class="font-semibold text-slate-900 hover:text-brand-700 dark:text-white dark:hover:text-brand-300"
-        >{@actor.name}</a><span
+        >{@actor.name}</.link><span
           :if={@actor[:handle] && @actor.handle != @actor.name}
           class="text-xs font-normal text-slate-600 dark:text-slate-400"
         > {@actor.handle}</span>

--- a/lib/vutuv_web/live/organization_live/following.ex
+++ b/lib/vutuv_web/live/organization_live/following.ex
@@ -30,6 +30,7 @@ defmodule VutuvWeb.OrganizationLive.Following do
   import VutuvWeb.OrganizationComponents,
     only: [manage_header: 1, organization_location: 1]
 
+  import VutuvWeb.FediverseComponents, only: [remote_actor_link: 3]
   import VutuvWeb.UserHelpers, only: [author_name: 1]
 
   alias Vutuv.Accounts
@@ -422,15 +423,24 @@ defmodule VutuvWeb.OrganizationLive.Following do
 
         <ul :if={@remote_follows != []} class="mt-2 divide-y divide-slate-100 dark:divide-slate-800">
           <li :for={follow <- @remote_follows} class="flex items-center gap-4 py-3">
-            <div class="min-w-0 flex-1">
-              <p class="truncate text-sm font-semibold text-slate-900 dark:text-slate-100">
-                {RemoteAccount.display_name(follow.remote_account) ||
-                  follow.remote_account.handle}
+            <%!-- The one remote-account list that named its rows in raw column
+            values and gave the reader nothing to press: a bare `handle` reads
+            `them` where every other surface says `@them@social.example`, and a
+            page whose admin is deciding whom to unfollow could not see who any
+            of them were. Same name, same card, same press as everywhere else
+            (`remote_actor_link/3`). --%>
+            <% handle = RemoteAccount.display_handle(follow.remote_account) %>
+            <.link
+              {remote_actor_link(follow.remote_account.id, follow.remote_account.actor_uri, handle)}
+              class="group min-w-0 flex-1"
+            >
+              <p class="truncate text-sm font-semibold text-slate-900 group-hover:text-brand-700 dark:text-slate-100 dark:group-hover:text-brand-300">
+                {RemoteAccount.label(follow.remote_account)}
               </p>
-              <p class="truncate text-sm text-slate-600 dark:text-slate-400">
-                {follow.remote_account.handle}
+              <p class="truncate text-sm text-slate-600 group-hover:text-brand-600 dark:text-slate-400 dark:group-hover:text-brand-300">
+                {handle}
               </p>
-            </div>
+            </.link>
 
             <%!-- "Requested" is the truth until the other server answers, and
             an account that approves by hand may never do so. Showing

--- a/lib/vutuv_web/live/post_live/filter_band.ex
+++ b/lib/vutuv_web/live/post_live/filter_band.ex
@@ -28,6 +28,7 @@ defmodule VutuvWeb.PostLive.FilterBand do
   """
   use VutuvWeb, :live_component
 
+  import VutuvWeb.FediverseComponents, only: [remote_actor_link: 3]
   import VutuvWeb.PostComponents, only: [rail_add_field: 1, rail_field_class: 0]
 
   alias Vutuv.ContentFilters
@@ -835,9 +836,16 @@ defmodule VutuvWeb.PostLive.FilterBand do
       <%!-- A row names somebody, so it goes to them. Deliberately not bold: six
       of these under a heading read as six headings, and the weight was never a
       decision — it came from `components.css`'s element-level `label` rule,
-      which this markup inherited by accident. --%>
+      which this markup inherited by accident.
+
+      An account on another network answers the press with its card, the way
+      its handle does on every post card in the feed this band is filtering
+      (`remote_actor_link/3`) — this list is where a reader scanning who fills
+      their feed decides they have had enough of somebody, and mute lives on
+      that card. Where the card cannot open, the row still leads to the account
+      page it always led to. --%>
       <.link
-        href={@row.path}
+        {row_link(@row)}
         class="min-w-0 shrink truncate text-sm font-normal text-slate-700 hover:text-brand-700 dark:text-slate-300 dark:hover:text-brand-300"
       >
         {@row.name}
@@ -852,6 +860,17 @@ defmodule VutuvWeb.PostLive.FilterBand do
     </div>
     """
   end
+
+  # Where a row leads and what a press on it does. A member or a page here is a
+  # destination and nothing more; an account on another network is the same
+  # question the feed's own cards answer with a card, so it is answered by the
+  # one function that owns that (`remote_actor_link/3`) rather than by a second
+  # spelling of it here.
+  # No actor URI: a band row is built from a stored account, so it always has an
+  # id and `remote_actor_link/3` never reaches its out-link fallback.
+  defp row_link(%{kind: :remote} = row), do: remote_actor_link(row.id, nil, row.address)
+
+  defp row_link(row), do: [href: row.path]
 
   attr(:id, :string, required: true)
   attr(:open?, :boolean, required: true)

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -1031,15 +1031,18 @@ the resulting ~200px rail width. --%>
               name: full_name(@user)
             )}
           </p>
+          <%!-- The sentence above asks the reader to follow an address, and the
+          card is the one place on the site where following one is a button
+          rather than a trip (`remote_actor_link/3`). An address we cannot read
+          as `@user@host` keeps the plain link out, which is all it ever was. --%>
           <p class="mt-3">
-            <a
+            <.link
               id="fediverse-moved-to"
-              href={@fediverse.moved_to}
-              rel="nofollow noopener noreferrer"
+              {remote_actor_link(nil, @fediverse.moved_to, @fediverse.moved_handle)}
               class="break-all text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
             >
               {@fediverse.moved_handle}
-            </a>
+            </.link>
           </p>
         <% else %>
           <.follow_us_from_elsewhere

--- a/lib/vutuv_web/views/user_html.ex
+++ b/lib/vutuv_web/views/user_html.ex
@@ -2,7 +2,7 @@ defmodule VutuvWeb.UserHTML do
   @moduledoc false
   use VutuvWeb, :html
 
-  import VutuvWeb.FediverseComponents, only: [follow_us_from_elsewhere: 1]
+  import VutuvWeb.FediverseComponents, only: [follow_us_from_elsewhere: 1, remote_actor_link: 3]
 
   import VutuvWeb.PostComponents,
     only: [

--- a/test/vutuv/feed_band_test.exs
+++ b/test/vutuv/feed_band_test.exs
@@ -17,13 +17,20 @@ defmodule Vutuv.FeedBandTest do
   alias Vutuv.FeedBand
   alias Vutuv.Social.Follow
 
+  # `handle` is the bare username the actor document's `preferredUsername`
+  # carries ("loud"), never the `@loud@loud.example` a reader is shown:
+  # `RemoteAccount.display_handle/1` composes that from this column and the
+  # host. Storing the composed form here fed `Handle.display/2` its own output
+  # and made the row's label look right for the wrong reason — the production
+  # value has no `@` to strip, so the band showed `loud` where a member's row
+  # shows `@stefan`.
   defp remote_account(host, handle) do
     actor = "https://#{host}/users/#{handle}"
 
     Repo.insert!(%RemoteAccount{
       actor_uri: actor,
       host: host,
-      handle: "@#{handle}@#{host}",
+      handle: handle,
       name: handle,
       inbox_uri: actor <> "/inbox"
     })

--- a/test/vutuv_web/components/remote_actor_link_test.exs
+++ b/test/vutuv_web/components/remote_actor_link_test.exs
@@ -1,0 +1,92 @@
+defmodule VutuvWeb.RemoteActorLinkTest do
+  @moduledoc """
+  The one function that decides where a remote handle leads and what a press on
+  it does (`VutuvWeb.FediverseComponents.remote_actor_link/3`), and the boost
+  banner as one caller that asks it rather than answering for itself.
+
+  A reader meets somebody from another network in a dozen places here, and every
+  one of them is the same question about the same account. This is the answer
+  written once: the account card opens over the handle, and the destination
+  underneath stays whatever it always was, for the middle click, the copied
+  link, the reader who is not signed in and the page whose JavaScript never
+  arrived.
+  """
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Fediverse.RemoteAccount
+  alias VutuvWeb.FediverseComponents
+  alias VutuvWeb.PostComponents
+
+  setup do
+    Gettext.put_locale(VutuvWeb.Gettext, "en")
+    :ok
+  end
+
+  defp account,
+    do: %RemoteAccount{
+      id: "01a0-account",
+      actor_uri: "https://social.example/users/them",
+      host: "social.example",
+      handle: "them",
+      name: "Them Themself"
+    }
+
+  describe "remote_actor_link/3" do
+    test "an account we hold leads to its page here and opens its card" do
+      assert [navigate: path, "data-remote-actor": address] =
+               FediverseComponents.remote_actor_link(
+                 "01a0-account",
+                 "https://social.example/users/them",
+                 "@them@social.example"
+               )
+
+      assert path == "/system/fediverse/account/01a0-account"
+      assert address == "them@social.example"
+    end
+
+    test "an account we do not hold leads out to their server and still opens its card" do
+      # No page here to show, so the fallback is the only place left — but the
+      # card can still answer "who is this", which is what the press is for.
+      attrs =
+        FediverseComponents.remote_actor_link(
+          nil,
+          "https://social.example/users/them",
+          "@them@social.example"
+        )
+
+      assert attrs[:href] == "https://social.example/users/them"
+      assert attrs[:target] == "_blank"
+      assert attrs[:rel] == "nofollow noopener noreferrer"
+      assert attrs[:"data-remote-actor"] == "them@social.example"
+    end
+
+    test "a handle that is not an address keeps today's link and no card" do
+      # `Handle.display/2` falls back to `@name` and to a bare `@host` when the
+      # actor document carried no username. The card is addressed by
+      # `user@host` and could only fail on either, so the hook stays off rather
+      # than opening a box that says so.
+      for handle <- ["@them", "@social.example", nil] do
+        attrs = FediverseComponents.remote_actor_link(nil, "https://social.example/x", handle)
+
+        refute Keyword.has_key?(attrs, :"data-remote-actor")
+        assert attrs[:href] == "https://social.example/x"
+      end
+    end
+  end
+
+  describe "the boost banner" do
+    test "it opens the boosting account's card" do
+      # The banner is the only thing on the card explaining why a stranger's
+      # post is in the reader's feed, so the account it names is exactly the one
+      # they want to know about — and the card is where "and stop showing me
+      # their boosts" lives.
+      html = render_component(&PostComponents.boosted_banner/1, account: account())
+
+      assert html =~ ~s(data-remote-actor="them@social.example")
+      assert html =~ "/system/fediverse/account/01a0-account"
+      assert html =~ "Them Themself"
+    end
+  end
+end

--- a/test/vutuv_web/live/fediverse_followers_live_test.exs
+++ b/test/vutuv_web/live/fediverse_followers_live_test.exs
@@ -53,6 +53,21 @@ defmodule VutuvWeb.FediverseFollowersLiveTest do
     refute has_element?(live, "#followers")
   end
 
+  test "a follower's name opens their card rather than leading off the site", %{conn: conn} do
+    {conn, user} = federating(conn)
+    follower(user, handle: "crse", name: "Christian Yoga", host: "social.linux.pizza")
+
+    {:ok, live, _html} = live(conn, ~p"/settings/fediverse/followers")
+
+    # One hook for every remote account on the site (`assets/js/mention_card.js`):
+    # the row names somebody the member may well want back, and "who is this,
+    # and do I follow them too" is answered on the card instead of on a server
+    # they have no account on. The `href` out there is still what a middle-click
+    # and a copied link take.
+    assert has_element?(live, ~s(a[data-remote-actor="crse@social.linux.pizza"]))
+    assert has_element?(live, ~s(a[href="https://social.linux.pizza/users/crse"]))
+  end
+
   describe "the table" do
     setup %{conn: conn} do
       {conn, user} = federating(conn)

--- a/test/vutuv_web/live/fediverse_following_live_test.exs
+++ b/test/vutuv_web/live/fediverse_following_live_test.exs
@@ -132,6 +132,22 @@ defmodule VutuvWeb.FediverseFollowingLiveTest do
       refute has_element?(view, "#no-following")
     end
 
+    test "the followed account opens its card rather than leading off the site", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/settings/fediverse/following")
+      view |> element("#follow-form") |> render_submit(%{"address" => "@them@social.example"})
+
+      # The one hook every remote account on the site wears
+      # (`assets/js/mention_card.js`): the card is where the follow state, the
+      # mutes and the way to their page here already live, so the row that names
+      # them opens it instead of handing the member to somebody else's server.
+      assert has_element?(view, ~s(a[data-remote-actor="them@social.example"]))
+
+      # And where the card cannot open, an account we already hold leads to its
+      # page here, not out to their server.
+      [account] = Repo.all(Vutuv.Fediverse.RemoteAccount)
+      assert has_element?(view, ~s(a[href="/system/fediverse/account/#{account.id}"]))
+    end
+
     test "an Accept flips the state on the open page, no reload", %{conn: conn, user: user} do
       {:ok, view, _html} = live(conn, ~p"/settings/fediverse/following")
       view |> element("#follow-form") |> render_submit(%{"address" => "@them@social.example"})

--- a/test/vutuv_web/live/feed_remote_thread_test.exs
+++ b/test/vutuv_web/live/feed_remote_thread_test.exs
@@ -238,6 +238,19 @@ defmodule VutuvWeb.FeedRemoteThreadTest do
       # what this feature replaced and is still far better than a 500.
       assert html |> String.split("was da draussen steht") |> length() == 2
 
+      # And that bare line names an account on another network, so a press on it
+      # opens the same card the handle in a card header opens
+      # (`remote_actor_link/3`) — this line is the reader's only handle on who
+      # is being answered, and it used to be the one that led nowhere useful.
+      # Scoped to the banner, not asserted against the whole page: the card
+      # drawn above the first answer carries the same hook in its header, so a
+      # bare `html =~` here passes with the banner unchanged and measures
+      # nothing.
+      assert has_element?(
+               view,
+               ~s([data-reply-banner="remote"] a[data-remote-actor="them@social.example"])
+             )
+
       # One action bar for it, too — the bar is what carries the id that
       # raised, and `subject_id` rides every one of its controls as
       # `phx-value-id`. Counting the like control is the closest the DOM comes

--- a/test/vutuv_web/live/filter_band_test.exs
+++ b/test/vutuv_web/live/filter_band_test.exs
@@ -20,13 +20,20 @@ defmodule VutuvWeb.PostLive.FilterBandTest do
   alias Vutuv.Posts
   alias Vutuv.Social.Follow
 
+  # `handle` is the bare username the actor document's `preferredUsername`
+  # carries ("them"), never the `@them@social.example` a reader is shown:
+  # `RemoteAccount.display_handle/1` composes that from this column and the
+  # host, and `remote_account_by_address/1` matches an address against it bare.
+  # Storing the composed form here fed `Handle.display/2` its own output —
+  # "@@them@social.example@social.example" — which is not a handle any surface
+  # can read back.
   defp remote_account(host, handle) do
     actor = "https://#{host}/users/#{handle}"
 
     Repo.insert!(%RemoteAccount{
       actor_uri: actor,
       host: host,
-      handle: "@#{handle}@#{host}",
+      handle: handle,
       name: handle,
       inbox_uri: actor <> "/inbox"
     })
@@ -183,6 +190,25 @@ defmodule VutuvWeb.PostLive.FilterBandTest do
 
       view |> element("#load-more") |> render_click()
       refute_received :band_reloaded
+    end
+
+    test "the account row opens its card, the way its handle does on a post", %{conn: conn} do
+      %{conn: conn, user: user} = with_friend(conn)
+      {:ok, _} = Posts.save_feed_rail(user, %{order: ["sources"], collapsed: [], removed: []})
+      account = remote_account("social.example", "them")
+      remote_follow(user, account)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      view |> twist("social.example") |> render()
+
+      # This list is where a reader scanning who fills their feed decides they
+      # have had enough of somebody, and mute lives on the card — so the row
+      # answers the press with the same card the handle above it opens, rather
+      # than with a page they have to come back from. The account page is still
+      # where the anchor leads when the card cannot open.
+      link = ~s(a[data-remote-actor="them@social.example"])
+      assert has_element?(view, link)
+      assert view |> element(link) |> render() =~ "/system/fediverse/account/#{account.id}"
     end
 
     # The one live path that changes follow state from OUTSIDE the card — the

--- a/test/vutuv_web/live/notification_live_test.exs
+++ b/test/vutuv_web/live/notification_live_test.exs
@@ -999,6 +999,27 @@ defmodule VutuvWeb.NotificationLiveTest do
       assert html =~ "and 1 more"
     end
 
+    test "the account opens its card here rather than leading off the site", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      remote_reaction!(
+        create_post!(user, %{body: "went out into the world"}),
+        "alice",
+        "announce"
+      )
+
+      {:ok, live, _html} = live(conn, ~p"/notifications")
+
+      # The same hook every other remote handle on the site wears
+      # (`assets/js/mention_card.js` binds the account card to it): a plain
+      # click answers "who is this and do I want their posts here" without
+      # leaving vutuv for a server the reader has no account on. The `href`
+      # stays the anchor's whole truth, so a middle-click, a copied link and a
+      # page whose JavaScript never arrived still go there.
+      assert has_element?(live, ~s(a[data-remote-actor="alice@social.example"]))
+      assert has_element?(live, ~s(a[href="https://social.example/users/alice"]))
+    end
+
     test "the posts filter tab keeps them", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       remote_reaction!(create_post!(user, %{body: "filtered"}), "alice", "like")

--- a/test/vutuv_web/live/user_profile_fediverse_test.exs
+++ b/test/vutuv_web/live/user_profile_fediverse_test.exs
@@ -66,6 +66,17 @@ defmodule VutuvWeb.UserProfileFediverseTest do
 
       assert has_element?(view, "#fediverse-moved-to")
       assert render(view) =~ "@greta@social.example"
+      # And the sentence above it asks the reader to follow that address, which
+      # is the one thing the account card is for: a press opens it here rather
+      # than handing them to a server they have no account on
+      # (`remote_actor_link/3`). The link out is still what the anchor carries.
+      assert has_element?(view, ~s(#fediverse-moved-to[data-remote-actor="greta@social.example"]))
+
+      assert has_element?(
+               view,
+               ~s(#fediverse-moved-to[href="https://social.example/users/greta"])
+             )
+
       # Following here would land on a redirect, so the tool is not offered.
       refute has_element?(view, @form)
       refute has_element?(view, @handle)


### PR DESCRIPTION
On `/notifications`, the account that boosted or replied to your post sent you
off to their server. The same handle on the post card above it opens the account
card (#1937). Same question, so it now gets the same answer — and so do the nine
other places a remote account is named.

`FediverseComponents.remote_actor_link/3` owns where such a handle leads and
what a press does; it moved there from `PostComponents`, since most callers hold
no post. Its docstring is the one list of them: the two lines on a post card,
notifications, the three account tables (an organization's had no link at all),
the feed's source band, a moved member's forwarding address.

Out by design: the quoted-post tile (already one link), your own move address, admin queues.

Two fixes on the way: the source band showed `them`, not `@them@social.example`
— two fixtures stored a handle the app never writes — and `display_handle/1`
re-parsed a URI for a host it held as a column.

Driven in a browser on each surface.

An AI agent wrote this text in my name. I know that is problematic.

https://claude.ai/code/session_01LK8QZB8a6kFhHuHHdVnL91
