### PR TITLE
Feed performance: a database 50x its own size, a compression level that cost more than it saved, and a crashing counts sweep

### DIFF
--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -426,7 +426,7 @@ map $cookie_vutuv_low_bandwidth $vutuv_saver {
 # reaching these members — and only the level differs.
 location @saver {
     include snippets/vutuv-proxy.conf;
-    brotli_comp_level 10;
+    brotli_comp_level 9;
 }
 ```
 
@@ -439,16 +439,25 @@ forgets the `Upgrade` or `Connection` header kills every live page for
 exactly the members the mode is for, while the pages themselves still load.
 Verify with the cookie that `/live/websocket` still answers 101.
 
-The level is 10, not 11, by measurement: on a 197 kB profile page brotli 6
-gives 26,847 bytes, 9 gives 26,282, 10 gives 24,012 and 11 gives 23,815 —
-level 9 buys one percent, level 10 nine tenths of what 11 buys at a third of
-its CPU (5 / 43 / 130 ms per page at 6 / 10 / 11). vutuv.de runs it this way
-(issue #1944): measured from outside, the profile page went from 26,562 to
-23,748 bytes with the cookie, the landing page from 10,681 to 9,593. When you
-measure with a bare `curl` and the cookie, know that the app answers such an
-anonymous request by deleting the cookie (`max-age=0`) — the route is tested,
-a member session is not. Their pictures, not their pages, are still where the
-mode earns its name, and those need no proxy change at all.
+**The level is 9, and the ceiling is not a preference — it is where brotli
+changes algorithm.** Quality 10 and 11 switch on a far more expensive search
+for backward references; everything up to 9 uses the fast hasher. On a 189 kB
+profile page, measured on the production CPU: level 6 costs 8 ms and 27,055
+bytes, 9 costs 17 ms and 26,476, **10 costs 78 ms** and 24,179, 11 costs
+222 ms and 23,792. So the step from 6 to 10 buys 2.9 kB for 70 ms of server
+time — which only pays for itself below roughly 330 kbit/s, and is charged to
+every request on the box, not only to the member who wanted the bytes.
+
+This installation ran level 10 from issue #1944 until 2026-09-02 and it was a
+net loss: measured through nginx, a saver member's page went from ~300 ms to
+~215 ms when the level dropped to 9, for 2.3 kB more. If you are tempted to
+raise it, measure the **time** as well as the size — the earlier note here
+compared only 10 against 11 and picked the cheaper of two expensive options.
+
+When you measure with a bare `curl` and the cookie, know that the app answers
+such an anonymous request by deleting the cookie (`max-age=0`) — the route is
+tested, a member session is not. Their pictures, not their pages, are still
+where the mode earns its name, and those need no proxy change at all.
 
 **Post images need no nginx setup**: they are audience-guarded, so the app
 authorizes and serves them itself (`send_file`).
@@ -627,6 +636,35 @@ Run on the server, against the release:
 (In a source checkout the same exist as `mix vutuv.images.regenerate` /
 `mix vutuv.review_covers.refresh` / `mix vutuv.admin.promote`; URL screenshots
 can be re-rendered with `mix urls.create_screenshots`.)
+
+### Watch the tables for bloat after a mass rewrite
+
+Autovacuum reclaims dead rows but never gives the pages back, so anything that
+touches every row of a table — a re-key, a column backfill, a repeated
+whole-table `UPDATE` — leaves the file at its old size, mostly empty. Nothing
+reports this: the row counts are right, the queries are right, and every scan
+just reads far more pages than it has to. On vutuv.de `users` sat at 82 MB for
+1.6 MB of live rows, and since every feed and profile query gates on that
+table (`frozen_at`, `deactivated_at`, `suspended_until`), one page load paid it
+dozens of times over.
+
+Compare each table against the space its rows actually need:
+
+```sql
+SELECT relname,
+       n_live_tup,
+       pg_size_pretty(pg_relation_size(relid)) AS heap
+  FROM pg_stat_user_tables
+ ORDER BY pg_relation_size(relid) DESC
+ LIMIT 15;
+```
+
+A table whose heap is many times `n_live_tup × the width of a row` is bloated.
+`VACUUM (FULL, ANALYZE) <table>;` rewrites it compactly and rebuilds its
+indexes. It takes an exclusive lock, so requests touching that table wait —
+but at this scale that is well under a second per table (the four bloated ones
+on vutuv.de took 1.7 s together and gave back 410 MB), and the page it fixed
+went from ~200 ms to ~85 ms.
 
 ## Book covers on review posts
 

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -6186,7 +6186,9 @@ defmodule Vutuv.Fediverse do
     with true <- enabled?(),
          true <- Note.public?(note),
          %Post{} = post <- Repo.get(Post, note.post_id),
-         %User{} = author <- Repo.get(User, post.user_id) do
+         # `Posts.author/1` for the same reason `counts_signer/1` uses it: a
+         # page's post has a NULL `user_id` and `Repo.get(User, nil)` raises.
+         %User{} = author <- Posts.author(post) do
       apply_refresh(note, fetch_remote_note(note.object_uri, signer(author)))
     else
       _ -> :skip
@@ -6919,9 +6921,17 @@ defmodule Vutuv.Fediverse do
     end
   end
 
+  # `Posts.author/1`, never `Repo.get(User, post.user_id)`: a page publishes
+  # with `organization_id` and a NULL `user_id` (issue #1334), and that raises
+  # rather than answering nothing. It raised inside the batch, so one reply
+  # under a page's post stopped the sweep for **every** object — on production
+  # from 2026-08-31, one log line every two minutes and no figure refreshed
+  # anywhere since. A page has no actor yet, so its posts' replies simply have
+  # nobody to sign as: `signer/1` answers nil for an actor-less subject and the
+  # ask is skipped and stamped, which is what the `%User{}` match spells out.
   defp counts_signer(%Note{} = note) do
     with %Post{} = post <- Repo.get(Post, note.post_id),
-         %User{} = author <- Repo.get(User, post.user_id) do
+         %User{} = author <- Posts.author(post) do
       signer(author)
     else
       _ -> nil

--- a/test/vutuv/fediverse_counts_test.exs
+++ b/test/vutuv/fediverse_counts_test.exs
@@ -17,6 +17,7 @@ defmodule Vutuv.FediverseCountsTest do
   alias Vutuv.Fediverse.PostBoost
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Posts.Post
 
   @actor "https://social.example/users/them"
 
@@ -464,6 +465,34 @@ defmodule Vutuv.FediverseCountsTest do
       serve(object(note))
 
       assert :skip = Fediverse.refresh_counts(note)
+    end
+
+    # A page publishes with `posts.organization_id` and a NULL `user_id`
+    # (issue #1334), and `Repo.get(User, nil)` RAISES rather than answering
+    # nothing. So a single reply under a page's post took the whole two-minute
+    # sweep down with it — not that one object, the batch — and no figure
+    # anywhere was refreshed again. On production that was one log line every
+    # two minutes and nothing else. Calibrated against the un-fixed code, where
+    # `refresh_due_counts/0` raises here instead of tallying a skip.
+    test "a reply under a page's post is skipped without taking the sweep down" do
+      organization = insert(:organization)
+
+      post =
+        Repo.insert!(%Post{
+          organization_id: organization.id,
+          acting_user_id: insert(:activated_user).id,
+          body: "Wir stellen ein.",
+          published_on: Vutuv.BerlinTime.today()
+        })
+
+      note = remote_note(insert(:activated_user), %{post_id: post.id})
+      serve(object(note))
+
+      assert %{skipped: 1, failed: 0} = Fediverse.refresh_due_counts()
+
+      # Stamped like every other skip, so it rejoins the ladder instead of
+      # holding the front of every batch from now on.
+      assert Repo.get!(Note, note.id).counts_checked_at
     end
   end
 

--- a/test/vutuv/fediverse_notes_test.exs
+++ b/test/vutuv/fediverse_notes_test.exs
@@ -773,6 +773,41 @@ defmodule Vutuv.FediverseNotesTest do
       assert :skip = Fediverse.refresh_note(Repo.one!(Note))
       assert Repo.aggregate(Note, :count) == 1
     end
+
+    # The retention sweep's half of the same nil (see the counts refresher):
+    # a page's post has a NULL `posts.user_id`, so reading the signer off that
+    # column raised instead of answering nothing — and a raise in a sweep is
+    # not one bad row, it is the sweep. Calibrated: without `Posts.author/1`
+    # this raises rather than skipping.
+    test "a reply under a page's post is skipped, not raised on" do
+      organization = insert(:organization)
+      now = DateTime.utc_now(:second)
+
+      post =
+        Repo.insert!(%Vutuv.Posts.Post{
+          organization_id: organization.id,
+          acting_user_id: insert(:activated_user).id,
+          body: "Wir stellen ein.",
+          published_on: Vutuv.BerlinTime.today()
+        })
+
+      note =
+        Repo.insert!(%Note{
+          post_id: post.id,
+          object_uri: "#{@actor}/statuses/page-reply",
+          actor_uri: @actor,
+          inbox_uri: @actor <> "/inbox",
+          handle: "alice",
+          content_text: "Viel Erfolg!",
+          audience: "public",
+          received_at: now,
+          expires_at: DateTime.add(now, 86_400)
+        })
+
+      stub_origin(fn _conn -> raise "a page's post has nobody to sign as" end)
+
+      assert :skip = Fediverse.refresh_note(note)
+    end
   end
 
   describe "cascades" do

--- a/test/vutuv_web/live/feed_calendar_test.exs
+++ b/test/vutuv_web/live/feed_calendar_test.exs
@@ -34,7 +34,7 @@ defmodule VutuvWeb.FeedCalendarTest do
     Social.follow(viewer, author.id)
 
     recent = PostsHelpers.create_post!(author, %{body: "from this morning"})
-    PostsHelpers.backdate_post!(recent, 3_600)
+    PostsHelpers.backdate_post!(recent, min(3_600, seconds_into_today()))
 
     old = PostsHelpers.create_post!(author, %{body: "from a week ago"})
     PostsHelpers.backdate_post!(old, 7 * @day)
@@ -48,6 +48,18 @@ defmodule VutuvWeb.FeedCalendarTest do
 
   defp iso(date), do: Date.to_iso8601(date)
   defp days_ago(n), do: Date.add(ViewerClock.today(), -n)
+
+  # How far into the German day it is. An hour counted back from "now" leaves
+  # the day it was meant for during the first hour of one — "from this morning"
+  # above then lands on YESTERDAY's cell and shades a day the heatmap test
+  # needs empty, so that test went red at 00:08 and would have gone green again
+  # at 01:00 on its own. Clamping keeps the post inside today whatever the hour,
+  # without moving it to midday (which is still in the future just after
+  # midnight, and a post in the future is a different bug).
+  defp seconds_into_today do
+    {day_start, _day_end} = ViewerClock.day_window(ViewerClock.today())
+    NaiveDateTime.diff(NaiveDateTime.utc_now(:second), day_start)
+  end
 
   # Unfolds the rail **at the month `day` sits in**, which is not the month it
   # opens at for the first days of a new one. The grid draws whole weeks from


### PR DESCRIPTION
`/feed` took 486 ms to first byte for a signed-in member. Three causes, measured — the first two were on the server and are already applied, the third is this diff.

**1. Postgres bloat.** `users` held 82 MB of heap for 1.6 MB of live rows — 51× the pages per scan — and every feed query gates on that table (`frozen_at`, `deactivated_at`, `suspended_until`). `VACUUM (FULL, ANALYZE)` on it plus `emails`, `user_tags` and `search_terms` took 1.7 s and gave back 410 MB.

**2. brotli level 10** in the low-bandwidth `@saver` location: +70 ms per page to save 2.9 kB. Lowered to 9 in nginx; `docs/ADMINS.md` carries the measured ladder now, because the note there recommended 10 having compared only size, never time.

**3. `counts_signer/1` raised** on a reply under a page's post, killing the whole two-minute sweep — no fediverse count had refreshed since 2026-08-31.

`/feed` is now 197 ms median, 145 ms best.

Where: `lib/vutuv/fediverse.ex`, `docs/ADMINS.md`.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_015uHLPurrJ61uaUE9G7d5xY
