### PR TITLE
Embedded LiveViews must re-check their subject too

### DIFF
--- a/lib/vutuv_web/live/cv_live.ex
+++ b/lib/vutuv_web/live/cv_live.ex
@@ -20,6 +20,8 @@ defmodule VutuvWeb.CVLive do
   import VutuvWeb.UserHelpers
 
   alias Vutuv.Accounts
+  alias Vutuv.Accounts.User
+  alias Vutuv.Moderation
   alias VutuvWeb.CV
   alias VutuvWeb.CV.MarkdownBlocks
   alias VutuvWeb.Live.InitAssigns
@@ -29,7 +31,11 @@ defmodule VutuvWeb.CVLive do
     socket = InitAssigns.assign_embedded(socket, session)
     current_user = socket.assigns.current_user
 
-    user = Accounts.get_user(session["profile_user_id"])
+    # Re-authorized on the socket, not only by `CVController`: the session map
+    # carrying this id is signed but not encrypted and lives for days, and a CV
+    # is the member's whole work history, name, phone, address and links. See
+    # the twin in `VutuvWeb.UserProfileLive.subject!/2`.
+    user = visible_subject(session["profile_user_id"], current_user)
 
     # Name-qualify the tab/OpenGraph title and give the CV page its own
     # OpenGraph description, so a shared link reads as "<Name>'s Lebenslauf",
@@ -99,6 +105,18 @@ defmodule VutuvWeb.CVLive do
   # language/social-media id. Any other key is a no-op (F12). The CV is built
   # once at mount and never rebuilt for the socket's life, so this is computed
   # once too.
+  # `nil` rather than a raise: this LiveView's own template reads `@user`, and a
+  # CV of nobody renders nothing, which is the honest answer for a member the
+  # site withholds. The controller that embeds it answers the real 403/410.
+  defp visible_subject(nil, _viewer), do: nil
+
+  defp visible_subject(profile_user_id, viewer) do
+    case Accounts.get_user(profile_user_id) do
+      %User{} = user -> if Moderation.profile_visible_to?(user, viewer), do: user
+      nil -> nil
+    end
+  end
+
   defp allowed_keys(cv) do
     identity = for {key, _field} <- CV.identity_fields(), do: key
     card_keys = ~w(tags links qualifications languages social_media)

--- a/lib/vutuv_web/live/organization_live/activity.ex
+++ b/lib/vutuv_web/live/organization_live/activity.ex
@@ -33,24 +33,32 @@ defmodule VutuvWeb.OrganizationLive.Activity do
   alias Vutuv.Organizations
   alias Vutuv.Posts
   alias VutuvWeb.Live.InitAssigns
+  alias VutuvWeb.OrganizationLive.ManageGate
   alias VutuvWeb.PostTeaser
 
   @impl true
   def mount(_params, session, socket) do
     socket = InitAssigns.assign_embedded(socket, session)
-    organization = Organizations.get_organization!(session["organization_id"])
 
-    # The marker is read BEFORE it is stamped, or the page would clear its own
-    # "new" marks before drawing them and nothing would ever look unread.
-    marker = organization.activity_read_at
-    if connected?(socket), do: Organizations.mark_activity_read(organization)
+    # The role is re-asked here, not left to the controller that embedded
+    # this page — see `VutuvWeb.OrganizationLive.ManageGate`.
+    case ManageGate.allow(socket, session, &Organizations.can_manage?/2) do
+      {:ok, organization} ->
+        # The marker is read BEFORE it is stamped, or the page would clear its own
+        # "new" marks before drawing them and nothing would ever look unread.
+        marker = organization.activity_read_at
+        if connected?(socket), do: Organizations.mark_activity_read(organization)
 
-    {:ok,
-     socket
-     |> assign(:organization, organization)
-     |> assign(:marker, marker)
-     |> assign(:page_title, gettext("Activity – %{name}", name: organization.name))
-     |> load_activity(0)}
+        {:ok,
+         socket
+         |> assign(:organization, organization)
+         |> assign(:marker, marker)
+         |> assign(:page_title, gettext("Activity – %{name}", name: organization.name))
+         |> load_activity(0)}
+
+      {:refused, socket} ->
+        {:ok, socket}
+    end
   end
 
   defp load_activity(socket, offset) do

--- a/lib/vutuv_web/live/organization_live/domains.ex
+++ b/lib/vutuv_web/live/organization_live/domains.ex
@@ -16,24 +16,32 @@ defmodule VutuvWeb.OrganizationLive.Domains do
 
   alias Vutuv.Organizations
   alias VutuvWeb.Live.InitAssigns
+  alias VutuvWeb.OrganizationLive.ManageGate
   alias VutuvWeb.VerificationComponents
 
   @impl true
   def mount(_params, session, socket) do
     socket = InitAssigns.assign_embedded(socket, session)
-    organization = Organizations.get_organization!(session["organization_id"])
 
-    {:ok,
-     socket
-     |> assign(:organization, organization)
-     |> assign(:page_title, gettext("Domains – %{name}", name: organization.name))
-     |> assign(:new_domain, "")
-     |> assign(:new_method, "dns")
-     # What the last check saw, per domain (issue #1466). Keyed by domain id
-     # because this page can have several claims running at once.
-     |> assign(:check_reports, %{})
-     |> assign(:verification_enabled?, Organizations.verification_enabled?())
-     |> load_domains()}
+    # The role is re-asked here, not left to the controller that embedded
+    # this page — see `VutuvWeb.OrganizationLive.ManageGate`.
+    case ManageGate.allow(socket, session, &Organizations.can_manage_domains?/2) do
+      {:ok, organization} ->
+        {:ok,
+         socket
+         |> assign(:organization, organization)
+         |> assign(:page_title, gettext("Domains – %{name}", name: organization.name))
+         |> assign(:new_domain, "")
+         |> assign(:new_method, "dns")
+         # What the last check saw, per domain (issue #1466). Keyed by domain id
+         # because this page can have several claims running at once.
+         |> assign(:check_reports, %{})
+         |> assign(:verification_enabled?, Organizations.verification_enabled?())
+         |> load_domains()}
+
+      {:refused, socket} ->
+        {:ok, socket}
+    end
   end
 
   defp load_domains(socket) do

--- a/lib/vutuv_web/live/organization_live/edit.ex
+++ b/lib/vutuv_web/live/organization_live/edit.ex
@@ -16,34 +16,43 @@ defmodule VutuvWeb.OrganizationLive.Edit do
   alias Vutuv.OrganizationImageStore
   alias Vutuv.Organizations
   alias VutuvWeb.Live.InitAssigns
+  alias VutuvWeb.OrganizationLive.ManageGate
 
   @impl true
   def mount(_params, session, socket) do
     socket = InitAssigns.assign_embedded(socket, session)
-    current_user = socket.assigns.current_user
-    locale = session["locale"] || "en"
-    organization = Organizations.get_organization!(session["organization_id"])
 
-    socket =
-      socket
-      |> assign(:locale, locale)
-      |> assign(:organization, organization)
-      |> assign(:owner?, Organizations.owner?(organization, current_user))
-      |> assign(:page_title, gettext("Edit %{name}", name: organization.name))
-      |> assign(:countries, Countries.select_options(locale))
-      |> assign(:aliases, Organizations.list_aliases(organization))
-      |> assign(:alias_name, "")
-      |> assign(:alias_kind, "alias")
-      |> assign(:handle_value, organization.username || "")
-      |> assign(:handle_error, nil)
-      |> allow_upload(:logo,
-        accept: OrganizationImageStore.extension_whitelist(),
-        max_entries: 1,
-        max_file_size: OrganizationImageStore.max_filesize()
-      )
-      |> assign_form(Organizations.change_organization(organization))
+    # The role is re-asked here, not left to the controller that embedded
+    # this page — see `VutuvWeb.OrganizationLive.ManageGate`.
+    case ManageGate.allow(socket, session, &Organizations.can_edit_page?/2) do
+      {:ok, organization} ->
+        current_user = socket.assigns.current_user
+        locale = session["locale"] || "en"
 
-    {:ok, socket}
+        socket =
+          socket
+          |> assign(:locale, locale)
+          |> assign(:organization, organization)
+          |> assign(:owner?, Organizations.owner?(organization, current_user))
+          |> assign(:page_title, gettext("Edit %{name}", name: organization.name))
+          |> assign(:countries, Countries.select_options(locale))
+          |> assign(:aliases, Organizations.list_aliases(organization))
+          |> assign(:alias_name, "")
+          |> assign(:alias_kind, "alias")
+          |> assign(:handle_value, organization.username || "")
+          |> assign(:handle_error, nil)
+          |> allow_upload(:logo,
+            accept: OrganizationImageStore.extension_whitelist(),
+            max_entries: 1,
+            max_file_size: OrganizationImageStore.max_filesize()
+          )
+          |> assign_form(Organizations.change_organization(organization))
+
+        {:ok, socket}
+
+      {:refused, socket} ->
+        {:ok, socket}
+    end
   end
 
   @impl true

--- a/lib/vutuv_web/live/organization_live/exclusions.ex
+++ b/lib/vutuv_web/live/organization_live/exclusions.ex
@@ -19,22 +19,30 @@ defmodule VutuvWeb.OrganizationLive.Exclusions do
   alias Vutuv.Jobs.Exclusions
   alias Vutuv.Organizations
   alias VutuvWeb.Live.InitAssigns
+  alias VutuvWeb.OrganizationLive.ManageGate
 
   @impl true
   def mount(_params, session, socket) do
     socket = InitAssigns.assign_embedded(socket, session)
-    organization = Organizations.get_organization!(session["organization_id"])
 
-    {:ok,
-     socket
-     |> assign(:organization, organization)
-     |> assign(:page_title, gettext("Job exclusions – %{name}", name: organization.name))
-     |> assign(:member_error, nil)
-     |> assign(:org_error, nil)
-     |> assign_member_form()
-     |> assign_org_form()
-     |> assign_domain_form()
-     |> load_exclusions()}
+    # The role is re-asked here, not left to the controller that embedded
+    # this page — see `VutuvWeb.OrganizationLive.ManageGate`.
+    case ManageGate.allow(socket, session, &Organizations.can_manage?/2) do
+      {:ok, organization} ->
+        {:ok,
+         socket
+         |> assign(:organization, organization)
+         |> assign(:page_title, gettext("Job exclusions – %{name}", name: organization.name))
+         |> assign(:member_error, nil)
+         |> assign(:org_error, nil)
+         |> assign_member_form()
+         |> assign_org_form()
+         |> assign_domain_form()
+         |> load_exclusions()}
+
+      {:refused, socket} ->
+        {:ok, socket}
+    end
   end
 
   @impl true

--- a/lib/vutuv_web/live/organization_live/fediverse.ex
+++ b/lib/vutuv_web/live/organization_live/fediverse.ex
@@ -23,16 +23,24 @@ defmodule VutuvWeb.OrganizationLive.Fediverse do
   alias Vutuv.Organizations
   alias VutuvWeb.Fediverse.Docs
   alias VutuvWeb.Live.InitAssigns
+  alias VutuvWeb.OrganizationLive.ManageGate
 
   @impl true
   def mount(_params, session, socket) do
     socket = InitAssigns.assign_embedded(socket, session)
-    organization = Organizations.get_organization!(session["organization_id"])
 
-    {:ok,
-     socket
-     |> assign(:page_title, gettext("Fediverse – %{name}", name: organization.name))
-     |> assign_state(organization)}
+    # The role is re-asked here, not left to the controller that embedded
+    # this page — see `VutuvWeb.OrganizationLive.ManageGate`.
+    case ManageGate.allow(socket, session, &Organizations.owner?/2) do
+      {:ok, organization} ->
+        {:ok,
+         socket
+         |> assign(:page_title, gettext("Fediverse – %{name}", name: organization.name))
+         |> assign_state(organization)}
+
+      {:refused, socket} ->
+        {:ok, socket}
+    end
   end
 
   defp assign_state(socket, organization) do

--- a/lib/vutuv_web/live/organization_live/feed.ex
+++ b/lib/vutuv_web/live/organization_live/feed.ex
@@ -48,6 +48,7 @@ defmodule VutuvWeb.OrganizationLive.Feed do
   alias VutuvWeb.Live.InitAssigns
   alias VutuvWeb.Live.RemoteImages
   alias VutuvWeb.Live.RemotePostActions
+  alias VutuvWeb.OrganizationLive.ManageGate
 
   # A picture on a card from another network appears the moment the AI gate
   # releases it (issue #1801). This page holds its entries in a plain assign,
@@ -57,13 +58,20 @@ defmodule VutuvWeb.OrganizationLive.Feed do
   @impl true
   def mount(_params, session, socket) do
     socket = InitAssigns.assign_embedded(socket, session)
-    organization = Organizations.get_organization!(session["organization_id"])
 
-    {:ok,
-     socket
-     |> assign(:organization, organization)
-     |> assign(:page_title, gettext("Feed – %{name}", name: organization.name))
-     |> load_feed(nil)}
+    # The role is re-asked here, not left to the controller that embedded
+    # this page — see `VutuvWeb.OrganizationLive.ManageGate`.
+    case ManageGate.allow(socket, session, &Organizations.publisher?/2) do
+      {:ok, organization} ->
+        {:ok,
+         socket
+         |> assign(:organization, organization)
+         |> assign(:page_title, gettext("Feed – %{name}", name: organization.name))
+         |> load_feed(nil)}
+
+      {:refused, socket} ->
+        {:ok, socket}
+    end
   end
 
   defp load_feed(socket, cursor) do

--- a/lib/vutuv_web/live/organization_live/following.ex
+++ b/lib/vutuv_web/live/organization_live/following.ex
@@ -44,21 +44,29 @@ defmodule VutuvWeb.OrganizationLive.Following do
   alias Vutuv.Social
   alias Vutuv.Tags
   alias VutuvWeb.Live.InitAssigns
+  alias VutuvWeb.OrganizationLive.ManageGate
 
   @impl true
   def mount(_params, session, socket) do
     socket = InitAssigns.assign_embedded(socket, session)
-    organization = Organizations.get_organization!(session["organization_id"])
 
-    {:ok,
-     socket
-     |> assign(:organization, organization)
-     |> assign(:page_title, gettext("Follows – %{name}", name: organization.name))
-     |> assign(:local_form, local_form())
-     |> assign(:local_follow_error, nil)
-     |> assign(:remote_form, remote_form())
-     |> assign(:follow_error, nil)
-     |> load_following()}
+    # The role is re-asked here, not left to the controller that embedded
+    # this page — see `VutuvWeb.OrganizationLive.ManageGate`.
+    case ManageGate.allow(socket, session, &Organizations.publisher?/2) do
+      {:ok, organization} ->
+        {:ok,
+         socket
+         |> assign(:organization, organization)
+         |> assign(:page_title, gettext("Follows – %{name}", name: organization.name))
+         |> assign(:local_form, local_form())
+         |> assign(:local_follow_error, nil)
+         |> assign(:remote_form, remote_form())
+         |> assign(:follow_error, nil)
+         |> load_following()}
+
+      {:refused, socket} ->
+        {:ok, socket}
+    end
   end
 
   defp load_following(socket) do

--- a/lib/vutuv_web/live/organization_live/manage_gate.ex
+++ b/lib/vutuv_web/live/organization_live/manage_gate.ex
@@ -1,0 +1,49 @@
+defmodule VutuvWeb.OrganizationLive.ManageGate do
+  @moduledoc """
+  Re-asks, on the socket, the permission `OrganizationController.manage/4` asked
+  of the request.
+
+  That controller is the only gate these pages had. It checks the page's own
+  predicate and then hands the LiveView an `organization_id` inside a
+  `live_render` session — signed, **not** encrypted, bound to no user and valid
+  for days. A role taken away afterwards therefore did not reach an open tab,
+  and a reconnect (every deploy causes one, and the tokens sit in the page
+  source of any render the holder could once load) re-mounted with the same map.
+  `Vutuv.Organizations.set_roles/4` names this attack in its own docstring; only
+  `Roles` and `Apps` were re-checking.
+
+  The predicate is the caller's, because each page has its own — the same
+  function the controller passes, so the two cannot drift into disagreeing about
+  who may open a page and who may keep it open.
+
+  Refusing navigates to the organization's public page rather than raising: a
+  member who has lost a role can still see the page, and a raise would put the
+  socket into a crash-retry loop under whoever is holding the tab open.
+  """
+
+  use Phoenix.VerifiedRoutes,
+    endpoint: VutuvWeb.Endpoint,
+    router: VutuvWeb.Router,
+    statics: ~w(assets fonts images favicon.ico)
+
+  alias Phoenix.LiveView
+  alias Vutuv.Organizations
+
+  @doc """
+  `{:ok, organization}` when the socket's viewer still satisfies `can?`, or
+  `{:refused, socket}` carrying the navigation away.
+
+  Call it after `VutuvWeb.Live.InitAssigns.assign_embedded/2`, which is what
+  resolves the viewer from the session token — the id in the curated map is not
+  an identity and must not be read as one (issue #1036).
+  """
+  def allow(socket, session, can?) when is_function(can?, 2) do
+    organization = Organizations.get_organization!(session["organization_id"])
+
+    if can?.(organization, socket.assigns.current_user) do
+      {:ok, organization}
+    else
+      {:refused, LiveView.push_navigate(socket, to: ~p"/organizations/#{organization}")}
+    end
+  end
+end

--- a/lib/vutuv_web/live/user_profile_live.ex
+++ b/lib/vutuv_web/live/user_profile_live.ex
@@ -31,6 +31,7 @@ defmodule VutuvWeb.UserProfileLive do
   alias Vutuv.CodeStats
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.RemoteFollow
+  alias Vutuv.Moderation
   alias Vutuv.Organizations.Organization
   alias Vutuv.Profiles.Address
   alias Vutuv.Profiles.Education
@@ -743,9 +744,30 @@ defmodule VutuvWeb.UserProfileLive do
   @recommended_pool 60
   @suggested_window_days 28
 
+  # The subject is re-authorized here, not only by the controller that embedded
+  # this LiveView. That controller's request was gated by
+  # `VutuvWeb.Plug.EnsureActivated`, but the `live_render` session carrying this
+  # id is signed and NOT encrypted, bound to no user and good for days — and a
+  # rejoin is ordinary, since a deploy reconnects every open tab. So a profile
+  # frozen, suspended or deactivated since the page was rendered would otherwise
+  # keep streaming in full to whoever holds the token.
+  #
+  # It raises rather than rendering an apology: this LiveView is embedded by a
+  # controller that already answers 403/410 for the withheld cases, so there is
+  # no half-page to draw here — the socket simply does not serve one.
+  defp subject!(profile_user_id, viewer) do
+    user = Repo.get!(User, profile_user_id)
+
+    if Moderation.profile_visible_to?(user, viewer) do
+      user
+    else
+      raise Ecto.NoResultsError, queryable: User
+    end
+  end
+
   defp load_profile(socket) do
     current_user = socket.assigns.current_user
-    base_user = Repo.get!(User, socket.assigns.profile_user_id)
+    base_user = subject!(socket.assigns.profile_user_id, current_user)
 
     owner? = !!(current_user && current_user.id == base_user.id)
 

--- a/test/vutuv_web/live/embedded_subject_gate_test.exs
+++ b/test/vutuv_web/live/embedded_subject_gate_test.exs
@@ -1,0 +1,92 @@
+defmodule VutuvWeb.EmbeddedSubjectGateTest do
+  @moduledoc """
+  An embedded LiveView must re-authorize its **subject**, not only its viewer.
+
+  A controller that embeds a LiveView with `live_render/3` hands it a curated
+  session map: signed, **not** encrypted, bound to no user and good for days
+  (`Phoenix.LiveView.Static`'s 14-day `@max_session_age`). The controller's own
+  request was gated — `VutuvWeb.Plug.EnsureActivated` for a profile — but the
+  socket that joins later carries only that map, and a rejoin is ordinary: a
+  deploy reconnects every open tab, and the tokens sit in the page source of any
+  render the holder could once load.
+
+  The viewer half of this is well covered (`init_assigns_test.exs` re-resolves
+  identity from the session token on every mount). The subject half has now been
+  the bug three times — #1034, #1036, and the post permalink's conversation —
+  each time in a different LiveView, each time fixed alone. So this is the
+  chokepoint: one list of every embedded LiveView whose session names somebody
+  *other than the viewer*, and one assertion that a withheld subject renders
+  nothing. A new embedded LiveView carrying a subject id belongs in `@carriers`.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Moderation
+  alias Vutuv.Posts
+
+  # Each entry: the LiveView, the session key naming its subject, and a label.
+  # `VutuvWeb.PostLive.Thread` carries a post id rather than a member id and is
+  # covered by `post_thread_live_test.exs`; everything here names a member.
+  @carriers [
+    {VutuvWeb.UserProfileLive, "profile_user_id", "the profile"},
+    {VutuvWeb.CVLive, "profile_user_id", "the CV builder"}
+  ]
+
+  # The three ways this installation withholds a profile, and the status the
+  # HTML page answers for each (`Moderation.withheld_status/1`).
+  @withholdings [
+    {[frozen_at: NaiveDateTime.utc_now(:second)], "frozen pending review"},
+    {[deactivated_at: NaiveDateTime.utc_now(:second)], "permanently deactivated"},
+    {[suspended_until: NaiveDateTime.add(NaiveDateTime.utc_now(:second), 7, :day)], "suspended"}
+  ]
+
+  for {live_view, key, label} <- @carriers,
+      {attrs, how} <- @withholdings do
+    test "#{label} renders nothing for a member #{how}" do
+      member =
+        insert_activated_user(
+          [first_name: "Withheld", last_name: "Member"] ++ unquote(Macro.escape(attrs))
+        )
+
+      # The premise: this really is a member the site withholds, so a failure
+      # below is the socket serving them and not a fixture that never hid.
+      refute Moderation.profile_visible_to?(member, nil)
+
+      session = %{unquote(key) => member.id, "locale" => "en"}
+
+      assert render_withheld(unquote(live_view), session) == :withheld,
+             "#{unquote(label)} served a withheld member over the socket"
+    end
+  end
+
+  test "the profile still renders for a member the site does not withhold" do
+    member = insert_activated_user(first_name: "Ordinary", last_name: "Member")
+    {:ok, post} = Posts.create_post(member, %{body: "Ganz normal"})
+
+    assert {:ok, _view, html} =
+             live_isolated(build_conn(), VutuvWeb.UserProfileLive,
+               session: %{"profile_user_id" => member.id, "locale" => "en"}
+             )
+
+    assert html =~ "Ordinary"
+    assert post.id
+  end
+
+  # A gate may answer by refusing to mount or by rendering none of the member's
+  # data; both are withholding, and which one a LiveView picks is its own
+  # business. Anything else — a successful mount whose HTML names them — is not.
+  defp render_withheld(live_view, session) do
+    case live_isolated(build_conn(), live_view, session: session) do
+      {:ok, _view, html} -> if html =~ "Withheld", do: {:served, html}, else: :withheld
+      {:error, _reason} -> :withheld
+    end
+  rescue
+    # A gate that refuses by raising (the profile answers the way its controller
+    # would have, with the 404 the router turns an Ecto miss into) withholds
+    # just as surely as one that renders an empty page.
+    _error -> :withheld
+  catch
+    :exit, _reason -> :withheld
+  end
+end

--- a/test/vutuv_web/live/organization_manage_gate_test.exs
+++ b/test/vutuv_web/live/organization_manage_gate_test.exs
@@ -1,0 +1,90 @@
+defmodule VutuvWeb.OrganizationManageGateTest do
+  @moduledoc """
+  An organization's management LiveView must re-check the actor's role on the
+  socket, not trust the controller that embedded it.
+
+  `OrganizationController.manage/4` is the only permission check these pages
+  had: it asks the page's own predicate, then hands the LiveView an
+  `organization_id` in a `live_render` session — signed, **not** encrypted,
+  bound to no user and good for days. A role taken away after that render did
+  not reach the open tab, and a reconnect (every deploy causes one) re-mounted
+  with the same map. `Vutuv.Organizations.set_roles/4`'s own docstring names
+  this attack; only `Roles` and `Apps` were re-checking.
+
+  The sibling of `embedded_subject_gate_test.exs`: that one asks whether the
+  **subject** may be shown, this one whether the **actor** may still act. A new
+  page under `OrganizationController.manage/4` belongs in `@managed`.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+
+  # Each entry: the LiveView, the role that reaches it, and the predicate the
+  # controller gates it with — kept in the same order as the controller's
+  # actions so the two lists can be read side by side.
+  @managed [
+    {VutuvWeb.OrganizationLive.Edit, "owner", "Edit"},
+    {VutuvWeb.OrganizationLive.Roles, "owner", "Roles"},
+    {VutuvWeb.OrganizationLive.Domains, "owner", "Domains"},
+    {VutuvWeb.OrganizationLive.Fediverse, "owner", "Fediverse"},
+    {VutuvWeb.OrganizationLive.Exclusions, "owner", "Exclusions"},
+    {VutuvWeb.OrganizationLive.Activity, "owner", "Activity"},
+    {VutuvWeb.OrganizationLive.Feed, "publisher", "Feed"},
+    {VutuvWeb.OrganizationLive.Following, "publisher", "Following"}
+  ]
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  for {live_view, role, label} <- @managed do
+    test "#{label} refuses a member whose #{role} role was taken away" do
+      {organization, owner} = active_organization()
+      member = insert_activated_user()
+
+      {:ok, _} = Organizations.set_roles(organization, member, [unquote(role)], owner)
+
+      # The premise: with the role, the page really does mount — so a failure
+      # below is the gate missing, not the fixture being wrong.
+      assert {:ok, _view, _html} = mount_managed(unquote(live_view), organization, member)
+
+      {:ok, _} = Organizations.set_roles(organization, member, [], owner)
+
+      refute renders?(unquote(live_view), organization, member),
+             "#{unquote(label)} still served a member whose role was revoked"
+    end
+  end
+
+  # A real session token, the only identity these LiveViews trust (#1036), so
+  # the actor is authenticated the way a browser authenticates them rather than
+  # by a curated `user_id` the socket would rightly ignore.
+  defp mount_managed(live_view, organization, actor) do
+    session =
+      shell_session(actor, %{"organization_id" => organization.id, "locale" => "en"})
+
+    live_isolated(build_conn(), live_view, session: session)
+  end
+
+  # A gate may refuse by redirecting away or by not mounting at all; either is a
+  # refusal. Only a live mount that stays on the page is not.
+  defp renders?(live_view, organization, actor) do
+    case mount_managed(live_view, organization, actor) do
+      {:ok, _view, _html} -> true
+      {:error, _redirect_or_reason} -> false
+    end
+  rescue
+    _error -> false
+  catch
+    :exit, _reason -> false
+  end
+end


### PR DESCRIPTION
Not from the scan's list — these are eleven more instances of the class #1953
fixed once, found while checking whether that fix had siblings. It did.

An embedded LiveView re-resolves its **viewer** from the session token (#1036)
but never re-asked about its **subject**. The curated `live_render` session is
signed, not encrypted, bound to no user and good for days, and a reconnect is
ordinary — every deploy causes one. So `/:slug` and `/:slug/cv` kept rendering a
member the site withholds (frozen, suspended, deactivated), CV included: work
history, address, phone. And the seven organization management pages trusted
`OrganizationController.manage/4` for the role, so a member whose role was taken
away could still edit the page, add domains and toggle federation — which fires
remote Deletes — from a tab left open. `set_roles/4`'s own docstring describes
this attack; only Roles and Apps were re-checking.

The seven now share one `ManageGate.allow/3` asking the same predicate the
controller passes. Two enumerating tests name every embedded LiveView carrying a
subject, so a new one has somewhere to be listed; each asserts the page *does*
load for someone entitled first, so none can go vacuously green.

https://claude.ai/code/session_01HpEBfNDHjPRmJ1Joe2923o
