### PR TITLE
Data-saving follow-ups: compressed LiveView socket, regenerated link screenshots, corrected nginx notes

### DIFF
--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -723,9 +723,10 @@ too.
 The lite versions are derived at upload like every other version, and for
 everything uploaded before they existed by the deploy's `regenerate_images`
 step — which, on the deploy that introduces them, re-derives every post
-photo, profile-link screenshot and cover from its original (on vutuv.de about
-1,900 screenshots, a few minutes of CPU after the traffic switch). Until a
-row has its lite file the page shows the full version, never a broken one.
+photo, screenshot (profile links, post links and organization homepages) and
+cover from its original (on vutuv.de about 3,800 screenshots, some minutes of
+CPU after the traffic switch). Until a row has its lite file the page shows
+the full version, never a broken one.
 Pictures from other networks keep no original, so only those fetched after
 the deploy have a lite. See "Data-saving mode" under nginx for the one thing
 the proxy can add.

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -370,16 +370,36 @@ The private `originals/` tree under `UPLOADS_DIR_PREFIX` must **not** get any
 `location`/`alias`: uploaded originals (with their EXIF/GPS metadata) are
 never served, by design.
 
+### Compressing pages
+
+The app server compresses its own responses: Bandit answers a client that
+offers gzip with gzip, and nginx never re-compresses a body that already
+carries a `Content-Encoding`. So `brotli on` in the vhost touches nothing but
+the precompressed assets — on vutuv.de it sat there for months without ever
+compressing a page — unless nginx keeps the negotiation for itself by
+stripping the header on the way upstream:
+
+```nginx
+location / {
+    proxy_set_header Accept-Encoding "";
+    proxy_pass http://127.0.0.1:4003;
+    # ... the proxy_* lines from above
+}
+```
+
+With that, every page goes out as brotli (level 6 by default) to a client
+that accepts it and as nginx's gzip to the rest, and the app spends nothing on
+compression. Measured on vutuv.de's landing page (59 kB of HTML, 2026-09-02):
+11.5 kB as the app's gzip, 10.7 kB as brotli 6.
+
 ### Data-saving mode (optional)
 
 Every browser request from a member in data-saving mode (see "Preference
 defaults" above) carries the cookie `vutuv_low_bandwidth=1`; the app keeps it
 in step with the preference, so nginx can tell these requests apart without
-asking the app. What it is for: compressing their **dynamic pages** harder.
-The precompressed assets are already brotli 11; the pages themselves are
-compressed per request at whatever level the vhost sets, and nginx cannot
-read that level from a variable — so the members with the cookie are sent
-through a named location of their own:
+asking the app. What it buys them is a harder brotli level on their pages.
+nginx cannot read the level from a variable, so these members go through a
+named location of their own:
 
 ```nginx
 # In the http block: the cookie, as a flag.
@@ -388,33 +408,40 @@ map $cookie_vutuv_low_bandwidth $vutuv_saver {
     default 0;
 }
 
-# In the server block, inside the `location /` that proxies to the app:
+# Inside the `location /` that proxies to the app — AFTER any other
+# `if … return` there (a maintenance gate): nginx takes the first one.
     if ($vutuv_saver) { return 418; }
     error_page 418 = @saver;
 
-# Beside it: the same proxy, compressed harder. Copy every proxy_* line of
-# `location /` — a named location inherits none of them.
+# The same proxy, harder. Hold exactly what `location /` holds — the same
+# `include` if the proxy lines live in a snippet, never a hand copy with a
+# literal port, or whatever your deploy rewrites in `location /` stops
+# reaching these members — and only the level differs.
 location @saver {
-    brotli on;
-    brotli_comp_level 11;
-    gzip_comp_level 9;
-    proxy_pass http://127.0.0.1:4003;
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    include snippets/vutuv-proxy.conf;
+    brotli_comp_level 10;
 }
 ```
 
-`return` inside `if` is one of the two things `if` does safely, and the
-`error_page` jump keeps the original URI. Know what it buys before you add it:
-the landing page (60 kB of HTML) is 12.0 kB as gzip, 11.4 kB at brotli 6 and
-10.4 kB at brotli 11, so the harder level saves these members about 1.7 kB a
-page load at roughly ten times the CPU per page (measured 2026-09-02) — a
-tenth of one lite photo. Their pictures, not their pages, are where the mode
-earns its name, and those need no proxy change at all.
+`return` inside `if` is one of the two things `if` does safely, the
+`error_page` jump keeps the original URI, and the `Accept-Encoding` strip
+from above has to reach `@saver` too (it does through the include) or nothing
+compresses there. **The include is not a style point: these members take
+`@saver` for the LiveView websocket as well.** A hand-written copy that
+forgets the `Upgrade` or `Connection` header kills every live page for
+exactly the members the mode is for, while the pages themselves still load.
+Verify with the cookie that `/live/websocket` still answers 101.
+
+The level is 10, not 11, by measurement: on a 197 kB profile page brotli 6
+gives 26,847 bytes, 9 gives 26,282, 10 gives 24,012 and 11 gives 23,815 —
+level 9 buys one percent, level 10 nine tenths of what 11 buys at a third of
+its CPU (5 / 43 / 130 ms per page at 6 / 10 / 11). vutuv.de runs it this way
+(issue #1944): measured from outside, the profile page went from 26,562 to
+23,748 bytes with the cookie, the landing page from 10,681 to 9,593. When you
+measure with a bare `curl` and the cookie, know that the app answers such an
+anonymous request by deleting the cookie (`max-age=0`) — the route is tested,
+a member session is not. Their pictures, not their pages, are still where the
+mode earns its name, and those need no proxy change at all.
 
 **Post images need no nginx setup**: they are audience-guarded, so the app
 authorizes and serves them itself (`send_file`).

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -392,6 +392,13 @@ that accepts it and as nginx's gzip to the rest, and the app spends nothing on
 compression. Measured on vutuv.de's landing page (59 kB of HTML, 2026-09-02):
 11.5 kB as the app's gzip, 10.7 kB as brotli 6.
 
+The LiveView **websocket** is the one thing nginx cannot compress: after the
+upgrade it only passes frames through. The app compresses those frames
+itself (`compress: true` on the `/live` socket, permessage-deflate), which is
+where most of a live page's bytes are — the feed's join is 531 kB of JSON
+uncompressed and 55 kB compressed. Nothing to configure in nginx; just do not
+strip the `Sec-WebSocket-Extensions` header on the way upstream.
+
 ### Data-saving mode (optional)
 
 Every browser request from a member in data-saving mode (see "Preference

--- a/lib/vutuv/uploads/regenerator.ex
+++ b/lib/vutuv/uploads/regenerator.ex
@@ -35,7 +35,9 @@ defmodule Vutuv.Uploads.Regenerator do
   import Ecto.Query
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Organizations.OrganizationScreenshot
   alias Vutuv.Posts.PostImage
+  alias Vutuv.Posts.PostScreenshot
   alias Vutuv.Profiles.Qualification
   alias Vutuv.Profiles.Url
   alias Vutuv.Repo
@@ -182,7 +184,16 @@ defmodule Vutuv.Uploads.Regenerator do
 
   defp rows(:avatars), do: Repo.all(from(u in User, where: not is_nil(u.avatar)))
   defp rows(:covers), do: Repo.all(from(u in User, where: not is_nil(u.cover_photo)))
-  defp rows(:screenshots), do: Repo.all(from(u in Url, where: not is_nil(u.screenshot)))
+  # Every scope `Vutuv.Screenshot` stores under `screenshots/<id>`: a profile
+  # link, a post's link and an organization's homepage. Listing only the
+  # first left the other two on the old Spec for good — a member's feed is
+  # mostly post links, so that was where a Spec change was least visible.
+  defp rows(:screenshots) do
+    Repo.all(from(u in Url, where: not is_nil(u.screenshot))) ++
+      Repo.all(from(s in PostScreenshot, where: not is_nil(s.screenshot))) ++
+      Repo.all(from(s in OrganizationScreenshot, where: not is_nil(s.screenshot)))
+  end
+
   defp rows(:post_images), do: Repo.all(PostImage)
   defp rows(:job_posting_images), do: Repo.all(Vutuv.Jobs.JobPostingImage)
 

--- a/lib/vutuv_web/endpoint.ex
+++ b/lib/vutuv_web/endpoint.ex
@@ -19,8 +19,21 @@ defmodule VutuvWeb.Endpoint do
   # UTF-8) rides well under it — while bounding a hostile frame. Only a single
   # frame above 1 MB (an oversized paste far past the 20,000-char post limit, or
   # a malicious payload) now closes the connection to reconnect.
+  #
+  # `compress: true` negotiates permessage-deflate, which Phoenix leaves off by
+  # default because every open socket then holds a zlib context (up to a few
+  # hundred kB). nginx cannot do this half: after the upgrade it only passes
+  # frames through, so the frames are compressed here or not at all. Measured
+  # on the feed as `@wintermeyer` (34 cards, 2026-09-02, Bandit's own frame
+  # counters): the join sent 530,711 bytes uncompressed and 55,299 with this
+  # on — a tenth, and more than every picture on the page together. Every
+  # later patch is text of the same kind.
   socket("/live", Phoenix.LiveView.Socket,
-    websocket: [connect_info: [session: @session_options], max_frame_size: 1_000_000]
+    websocket: [
+      connect_info: [session: @session_options],
+      max_frame_size: 1_000_000,
+      compress: true
+    ]
   )
 
   # Mastodon's streaming API. Mounted on the shared endpoint because a socket

--- a/test/vutuv/uploads/regenerator_test.exs
+++ b/test/vutuv/uploads/regenerator_test.exs
@@ -188,6 +188,50 @@ defmodule Vutuv.Uploads.RegeneratorTest do
       assert Enum.sort(File.ls!(dir)) == ["lite-a1b2c3d4e5f6.avif", "thumb-a1b2c3d4e5f6.avif"]
       assert File.exists?(Path.join(tmp, "originals/screenshots/#{url.id}/original.png"))
     end
+
+    # A post's link screenshot and an organization's homepage capture are
+    # stored by the same `Vutuv.Screenshot` under the same tree, so a Spec
+    # change has to reach them too. Until 2026-09-02 the regenerator listed
+    # only profile links, and the seven link screenshots on a member's feed —
+    # 249 kB, the biggest picture cost on the page — kept serving without a
+    # lite version while the lite existed for everything else.
+    test "reaches a post's and an organization's screenshot as well", %{tmp: tmp} do
+      post_shot =
+        Repo.insert!(%Vutuv.Posts.PostScreenshot{
+          post_id: insert(:post).id,
+          url: "https://example.org/article",
+          status: "ready",
+          screenshot: "b1b2c3d4e5f6.png",
+          moderation: "approved"
+        })
+
+      org_shot =
+        Repo.insert!(%Vutuv.Organizations.OrganizationScreenshot{
+          organization_id: insert(:organization).id,
+          url: "https://example.org/",
+          status: "ready",
+          screenshot: "c1c2c3d4e5f6.png",
+          moderation: "approved"
+        })
+
+      for shot <- [post_shot, org_shot] do
+        dir = Path.join(tmp, "screenshots/#{shot.id}")
+        hash = Path.rootname(shot.screenshot)
+        jpeg!(Path.join(dir, "thumb-#{hash}.avif"))
+        jpeg!(Path.join(dir, "original-#{hash}.png"), width: 1280, height: 844)
+      end
+
+      summary = Regenerator.run(only: :screenshots)
+
+      assert summary.screenshots == %{regenerated: 2, unchanged: 0, skipped: 0, failed: 0}
+
+      for shot <- [post_shot, org_shot] do
+        hash = Path.rootname(shot.screenshot)
+
+        assert Enum.sort(File.ls!(Path.join(tmp, "screenshots/#{shot.id}"))) ==
+                 ["lite-#{hash}.avif", "thumb-#{hash}.avif"]
+      end
+    end
   end
 
   describe "post images" do

--- a/test/vutuv_web/live_socket_compression_test.exs
+++ b/test/vutuv_web/live_socket_compression_test.exs
@@ -1,0 +1,25 @@
+defmodule VutuvWeb.LiveSocketCompressionTest do
+  @moduledoc """
+  The LiveView socket negotiates permessage-deflate (`compress: true` on the
+  `/live` socket in `VutuvWeb.Endpoint`).
+
+  Pinned because it is the single largest lever on what a page costs and the
+  easiest one to lose in a refactor of the socket line: the feed's join for
+  `@wintermeyer` (34 cards, measured 2026-09-02 with Bandit's frame counters)
+  sent 530,711 bytes over the socket uncompressed and 55,299 compressed —
+  the uncompressed figure is more than every picture on the page together,
+  and nginx cannot compress a websocket for us, after the upgrade it only
+  passes frames through.
+  """
+  use ExUnit.Case, async: true
+
+  test "the LiveView socket compresses its frames" do
+    {"/live", Phoenix.LiveView.Socket, opts} =
+      Enum.find(VutuvWeb.Endpoint.__sockets__(), fn {path, _module, _opts} -> path == "/live" end)
+
+    assert opts[:websocket][:compress] == true
+    # The frame cap and the session hand-over stay as they were.
+    assert opts[:websocket][:max_frame_size] == 1_000_000
+    assert Keyword.has_key?(opts[:websocket][:connect_info], :session)
+  end
+end


### PR DESCRIPTION
Three things the feed measurement for a member turned up. The LiveView join of one feed page sent 531 kB of JSON over the websocket uncompressed, more than every picture on the page together; the socket now negotiates permessage-deflate (`compress: true` in `VutuvWeb.Endpoint`, pinned by `live_socket_compression_test.exs`), measured at 55 kB for the same join. Seven of the feed's thirteen pictures were link screenshots of posts, which `Vutuv.Uploads.Regenerator` never listed, so they had no lite version; it now covers post and organization screenshots too, and the next deploy re-derives about 1,900 of them after the traffic switch. And `docs/ADMINS.md` no longer claims nginx compresses pages on its own: Bandit gzips first, so the vhost has to strip `Accept-Encoding` upstream, the level-10 recipe for the data-saving cookie is corrected, and the numbers are the ones measured on the server.

To know: the compression holds one zlib context per open socket.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01WbzehkYE8bfbeYb1Png6Uk