### PR TITLE
A stranger's URL took a whole profile down, a member's own rule took the feed

### DIFF
--- a/lib/vutuv/changeset_helpers.ex
+++ b/lib/vutuv/changeset_helpers.ex
@@ -115,6 +115,59 @@ defmodule Vutuv.ChangesetHelpers do
     end)
   end
 
+  @doc """
+  Drops any of `fields` whose change is not an ordinary `http(s)` web address.
+
+  The sibling of `scrub_nul/1`, and for the same reason: these columns hold URLs
+  copied out of another server's JSON, and they end up in an `href`. A value
+  like `javascript:1` does not merely render oddly — `Phoenix.Component.link/1`
+  calls `valid_destination!/2`, which **raises** on a scheme it does not know,
+  so one hostile URL takes down every render of the page that shows it. The
+  member whose feed it is has no way to remove it, and the socket dies on each
+  reconnect until the cache entry expires.
+
+  Dropped, not refused. These are optional display fields, and the rule the
+  quote-URI cap already states holds here too: one bad optional field must not
+  take an otherwise good post out of every feed. What is lost is a link; what a
+  refusal would lose is the post.
+
+  Run after the last `cast/3`, like `scrub_nul/1`, so what is validated is what
+  would be stored.
+  """
+  def drop_non_web_urls(%Ecto.Changeset{} = changeset, fields) do
+    Enum.reduce(fields, changeset, &drop_unless_web_url/2)
+  end
+
+  defp drop_unless_web_url(field, changeset) do
+    case fetch_change(changeset, field) do
+      {:ok, value} when is_binary(value) -> keep_or_drop(changeset, field, value)
+      _ -> changeset
+    end
+  end
+
+  defp keep_or_drop(changeset, field, value) do
+    if web_url?(value), do: changeset, else: put_change(changeset, field, nil)
+  end
+
+  @doc """
+  Whether `value` is an ordinary web address: `http`/`https` and a real host.
+
+  The one definition of "safe to put in an `href`" for a string that came from
+  somewhere else. Everything `Phoenix.Component.link/1` would raise on — and
+  everything a browser would treat as a script or a local file — answers false.
+  """
+  def web_url?(value) when is_binary(value) do
+    case URI.parse(value) do
+      %URI{scheme: scheme, host: host} when scheme in ["http", "https"] and is_binary(host) ->
+        host != ""
+
+      _ ->
+        false
+    end
+  end
+
+  def web_url?(_value), do: false
+
   def normalize_name(string) do
     string
     |> String.normalize(:nfd)

--- a/lib/vutuv/content_filters.ex
+++ b/lib/vutuv/content_filters.ex
@@ -28,6 +28,9 @@ defmodule Vutuv.ContentFilters do
   # bored user) can't turn every feed page into a compile of hundreds of regexes.
   @max_filters 200
 
+  # See `max_wildcards/0` for why three.
+  @max_wildcards 3
+
   @doc "The maximum number of filters one member may keep."
   def max_filters, do: @max_filters
 
@@ -265,9 +268,38 @@ defmodule Vutuv.ContentFilters do
   # escaped, so no user input reaches the regex engine as syntax. With
   # `whole_word` the match is bounded by word boundaries, except on a side the
   # pattern opens with a `*` (that side is deliberately affix/substring).
-  # Returns `nil` if the pattern cannot compile (defensive; the changeset
-  # already caps the length).
+  # Returns `nil` if the pattern cannot compile, or if it names more wildcards
+  # than `max_wildcards/0` allows.
   defp compile_pattern(pattern, whole_word) do
+    if too_many_wildcards?(pattern) do
+      nil
+    else
+      compile_bounded_pattern(pattern, whole_word)
+    end
+  end
+
+  @doc """
+  The most `*` segments one rule may name.
+
+  Escaping the literal parts keeps the member's text out of the regex syntax,
+  but `*` is syntax by design and each one becomes a `.*`. The length cap alone
+  left room for about fifty of them, and `a.*a.*a.*…` against a long post that
+  does not match is the textbook exponential backtrack — run over every post in
+  the feed, and over every keystroke of the live preview, by a rule the member
+  writes for themselves.
+
+  Three covers what the feature is for: a prefix, a suffix, and one hole in the
+  middle (`*@social.heise.de`, `Arbeits*zeugnis*`).
+  """
+  def max_wildcards, do: @max_wildcards
+
+  @doc "Whether `pattern` names more `*` segments than `max_wildcards/0`."
+  def too_many_wildcards?(pattern) when is_binary(pattern),
+    do: length(String.split(pattern, "*")) - 1 > @max_wildcards
+
+  def too_many_wildcards?(_pattern), do: false
+
+  defp compile_bounded_pattern(pattern, whole_word) do
     body =
       pattern
       |> String.split("*")

--- a/lib/vutuv/content_filters/content_filter.ex
+++ b/lib/vutuv/content_filters/content_filter.ex
@@ -30,6 +30,8 @@ defmodule Vutuv.ContentFilters.ContentFilter do
 
   use VutuvWeb, :model
 
+  alias Vutuv.ContentFilters
+
   @kinds [:tag, :keyword]
 
   # A muted tag slug is short; a muted phrase can be a few words. Capped so a
@@ -92,6 +94,14 @@ defmodule Vutuv.ContentFilters.ContentFilter do
     |> validate_format(:pattern, ~r/[^\s*]/,
       message: "must contain something to match, not only wildcards"
     )
+    # Each `*` becomes a `.*`, and the length cap alone left room for about
+    # fifty of them — `a.*a.*a.*…` against a post that does not match is the
+    # textbook exponential backtrack, run over every post in the feed and on
+    # every keystroke of the live preview. `Vutuv.ContentFilters.compile_pattern/2`
+    # refuses to build such a regex at all; this is so the member is told rather
+    # than left with a rule that quietly matches nothing.
+    |> validate_wildcards(:pattern)
+    |> validate_wildcards(:account)
     # The account half has no such rule — `*` is exactly the wildcard-only value
     # it is supposed to carry — but it does share the column's ceiling.
     |> validate_length(:account, min: 1, max: @max_pattern)
@@ -104,6 +114,19 @@ defmodule Vutuv.ContentFilters.ContentFilter do
       name: :content_filters_user_id_kind_pattern_index,
       message: "you already mute this"
     )
+  end
+
+  defp validate_wildcards(changeset, field) do
+    validate_change(changeset, field, fn ^field, value ->
+      if ContentFilters.too_many_wildcards?(value) do
+        [
+          {field,
+           {"may use at most %{max} wildcards (*).", [max: ContentFilters.max_wildcards()]}}
+        ]
+      else
+        []
+      end
+    end)
   end
 
   # Trim and collapse inner whitespace so "  machine   learning " and

--- a/lib/vutuv/fediverse/note.ex
+++ b/lib/vutuv/fediverse/note.ex
@@ -30,7 +30,7 @@ defmodule Vutuv.Fediverse.Note do
 
   use VutuvWeb, :model
 
-  import Vutuv.ChangesetHelpers, only: [scrub_nul: 1]
+  import Vutuv.ChangesetHelpers, only: [drop_non_web_urls: 2, scrub_nul: 1]
 
   alias Vutuv.Fediverse.Handle
   alias Vutuv.Translations
@@ -178,6 +178,11 @@ defmodule Vutuv.Fediverse.Note do
     ])
     # Remote strings, and a NUL in one raises on insert (issue #1767).
     |> scrub_nul()
+    # The URLs that become an `href`: `Phoenix.Component.link/1` raises on a
+    # scheme it does not know, so one hostile value would take down every render
+    # that shows this row. Dropped rather than refused — see
+    # `Vutuv.ChangesetHelpers.drop_non_web_urls/2`.
+    |> drop_non_web_urls([:origin_url])
     |> validate_required([
       :object_uri,
       :actor_uri,

--- a/lib/vutuv/fediverse/remote_account.ex
+++ b/lib/vutuv/fediverse/remote_account.ex
@@ -22,7 +22,7 @@ defmodule Vutuv.Fediverse.RemoteAccount do
 
   use VutuvWeb, :model
 
-  import Vutuv.ChangesetHelpers, only: [scrub_nul: 1]
+  import Vutuv.ChangesetHelpers, only: [drop_non_web_urls: 2, scrub_nul: 1]
 
   alias Vutuv.Fediverse.Handle
 
@@ -88,6 +88,11 @@ defmodule Vutuv.Fediverse.RemoteAccount do
     ])
     # Remote strings, and a NUL in one raises on insert (issue #1767).
     |> scrub_nul()
+    # The URLs that become an `href`: `Phoenix.Component.link/1` raises on a
+    # scheme it does not know, so one hostile value would take down every render
+    # that shows this row. Dropped rather than refused — see
+    # `Vutuv.ChangesetHelpers.drop_non_web_urls/2`.
+    |> drop_non_web_urls([:actor_uri, :moved_to])
     |> validate_required([:actor_uri, :host, :inbox_uri])
     |> validate_length(:actor_uri, max: @max_uri, count: :bytes)
     |> validate_length(:inbox_uri, max: @max_uri, count: :bytes)

--- a/lib/vutuv/fediverse/remote_post.ex
+++ b/lib/vutuv/fediverse/remote_post.ex
@@ -35,7 +35,7 @@ defmodule Vutuv.Fediverse.RemotePost do
 
   use VutuvWeb, :model
 
-  import Vutuv.ChangesetHelpers, only: [scrub_nul: 1]
+  import Vutuv.ChangesetHelpers, only: [drop_non_web_urls: 2, scrub_nul: 1]
 
   alias Vutuv.Translations
 
@@ -314,6 +314,12 @@ defmodule Vutuv.Fediverse.RemotePost do
     # After both casts, before the validations: remote strings, and a NUL in one
     # raises on insert (issue #1767).
     |> scrub_nul()
+    # The URLs a card turns into an `href`. A remote server may put anything
+    # here, and `Phoenix.Component.link/1` RAISES on a scheme it does not know,
+    # so one `javascript:` value would take down every render of the feed that
+    # shows this post. Dropped rather than refused: losing a link beats losing
+    # the post.
+    |> drop_non_web_urls([:origin_url, :quote_uri])
     # And so it cannot be `validate_required` either (which reads "" as missing
     # too). The column stays NOT NULL, and both write paths in `Vutuv.Fediverse`
     # compute the body through one `is_binary` gate, so it is never nil.

--- a/lib/vutuv/mastodon.ex
+++ b/lib/vutuv/mastodon.ex
@@ -20,6 +20,7 @@ defmodule Vutuv.Mastodon do
 
   require Logger
 
+  alias Vutuv.ChangesetHelpers
   alias Vutuv.Fediverse.Handle
   alias Vutuv.RemoteHtml
   alias Vutuv.SocialFeed.Feed
@@ -114,10 +115,18 @@ defmodule Vutuv.Mastodon do
     %{
       id: to_string(account["id"]),
       name: name,
-      url: Post.presence(account["url"]) || "https://#{instance}/@#{user}",
+      # The account page we link to. A remote server may answer with anything;
+      # `Phoenix.Component.link/1` raises on a scheme it does not know, so an
+      # unusable value falls back to the address we already know rather than
+      # taking the profile's render down.
+      url: account_url(account["url"]) || "https://#{instance}/@#{user}",
       avatar_url: Post.presence(account["avatar_static"]) || Post.presence(account["avatar"]),
       followers: Feed.follower_count(account["followers_count"])
     }
+  end
+
+  defp account_url(value) do
+    if ChangesetHelpers.web_url?(value), do: value
   end
 
   defp fetch_statuses(instance, id) do
@@ -149,12 +158,14 @@ defmodule Vutuv.Mastodon do
     |> Enum.take(@posts_shown)
   end
 
+  # A status with no usable permalink is dropped rather than rendered: the card
+  # is a link to the original, so there is nothing to show without one.
   defp to_post(status) do
     text = post_text(status)
     url = status["url"]
     created = status["created_at"]
 
-    with true <- is_binary(url) and url != "" and text != "" and is_binary(created),
+    with true <- ChangesetHelpers.web_url?(url) and text != "" and is_binary(created),
          false <- is_nil(status["id"]),
          {:ok, created_at, _offset} <- DateTime.from_iso8601(created) do
       %Post{id: to_string(status["id"]), url: url, text: text, created_at: created_at}

--- a/test/vutuv/content_filter_wildcards_test.exs
+++ b/test/vutuv/content_filter_wildcards_test.exs
@@ -1,0 +1,98 @@
+defmodule Vutuv.ContentFilterWildcardsTest do
+  @moduledoc """
+  How many `*` one mute rule may name, and why the number is small.
+
+  Each `*` becomes a `.*`, and the 100-character cap alone left room for about
+  fifty of them. In the whole-word shape — which every **tag** rule uses
+  (`compile_pattern(normalized, true)`) — the `\\b` at each end takes away
+  PCRE's required-literal shortcut, and `\\ba.*a.*a…a\\b` against a long run of
+  the same letter backtracks hard. Measured on a 3,000-character subject that
+  does **not** match: 5 wildcards cost 767 reductions, 15 cost 13,042, and 30
+  cost 1,875,753 — and that is per post in the feed, and again on every
+  keystroke of the filter band's live preview.
+
+  So the rule never becomes a regex at all past the cap, and the changeset says
+  so rather than leaving the member a rule that quietly matches nothing.
+  """
+  use Vutuv.DataCase, async: true
+
+  import Vutuv.WorkCounter
+
+  alias Vutuv.ContentFilters
+  alias Vutuv.ContentFilters.ContentFilter
+  alias Vutuv.Posts.Post
+
+  defp tag_rule(pattern) do
+    %ContentFilter{kind: :tag, pattern: pattern, whole_word: true}
+  end
+
+  defp keyword_rule(pattern) do
+    %ContentFilter{kind: :keyword, pattern: pattern, whole_word: true, account: "*"}
+  end
+
+  describe "the cap" do
+    test "a rule inside it compiles" do
+      assert %{tags: [_]} = ContentFilters.compile([tag_rule("Arbeits*zeugnis*")])
+    end
+
+    test "a rule past it never becomes a regex" do
+      hostile = String.duplicate("a*", 30) <> "a"
+
+      assert %{tags: [], keywords: []} = ContentFilters.compile([tag_rule(hostile)])
+    end
+
+    # The bound that matters, measured on the path the feed really walks:
+    # 1,667,110 reductions per post with the rule compiled, a few hundred with
+    # it refused. An order of magnitude of headroom either way.
+    test "a hostile rule costs the feed nothing per post" do
+      hostile = String.duplicate("a*", 30) <> "a"
+      # A whole-word KEYWORD rule, because that is the one matched against the
+      # post's body — a tag rule only ever sees the tag names, so it would not
+      # run this regex over 3,000 characters and the bound would prove nothing.
+      compiled = ContentFilters.compile([keyword_rule(hostile)])
+      post = %Post{body: String.duplicate("a", 3_000) <> " ", tags: []}
+
+      {work, result} = count_reductions(fn -> ContentFilters.filtered(post, compiled) end)
+
+      assert result == nil
+      assert work < 100_000
+    end
+  end
+
+  describe "the changeset" do
+    test "refuses a pattern past the cap, naming the limit" do
+      changeset =
+        ContentFilter.changeset(%ContentFilter{}, %{
+          "kind" => "keyword",
+          "pattern" => String.duplicate("a*", 30) <> "a"
+        })
+
+      refute changeset.valid?
+      assert %{pattern: [message]} = errors_on(changeset)
+      assert message =~ "at most"
+    end
+
+    test "refuses an account scope past the cap too" do
+      changeset =
+        ContentFilter.changeset(%ContentFilter{}, %{
+          "kind" => "keyword",
+          "pattern" => "crypto",
+          "account" => String.duplicate("a*", 30) <> "a"
+        })
+
+      refute changeset.valid?
+      assert %{account: [_]} = errors_on(changeset)
+    end
+
+    test "leaves an ordinary rule alone" do
+      changeset =
+        ContentFilter.changeset(%ContentFilter{}, %{
+          "kind" => "keyword",
+          "pattern" => "Arbeits*zeugnis",
+          "account" => "*@social.heise.de"
+        })
+
+      assert changeset.valid?
+    end
+  end
+end

--- a/test/vutuv/remote_url_scrub_test.exs
+++ b/test/vutuv/remote_url_scrub_test.exs
@@ -1,0 +1,100 @@
+defmodule Vutuv.RemoteUrlScrubTest do
+  @moduledoc """
+  A URL copied out of another server's JSON must never reach an `href` unchecked.
+
+  `Phoenix.Component.link/1` calls `valid_destination!/2`, which **raises** for a
+  scheme it does not know — it does not sanitize. So a remote post carrying
+  `"url": "javascript:1"` does not render oddly, it takes down every render of
+  the page that shows it: the socket dies, the client retries, and the member
+  whose feed it is has no way to remove the post.
+
+  `Vutuv.ChangesetHelpers.drop_non_web_urls/2` drops such a value at the write
+  instead, the way `scrub_nul/1` drops a NUL byte. Dropped, never refused: these
+  are optional display fields, and losing a link beats losing the post.
+  """
+  use Vutuv.DataCase, async: true
+
+  alias Vutuv.ChangesetHelpers
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+
+  describe "web_url?/1" do
+    test "accepts an ordinary web address" do
+      assert ChangesetHelpers.web_url?("https://social.example/@alice/1")
+      assert ChangesetHelpers.web_url?("http://social.example/1")
+    end
+
+    # Every one of these raises inside `link/1` rather than being escaped.
+    test "refuses everything that is not one" do
+      refute ChangesetHelpers.web_url?("javascript:alert(1)")
+      refute ChangesetHelpers.web_url?("data:text/html,<script>alert(1)</script>")
+      refute ChangesetHelpers.web_url?("file:///etc/passwd")
+      refute ChangesetHelpers.web_url?("foo:bar")
+      # A scheme-less or hostless string is not a destination either.
+      refute ChangesetHelpers.web_url?("/just/a/path")
+      refute ChangesetHelpers.web_url?("https://")
+      refute ChangesetHelpers.web_url?("")
+      refute ChangesetHelpers.web_url?(nil)
+    end
+  end
+
+  describe "a remote post" do
+    defp post_attrs(overrides) do
+      Map.merge(
+        %{
+          object_uri: "https://social.example/notes/#{System.unique_integer([:positive])}",
+          content_text: "Sehr treffend.",
+          audience: "public",
+          kind: "note",
+          published_at: DateTime.utc_now(:second),
+          received_at: DateTime.utc_now(:second),
+          expires_at: DateTime.add(DateTime.utc_now(:second), 86_400)
+        },
+        overrides
+      )
+    end
+
+    test "keeps an ordinary permalink" do
+      url = "https://social.example/@alice/1"
+      changeset = RemotePost.changeset(%RemotePost{}, post_attrs(%{origin_url: url}))
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :origin_url) == url
+    end
+
+    test "drops a hostile permalink but keeps the post" do
+      changeset =
+        RemotePost.changeset(%RemotePost{}, post_attrs(%{origin_url: "javascript:1"}))
+
+      assert changeset.valid?, "the post must survive its own bad link"
+      assert Ecto.Changeset.get_field(changeset, :origin_url) == nil
+      assert Ecto.Changeset.get_field(changeset, :content_text) == "Sehr treffend."
+    end
+
+    test "drops a hostile quote URI" do
+      changeset =
+        RemotePost.changeset(%RemotePost{}, post_attrs(%{quote_uri: "data:text/html,x"}))
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :quote_uri) == nil
+    end
+  end
+
+  describe "a remote account" do
+    test "drops a hostile actor URI and a hostile forwarding address" do
+      changeset =
+        RemoteAccount.changeset(%RemoteAccount{}, %{
+          actor_uri: "javascript:1",
+          host: "evil.example",
+          handle: "@mallory@evil.example",
+          inbox_uri: "https://evil.example/inbox",
+          moved_to: "file:///etc/passwd"
+        })
+
+      assert Ecto.Changeset.get_field(changeset, :actor_uri) == nil
+      assert Ecto.Changeset.get_field(changeset, :moved_to) == nil
+      # The inbox is not an href — it is where we POST — so it is left alone.
+      assert Ecto.Changeset.get_field(changeset, :inbox_uri) == "https://evil.example/inbox"
+    end
+  end
+end


### PR DESCRIPTION
Two ways somebody else decides what a page here costs, or whether it renders at
all. Same scan as #1939, #1943 and #1945.

**From outside.** The URLs a card turns into an `href` are copied out of another
server's JSON, and `Phoenix.Component.link/1` does not sanitize an unknown
scheme — it **raises**. So a cached post carrying `"url": "javascript:1"` was
not a display glitch but the crash of every render of the page showing it: the
socket died, the client retried, and the member whose feed it is had no way to
remove it. `ChangesetHelpers.drop_non_web_urls/2` drops such values at the
write, the sibling of `scrub_nul/1`. Dropped, not refused — a link is
expendable, the post is not.

**From inside.** Each `*` in a mute rule becomes a `.*`, and the 100-character
cap left room for about fifty. In the whole-word shape, which every tag rule
uses, the `\b` at each end takes away PCRE's required-literal shortcut:
`\ba.*a.*a…a\b` against a 3,000-character post measured **1,667,110 reductions**
— per post in the feed, and again on every keystroke of the live preview. Three
wildcards cover what the feature is for.

The measurement is the substance here. The obvious shape (`a.*a.*z` against text
with no `z`) costs a flat 685 reductions, because PCRE sees the missing required
byte first; only the whole-word variant blows up. And the first work-bound test I
wrote measured a *tag* rule, which never touches the body — it would have stayed
green either way.

https://claude.ai/code/session_01HpEBfNDHjPRmJ1Joe2923o
