### PR TITLE
Escape untrusted text where it becomes document syntax

### DIFF
--- a/lib/vutuv/api_auth/app.ex
+++ b/lib/vutuv/api_auth/app.ex
@@ -56,6 +56,11 @@ defmodule Vutuv.ApiAuth.App do
     |> cast(params, [:name, :description, :homepage_url, :redirect_uris])
     |> validate_required([:name])
     |> validate_length(:name, max: 60)
+    # The name is whatever the client registered under, and it is read in two
+    # places that treat a line break as structure: the consent screen a member
+    # decides on, and the operator's log line naming a runaway client. `\A`/`\z`
+    # rather than `^`/`$`, which in PCRE still admit a trailing newline.
+    |> validate_format(:name, ~r/\A[^[:cntrl:]]+\z/u, message: "must be a single line")
     |> validate_length(:description, max: 500)
     |> validate_length(:homepage_url, max: 255)
     |> update_change(:redirect_uris, &clean_uris/1)

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -104,7 +104,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   end
 
   def render(%{type: "post"} = doc) do
-    author_link = "[#{md_text(doc.author.name)}](#{doc.author.url})"
+    author_link = md_link(doc.author.name, doc.author.url)
 
     [
       frontmatter(doc),
@@ -144,7 +144,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   # opened answering, #1334 already brought the remote replies), under the same
   # headings, so a reader parsing both meets the same field in the same place.
   def render(%{type: "organization_post"} = doc) do
-    author_link = "[#{md_text(doc.author.name)}](#{doc.author.url})"
+    author_link = md_link(doc.author.name, doc.author.url)
 
     [
       frontmatter(doc),
@@ -170,7 +170,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   end
 
   def render(%{type: "post_archive"} = doc) do
-    author_link = "[#{md_text(doc.author.name)}](#{doc.author.url})"
+    author_link = md_link(doc.author.name, doc.author.url)
 
     [
       frontmatter(doc),
@@ -301,7 +301,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
       "# #{doc.title}",
       doc.description,
       Enum.map_join(doc.postings, "\n\n", &job_summary/1),
-      doc.next && "[#{gettext("Next page")}](#{doc.next})"
+      doc.next && md_link(gettext("Next page"), doc.next)
     ]
     |> join_blocks()
   end
@@ -396,13 +396,13 @@ defmodule VutuvWeb.AgentDocs.Markdown do
       |> Enum.sort_by(&elem(&1, 0))
       |> Enum.map_join("\n", fn {label, value} -> "- #{label}: #{value}" end),
       "## Brand assets",
-      Enum.map_join(doc.assets, "\n", &"- [#{&1.name}](#{&1.url}) (#{&1.kind}) - #{&1.note}"),
+      Enum.map_join(doc.assets, "\n", &"- #{md_link(&1.name, &1.url)} (#{&1.kind}) - #{&1.note}"),
       "## Colours",
       Enum.map_join(doc.colors, "\n", &"- #{&1.name} `#{&1.hex}` - #{&1.note}"),
       "## Typography",
       Enum.map_join(doc.typography, "\n", &"- #{&1.role}: #{&1.name} - #{&1.note}"),
       "## Screenshots",
-      Enum.map_join(doc.screenshots, "\n", &"- [#{&1.name}](#{&1.url}) - #{&1.note}"),
+      Enum.map_join(doc.screenshots, "\n", &"- #{md_link(&1.name, &1.url)} - #{&1.note}"),
       "## Using all this",
       Enum.map_join(doc.usage, "\n", &("- " <> &1)),
       "## Press contact",
@@ -425,7 +425,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   defp followed_organizations(%{organizations: [_ | _] = organizations}) do
     join_blocks([
       "## " <> gettext("Organizations"),
-      Enum.map_join(organizations, "\n", &"- [#{&1.name}](#{&1.url})")
+      Enum.map_join(organizations, "\n", &"- #{md_link(&1.name, &1.url)}")
     ])
   end
 
@@ -443,7 +443,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
     [
       "## #{gettext("People")}",
       Enum.map_join(people, "\n", fn person ->
-        "- [#{person.name}](#{person.url})" <>
+        "- #{md_link(person.name, person.url)}" <>
           if(person.title, do: " · #{person.title}", else: "") <>
           if(person.current, do: "", else: " (#{gettext("former")})")
       end)
@@ -455,7 +455,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
 
   defp job_employer(%{name: name, verified: verified, url: url}) do
     verified_mark = if verified, do: " (#{gettext("verified")})", else: ""
-    if url, do: "[#{name}](#{url})#{verified_mark}", else: "#{name}#{verified_mark}"
+    md_maybe_link(name, url) <> verified_mark
   end
 
   defp job_location(%{location: %{city: city, country_name: country}}),
@@ -478,13 +478,13 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   defp job_tags(_label, []), do: nil
 
   defp job_tags(label, tags) do
-    "## #{label}\n" <> Enum.map_join(tags, "\n", &"- [#{&1.name}](#{&1.url})")
+    "## #{label}\n" <> Enum.map_join(tags, "\n", &"- #{md_link(&1.name, &1.url)}")
   end
 
   # One posting summary block on the board (/jobs) or an "Offene Stellen" section.
   defp job_summary(entry) do
     [
-      "## [#{md_text(entry.title)}](#{entry.url})",
+      "## #{md_link(entry.title, entry.url)}",
       "- #{gettext("Employer")}: #{job_employer(entry.employer)}",
       "- #{gettext("Employment type")}: #{entry.employment_type}",
       "- #{gettext("Workplace")}: #{entry.workplace_type}",
@@ -500,7 +500,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   defp job_summary_tags([]), do: nil
 
   defp job_summary_tags(tags),
-    do: "- #{gettext("Tags")}: " <> Enum.map_join(tags, ", ", &"[#{&1.name}](#{&1.url})")
+    do: "- #{gettext("Tags")}: " <> Enum.map_join(tags, ", ", &md_link(&1.name, &1.url))
 
   # The tag page's "Offene Stellen" section (#933): the postings carrying the
   # tag, then a link into the pre-filtered board.
@@ -508,7 +508,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
     [
       "## #{gettext("Open positions")}",
       Enum.map_join(postings, "\n\n", &job_summary/1),
-      doc[:jobs_url] && "[#{gettext("All jobs with this tag")}](#{doc.jobs_url})"
+      doc[:jobs_url] && md_link(gettext("All jobs with this tag"), doc.jobs_url)
     ]
     |> Enum.filter(&is_binary/1)
     |> Enum.join("\n\n")
@@ -639,10 +639,10 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   # An honor tag is an admin-granted badge, not a peer-vouched skill, so it shows
   # the "honor tag" marker in place of the endorsement count.
   defp entry_line("tags", %{honor: true} = tag),
-    do: "- [#{tag.name}](#{tag.url}) (#{gettext("honor tag")})"
+    do: "- #{md_link(tag.name, tag.url)} (#{gettext("honor tag")})"
 
   defp entry_line("tags", tag),
-    do: "- [#{tag.name}](#{tag.url}) (#{endorsements_label(tag)}#{endorser_names(tag)})"
+    do: "- #{md_link(tag.name, tag.url)} (#{endorsements_label(tag)}#{endorser_names(tag)})"
 
   defp entry_line("work_experiences", work), do: work_line(work)
   defp entry_line("educations", edu), do: education_line(edu)
@@ -654,11 +654,20 @@ defmodule VutuvWeb.AgentDocs.Markdown do
     do: "- #{md_text(language.name)}: #{language.level}#{language_preferred_gloss(language)}"
 
   defp entry_line("links", link), do: link_line(link)
-  defp entry_line("emails", email), do: "- #{email.type}: <#{email.value}>"
+
+  defp entry_line("emails", email),
+    do: "- #{md_text(email.type)}: #{md_autolink(email.value)}"
+
   defp entry_line("social_media_accounts", account), do: social_line(account)
   defp entry_line("messengers", messenger), do: messenger_line(messenger)
-  defp entry_line("phone_numbers", phone), do: "- #{phone.type}: #{phone.value}"
-  defp entry_line("addresses", address), do: "- " <> address_line(address)
+
+  defp entry_line("phone_numbers", phone),
+    do: "- #{md_text(phone.type)}: #{md_text(phone.value)}"
+
+  # `address_line/1` and `code_stats_facts/1` are shared with the plain-text
+  # renderer, which must not carry backslashes, so the Markdown side escapes
+  # what it is handed rather than the fragment escaping itself.
+  defp entry_line("addresses", address), do: "- " <> md_text(address_line(address))
 
   # One code-forge account of the profile's "Code" section (Vutuv.CodeStats):
   # the account line with its glanceable facts, then one indented line per top
@@ -666,14 +675,15 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   # list) so the loose section join separates accounts, not an account from its
   # own repos.
   defp code_stats_block(account) do
-    ["- #{account.provider}: #{account.url} (#{code_stats_facts(account)})"]
+    [
+      "- #{md_text(account.provider)}: #{md_url(account.url)} (#{md_text(code_stats_facts(account))})"
+    ]
     |> Kernel.++(Enum.map(account.top_repos, &code_repo_line/1))
     |> Enum.join("\n")
   end
 
   defp code_repo_line(repo) do
-    name = md_text(repo.name || "")
-    linked = if repo.url, do: "[#{name}](#{repo.url})", else: name
+    linked = md_maybe_link(repo.name || "", repo.url)
 
     details =
       [
@@ -734,7 +744,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   # links after the count. The profile's tag list carries no roster, so it
   # renders nothing there.
   defp endorser_names(%{endorsers: [_ | _] = people}),
-    do: ": " <> Enum.map_join(people, ", ", &"[#{md_text(&1.name)}](#{&1.url})")
+    do: ": " <> Enum.map_join(people, ", ", &md_link(&1.name, &1.url))
 
   defp endorser_names(_tag), do: ""
 
@@ -756,7 +766,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
     qualification_note = work_qualification_note(work)
 
     ["- ", Enum.join([work.title, work.organization] |> Enum.filter(& &1), " @ ")]
-    |> Kernel.++(if page, do: [" ([#{page.name}](#{page.url}))"], else: [])
+    |> Kernel.++(if page, do: [" (#{md_link(page.name, page.url)})"], else: [])
     |> Kernel.++(if kind_note, do: [" [#{kind_note}]"], else: [])
     |> Kernel.++(if period, do: [" (#{period})"], else: [])
     |> Kernel.++(if qualification_note, do: [" [#{qualification_note}]"], else: [])
@@ -841,7 +851,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
     base
     |> append_if(
       reference.document,
-      &(&1 <> " [#{gettext("document")}](#{md_url(reference.document.url)})")
+      &(&1 <> " " <> md_link(gettext("document"), reference.document.url))
     )
     |> append_if(reference.text, &(&1 <> "\n\n  " <> md_text(reference.text)))
   end
@@ -856,10 +866,10 @@ defmodule VutuvWeb.AgentDocs.Markdown do
 
     line =
       base
-      |> append_if(qualification.url, &(&1 <> " <#{md_url(qualification.url)}>"))
+      |> append_if(qualification.url, &(&1 <> " " <> md_autolink(qualification.url)))
       |> append_if(
         qualification.document,
-        &(&1 <> " [#{gettext("proof document")}](#{md_url(qualification.document.url)})")
+        &(&1 <> " " <> md_link(gettext("proof document"), qualification.document.url))
       )
 
     # The jobs the credential earned (issue #1109), one indented line each —
@@ -878,8 +888,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   end
 
   defp citing_job_line(job) do
-    title = md_text(job.title)
-    linked = if job.url, do: "[#{title}](#{md_url(job.url)})", else: title
+    linked = md_maybe_link(job.title, job.url)
     facts = citing_job_facts(job)
 
     if facts == "", do: "  - #{linked}", else: "  - #{linked}: #{md_text(facts)}"
@@ -947,10 +956,10 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   end
 
   defp link_line(%{description: nil, url: url} = link),
-    do: "- <#{md_url(url)}>" <> verified_suffix(link)
+    do: "- " <> md_autolink(url) <> verified_suffix(link)
 
   defp link_line(%{description: description, url: url} = link),
-    do: "- [#{md_text(description)}](#{md_url(url)})" <> verified_suffix(link)
+    do: "- #{md_link(description, url)}" <> verified_suffix(link)
 
   # A verified link (proved to be the member's own webpage) carries the same
   # marker the profile's verified mark shows.
@@ -961,10 +970,10 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   # section. A provider without a canonical URL scheme (Snapchat) carries
   # only the account name, so there is no link to offer.
   defp social_line(%{provider: provider, url: "http" <> _ = url} = account),
-    do: "- [#{provider}](#{md_url(url)})" <> verified_profile_suffix(account)
+    do: "- " <> md_link(provider, url) <> verified_profile_suffix(account)
 
   defp social_line(%{provider: provider, url: value} = account),
-    do: "- #{provider}: #{value}" <> verified_profile_suffix(account)
+    do: "- #{md_text(provider)}: #{md_text(value)}" <> verified_profile_suffix(account)
 
   # A verified social account (proved to be the member's own) carries the same
   # marker its verified mark shows on the profile card.
@@ -976,13 +985,13 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   # shows the bare contact. A contact link IS its own address, so it is printed
   # once rather than as a link labelled with itself.
   defp messenger_line(%{provider: provider, kind: "link", url: "http" <> _ = url}),
-    do: "- #{provider}: <#{md_url(url)}>"
+    do: "- #{md_text(provider)}: " <> md_autolink(url)
 
   defp messenger_line(%{provider: provider, contact: contact, url: "http" <> _ = url}),
-    do: "- #{provider}: [#{contact}](#{md_url(url)})"
+    do: "- #{md_text(provider)}: #{md_link(contact, url)}"
 
   defp messenger_line(%{provider: provider, contact: contact}),
-    do: "- #{provider}: #{contact}"
+    do: "- #{md_text(provider)}: #{md_text(contact)}"
 
   @doc false
   def address_line(address) do
@@ -1008,7 +1017,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   defp post_line(post) do
     line =
       "- #{post.published_on}#{pin_suffix(post)}#{repost_suffix(post)}: " <>
-        "[#{md_text(entry_label(post))}](#{post.url})#{quote_suffix(post)}"
+        md_link(entry_label(post), post.url) <> md_text(quote_suffix(post))
 
     Enum.join([line | Enum.map(thread_context(post), &thread_context_line/1)], "\n")
   end
@@ -1022,7 +1031,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   # Indented under the entry it belongs to, and naming its author — which is
   # what tells it apart from an entry line, since those carry no author.
   defp thread_context_line(post) do
-    "  - #{post.published_on} [#{md_text(post.author)}](#{post.url}): " <>
+    "  - #{post.published_on} #{md_link(post.author, post.url)}: " <>
       md_text(entry_label(post))
   end
 
@@ -1048,6 +1057,11 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   # The card on the page shows the quoted post's author and words; an agent gets
   # the same two facts as a sentence, because an entry that only reacts to
   # something ("exactly this") is unreadable without it.
+  #
+  # Both halves are the quoting server's. The escaping is the Markdown caller's
+  # (the plain-text renderer must not carry backslashes), and it escapes the
+  # whole assembled sentence — the surrounding words are ours and hold none of
+  # the three characters `md_text/1` touches.
   def quote_suffix(%{quote: %{url: url, author: nil}}),
     do: " — " <> gettext("Quotes %{url}", url: url)
 
@@ -1092,8 +1106,8 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   defp person_line(person), do: "- #{person_text(person)}"
 
   defp person_text(person) do
-    "[#{md_text(person.name)}](#{person.url})" <>
-      if(person.work_info, do: " — #{person.work_info}", else: "") <>
+    md_link(person.name, person.url) <>
+      if(person.work_info, do: " — " <> md_text(person.work_info), else: "") <>
       tags_suffix(Map.get(person, :tags))
   end
 
@@ -1103,7 +1117,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   defp tags_suffix(nil), do: ""
 
   defp tags_suffix(%{top: top, total: total}) do
-    links = Enum.map_join(top, ", ", fn tag -> "[#{md_text(tag.name)}](#{tag.url})" end)
+    links = Enum.map_join(top, ", ", fn tag -> md_link(tag.name, tag.url) end)
     " · #{gettext("Tags")}: #{links} (#{gettext("%{count} total", count: total)})"
   end
 
@@ -1125,7 +1139,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
     do: "> " <> gettext("In reply to a deleted post by %{name}.", name: author)
 
   defp in_reply_to_line(%{url: url, author: author}) do
-    author_link = "[#{md_text(author)}](#{url})"
+    author_link = md_link(author, url)
     "> " <> gettext("In reply to a post by %{name}.", name: author_link)
   end
 
@@ -1288,10 +1302,11 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   # so a reader (human or machine) can tell the facts apart.
   defp image_line(image) do
     [
-      "- ![#{image.alt || "image"}](#{image_url(image)})",
+      "- " <> md_image(image.alt || "image", image_url(image)),
       image[:caption] && "  #{md_text(image.caption)}",
       camera_line(image),
-      image[:download_url] && "  [#{gettext("Download the original")}](#{image.download_url})"
+      image[:download_url] &&
+        "  " <> md_link(gettext("Download the original"), image.download_url)
     ]
     |> Enum.reject(&is_nil/1)
     |> Enum.join("\n")
@@ -1324,7 +1339,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   # same rule the HTML page follows, so the formats cannot disagree about
   # whether a post says anything about reuse.
   defp license_line(%{spdx: spdx, name: name, url: url}) when is_binary(spdx) do
-    "**#{gettext("Photos:")}** [#{md_text(name)}](#{url})"
+    "**#{gettext("Photos:")}** #{md_link(name, url)}"
   end
 
   defp license_line(_license), do: nil
@@ -1345,7 +1360,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
     heading = String.duplicate("#", min(3 + entry.depth, 6))
 
     [
-      "#{heading} [#{md_text(entry.author)}](#{entry.url}) · #{entry.published_on}",
+      "#{heading} #{md_link(entry.author, entry.url)} · #{entry.published_on}",
       reply_to,
       entry.body_markdown
     ]
@@ -1363,7 +1378,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
       entry.content_warning &&
         "> " <> gettext("Content warning") <> ": " <> md_text(entry.content_warning),
       md_text(entry.text),
-      "[#{gettext("View the original")}](#{entry.url})"
+      md_link(gettext("View the original"), entry.url)
     ]
     |> Enum.reject(&is_nil/1)
     |> Enum.join("\n\n")
@@ -1416,6 +1431,36 @@ defmodule VutuvWeb.AgentDocs.Markdown do
 
     ~s(") <> escaped <> ~s(")
   end
+
+  # One Markdown link, both halves escaped. A link assembled at the call site is
+  # a place the next author has to remember md_text/1 and md_url/1 again, and a
+  # dozen of them had already forgotten one or both: a member's own free text
+  # (an employer name, a display name, a tag) closed the `]` and forged a second
+  # link, and a remote server's URL closed the `)`.
+  defp md_link(label, url), do: "[" <> md_label(label) <> "](" <> md_url(url) <> ")"
+
+  # `[label](url)` for a label that may be absent a destination, which three
+  # sections need: a code repository, a job that cites a credential, an employer.
+  defp md_maybe_link(label, nil), do: md_text(label)
+  defp md_maybe_link(label, url), do: md_link(label, url)
+
+  # `![alt](url)`. The `!` is the only thing between an image and a link, so it
+  # belongs beside the function that owns the rest of the shape.
+  defp md_image(alt, url), do: "!" <> md_link(alt, url)
+
+  # `<url>`, the other link syntax. Same reason as `md_link/2`: the angle
+  # brackets were written out at four call sites and one of them had forgotten
+  # the escaper.
+  defp md_autolink(url), do: "<" <> md_url(url) <> ">"
+
+  # A link label is one line by definition, so a newline in it does not merely
+  # read oddly — it ends the list item the link sits in and hands the rest of a
+  # member's name to the document as structure of its own. `md_text/1` cannot
+  # do this for everyone: it also escapes post bodies and remote replies, where
+  # a line break is the author's.
+  defp md_label(value), do: value |> to_string() |> fold_lines() |> md_text()
+
+  defp fold_lines(value), do: String.replace(value, ~r/\s*[\r\n]+\s*/u, " ")
 
   # Escape the Markdown link-syntax characters in user-controlled link *text*
   # (names, excerpts), so a value like `x](http://evil)` cannot break out of

--- a/lib/vutuv_web/controllers/acting_as_controller.ex
+++ b/lib/vutuv_web/controllers/acting_as_controller.ex
@@ -62,11 +62,10 @@ defmodule VutuvWeb.ActingAsController do
 
   # Back where they were, so leaving the mode is not also a navigation. Only a
   # same-site path is honored: an absolute URL in a parameter is an open
-  # redirect, and this one is reachable from every page.
+  # redirect, and this one is reachable from every page. The rule itself is
+  # `ControllerHelpers.safe_return_to/2` — this used to carry its own copy,
+  # which knew about `//` and not about the backslash a browser reads as one.
   defp return_to(conn) do
-    case conn.params["return_to"] do
-      "/" <> _ = path -> if String.starts_with?(path, "//"), do: ~p"/feed", else: path
-      _ -> ~p"/feed"
-    end
+    ControllerHelpers.safe_return_to(conn.params["return_to"]) || ~p"/feed"
   end
 end

--- a/lib/vutuv_web/controllers/admin/account_controller.ex
+++ b/lib/vutuv_web/controllers/admin/account_controller.ex
@@ -113,12 +113,12 @@ defmodule VutuvWeb.Admin.AccountController do
   # Only ever redirect back inside the admin area. A caller-supplied return_to
   # that is not a local /admin/ path (a full URL, a scheme-relative //host, a
   # different scope) falls back to the frozen list, so the hidden field can
-  # never be turned into an open redirect.
-  defp safe_return("/admin/" <> _ = path) do
-    if String.starts_with?(path, "/admin//"), do: default_return(), else: path
+  # never be turned into an open redirect. The prefix is what this page adds;
+  # the rule is the shared one, so the admin path also gets the backslash and
+  # stripped-character coverage its own copy never had.
+  defp safe_return(value) do
+    ControllerHelpers.safe_return_to(value, "/admin/") || default_return()
   end
-
-  defp safe_return(_other), do: default_return()
 
   defp default_return, do: ~p"/admin/accounts/frozen"
 end

--- a/lib/vutuv_web/controllers/controller_helpers.ex
+++ b/lib/vutuv_web/controllers/controller_helpers.ex
@@ -76,9 +76,16 @@ defmodule VutuvWeb.ControllerHelpers do
   route sigil expands at the call site with that controller's correct default.
   """
   def referrer_url(%Conn{} = conn, fallback) when is_binary(fallback) do
-    case Conn.get_req_header(conn, "referer") do
-      [referer | _] -> URI.parse(referer).path || fallback
-      [] -> fallback
+    # A referer is as caller-supplied as a `return_to` parameter — a header is
+    # whatever the client sent — and `https://evil.example//x` parses to the
+    # path `//x`, which is the first shape `safe_return_to/2` refuses. So the
+    # two go through one rule rather than one of them being the careful half.
+    with [referer | _] <- Conn.get_req_header(conn, "referer"),
+         path when is_binary(path) <- URI.parse(referer).path,
+         local when is_binary(local) <- safe_return_to(path) do
+      local
+    else
+      _ -> fallback
     end
   end
 
@@ -95,16 +102,53 @@ defmodule VutuvWeb.ControllerHelpers do
   defp profile_path(%User{} = user), do: ~p"/#{user}"
   defp profile_path(_), do: ~p"/"
 
-  @doc """
+  # Lowercase only: the value is downcased before the test, so a spelling can
+  # never be added in one case and forgotten in the other.
+  @never_local ["\\", "\t", "\n", "\r", "%09", "%0a", "%0d"]
+
+  @doc ~S"""
   Validates a caller-supplied redirect target, returning the path only when it
   is a same-origin absolute path (`/foo`) and `nil` otherwise.
 
-  Protocol-relative URLs (`//evil.com`) are external and rejected; matching the
-  prefixes (rather than slicing) also keeps the bare `"/"` from raising.
+  `prefix` narrows what counts as local — `safe_return_to(value, "/admin/")`
+  answers only for a path inside the admin area — so a scope that must not be
+  left says so here rather than writing the rule again.
+
+  The value reaches an `href` and a `redirect(to:)`, so what decides it is how a
+  **browser** resolves the string, not how it reads. Two things move it to
+  another origin, and only the first is the obvious one:
+
+    * a second slash right after the leading one (`//evil.example`) — and a
+      backslash counts, because the WHATWG URL parser treats `\` as `/` for an
+      http(s) document, so `/\evil.example` navigates to `evil.example` in
+      Chrome, Firefox and Safari alike. That is the shape this used to admit;
+    * a character the browser **removes before it parses at all** — tab, LF and
+      CR — which hides such a slash from any check that reads the string as
+      written: `/\tevil.example` is `//evil.example` by the time it is resolved.
+
+  So the shape is rejected rather than repaired, in the same spelling Phoenix's
+  own `redirect(to:)` refuses (it raises there; this is the read-only half that
+  has to answer instead of blowing up a page render). Their percent-encoded
+  forms go with them, since anything decoding once hands the browser the raw
+  character back.
   """
-  def safe_return_to("//" <> _), do: nil
-  def safe_return_to("/" <> _ = path), do: path
-  def safe_return_to(_), do: nil
+  def safe_return_to(value, prefix \\ "/")
+
+  def safe_return_to(value, prefix) when is_binary(value) and is_binary(prefix) do
+    # The second segment is what can move the value to another origin, so it is
+    # read relative to the prefix rather than to the string: inside `/admin/`
+    # the shape to refuse is `/admin//evil.example`, not `//evil.example`.
+    rest = String.replace_prefix(value, prefix, "")
+
+    cond do
+      not String.starts_with?(value, prefix) -> nil
+      String.starts_with?(rest, ["/", "\\"]) -> nil
+      String.contains?(String.downcase(value), @never_local) -> nil
+      true -> value
+    end
+  end
+
+  def safe_return_to(_value, _prefix), do: nil
 
   @doc """
   Loads an owned member resource: `Repo.get!` scoped to the path user's

--- a/lib/vutuv_web/controllers/oauth_controller.ex
+++ b/lib/vutuv_web/controllers/oauth_controller.ex
@@ -149,9 +149,14 @@ defmodule VutuvWeb.OauthController do
          limit: 1,
          window_ms: @consent_window
        ) == :ok do
+      # `inspect/1` escapes a newline rather than letting it
+      # end the record and start a plausible second one — an operator reading
+      # this line is diagnosing the very client that wrote them, so it must not
+      # be forgeable by that client. It also delimits each value, which is what
+      # says where an app called `Ivory user_agent=curl` ends.
       Logger.error(
-        "oauth: consent budget spent, app=#{request.app.name} " <>
-          "user_agent=#{UserAgent.capture(conn) || "(none sent)"}"
+        "oauth: consent budget spent, app=#{inspect(request.app.name)} " <>
+          "user_agent=#{inspect(UserAgent.capture(conn) || "(none sent)")}"
       )
     end
   end

--- a/test/vutuv/api_auth_oauth_test.exs
+++ b/test/vutuv/api_auth_oauth_test.exs
@@ -85,6 +85,30 @@ defmodule Vutuv.ApiAuth.OAuthTest do
       assert %{redirect_uris: _} = errors_on(changeset)
     end
 
+    # The name is read by two things that treat a line break as structure: the
+    # consent screen a member decides on, and the operator's log line naming a
+    # runaway client. Both self-service registration paths take it, so the rule
+    # sits on the changeset they share.
+    test "an app name spanning two lines is refused", %{developer: developer} do
+      forged = "Ivory\n[error] oauth: consent budget spent"
+
+      assert {:error, changeset} =
+               ApiAuth.create_app(developer, %{
+                 "name" => forged,
+                 "redirect_uris" => ["https://example.org/cb"]
+               })
+
+      assert %{name: ["must be a single line"]} = errors_on(changeset)
+
+      assert {:error, changeset} =
+               ApiAuth.create_mastodon_app(%{
+                 "name" => forged,
+                 "redirect_uris" => ["org.example.client://oauth"]
+               })
+
+      assert %{name: ["must be a single line"]} = errors_on(changeset)
+    end
+
     test "regenerating the secret invalidates the old one", %{
       member: member,
       app: app,

--- a/test/vutuv_web/agent_docs/agent_format_test.exs
+++ b/test/vutuv_web/agent_docs/agent_format_test.exs
@@ -7,6 +7,8 @@ defmodule VutuvWeb.AgentFormatTest do
 
   use VutuvWeb.ConnCase, async: true
 
+  alias Vutuv.Posts
+
   setup do
     user = insert_activated_user(username: "agent_tester", first_name: "Agatha")
     %{user: user}
@@ -241,6 +243,90 @@ defmodule VutuvWeb.AgentFormatTest do
       # link text and smuggle in an attacker URL.
       assert body =~ "x\\]"
       refute body =~ "[Eve x](https://evil.example)"
+    end
+
+    # Every link in an agent document is built by `Markdown.md_link/2`, so these
+    # aim at surfaces that reach it by different routes — a people list, an
+    # image line, a remote reply — rather than at the helper itself.
+    @forged "x](https://phish.example/payroll)"
+    @escaped "x\\](https://phish.example/payroll)"
+
+    test "a hostile name cannot forge a link in an organization's people list" do
+      organization = insert(:organization)
+
+      member =
+        insert_activated_user(username: "org_person", first_name: "Eve", last_name: @forged)
+
+      insert(:work_experience,
+        user: member,
+        organization_id: organization.id,
+        organization: "Acme GmbH"
+      )
+
+      body = get(build_conn(), "/organizations/#{organization.slug}.md").resp_body
+
+      assert body =~ @escaped
+      refute body =~ @forged
+    end
+
+    test "a hostile photo alt cannot forge a link on the post permalink" do
+      author = insert_activated_user(username: "photo_author")
+      post = insert(:post, user: author)
+      insert(:post_image, post: post, user: author, alt: @forged)
+
+      body = get(build_conn(), Posts.path(post) <> ".md").resp_body
+
+      # The alt text still reads as the attacker wrote it — it is the escaped
+      # `]` that keeps it inside the label instead of ending it.
+      assert body =~ @escaped
+      refute body =~ @forged
+    end
+
+    test "a remote reply's URL cannot close the link it sits in" do
+      author = insert_activated_user(username: "reply_target")
+      post = insert(:post, user: author)
+
+      # `origin_url` is filtered on ingest; `object_uri` is what `Note.origin/1`
+      # falls back to, and nothing about its shape is checked.
+      insert(:note,
+        post: post,
+        audience: "public",
+        origin_url: nil,
+        object_uri: "https://evil.example/x) [Verify](https://phish.example/"
+      )
+
+      body = get(build_conn(), Posts.path(post) <> ".md").resp_body
+
+      # The `)` that would have ended the destination is percent-encoded, so the
+      # attacker's own bracket pair never becomes a link of its own.
+      assert body =~ "evil.example/x%29"
+      refute body =~ "[Verify](https://phish.example/)"
+    end
+
+    # A link label is one line, so a newline in a name does not merely read
+    # oddly: it ends the list item and hands the rest to the document as
+    # structure. Names carry only a length rule, so the renderer folds it.
+    test "a newline in a member's name cannot open a heading of its own", %{user: target} do
+      evil =
+        insert_activated_user(first_name: "Eve", last_name: "x\n## Verified partner")
+
+      follow!(evil, target)
+
+      body = get(build_conn(), "/agent_tester/followers.md").resp_body
+
+      refute body =~ "\n## Verified partner"
+      assert body =~ "Eve x ## Verified partner"
+    end
+
+    # The Addresses section reaches the document through a fragment shared with
+    # the plain-text renderer, so it never passed through a link helper.
+    test "a hostile address line cannot forge a link on the profile", %{user: user} do
+      insert(:address, user: user, line_1: @forged, city: "Köln", country: "Germany")
+
+      body = get(build_conn(), "/agent_tester.md").resp_body
+
+      assert body =~ @escaped
+      refute body =~ @forged
     end
 
     test "YAML frontmatter keeps interpolation-looking text literal", %{user: _user} do

--- a/test/vutuv_web/controllers/controller_helpers_test.exs
+++ b/test/vutuv_web/controllers/controller_helpers_test.exs
@@ -27,6 +27,54 @@ defmodule VutuvWeb.ControllerHelpersTest do
       assert ControllerHelpers.safe_return_to("") == nil
       assert ControllerHelpers.safe_return_to(nil) == nil
     end
+
+    # A backslash is a slash to the WHATWG URL parser on an http(s) document, so
+    # every current browser reads this as the host `evil.com` — while a check
+    # that only knows about `//` reads it as a path here and hands it to an href.
+    test "rejects a backslash where the second slash would go" do
+      assert ControllerHelpers.safe_return_to("/\\evil.com") == nil
+      assert ControllerHelpers.safe_return_to("/\\\\evil.com") == nil
+      assert ControllerHelpers.safe_return_to("/feed\\evil.com") == nil
+    end
+
+    # The browser deletes these before it parses, so the string a check reads is
+    # not the string that gets resolved: this one becomes `//evil.com`.
+    test "rejects the characters a browser strips out of a URL" do
+      assert ControllerHelpers.safe_return_to("/\t/evil.com") == nil
+      assert ControllerHelpers.safe_return_to("/\n/evil.com") == nil
+      assert ControllerHelpers.safe_return_to("/\r/evil.com") == nil
+      assert ControllerHelpers.safe_return_to("/%09/evil.com") == nil
+    end
+
+    test "keeps an ordinary path with a query and a fragment" do
+      assert ControllerHelpers.safe_return_to("/feed?type=replies") == "/feed?type=replies"
+      assert ControllerHelpers.safe_return_to("/ch_alice/posts#x") == "/ch_alice/posts#x"
+    end
+
+    # The admin pages must not be left at all, so they pass their own prefix
+    # rather than repeating the rule. The shape to refuse moves with it.
+    test "a prefix narrows what counts as local" do
+      assert ControllerHelpers.safe_return_to("/admin/accounts", "/admin/") == "/admin/accounts"
+      assert ControllerHelpers.safe_return_to("/feed", "/admin/") == nil
+      assert ControllerHelpers.safe_return_to("/admin//evil.com", "/admin/") == nil
+      assert ControllerHelpers.safe_return_to("/admin/\\evil.com", "/admin/") == nil
+    end
+  end
+
+  describe "referrer_url/2" do
+    # A header is as caller-supplied as a query parameter, and this path used to
+    # be handed to `redirect(to:)` with no check at all.
+    test "falls back rather than returning a referer's off-origin path" do
+      conn = build_conn() |> Plug.Conn.put_req_header("referer", "https://evil.example//x")
+
+      assert ControllerHelpers.referrer_url(conn, "/feed") == "/feed"
+    end
+
+    test "keeps an ordinary referer path" do
+      conn = build_conn() |> Plug.Conn.put_req_header("referer", "https://vutuv.de/ch_alice")
+
+      assert ControllerHelpers.referrer_url(conn, "/feed") == "/ch_alice"
+    end
   end
 
   describe "referrer_or_profile/2" do

--- a/test/vutuv_web/controllers/oauth_consent_limit_test.exs
+++ b/test/vutuv_web/controllers/oauth_consent_limit_test.exs
@@ -154,8 +154,31 @@ defmodule VutuvWeb.OauthConsentLimitTest do
       end)
 
     assert log =~ "consent budget spent"
-    assert log =~ "app=#{app.name}"
+    assert log =~ ~s(app="#{app.name}")
     assert log =~ "Ivory/1.2"
+  end
+
+  # The app name is the client's own free text, and this line exists to be read
+  # by an operator diagnosing that very client — so the client must not be able
+  # to write a second, plausible record into it. A row that predates the
+  # single-line rule on `App.common_changeset/2` still can hold a newline, which
+  # is why the guard is at the log line and not only at the write.
+  test "a newline in the app name cannot forge a second log record", %{conn: conn, app: app} do
+    forged = "Ivory\n2026-09-02 12:00:00.000 [error] oauth: consent budget spent, app=Innocent"
+    # `change/2`, not the changeset, so the row can hold what the rule now
+    # refuses — which is the point: the log guard must stand without it.
+    Repo.update!(change(app, name: forged))
+
+    log =
+      ExUnit.CaptureLog.capture_log([level: :error], fn ->
+        exhaust_budget(conn, app)
+      end)
+
+    assert log =~ "consent budget spent"
+    # The newline is escaped into the value, so the fabricated record is text
+    # inside our line rather than a line of its own.
+    assert log =~ ~S(app="Ivory\n2026-09-02)
+    refute log =~ "\n2026-09-02 12:00:00.000 [error]"
   end
 
   # A budget shared across apps would let one looping client lock a member out


### PR DESCRIPTION
Four more from the scan (after #1939, #1943, #1945, #1947, #1950).

**Untrusted text reached places where characters mean something.** The `.md`
siblings are written for agents, so a member's name or photo alt text, and a URL
from another server, are Markdown *source* on arrival: `x](https://phish.example)`
closes the label of the link it sits in and opens one the page never wrote. About
thirty links were assembled by hand and a dozen had forgotten an escaper, so
`VutuvWeb.AgentDocs.Markdown.md_link/2` builds them all now — and folds newlines
in a label, since a name carrying `\n## ` otherwise opened a heading of its own.

**Two more of the same shape.** An OAuth app name is its operator's free text and
went unescaped into the very log line an operator reads about a runaway client.
And `ControllerHelpers.safe_return_to/1` only knew about `//`, though a backslash
is a slash to the WHATWG URL parser; the two hand-written copies of that rule (page
mode, admin) knew it no better and now share one function, which takes a prefix.

Each check was reverted once to watch its test go red.

https://claude.ai/code/session_01HpEBfNDHjPRmJ1Joe2923o
