### PR TITLE
Six places now ask for themselves who is watching

### DIFF
--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -758,8 +758,24 @@ defmodule Vutuv.Organizations do
   Taking `owner` away runs under the same `guard_last_owner/2` row lock the
   single-role path used: two concurrent edits each dropping a *different* owner
   could otherwise both read "there are two owners" and both commit, leaving zero.
+
+  `actor` is **authorized here**, not merely recorded as `granted_by`. It used to
+  be the latter only, so the whole rule that this is an owner's operation lived in
+  the controller that renders the roster — and the roster is an embedded LiveView
+  whose `live_render` session map is signed but not encrypted and valid for days.
+  A replayed payload, or simply a tab still open after the member's own owner role
+  was taken away, could push `set_roles` and grant itself anything. Returns
+  `{:error, :unauthorized}` for anyone who may not manage this page's roles.
   """
   def set_roles(%Organization{} = organization, %User{} = user, roles, %User{} = actor) do
+    if can_manage_roles?(organization, actor) do
+      do_set_roles(organization, user, roles, actor)
+    else
+      {:error, :unauthorized}
+    end
+  end
+
+  defp do_set_roles(organization, user, roles, actor) do
     wanted = roles |> Enum.filter(&(&1 in @roles)) |> Enum.uniq()
     held = roles_of(organization, user)
 

--- a/lib/vutuv/search.ex
+++ b/lib/vutuv/search.ex
@@ -192,12 +192,13 @@ defmodule Vutuv.Search do
     if runnable?(parsed) do
       {exact, similar} = people(parsed)
       tags = tags(parsed)
+      viewer = opts[:viewer]
 
       %{
         query: parsed.raw,
         parsed: parsed,
-        exact_people: exact,
-        similar_people: similar,
+        exact_people: status_visible(exact, parsed, viewer),
+        similar_people: status_visible(similar, parsed, viewer),
         tags: tags,
         tag_member_counts: tag_member_counts(tags),
         posts: posts(parsed)
@@ -280,6 +281,25 @@ defmodule Vutuv.Search do
 
   defp honor_status_exclusion(people, _parsed, _viewer), do: people
 
+  # The live `/search` results get the same gate as the alert mail. It used to be
+  # skipped here, called "a transient interactive query" — but the exclusion list
+  # (#938) is a promise about one fact, and hiding that fact on the profile while
+  # `status:looking` still lists the member is not keeping it.
+  #
+  # `viewer_excluded?/2` rather than the alert path's `job_search_visibility/2`:
+  # the rows here come from `list_people/1`, which selects a narrow struct, so
+  # every visibility column reads `nil` and that predicate would answer "hidden"
+  # for everybody. It does not have to be asked anyway — `filter_status/2` has
+  # already required a non-hidden status in SQL and the operator only runs for a
+  # signed-in viewer, so the exclusion is the one question left, and it needs
+  # nothing but the two ids.
+  defp status_visible(people, %{status: status}, %User{} = viewer)
+       when status in @status_values do
+    Enum.reject(people, &Accounts.viewer_excluded?(&1, viewer))
+  end
+
+  defp status_visible(people, _parsed, _viewer), do: people
+
   defp people(%{scope: scope}) when scope not in [:all, :people], do: {[], []}
 
   defp people(parsed) do
@@ -357,8 +377,8 @@ defmodule Vutuv.Search do
 
   # A member matches `status:` when they carry that availability and it is
   # visible to a signed-in member (never "hidden" — issue #928). The per-viewer
-  # exclusion list (#938) is honored on the profile and in the alert mail, not
-  # in this live operator (a transient interactive query).
+  # exclusion list (#938) is applied after this, in `status_visible/3`, because
+  # it is a per-pair question this SQL predicate cannot ask.
   defp filter_status(query, status) when status in @status_values do
     where(
       query,

--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -18,6 +18,7 @@ defmodule Vutuv.Tags do
   alias Vutuv.Repo
   alias Vutuv.SearchText
   alias Vutuv.SlugHelpers
+  alias Vutuv.Social
   require Vutuv.Tags.MatchKey
 
   alias Vutuv.Tags.LinkableCache
@@ -1106,36 +1107,68 @@ defmodule Vutuv.Tags do
   Endorse a user's tag. The chokepoint for endorsements: besides inserting the
   row it pushes the live in-app notification to the tag's owner, so all
   endorsement paths must come through here (not a raw `Repo.insert`).
+
+  Three rules are enforced here rather than at the controls, because the profile
+  and the tag list page each render their own and a crafted request reaches
+  neither: an honor tag is not endorsable, you may not endorse your own tag, and
+  a block in either direction refuses the vouch. The last two used to live only
+  in the rendered control, so a `POST /user_tag_endorsements` still let somebody
+  vouch for themselves, and let a blocked member both endorse the person who
+  blocked them and send them a notification saying so.
   """
   def create_endorsement(attrs) do
-    if endorsement_target_honor?(attrs) do
-      # An honor tag is an authoritative badge, not a peer vouch, so it
-      # is not endorsable. The profile hides the pill; this guards a crafted
-      # request that reaches the chokepoint anyway.
-      {:error, :honor}
-    else
-      result = %UserTagEndorsement{} |> UserTagEndorsement.changeset(attrs) |> Repo.insert()
+    endorser = endorsement_attr(attrs, :user_id)
 
-      with {:ok, endorsement} <- result do
-        # notify_endorsement preloaded the owner already, so reuse the id it
-        # returns for the live-count broadcast instead of re-querying it.
-        broadcast_endorsement_changed(notify_endorsement(endorsement), endorsement.user_tag_id)
-      end
-
-      result
+    case endorsement_target(endorsement_attr(attrs, :user_tag_id)) do
+      # An honor tag is an authoritative badge, not a peer vouch, so it is not
+      # endorsable. The profile hides the pill; this guards a crafted request
+      # that reaches the chokepoint anyway.
+      %{honor?: true} -> {:error, :honor}
+      %{user_id: ^endorser} -> {:error, :self}
+      %{user_id: owner} -> insert_unless_blocked(attrs, endorser, owner)
+      # No such user_tag: let the changeset's own foreign-key error answer.
+      nil -> insert_endorsement(attrs)
     end
   end
 
-  defp endorsement_target_honor?(attrs) do
-    user_tag_id = Map.get(attrs, :user_tag_id) || Map.get(attrs, "user_tag_id")
-
-    is_binary(user_tag_id) and
-      Repo.exists?(
-        from(ut in UserTag,
-          join: t in assoc(ut, :tag),
-          where: ut.id == ^user_tag_id and t.honor?
-        )
+  # One row read for all three questions — who owns this tag, and is it an honor
+  # tag. Shared with `delete_endorsement/2`, which needs the owner to broadcast.
+  defp endorsement_target(user_tag_id) when is_binary(user_tag_id) do
+    Repo.one(
+      from(ut in UserTag,
+        join: t in assoc(ut, :tag),
+        where: ut.id == ^user_tag_id,
+        select: %{user_id: ut.user_id, honor?: t.honor?}
       )
+    )
+  end
+
+  defp endorsement_target(_user_tag_id), do: nil
+
+  # A block cuts both ways: neither side endorses the other, and neither gets a
+  # notification out of the attempt.
+  defp insert_unless_blocked(attrs, endorser, owner) do
+    if is_binary(endorser) and Social.blocked_between?(endorser, owner) do
+      {:error, :blocked}
+    else
+      insert_endorsement(attrs)
+    end
+  end
+
+  defp insert_endorsement(attrs) do
+    result = %UserTagEndorsement{} |> UserTagEndorsement.changeset(attrs) |> Repo.insert()
+
+    with {:ok, endorsement} <- result do
+      # notify_endorsement preloaded the owner already, so reuse the id it
+      # returns for the live-count broadcast instead of re-querying it.
+      broadcast_endorsement_changed(notify_endorsement(endorsement), endorsement.user_tag_id)
+    end
+
+    result
+  end
+
+  defp endorsement_attr(attrs, key) do
+    Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
   end
 
   @doc """

--- a/lib/vutuv_web/controllers/avatar_controller.ex
+++ b/lib/vutuv_web/controllers/avatar_controller.ex
@@ -10,19 +10,28 @@ defmodule VutuvWeb.AvatarController do
   404s: unknown slugs, unactivated members and members without an avatar
   all look the same. The public cache lifetime keeps repeat scraper
   traffic off libvips.
+
+  A member the site withholds keeps their picture withheld too. `email_confirmed?`
+  alone let this endpoint answer for a suspended, frozen or deactivated account
+  whose every other page is a 404 or a 410 — and it answers **anonymously**, so
+  the face stayed readable by anybody who knew the handle. The gate is now the
+  one the rest of the slug space uses, asked with no viewer, exactly as
+  `VutuvWeb.OrganizationAvatarController` asks it for a page.
   """
 
   use VutuvWeb, :controller
 
   alias Vutuv.Accounts.User
   alias Vutuv.Avatar
+  alias Vutuv.Moderation
   alias Vutuv.Repo
   alias VutuvWeb.ControllerHelpers
 
   def show(conn, %{"slug" => slug}) do
     bytes =
-      with %User{email_confirmed?: true, avatar: avatar} = user when not is_nil(avatar) <-
-             Repo.get_by(User, username: slug) do
+      with %User{avatar: avatar} = user when not is_nil(avatar) <-
+             Repo.get_by(User, username: slug),
+           true <- Moderation.profile_visible_to?(user, nil) do
         Avatar.og_jpeg(user)
       end
 

--- a/lib/vutuv_web/controllers/user_tag_endorsement_controller.ex
+++ b/lib/vutuv_web/controllers/user_tag_endorsement_controller.ex
@@ -20,18 +20,27 @@ defmodule VutuvWeb.UserTagEndorsementController do
   def create(conn, _params) do
     # Through the Tags.create_endorsement/1 chokepoint so the tag's owner also
     # gets the live in-app notification.
-    Tags.create_endorsement(%{
-      user_tag_id: conn.assigns[:user_tag_id],
-      user_id: conn.assigns[:current_user_id]
-    })
+    result =
+      Tags.create_endorsement(%{
+        user_tag_id: conn.assigns[:user_tag_id],
+        user_id: conn.assigns[:current_user_id]
+      })
 
-    respond(conn, gettext("Endorsement successful."))
+    respond(conn, create_flash(result))
   end
+
+  # The chokepoint refuses an honor tag, your own tag and a vouch across a block,
+  # and the no-JS path used to claim success for all three. One wording for every
+  # refusal on purpose: naming the block would tell the blocked member it exists,
+  # which is precisely what a block is not supposed to announce. The AJAX branch
+  # needs none of this — it reads the true state back from the database.
+  defp create_flash({:ok, _endorsement}), do: {:info, gettext("Endorsement successful.")}
+  defp create_flash({:error, _reason}), do: {:error, gettext("That endorsement is not possible.")}
 
   def delete(conn, _params) do
     Tags.delete_endorsement(conn.assigns[:user_tag_id], conn.assigns[:current_user_id])
 
-    respond(conn, gettext("Unendorsed tag successfully."))
+    respond(conn, {:info, gettext("Unendorsed tag successfully.")})
   end
 
   # The profile's upvote pill toggles over fetch (the `TagVote` enhancement in
@@ -40,7 +49,7 @@ defmodule VutuvWeb.UserTagEndorsementController do
   # submit still gets the classic flash + redirect. State is read back from the
   # DB, so the response is correct whether the write succeeded, was a duplicate,
   # or raced another tab.
-  defp respond(conn, flash) do
+  defp respond(conn, {kind, flash}) do
     user_tag_id = conn.assigns[:user_tag_id]
 
     if ajax?(conn) do
@@ -50,7 +59,7 @@ defmodule VutuvWeb.UserTagEndorsementController do
       })
     else
       conn
-      |> put_flash(:info, flash)
+      |> put_flash(kind, flash)
       |> redirect(to: referrer_url(conn))
     end
   end

--- a/lib/vutuv_web/live/admin/dashboard_live.ex
+++ b/lib/vutuv_web/live/admin/dashboard_live.ex
@@ -16,9 +16,11 @@ defmodule VutuvWeb.Admin.DashboardLive do
   disconnects (they ride the `VutuvWeb.Presence` diffs, in-memory, no database);
   the database figures refresh on a gentle timer.
 
-  Access control is the host page's job: `/admin` is gated by the `:admin`
-  pipeline (403 for non-admins), so only an admin is ever handed the signed
-  session that lets this embedded LiveView's socket connect.
+  **The socket does its own access control**, per the standing rule for
+  off-router `live_render` children: `/admin` behind the `:admin` pipeline gates
+  the page, not this child's socket. The connected mount resolves the viewer
+  through `VutuvWeb.Live.InitAssigns.assign_embedded/2` and sends anybody who is
+  not an admin away, subscribing to nothing and starting no timer for them.
   """
   use Phoenix.LiveView
 
@@ -34,6 +36,7 @@ defmodule VutuvWeb.Admin.DashboardLive do
 
   alias Vutuv.Accounts.User
   alias Vutuv.Dashboard
+  alias VutuvWeb.Live.InitAssigns
   alias VutuvWeb.Presence
 
   # The database figures change slowly, so a relaxed cadence keeps them fresh
@@ -43,21 +46,35 @@ defmodule VutuvWeb.Admin.DashboardLive do
 
   @impl true
   def mount(_params, session, socket) do
-    # Embedded outside the admin live_session, so re-apply the request locale
-    # (the labels are gettext, the admin UI is German) the way ShellLive does.
-    VutuvWeb.LiveLocale.put_viewer(session)
+    # The shared preamble for an off-router child: resolves the viewer from the
+    # cookie's session token and applies their locale and clock.
+    socket = InitAssigns.assign_embedded(socket, session)
 
-    if connected?(socket) do
-      Presence.subscribe_online()
-      schedule_refresh()
+    cond do
+      # The throwaway dead render: the HTTP request that produced it already
+      # passed the `:admin` pipeline, and it is replaced the instant the socket
+      # connects and re-checks the token.
+      not connected?(socket) -> {:ok, assign_figures(socket)}
+      admin?(socket.assigns.current_user) -> {:ok, mount_admin(socket)}
+      _anyone_else = true -> {:ok, push_navigate(socket, to: ~p"/")}
     end
+  end
 
-    {:ok,
-     socket
-     |> assign_online()
-     |> assign_snapshot()
-     |> assign_newest_members()
-     |> assign(:gender_breakdown, Dashboard.gender_breakdown())}
+  defp admin?(%User{admin?: true}), do: true
+  defp admin?(_viewer), do: false
+
+  defp mount_admin(socket) do
+    Presence.subscribe_online()
+    schedule_refresh()
+    assign_figures(socket)
+  end
+
+  defp assign_figures(socket) do
+    socket
+    |> assign_online()
+    |> assign_snapshot()
+    |> assign_newest_members()
+    |> assign(:gender_breakdown, Dashboard.gender_breakdown())
   end
 
   @impl true

--- a/lib/vutuv_web/live/job_posting_live/show.ex
+++ b/lib/vutuv_web/live/job_posting_live/show.ex
@@ -9,6 +9,14 @@ defmodule VutuvWeb.JobPostingLive.Show do
   "Wünschenswert" (a signed-in viewer's own matching tags highlighted), the
   apply button and the like / bookmark bar. The like count is live over PubSub;
   a closure or edit updates open tabs.
+
+  **The socket re-asks whether the viewer may see the posting.** The controller
+  answering that on the dead render is not enough: the `live_render` session map
+  is signed but not encrypted and stays valid for days, so a captured payload
+  could be replayed straight at `/live/websocket` with the slug in it — and a
+  draft, an expired or a withdrawn posting would render in full. So the mount
+  resolves through `Jobs.fetch_visible_job_posting/2`, and every later refresh
+  asks again, because a posting can be closed while a tab is open.
   """
 
   use VutuvWeb, :live_view
@@ -25,18 +33,32 @@ defmodule VutuvWeb.JobPostingLive.Show do
     socket = InitAssigns.assign_embedded(socket, session)
     current_user = socket.assigns.current_user
 
-    posting = Jobs.get_job_posting_by_slug(session["slug"])
+    case visible_posting(session["slug"], current_user) do
+      {:ok, posting} ->
+        if connected?(socket), do: on_connect(posting, current_user)
+        {:ok, assign_posting(socket, posting, current_user)}
 
-    if connected?(socket) do
-      Jobs.subscribe(posting.id)
-      # Approximate view counting; skip the owner's own visits.
-      unless Jobs.owner?(posting, current_user), do: Jobs.increment_view(posting)
+      {:error, :not_found} ->
+        {:ok, push_navigate(socket, to: ~p"/jobs")}
     end
-
-    socket = assign_posting(socket, posting, current_user)
-
-    {:ok, socket}
   end
+
+  defp on_connect(posting, viewer) do
+    Jobs.subscribe(posting.id)
+    # Approximate view counting; skip the owner's own visits.
+    unless Jobs.owner?(posting, viewer), do: Jobs.increment_view(posting)
+  end
+
+  # The gate, asked on the socket rather than inherited from the dead render.
+  # `fetch_visible_job_posting/2` deliberately returns an unpreloaded row, so the
+  # associations this page renders are loaded only once it has said yes.
+  defp visible_posting(slug, viewer) when is_binary(slug) do
+    with {:ok, posting} <- Jobs.fetch_visible_job_posting(slug, viewer) do
+      {:ok, Jobs.preload_for_show(posting)}
+    end
+  end
+
+  defp visible_posting(_slug, _viewer), do: {:error, :not_found}
 
   defp assign_posting(socket, posting, viewer) do
     socket
@@ -68,9 +90,15 @@ defmodule VutuvWeb.JobPostingLive.Show do
     {:noreply, assign(socket, :engagement, %{socket.assigns.engagement | likes: likes})}
   end
 
+  # A posting can be withdrawn, frozen or expire while a tab sits open, so the
+  # refresh asks the gate again rather than re-reading the row unconditionally.
   def handle_info({:job_posting_updated, _}, socket) do
-    posting = Jobs.get_job_posting_by_slug(socket.assigns.posting.slug)
-    {:noreply, assign_posting(socket, posting, socket.assigns.current_user)}
+    viewer = socket.assigns.current_user
+
+    case visible_posting(socket.assigns.posting.slug, viewer) do
+      {:ok, posting} -> {:noreply, assign_posting(socket, posting, viewer)}
+      {:error, :not_found} -> {:noreply, push_navigate(socket, to: ~p"/jobs")}
+    end
   end
 
   def handle_info(_msg, socket), do: {:noreply, socket}

--- a/lib/vutuv_web/live/organization_live/roles.ex
+++ b/lib/vutuv_web/live/organization_live/roles.ex
@@ -11,8 +11,13 @@ defmodule VutuvWeb.OrganizationLive.Roles do
   would have silently taken their `admin` away, which is the mistake the whole
   role separation exists to prevent.
 
-  Embedded via `live_render` from `VutuvWeb.OrganizationController`, which gates it on
-  an owner.
+  Embedded via `live_render` from `VutuvWeb.OrganizationController`, which gates
+  the page on an owner — and this asks the same question again on the socket,
+  because that map is signed but not encrypted and stays valid for days. The
+  real backstop is `Organizations.set_roles/4`, which authorizes its actor
+  rather than merely recording them, so no surface can grant a role by pushing
+  an event; the two checks here are what make the refusal visible instead of
+  silent.
   """
 
   use VutuvWeb, :live_view
@@ -30,17 +35,24 @@ defmodule VutuvWeb.OrganizationLive.Roles do
     socket = InitAssigns.assign_embedded(socket, session)
     organization = Organizations.get_organization!(session["organization_id"])
 
-    {:ok,
-     socket
-     |> assign(:organization, organization)
-     |> assign(:page_title, gettext("Team – %{name}", name: organization.name))
-     |> assign(:identifier, "")
-     # Nothing pre-ticked: with four roles a guessed default is wrong more often
-     # than right, and `publisher` in particular must never arrive by accident.
-     |> assign(:add_roles, [])
-     |> assign(:roles_options, Organizations.roles())
-     |> assign(:suggestions, [])
-     |> load_team()}
+    if Organizations.can_manage_roles?(organization, socket.assigns.current_user) do
+      {:ok, mount_roster(socket, organization)}
+    else
+      {:ok, push_navigate(socket, to: ~p"/organizations/#{organization}")}
+    end
+  end
+
+  defp mount_roster(socket, organization) do
+    socket
+    |> assign(:organization, organization)
+    |> assign(:page_title, gettext("Team – %{name}", name: organization.name))
+    |> assign(:identifier, "")
+    # Nothing pre-ticked: with four roles a guessed default is wrong more often
+    # than right, and `publisher` in particular must never arrive by accident.
+    |> assign(:add_roles, [])
+    |> assign(:roles_options, Organizations.roles())
+    |> assign(:suggestions, [])
+    |> load_team()
   end
 
   defp load_team(socket) do
@@ -118,6 +130,9 @@ defmodule VutuvWeb.OrganizationLive.Roles do
 
       {:error, :last_owner} ->
         {:noreply, socket |> load_team() |> put_flash(:error, last_owner_error())}
+
+      {:error, :unauthorized} ->
+        {:noreply, push_navigate(socket, to: ~p"/organizations/#{socket.assigns.organization}")}
     end
   end
 

--- a/test/vutuv/organizations_management_test.exs
+++ b/test/vutuv/organizations_management_test.exs
@@ -189,6 +189,38 @@ defmodule Vutuv.OrganizationsManagementTest do
       assert {:ok, ["admin"]} = Organizations.set_roles(organization, owner, ["admin"], owner)
     end
 
+    # `actor` used to be recorded as `granted_by` and nothing else, so the "this
+    # is an owner's operation" rule lived only in the controller that renders the
+    # roster — an embedded LiveView whose session map is signed but not encrypted
+    # and valid for days. Pushing the event was enough to grant yourself a role.
+    test "set_roles refuses an actor who may not manage roles" do
+      {organization, owner} = active_organization()
+      member = insert(:activated_user)
+      outsider = insert(:activated_user)
+      {:ok, _} = Organizations.set_roles(organization, member, ["publisher"], owner)
+
+      assert {:error, :unauthorized} =
+               Organizations.set_roles(organization, member, ["owner"], outsider)
+
+      # An admin is on the team and still may not hand out roles.
+      {:ok, _} = Organizations.set_roles(organization, member, ["admin"], owner)
+
+      assert {:error, :unauthorized} =
+               Organizations.set_roles(organization, member, ["owner"], member)
+
+      assert Organizations.roles_of(organization, member) == ["admin"]
+    end
+
+    test "set_roles refuses a former owner whose own role was taken away" do
+      {organization, owner} = active_organization()
+      second = insert(:activated_user)
+      {:ok, _} = Organizations.set_roles(organization, second, ["owner"], owner)
+      {:ok, _} = Organizations.set_roles(organization, second, [], owner)
+
+      assert {:error, :unauthorized} =
+               Organizations.set_roles(organization, second, ["owner"], second)
+    end
+
     test "list_team gives one entry per member with every role they hold" do
       {organization, owner} = active_organization()
       member = insert(:activated_user)

--- a/test/vutuv/search_test.exs
+++ b/test/vutuv/search_test.exs
@@ -2,7 +2,9 @@ defmodule Vutuv.SearchTest do
   use Vutuv.DataCase, async: true
 
   alias Vutuv.Accounts.SearchTerm
+  alias Vutuv.Accounts.ViewerExclusion
   alias Vutuv.Search
+  alias Vutuv.Social
 
   # A user findable by name search: the factory does not create search terms
   # (Accounts.create_user does), so insert the same terms create_user would.
@@ -266,6 +268,25 @@ defmodule Vutuv.SearchTest do
 
       results = Search.instant("status:looking", viewer: ctx.viewer)
       assert Enum.map(results.exact_people, & &1.id) == [ctx.looking.id]
+    end
+
+    # The exclusion list (#938) is a promise about exactly this fact. Hiding it
+    # on the profile while `status:looking` still lists the member does not keep
+    # that promise, so the live operator applies the same gate the alert mail does.
+    test "a member who excluded the viewer never matches", ctx do
+      Repo.insert!(ViewerExclusion.member_changeset(ctx.looking, ctx.viewer))
+
+      results = Search.instant("status:looking", viewer: ctx.viewer)
+
+      refute ctx.looking.id in Enum.map(results.exact_people, & &1.id)
+    end
+
+    test "a block hides the status from the blocked viewer's search", ctx do
+      Social.block_user(ctx.looking, ctx.viewer)
+
+      results = Search.instant("status:looking", viewer: ctx.viewer)
+
+      refute ctx.looking.id in Enum.map(results.exact_people, & &1.id)
     end
 
     test "logged-out search ignores the operator", ctx do

--- a/test/vutuv/tags_test.exs
+++ b/test/vutuv/tags_test.exs
@@ -798,6 +798,51 @@ defmodule Vutuv.TagsTest do
       assert endorsement.user_tag_id == user_tag.id
     end
 
+    # Both rules used to live only in the rendered control, so a crafted POST
+    # walked past them — and the block case also delivered a notification to the
+    # very member who blocked the endorser.
+    test "create_endorsement/1 refuses your own tag" do
+      owner = insert(:user)
+      user_tag = insert(:user_tag, user: owner, tag: insert(:tag))
+
+      assert {:error, :self} =
+               Tags.create_endorsement(%{user_id: owner.id, user_tag_id: user_tag.id})
+
+      refute Tags.endorsed?(user_tag.id, owner.id)
+    end
+
+    test "create_endorsement/1 refuses across a block, in either direction" do
+      blocker = insert(:user)
+      blocked = insert(:user)
+      Vutuv.Social.block_user(blocker, blocked)
+
+      blocker_tag = insert(:user_tag, user: blocker, tag: insert(:tag))
+      blocked_tag = insert(:user_tag, user: blocked, tag: insert(:tag))
+
+      assert {:error, :blocked} =
+               Tags.create_endorsement(%{user_id: blocked.id, user_tag_id: blocker_tag.id})
+
+      assert {:error, :blocked} =
+               Tags.create_endorsement(%{user_id: blocker.id, user_tag_id: blocked_tag.id})
+
+      refute Tags.endorsed?(blocker_tag.id, blocked.id)
+      refute Tags.endorsed?(blocked_tag.id, blocker.id)
+    end
+
+    test "create_endorsement/1 sends no notification across a block" do
+      blocker = insert(:user)
+      blocked = insert(:user)
+      Vutuv.Social.block_user(blocker, blocked)
+      user_tag = insert(:user_tag, user: blocker, tag: insert(:tag))
+
+      Vutuv.Activity.subscribe(blocker.id)
+
+      assert {:error, :blocked} =
+               Tags.create_endorsement(%{user_id: blocked.id, user_tag_id: user_tag.id})
+
+      refute_receive {:endorsement_changed, _}, 100
+    end
+
     test "create_endorsement/1 pushes a live notification to the tag's owner" do
       endorser = insert(:user, first_name: "Ada", last_name: "Lovelace")
       tag_owner = insert(:user)
@@ -814,14 +859,17 @@ defmodule Vutuv.TagsTest do
       assert n.actor_param == endorser.username
     end
 
-    test "create_endorsement/1 does not notify on a self-endorsement" do
+    # This used to let the row through and merely skip the notification. The
+    # rule the controls state is that you cannot vouch for yourself at all, so
+    # the chokepoint now says so — and still notifies nobody.
+    test "create_endorsement/1 refuses a self-endorsement without notifying" do
       tag_owner = insert(:user)
       tag = insert(:tag)
       user_tag = insert(:user_tag, user: tag_owner, tag: tag)
 
       Vutuv.Activity.subscribe(tag_owner.id)
 
-      assert {:ok, _} =
+      assert {:error, :self} =
                Tags.create_endorsement(%{user_id: tag_owner.id, user_tag_id: user_tag.id})
 
       refute_receive {:new_notification, _}

--- a/test/vutuv_web/controllers/avatar_controller_test.exs
+++ b/test/vutuv_web/controllers/avatar_controller_test.exs
@@ -79,4 +79,32 @@ defmodule VutuvWeb.AvatarControllerTest do
     sleepy = insert_activated_user(email_confirmed?: false, avatar: "selfie.jpg")
     assert get(conn, "/#{sleepy.username}/avatar.jpg").status == 404
   end
+
+  # This endpoint answers anonymously, so a face it hands out is readable by
+  # anybody who knows the handle. A member the rest of the slug space withholds
+  # has to be withheld here too — `email_confirmed?` on its own is not that gate.
+  test "404 for a member the site withholds", %{conn: conn} do
+    user = member_with_avatar()
+    assert get(conn, "/#{user.username}/avatar.jpg").status == 200
+
+    suspended =
+      user
+      |> Ecto.Changeset.change(
+        suspended_until: NaiveDateTime.add(NaiveDateTime.utc_now(:second), 86_400)
+      )
+      |> Repo.update!()
+
+    assert get(conn, "/#{suspended.username}/avatar.jpg").status == 404
+  end
+
+  test "404 for a deactivated member", %{conn: conn} do
+    user = member_with_avatar()
+
+    deactivated =
+      user
+      |> Ecto.Changeset.change(deactivated_at: NaiveDateTime.utc_now(:second))
+      |> Repo.update!()
+
+    assert get(conn, "/#{deactivated.username}/avatar.jpg").status == 404
+  end
 end

--- a/test/vutuv_web/job_posting_test.exs
+++ b/test/vutuv_web/job_posting_test.exs
@@ -289,6 +289,28 @@ defmodule VutuvWeb.JobPostingTest do
 
       assert conn |> get(~p"/jobs/#{posting.slug}") |> response(404)
     end
+
+    # The controller answering the gate on the dead render is not the gate: the
+    # live_render session map is signed but not encrypted and lives for days, so
+    # a captured payload can be replayed at /live/websocket with the slug in it.
+    # The socket has to refuse for itself.
+    test "the socket refuses a members-only posting on its own", %{conn: conn} do
+      posting = publish_job!()
+      {:ok, _} = posting |> Ecto.Changeset.change(visibility: :members) |> Repo.update()
+
+      assert {:error, {:live_redirect, %{to: "/jobs"}}} =
+               live_isolated(conn, VutuvWeb.JobPostingLive.Show,
+                 session: %{"slug" => posting.slug}
+               )
+    end
+
+    test "the socket refuses a draft posting on its own", %{conn: conn} do
+      owner = insert(:activated_user)
+      {:ok, draft} = Jobs.create_draft(owner, %{"title" => "Secret role"})
+
+      assert {:error, {:live_redirect, %{to: "/jobs"}}} =
+               live_isolated(conn, VutuvWeb.JobPostingLive.Show, session: %{"slug" => draft.slug})
+    end
   end
 
   describe "report → freeze" do

--- a/test/vutuv_web/live/admin/dashboard_live_test.exs
+++ b/test/vutuv_web/live/admin/dashboard_live_test.exs
@@ -23,6 +23,11 @@ defmodule VutuvWeb.Admin.DashboardLiveTest do
     for _ <- 1..count, do: insert(:post, inserted_at: today_start, updated_at: today_start)
   end
 
+  # `shell_session/2` (ConnCase) builds exactly the map a browser hands an
+  # off-router `live_render` child: a real session token under "session_token".
+  defp mount_dashboard(session),
+    do: live_isolated(build_conn(), VutuvWeb.Admin.DashboardLive, session: session)
+
   describe "embedded on the admin home page" do
     test "the admin home renders the live dashboard at the top", %{conn: conn} do
       {conn, _admin} = create_and_login_admin(conn)
@@ -34,11 +39,46 @@ defmodule VutuvWeb.Admin.DashboardLiveTest do
     end
   end
 
+  # `/admin` behind the :admin pipeline gates the page, not this child's socket —
+  # the standing rule for off-router `live_render` children. The mount resolves
+  # the viewer from the cookie's session token and sends everyone else away.
+  describe "the socket's own access control" do
+    test "an anonymous socket is turned away" do
+      insert(:user, email_confirmed?: true)
+
+      assert {:error, {:live_redirect, %{to: "/"}}} = mount_dashboard(%{})
+    end
+
+    test "a signed-in member who is not an admin is turned away" do
+      member = insert(:user, email_confirmed?: true)
+
+      assert {:error, {:live_redirect, %{to: "/"}}} = mount_dashboard(shell_session(member))
+    end
+
+    # A token that has been revoked server-side (the member logged this device
+    # out remotely) must not keep the socket alive either.
+    test "a revoked session is turned away" do
+      admin = insert(:user, admin?: true, email_confirmed?: true)
+      session = shell_session(admin)
+
+      session["session_token"]
+      |> Vutuv.Sessions.active_session()
+      |> Vutuv.Sessions.revoke()
+
+      assert {:error, {:live_redirect, %{to: "/"}}} = mount_dashboard(session)
+    end
+  end
+
   describe "the live dashboard" do
-    test "renders the activity tiles with formatted counts", %{conn: conn} do
+    setup do
+      admin = insert(:user, admin?: true, email_confirmed?: true)
+      %{admin: admin, session: shell_session(admin)}
+    end
+
+    test "renders the activity tiles with formatted counts", %{session: session} do
       seed_posts_today(2)
 
-      {:ok, view, _html} = live_isolated(conn, VutuvWeb.Admin.DashboardLive)
+      {:ok, view, _html} = mount_dashboard(session)
 
       assert has_element?(view, "#stat-online", "0")
       assert has_element?(view, "#stat-posts-today", "2")
@@ -46,8 +86,9 @@ defmodule VutuvWeb.Admin.DashboardLiveTest do
       assert render(view) =~ "New members"
     end
 
-    test "the currently-online count tracks presence live", %{conn: conn} do
-      {:ok, view, _html} = live_isolated(conn, VutuvWeb.Admin.DashboardLive)
+    test "the currently-online count tracks presence live", %{session: session} do
+      {:ok, view, _html} = mount_dashboard(session)
+
       assert has_element?(view, "#stat-online", "0")
 
       # Subscribe here too so we can wait for the join diff deterministically.
@@ -66,8 +107,9 @@ defmodule VutuvWeb.Admin.DashboardLiveTest do
       assert has_element?(view, "#stat-online", "1")
     end
 
-    test "the currently-online card links to each online member's profile", %{conn: conn} do
-      {:ok, view, _html} = live_isolated(conn, VutuvWeb.Admin.DashboardLive)
+    test "the currently-online card links to each online member's profile", %{session: session} do
+      {:ok, view, _html} = mount_dashboard(session)
+
       assert has_element?(view, "#online-members", "Nobody is online right now")
 
       Presence.subscribe_online()
@@ -82,18 +124,19 @@ defmodule VutuvWeb.Admin.DashboardLiveTest do
       assert has_element?(view, "#online-members a[href='/#{online.username}']")
     end
 
-    test "the new-members card links to the newest confirmed members", %{conn: conn} do
+    test "the new-members card links to the newest confirmed members", %{session: session} do
       member = insert(:user, email_confirmed?: true)
       unconfirmed = insert(:user, email_confirmed?: false)
 
-      {:ok, view, _html} = live_isolated(conn, VutuvWeb.Admin.DashboardLive)
+      {:ok, view, _html} = mount_dashboard(session)
 
       assert has_element?(view, "#newest-members a[href='/#{member.username}']")
       refute has_element?(view, "#newest-members a[href='/#{unconfirmed.username}']")
     end
 
-    test "a refresh picks up posts created after mount", %{conn: conn} do
-      {:ok, view, _html} = live_isolated(conn, VutuvWeb.Admin.DashboardLive)
+    test "a refresh picks up posts created after mount", %{session: session} do
+      {:ok, view, _html} = mount_dashboard(session)
+
       assert has_element?(view, "#stat-posts-today", "0")
 
       seed_posts_today(3)
@@ -107,7 +150,7 @@ defmodule VutuvWeb.Admin.DashboardLiveTest do
     # the card has to actually show it — and it has to show it over the right
     # denominator. A share computed against every member would count the silent
     # majority as an answer and quietly understate every group.
-    test "the gender card counts shares against the members who answered", %{conn: conn} do
+    test "the gender card counts shares against the members who answered", %{session: session} do
       insert_activated_user(gender: "female")
       insert_activated_user(gender: "female")
       insert_activated_user(gender: "male")
@@ -115,30 +158,36 @@ defmodule VutuvWeb.Admin.DashboardLiveTest do
       insert_activated_user(gender: nil)
       insert_activated_user(gender: nil)
 
-      {:ok, view, _html} = live_isolated(conn, VutuvWeb.Admin.DashboardLive)
+      {:ok, view, _html} = mount_dashboard(session)
 
       # 2 of the 4 answers, not 2 of the 6 members.
       assert has_element?(view, "#stat-gender [data-gender=female]", "50%")
       assert has_element?(view, "#stat-gender [data-gender=male]", "25%")
       assert has_element?(view, "#stat-gender [data-gender=diverse]", "25%")
       assert render(view) =~ "4 members who answered"
-      assert render(view) =~ "2 gave no answer"
+      # Three, not two: the admin this describe block signs in is a member of
+      # the installation like any other, and gave no answer either.
+      assert render(view) =~ "3 gave no answer"
     end
 
     # Nobody has answered yet: the shares must read as "no data" rather than as
     # a measured zero, and the card must not divide by zero.
-    test "the gender card survives a membership that has answered nothing", %{conn: conn} do
+    test "the gender card survives a membership that has answered nothing", %{session: session} do
       insert_activated_user(gender: nil)
 
-      {:ok, view, _html} = live_isolated(conn, VutuvWeb.Admin.DashboardLive)
+      {:ok, view, _html} = mount_dashboard(session)
 
       assert has_element?(view, "#stat-gender [data-gender=female]", "—")
       refute render(view) =~ "0%"
     end
 
-    test "renders the admin's German labels when the session carries the de locale", %{conn: conn} do
-      {:ok, view, _html} =
-        live_isolated(conn, VutuvWeb.Admin.DashboardLive, session: %{"locale" => "de"})
+    # The admin's own stored locale is what decides, not the request's — the
+    # socket resolves the viewer, so their setting beats whatever machine they
+    # happen to be reading on (#1502).
+    test "renders the admin's German labels when the admin's locale is de" do
+      admin = insert(:user, admin?: true, email_confirmed?: true, locale: "de")
+
+      {:ok, view, _html} = mount_dashboard(shell_session(admin))
 
       html = render(view)
       assert html =~ "Gerade online"


### PR DESCRIPTION
Six authorization gaps from the same scan as #1939.

Four are one shape: an embedded LiveView inheriting the host page's check. That
session map is signed but not encrypted and valid for days, so a replayed
payload at `/live/websocket` got the **admin dashboard** (member names, profile
links, the online set) and the **job-posting page** (drafts, withdrawn and
members-only postings), while the **organization team roster** accepted a
`set_roles` push — `Organizations.set_roles/4` has always taken an `actor` and
only ever recorded it as `granted_by`. Each now asks on the socket, and roles
ask at the chokepoint, so any future caller inherits it.

The other two are promises a second surface reopened. The job-search exclusion
list (#938) hides the status on the profile while `status:looking` still listed
the member; `/:slug/avatar.jpg` served suspended and deactivated members' faces
anonymously, though every other page of those accounts is a 404 or a 410.

Plus endorsements: `create_endorsement/1` knew only the honor rule, so a blocked
member could still vouch for the person who blocked them — and notify them.

**Decide:** the search change reverses a comment that called the exclusion
"honored on the profile and in the alert mail, not in this live operator". If
that was deliberate, revert that hunk.

Every check was reverted once to watch its test go red.

https://claude.ai/code/session_01HpEBfNDHjPRmJ1Joe2923o
