### PR TITLE
The desk gave away who sits at it

### DIFF
--- a/lib/vutuv/pages.ex
+++ b/lib/vutuv/pages.ex
@@ -99,5 +99,12 @@ defmodule Vutuv.Pages do
     end
   end
 
-  defp sanitize_page(page), do: max(page, 1)
+  defp sanitize_page(page) when is_integer(page), do: max(page, 1)
+
+  # Anything else is page 1. `?page[]=1` hands this a **list**, and `max/2` does
+  # not raise on one — Elixir's term ordering puts a list above an integer, so
+  # `max(["1"], 1)` answered `["1"]` and the `(page - 1)` in `effective_page/3`
+  # then raised `ArithmeticError`: a 500 on a public listing from a query string
+  # anybody can type.
+  defp sanitize_page(_page), do: 1
 end

--- a/lib/vutuv_web/controllers/sitemap_controller.ex
+++ b/lib/vutuv_web/controllers/sitemap_controller.ex
@@ -51,8 +51,14 @@ defmodule VutuvWeb.SitemapController do
   # its list from `Sitemap.chunk_counts/0`) and this action answered it 404.
   # One list decides what exists.
   def show(conn, %{"name" => name}) do
+    # The chunk is bounded in the pattern, not only by the empty list below. The
+    # comment about "windowing off the end" holds while the number fits a
+    # bigint; past 2^63 Postgres never sees a query at all — Postgrex raises
+    # `DBConnection.EncodeError` on the OFFSET parameter, so an unbounded run of
+    # digits in the URL was a 500 rather than the 404 this action promises. Seven
+    # digits is far more chunks than any installation will ever have.
     with %{"type" => type, "chunk" => chunk} <-
-           Regex.named_captures(~r/^(?<type>[a-z_]+)-(?<chunk>[1-9]\d*)\.xml$/, name),
+           Regex.named_captures(~r/^(?<type>[a-z_]+)-(?<chunk>[1-9]\d{0,6})\.xml$/, name),
          {:ok, entries_fun} <- Map.fetch(@entry_funs, type),
          [_ | _] = entries <- entries_fun.(String.to_integer(chunk)) do
       send_xml(conn, urlset(entries))

--- a/lib/vutuv_web/live/message_live/index.ex
+++ b/lib/vutuv_web/live/message_live/index.ex
@@ -47,7 +47,6 @@ defmodule VutuvWeb.MessageLive.Index do
      socket
      |> assign_viewer()
      |> assign(:page_title, gettext("Messages"))
-     |> assign(:user_name, display_name(user))
      |> assign(:typing_tokens, %{})
      |> assign(:online_ids, Presence.online_ids())
      |> assign(:conversation, nil)
@@ -65,8 +64,19 @@ defmodule VutuvWeb.MessageLive.Index do
   # else reads their own. `:acting_as` is resolved by `Live.InitAssigns` from
   # the roles on every mount, never trusted out of the session, so a stale
   # session naming a page the member no longer speaks for lands on themselves.
-  defp assign_viewer(socket),
-    do: assign(socket, :viewer, socket.assigns[:acting_as] || socket.assigns.current_user)
+  # `:user_name` is derived here rather than in `mount/3`, and from the VIEWER
+  # rather than from `current_user`: it is the name the typing indicator
+  # broadcasts to the other side, and every message a publisher sends is signed
+  # with the page. Taking it from `current_user` told the other side the human's
+  # real name the moment somebody started typing — the one place the page's desk
+  # leaked the person sitting at it.
+  defp assign_viewer(socket) do
+    viewer = socket.assigns[:acting_as] || socket.assigns.current_user
+
+    socket
+    |> assign(:viewer, viewer)
+    |> assign(:user_name, display_name(viewer))
+  end
 
   # The sidebar lists load only on the connected mount (the page is
   # login-required, so the static render is replaced a moment later — no

--- a/test/vutuv_web/live/message_live_test.exs
+++ b/test/vutuv_web/live/message_live_test.exs
@@ -2,8 +2,11 @@ defmodule VutuvWeb.MessageLiveTest do
   use VutuvWeb.ConnCase
 
   import Phoenix.LiveViewTest
+  import Vutuv.OrganizationsHelpers
 
   alias Vutuv.Chat
+  alias Vutuv.Identity
+  alias Vutuv.Organizations
 
   # A second browser session for another member.
   defp login_other_user(name \\ "Other") do
@@ -679,6 +682,55 @@ defmodule VutuvWeb.MessageLiveTest do
       _ = :sys.get_state(view.pid)
 
       assert has_element?(view, "#other-online")
+    end
+  end
+
+  # Its own describe: the organization helpers need a global flag, which this
+  # sync module may set but which should not be held for the whole file.
+  describe "speaking for a page" do
+    setup do
+      Application.put_env(:vutuv, :verify_organization_domains, true)
+
+      on_exit(fn ->
+        Application.put_env(:vutuv, :verify_organization_domains, false)
+        Application.delete_env(:vutuv, :organizations_dns_resolver)
+      end)
+
+      :ok
+    end
+
+    # Every message a publisher sends is signed with the page, and the whole
+    # point of speaking for a page is that the desk answers rather than the
+    # person at it. The typing indicator took its name from `current_user`, so
+    # the moment they started typing the other side was told who they really are.
+    test "a publisher typing for a page shows the page's name, not their own", %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+      # Both logins first: `sent_pin/0` reads the most recent email, and the
+      # role-grant notification below would otherwise be sitting on top of it.
+      {other_conn, other} = login_other_user()
+
+      page = active_organization_for(owner, %{"name" => "Acme GmbH"})
+      {:ok, _role} = Organizations.add_role(page, owner, "publisher", owner)
+
+      conn =
+        conn
+        |> post(~p"/organizations/#{page.slug}/act_as")
+        |> recycle()
+        |> Map.put(:secret_key_base, conn.secret_key_base)
+
+      # `login_other_user/0` hands back the struct `register_user/2` returned,
+      # which is still unconfirmed; the PIN login confirmed the row, not the copy.
+      {:ok, conversation} = Chat.find_or_create_conversation(Repo.reload!(other), page)
+
+      {:ok, typer, _} = live(conn, ~p"/messages/#{conversation.id}")
+      {:ok, watcher, _} = live(other_conn, ~p"/messages/#{conversation.id}")
+
+      typer |> form("#message-form", message: %{body: "hallo"}) |> render_change()
+      _ = :sys.get_state(watcher.pid)
+
+      html = render(watcher)
+      assert html =~ "Acme GmbH"
+      refute html =~ Identity.display_name(owner)
     end
   end
 end

--- a/test/vutuv_web/url_parameter_500s_test.exs
+++ b/test/vutuv_web/url_parameter_500s_test.exs
@@ -1,0 +1,53 @@
+defmodule VutuvWeb.UrlParameter500sTest do
+  @moduledoc """
+  Two public URLs that answered a crafted query string with a 500.
+
+  Neither is a data leak; both are a stranger being able to put an error page
+  where a listing belongs, from a URL they can type. They are here together
+  because they are the same mistake: a parameter whose shape was assumed rather
+  than checked, and a guard that looked total and was not.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  alias Vutuv.Pages
+
+  describe "?page= on an offset-paginated listing" do
+    # `?page[]=1` arrives as a LIST. `max/2` does not raise on one — Elixir's
+    # term ordering puts a list above an integer, so `max(["1"], 1)` answered
+    # `["1"]` and the `(page - 1)` that follows raised ArithmeticError.
+    test "a non-integer page collapses to the first page" do
+      assert Pages.effective_page(%{"page" => ["1"]}, 500) == 1
+      assert Pages.effective_page(%{"page" => %{"a" => "1"}}, 500) == 1
+      assert Pages.effective_page(%{"page" => nil}, 500) == 1
+      assert Pages.effective_page(%{"page" => "not-a-number"}, 500) == 1
+    end
+
+    test "an ordinary page still works" do
+      assert Pages.effective_page(%{"page" => "2"}, 500) == 2
+      assert Pages.effective_page(%{"page" => 2}, 500) == 2
+      # Past the data, back to the first page — the pre-existing rule.
+      assert Pages.effective_page(%{"page" => "99"}, 10) == 1
+    end
+
+    test "the member directory survives it end to end", %{conn: conn} do
+      assert conn |> get("/system/members?page[]=1") |> response(200)
+    end
+  end
+
+  describe "a sitemap chunk number" do
+    # Past 2^63 Postgres never sees a query: Postgrex raises
+    # DBConnection.EncodeError on the OFFSET parameter, so the action's promised
+    # 404 was a 500.
+    test "an absurd chunk number is a 404, not a 500", %{conn: conn} do
+      assert conn |> get("/sitemaps/users-99999999999999999999.xml") |> response(404)
+    end
+
+    test "a chunk beyond the data is still a 404", %{conn: conn} do
+      assert conn |> get("/sitemaps/users-9999.xml") |> response(404)
+    end
+
+    test "an unknown type is still a 404", %{conn: conn} do
+      assert conn |> get("/sitemaps/nonsense-1.xml") |> response(404)
+    end
+  end
+end


### PR DESCRIPTION
Three more from the scan (after #1939, #1943, #1945, #1947).

**The desk gave away who sits at it.** Speaking for a page means the page
answers, and every message a publisher sends is signed with it — but the typing
indicator took its name from `current_user`, so the other side learned the
human's real name the moment they started typing. The name is now derived where
the viewer is decided, so the two cannot drift apart again.

**Two public URLs answered a typed query string with an error page.**
`?page[]=1` arrives as a list, and `max/2` does not raise on one: Elixir's term
ordering puts a list above an integer, so `max(["1"], 1)` returned the list and
the `(page - 1)` after it raised `ArithmeticError`. And a sitemap chunk number
past 2^63 never reaches Postgres — Postgrex raises `DBConnection.EncodeError` on
the OFFSET parameter first, turning this action's promised 404 into a 500.
Neither leaks anything; both let a stranger put an error page where a listing
belongs.

Each check was reverted once to watch its test go red.

https://claude.ai/code/session_01HpEBfNDHjPRmJ1Joe2923o
