### PR TITLE
Two inboxes verified a signature over a body they never read

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -10556,7 +10556,14 @@ defmodule Vutuv.Fediverse do
          {:ssrf, false} <- {:ssrf, Vutuv.Ssrf.resolves_to_internal?(host)},
          {:ok, %Req.Response{status: 200, body: body}} <- ap_get(bare, signer),
          {:size, true} <- {:size, byte_size(body) <= @max_body_bytes},
-         {:ok, %{"id" => id, "inbox" => inbox} = doc} <- Jason.decode(body) do
+         {:ok, %{"id" => id, "inbox" => inbox} = doc} <- Jason.decode(body),
+         # The document is only allowed to name itself. Without this a server we
+         # fetched from could answer with `"id": "https://mastodon.social/users/x"`
+         # and every caller that stores or keys on that id — `upsert_remote_account/1`
+         # above all — would file a stranger's document under somebody else's
+         # identity. The inbox already applies this rule to `keyId`; the actor
+         # fetch is the same rule on the other side of the request.
+         {:bound, true} <- {:bound, same_host?(bare, id)} do
       {:ok,
        %{
          id: id,
@@ -10586,6 +10593,7 @@ defmodule Vutuv.Fediverse do
       {:parse, _} -> {:error, :https_only}
       {:ssrf, true} -> {:error, :internal_host}
       {:size, false} -> {:error, :too_large}
+      {:bound, false} -> {:error, :actor_host_mismatch}
       {:ok, %Req.Response{status: status}} -> {:error, {:http, status}}
       {:error, _} = error -> error
       other -> {:error, {:bad_actor, other}}

--- a/lib/vutuv/fediverse/http_signature.ex
+++ b/lib/vutuv/fediverse/http_signature.ex
@@ -58,7 +58,8 @@ defmodule Vutuv.Fediverse.HttpSignature do
   names lowercase) against the sender's public key PEM.
   """
   def valid?(%{method: method, path: path, headers: headers, body: body}, public_key_pem) do
-    with {:ok, params} <- parse(headers["signature"]),
+    with :ok <- check_body_captured(method, body),
+         {:ok, params} <- parse(headers["signature"]),
          :ok <- check_required(params.headers, body),
          :ok <- check_digest(headers["digest"], body),
          :ok <- check_date(headers["date"]),
@@ -102,6 +103,17 @@ defmodule Vutuv.Fediverse.HttpSignature do
       _ -> {:error, :no_key_id}
     end
   end
+
+  # A POST always carries a payload, so a `nil` body here does not mean "there
+  # was nothing to hash" — it means the raw bytes were never captured
+  # (`VutuvWeb.RawBodyReader` keeps them per route). Verifying anyway would drop
+  # `digest` from the required headers below and skip `check_digest/2` entirely,
+  # so the signature would vouch for the headers and **any** payload could ride
+  # them. Two of the four inbox routes were in exactly that state. Fails closed,
+  # so the next route added without a reader clause is refused rather than
+  # trusted. A GET (authorized fetch) legitimately has no body.
+  defp check_body_captured("post", nil), do: {:error, :body_not_captured}
+  defp check_body_captured(_method, _body), do: :ok
 
   # The signature must cover the target, the date (replay window) and, when
   # a body exists, its digest — otherwise a valid signature could be replayed

--- a/lib/vutuv/organizations/organization.ex
+++ b/lib/vutuv/organizations/organization.ex
@@ -160,7 +160,7 @@ defmodule Vutuv.Organizations.Organization do
     |> shared_validations()
   end
 
-  @doc "Owner edit: the wizard fields minus verification, plus description + toggles + logo."
+  @doc "Owner edit: the wizard fields minus verification, plus description + toggles."
   def edit_changeset(organization, attrs) do
     organization
     |> cast(attrs, [
@@ -174,8 +174,13 @@ defmodule Vutuv.Organizations.Organization do
       :state,
       :country,
       :seo?,
-      :geo?,
-      :logo
+      :geo?
+      # `:logo` is deliberately NOT castable. It holds the image token that
+      # `Vutuv.Organizations.store_logo/4` mints after a real upload, and
+      # `release_logo/1` / `remove_logo/1` clear — the same rule this project
+      # states for every programmatically-set field. No form posts it, and
+      # while it was in this list an ordinary edit could point a page's logo at
+      # any other page's stored image just by naming its token.
     ])
     |> validate_required([:name, :kind, :city, :country])
     |> validate_length(:description, max: 10_000)

--- a/lib/vutuv/ssrf.ex
+++ b/lib/vutuv/ssrf.ex
@@ -48,7 +48,7 @@ defmodule Vutuv.Ssrf do
 
       bare ->
         case :inet.parse_address(to_charlist(bare)) do
-          {:ok, addr} -> internal_ip?(addr)
+          {:ok, addr} -> unroutable_ip?(addr)
           _ -> false
         end
     end
@@ -71,7 +71,7 @@ defmodule Vutuv.Ssrf do
     cond do
       internal_host?(host) -> true
       literal_ip?(bare) -> false
-      true -> Enum.any?(resolved_addresses(bare), &internal_ip?/1)
+      true -> Enum.any?(resolved_addresses(bare), &unroutable_ip?/1)
     end
   end
 
@@ -110,7 +110,7 @@ defmodule Vutuv.Ssrf do
   defp vet_resolved([]), do: {:error, :unresolvable}
 
   defp vet_resolved([first | _] = addrs) do
-    if Enum.any?(addrs, &internal_ip?/1), do: {:error, :internal}, else: {:ok, first}
+    if Enum.any?(addrs, &unroutable_ip?/1), do: {:error, :internal}, else: {:ok, first}
   end
 
   defp parse_ip!(bare) do
@@ -136,7 +136,16 @@ defmodule Vutuv.Ssrf do
     end
   end
 
-  @doc false
+  @doc """
+  Whether `ip` belongs to a **private or loopback** network.
+
+  Deliberately narrower than `unroutable_ip?/1`, because this one is not only an
+  SSRF predicate: `Vutuv.Geo.private_or_loopback?/1` classifies a visitor's own
+  client address with it, and `Vutuv.Dns` uses it to drop nameservers. For those
+  a documentation or multicast address is not "private" — it is simply not a
+  client and not a nameserver. Widening this function once made `203.0.113.7`
+  read as a private client and `2001:db8::1` as an unusable nameserver.
+  """
   def internal_ip?({0, _, _, _}), do: true
   def internal_ip?({10, _, _, _}), do: true
   def internal_ip?({127, _, _, _}), do: true
@@ -150,8 +159,67 @@ defmodule Vutuv.Ssrf do
   def internal_ip?({0, 0, 0, 0, 0, 0xFFFF, a, b}),
     do: internal_ip?({div(a, 256), rem(a, 256), div(b, 256), rem(b, 256)})
 
+  # IPv4-compatible IPv6 (::a.b.c.d), deprecated but still parsed and still
+  # routed to the embedded v4 address by some stacks — so `::127.0.0.1` is a
+  # loopback address written the long way round, and belongs here rather than
+  # among the merely-reserved ranges below.
+  def internal_ip?({0, 0, 0, 0, 0, 0, a, b}) when {a, b} != {0, 0},
+    do: internal_ip?({div(a, 256), rem(a, 256), div(b, 256), rem(b, 256)})
+
   # Unique-local fc00::/7 and link-local fe80::/10.
   def internal_ip?({n, _, _, _, _, _, _, _}) when n in 0xFC00..0xFDFF, do: true
   def internal_ip?({n, _, _, _, _, _, _, _}) when n in 0xFE80..0xFEBF, do: true
+
+  # Deprecated site-local fec0::/10 (RFC 3879) — still accepted by resolvers.
+  def internal_ip?({n, _, _, _, _, _, _, _}) when n in 0xFEC0..0xFEFF, do: true
+
   def internal_ip?(_), do: false
+
+  @doc """
+  Whether `ip` is anything an outbound fetch may not be pointed at: private and
+  loopback (`internal_ip?/1`) **plus** the ranges that are not globally routable
+  unicast at all.
+
+  A deny list is only as good as what it names, and the private ranges alone
+  left seven doors open. Carrier-grade NAT is somebody's provider equipment; the
+  IETF and benchmarking ranges terminate on local kit; anything answering on a
+  documentation range is a stand-in for the host the member actually named; and
+  multicast and the reserved 240/4 block are not a host to fetch from in the
+  first place.
+
+  This is the predicate every SSRF decision uses. `internal_ip?/1` stays the
+  narrower "is this a private address" question its other callers ask.
+  """
+  def unroutable_ip?(ip), do: internal_ip?(ip) or reserved_ip?(ip)
+
+  # Carrier-grade NAT (RFC 6598).
+  defp reserved_ip?({100, b, _, _}) when b in 64..127, do: true
+
+  # IETF protocol assignments (RFC 6890), incl. the DS-Lite 192.0.0.0/29 range
+  # that terminates on the local router.
+  defp reserved_ip?({192, 0, 0, _}), do: true
+
+  # Benchmarking (RFC 2544): routed to a lab, never to the public internet.
+  defp reserved_ip?({198, b, _, _}) when b in 18..19, do: true
+
+  # The three IPv4 documentation ranges (RFC 5737).
+  defp reserved_ip?({192, 0, 2, _}), do: true
+  defp reserved_ip?({198, 51, 100, _}), do: true
+  defp reserved_ip?({203, 0, 113, _}), do: true
+
+  # Multicast (224/4) and reserved (240/4, which holds the 255.255.255.255
+  # broadcast address).
+  defp reserved_ip?({a, _, _, _}) when a in 224..255, do: true
+
+  # The embedded v4 address of both IPv6 mappings gets the same reading.
+  defp reserved_ip?({0, 0, 0, 0, 0, 0xFFFF, a, b}),
+    do: reserved_ip?({div(a, 256), rem(a, 256), div(b, 256), rem(b, 256)})
+
+  defp reserved_ip?({0, 0, 0, 0, 0, 0, a, b}) when {a, b} != {0, 0},
+    do: reserved_ip?({div(a, 256), rem(a, 256), div(b, 256), rem(b, 256)})
+
+  # IPv6 documentation range 2001:db8::/32 (RFC 3849).
+  defp reserved_ip?({0x2001, 0x0DB8, _, _, _, _, _, _}), do: true
+
+  defp reserved_ip?(_), do: false
 end

--- a/lib/vutuv/ssrf/socks_proxy.ex
+++ b/lib/vutuv/ssrf/socks_proxy.ex
@@ -44,7 +44,7 @@ defmodule Vutuv.Ssrf.SocksProxy do
   through untouched either way (no MITM).
 
   A CONNECT that names an IP **literal** (ATYP 1/4) is vetted against
-  `Vutuv.Ssrf.internal_ip?/1` directly — which the resolver-rule approach
+  `Vutuv.Ssrf.unroutable_ip?/1` directly — which the resolver-rule approach
   could not reliably cover, since a literal never consults the resolver. So
   `<img src="http://127.0.0.1:9100/...">` is refused here, by the same guard.
 
@@ -120,12 +120,12 @@ defmodule Vutuv.Ssrf.SocksProxy do
   @doc """
   The production vetting: a hostname goes through `Vutuv.Ssrf.vetted_address/1`
   (resolve once, refuse if any answer is internal, dial exactly the vetted IP);
-  an IP literal is checked against `Vutuv.Ssrf.internal_ip?/1` directly.
+  an IP literal is checked against `Vutuv.Ssrf.unroutable_ip?/1` directly.
   """
   def default_vet({:domain, host}), do: Ssrf.vetted_address(host)
 
   def default_vet({:ip, ip}) do
-    if Ssrf.internal_ip?(ip), do: {:error, :internal}, else: {:ok, ip}
+    if Ssrf.unroutable_ip?(ip), do: {:error, :internal}, else: {:ok, ip}
   end
 
   @impl true

--- a/lib/vutuv_web/raw_body_reader.ex
+++ b/lib/vutuv_web/raw_body_reader.ex
@@ -1,14 +1,24 @@
 defmodule VutuvWeb.RawBodyReader do
   @moduledoc """
   The endpoint's `Plug.Parsers` body reader: passes every body through
-  unchanged, but keeps a copy of the **raw bytes** for the two ActivityPub
-  inboxes (`POST /:slug/actor/inbox` and the installation-wide
-  `POST /system/inbox`, issue #1073) in `conn.private[:fediverse_raw_body]`.
+  unchanged, but keeps a copy of the **raw bytes** for the ActivityPub inboxes
+  in `conn.private[:fediverse_raw_body]`.
 
   HTTP-signature verification (`Vutuv.Fediverse.HttpSignature`) must hash the
   body exactly as sent — after `Plug.Parsers` has consumed it into
   `body_params`, the original bytes are otherwise gone. Only those paths pay
   the copy; every other request streams through untouched.
+
+  **All four inbox routes, not two.** This used to match `[_slug, "actor",
+  "inbox"]` and `["system", "inbox"]` only, so the organization inbox (four
+  segments, `router.ex`) and the tag inbox (two, on the `tags.` host) never got
+  their bytes kept. That is not a missing optimisation: with no body,
+  `HttpSignature.valid?/2` dropped `digest` from the headers it requires and
+  `check_digest/2` answered `:ok` for a `nil` body, so those two inboxes
+  verified a signature over the headers alone and accepted **any** payload
+  carrying them. `valid?/2` now refuses a POST whose body was not captured, so
+  a future route added without a clause here fails closed instead of silently
+  trusting its callers.
   """
 
   def read_body(conn, opts) do
@@ -25,12 +35,21 @@ defmodule VutuvWeb.RawBodyReader do
 
   def raw_body(_conn), do: nil
 
+  # A member's actor inbox.
   defp store(%Plug.Conn{path_info: [_slug, "actor", "inbox"]} = conn, chunk),
+    do: keep(conn, chunk)
+
+  # A page's actor inbox (issue #1334) — four segments, which is why the clause
+  # above never matched it.
+  defp store(%Plug.Conn{path_info: ["organizations", _slug, "actor", "inbox"]} = conn, chunk),
     do: keep(conn, chunk)
 
   # The installation-wide inbox (issue #1073) verifies the very same signature,
   # so it needs the very same copy of the bytes.
   defp store(%Plug.Conn{path_info: ["system", "inbox"]} = conn, chunk), do: keep(conn, chunk)
+
+  # A topic's inbox, routed on the `tags.` host as two segments.
+  defp store(%Plug.Conn{path_info: [_slug, "inbox"]} = conn, chunk), do: keep(conn, chunk)
 
   defp store(conn, _chunk), do: conn
 

--- a/test/vutuv/fediverse/http_signature_test.exs
+++ b/test/vutuv/fediverse/http_signature_test.exs
@@ -62,6 +62,28 @@ defmodule Vutuv.Fediverse.HttpSignatureTest do
                )
     end
 
+    # `nil` on a POST means the raw bytes were never captured, not that there was
+    # nothing to hash. Verifying anyway drops `digest` from the required header
+    # list and makes `check_digest/2` answer `:ok`, so the signature would vouch
+    # for the headers alone and any payload could ride them — which is what the
+    # organization and tag inboxes did until `VutuvWeb.RawBodyReader` learned
+    # their path shapes. It fails closed so the next route added without a
+    # reader clause is refused rather than trusted.
+    test "a POST whose body was never captured is refused", %{
+      priv: priv,
+      pub: pub,
+      key_id: key_id
+    } do
+      headers =
+        HttpSignature.signed_headers("post", "https://m.example/inbox", "payload", key_id, priv)
+
+      assert {:error, :body_not_captured} ==
+               HttpSignature.valid?(
+                 %{method: "post", path: "/inbox", headers: Map.new(headers), body: nil},
+                 pub
+               )
+    end
+
     test "a tampered body is rejected (digest mismatch)", %{priv: priv, pub: pub, key_id: key_id} do
       headers =
         HttpSignature.signed_headers("post", "https://m.example/inbox", "original", key_id, priv)

--- a/test/vutuv/fediverse_test.exs
+++ b/test/vutuv/fediverse_test.exs
@@ -440,12 +440,19 @@ defmodule Vutuv.FediverseTest do
       assert Repo.reload(user).moved_to == nil
     end
 
-    test "refuses to move to this same account" do
+    # The target document names our own actor URL as its id. That is a document
+    # on one host claiming an identity on another, so `fetch_remote_actor/2`'s
+    # host binding now refuses it before the `:self_target` guard is reached —
+    # the same refusal, from the more general rule. `:self_target` still answers
+    # a move whose target really is this account's own URL.
+    test "refuses a target whose document claims our own actor URL" do
       user = with_follower(federated_user())
-      # The fetched target's id IS our own actor URL.
       stub_target([Docs.actor_url(user)], Docs.actor_url(user))
 
-      assert {:error, :self_target} = Fediverse.move_out(user, @target)
+      assert {:error, reason} = Fediverse.move_out(user, @target)
+      assert reason in [:self_target, :target_unreachable]
+      assert Repo.aggregate(Delivery, :count) == 0
+      assert Repo.reload(user).moved_to == nil
     end
 
     test "rejects a non-https target without reaching the network" do
@@ -589,6 +596,33 @@ defmodule Vutuv.FediverseTest do
       assert remote.preferred_username == "alice"
       assert remote.name == "Alice Example"
       assert remote.public_key_pem =~ "BEGIN PUBLIC KEY"
+    end
+
+    # A document may only name itself. Without this, a server answers a fetch of
+    # its own actor with somebody else's `id` and every caller that keys on that
+    # id — `upsert_remote_account/1` first of all — files the stranger's inbox,
+    # public key and display name under the impersonated account.
+    test "refuses a document claiming an id on another host" do
+      stub_remote(fn conn ->
+        body =
+          Jason.encode!(%{
+            "id" => "https://mastodon.example/users/victim",
+            "type" => "Person",
+            "preferredUsername" => "victim",
+            "inbox" => "https://evil.example/users/mallory/inbox",
+            "publicKey" => %{
+              "id" => "https://mastodon.example/users/victim#main-key",
+              "publicKeyPem" => "-----BEGIN PUBLIC KEY-----..."
+            }
+          })
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/activity+json")
+        |> Plug.Conn.send_resp(200, body)
+      end)
+
+      assert {:error, :actor_host_mismatch} =
+               Fediverse.fetch_remote_actor("https://evil.example/users/mallory")
     end
 
     test "refuses plain-http and internal hosts" do

--- a/test/vutuv/organizations_management_test.exs
+++ b/test/vutuv/organizations_management_test.exs
@@ -356,6 +356,23 @@ defmodule Vutuv.OrganizationsManagementTest do
       assert Enum.any?(former, &(&1.name == "Acme GmbH" and &1.kind == "former"))
     end
 
+    # `logo` holds the image token `store_logo/4` mints after a real upload. No
+    # form posts it, and while it was castable an ordinary edit could point a
+    # page's logo at any other page's stored image just by naming its token.
+    test "the edit form cannot set or clear the logo token" do
+      {organization, _owner} = active_organization()
+      stored = organization |> Ecto.Changeset.change(logo: "own-token") |> Repo.update!()
+
+      {:ok, updated} =
+        Organizations.update_organization(stored, %{
+          "name" => "Acme Holding GmbH",
+          "logo" => "somebody-elses-token"
+        })
+
+      assert updated.name == "Acme Holding GmbH"
+      assert updated.logo == "own-token"
+    end
+
     test "an alias equal to another verified organization's name is flagged for the admin queue" do
       {organization_a, _} = active_organization()
 

--- a/test/vutuv/ssrf_test.exs
+++ b/test/vutuv/ssrf_test.exs
@@ -40,10 +40,61 @@ defmodule Vutuv.SsrfTest do
       assert Ssrf.internal_host?("[::ffff:10.0.0.5]")
     end
 
+    # The filter is a deny list, so every range it does not name is reachable.
+    # These eight were missing: an address that is not RFC 1918 can still be
+    # somebody's internal network (carrier-grade NAT), a lab, a local stand-in
+    # (the documentation ranges), or not a unicast host at all.
+    test "rejects the reserved ranges that are not RFC 1918" do
+      for host <- ~w(100.64.0.1 100.127.255.254 192.0.0.8 192.0.2.1 198.18.0.1
+                     198.51.100.1 203.0.113.1 224.0.0.1 239.255.255.250
+                     240.0.0.1 255.255.255.255) do
+        assert Ssrf.internal_host?(host), "expected #{host} to be internal"
+      end
+
+      assert Ssrf.internal_host?("[fec0::1]")
+      assert Ssrf.internal_host?("[2001:db8::1]")
+      # IPv4-compatible IPv6, the deprecated ::a.b.c.d form.
+      assert Ssrf.internal_host?("[::127.0.0.1]")
+      assert Ssrf.internal_host?("[::169.254.169.254]")
+    end
+
+    # The neighbours of each new range, so a guard's bounds are pinned rather
+    # than just its middle.
+    test "leaves the public addresses next to those ranges alone" do
+      for host <- ~w(100.63.255.255 100.128.0.1 192.0.1.1 192.0.3.1 198.17.255.255
+                     198.20.0.1 198.51.99.1 203.0.112.1 223.255.255.255) do
+        refute Ssrf.internal_host?(host), "expected #{host} to be public"
+      end
+    end
+
     test "accepts public hosts and public IP literals" do
       refute Ssrf.internal_host?("example.org")
       refute Ssrf.internal_host?("93.184.216.34")
       refute Ssrf.internal_host?("[2606:2800:220:1:248:1893:25c8:1946]")
+    end
+
+    # The two predicates answer different questions and must not be merged.
+    # `internal_ip?/1` is also `Vutuv.Geo.private_or_loopback?/1` (is this
+    # visitor's own address private?) and the filter `Vutuv.Dns` drops
+    # nameservers with. Folding the reserved ranges into it made 203.0.113.7
+    # read as a private client and 2001:db8::1 as an unusable nameserver.
+    test "reserved is not the same question as private" do
+      for ip <- [
+            {203, 0, 113, 7},
+            {100, 64, 0, 1},
+            {224, 0, 0, 1},
+            {0x2001, 0x0DB8, 0, 0, 0, 0, 0, 1}
+          ] do
+        refute Ssrf.internal_ip?(ip), "#{inspect(ip)} is reserved, not private"
+        assert Ssrf.unroutable_ip?(ip), "#{inspect(ip)} must still be refused an outbound fetch"
+      end
+
+      # Private addresses are both, and the loopback written the long way round
+      # is genuinely loopback rather than merely reserved.
+      for ip <- [{127, 0, 0, 1}, {10, 0, 0, 5}, {0, 0, 0, 0, 0, 0, 0x7F00, 1}] do
+        assert Ssrf.internal_ip?(ip)
+        assert Ssrf.unroutable_ip?(ip)
+      end
     end
 
     test "a nil / hostless URL is not a target" do

--- a/test/vutuv_web/open_graph_test.exs
+++ b/test/vutuv_web/open_graph_test.exs
@@ -334,9 +334,12 @@ defmodule VutuvWeb.OpenGraphTest do
 
       {:ok, organization} =
         Organizations.update_organization(organization, %{
-          "description" => "We build **great** widgets.\n\nSince 1994.",
-          "logo" => "logo-token"
+          "description" => "We build **great** widgets.\n\nSince 1994."
         })
+
+      # `logo` is not castable from the edit form — `Organizations.store_logo/4`
+      # owns that column — so set it the way the upload path does.
+      organization = organization |> Ecto.Changeset.change(logo: "logo-token") |> Repo.update!()
 
       html = conn |> get(~p"/organizations/#{organization.slug}") |> html_response(200)
 
@@ -462,7 +465,8 @@ defmodule VutuvWeb.OpenGraphTest do
     test "a page's post previews like a member's: teaser, date and the page's logo",
          %{conn: conn} do
       {organization, owner} = active_organization(%{"name" => "Acme GmbH"})
-      {:ok, organization} = Organizations.update_organization(organization, %{"logo" => "tok"})
+      # `logo` is not castable from the edit form; the upload path owns it.
+      organization = organization |> Ecto.Changeset.change(logo: "tok") |> Repo.update!()
       {:ok, _role} = Organizations.add_role(organization, owner, "publisher", owner)
 
       {:ok, post} =

--- a/test/vutuv_web/raw_body_reader_test.exs
+++ b/test/vutuv_web/raw_body_reader_test.exs
@@ -1,0 +1,55 @@
+defmodule VutuvWeb.RawBodyReaderTest do
+  @moduledoc """
+  Which requests keep a copy of their raw body, and why it has to be every inbox.
+
+  `Vutuv.Fediverse.HttpSignature.valid?/2` hashes the bytes as sent. Without
+  them it used to drop `digest` from the headers it demands and let
+  `check_digest/2` answer `:ok`, so an inbox with no captured body verified a
+  signature over the headers alone and accepted any payload carrying them. The
+  organization inbox (four path segments) and the tag inbox (two, on the `tags.`
+  host) were in exactly that state, because the reader matched only the
+  three-segment member inbox and `system/inbox`.
+
+  This file pins the path shapes. The fail-closed half — that a POST with no
+  captured body is refused outright — lives in
+  `test/vutuv/fediverse/http_signature_test.exs`.
+  """
+  use ExUnit.Case, async: true
+
+  import Plug.Test, only: [conn: 3]
+
+  alias VutuvWeb.RawBodyReader
+
+  @body ~s({"type":"Follow"})
+
+  defp kept_body(path) do
+    {:ok, @body, conn} = RawBodyReader.read_body(conn(:post, path, @body), [])
+    RawBodyReader.raw_body(conn)
+  end
+
+  describe "every inbox route keeps its bytes" do
+    test "a member's actor inbox" do
+      assert kept_body("/alice/actor/inbox") == @body
+    end
+
+    test "a page's actor inbox" do
+      assert kept_body("/organizations/acme/actor/inbox") == @body
+    end
+
+    test "the installation-wide inbox" do
+      assert kept_body("/system/inbox") == @body
+    end
+
+    test "a topic's inbox, two segments on the tags host" do
+      assert kept_body("/elixir/inbox") == @body
+    end
+  end
+
+  describe "everything else streams through untouched" do
+    test "an ordinary path pays no copy" do
+      for path <- ["/feed", "/alice", "/alice/actor", "/organizations/acme", "/system"] do
+        assert kept_body(path) == nil, "#{path} should not keep a raw body copy"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Four fediverse and SSRF findings from the same scan as #1939 and #1943.

The raw request body was kept for only two of the four inbox routes, because
the clauses matched path shapes: a page's inbox has four segments, a topic's
two. With no body, `HttpSignature.valid?/2` dropped `digest` from the headers it
requires and `check_digest/2` answered `:ok` — so those two inboxes verified a
signature over the headers alone and **any** payload could ride them. Both
clauses are added, and a POST with no captured body is now refused outright, so
the next route added without one fails closed.

Also: an actor document could claim an id on another host, letting any server
file its inbox, key and display name under somebody else's account; the SSRF
deny list knew only RFC 1918, so CGNAT, the documentation and benchmarking
ranges, multicast and 240/4 were all reachable; and a page's edit form cast
`:logo`, the token only `store_logo/4` should mint.

The deny-list split is the part to look at: `internal_ip?/1` also answers "is
this visitor's own address private" for `Vutuv.Geo` and filters nameservers in
`Vutuv.Dns`. Reserved is not private there — the first version made 203.0.113.7
a private client and 2001:db8::1 an unusable nameserver. The extra ranges hang
off `unroutable_ip?/1` instead.

**Not in here:** the four check-then-use SSRF sites (#F16/F21/F22/F31) need the
fetch pinned to the vetted IP. Every test stubs Req with `plug:`, so the suite
cannot see a transport change — the shape of the 18-day fetch outage. That one
wants a real-network smoke test first.

https://claude.ai/code/session_01HpEBfNDHjPRmJ1Joe2923o
