### PR TITLE
Re-check the subject, not just the viewer, on five paths

### DIFF
--- a/lib/vutuv/moderation.ex
+++ b/lib/vutuv/moderation.ex
@@ -93,15 +93,15 @@ defmodule Vutuv.Moderation do
   :already_reported | changeset}`.
   """
   def report_content(%User{} = reporter, content, attrs) do
-    # An open case means the content was already frozen by an earlier report;
-    # the visibility check would now refuse everyone, but further reports on
-    # an open case are wanted (they add weight), so the case wins.
+    # The gate is `can_report?/2`, the one `ReportController.new` already asks —
+    # see its `@doc` for why the open-case allowance has to be reporter-specific.
+    # It also answers the missing-owner case, so there is no separate branch for
+    # it here.
     open = open_case_for(content)
 
     cond do
-      owner_id(content) == nil -> {:error, :not_allowed}
       owner_id(content) == reporter.id -> {:error, :own_content}
-      is_nil(open) and not reportable_by?(reporter, content) -> {:error, :not_allowed}
+      not can_report?(reporter, content, open) -> {:error, :not_allowed}
       is_nil(open) -> open_new_case(reporter, content, attrs)
       true -> join_case(open, reporter, content, attrs)
     end
@@ -121,17 +121,22 @@ defmodule Vutuv.Moderation do
   moment a case was opened. A bystander with no report on the case falls through
   to the ordinary visibility check.
   """
-  def can_report?(%User{} = reporter, content) do
+  def can_report?(%User{} = reporter, content),
+    do: can_report?(reporter, content, open_case_for(content))
+
+  # The arity-3 twin exists so `report_content/3`, which has already loaded the
+  # open case to decide what to do with it, does not read the same row twice.
+  defp can_report?(%User{} = reporter, content, open) do
     owner_id(content) != nil and
-      (reporter_on_open_case?(reporter, content) or reportable_by?(reporter, content))
+      (reporter_on_open_case?(reporter, open) or reportable_by?(reporter, content))
   end
 
   # Whether `reporter` already filed a report on `content`'s open case. Being
   # tied to the case this way keeps the report form reachable (e.g. to file a
   # follow-up), but a case nobody else can see never opens the form to a
   # stranger who cannot otherwise view the content.
-  defp reporter_on_open_case?(%User{id: reporter_id}, content) do
-    case open_case_for(content) do
+  defp reporter_on_open_case?(%User{id: reporter_id}, open) do
+    case open do
       nil ->
         false
 

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -5407,8 +5407,15 @@ defmodule Vutuv.Posts do
 
     truncated? = length(scoped) > limit
 
+    # The focus post is unioned back in because the cap can cut it — but only
+    # when this viewer may see it, the same rule `thread_skeletons/3` follows.
+    # Every caller pre-gates today, so this changes nothing for them; it stops
+    # the function from being able to hand a caller the one post it just scoped
+    # away, which is the shape that bit the permalink socket.
+    focus = if visible_to?(post, viewer), do: [post], else: []
+
     posts =
-      (Enum.take(scoped, limit) ++ up ++ [post] ++ list_replies(post, viewer))
+      (Enum.take(scoped, limit) ++ up ++ focus ++ list_replies(post, viewer))
       |> Enum.uniq_by(& &1.id)
       |> Repo.preload(post_preloads())
       |> thread_order()
@@ -5597,16 +5604,22 @@ defmodule Vutuv.Posts do
         truncated? = length(rows) > limit
         rows = if truncated?, do: Enum.take(rows, limit), else: rows
 
-        # The permalinked post itself must always be in its own window, like
-        # list_thread/3's union floor — even when the cap cut its tail.
-        rows =
-          if Enum.any?(rows, &(elem(&1, 0) == post.id)) do
-            rows
-          else
-            rows ++ [{post.id, reply_row && elem(reply_row, 1)}]
-          end
+        {with_focus(rows, post, viewer, reply_row), truncated?}
+    end
+  end
 
-        {rows, truncated?}
+  # The permalinked post itself must always be in its own window, like
+  # list_thread/3's union floor — even when the cap cut its tail. But only when
+  # this viewer may see it: `scope_visible/2` dropped it for a reason when it
+  # dropped it for them, and re-adding it unconditionally handed the caller back
+  # the one post it had just scoped away. That is what let a captured permalink
+  # socket keep rendering a post after its author narrowed the audience or
+  # moderation froze it.
+  defp with_focus(rows, post, viewer, reply_row) do
+    if not List.keymember?(rows, post.id, 0) and visible_to?(post, viewer) do
+      rows ++ [{post.id, reply_row && elem(reply_row, 1)}]
+    else
+      rows
     end
   end
 

--- a/lib/vutuv/profiles/url.ex
+++ b/lib/vutuv/profiles/url.ex
@@ -129,9 +129,15 @@ defmodule Vutuv.Profiles.Url do
   # Screenshots are generated server-side (headless Chromium) and stored via
   # the uploader, so the field is set programmatically rather than cast from
   # params.
-  defp put_screenshot(changeset, %{"screenshot" => %Plug.Upload{} = upload}),
-    do: store_screenshot(changeset, upload)
-
+  #
+  # ATOM key only, and that is the whole guard: request params are always
+  # string-keyed, so this clause can be reached by `Vutuv.PageScreenshot` and by
+  # nothing a member can send. A string-key twin used to sit here, which meant
+  # `:screenshot` was left out of `cast/3` and then read straight back out of
+  # the raw params — a member could put any picture in the slot the profile
+  # presents as an automatic capture OF THE LINKED PAGE, and the file was
+  # written to disk from inside the changeset, so it landed even when the row
+  # was never inserted. Never add a string-key clause here.
   defp put_screenshot(changeset, %{screenshot: %Plug.Upload{} = upload}),
     do: store_screenshot(changeset, upload)
 

--- a/lib/vutuv/webhooks.ex
+++ b/lib/vutuv/webhooks.ex
@@ -25,7 +25,7 @@ defmodule Vutuv.Webhooks do
 
   alias Vutuv.Accounts.User
   alias Vutuv.ApiAuth
-  alias Vutuv.ApiAuth.{App, Grant}
+  alias Vutuv.ApiAuth.{App, Grant, Scopes}
   alias Vutuv.Repo
   alias Vutuv.SocialFeed.Http
   alias Vutuv.Webhooks.{Deliverer, Delivery, Subscription}
@@ -148,7 +148,7 @@ defmodule Vutuv.Webhooks do
     if subscription_ids == [] do
       :ok
     else
-      queue_all(subscription_ids, event, envelope(member_id, event, data))
+      queue_all(member_id, subscription_ids, event, envelope(member_id, event, data))
     end
   end
 
@@ -164,7 +164,7 @@ defmodule Vutuv.Webhooks do
     }
   end
 
-  defp queue_all(subscription_ids, event, payload) do
+  defp queue_all(member_id, subscription_ids, event, payload) do
     now = DateTime.utc_now(:second)
     naive_now = NaiveDateTime.utc_now(:second)
 
@@ -173,6 +173,7 @@ defmodule Vutuv.Webhooks do
         %{
           id: Vutuv.UUIDv7.generate(),
           subscription_id: subscription_id,
+          member_id: member_id,
           event: event,
           payload: payload,
           next_attempt_at: now,
@@ -229,6 +230,7 @@ defmodule Vutuv.Webhooks do
           limit: 100
         )
       )
+      |> drop_revoked()
 
     due
     |> Task.async_stream(&safe_attempt/1,
@@ -239,6 +241,77 @@ defmodule Vutuv.Webhooks do
     |> Stream.run()
 
     length(due)
+  end
+
+  # The member's own revocation has to cut in-flight deliveries the way the
+  # app-level kill switch above does. Their grant is checked when the row is
+  # queued, so without this a revocation reached only *future* events while the
+  # backoff ladder kept retrying the queued ones for about four hours — the
+  # opposite of what the moduledoc promises about cutting a leak.
+  #
+  # Asked here rather than in the due query because the scope a row needs comes
+  # from its `event` (`required_scope/1`), which no column holds; the batch is
+  # capped at 100, so it costs one query for the whole pass.
+  #
+  # **A row that fails this is retired, not merely skipped.** The due query's
+  # only exit is `attempts < @max_attempts`, so a row filtered out of the batch
+  # keeps its past `next_attempt_at` forever and is selected again every pass —
+  # and since the batch is capped and unordered, enough of them starve the real
+  # deliveries out of it entirely. Stamping the counter is the scheduler's
+  # bookkeeping, not a claim that anything was attempted, which is what
+  # `last_error` records.
+  defp drop_revoked(deliveries) do
+    live_scopes =
+      deliveries
+      |> Enum.map(& &1.member_id)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+      |> live_grant_scopes()
+
+    {keep, revoked} = Enum.split_with(deliveries, &granted?(&1, live_scopes))
+
+    retire(revoked)
+    keep
+  end
+
+  defp retire([]), do: :ok
+
+  defp retire(deliveries) do
+    ids = Enum.map(deliveries, & &1.id)
+
+    Repo.update_all(
+      from(d in Delivery, where: d.id in ^ids),
+      set: [
+        attempts: @max_attempts,
+        last_error: "grant revoked before delivery",
+        updated_at: NaiveDateTime.utc_now(:second)
+      ]
+    )
+
+    :ok
+  end
+
+  defp live_grant_scopes([]), do: %{}
+
+  # One row per member × app (`oauth_grants` carries a unique index on the
+  # pair), so the map is built rather than merged.
+  defp live_grant_scopes(member_ids) do
+    from(g in Grant,
+      where: g.user_id in ^member_ids and is_nil(g.revoked_at),
+      select: {{g.user_id, g.app_id}, g.scopes}
+    )
+    |> Repo.all()
+    |> Map.new()
+  end
+
+  # A ping carries no member and nothing of anyone's, and a row queued before
+  # the column existed records no member to ask about — neither is gated.
+  defp granted?(%Delivery{member_id: nil}, _live_scopes), do: true
+
+  defp granted?(%Delivery{} = delivery, live_scopes) do
+    live_scopes
+    |> Map.get({delivery.member_id, delivery.subscription.app_id}, [])
+    |> Scopes.granted?(required_scope(delivery.event))
   end
 
   # One delivery raising must not take down the whole batch (and the Deliverer

--- a/lib/vutuv/webhooks/delivery.ex
+++ b/lib/vutuv/webhooks/delivery.ex
@@ -11,6 +11,11 @@ defmodule Vutuv.Webhooks.Delivery do
   schema "webhook_deliveries" do
     belongs_to(:subscription, Vutuv.Webhooks.Subscription)
 
+    # Whose event this carries, so the sender can re-ask whether they still
+    # authorize the app. `nil` for a ping (no member, no grant) and for a row
+    # queued before the column existed.
+    belongs_to(:member, Vutuv.Accounts.User)
+
     field(:event, :string)
     field(:payload, :map, default: %{})
     field(:attempts, :integer, default: 0)

--- a/lib/vutuv_web/controllers/mastodon_api/account_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/account_controller.ex
@@ -5,20 +5,17 @@ defmodule VutuvWeb.MastodonApi.AccountController do
 
   import VutuvWeb.MastodonApi.Errors
 
-  alias Vutuv.Accounts
   alias Vutuv.Accounts.User
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.MastodonApi.AccountCounts
   alias Vutuv.MastodonApi.Presenter
-  alias Vutuv.Moderation
-  alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias Vutuv.Profiles.VerifiedLinks
   alias Vutuv.Repo
   alias Vutuv.Social
-  alias Vutuv.UUIDv7
+  alias VutuvWeb.MastodonApi.AccountIds
   alias VutuvWeb.MastodonApi.Handles
   alias VutuvWeb.MastodonApi.Pagination
   alias VutuvWeb.MastodonApi.Statuses
@@ -49,7 +46,7 @@ defmodule VutuvWeb.MastodonApi.AccountController do
   def lookup(conn, _params), do: not_found(conn)
 
   def show(conn, %{"id" => id}) do
-    case target(conn, id) do
+    case AccountIds.visible(conn, id) do
       nil -> not_found(conn)
       account -> json(conn, Presenter.account(with_links(account), counts(conn, account)))
     end
@@ -62,13 +59,13 @@ defmodule VutuvWeb.MastodonApi.AccountController do
   # account embedded in a status, so the same page reported two different post
   # counts depending on which object the client happened to read.
   # The viewer differs by subject and always has: a page's own publisher may see
-  # its frozen posts, a member's profile is read as `profile_viewer/1` decides.
+  # its frozen posts, a member's profile is read as `AccountIds.viewer/1` decides.
   # Only the *arithmetic* moved out; passing the viewer stays here, because this
   # is the only layer that knows which page the request is acting for.
   defp counts(conn, %Organization{} = page),
-    do: AccountCounts.for_account(page, organization_viewer(conn, page))
+    do: AccountCounts.for_account(page, AccountIds.organization_viewer(conn, page))
 
-  defp counts(conn, subject), do: AccountCounts.for_account(subject, profile_viewer(conn))
+  defp counts(conn, subject), do: AccountCounts.for_account(subject, AccountIds.viewer(conn))
 
   def follow(conn, %{"id" => id}), do: relationship_action(conn, id, :follow)
   def unfollow(conn, %{"id" => id}), do: relationship_action(conn, id, :unfollow)
@@ -92,7 +89,7 @@ defmodule VutuvWeb.MastodonApi.AccountController do
       |> List.wrap()
       |> Enum.uniq()
       |> Enum.take(@max_relationships)
-      |> Enum.map(&target(conn, &1))
+      |> Enum.map(&AccountIds.visible(conn, &1))
       |> Enum.reject(&is_nil/1)
       |> Enum.map(&relationship(conn, &1))
 
@@ -110,8 +107,8 @@ defmodule VutuvWeb.MastodonApi.AccountController do
     # remote account we only cache, so both answer the empty list rather than
     # their newest post.
     posts =
-      case target(conn, id) do
-        %User{} = user -> user |> Posts.pinned_post(profile_viewer(conn)) |> List.wrap()
+      case AccountIds.visible(conn, id) do
+        %User{} = user -> user |> Posts.pinned_post(AccountIds.viewer(conn)) |> List.wrap()
         _page_or_remote -> []
       end
 
@@ -123,15 +120,15 @@ defmodule VutuvWeb.MastodonApi.AccountController do
     opts = Pagination.opts(page)
 
     statuses =
-      case target(conn, id) do
+      case AccountIds.visible(conn, id) do
         %User{} = user ->
           user
-          |> Posts.author_statuses(profile_viewer(conn), opts)
+          |> Posts.author_statuses(AccountIds.viewer(conn), opts)
           |> Presenter.statuses(viewer(conn))
 
         %Organization{} = organization ->
           organization
-          |> Posts.organization_statuses(organization_viewer(conn, organization), opts)
+          |> Posts.organization_statuses(AccountIds.organization_viewer(conn, organization), opts)
           |> Presenter.statuses(viewer(conn))
 
         # The only source here that cannot be bounded in its query: what we
@@ -166,7 +163,7 @@ defmodule VutuvWeb.MastodonApi.AccountController do
     opts = Pagination.opts(page)
 
     accounts =
-      case {target(conn, id), conn.assigns.current_organization} do
+      case {AccountIds.visible(conn, id), conn.assigns.current_organization} do
         {%User{} = user, _identity} ->
           user_following(conn, user, opts)
 
@@ -192,7 +189,7 @@ defmodule VutuvWeb.MastodonApi.AccountController do
   end
 
   defp relationship_action(conn, id, action) do
-    case target(conn, id) do
+    case AccountIds.visible(conn, id) do
       nil ->
         not_found(conn)
 
@@ -443,28 +440,6 @@ defmodule VutuvWeb.MastodonApi.AccountController do
       Social.organization_followed_pages(organization, opts) ++ remote_accounts
   end
 
-  defp target(_conn, "remote-" <> id), do: Fediverse.get_remote_account(id)
-
-  defp target(conn, id) do
-    with uuid when not is_nil(uuid) <- UUIDv7.cast_or_nil(id) do
-      visible_target(conn, Accounts.get_user(uuid) || Organizations.get_organization(uuid))
-    end
-  end
-
-  defp visible_target(conn, %User{} = user) do
-    if Moderation.profile_visible_to?(user, profile_viewer(conn)), do: user
-  end
-
-  defp visible_target(conn, %Organization{} = organization) do
-    if Organizations.organization_visible_to?(
-         organization,
-         organization_viewer(conn, organization)
-       ),
-       do: organization
-  end
-
-  defp visible_target(_conn, nil), do: nil
-
   # The webpages a member has PROVED are their own, which is what the account's
   # Mastodon `fields` are built from. Loaded here rather than in the presenter,
   # so this stays the endpoints that answer with a **single** account: a
@@ -475,27 +450,11 @@ defmodule VutuvWeb.MastodonApi.AccountController do
   defp with_links(%User{} = user), do: Repo.preload(user, VerifiedLinks.preload_spec())
   defp with_links(other), do: other
 
-  defp profile_viewer(%{assigns: %{current_organization: nil, current_user: user}}), do: user
-  defp profile_viewer(_conn), do: nil
-
   # The acting identity, for the engagement figures on a status. Distinct from
-  # `profile_viewer/1`, which answers who may *see* a profile: a page identity
-  # sees what an anonymous reader sees, but it likes and bookmarks as itself.
+  # `AccountIds.viewer/1`, which answers who may *see* a profile: a page
+  # identity sees what an anonymous reader sees, but it likes and bookmarks as
+  # itself.
   defp viewer(conn), do: Statuses.viewer(conn)
-
-  defp organization_viewer(
-         %{assigns: %{current_organization: %Organization{id: id}, current_user: user}},
-         %Organization{id: id}
-       ),
-       do: user
-
-  defp organization_viewer(
-         %{assigns: %{current_organization: nil, current_user: user}},
-         _organization
-       ),
-       do: user
-
-  defp organization_viewer(_conn, _organization), do: nil
 
   defp action_error(conn, :not_following),
     do: error(conn, 422, "The account is not followed")

--- a/lib/vutuv_web/controllers/mastodon_api/list_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/list_controller.ex
@@ -21,7 +21,6 @@ defmodule VutuvWeb.MastodonApi.ListController do
 
   import Ecto.Query, only: [from: 2]
 
-  alias Vutuv.Accounts
   alias Vutuv.Accounts.User
   alias Vutuv.Fediverse
   alias Vutuv.Keyset
@@ -30,7 +29,7 @@ defmodule VutuvWeb.MastodonApi.ListController do
   alias Vutuv.Posts.Post
   alias Vutuv.Repo
   alias Vutuv.Social
-  alias Vutuv.UUIDv7
+  alias VutuvWeb.MastodonApi.AccountIds
   alias VutuvWeb.MastodonApi.Pagination
   alias VutuvWeb.MastodonApi.Statuses
 
@@ -53,21 +52,25 @@ defmodule VutuvWeb.MastodonApi.ListController do
   def favourites(conn, params),
     do: engaged(conn, params, [&Posts.liked_statuses/2, &Fediverse.liked_statuses/2])
 
+  # The roster of an account this installation withholds is not ours to serve,
+  # and a non-empty answer would confirm the account exists where the profile
+  # itself answers 403 — so the subject goes through the same gate the sibling
+  # endpoints in `AccountController` apply, and a withheld one 404s.
   def followers(conn, %{"id" => id} = params) do
     page = Pagination.params(params)
 
-    accounts =
-      case UUIDv7.with_cast(id, &Accounts.get_user/1) do
-        %User{} = user ->
+    case AccountIds.visible(conn, id) do
+      %User{} = user ->
+        accounts =
           user
           |> Social.follow_accounts(:followers, Pagination.opts(page))
           |> Enum.map(&Presenter.account/1)
 
-        nil ->
-          []
-      end
+        respond(conn, accounts, page)
 
-    respond(conn, accounts, page)
+      _withheld_or_absent ->
+        not_found(conn)
+    end
   end
 
   def blocks(conn, params) do

--- a/lib/vutuv_web/live/post_live/thread.ex
+++ b/lib/vutuv_web/live/post_live/thread.ex
@@ -218,15 +218,29 @@ defmodule VutuvWeb.PostLive.Thread do
 
   def handle_info(_other, socket), do: {:noreply, socket}
 
+  defp visible_focus(post_id, viewer) do
+    with %Posts.Post{} = post <- Posts.get_post(post_id),
+         true <- Posts.visible_to?(post, viewer) do
+      post
+    else
+      _withheld_or_gone -> nil
+    end
+  end
+
   # (Re)computes the window for the current budgets and batches what the
   # cards need: engagement for every shown post's action bar and the viewer's
   # follow edges for the ⋯ menus' mute items — the way the feed does it.
   defp load_window(socket) do
     viewer = socket.assigns.current_user
 
-    case Posts.get_post(socket.assigns.post_id) do
+    # The controller checked visibility once, for the request that rendered the
+    # page. This session map is signed but not encrypted and lives for days, so
+    # a socket joining with it has to be told again — a post narrowed or frozen
+    # since then is as absent here as a deleted one.
+    case visible_focus(socket.assigns.post_id, viewer) do
       nil ->
-        # Deleted while the socket lived; the controller 404s the next load.
+        # Deleted, or no longer this viewer's to see; the controller answers the
+        # next full load.
         socket
         |> assign(:window, nil)
         |> assign(:focus, nil)

--- a/lib/vutuv_web/mastodon_api/account_ids.ex
+++ b/lib/vutuv_web/mastodon_api/account_ids.ex
@@ -1,0 +1,103 @@
+defmodule VutuvWeb.MastodonApi.AccountIds do
+  @moduledoc """
+  Turning an account id a client sent into the account it names, and deciding
+  whether this installation will speak about it at all.
+
+  The id twin of `VutuvWeb.MastodonApi.Handles`, and the same shape as
+  `VutuvWeb.MastodonApi.Statuses`: resolving and gating are one call, because an
+  id is not a secret. It travels in every timeline, follower list and status the
+  caller ever fetched, and it keeps working after the account is frozen,
+  suspended or deactivated — so a caller that resolves first and remembers to
+  gate second is a caller that will one day forget.
+
+  One did. `AccountController` gated `show`, `statuses`, `following` and the
+  relationship actions through its own private `target/2`, while the follower
+  list lives in `ListController` and resolved the same parameter with a bare
+  `Accounts.get_user/1` — so a withheld member's roster was served in full, and
+  its non-emptiness confirmed the account still existed where the profile page
+  answers 403.
+
+  `visible_to_identity/2` is the gate itself, and `Handles` reads it from here
+  rather than keeping a second copy: "may this identity see this account" is one
+  question whether the client spelled the account as an id or as a handle.
+  """
+
+  alias Vutuv.Accounts
+  alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse
+  alias Vutuv.Moderation
+  alias Vutuv.Organizations
+  alias Vutuv.Organizations.Organization
+  alias Vutuv.UUIDv7
+
+  @doc """
+  The member, page or remote account `id` names, or `nil` when this
+  installation withholds it — which every caller answers as a 404, the
+  adapter's documented "same answer for missing and hidden".
+
+  A `remote-`-prefixed id is another server's account, cached here; nothing
+  about our own moderation state applies to it.
+  """
+  def visible(_conn, "remote-" <> id), do: Fediverse.get_remote_account(id)
+
+  def visible(conn, id) do
+    with uuid when not is_nil(uuid) <- UUIDv7.cast_or_nil(id) do
+      visible_to_identity(Accounts.get_user(uuid) || Organizations.get_organization(uuid), conn)
+    end
+  end
+
+  @doc """
+  Whether the reading identity may see `account`, or `nil` if not.
+
+  Shared with `VutuvWeb.MastodonApi.Handles`, which asks the same question of an
+  account it found by handle.
+  """
+  def visible_to_identity(%User{} = user, conn) do
+    if Moderation.profile_visible_to?(user, viewer(conn)), do: user
+  end
+
+  # A member viewer gets the **account** rule, the one `GET /api/v1/accounts/:id`
+  # answers by (`Organizations.organization_visible_to?/2`, which also covers a
+  # manager and a site admin). Anything narrower means an owner can fetch their
+  # own frozen page by id and is told "no such account" when they look the same
+  # page up by handle. A client acting **as** a page has no member to ask about,
+  # so it sees the public pages and itself.
+  def visible_to_identity(%Organization{} = organization, conn) do
+    if Organizations.organization_visible_to?(
+         organization,
+         organization_viewer(conn, organization)
+       ),
+       do: organization
+  end
+
+  def visible_to_identity(nil, _conn), do: nil
+
+  @doc """
+  Who is reading, for the purpose of deciding what may be seen.
+
+  A member reads as themselves; an identity acting for a page reads as an
+  anonymous visitor, because a page has no standing to see a withheld profile.
+  Distinct from the acting identity a like or a bookmark is recorded under,
+  which is `VutuvWeb.MastodonApi.Statuses.viewer/1`.
+  """
+  def viewer(%{assigns: %{current_organization: nil, current_user: user}}), do: user
+  def viewer(_conn), do: nil
+
+  @doc """
+  Who is reading, when the subject is a page: its own team reads as the member
+  behind the identity, everyone else as themselves.
+  """
+  def organization_viewer(
+        %{assigns: %{current_organization: %Organization{id: id}, current_user: user}},
+        %Organization{id: id}
+      ),
+      do: user
+
+  def organization_viewer(
+        %{assigns: %{current_organization: nil, current_user: user}},
+        _organization
+      ),
+      do: user
+
+  def organization_viewer(_conn, _organization), do: nil
+end

--- a/lib/vutuv_web/mastodon_api/handles.ex
+++ b/lib/vutuv_web/mastodon_api/handles.ex
@@ -14,12 +14,10 @@ defmodule VutuvWeb.MastodonApi.Handles do
   """
 
   alias Vutuv.Accounts
-  alias Vutuv.Accounts.User
   alias Vutuv.Fediverse
   alias Vutuv.MastodonApi
-  alias Vutuv.Moderation
   alias Vutuv.Organizations
-  alias Vutuv.Organizations.Organization
+  alias VutuvWeb.MastodonApi.AccountIds
   alias VutuvWeb.MastodonApi.Statuses
 
   @doc """
@@ -85,7 +83,7 @@ defmodule VutuvWeb.MastodonApi.Handles do
     handle
     |> String.downcase()
     |> known_account()
-    |> visible_to_identity(conn)
+    |> AccountIds.visible_to_identity(conn)
   end
 
   defp known_account(handle) do
@@ -93,29 +91,4 @@ defmodule VutuvWeb.MastodonApi.Handles do
       Organizations.get_organization_by_username(handle) ||
       Organizations.get_organization_by_slug(handle)
   end
-
-  defp visible_to_identity(%User{} = user, conn) do
-    viewer = if is_nil(conn.assigns.current_organization), do: conn.assigns.current_user
-    if Moderation.profile_visible_to?(user, viewer), do: user
-  end
-
-  # A member viewer gets the **account** rule, the one `GET /api/v1/accounts/:id`
-  # answers by (`Organizations.organization_visible_to?/2`, which also covers a
-  # manager and a site admin). Anything narrower means an owner can fetch their
-  # own frozen page by id and is told "no such account" when they look the same
-  # page up by handle. A client acting **as** a page has no member to ask about,
-  # so it sees the public pages and itself.
-  defp visible_to_identity(%Organization{} = organization, conn) do
-    case conn.assigns.current_organization do
-      %Organization{id: id} ->
-        if Organizations.public_visible?(organization) or id == organization.id,
-          do: organization
-
-      nil ->
-        if Organizations.organization_visible_to?(organization, conn.assigns.current_user),
-          do: organization
-    end
-  end
-
-  defp visible_to_identity(nil, _conn), do: nil
 end

--- a/priv/repo/migrations/20260902210604_add_member_id_to_webhook_deliveries.exs
+++ b/priv/repo/migrations/20260902210604_add_member_id_to_webhook_deliveries.exs
@@ -1,0 +1,24 @@
+defmodule Vutuv.Repo.Migrations.AddMemberIdToWebhookDeliveries do
+  use Ecto.Migration
+
+  # Which member's event a queued delivery carries, so `deliver_due/0` can ask
+  # again whether they still authorize the app — the grant was checked once, at
+  # emit, and a revocation therefore did not reach anything already queued or
+  # retrying (the backoff ladder runs about four hours).
+  #
+  # Nullable, and it stays nullable: a `ping` has no member and no grant, and
+  # rows queued by the release before this one have no member recorded. Both are
+  # exempted in the query rather than backfilled — a ping legitimately, an old
+  # row because guessing its member from the payload slug would be inventing
+  # the fact this column exists to record.
+  #
+  # A plain nullable add plus an index, so the currently deployed release keeps
+  # working unchanged (N-1).
+  def change do
+    alter table(:webhook_deliveries) do
+      add(:member_id, references(:users, on_delete: :delete_all, type: :binary_id))
+    end
+
+    create(index(:webhook_deliveries, [:member_id]))
+  end
+end

--- a/test/vutuv/moderation_test.exs
+++ b/test/vutuv/moderation_test.exs
@@ -97,19 +97,42 @@ defmodule Vutuv.ModerationTest do
                Moderation.report_content(reporter, post, %{"category" => "spam"})
     end
 
-    test "a second reporter joins the existing open case", %{owner: owner, reporter: reporter} do
+    # Weight still accumulates where accumulating it means something: an
+    # untrusted reporter only *flags*, so the content stays visible and anyone
+    # who can see it may add their report to the open case.
+    test "a second reporter joins the open case on content still visible", %{owner: owner} do
+      bad_reporter = make_untrusted!(insert(:activated_user))
       post = insert_post(owner)
-      case_record = report!(reporter, post)
+      case_record = report!(bad_reporter, post)
 
-      other = insert(:activated_user)
-      # Reload: the post is frozen now, but reports on an open case must
-      # still be accepted (they add weight to the case).
+      refute Repo.get!(Vutuv.Posts.Post, post.id).frozen_at
+
+      assert %Case{id: same_id} = report!(insert(:activated_user), post)
+      assert same_id == case_record.id
+      # Scoped to this case: make_untrusted!/1 files a report of its own.
+      assert Repo.aggregate(from(r in Report, where: r.case_id == ^same_id), :count) == 2
+    end
+
+    # This used to be allowed, and it was the hole: an open case made the
+    # visibility check unreachable for *everyone*, so once a first report froze
+    # the post, a stranger who could no longer see it (and a member the author
+    # had blocked) could still file — and a trusted reporter's report is what
+    # upgrades a flagged case and freezes content. The allowance is
+    # reporter-specific now, which is what the report form always asked.
+    test "a stranger cannot report content the freeze has already hidden", %{
+      owner: owner,
+      reporter: reporter
+    } do
+      post = insert_post(owner)
+      report!(reporter, post)
+
       post = Repo.get!(Vutuv.Posts.Post, post.id)
       assert post.frozen_at
 
-      assert %Case{id: same_id} = report!(other, post)
-      assert same_id == case_record.id
-      assert Repo.aggregate(Report, :count) == 2
+      assert {:error, :not_allowed} =
+               Moderation.report_content(insert(:activated_user), post, %{"category" => "spam"})
+
+      assert Repo.aggregate(Report, :count) == 1
     end
 
     test "a report from an untrusted reporter only flags, without freezing", %{owner: owner} do

--- a/test/vutuv/posts_test.exs
+++ b/test/vutuv/posts_test.exs
@@ -2285,6 +2285,32 @@ defmodule Vutuv.PostsTest do
     end
   end
 
+  describe "thread_window/3 visibility" do
+    # The window re-adds the permalinked post to its own slice because the
+    # skeleton cap can cut it — but it did so whatever the viewer may see, so
+    # the function handed its caller back the one post it had just scoped away.
+    # That is what let a captured permalink socket keep rendering a post after
+    # its author narrowed the audience or moderation froze it.
+    test "does not hand back a post the viewer may not see" do
+      writer = insert_activated_user()
+
+      {:ok, post} =
+        Posts.create_post(writer, %{
+          body: "Nur für Follower",
+          denials: [%{"wildcard" => "everyone"}]
+        })
+
+      # A short conversation comes back whole (mode :all), so the focus post is
+      # in `posts` — or, for a viewer who may not see it, in nothing at all.
+      assert %{mode: :all, posts: []} = Posts.thread_window(post, nil, ancestors: 5, replies: 5)
+
+      assert %{mode: :all, posts: [%{id: id}]} =
+               Posts.thread_window(post, writer, ancestors: 5, replies: 5)
+
+      assert id == post.id
+    end
+  end
+
   describe "thread_window/3" do
     # A chain thread: root, then `depth` replies each answering the previous
     # one. Returns `[root, c1, ..., cN]`.

--- a/test/vutuv/profiles/url_test.exs
+++ b/test/vutuv/profiles/url_test.exs
@@ -13,6 +13,33 @@ defmodule Vutuv.Profiles.UrlTest do
     Url.changeset(%Url{}, %{"value" => value, "description" => "x"}).valid?
   end
 
+  # The capture is what the profile presents as an automatic picture *of the
+  # linked page*, and it is taken server-side for exactly that reason. The
+  # changeset leaves `:screenshot` out of `cast/3` and then read it back out of
+  # the raw params under its string key — the one shape only a multipart request
+  # produces — so a member could upload any image into the slot, and the file
+  # was written to disk from inside the changeset, before any insert.
+  test "a screenshot cannot be uploaded through the params" do
+    # A real file, so the test fails on the upload being stored rather than on
+    # the fixture being absent.
+    path = Path.join(System.tmp_dir!(), "not-a-capture-#{System.unique_integer([:positive])}.png")
+    File.write!(path, <<0x89, ?P, ?N, ?G, 13, 10, 26, 10>>)
+    on_exit(fn -> File.rm(path) end)
+
+    upload = %Plug.Upload{path: path, filename: Path.basename(path), content_type: "image/png"}
+
+    changeset =
+      Url.changeset(%Url{}, %{
+        "value" => "https://example.org",
+        "description" => "x",
+        "screenshot" => upload
+      })
+
+    assert changeset.valid?
+    assert Ecto.Changeset.get_change(changeset, :screenshot) == nil
+    assert Ecto.Changeset.get_change(changeset, :screenshot_moderation) == nil
+  end
+
   test "accepts ordinary public URLs" do
     assert valid?("https://example.org/profile")
     assert valid?("example.org")

--- a/test/vutuv/webhooks_test.exs
+++ b/test/vutuv/webhooks_test.exs
@@ -290,6 +290,32 @@ defmodule Vutuv.WebhooksTest do
       assert Webhooks.deliver_due() == 0
     end
 
+    # The app-level kill switch above cuts in-flight deliveries; the member's own
+    # revocation did not, because the grant was checked once at emit and never
+    # again. The backoff ladder retries a failing endpoint for about four hours,
+    # so "I revoked it" and "it stopped receiving my events" were hours apart.
+    test "a revoked grant stops an already-queued delivery", %{member: member, app: app} do
+      subscribe!(app, ["follower.created"])
+      grant!(member, app, ["social:read"])
+      Webhooks.emit(member.id, "follower.created", %{"follower" => "anna"})
+
+      assert Repo.aggregate(Delivery, :count) == 1
+
+      [grant] = ApiAuth.list_grants(member)
+      ApiAuth.revoke_grant!(grant)
+
+      assert Webhooks.deliver_due() == 0
+
+      # And the row is retired, not merely skipped: the due query only lets a
+      # row go at @max_attempts, so one that is filtered out of the batch would
+      # otherwise be selected again every 15 s forever — and, the batch being
+      # capped and unordered, would eventually starve real deliveries out of it.
+      assert Webhooks.deliver_due() == 0
+      assert %{attempts: attempts, last_error: reason} = Repo.one(Delivery)
+      assert attempts == Webhooks.max_attempts()
+      assert reason =~ "revoked"
+    end
+
     test "failures back off and eventually disable the subscription", %{member: member, app: app} do
       {subscription, _secret} = subscribe!(app, ["follower.created"])
       grant!(member, app, ["social:read"])
@@ -371,6 +397,8 @@ defmodule Vutuv.WebhooksTest do
       assert [%Delivery{delivered_at: nil, last_status: 302}] = Repo.all(Delivery)
     end
 
+    # Also the guard on the send-time grant check: a ping carries no member and
+    # no grant, so it is the one delivery deliberately left ungated.
     test "ping delivers without any grant", %{app: app} do
       {subscription, _secret} = subscribe!(app, ["follower.created"])
 

--- a/test/vutuv_web/controllers/mastodon_api/list_controller_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/list_controller_test.exs
@@ -195,6 +195,22 @@ defmodule VutuvWeb.MastodonApi.ListControllerTest do
     assert Enum.map(accounts, & &1["id"]) == [follower.id]
   end
 
+  # Every sibling endpoint resolves its subject through the profile gate, so a
+  # frozen account answers nothing about itself; this one read the roster with a
+  # bare lookup, which both leaked the list and confirmed the account exists.
+  test "a withheld member's follower list is not served", %{conn: conn} do
+    frozen = insert_activated_user(frozen_at: NaiveDateTime.utc_now(:second))
+    follower = insert(:activated_user)
+    {:ok, _} = Social.follow(follower, frozen.id)
+
+    token = mastodon_token(insert(:activated_user), ["read"])
+
+    assert conn
+           |> mastodon_conn(token)
+           |> get("/api/v1/accounts/#{frozen.id}/followers")
+           |> response(404)
+  end
+
   test "blocked and muted members are listed", %{conn: conn} do
     member = insert(:activated_user)
     blocked = insert(:activated_user)

--- a/test/vutuv_web/controllers/report_controller_test.exs
+++ b/test/vutuv_web/controllers/report_controller_test.exs
@@ -4,6 +4,11 @@ defmodule VutuvWeb.ReportControllerTest do
   alias Vutuv.Moderation
   alias Vutuv.Moderation.Case
 
+  # Both members must be logged in before a freeze fires its owner-notification
+  # email, so each login PIN is still the newest mail; each needs its own
+  # session-initialised conn (see the ConnCase setup).
+  defp fresh_conn, do: Plug.Test.init_test_session(build_conn(), %{})
+
   setup %{conn: conn} do
     author = insert_activated_user()
     post = insert(:post, user: author)
@@ -95,12 +100,8 @@ defmodule VutuvWeb.ReportControllerTest do
     end
 
     test "a bystander cannot preview frozen content once a case is open, but the author can" do
-      # Log both members in first, so each login PIN is read from the mailbox
-      # before the freeze fires its owner-notification email. Each needs its own
-      # session-initialised conn (see the ConnCase setup).
-      fresh_conn = fn -> Plug.Test.init_test_session(build_conn(), %{}) end
-      {author_conn, author} = create_and_login_user(fresh_conn.())
-      {bystander_conn, _bystander} = create_and_login_user(fresh_conn.())
+      {author_conn, author} = create_and_login_user(fresh_conn())
+      {bystander_conn, _bystander} = create_and_login_user(fresh_conn())
 
       post = insert(:post, user: author)
 
@@ -177,6 +178,30 @@ defmodule VutuvWeb.ReportControllerTest do
       assert flash =~ "paused"
       assert flash =~ "either"
       assert flash =~ "unfounded"
+    end
+
+    # The `new` action has refused a bystander since #F10, but `create` never
+    # shared the gate: an open case made the visibility check unreachable for
+    # *everyone*, so a member the author had blocked could still file — and a
+    # trusted reporter's report is what upgrades a flagged case and freezes the
+    # content. The form 404ing while the POST behind it worked is the whole bug.
+    test "a bystander cannot file on an open case they could not see" do
+      {_author_conn, author} = create_and_login_user(fresh_conn())
+      {bystander_conn, bystander} = create_and_login_user(fresh_conn())
+
+      post = insert(:post, user: author)
+      {:ok, _} = Vutuv.Social.block_user(author, bystander)
+
+      {:ok, _} = Moderation.report_content(insert_activated_user(), post, %{"category" => "spam"})
+      cases_before = Repo.aggregate(Case, :count)
+
+      assert bystander_conn
+             |> post(~p"/reports", %{
+               "report" => %{"type" => "post", "id" => post.id, "category" => "spam"}
+             })
+             |> response(404)
+
+      assert Repo.aggregate(Case, :count) == cases_before
     end
 
     test "reporting your own content is refused", %{conn: conn} do

--- a/test/vutuv_web/live/post_thread_live_test.exs
+++ b/test/vutuv_web/live/post_thread_live_test.exs
@@ -50,6 +50,28 @@ defmodule VutuvWeb.PostThreadLiveTest do
     {root, chain |> Enum.reverse() |> tl()}
   end
 
+  describe "the focus post is authorized on the socket" do
+    # The `post_id` reaches this LiveView through the controller-curated
+    # `live_render` session — signed, unencrypted, bound to no user and good for
+    # days. The controller checked visibility once, when the page was public;
+    # nothing re-asked. So a token lifted from a public permalink kept serving
+    # the post in full after its author narrowed it, to a socket carrying no
+    # cookie at all.
+    test "a post restricted after the token was minted is not rendered" do
+      writer = author()
+      post = create_post!(writer, %{body: "Erst öffentlich, dann nicht mehr"})
+
+      {:ok, _view, html} = thread_view(post)
+      assert html =~ "Erst öffentlich, dann nicht mehr"
+
+      {:ok, restricted} =
+        Posts.update_post(post, %{body: post.body, denials: [%{"wildcard" => "everyone"}]})
+
+      {:ok, _view, html} = thread_view(restricted)
+      refute html =~ "Erst öffentlich, dann nicht mehr"
+    end
+  end
+
   describe "small conversations (unchanged, issue #1006)" do
     test "a lone post renders as a single card without the thread frame" do
       post = create_post!(author(), %{body: "all alone here"})


### PR DESCRIPTION
Five more from the scan (after #1939, #1943, #1945, #1947, #1950, #1951). Each
had the same check somewhere else already.

`GET /api/v1/accounts/:id/followers` resolved its subject with a bare lookup
while every sibling endpoint gated it, so a frozen member's roster was served in
full — and its non-emptiness confirmed the account exists where the profile
answers 403. The gate now lives in `VutuvWeb.MastodonApi.AccountIds` and
`Handles` reads it from there instead of keeping a second copy.

`POST /reports` never asked `can_report?/2`, the gate its own form uses: an open
case made the visibility check unreachable for *everyone*, and a trusted
reporter's report is what freezes content. The permalink's embedded conversation
took its post id from a signed, unencrypted session map good for days and never
re-asked. A webhook delivery checked the member's grant once, at enqueue, so
revoking reached only future events while the backoff ladder retried the queued
ones for hours. And `Url.changeset/2` read `:screenshot` back out of the raw
params under the string key only a request produces.

One migration: a nullable column plus index, so N-1 holds. Every check was
reverted once to watch its test go red.

https://claude.ai/code/session_01HpEBfNDHjPRmJ1Joe2923o
