### PR TITLE
Notifications: one card per post instead of one row per event

### DIFF
--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -445,22 +445,51 @@ item name the same row. Opening /notifications deletes the member's dismissals:
 the marker now covers them, so the table only ever holds the exceptions that
 still matter.
 
-### The notifications page (2026-07 redesign)
+### The notifications page (2026-09 cards)
 
-`VutuvWeb.NotificationLive.Index` renders the derived feed as **grouped rows
-under calendar-day sections** (`VutuvWeb.NotificationLive.Groups`, a pure
-function over the item list; the days are the **reader's**, like post stamps).
-What reads as one piece of news merges into one row, keyed within a day: same-day likes of one post, the day's
-new followers ("Anna, Ben and 111 more are now following you.", the overflow
-linking to the member's followers list), the day's new connections, one
-endorser's endorsements ("endorsed you for Elixir and Phoenix."), and same-day
-thread events of one thread ("Anna and Ben replied in a thread you posted
-in."). Direct replies and the rarer kinds (moderation, CV updates, handle
-changes, ...) stay one row per event. Because grouping is pure, every change —
-a page, a live push, the
-DayClock midnight rollover — recomputes the sections wholesale; there is no
-LiveView stream to patch, and a live-pushed like merges into the derived row
-for its post/day.
+`VutuvWeb.NotificationLive.Index` renders the derived feed as **cards under
+calendar-day sections** (`VutuvWeb.NotificationLive.Groups`, a pure function
+over the item list; the days are the **reader's**, like post stamps). The
+grouping key is the **subject**, not the verb — measured on the real feed
+before the change, 39 events on one day were about 11 posts, and the busiest
+post showed up three times as verb-keyed rows (a like row, a fediverse card, a
+reply row), every reply repeating its "Your post" breadcrumb.
+
+* A **post card** (`kind: "post"`) holds everything about one post: likes,
+  replies, mentions, answers deeper in its thread (keyed on the thread's
+  `root_post_id`) and whatever another network sent back. Its head is an
+  eyebrow saying whose post it is ("Your post", "Post by Anna", "Thread by
+  Anna"), the post's two-line teaser (`VutuvWeb.PostTeaser`, linked to the
+  permalink), a count of what came back, and on the right the post's first
+  two released photos or — for a photo-less link post — its ready link
+  screenshot (`Vutuv.Posts.Screenshots.ready_by_post_ids/1`). Under it one
+  line per verb: every reply keeps a line of its own carrying its words (the
+  teaser, two lines, as a button), the likes merge into one line — a member's
+  like and a favourite from another network are the same verb, the globe on a
+  name says where it came from — the re-shares into another. Replies lead,
+  then likes, then shares; a card shows four lines and folds the rest behind
+  "Show N more" (`unfold`). Tapping a reply line (`toggle_line`) unfolds the
+  reply formatted like a feed post (cut to `:notification_post_lines`) plus a
+  Reply link to its permalink; both are socket round trips, so the dead render
+  is exactly what the connected one starts from.
+* A **people card** (`kind: "people"`), one per day: an avatar row, a tally
+  ("2 new connections · 1 new follower · 1 endorsement") and one line per
+  verb — followers merged ("Anna, Ben and 111 more are now following you.",
+  the overflow linking to the member's followers list), connections merged,
+  one endorser's endorsements merged ("endorsed you for Elixir and Phoenix.").
+  A same-day mutual follow suppresses the redundant follower line.
+* The rarer kinds (moderation, CV updates, handle changes, the welcome note,
+  ...) stay one row per event.
+
+Within a day the cards with an **unanswered reply** come first, then the rest
+of what is new since the last visit, then what the reader has seen; the page
+draws a "Seen before" rule at that transition (`with_seen_rule/1`). Because
+grouping is pure, every change — a page, a live push, the DayClock midnight
+rollover, a line unfolding — recomputes the sections wholesale; there is no
+LiveView stream to patch, and a live-pushed like merges into the derived card
+for its post/day. The card heads are built once per **post**, not per event
+(`post_cards/3`): the page payload crosses `MountHandoff`'s ETS table, which
+does not preserve sharing, so one card per raw item would multiply it.
 
 Around the list:
 
@@ -480,19 +509,21 @@ Around the list:
   its own overflow item so the page stays one page long.
 
 * **Unread highlighting**: events newer than the previous visit's read marker
-  get a tint + coral dot and a "N new notifications" header line; the visit
-  itself still advances `users.notifications_read_at` and clears the bell. A row
-  whose post the reader already engaged with is exempt (see the read-state
-  section above) — it is listed, plain.
-* **Filter tabs** (all / posts / people / more) restrict the feed server-side
-  via `Activity.notifications_page/2`'s `kinds:` option (only the matching
-  source queries run, so pagination stays exact) and live in the URL
-  (`?filter=`), patched without a reload.
-* **The rail** (right column on md+, below the list on phones), loaded on the
-  connected mount only: **Follow back** — `Social.followers_to_follow_back/2`,
-  recent followers not yet followed back, followed reload-free via the shared
-  `<.user_row live?>` — and **Last 30 days**, a per-kind count card from
-  `Activity.activity_summary/2` (one round trip of scalar subqueries).
+  get a tint + coral dot (card and line) and a "N new notifications" header
+  line; the visit itself still advances `users.notifications_read_at` and
+  clears the bell. A line whose post the reader already engaged with is exempt
+  (see the read-state section above) — it is listed, plain.
+* **Filter chips** (all / replies / reactions / people / more) restrict the
+  feed server-side via `Activity.notifications_page/2`'s `kinds:` option (only
+  the matching source queries run, so pagination stays exact) and live in the
+  URL (`?filter=`), patched without a reload. Each chip carries the count of
+  what is new under it (`Activity.unread_notification_count/2`, per chip one
+  query, and only when the whole-feed count is not zero).
+* **Last 30 days** is one line under the title (`Activity.activity_summary/2`,
+  one round trip of scalar subqueries). **The rail** (right column on md+,
+  below the list on phones), loaded on the connected mount only, keeps
+  **Follow back** — `Social.followers_to_follow_back/2`, recent followers not
+  yet followed back, followed reload-free via the shared `<.user_row live?>`.
 
 Row times are the reader's own wall clock in their own date region (like post
 stamps), server-rendered final with an ISO-8601 UTC `datetime` for machines.

--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -1183,6 +1183,41 @@ defmodule Vutuv.Activity do
     total_count(user_id, read_at, nil, true)
   end
 
+  @doc """
+  `unread_notification_count/1` split by named kind groups — `groups` is
+  `%{name => [kind, ...]}` (the kind strings `notifications_page/2`'s `kinds:`
+  takes) — as `%{name => count}`: what the notifications page's filter chips
+  show. ONE query for all of them: every kind's count subquery is added into
+  its group's column of a single SELECT, the way `total_count/4` sums the
+  whole feed. A group whose kinds count nothing answers 0.
+  """
+  def unread_notification_counts(%User{id: user_id, notifications_read_at: read_at}, groups)
+      when is_map(groups) do
+    arms =
+      for spec <- kind_specs(user_id, read_at, true),
+          {count, dismiss} <- Enum.zip(spec.counts, spec.dismiss),
+          do: {spec.kind, unless_dismissed(count, user_id, dismiss, true)}
+
+    case arms do
+      [] ->
+        Map.new(groups, fn {name, _kinds} -> {name, 0} end)
+
+      [{_kind, first} | _rest] ->
+        columns = Map.new(groups, fn {name, kinds} -> {name, group_sum(arms, kinds)} end)
+        Repo.one(from(s in subquery(first), select: ^columns))
+    end
+  end
+
+  # One group's column: its kinds' count subqueries added up, from a zero so a
+  # group with no arm at all still selects a number.
+  defp group_sum(arms, kinds) do
+    arms
+    |> Enum.filter(fn {kind, _count} -> kind in kinds end)
+    |> Enum.reduce(dynamic(fragment("0")), fn {_kind, count}, acc ->
+      dynamic(^acc + subquery(count))
+    end)
+  end
+
   # The feed sources are counted in a single round trip: each count is a
   # scalar subquery, summed in one SELECT. unread_notification_count/1 still
   # needs one prior read for the marker, so it ends up at 2 queries;

--- a/lib/vutuv/posts/screenshots.ex
+++ b/lib/vutuv/posts/screenshots.ex
@@ -346,6 +346,21 @@ defmodule Vutuv.Posts.Screenshots do
   @doc "Loads one job by id, raising when it is gone (the admin views' reads)."
   def get_job!(id), do: Repo.get!(PostScreenshot, id)
 
+  @doc """
+  The screenshots ready to render for these member posts, as
+  `%{post_id => %PostScreenshot{}}` — captured **and** released by the image
+  scan (`PostScreenshot.ready?/1`), nothing else. One query for a page of
+  posts; a post with no capture, a pending one or a held one is simply absent.
+  """
+  def ready_by_post_ids([]), do: %{}
+
+  def ready_by_post_ids(post_ids) when is_list(post_ids) do
+    from(s in PostScreenshot, where: s.post_id in ^post_ids and s.status == "ready")
+    |> Repo.all()
+    |> Enum.filter(&PostScreenshot.ready?/1)
+    |> Map.new(&{&1.post_id, &1})
+  end
+
   ## Draining the queue
 
   @doc """

--- a/lib/vutuv_web/live/notification_live/groups.ex
+++ b/lib/vutuv_web/live/notification_live/groups.ex
@@ -1,59 +1,89 @@
 defmodule VutuvWeb.NotificationLive.Groups do
   @moduledoc """
   Pure presentation grouping behind the notifications page: raw
-  `Vutuv.Activity` feed items in, calendar-day sections of merged rows out.
+  `Vutuv.Activity` feed items in, calendar-day sections of cards out.
 
   The feed's event tables make one item per row, which floods the page - 113
   followers on one day were 113 identical cards. Grouping merges what reads
-  as one piece of news into one row, keyed within a calendar day — the
-  **reader's** day (`Vutuv.ViewerClock`, issue #1502), like post timestamps:
+  as one piece of news, keyed within a calendar day — the **reader's** day
+  (`Vutuv.ViewerClock`, issue #1502), like post timestamps. Since 2026-09 the
+  key is the **subject**, not the verb:
 
-    * likes of the **same post** - "Anna and Ben liked your post."
-    * new **followers** - "Anna, Ben and 111 more are now following you."
-    * new **connections** (mutual follows) - same day-bucket rule
-    * one endorser's **endorsements** - "endorsed you for Elixir and Phoenix."
-    * **thread** events of the same thread - "Anna and Ben replied in a
-      thread you posted in."
-    * everything **another network** sent back about the same post - favourites,
-      re-shares and replies together - as one **post card** (`kind:
-      "fediverse_post"`), headed by the post itself and carrying an `:events`
-      list of one line per verb. The three used to be three rows that named the
-      senders and the verb but never the post, so a reader with more than one
-      post that day could not tell which of them anybody meant.
+    * everything about **one post** — likes, replies, mentions, answers deeper
+      in its thread, and whatever another network sent back about it — is one
+      **post card** (`kind: "post"`), headed by the post and carrying an
+      `:events` list of lines: every reply keeps a line of its own, because it
+      brings its own words; the likes merge into one line (local and fediverse
+      alike, a globe on the name says where each came from), the re-shares into
+      another. Measured on the real feed: 39 events on one day were about 11
+      posts, and one post alone carried 16 of them — as verb-keyed rows the
+      same post appeared three times, and every reply repeated its context.
+    * the day's **people** events — followers, connections, endorsements — are
+      one **people card** (`kind: "people"`) with one line per verb (followers
+      merged, connections merged, one endorser's endorsements merged). A
+      same-day mutual follow suppresses the redundant follower line: "is now
+      connected" implies "follows you".
 
-  Direct replies, mentions and every rarer kind (moderation, CV updates,
-  handle changes, ...) stay one row per event - each carries its own content.
+  Every rarer kind (moderation, CV updates, handle changes, the welcome note,
+  ...) stays one row per event - each carries its own content.
 
-  Everything here is a pure function over the item list, so the LiveView
-  recomputes sections wholesale on every change (load more, live push,
-  midnight rollover) instead of patching a stream in place.
+  Within a day the cards with an **unanswered reply** come first, then the rest
+  of what is new, then what the reader has seen; the page draws a "seen
+  before" rule at that last transition. Everything here is a pure function over
+  the item list, so the LiveView recomputes sections wholesale on every change
+  (paging, live push, midnight rollover) instead of patching a stream in place.
   """
 
   alias Vutuv.ViewerClock
 
-  # How many actors a row names before folding the rest into "and N more".
+  # How many actors a line names before folding the rest into "and N more".
   @named_actors 2
 
   def named_actors, do: @named_actors
 
-  # The kinds that answer a post from another network. They share one card per
-  # post; `Vutuv.Activity` keeps them as separate kinds, and the filter tabs
-  # still speak in those.
-  @post_card_kinds ~w(fediverse_reaction fediverse_reply)
+  # The kinds that are about one post and share its card. A thread answer is
+  # about the thread's root (`root_post_id`), every other one names `post_id`.
+  @post_kinds ~w(like reply mention fediverse_reaction fediverse_reply)
+  @people_kinds ~w(follower connection endorsement)
 
-  @doc "The event kinds a post card merges (`kind: \"fediverse_post\"`)."
-  def post_card_kinds, do: @post_card_kinds
+  # The verbs that carry words of their own — a card with one of these unread
+  # is what "unanswered" means, and what sorts a card to the top of its day.
+  @reply_verbs [:reply, :thread, :mention, :remote_reply]
+
+  @doc """
+  The post an event is about — a thread answer's root, otherwise the post the
+  event names — or nil for the kinds that get a row of their own. The one
+  place that knows which field carries a kind's post id: the grouping keys
+  on it, and the page builds its card heads from it.
+  """
+  def post_id_of(%{kind: "thread", root_post_id: id}) when is_binary(id), do: id
+  def post_id_of(%{kind: kind, post_id: id}) when kind in @post_kinds and is_binary(id), do: id
+  def post_id_of(_item), do: nil
+
+  @doc "The event kinds a people card merges (`kind: \"people\"`)."
+  def people_kinds, do: @people_kinds
+
+  @doc "Whether a card line is a reply of some kind (it carries its own words)."
+  def reply_verb?(%{verb: verb}), do: verb in @reply_verbs
+  def reply_verb?(_line), do: false
 
   @doc """
   Group `items` into `[%{day: Date, groups: [group]}]`, newest day first.
 
   Each group carries `:id` (a stable DOM key), `:kind`, `:at` (its newest
   member's time), `:actors` (distinct, newest first), `:actor_count`,
-  `:tags` (endorsement groups: chronological), `:item` (the newest raw item,
-  for kind-specific fields and post previews) and `:unread?` - true when any
+  `:tags` (endorsement lines: chronological), `:item` (the newest raw item,
+  for kind-specific fields and post previews), `:unread?` - true when any
   member is newer than `read_marker` (nil marker = everything unread) and not
   already marked `:seen?` by the caller (the reader engaged with the post the
-  item is about, see `Vutuv.Activity.mark_post_seen/2`).
+  item is about, see `Vutuv.Activity.mark_post_seen/2`) - and `:unread_reply?`,
+  true for a card holding an unread reply line.
+
+  A post card (`kind: "post"`) also carries `:post_id` and `:events`, the
+  lines; each line is a group of the same shape plus a `:verb` (`:reply`,
+  `:thread`, `:mention`, `:remote_reply`, `:like`, `:share`, `:reaction`). A
+  people card (`kind: "people"`) carries `:events` with the verbs `:follower`,
+  `:connection` and `:endorsement`.
   """
   def sections(items, read_marker) do
     items
@@ -66,12 +96,13 @@ defmodule VutuvWeb.NotificationLive.Groups do
     end)
   end
 
-  # Merge one day's items into rows, preserving newest-first order of first
-  # appearance (Enum.group_by would lose it).
+  # Merge one day's items into cards. `Enum.sort_by/3` is stable, so within
+  # each of its three tiers the cards keep the newest-first order they were
+  # bucketed in.
   defp day_groups(day, day_items, read_marker) do
     # "Is now connected with you" implies "follows you": when the same actor
     # has both events on one day (a mutual follow completed), the follower
-    # item is redundant noise and the connection row alone tells the story.
+    # item is redundant noise and the connection line alone tells the story.
     connected =
       day_items
       |> Enum.filter(&(&1.kind == "connection"))
@@ -86,12 +117,13 @@ defmodule VutuvWeb.NotificationLive.Groups do
     day_items
     |> bucket(&group_key/1)
     |> Enum.map(fn {key, members} -> build_group(key, day, members, read_marker) end)
+    |> Enum.sort_by(&{&1.unread_reply?, &1.unread?}, :desc)
   end
 
   # Bucket `items` by `key_fun` into `[{key, members}]`, both the buckets and
   # the members in the newest-first order they arrived in (`Enum.group_by`
-  # keeps neither). Used twice: once to cut a day into rows, once more to cut a
-  # post card into one line per verb.
+  # keeps neither). Used twice: once to cut a day into cards, once more to cut
+  # a card into one line per verb.
   defp bucket(items, key_fun) do
     {keys, members} =
       Enum.reduce(items, {[], %{}}, fn item, {keys, members} ->
@@ -108,60 +140,102 @@ defmodule VutuvWeb.NotificationLive.Groups do
     |> Enum.map(&{&1, Enum.reverse(members[&1])})
   end
 
-  # What merges: same-day likes per post, same-day followers/connections as
-  # one bucket each, one endorser's same-day endorsements. Everything else is
-  # its own row.
-  defp group_key(%{kind: "like", post_id: post_id}) when is_binary(post_id),
-    do: {:like, post_id}
+  # What merges: everything about one post into its card, the day's people
+  # events into the people card. Everything else is its own row.
+  defp group_key(%{kind: kind}) when kind in @people_kinds, do: :people
 
-  defp group_key(%{kind: "thread", root_post_id: root_id}) when is_binary(root_id),
-    do: {:thread, root_id}
+  defp group_key(item) do
+    case post_id_of(item) do
+      nil -> {:single, item.id}
+      post_id -> {:post, post_id}
+    end
+  end
 
-  # Everything one post collected from the other networks — favourites,
-  # re-shares and replies alike — merges into a single card headed by that post
-  # (`event_key/1` splits it back into one line per verb below). Before this the
-  # three arrived as three separate rows that named the senders and the verb but
-  # never the post, so a reader with more than one post that day could not tell
-  # which of them anybody meant.
-  defp group_key(%{kind: kind, post_id: post_id})
-       when kind in @post_card_kinds and is_binary(post_id),
-       do: {:fediverse_post, post_id}
-
-  defp group_key(%{kind: "follower"}), do: :follower
-  defp group_key(%{kind: "connection"}), do: :connection
-  defp group_key(%{kind: "endorsement"} = item), do: {:endorsement, actor_key(item)}
-  defp group_key(item), do: {:single, item.id}
-
-  # A post card is a group of groups: the head names the post, and each of its
+  # A card is a group of groups: the head names the subject, and each of its
   # `:events` is an ordinary group built by the very same function one level
-  # down. Its own `actors` are empty on purpose — every actor belongs to one of
-  # the event lines, and the card has no sentence of its own for them to be the
-  # subject of.
-  defp build_group({:fediverse_post, post_id} = key, day, members, read_marker) do
+  # down. A post card's own `actors` are empty on purpose — every actor belongs
+  # to one of the lines, and the card has no sentence of its own for them to be
+  # the subject of; the people card keeps its actors, they are its avatar row.
+  defp build_group({:post, post_id} = key, day, members, read_marker) do
     events =
       members
-      |> bucket(&event_key(post_id, &1))
-      |> Enum.map(fn {key, event_members} ->
-        build_group(key, day, event_members, read_marker)
-      end)
+      |> bucket(&line_key(post_id, &1))
+      |> Enum.map(fn {line, line_members} -> build_line(line, day, line_members, read_marker) end)
+      |> Enum.sort_by(&line_rank/1)
 
     key
     |> base_group(day, members, read_marker)
-    |> Map.merge(%{kind: "fediverse_post", actors: [], actor_count: 0, events: events})
+    |> Map.merge(%{
+      kind: "post",
+      post_id: post_id,
+      actors: [],
+      actor_count: 0,
+      events: events,
+      unread_reply?: Enum.any?(events, &(reply_verb?(&1) and &1.unread?))
+    })
+  end
+
+  defp build_group(:people = key, day, members, read_marker) do
+    events =
+      members
+      |> bucket(&people_line_key/1)
+      |> Enum.map(fn {line, line_members} -> build_line(line, day, line_members, read_marker) end)
+
+    key
+    |> base_group(day, members, read_marker)
+    |> Map.merge(%{kind: "people", events: events, unread_reply?: false})
   end
 
   defp build_group(key, day, members, read_marker),
-    do: base_group(key, day, members, read_marker)
+    do: key |> base_group(day, members, read_marker) |> Map.put(:unread_reply?, false)
 
-  # One line per verb inside a card: the favourites merge into one, the
+  # One line per verb inside a post card: the likes merge into one — a member's
+  # like and a favourite from another network are the same verb — the
   # re-shares into another, and every reply keeps its own line, because each
-  # carries its own words. The keys are the same ones a row would use, so the
-  # ids stay what they were before the card existed.
-  defp event_key(post_id, %{kind: "fediverse_reaction", reaction_kind: reaction_kind})
-       when is_binary(reaction_kind),
-       do: {:fediverse_reaction, post_id, reaction_kind}
+  # carries its own words. The keys are the same ones a row used to have, so
+  # the ids stay what they were before the card existed.
+  defp line_key(post_id, %{kind: "like"}), do: {:like, post_id}
 
-  defp event_key(_post_id, item), do: {:single, item.id}
+  defp line_key(post_id, %{kind: "fediverse_reaction", reaction_kind: "like"}),
+    do: {:like, post_id}
+
+  defp line_key(post_id, %{kind: "fediverse_reaction", reaction_kind: "announce"}),
+    do: {:share, post_id}
+
+  defp line_key(post_id, %{kind: "fediverse_reaction", reaction_kind: reaction_kind})
+       when is_binary(reaction_kind),
+       do: {:reaction, post_id, reaction_kind}
+
+  defp line_key(_post_id, item), do: {:single, item.id}
+
+  defp people_line_key(%{kind: "follower"}), do: :follower
+  defp people_line_key(%{kind: "connection"}), do: :connection
+  defp people_line_key(%{kind: "endorsement"} = item), do: {:endorsement, actor_key(item)}
+
+  defp build_line(key, day, members, read_marker) do
+    key
+    |> base_group(day, members, read_marker)
+    |> Map.put(:verb, verb(key, hd(members)))
+  end
+
+  defp verb({:like, _post_id}, _newest), do: :like
+  defp verb({:share, _post_id}, _newest), do: :share
+  defp verb({:reaction, _post_id, _kind}, _newest), do: :reaction
+  defp verb(:follower, _newest), do: :follower
+  defp verb(:connection, _newest), do: :connection
+  defp verb({:endorsement, _actor}, _newest), do: :endorsement
+  defp verb({:single, _id}, %{kind: "reply"}), do: :reply
+  defp verb({:single, _id}, %{kind: "thread"}), do: :thread
+  defp verb({:single, _id}, %{kind: "mention"}), do: :mention
+  defp verb({:single, _id}, %{kind: "fediverse_reply"}), do: :remote_reply
+  defp verb({:single, _id}, _newest), do: :other
+
+  # Replies lead (each newest-first, as bucketed), then the like line, then the
+  # re-shares, then any other reaction kind.
+  defp line_rank(%{verb: verb}) when verb in @reply_verbs, do: 0
+  defp line_rank(%{verb: :like}), do: 1
+  defp line_rank(%{verb: :share}), do: 2
+  defp line_rank(_line), do: 3
 
   # `members` arrive newest-first.
   defp base_group(key, day, members, read_marker) do
@@ -181,14 +255,13 @@ defmodule VutuvWeb.NotificationLive.Groups do
   end
 
   defp group_id({:single, id}, _day, _newest), do: id
+  defp group_id({:post, post_id}, day, _newest), do: "post-#{post_id}-#{day_key(day)}"
+  defp group_id(:people, day, _newest), do: "people-#{day_key(day)}"
   defp group_id({:like, post_id}, day, _newest), do: "like-#{post_id}-#{day_key(day)}"
-  defp group_id({:thread, root_id}, day, _newest), do: "thread-#{root_id}-#{day_key(day)}"
+  defp group_id({:share, post_id}, day, _newest), do: "share-#{post_id}-#{day_key(day)}"
 
-  defp group_id({:fediverse_post, post_id}, day, _newest),
-    do: "fediverse-post-#{post_id}-#{day_key(day)}"
-
-  defp group_id({:fediverse_reaction, post_id, reaction_kind}, day, _newest),
-    do: "fediverse-reaction-#{reaction_kind}-#{post_id}-#{day_key(day)}"
+  defp group_id({:reaction, post_id, reaction_kind}, day, _newest),
+    do: "reaction-#{reaction_kind}-#{post_id}-#{day_key(day)}"
 
   defp group_id(:follower, day, _newest), do: "follower-#{day_key(day)}"
   defp group_id(:connection, day, _newest), do: "connection-#{day_key(day)}"
@@ -198,7 +271,7 @@ defmodule VutuvWeb.NotificationLive.Groups do
 
   defp day_key(day), do: Date.to_iso8601(day, :basic)
 
-  # An endorsement group's tag names in the order they were given (name as a
+  # An endorsement line's tag names in the order they were given (name as a
   # deterministic tiebreaker for the second-precision timestamps).
   defp group_tags("endorsement", members) do
     members
@@ -226,7 +299,7 @@ defmodule VutuvWeb.NotificationLive.Groups do
         kind: &1[:actor_kind],
         avatar: &1[:actor_avatar],
         # Somebody on another network (issue #1069): no vutuv profile to link
-        # to, so the row links out to their account instead and names them by
+        # to, so the line links out to their account instead and names them by
         # their `@handle@host`.
         url: &1[:actor_url],
         handle: &1[:actor_handle]
@@ -238,7 +311,7 @@ defmodule VutuvWeb.NotificationLive.Groups do
   # account URL, then their route param, and only as a last resort a hash of the
   # display name (live-pushed test payloads carry bare maps). The remote URL
   # matters — without it two different strangers who happen to share a display
-  # name would fold into a single row.
+  # name would fold into a single line.
   defp actor_key(item) do
     item[:actor_id] || item[:actor_url] || item[:actor_param] ||
       "anon-#{:erlang.phash2(item[:actor_name])}"

--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -4,41 +4,43 @@ defmodule VutuvWeb.NotificationLive.Index do
   `Vutuv.Activity.notifications_page/2` from the event tables that already
   exist, so it reaches back to events from before this page existed.
 
-  Presentation (the 2026-07 redesign):
+  Presentation (the 2026-09 card layout, replacing the 2026-07 rows):
 
-    * Raw events are **merged into grouped rows** under **Berlin-day sections**
-      by `VutuvWeb.NotificationLive.Groups` - same-day likes of one post, the
-      day's followers, one endorser's endorsements each read as a single row
-      instead of a card per event.
-    * Events newer than the previous visit's read marker are highlighted as
-      unread (tint + coral dot); the visit itself still advances the marker
-      and clears the shell's bell badge, exactly as before.
-    * **Filter tabs** (all / posts / people / more) restrict the feed
-      server-side via `notifications_page`'s `kinds:` option and live in the
-      URL (`?filter=`), patched without a reload. A press **paints itself**
-      rather than waiting for the answer: the bar is `data-filter-bar="track"`,
-      each tab `data-filter-tab`, and the whole list `data-filter-list` inside
-      the column's `data-filter-scope` — the shared in-flight rules in
-      `app.css` do the rest, off the `phx-click-loading` LiveView puts on a
-      pressed patch link. Without it a slow line shows nothing at all between
-      the press and a page of rows arriving, which reads as a dead control.
-    * A rail (right column on md+, below the list on phones) offers **Follow
-      back** suggestions (recent followers, reload-free follow via
-      `Vutuv.Social`) and a **Last 30 days** summary
-      (`Vutuv.Activity.activity_summary/2`).
-    * A post a row quotes (the liked post, the reply) is **formatted the way
-      /feed formats a post** - rendered from its Markdown source through
-      `VutuvWeb.Markdown` into the `.markdown markdown--post` body recipe, so
-      bold, lists, links, @mentions and #hashtags read as themselves instead of
-      as source markers. It is cut to the reader's own line budget -
-      `Vutuv.Accounts.User.notification_post_lines/1`, the
-      `:notification_post_lines` preference: server-side to that many source
-      lines, and visually by the `.notif-clamp` CSS clamp fed through the
-      inline `--notif-clamp` custom property. The compact one-line contexts (a
-      reply's "Your post:" breadcrumb, the handle-change list) sit inside the
-      row's own link, so they cannot carry links of their own: those come from
-      `VutuvWeb.PostTeaser`, the app's shared one-line teaser, which flattens
-      the line and skips the openers no reader learns anything from.
+    * Raw events are grouped **by subject** under **the reader's calendar
+      days** by `VutuvWeb.NotificationLive.Groups`: everything about one post
+      — likes, replies, mentions, answers deeper in its thread, and what other
+      networks sent back — is one **post card** headed by the post itself (a
+      two-line teaser, its first pictures or its link screenshot on the right,
+      a count of what came back), followed by one line per verb: every reply
+      keeps a line of its own carrying its words, likes and re-shares merge
+      into one line each. The day's followers, connections and endorsements
+      are one **people card**. Measured on the real feed before the change: 39
+      events on one day were about 11 posts, and the verb-keyed rows showed
+      the busiest post three times over.
+    * A reply line **unfolds** on tap (`toggle_line`) into the reply formatted
+      the way /feed formats a post (`<.quoted_post>`, cut to the reader's
+      `:notification_post_lines`) plus a Reply link to its permalink; a card
+      with more than `@card_lines` lines folds the rest behind "Show N more"
+      (`unfold`). Both are socket round trips, so the dead render is exactly
+      what the connected one starts from.
+    * Within a day the cards with an **unanswered reply** come first, then the
+      rest of what is new since the previous visit, then what the reader has
+      seen — the page draws a "Seen before" rule at that transition. Unread is
+      still the pre-visit read marker (tint + coral dot), and the visit still
+      advances the marker and clears the shell's bell badge.
+    * The **filter chips** (all / replies / reactions / people / more) count
+      what is new since the last visit and restrict the feed server-side via
+      `notifications_page`'s `kinds:` option; they live in the URL
+      (`?filter=`), patched without a reload. A press **paints itself** rather
+      than waiting for the answer: the bar is `data-filter-bar="track"`, each
+      chip `data-filter-tab`, and the whole list `data-filter-list` inside the
+      column's `data-filter-scope` — the shared in-flight rules in `app.css`
+      do the rest, off the `phx-click-loading` LiveView puts on a pressed patch
+      link.
+    * The last 30 days are one line under the title
+      (`Vutuv.Activity.activity_summary/2`); the rail (right column on md+,
+      below the list on phones) keeps the **Follow back** suggestions (recent
+      followers, reload-free follow via `Vutuv.Social`).
 
   The page is **numbered** (`?page=`), not an endless list: both the page and
   the filter live in the URL, so a page can be linked to and the back button
@@ -48,7 +50,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   **static** mount too (issue #919), so the list is in the first HTTP paint.
 
   Live events arrive over `Vutuv.Activity` (PubSub `"user:<id>"`) and merge into
-  their group, but only while the reader is on page 1 - an older page is a
+  their card, but only while the reader is on page 1 - an older page is a
   fixed window into the past and must not shift under them. Because grouping is
   a pure function over the retained item list, every change (paging, live push,
   the DayClock's midnight rollover) simply recomputes the sections - there is no
@@ -65,10 +67,8 @@ defmodule VutuvWeb.NotificationLive.Index do
     only: [
       cv_entry_label: 1,
       cv_entry_path: 2,
-      fediverse_reaction_text: 2,
       notification_target: 2,
-      notification_text: 1,
-      thread_text: 1
+      notification_text: 1
     ]
 
   # Like the feed and messages: not a page for anonymous visitors —
@@ -78,10 +78,13 @@ defmodule VutuvWeb.NotificationLive.Index do
   alias Vutuv.Accounts.User
   alias Vutuv.Activity
   alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Note
   alias Vutuv.Pages
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostImage
+  alias Vutuv.Posts.Screenshots
+  alias Vutuv.Screenshot
   alias Vutuv.Social
   alias Vutuv.ViewerClock
   alias VutuvWeb.Live.MountHandoff
@@ -95,21 +98,23 @@ defmodule VutuvWeb.NotificationLive.Index do
   @summary_days 30
   @follow_back_limit 5
 
-  # The kinds `Groups` folds into a post card, read from it at compile time so
-  # the list has one home and a guard can still use it.
-  @post_card_kinds Groups.post_card_kinds()
+  # How many lines a card shows before folding the rest behind a count. Four
+  # keeps a card with a dozen answers to the height of the busiest real one
+  # (three replies and a like line) while a tap still reaches everything.
+  @card_lines 4
 
-  # The filter tabs: each maps to the event kinds `notifications_page`'s
+  # The filter chips: each maps to the event kinds `notifications_page`'s
   # `kinds:` option keeps. "all" passes nil (every source).
   #
-  # Every kind in `Vutuv.Activity.kinds/0` must appear under exactly one tab, or
-  # it is unreachable from the tabs AND `filtered_out?/2` drops it from the live
-  # push for any reader not on "All" — which is what happened to
+  # Every kind in `Vutuv.Activity.kinds/0` must appear under exactly one chip,
+  # or it is unreachable from the chips AND `filtered_out?/2` drops it from the
+  # live push for any reader not on "All" — which is what happened to
   # `reference_check`. `notification_filter_coverage_test.exs` fails the build
   # when the two lists drift apart again.
   @filters %{
     "all" => nil,
-    "posts" => ~w(reply thread mention like fediverse_reply fediverse_reaction),
+    "replies" => ~w(reply thread mention fediverse_reply),
+    "reactions" => ~w(like fediverse_reaction),
     "people" => ~w(follower connection endorsement),
     "other" =>
       ~w(organization_role moderation image_rejected report_protection handle_change cv_update
@@ -124,10 +129,10 @@ defmodule VutuvWeb.NotificationLive.Index do
     user = socket.assigns.current_user
 
     # The previous visit's read marker - what "new since your last visit"
-    # highlights - and its badge count, both captured *before* this visit
-    # advances the marker below.
+    # highlights - and its per-chip badge counts, all captured *before* this
+    # visit advances the marker below.
     read_marker = user.notifications_read_at
-    new_count = if connected?(socket), do: Activity.unread_notification_count(user), else: 0
+    new_counts = if connected?(socket), do: unread_counts(user), else: %{}
 
     # The rows the member already acknowledged one by one, from the browser
     # notifications they clicked — captured here for the same reason as the
@@ -146,15 +151,17 @@ defmodule VutuvWeb.NotificationLive.Index do
      socket
      |> assign(:page_title, gettext("Notifications"))
      |> assign(:read_marker, read_marker)
-     |> assign(:new_count, new_count)
+     |> assign(:new_counts, new_counts)
      |> assign(:dismissed, dismissed)
      |> assign(:today, ViewerClock.today())
      |> assign(:quote_lines, User.notification_post_lines(user))
+     |> assign(:expanded, MapSet.new())
+     |> assign(:unfolded, MapSet.new())
      |> assign_rail(connected?(socket))}
   end
 
-  # Both the filter (?filter=posts) and the page (?page=3) live in the URL, so
-  # the tabs and the pager are patch links and the back button works; an
+  # Both the filter (?filter=replies) and the page (?page=3) live in the URL, so
+  # the chips and the pager are patch links and the back button works; an
   # unknown filter falls back to "all", an unparseable page to 1. Runs on both
   # the static and the connected mount, so the page is in the first HTTP paint
   # (issue #919).
@@ -185,6 +192,35 @@ defmodule VutuvWeb.NotificationLive.Index do
     {:noreply, assign_rail(socket, true)}
   end
 
+  # A reply line unfolds into the formatted quote and folds again on the next
+  # tap. Kept per line id, so a live push or a midnight rollover that rebuilds
+  # the sections leaves an open line open. The quote itself is rendered here,
+  # on the unfold, not for every reply on the page: a full Markdown pass per
+  # line was paid for fifty lines and shown for none until somebody tapped.
+  def handle_event("toggle_line", %{"id" => id}, socket) do
+    expanded = socket.assigns.expanded
+
+    if MapSet.member?(expanded, id) do
+      {:noreply, assign(socket, :expanded, MapSet.delete(expanded, id))}
+    else
+      viewer = socket.assigns.current_user
+      lines = socket.assigns.quote_lines
+
+      {:noreply,
+       socket
+       |> assign(:expanded, MapSet.put(expanded, id))
+       |> update(:items, fn items ->
+         Enum.map(items, &if(&1.id == id, do: with_reply_preview(&1, viewer, lines), else: &1))
+       end)
+       |> assign_sections()}
+    end
+  end
+
+  # "Show N more" on a card: every line from then on, for this card.
+  def handle_event("unfold", %{"id" => id}, socket) do
+    {:noreply, update(socket, :unfolded, &MapSet.put(&1, id))}
+  end
+
   @impl true
   def handle_info({:new_notification, notification}, socket) do
     # The user is watching the event arrive, so it is already read: advance
@@ -205,8 +241,8 @@ defmodule VutuvWeb.NotificationLive.Index do
       |> Map.put_new(:id, "live-#{System.unique_integer([:positive, :monotonic])}")
 
     cond do
-      # Not part of what this tab shows: it belongs to neither the list nor
-      # the tab's total.
+      # Not part of what this chip shows: it belongs to neither the list nor
+      # the chip's total.
       filtered_out?(item, socket.assigns.filter) ->
         {:noreply, socket}
 
@@ -248,7 +284,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   # pass stashes what it computed and the connected mount's handle_params —
   # moments later, same viewer, same URL — takes it instead of re-running the
   # same queries (`VutuvWeb.Live.MountHandoff`). The subject carries the
-  # filter and the *requested* page, so a patch to another tab or page can
+  # filter and the *requested* page, so a patch to another chip or page can
   # never reuse a stale stash; any miss (expired, consumed, a patch, a
   # reconnect) falls back to the plain full load. The visit's mark-read write
   # lives in mount, not here, so the handoff leaves it at exactly once.
@@ -322,11 +358,31 @@ defmodule VutuvWeb.NotificationLive.Index do
   end
 
   defp assign_sections(socket) do
-    sections = Groups.sections(socket.assigns.items, socket.assigns.read_marker)
+    sections =
+      socket.assigns.items
+      |> Groups.sections(socket.assigns.read_marker)
+      |> Enum.map(&Map.put(&1, :rows, with_seen_rule(&1.groups)))
 
     socket
     |> assign(:sections, sections)
     |> assign(:empty?, sections == [])
+  end
+
+  # `[{group, rule?}]`: the "Seen before" rule sits before the first seen card
+  # that follows a new one in the same day — once, since `Groups` sorts a
+  # day's new cards ahead of its seen ones. A day that is all new or all seen
+  # draws no rule.
+  defp with_seen_rule(groups) do
+    {rows, _state} =
+      Enum.map_reduce(groups, :before, fn group, state ->
+        cond do
+          group.unread? -> {{group, false}, :new_seen}
+          state == :new_seen -> {{group, true}, :done}
+          true -> {{group, false}, state}
+        end
+      end)
+
+    rows
   end
 
   defp filtered_out?(item, filter) do
@@ -336,15 +392,32 @@ defmodule VutuvWeb.NotificationLive.Index do
     end
   end
 
-  # The id of the day's first "thread" group, so its row alone carries the
-  # opt-out hint (issue #1025) - one hint per Berlin-day section, not per row.
-  # nil when the day has no thread row, so nothing is marked.
-  defp first_thread_group_id(groups) do
-    Enum.find_value(groups, fn group -> group.kind == "thread" && group.id end)
+  # The day's first thread line, for the opt-out hint (issue #1025): one hint
+  # per day, on the first line that would be silenced.
+  defp first_thread_line_id(groups) do
+    Enum.find_value(groups, fn
+      %{kind: "post", events: events} -> Enum.find_value(events, &(&1.verb == :thread && &1.id))
+      _group -> nil
+    end)
   end
 
-  # The rail data (follow-back suggestions + 30-day summary) is skipped on
-  # the static mount, like the remaining count, to keep the first paint lean.
+  # What is new since the last visit, per chip. The whole-feed count is what
+  # the shell badge showed; the split into chips is one more query, and only
+  # when there is something to split.
+  defp unread_counts(user) do
+    case Activity.unread_notification_count(user) do
+      0 ->
+        %{"all" => 0}
+
+      all ->
+        user
+        |> Activity.unread_notification_counts(Map.delete(@filters, "all"))
+        |> Map.put("all", all)
+    end
+  end
+
+  # The rail and the summary line need the DB and the viewer's follow graph;
+  # the static render skips both (they arrive with the connected mount).
   defp assign_rail(socket, false) do
     socket
     |> assign(:follow_back, [])
@@ -355,14 +428,13 @@ defmodule VutuvWeb.NotificationLive.Index do
   defp assign_rail(socket, true) do
     user = socket.assigns.current_user
     follow_back = Social.followers_to_follow_back(user.id, @follow_back_limit)
-
     since = NaiveDateTime.add(NaiveDateTime.utc_now(:second), -@summary_days, :day)
     summary = Activity.activity_summary(user.id, since)
 
     socket
     |> assign(:follow_back, follow_back)
     |> assign(:work_info_by_id, UserHelpers.work_information_map(follow_back, 45))
-    |> assign(:summary, if(summary_total(summary) > 0, do: summary))
+    |> assign(:summary, if(summary_total(summary) > 0, do: summary, else: nil))
   end
 
   defp summary_total(summary) do
@@ -375,23 +447,37 @@ defmodule VutuvWeb.NotificationLive.Index do
     ~H"""
     <div id="notifications" class="py-6 md:py-8">
       <div class="grid gap-6 md:grid-cols-3">
-        <%!-- `data-filter-scope` pairs the tabs with the list they replace: the
+        <%!-- `data-filter-scope` pairs the chips with the list they replace: the
         in-flight paint in `app.css` dims every `[data-filter-list]` inside this
-        container while one of its tabs is waiting for an answer, so both
+        container while one of its chips is waiting for an answer, so both
         markers have to stay under this one element. --%>
         <div data-filter-scope class="min-w-0 md:col-span-2">
           <div class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
             <h1 class="text-2xl font-bold text-slate-800 dark:text-slate-100">
               {gettext("Notifications")}
             </h1>
-            <p :if={@new_count > 0} id="new-count" class="mb-0 text-sm font-semibold text-accent">
-              {new_count_label(@new_count)}
+            <p
+              :if={unread_badge(@new_counts, "all")}
+              id="new-count"
+              class="mb-0 text-sm font-semibold text-accent"
+            >
+              {new_count_label(unread_badge(@new_counts, "all"))}
             </p>
           </div>
 
+          <%!-- The last 30 days as one quiet line: the context the reader
+          glances at, never the thing they came for. --%>
+          <p
+            :if={@summary}
+            id="activity-summary"
+            class="mb-0 mt-1 text-xs text-slate-600 dark:text-slate-400"
+          >
+            {summary_line(@summary)}
+          </p>
+
           <%!-- `data-filter-bar="track"` picks which of the app's two tab looks
           the in-flight paint reaches for: here the white pill on a filled
-          trough, so a pressed tab turns into this bar's own active tab rather
+          trough, so a pressed chip turns into this bar's own active chip rather
           than into the brand pill the post filter tabs wear. --%>
           <div
             id="notification-filter"
@@ -405,12 +491,16 @@ defmodule VutuvWeb.NotificationLive.Index do
               aria-current={@filter == value && "page"}
               class={filter_tab_class(@filter == value)}
             >
-              {label}
+              {label}<span
+                :if={unread_badge(@new_counts, value)}
+                data-filter-count
+                class="ml-1.5 inline-flex min-w-5 items-center justify-center rounded-full bg-accent px-1.5 text-[11px] font-bold leading-5 text-white"
+              >{compact_count(unread_badge(@new_counts, value))}</span>
             </.link>
           </div>
 
-          <%!-- Everything a tab replaces lives in one `data-filter-list`, so the
-          shared paint can dim it while the answer is on its way. The tabs stay
+          <%!-- Everything a chip replaces lives in one `data-filter-list`, so the
+          shared paint can dim it while the answer is on its way. The chips stay
           outside it: the reader has to keep seeing which one they pressed. --%>
           <div data-filter-list>
             <section :for={section <- @sections} data-day-section>
@@ -420,16 +510,28 @@ defmodule VutuvWeb.NotificationLive.Index do
               >
                 {day_label(section.day, @today)}
               </h2>
-              <% first_thread_id = first_thread_group_id(section.groups) %>
-              <div class="mt-2 divide-y divide-slate-100 overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-slate-200 dark:divide-slate-800 dark:bg-slate-900 dark:ring-slate-800">
-                <.notification_row
-                  :for={group <- section.groups}
-                  group={group}
-                  current_user={@current_user}
-                  quote_lines={@quote_lines}
-                  post_cards={@post_cards}
-                  thread_hint={group.kind == "thread" and group.id == first_thread_id}
-                />
+              <% thread_hint_id = first_thread_line_id(section.groups) %>
+              <div class="mt-2 space-y-3">
+                <%= for {group, rule?} <- section.rows do %>
+                  <div
+                    :if={rule?}
+                    data-seen-rule
+                    class="flex items-center gap-3 px-1 pt-1 text-xs font-semibold text-slate-500 dark:text-slate-400"
+                  >
+                    <span class="h-px flex-1 bg-slate-200 dark:bg-slate-700" aria-hidden="true"></span>
+                    {gettext("Seen before")}
+                    <span class="h-px flex-1 bg-slate-200 dark:bg-slate-700" aria-hidden="true"></span>
+                  </div>
+                  <.notification_card
+                    group={group}
+                    current_user={@current_user}
+                    quote_lines={@quote_lines}
+                    post_cards={@post_cards}
+                    expanded={@expanded}
+                    unfolded={@unfolded}
+                    thread_hint_id={thread_hint_id}
+                  />
+                <% end %>
               </div>
             </section>
 
@@ -464,29 +566,6 @@ defmodule VutuvWeb.NotificationLive.Index do
               />
             </ul>
           </.card>
-
-          <.card :if={@summary} id="activity-summary" class="p-5">
-            <.section_title>{gettext("Last 30 days")}</.section_title>
-            <ul class="mt-4 space-y-2.5">
-              <li
-                :for={{kind, count} <- summary_rows(@summary)}
-                class="flex items-center gap-3 text-sm"
-              >
-                <span class={[
-                  "flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-bold",
-                  kind_classes(kind)
-                ]}>
-                  {kind_glyph(kind)}
-                </span>
-                <span class="min-w-0 flex-1 truncate text-slate-700 dark:text-slate-300">
-                  {summary_label(kind)}
-                </span>
-                <span class="font-semibold text-slate-900 dark:text-white">
-                  {compact_count(count)}
-                </span>
-              </li>
-            </ul>
-          </.card>
         </aside>
       </div>
     </div>
@@ -497,69 +576,111 @@ defmodule VutuvWeb.NotificationLive.Index do
   # assigns, not the module attribute.
   defp page_size, do: @page_size
 
-  # The pager carries the active tab onto every page link, so paging inside a
-  # filtered feed stays in that filter. "all" is the default and needs no param.
+  # The pager carries the active chip onto every page link, so paging inside a
+  # filter stays inside it.
   defp pager_query("all"), do: %{}
   defp pager_query(filter), do: %{"filter" => filter}
 
-  # ── One grouped row ──
+  # ── One card ──
 
   attr(:group, :map, required: true)
   attr(:current_user, :any, required: true)
   attr(:quote_lines, :integer, required: true)
   attr(:post_cards, :map, default: %{})
-  attr(:thread_hint, :boolean, default: false)
+  attr(:expanded, :any, required: true)
+  attr(:unfolded, :any, required: true)
+  attr(:thread_hint_id, :string, default: nil)
 
-  defp notification_row(%{group: %{kind: "fediverse_post"}} = assigns) do
-    assigns = assign(assigns, :card, Map.get(assigns.post_cards, assigns.group.item[:post_id]))
+  defp notification_card(%{group: %{kind: "post"}} = assigns) do
+    lines = assigns.group.events
+    unfolded? = MapSet.member?(assigns.unfolded, assigns.group.id)
+    shown = if unfolded?, do: lines, else: Enum.take(lines, @card_lines)
+
+    assigns =
+      assigns
+      |> assign(:card, Map.get(assigns.post_cards, assigns.group.post_id))
+      |> assign(:shown, shown)
+      |> assign(:hidden, length(lines) - length(shown))
 
     ~H"""
     <.notification_article group={@group}>
-      <.post_card_head card={@card} counts={event_counts(@group.events)} />
+      <.post_card_head
+        card={@card}
+        eyebrow={card_eyebrow(@card, @group, @current_user)}
+        counts={card_counts(@group.events)}
+        at={@group.at}
+        unread?={@group.unread?}
+      />
 
-      <%!-- One line per verb, on the same quote rail the row quotes wear: the
-      card head already said which post, so each line only has to say who and
-      what. --%>
-      <ul class="mt-2.5 space-y-1 border-l-2 border-slate-200 pl-3 dark:border-slate-700">
-        <li
-          :for={event <- @group.events}
-          data-notification-event
-          data-event-kind={event.kind}
-          data-unread={event.unread? && "true"}
-        >
-          <div class="flex items-baseline gap-2 text-sm leading-relaxed text-slate-800 dark:text-slate-100">
-            <span class="shrink-0 text-xs" aria-hidden="true">{kind_glyph(event.kind)}</span>
-            <p class="mb-0 min-w-0 flex-1">
-              <span class="sr-only">{kind_label(event.kind)}:</span>
-              <.actor_links group={event} current_user={@current_user} />
-              <.link
-                href={card_event_target(event, @current_user)}
-                class="hover:text-brand-700 hover:underline dark:hover:text-brand-300"
-              >
-                {card_event_text(event)}
-              </.link>
-            </p>
-            <.row_time at={event.at} />
-            <.unread_dot :if={event.unread?} class="mt-1.5 shrink-0" />
-          </div>
+      <ul class="mt-2 divide-y divide-slate-100 dark:divide-slate-800">
+        <.card_line
+          :for={line <- @shown}
+          line={line}
+          current_user={@current_user}
+          quote_lines={@quote_lines}
+          expanded={MapSet.member?(@expanded, line.id)}
+          thread_hint={line.id == @thread_hint_id}
+        />
+      </ul>
 
-          <%!-- A reply brings words of its own, so it keeps the quote (and the
-          private-reply warning) it had as its own row — the reader has to know
-          a reply is private before they answer it. --%>
-          <.remote_reply
-            :if={event.kind == "fediverse_reply" and event.item[:note_text]}
-            id={"quote-remote-#{event.id}"}
-            n={event.item}
-            current_user={@current_user}
-            quote_lines={@quote_lines}
+      <button
+        :if={@hidden > 0}
+        type="button"
+        phx-click="unfold"
+        phx-value-id={@group.id}
+        data-card-more
+        class="mt-1 inline-flex min-h-10 items-center text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+      >
+        {gettext("Show %{formatted} more", formatted: compact_count(@hidden))}
+      </button>
+    </.notification_article>
+    """
+  end
+
+  # The day's people: their avatars, a tally, and one line per verb.
+  defp notification_card(%{group: %{kind: "people"}} = assigns) do
+    ~H"""
+    <.notification_article group={@group}>
+      <div class="flex items-start gap-3">
+        <div class="flex shrink-0 -space-x-2">
+          <.avatar
+            :for={actor <- Enum.take(@group.actors, 4)}
+            src={actor.avatar}
+            size="sm"
+            presence
+            presence_id={actor.id}
+            alt={"Avatar of #{actor.name}"}
+            class="ring-2 ring-white dark:ring-slate-900"
           />
-        </li>
+        </div>
+        <div class="min-w-0 flex-1">
+          <span data-card-eyebrow class={eyebrow_class()}>{gettext("People")}</span>
+          <span
+            data-card-title
+            class="mt-0.5 block text-sm font-medium text-slate-900 dark:text-white"
+          >
+            {people_title(@group)}
+          </span>
+        </div>
+        <.row_meta at={@group.at} unread?={@group.unread?} />
+      </div>
+
+      <ul class="mt-2 divide-y divide-slate-100 dark:divide-slate-800">
+        <.card_line
+          :for={line <- @group.events}
+          line={line}
+          current_user={@current_user}
+          quote_lines={@quote_lines}
+          expanded={false}
+          thread_hint={false}
+        />
       </ul>
     </.notification_article>
     """
   end
 
-  defp notification_row(assigns) do
+  # Every rarer kind: one row per event, each carrying its own content.
+  defp notification_card(assigns) do
     assigns = assign(assigns, :n, assigns.group.item)
 
     ~H"""
@@ -580,88 +701,6 @@ defmodule VutuvWeb.NotificationLive.Index do
             <% true -> %>
               {group_text(@group)}
           <% end %>
-        </p>
-
-        <%!-- A like quotes the liked post once, formatted like a feed post and
-        cut to the reader's line budget (:notification_post_lines). --%>
-        <.quoted_post
-          :if={@group.kind == "like" and @n[:post_preview]}
-          id={"quote-#{@group.id}"}
-          href={~p"/#{@current_user}/posts/#{@n.post_id}"}
-          html={@n.post_preview.html}
-          quote_lines={@quote_lines}
-          class="mt-1.5"
-        />
-
-        <%!-- A mention quotes the post that named the reader. Its permalink
-        lives under the post's own author, not under the reader — and that
-        author may be an organization (issue #1334), so it is asked of
-        `Posts.path/1` rather than assembled here from a member handle. --%>
-        <.quoted_post
-          :if={@group.kind == "mention" and @n[:post_preview]}
-          id={"quote-#{@group.id}"}
-          href={Posts.path(@n.post_preview.post)}
-          html={@n.post_preview.html}
-          quote_lines={@quote_lines}
-          class="mt-1.5"
-        />
-
-        <%!-- A reply quotes the reply itself, under a one-line breadcrumb naming
-        the recipient's own post it answers. A thread event carries no post of
-        the recipient's, so there only the reply quotes. --%>
-        <div
-          :if={@group.kind in ["reply", "thread"] and (@n[:post_preview] || @n[:reply_preview])}
-          class="mt-1.5 space-y-1"
-        >
-          <.link
-            :if={@n[:post_preview]}
-            data-post-preview="true"
-            href={~p"/#{@current_user}/posts/#{@n.post_id}"}
-            class="block text-xs text-slate-500 hover:text-brand-700 dark:text-slate-400 dark:hover:text-brand-300"
-          >
-            <span class="font-medium">{gettext("Your post")}:</span>
-            <span class="line-clamp-1 whitespace-pre-line align-bottom">{@n.post_preview.text}</span>
-          </.link>
-          <.quoted_post
-            :if={@n[:reply_preview]}
-            id={"quote-reply-#{@group.id}"}
-            data-reply-preview="true"
-            href={Posts.path(@n.reply_preview.post)}
-            html={@n.reply_preview.html}
-            quote_lines={@quote_lines}
-          />
-        </div>
-
-        <%!-- A reply from another network quotes its text (issue #1069). Plain
-        text, clamped like the other quotes and deliberately NOT run through the
-        Markdown renderer: a stranger's words must not be able to mint links,
-        least of all @mention links into local profiles. A private reply
-        (issue #1071) says so, since the member has to know that before they
-        answer. --%>
-        <.remote_reply
-          :if={@group.kind == "fediverse_reply" and @n[:note_text]}
-          id={"quote-remote-#{@group.id}"}
-          n={@n}
-          current_user={@current_user}
-          quote_lines={@quote_lines}
-        />
-
-        <%!-- The day's first thread row says why it is here and links to the
-        switch that stops it (issue #1025), once per day so it stays a hint and
-        not a banner. It shows only when thread events reach this reader, which
-        is exactly when the switch is still on. --%>
-        <p
-          :if={@thread_hint}
-          data-thread-hint
-          class="mb-0 mt-1.5 text-xs text-slate-500 dark:text-slate-400"
-        >
-          {gettext("You wrote in this thread.")}
-          <.link
-            href={~p"/settings/notifications"}
-            class="font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
-          >
-            {gettext("Turn off thread notifications")} ›
-          </.link>
         </p>
 
         <%!-- A CV update covering several entries names them, each linking to
@@ -701,18 +740,15 @@ defmodule VutuvWeb.NotificationLive.Index do
           </p>
         </div>
       </div>
-      <div class="flex shrink-0 flex-col items-end gap-1.5 pt-0.5">
-        <.row_time at={@group.at} />
-        <.unread_dot :if={@group.unread?} />
-      </div>
+      <.row_meta at={@group.at} unread?={@group.unread?} />
     </.notification_article>
     """
   end
 
-  # The shell every row wears, whatever it holds: the id and the markers the
+  # The shell every card wears, whatever it holds: the id and the markers the
   # tests and the CSS key on (`assets/css/components.css` reads
   # `[data-notification-row][data-unread]` to paint the quote clamp's fade on
-  # the row's own tint, so the tint cannot live in only one of the clauses).
+  # the card's own tint, so the tint cannot live in only one of the clauses).
   attr(:group, :map, required: true)
   attr(:class, :string, default: nil)
   slot(:inner_block, required: true)
@@ -725,13 +761,27 @@ defmodule VutuvWeb.NotificationLive.Index do
       data-kind={@group.kind}
       data-unread={@group.unread? && "true"}
       class={[
-        "px-4 py-3 sm:px-5",
+        "rounded-2xl bg-white px-4 py-3 shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800 sm:px-5",
         @class,
         @group.unread? && "bg-brand-50/60 dark:bg-brand-900/15"
       ]}
     >
       {render_slot(@inner_block)}
     </article>
+    """
+  end
+
+  # The right edge of a card head, a card line and a single row alike: the
+  # clock time over the unread dot.
+  attr(:at, :any, required: true)
+  attr(:unread?, :boolean, required: true)
+
+  defp row_meta(assigns) do
+    ~H"""
+    <div class="flex shrink-0 flex-col items-end gap-1.5 pt-0.5">
+      <.row_time at={@at} />
+      <.unread_dot :if={@unread?} />
+    </div>
     """
   end
 
@@ -745,95 +795,64 @@ defmodule VutuvWeb.NotificationLive.Index do
     """
   end
 
-  # The post a row quotes, formatted exactly the way /feed formats a post: the
-  # rendered Markdown in the `.markdown markdown--post` body recipe (headings
-  # flattened to bold, @mentions and #hashtags linked), clipped by `.notif-clamp`
-  # to the reader's line budget.
+  defp eyebrow_class,
+    do:
+      "block text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
+
+  # ── The head of a post card ──
+
+  # What the post says on the left, its first photos or its link screenshot on
+  # the right, and under the text a line counting what came back. Above it all
+  # an eyebrow saying whose post this is — the reader's own for a like or a
+  # reply, somebody else's for a mention, a thread they wrote in.
   #
-  # It is a block with a *stretched* permalink link rather than one big `<a>`,
-  # because a formatted body carries links of its own and an `<a>` inside an
-  # `<a>` is invalid: the prose falls through to the stretched link, so a click
-  # anywhere still opens the post, while a mention/hashtag/URL keeps its own
-  # target. The feed's "Suggested posts" rail is arranged the same way.
-  # `id` is what lets the clamp measurement re-run after a patch: the row is
-  # marked `data-post-preview` and the body `data-clamp-body`, the same pair the
-  # feed's post previews use, so app.js measures the quote and sets `is-clamped`
-  # on the wrapper — which is what paints the "…" that says the quote goes on
-  # (see the excerpt-clamp block in components.css). Whether the reader's line
-  # budget was enough depends on column width and font, so only the browser can
-  # decide it.
-  attr(:id, :string, required: true)
-  attr(:href, :string, required: true)
-  attr(:html, :any, required: true)
-  attr(:quote_lines, :integer, required: true)
-  attr(:class, :string, default: nil)
-  attr(:rest, :global)
-
-  defp quoted_post(assigns) do
-    ~H"""
-    <div
-      id={@id}
-      phx-hook="PostPreviewClamp"
-      data-post-preview
-      class={[
-        "relative border-l-2 border-slate-200 pl-2.5 transition-colors hover:border-brand-400",
-        "dark:border-slate-700 dark:hover:border-brand-500",
-        @class
-      ]}
-      {@rest}
-    >
-      <.link href={@href} aria-label={gettext("View post")} class="absolute inset-0 z-10"></.link>
-      <%!-- The type size and line height come from `.notif-clamp` itself: the
-      reader's line budget is a box height counted in them, so a `text-*` here
-      would cut the quote mid-letter. --%>
-      <div
-        data-clamp-body
-        class="markdown markdown--post notif-clamp text-slate-600 dark:text-slate-400 [&_a]:relative [&_a]:z-20"
-        {clamp_attrs(@quote_lines)}
-      >
-        {@html}
-      </div>
-    </div>
-    """
-  end
-
-  # ── The post card ──
-
-  # The head of a post card: what the post says on the left, its first photos on
-  # the right, and under the text a line counting what came back.
-  #
-  # The text starts at the same edge whether the post carries a photo or not —
-  # the photos hang off the right — so a column of cards reads as one column
-  # rather than as two indents. The card is one link to the post: the reader's
-  # question is "which post was that", and the answer is one tap away.
+  # The text starts at the same edge whether the post carries a picture or not
+  # — the pictures hang off the right — so a column of cards reads as one
+  # column rather than as two indents. The head is one link to the post: the
+  # reader's question is "which post was that", and the answer is one tap away.
   attr(:card, :any, required: true)
+  attr(:eyebrow, :string, required: true)
   attr(:counts, :list, required: true)
+  attr(:at, :any, required: true)
+  attr(:unread?, :boolean, required: true)
 
   defp post_card_head(assigns) do
     ~H"""
-    <div :if={@card} class="flex items-start gap-3">
-      <.link
-        href={Posts.path(@card.post)}
-        data-post-card
-        class="min-w-0 flex-1 text-sm font-medium text-slate-900 hover:text-brand-700 dark:text-white dark:hover:text-brand-300"
-      >
-        <%!-- A photo post has no text to name it with (`PostTeaser` skips an
-        image-only line), so the card says so rather than opening on a blank
-        line the reader has to interpret. --%>
-        <span
-          :if={@card.text == ""}
-          data-post-card-textless
-          class="italic font-normal text-slate-500 dark:text-slate-400"
+    <div class="flex items-start gap-3">
+      <div class="min-w-0 flex-1">
+        <span :if={@eyebrow} data-card-eyebrow class={eyebrow_class()}>{@eyebrow}</span>
+        <.link
+          :if={@card}
+          href={Posts.path(@card.post)}
+          data-post-card
+          class="mt-0.5 block text-sm font-medium text-slate-900 hover:text-brand-700 dark:text-white dark:hover:text-brand-300"
         >
-          {gettext("Post without text")}
-        </span>
-        <span :if={@card.text != ""} class="line-clamp-2 whitespace-pre-line">{@card.text}</span>
-        <span class="mt-0.5 block text-xs font-normal text-slate-500 dark:text-slate-400">
+          <%!-- A photo post has no text to name it with (`PostTeaser` skips an
+          image-only line), so the card says so rather than opening on a blank
+          line the reader has to interpret. --%>
+          <span
+            :if={@card.text == ""}
+            data-post-card-textless
+            class="italic font-normal text-slate-500 dark:text-slate-400"
+          >
+            {gettext("Post without text")}
+          </span>
+          <span :if={@card.text != ""} class="line-clamp-2 whitespace-pre-line">{@card.text}</span>
+        </.link>
+        <%!-- The post is hidden from the reader or gone (a visibility-scoped
+        lookup returned nothing): the lines below still say what happened. --%>
+        <p :if={!@card} class="mb-0 mt-0.5 text-sm italic text-slate-500 dark:text-slate-400">
+          {gettext("The post is no longer available.")}
+        </p>
+        <span :if={@counts != []} class="mt-0.5 block text-xs text-slate-500 dark:text-slate-400">
           {Enum.join(@counts, " · ")}
         </span>
-      </.link>
+      </div>
 
-      <.post_card_images card={@card} big={@card.text == ""} />
+      <.post_card_images :if={@card} card={@card} big={@card.text == ""} />
+      <.post_card_screenshot :if={@card && @card.images == [] && @card.screenshot} card={@card} />
+
+      <.row_meta at={@at} unread?={@unread?} />
     </div>
     """
   end
@@ -875,6 +894,210 @@ defmodule VutuvWeb.NotificationLive.Index do
     """
   end
 
+  # A link post's auto screenshot, in the slot the photos would take: the same
+  # capture the feed floats beside the post, at thumbnail size, so a card about
+  # a shared link shows the page it points at. Decorative — the head's text link
+  # already names and opens the post — so it is kept out of the tab order.
+  attr(:card, :map, required: true)
+
+  defp post_card_screenshot(assigns) do
+    ~H"""
+    <.link
+      href={Posts.path(@card.post)}
+      data-post-card-screenshot
+      aria-hidden="true"
+      tabindex="-1"
+      class="shrink-0"
+    >
+      <.picture
+        picture={Screenshot.picture({@card.screenshot.screenshot, @card.screenshot})}
+        width="72"
+        height="48"
+        loading="lazy"
+        alt=""
+        class="h-12 w-[4.5rem] rounded-lg object-cover ring-1 ring-slate-200 dark:ring-slate-800"
+      />
+    </.link>
+    """
+  end
+
+  # ── One line inside a card ──
+
+  # Who did what, on one line: a small kind glyph, the actors, the verb — and
+  # for a reply its words, clamped to two lines, as the button that unfolds
+  # the formatted quote. The card's head already named the post, so no line
+  # repeats it.
+  attr(:line, :map, required: true)
+  attr(:current_user, :any, required: true)
+  attr(:quote_lines, :integer, required: true)
+  attr(:expanded, :boolean, required: true)
+  attr(:thread_hint, :boolean, default: false)
+
+  defp card_line(assigns) do
+    assigns =
+      assigns
+      |> assign(:n, assigns.line.item)
+      |> assign(:teaser, line_teaser(assigns.line))
+      |> assign(:kind, line_kind(assigns.line))
+
+    ~H"""
+    <li
+      id={"notification-#{@line.id}"}
+      data-notification-event
+      data-event-kind={@kind}
+      data-unread={@line.unread? && "true"}
+      class="py-2 first:pt-0 last:pb-0"
+    >
+      <div class="flex items-start gap-2.5">
+        <span
+          class={[
+            "mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-bold",
+            kind_classes(@kind)
+          ]}
+          aria-hidden="true"
+        >
+          {kind_glyph(@kind)}
+        </span>
+        <div class="min-w-0 flex-1">
+          <p class="mb-0 text-sm leading-relaxed text-slate-800 dark:text-slate-100">
+            <span class="sr-only">{kind_label(@kind)}:</span>
+            <.actor_links group={@line} current_user={@current_user} named={named_actors(@line)} />
+            {line_text(@line)}
+          </p>
+
+          <%!-- Folded: the reply's words, two lines of them, as the button that
+          opens the rest. A private reply from another network (issue #1071)
+          says so right here, since the member has to know that before they
+          answer, not after they unfold it. --%>
+          <button
+            :if={@teaser && !@expanded}
+            type="button"
+            phx-click="toggle_line"
+            phx-value-id={@line.id}
+            data-line-toggle
+            aria-expanded="false"
+            class="mt-0.5 block w-full text-left text-sm text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200"
+          >
+            <span :if={remote_private?(@n)} data-remote-private aria-hidden="true">🔒</span>
+            <span data-reply-teaser class="line-clamp-2 whitespace-pre-line">{@teaser}</span>
+          </button>
+
+          <%!-- Unfolded: the quote formatted like a feed post (or the remote
+          reply's plain text), the Reply link to where an answer is written,
+          and the way back. --%>
+          <div :if={@expanded} class="mt-1.5 space-y-1.5">
+            <.quoted_post
+              :if={local_reply?(@line) and @n[:reply_preview]}
+              id={"quote-#{@line.id}"}
+              data-reply-preview="true"
+              href={Posts.path(@n.reply_preview.post)}
+              html={@n.reply_preview.html}
+              quote_lines={@quote_lines}
+            />
+            <.remote_reply
+              :if={@line.verb == :remote_reply and @n[:note_text]}
+              id={"quote-remote-#{@line.id}"}
+              n={@n}
+              current_user={@current_user}
+              quote_lines={@quote_lines}
+            />
+            <div class="flex flex-wrap items-center gap-x-4">
+              <.link
+                href={reply_target(@line, @current_user)}
+                data-reply-link
+                class="inline-flex min-h-10 items-center text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+              >
+                {gettext("Reply")} ›
+              </.link>
+              <button
+                type="button"
+                phx-click="toggle_line"
+                phx-value-id={@line.id}
+                data-line-toggle
+                aria-expanded="true"
+                class="inline-flex min-h-10 items-center text-sm font-medium text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200"
+              >
+                {gettext("Less")}
+              </button>
+            </div>
+          </div>
+
+          <%!-- The day's first thread line says why it is here and links to the
+          switch that stops it (issue #1025), once per day so it stays a hint and
+          not a banner. It shows only when thread events reach this reader, which
+          is exactly when the switch is still on. --%>
+          <p
+            :if={@thread_hint}
+            data-thread-hint
+            class="mb-0 mt-1 text-xs text-slate-500 dark:text-slate-400"
+          >
+            {gettext("You wrote in this thread.")}
+            <.link
+              href={~p"/settings/notifications"}
+              class="font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+            >
+              {gettext("Turn off thread notifications")} ›
+            </.link>
+          </p>
+        </div>
+        <.row_meta at={@line.at} unread?={@line.unread?} />
+      </div>
+    </li>
+    """
+  end
+
+  # The post a line quotes, formatted exactly the way /feed formats a post: the
+  # rendered Markdown in the `.markdown markdown--post` body recipe (headings
+  # flattened to bold, @mentions and #hashtags linked), clipped by `.notif-clamp`
+  # to the reader's line budget.
+  #
+  # It is a block with a *stretched* permalink link rather than one big `<a>`,
+  # because a formatted body carries links of its own and an `<a>` inside an
+  # `<a>` is invalid: the prose falls through to the stretched link, so a click
+  # anywhere still opens the post, while a mention/hashtag/URL keeps its own
+  # target. The feed's "Suggested posts" rail is arranged the same way.
+  # `id` is what lets the clamp measurement re-run after a patch: the block is
+  # marked `data-post-preview` and the body `data-clamp-body`, the same pair the
+  # feed's post previews use, so app.js measures the quote and sets `is-clamped`
+  # on the wrapper — which is what paints the "…" that says the quote goes on
+  # (see the excerpt-clamp block in components.css). Whether the reader's line
+  # budget was enough depends on column width and font, so only the browser can
+  # decide it.
+  attr(:id, :string, required: true)
+  attr(:href, :string, required: true)
+  attr(:html, :any, required: true)
+  attr(:quote_lines, :integer, required: true)
+  attr(:class, :string, default: nil)
+  attr(:rest, :global)
+
+  defp quoted_post(assigns) do
+    ~H"""
+    <div
+      id={@id}
+      phx-hook="PostPreviewClamp"
+      data-post-preview
+      class={[
+        "relative border-l-2 border-slate-200 pl-2.5 transition-colors hover:border-brand-400",
+        "dark:border-slate-700 dark:hover:border-brand-500",
+        @class
+      ]}
+      {@rest}
+    >
+      <.link href={@href} aria-label={gettext("View post")} class="absolute inset-0 z-10"></.link>
+      <%!-- The type size and line height come from `.notif-clamp` itself: the
+      reader's line budget is a box height counted in them, so a `text-*` here
+      would cut the quote mid-letter. --%>
+      <div
+        data-clamp-body
+        class="markdown markdown--post notif-clamp text-slate-600 dark:text-slate-400 [&_a]:relative [&_a]:z-20"
+        {clamp_attrs(@quote_lines)}
+      >
+        {@html}
+      </div>
+    </div>
+    """
+  end
+
   # A reply written on another network (issue #1069). Plain text, clamped like
   # the other quotes and deliberately NOT run through the Markdown renderer: a
   # stranger's words must not be able to mint links, least of all @mention links
@@ -888,8 +1111,8 @@ defmodule VutuvWeb.NotificationLive.Index do
   #
   # And it is a link, on the same stretched-overlay arrangement as
   # <.quoted_post>: a readable block of somebody's words is what the reader
-  # reaches for, so a quote that does nothing on tap reads as a broken row,
-  # whichever network the words came from. It goes where the row's own sentence
+  # reaches for, so a quote that does nothing on tap reads as a broken line,
+  # whichever network the words came from. It goes where the line's own sentence
   # already goes (the reader's post, not the stranger's server, which the card
   # over there links to) and carries the note's anchor, so a post that collected
   # several replies opens on this one. No `[&_a]:relative` escape hatch is needed
@@ -902,9 +1125,9 @@ defmodule VutuvWeb.NotificationLive.Index do
 
   defp remote_reply(assigns) do
     ~H"""
-    <div class="mt-1.5 space-y-1">
+    <div class="space-y-1">
       <p
-        :if={@n[:note_audience] && @n.note_audience != "public"}
+        :if={remote_private?(@n)}
         data-remote-private
         class="mb-0 text-xs font-medium text-slate-600 dark:text-slate-400"
       >
@@ -938,10 +1161,12 @@ defmodule VutuvWeb.NotificationLive.Index do
     """
   end
 
-  # The row's left visual: the lead (newest) actor's avatar with a small
-  # kind badge riding its corner - or, for a picture-less lead actor and the
-  # actor-less kinds (moderation, image review), the colored kind glyph
-  # circle. Either way a present actor gets the online-presence dot via
+  defp remote_private?(n), do: is_binary(n[:note_audience]) and n.note_audience != "public"
+
+  # The row's left visual (the single rows): the lead (newest) actor's avatar
+  # with a small kind badge riding its corner - or, for a picture-less lead
+  # actor and the actor-less kinds (moderation, image review), the colored kind
+  # glyph circle. Either way a present actor gets the online-presence dot via
   # <.presence_wrap> (the dot sits bottom-right, the kind badge bottom-left).
   attr(:group, :map, required: true)
 
@@ -987,14 +1212,15 @@ defmodule VutuvWeb.NotificationLive.Index do
     """
   end
 
-  # The sentence's subject: up to two linked actor names, the rest folded
+  # The sentence's subject: up to `named` linked actor names, the rest folded
   # into "and N more" - which links to the recipient's own followers /
   # connections list where that is the natural place to see everyone.
   attr(:group, :map, required: true)
   attr(:current_user, :any, required: true)
+  attr(:named, :integer, default: nil, doc: "nil: the page's default from Groups")
 
   defp actor_links(assigns) do
-    named = Enum.take(assigns.group.actors, Groups.named_actors())
+    named = Enum.take(assigns.group.actors, assigns.named || Groups.named_actors())
     overflow = assigns.group.actor_count - length(named)
 
     assigns =
@@ -1018,42 +1244,34 @@ defmodule VutuvWeb.NotificationLive.Index do
     """
   end
 
+  # One actor's name, linked. Three shapes: a member or a page
+  # (`actor_path/1`, never `~p"/#{@actor.param}"` — a page's param is a slug
+  # under /organizations/:slug, and the root belongs to member handles, issue
+  # #1336); somebody on another network (issue #1069) — no vutuv profile behind
+  # the name, so a press opens the account card over it, the same card their
+  # handle opens on a post card (`remote_actor_link/3`), with the `@handle@host`
+  # beside the name saying which network answered and the `href` out there
+  # still what a middle click takes; and a bare name for a payload with neither.
+  #
+  # Deliberately ONE line of markup: the pieces sit inside a sentence, and any
+  # newline between them is whitespace the browser renders — which is how the
+  # old `cond` put a space before every comma ("Anna , Ben und 3 weitere").
   attr(:actor, :map, required: true)
 
   defp actor_link(assigns) do
+    assigns =
+      assigns
+      |> assign(:remote?, is_nil(assigns.actor.param) and is_binary(assigns.actor[:url]))
+      |> assign(:bare?, is_nil(assigns.actor.param) and not is_binary(assigns.actor[:url]))
+
     ~H"""
-    <%= cond do %>
-      <% @actor.param -> %>
-        <%!-- `actor_path/1`, never `~p"/#{@actor.param}"`: a page's param is a
-        slug under /organizations/:slug, and the root belongs to member handles
-        (issue #1336). This is the second link on the row and the one that is
-        easy to miss — `actor_target/1` below covers the row's own href. --%>
-        <.link
-          href={actor_path(@actor)}
-          class="font-semibold text-slate-900 hover:text-brand-700 dark:text-white dark:hover:text-brand-300"
-        >{@actor.name}</.link>
-      <% @actor[:url] -> %>
-        <%!-- Somebody on another network (issue #1069). There is no vutuv
-        profile behind the name, so a press opens the account card over it —
-        who they are, one Follow button, both mutes — the same card their
-        handle opens on a post card and inside a post body
-        (`remote_actor_link/3`). This row is where a member most often meets a
-        stranger for the first time, and until now it was the one place that
-        answered "who just boosted me" by handing them to a server they have no
-        account on. The `@handle@host` beside the name still says which network
-        answered, and the `href` out there is still what a middle click takes. --%>
-        <.link
-          {remote_actor_link(nil, @actor.url, @actor[:handle])}
-          class="font-semibold text-slate-900 hover:text-brand-700 dark:text-white dark:hover:text-brand-300"
-        >{@actor.name}</.link><span
-          :if={@actor[:handle] && @actor.handle != @actor.name}
-          class="text-xs font-normal text-slate-600 dark:text-slate-400"
-        > {@actor.handle}</span>
-      <% true -> %>
-        <span class="font-semibold">{@actor.name}</span>
-    <% end %>
+    <.link :if={@actor.param} href={actor_path(@actor)} class={actor_name_class()}>{@actor.name}</.link><.link :if={@remote?} {remote_actor_link(nil, @actor.url, @actor[:handle])} class={actor_name_class()}>{@actor.name}</.link><span :if={@remote? and @actor[:handle] && @actor.handle != @actor.name} class="text-xs font-normal text-slate-600 dark:text-slate-400"> {@actor.handle}</span><span :if={@bare?} class="font-semibold">{@actor.name}</span>
     """
   end
+
+  defp actor_name_class,
+    do:
+      "font-semibold text-slate-900 hover:text-brand-700 dark:text-white dark:hover:text-brand-300"
 
   # The welcome note is the one row that is NOT one big link: the handle points
   # at the member's own profile and the two URLs at the pages they name, so
@@ -1117,7 +1335,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   defp separator(_index, _named, _overflow), do: ", "
 
   # Where "and N more" leads: the recipient's own people lists for the
-  # people kinds; nowhere for a like group (there is no public likers list).
+  # people kinds; nowhere for a like line (there is no public likers list).
   defp overflow_href("follower", viewer), do: ~p"/#{viewer}/followers"
   defp overflow_href("connection", viewer), do: ~p"/#{viewer}/connections"
   defp overflow_href(_kind, _viewer), do: nil
@@ -1127,7 +1345,8 @@ defmodule VutuvWeb.NotificationLive.Index do
   defp filter_options do
     [
       {"all", gettext("All")},
-      {"posts", gettext("Posts")},
+      {"replies", gettext("Replies")},
+      {"reactions", gettext("Reactions")},
       {"people", gettext("People")},
       {"other", gettext("More")}
     ]
@@ -1136,15 +1355,23 @@ defmodule VutuvWeb.NotificationLive.Index do
   defp filter_path("all"), do: ~p"/notifications"
   defp filter_path(value), do: ~p"/notifications?filter=#{value}"
 
-  # The active tab reads as a raised white pill, the rest as quiet muted text
+  # The active chip reads as a raised white pill, the rest as quiet muted text
   # - the segmented-control treatment of the post-type filter tabs.
   defp filter_tab_class(true),
     do:
-      "whitespace-nowrap rounded-md bg-white px-3 py-1 font-semibold text-brand-700 shadow-sm dark:bg-slate-900 dark:text-brand-100"
+      "inline-flex min-h-9 items-center whitespace-nowrap rounded-md bg-white px-3 py-1 font-semibold text-brand-700 shadow-sm dark:bg-slate-900 dark:text-brand-100"
 
   defp filter_tab_class(false),
     do:
-      "whitespace-nowrap rounded-md px-3 py-1 font-medium text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
+      "inline-flex min-h-9 items-center whitespace-nowrap rounded-md px-3 py-1 font-medium text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
+
+  # A chip's badge: the count of what is new under it, nothing at zero.
+  defp unread_badge(counts, filter) do
+    case Map.get(counts, filter) do
+      count when is_integer(count) and count > 0 -> count
+      _ -> nil
+    end
+  end
 
   defp new_count_label(count) do
     ngettext("%{formatted} new notification", "%{formatted} new notifications", count,
@@ -1169,7 +1396,7 @@ defmodule VutuvWeb.NotificationLive.Index do
     end
   end
 
-  # The row's clock time: sections are the reader's calendar days, so the
+  # The line's clock time: sections are the reader's calendar days, so the
   # visible time is their own wall clock in their own region (like post
   # stamps); the <time> keeps an unambiguous ISO-8601 UTC datetime for
   # machines. Server-rendered final - deliberately no data-localtime rewrite.
@@ -1191,31 +1418,37 @@ defmodule VutuvWeb.NotificationLive.Index do
     """
   end
 
-  # ── The 30-day summary card ──
+  # ── The 30-day summary line ──
 
-  defp summary_rows(summary) do
-    [
-      {"follower", summary.followers},
-      {"connection", summary.connections},
-      {"like", summary.likes},
-      {"reply", summary.replies},
-      {"endorsement", summary.endorsements}
-    ]
-    |> Enum.filter(fn {_kind, count} -> count > 0 end)
+  # "Last 30 days: 163 likes · 68 replies · 47 followers …", zero parts
+  # dropped. Every part is its own complete translatable phrase — the line is a
+  # list of facts, not a sentence assembled from pieces.
+  defp summary_line(summary) do
+    parts =
+      [
+        likes_label(summary.likes),
+        replies_label(summary.replies),
+        count_label(
+          summary.followers,
+          &ngettext("%{formatted} follower", "%{formatted} followers", &1, &2)
+        ),
+        count_label(
+          summary.connections,
+          &ngettext("%{formatted} connection", "%{formatted} connections", &1, &2)
+        ),
+        endorsements_label(summary.endorsements)
+      ]
+      |> Enum.reject(&is_nil/1)
+
+    gettext("Last 30 days: %{parts}", parts: Enum.join(parts, " · "))
   end
-
-  defp summary_label("follower"), do: gettext("Followers")
-  defp summary_label("connection"), do: gettext("Connections")
-  defp summary_label("like"), do: gettext("Likes")
-  defp summary_label("reply"), do: gettext("Replies")
-  defp summary_label("endorsement"), do: gettext("Endorsements")
 
   # ── Kind styling (badge colour + glyph + accessible label) ──
 
   # Event kinds that share the brand badge colour, so the class string lives
   # in one place.
   @brand_kind_classes "bg-brand-50 text-brand-700 dark:bg-brand-900/40 dark:text-brand-100"
-  @brand_kinds ~w(follower reply thread mention connection report_protection organization_role handle_change cv_update fediverse_reply fediverse_reaction)
+  @brand_kinds ~w(follower reply thread mention connection report_protection organization_role handle_change cv_update fediverse_reply fediverse_reaction share)
 
   defp kind_classes("endorsement"),
     do: "bg-emerald-50 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-300"
@@ -1238,17 +1471,20 @@ defmodule VutuvWeb.NotificationLive.Index do
   defp kind_glyph("reply"), do: "↩"
   # A reply elsewhere in a thread the recipient writes in.
   defp kind_glyph("thread"), do: "⤷"
-  # Being named by @handle. Shares the glyph with the (rare, "More"-tab)
+  # Being named by @handle. Shares the glyph with the (rare, "More"-chip)
   # handle-change kind: both are about a handle, and the badge's title/sr-only
   # label tells them apart where the glyph alone would not.
   defp kind_glyph("mention"), do: "@"
   defp kind_glyph("like"), do: "♥"
+  # A re-share from another network (issue #1068): the arrows, since the line
+  # beside it names the verb and the globe already sits on the sharer's name.
+  defp kind_glyph("share"), do: "↻"
   # A reply written on another network (issue #1069) — the same globe the
   # post card's "from other networks" line uses, so one glyph means one thing.
   defp kind_glyph("fediverse_reply"), do: "🌐"
-  # A favourite or a re-share from out there (issue #1068) — same globe, since
-  # "this came from another network" is the one thing the glyph has to say; the
-  # sentence beside it names the verb.
+  # A reaction from out there of a kind that is neither a favourite nor a
+  # re-share — the globe, since "this came from another network" is the one
+  # thing the glyph has to say; the sentence beside it names the verb.
   defp kind_glyph("fediverse_reaction"), do: "🌐"
   # "connection" is the vernetzt (mutual-follow) event; the handshake glyph.
   defp kind_glyph("connection"), do: "🤝"
@@ -1275,6 +1511,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   defp kind_label("mention"), do: gettext("Mention")
   defp kind_label("like"), do: gettext("Like")
   defp kind_label("fediverse_reply"), do: gettext("Reply from another network")
+  defp kind_label("share"), do: gettext("Reaction from another network")
   defp kind_label("fediverse_reaction"), do: gettext("Reaction from another network")
   defp kind_label("connection"), do: gettext("Connection")
   defp kind_label("moderation"), do: gettext("Moderation")
@@ -1287,14 +1524,83 @@ defmodule VutuvWeb.NotificationLive.Index do
   defp kind_label("reference_check"), do: gettext("Employment reference review")
   defp kind_label(_), do: gettext("Activity")
 
-  # ── The sentence ──
+  # ── A card line's vocabulary ──
 
-  # The grouped sentence tail after the actor names. Only the forms that differ
-  # from the single-actor one are spelled here - German conjugates the
-  # follower/connection verbs across the count where English does not, hence
-  # the count-branched msgids. Everything else falls through to
-  # VutuvWeb.NotificationText, which the browser notification shares, so one
-  # event cannot read differently in the two places (issue #1249).
+  # The verbs whose kind string is the verb's own name.
+  @named_verbs [:reply, :thread, :mention, :follower, :connection, :endorsement]
+
+  # The two verbs that quote a member's post: a folded line carries its
+  # teaser, an unfolded one the formatted quote. A mention is deliberately not
+  # one of them — the card's head already IS the naming post — and a remote
+  # reply quotes a note rather than a post.
+  @local_reply_verbs [:reply, :thread]
+
+  # The one kind string a card line wears — for its glyph, colour and label
+  # AND for its `data-event-kind`, so what the line looks like and what a test
+  # or a stylesheet keys on can never say two different things. The verb
+  # decides, not the newest item's kind: a merged like line may have a
+  # favourite from another network as its newest member and is still "like".
+  defp line_kind(%{verb: :like}), do: "like"
+  defp line_kind(%{verb: :share}), do: "share"
+  defp line_kind(%{verb: :reaction}), do: "fediverse_reaction"
+  defp line_kind(%{verb: :remote_reply}), do: "fediverse_reply"
+  defp line_kind(%{verb: verb}) when verb in @named_verbs, do: Atom.to_string(verb)
+  defp line_kind(%{kind: kind}), do: kind
+
+  defp local_reply?(%{verb: verb}), do: verb in @local_reply_verbs
+
+  # A like or re-share line names three before folding; the people lines and
+  # the single rows keep the page's default of two.
+  defp named_actors(%{verb: verb}) when verb in [:like, :share, :reaction], do: 3
+  defp named_actors(_line), do: Groups.named_actors()
+
+  # The sentence after the actor names. The card's head already named the post,
+  # so a line says only what was done. German conjugates the verb across the
+  # count where English conjugates it the other way round ("likes this" is the
+  # singular), so those are count-branched msgids rather than one string with a
+  # number in it.
+  defp line_text(%{verb: :like, actor_count: count}),
+    do: ngettext("likes this.", "like this.", count)
+
+  defp line_text(%{verb: :share, actor_count: count}),
+    do: ngettext("shared this.", "shared this.", count)
+
+  defp line_text(%{verb: :reaction, actor_count: count}),
+    do: ngettext("reacted to this.", "reacted to this.", count)
+
+  defp line_text(%{verb: verb}) when verb in [:reply, :remote_reply], do: gettext("replied.")
+  defp line_text(%{verb: :thread}), do: gettext("replied in the thread.")
+  defp line_text(%{verb: :mention}), do: gettext("mentioned you.")
+  defp line_text(line), do: group_text(line)
+
+  # The reply's words on the folded line: the local reply's teaser, or the
+  # remote note's text folded to one line. Nothing for a like, a share or a
+  # reply the reader may not see.
+  defp line_teaser(%{verb: verb, item: item}) when verb in @local_reply_verbs,
+    do: item[:reply_teaser]
+
+  defp line_teaser(%{verb: :remote_reply, item: item}), do: item[:note_teaser]
+  defp line_teaser(_line), do: nil
+
+  # Where a line's Reply link leads: the reply itself, so the answer is written
+  # under the words it answers; a remote reply to the conversation anchored at
+  # that note; anything else to what the notification itself opens.
+  defp reply_target(%{verb: verb, item: %{reply_preview: %{post: post}}}, _viewer)
+       when verb in @local_reply_verbs,
+       do: Posts.path(post)
+
+  defp reply_target(%{verb: :remote_reply, item: item}, viewer),
+    do: remote_reply_target(item, viewer)
+
+  defp reply_target(%{item: item}, viewer), do: notification_target(item, viewer)
+
+  # The grouped sentence tail after the actor names, for the people lines and
+  # the single rows. Only the forms that differ from the single-actor one are
+  # spelled here - German conjugates the follower/connection verbs across the
+  # count where English does not, hence the count-branched msgids. Everything
+  # else falls through to VutuvWeb.NotificationLine, which the browser
+  # notification shares, so one event cannot read differently in the two places
+  # (issue #1249).
   defp group_text(%{kind: "follower", actor_count: count}) when count > 1,
     do: gettext("are now following you.")
 
@@ -1307,56 +1613,64 @@ defmodule VutuvWeb.NotificationLive.Index do
   defp group_text(%{kind: "endorsement", tags: [_ | _] = tags}),
     do: gettext("endorsed you for %{tags}.", tags: join_names(tags))
 
-  defp group_text(%{kind: "thread", actor_count: count}), do: thread_text(count)
-
-  defp group_text(%{kind: "fediverse_reaction", actor_count: count, item: item}),
-    do: fediverse_reaction_text(item[:reaction_kind], count)
-
   defp group_text(%{item: item}), do: notification_text(item)
 
-  # ── A post card's lines ──
+  # ── The card heads ──
 
-  # The sentence on one line inside a post card. It says only what was done:
-  # the card's head already named the post, so the row's "your post in another
-  # network" would be repeating the heading in every line under it.
-  defp card_event_text(%{kind: "fediverse_reply"}), do: gettext("replied.")
+  # Whose post a card is about. The reader's own for a like, a reply, a thread
+  # they rooted; somebody else's for a mention or a thread they wrote in — the
+  # thread wording says why a stranger's post is on the reader's page at all.
+  # Nothing when the post itself is out of reach: the head says so in words.
+  defp card_eyebrow(nil, _group, _viewer), do: nil
 
-  defp card_event_text(%{kind: "fediverse_reaction", actor_count: count, item: item}),
-    do: card_reaction_text(item[:reaction_kind], count)
+  defp card_eyebrow(%{post: post}, group, viewer) do
+    cond do
+      Posts.self_vote?(post, viewer) ->
+        gettext("Your post")
 
-  # German conjugates the verb across the count where English conjugates it the
-  # other way round ("likes this" is the singular), so both are count-branched
-  # msgids rather than one string with a number in it.
-  defp card_reaction_text("like", count),
-    do: ngettext("likes this.", "like this.", count)
+      Enum.any?(group.events, &(&1.verb == :thread)) ->
+        gettext("Thread by %{name}", name: PostTeaser.author_of(post).name)
 
-  defp card_reaction_text("announce", count),
-    do: ngettext("shared this.", "shared this.", count)
+      true ->
+        gettext("Post by %{name}", name: PostTeaser.author_of(post).name)
+    end
+  end
 
-  defp card_reaction_text(_kind, count),
-    do: ngettext("reacted to this.", "reacted to this.", count)
+  # What the card's head counts: likes and re-shares by distinct actor, and
+  # every line that carries words — a reply, a thread answer, a mention, one
+  # from another network. Each fragment is its own complete translatable
+  # phrase — the line is a list of facts, not a sentence assembled from pieces.
+  defp card_counts(events) do
+    likes = actor_sum(events, :like)
+    shares = actor_sum(events, :share)
+    replies = Enum.count(events, &Groups.reply_verb?/1)
 
-  # Where a card line leads: a reply to the reader's own post anchored at that
-  # reply, a favourite or re-share to the post itself.
-  defp card_event_target(%{kind: "fediverse_reply", item: item}, viewer),
-    do: remote_reply_target(item, viewer)
+    [likes_label(likes), shares_label(shares), replies_label(replies)]
+    |> Enum.reject(&is_nil/1)
+  end
 
-  defp card_event_target(%{item: item}, viewer), do: notification_target(item, viewer)
+  defp actor_sum(events, verb) do
+    events
+    |> Enum.filter(&(&1.verb == verb))
+    |> Enum.map(& &1.actor_count)
+    |> Enum.sum()
+  end
 
-  # What the card's head counts: the reactions folded into its lines, one
-  # fragment per verb. Each fragment is its own complete translatable phrase —
-  # the line is a list of facts, not a sentence assembled from pieces.
-  defp event_counts(events) do
-    likes = reaction_count(events, "like")
-    shares = reaction_count(events, "announce")
-    replies = Enum.count(events, &(&1.kind == "fediverse_reply"))
-
+  # The people card's title: the day's tally, each part its own phrase.
+  defp people_title(%{events: events}) do
     [
-      count_label(likes, &ngettext("%{formatted} like", "%{formatted} likes", &1, &2)),
-      count_label(shares, &ngettext("%{formatted} share", "%{formatted} shares", &1, &2)),
-      count_label(replies, &ngettext("%{formatted} reply", "%{formatted} replies", &1, &2))
+      count_label(
+        actor_sum(events, :connection),
+        &ngettext("%{formatted} new connection", "%{formatted} new connections", &1, &2)
+      ),
+      count_label(
+        actor_sum(events, :follower),
+        &ngettext("%{formatted} new follower", "%{formatted} new followers", &1, &2)
+      ),
+      endorsements_label(Enum.count(events, &(&1.verb == :endorsement)))
     ]
     |> Enum.reject(&is_nil/1)
+    |> Enum.join(" · ")
   end
 
   # `ngettext/3` binds `%{count}` to the raw integer and a `count:` binding does
@@ -1364,14 +1678,19 @@ defmodule VutuvWeb.NotificationLive.Index do
   defp count_label(0, _phrase), do: nil
   defp count_label(count, phrase), do: phrase.(count, formatted: compact_count(count))
 
-  defp reaction_count(events, reaction_kind) do
-    events
-    |> Enum.filter(
-      &(&1.kind == "fediverse_reaction" and &1.item[:reaction_kind] == reaction_kind)
-    )
-    |> Enum.map(& &1.actor_count)
-    |> Enum.sum()
-  end
+  # One phrase per noun, shared by the card head's counts, the people tally
+  # and the 30-day line, so the same fact is never worded twice.
+  defp likes_label(n),
+    do: count_label(n, &ngettext("%{formatted} like", "%{formatted} likes", &1, &2))
+
+  defp shares_label(n),
+    do: count_label(n, &ngettext("%{formatted} share", "%{formatted} shares", &1, &2))
+
+  defp replies_label(n),
+    do: count_label(n, &ngettext("%{formatted} reply", "%{formatted} replies", &1, &2))
+
+  defp endorsements_label(n),
+    do: count_label(n, &ngettext("%{formatted} endorsement", "%{formatted} endorsements", &1, &2))
 
   # "Elixir, Phoenix and Rails" - all but the last joined by commas, the last
   # by the localized joining word.
@@ -1382,10 +1701,10 @@ defmodule VutuvWeb.NotificationLive.Index do
     Enum.join(front, ", ") <> " " <> gettext("and") <> " " <> last
   end
 
-  # Where the quoted remote reply itself goes: the same conversation the row's
+  # Where the quoted remote reply itself goes: the same conversation the line's
   # sentence opens, plus the anchor of this note (`Fediverse.reply_anchor/1`),
   # so a post that collected several replies lands on the one being quoted
-  # rather than at the top. The anchor is dropped when the row somehow carries
+  # rather than at the top. The anchor is dropped when the line somehow carries
   # no note id, which leaves the plain conversation link rather than a dead "#".
   defp remote_reply_target(n, viewer) do
     target = notification_target(n, viewer)
@@ -1409,20 +1728,23 @@ defmodule VutuvWeb.NotificationLive.Index do
 
   # ── Post previews ──
 
-  # Reply and like notifications carry post ids the row can quote: a like the
-  # liked post (`:post_id`), a reply both the recipient's own post that was
-  # replied to (`:post_id`) and the reply itself (`:reply_post_id`). Look every
-  # referenced post up in one batched, visibility-scoped query and attach a
-  # preview map (`%{post:, html:}` or `%{post:, text:}`, see `render_excerpt/3`)
-  # as `:post_preview` / `:reply_preview`. Other kinds carry no ids, a post with
-  # no text (a photo-only one) yields no preview, and a reply hidden from the
-  # viewer is absent from `posts`, so all pass through unchanged.
+  # Reply and thread notifications carry the reply's post id (`:reply_post_id`);
+  # every post-bound kind carries the post the card is about (`:post_id`, or a
+  # thread's `:root_post_id`); a handle change lists rewritten posts. Look every
+  # referenced post up in one batched, visibility-scoped query and attach what
+  # the folded lines show: the reply's one-line teaser (`:reply_teaser`) and a
+  # remote note's text teased the same way (`:note_teaser`). The formatted
+  # quote waits for the unfold (`with_reply_preview/3`). A post the viewer may
+  # not see is absent from `posts`, so such an entry passes through unchanged
+  # and its line shows the sentence alone.
   # Returns `{entries, posts}` — the looked-up posts come back out so the post
   # cards can be built from the same batch instead of asking for them again.
   defp with_post_previews(entries, viewer) do
     posts =
       entries
-      |> Enum.flat_map(&[&1[:post_id], &1[:reply_post_id] | List.wrap(&1[:post_ids])])
+      |> Enum.flat_map(
+        &[&1[:post_id], &1[:reply_post_id], &1[:root_post_id] | List.wrap(&1[:post_ids])]
+      )
       |> then(&Posts.visible_posts_by_ids(viewer, &1))
 
     lines = User.notification_post_lines(viewer)
@@ -1430,13 +1752,30 @@ defmodule VutuvWeb.NotificationLive.Index do
     entries =
       Enum.map(entries, fn entry ->
         entry
-        |> put_preview(:post_preview, entry[:post_id], posts, lines, quoted_form(entry))
-        |> put_preview(:reply_preview, entry[:reply_post_id], posts, lines, :html)
+        |> put_teaser(posts)
         |> put_change_previews(posts, lines)
       end)
 
     {entries, posts}
   end
+
+  # The formatted quote a line shows once unfolded (`toggle_line`), rendered
+  # then and not before: one full Markdown pass, for the one reply somebody
+  # opened. A line that already carries its quote keeps it.
+  defp with_reply_preview(%{reply_preview: %{}} = item, _viewer, _lines), do: item
+
+  defp with_reply_preview(%{reply_post_id: id} = item, viewer, lines) when is_binary(id),
+    do:
+      put_preview(
+        item,
+        :reply_preview,
+        id,
+        Posts.visible_posts_by_ids(viewer, [id]),
+        lines,
+        :html
+      )
+
+  defp with_reply_preview(item, _viewer, _lines), do: item
 
   # ── The head of a post card ──
 
@@ -1450,7 +1789,8 @@ defmodule VutuvWeb.NotificationLive.Index do
   @card_teaser_lines 2
 
   # The card heads for one page, as `%{post_id => card}`: the post itself, its
-  # one-line teaser and its released photos.
+  # two-line teaser, its released photos and — for a link post with no photos
+  # — its ready link screenshot.
   #
   # One entry per *post*, not per event — a post that collected a favourite, a
   # re-share and a reply is one card, and hanging that card off each raw item
@@ -1472,13 +1812,19 @@ defmodule VutuvWeb.NotificationLive.Index do
     # already visibility-scoped, so a hidden or deleted post costs nothing here.
     ids =
       for entry <- entries,
-          entry[:kind] in @post_card_kinds,
-          is_map_key(posts, entry[:post_id]),
-          not is_map_key(known, entry[:post_id]),
+          id = Groups.post_id_of(entry),
+          is_map_key(posts, id),
+          not is_map_key(known, id),
           uniq: true,
-          do: entry[:post_id]
+          do: id
 
     images = Posts.released_images_by_ids(ids)
+
+    # Only a post with no photos shows its link screenshot, so only those ask.
+    screenshots =
+      ids
+      |> Enum.filter(&(Map.get(images, &1, []) == []))
+      |> Screenshots.ready_by_post_ids()
 
     for id <- ids, into: %{} do
       post = Map.fetch!(posts, id)
@@ -1489,24 +1835,11 @@ defmodule VutuvWeb.NotificationLive.Index do
          post: post,
          text: PostTeaser.plain_line(post, length: char_budget(@card_teaser_lines)),
          images: Enum.take(photos, @card_images),
-         more_images: max(length(photos) - @card_images, 0)
+         more_images: max(length(photos) - @card_images, 0),
+         screenshot: if(photos == [], do: Map.get(screenshots, id))
        }}
     end
   end
-
-  # A reply row shows the recipient's own post only as the one-line breadcrumb
-  # above the reply it quotes in full, so that one is flattened to text. Every
-  # other quoted post is rendered formatted. Deciding here (rather than building
-  # both forms) keeps a page of 50 rows off the Markdown renderer's DB lookups
-  # for bodies nothing will show formatted.
-  defp quoted_form(%{kind: "reply"}), do: :text
-
-  # A post card renders the post's *head*, never a formatted quote of it, so
-  # rendering one would be a full Markdown pass (Earmark + sanitizer +
-  # highlighter, ~0.2 ms) per event, thrown away — and it is per event, so 50
-  # reactions to one post paid for it 50 times on the blocking first paint.
-  defp quoted_form(%{kind: kind}) when kind in @post_card_kinds, do: :none
-  defp quoted_form(_entry), do: :html
 
   # A handle-change entry links the recipient's own posts that were rewritten:
   # the newest few as excerpt lines, with `handle_change_more/1` counting the
@@ -1551,13 +1884,40 @@ defmodule VutuvWeb.NotificationLive.Index do
     end
   end
 
+  # The folded line's words, through the app's one teaser rule for both: a
+  # member's reply as the post it is, a remote note as the `%Note{}` its text
+  # came from (`Vutuv.RemoteHtml.to_text/3` reduced it to plain text at the
+  # inbox, and `PostTeaser` knows not to run that through Markdown).
+  defp put_teaser(%{kind: kind, reply_post_id: id} = entry, posts)
+       when kind in ~w(reply thread) and is_binary(id) do
+    case Map.get(posts, id) do
+      %Post{} = post ->
+        Map.put(entry, :reply_teaser, blank_to_nil(PostTeaser.plain_line(post)))
+
+      _ ->
+        entry
+    end
+  end
+
+  defp put_teaser(%{kind: "fediverse_reply", note_text: text} = entry, _posts)
+       when is_binary(text),
+       do:
+         Map.put(
+           entry,
+           :note_teaser,
+           blank_to_nil(PostTeaser.plain_line(%Note{content_text: text}))
+         )
+
+  defp put_teaser(entry, _posts), do: entry
+
+  defp blank_to_nil(""), do: nil
+  defp blank_to_nil(text), do: text
+
   # The one-line form is the app's shared post teaser, so this page skips a
   # quote post's `RE: <url>` opener and an image-only first line exactly as the
   # feed's ticker and the RSS description do; the reader's line budget only
   # decides how many characters may ride the row. The formatted multi-line
-  # quote below it is this page's own, and stays here.
-  defp quoted_excerpt(_post, _lines, :none), do: nil
-
+  # quote is this page's own, and stays here.
   defp quoted_excerpt(post, lines, :text) do
     case PostTeaser.plain_line(post, length: char_budget(lines)) do
       "" -> nil
@@ -1579,7 +1939,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   # picture would quote an empty box.
   @inline_image ~r/!\[[^\]]*\]\([^)]*\)/
 
-  # The excerpt shown under a reply/like notification: the post's first `lines`
+  # The excerpt an unfolded reply line shows: the post's first `lines`
   # non-empty lines (the reader's `:notification_post_lines` preference), cut
   # server-side (not only by the CSS clamp) so the rest of a quoted body never
   # reaches the DOM. Returns nil for a body with no text left to show.
@@ -1613,9 +1973,7 @@ defmodule VutuvWeb.NotificationLive.Index do
 
   # The formatted rendering /feed gives a post, block-cut at the character
   # budget so one essay-long line still ships a small DOM. Images are
-  # deliberately not passed: a quote is text. The compact one-line contexts (the
-  # "Your post:" breadcrumb above a reply, the handle-change list) do not come
-  # through here at all — see `quoted_excerpt/3`.
+  # deliberately not passed: a quote is text.
   defp render_excerpt(source, lines) do
     {html, _truncated?} = Markdown.render_preview(source, [], limit: char_budget(lines))
     %{html: html}

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -15,8 +15,8 @@ msgstr "Language: de\n"
 msgid "About us"
 msgstr "Impressum"
 
-#: lib/vutuv_web/components/ui.ex:4586
-#: lib/vutuv_web/components/ui.ex:4591
+#: lib/vutuv_web/components/ui.ex:4598
+#: lib/vutuv_web/components/ui.ex:4603
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
 #: lib/vutuv_web/live/organization_live/domains.ex:267
@@ -62,7 +62,7 @@ msgstr "Eine Adresse wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/text.ex:71
-#: lib/vutuv_web/components/ui.ex:4904
+#: lib/vutuv_web/components/ui.ex:4916
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -75,14 +75,14 @@ msgstr "Eine Adresse wurde geändert."
 msgid "Addresses"
 msgstr "Adressen"
 
-#: lib/vutuv_web/components/ui.ex:1594
+#: lib/vutuv_web/components/ui.ex:1606
 #: lib/vutuv_web/templates/page/index.html.heex:325
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr "Schon ein Mitglied? Einloggen."
 
-#: lib/vutuv_web/components/ui.ex:4377
-#: lib/vutuv_web/components/ui.ex:4476
+#: lib/vutuv_web/components/ui.ex:4389
+#: lib/vutuv_web/components/ui.ex:4488
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -110,7 +110,7 @@ msgid "Birthday"
 msgstr "Geburtstag"
 
 #: lib/vutuv_web/components/saved_search_components.ex:104
-#: lib/vutuv_web/components/ui.ex:4371
+#: lib/vutuv_web/components/ui.ex:4383
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
 #: lib/vutuv_web/live/admin/user_delete_live.ex:202
@@ -163,7 +163,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
 #: lib/vutuv_web/components/post_components.ex:3635
-#: lib/vutuv_web/components/ui.ex:4478
+#: lib/vutuv_web/components/ui.ex:4490
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:657
@@ -211,7 +211,7 @@ msgid "Download"
 msgstr "Download"
 
 #: lib/vutuv_web/components/post_components.ex:3600
-#: lib/vutuv_web/components/ui.ex:4469
+#: lib/vutuv_web/components/ui.ex:4481
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
@@ -285,7 +285,7 @@ msgstr "E-Mail-Adresse eingeben"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:4868
+#: lib/vutuv_web/components/ui.ex:4880
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -315,7 +315,6 @@ msgstr "Vorname"
 #: lib/vutuv_web/agent_docs/text.ex:595
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
-#: lib/vutuv_web/live/notification_live/index.ex:1207
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:27
@@ -326,8 +325,8 @@ msgstr "Follower"
 #: lib/vutuv_web/agent_docs/markdown.ex:632
 #: lib/vutuv_web/agent_docs/text.ex:596
 #: lib/vutuv_web/components/fediverse_components.ex:468
-#: lib/vutuv_web/components/ui.ex:2871
-#: lib/vutuv_web/components/ui.ex:2906
+#: lib/vutuv_web/components/ui.ex:2883
+#: lib/vutuv_web/components/ui.ex:2918
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:608
@@ -454,7 +453,7 @@ msgstr "Einloggen"
 msgid "Middle Name"
 msgstr "Zweiter Vorname"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1132
+#: lib/vutuv_web/live/notification_live/index.ex:1344
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:193
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:201
 #, elixir-autogen
@@ -474,7 +473,7 @@ msgid "Name"
 msgstr "Name"
 
 #: lib/vutuv_web/components/post_components.ex:723
-#: lib/vutuv_web/live/notification_live/index.ex:743
+#: lib/vutuv_web/live/notification_live/index.ex:774
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
@@ -613,7 +612,7 @@ msgstr "Provider"
 msgid "Public"
 msgstr "Öffentlich"
 
-#: lib/vutuv_web/components/ui.ex:4370
+#: lib/vutuv_web/components/ui.ex:4382
 #: lib/vutuv_web/live/organization_live/edit.ex:367
 #: lib/vutuv_web/live/post_live/composer.ex:1937
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -790,13 +789,13 @@ msgstr "Profil aktualisiert."
 msgid "User verified successfully."
 msgstr "User wurde verifiziert."
 
-#: lib/vutuv_web/components/ui.ex:4864
+#: lib/vutuv_web/components/ui.ex:4876
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:832
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
 #: lib/vutuv_web/live/directory_search_live.ex:134
-#: lib/vutuv_web/live/notification_live/index.ex:1286
+#: lib/vutuv_web/live/notification_live/index.ex:1522
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:51
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -842,7 +841,7 @@ msgstr "Benutzername"
 msgid "Users"
 msgstr "Benutzer"
 
-#: lib/vutuv_web/components/ui.ex:1401
+#: lib/vutuv_web/components/ui.ex:1413
 #: lib/vutuv_web/views/user_html.ex:562
 #: lib/vutuv_web/views/user_html.ex:563
 #: lib/vutuv_web/views/user_html.ex:577
@@ -850,7 +849,7 @@ msgstr "Benutzer"
 msgid "vCard"
 msgstr "vCard"
 
-#: lib/vutuv_web/components/ui.ex:4539
+#: lib/vutuv_web/components/ui.ex:4551
 #: lib/vutuv_web/templates/user/show.html.heex:981
 #: lib/vutuv_web/templates/user/show.html.heex:1004
 #, elixir-autogen
@@ -1400,7 +1399,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:522
 #: lib/vutuv_web/agent_docs/text.ex:768
-#: lib/vutuv_web/components/ui.ex:4889
+#: lib/vutuv_web/components/ui.ex:4901
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1646,7 +1645,7 @@ msgstr "Zur Startseite"
 msgid "Check your inbox"
 msgstr "Schauen Sie in Ihr Postfach"
 
-#: lib/vutuv_web/components/ui.ex:3030
+#: lib/vutuv_web/components/ui.ex:3042
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:477
 #: lib/vutuv_web/live/admin/organization_live.ex:296
@@ -1703,20 +1702,20 @@ msgstr "Mein Konto löschen"
 msgid "Edit profile"
 msgstr "Profil bearbeiten"
 
-#: lib/vutuv_web/components/ui.ex:2113
-#: lib/vutuv_web/components/ui.ex:2122
-#: lib/vutuv_web/components/ui.ex:2600
+#: lib/vutuv_web/components/ui.ex:2125
+#: lib/vutuv_web/components/ui.ex:2134
+#: lib/vutuv_web/components/ui.ex:2612
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr "Empfehlen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:244
-#: lib/vutuv_web/components/ui.ex:2836
-#: lib/vutuv_web/components/ui.ex:2836
-#: lib/vutuv_web/components/ui.ex:2853
-#: lib/vutuv_web/components/ui.ex:2862
-#: lib/vutuv_web/components/ui.ex:2878
-#: lib/vutuv_web/components/ui.ex:2940
+#: lib/vutuv_web/components/ui.ex:2848
+#: lib/vutuv_web/components/ui.ex:2848
+#: lib/vutuv_web/components/ui.ex:2865
+#: lib/vutuv_web/components/ui.ex:2874
+#: lib/vutuv_web/components/ui.ex:2890
+#: lib/vutuv_web/components/ui.ex:2952
 #: lib/vutuv_web/live/fediverse_account_live.ex:400
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:312
@@ -1757,7 +1756,7 @@ msgstr "Ausloggen"
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
 #: lib/vutuv_web/live/admin/user_delete_live.ex:143
 #: lib/vutuv_web/live/admin/user_live.ex:154
-#: lib/vutuv_web/live/message_live/index.ex:538
+#: lib/vutuv_web/live/message_live/index.ex:548
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:32
 #: lib/vutuv_web/templates/admin/account/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:28
@@ -1776,7 +1775,7 @@ msgstr "Nachricht"
 
 #: lib/vutuv_web/controllers/page_controller.ex:228
 #: lib/vutuv_web/live/message_live/index.ex:49
-#: lib/vutuv_web/live/message_live/index.ex:624
+#: lib/vutuv_web/live/message_live/index.ex:634
 #: lib/vutuv_web/live/shell_live.ex:1249
 #: lib/vutuv_web/live/shell_live.ex:1427
 #: lib/vutuv_web/templates/layout/app.html.heex:152
@@ -1791,7 +1790,7 @@ msgid "Network"
 msgstr "Netzwerk"
 
 #: lib/vutuv_web/components/post_components.ex:459
-#: lib/vutuv_web/components/ui.ex:4588
+#: lib/vutuv_web/components/ui.ex:4600
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
@@ -1801,16 +1800,16 @@ msgstr "Netzwerk"
 msgid "Nothing here yet."
 msgstr "Hier gibt es noch nichts."
 
-#: lib/vutuv_web/live/notification_live/index.ex:437
+#: lib/vutuv_web/live/notification_live/index.ex:528
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr "Noch nichts Neues."
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:4926
+#: lib/vutuv_web/components/ui.ex:4938
 #: lib/vutuv_web/controllers/page_controller.ex:229
-#: lib/vutuv_web/live/notification_live/index.ex:147
-#: lib/vutuv_web/live/notification_live/index.ex:385
+#: lib/vutuv_web/live/notification_live/index.ex:156
+#: lib/vutuv_web/live/notification_live/index.ex:450
 #: lib/vutuv_web/live/shell_live.ex:1261
 #: lib/vutuv_web/templates/layout/app.html.heex:153
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
@@ -1833,7 +1832,7 @@ msgid "Pardon us! Something went wrong."
 msgstr "Entschuldigung! Etwas ist schiefgelaufen."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:902
+#: lib/vutuv_web/live/message_live/index.ex:912
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
@@ -1913,8 +1912,8 @@ msgstr ""
 msgid "Who to follow"
 msgstr "Vorgeschlagene Profile"
 
-#: lib/vutuv_web/live/message_live/index.ex:891
-#: lib/vutuv_web/live/message_live/index.ex:892
+#: lib/vutuv_web/live/message_live/index.ex:901
+#: lib/vutuv_web/live/message_live/index.ex:902
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr "Nachricht schreiben…"
@@ -1959,14 +1958,14 @@ msgstr "ist jetzt mit Ihnen vernetzt."
 msgid "started following you."
 msgstr "folgt Ihnen jetzt."
 
-#: lib/vutuv_web/components/ui.ex:3871
-#: lib/vutuv_web/components/ui.ex:4016
+#: lib/vutuv_web/components/ui.ex:3883
+#: lib/vutuv_web/components/ui.ex:4028
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr "Seitennavigation"
 
-#: lib/vutuv_web/components/ui.ex:4613
+#: lib/vutuv_web/components/ui.ex:4625
 #: lib/vutuv_web/live/organization_live/activity.ex:151
 #: lib/vutuv_web/live/organization_live/feed.ex:209
 #: lib/vutuv_web/live/organization_live/show.ex:777
@@ -1981,13 +1980,13 @@ msgstr ""
 "Die Adresse selbst kann nicht geändert werden. Um eine andere zu verwenden, "
 "legen Sie sie als neue E-Mail-Adresse an und löschen Sie diese hier."
 
-#: lib/vutuv_web/components/ui.ex:4380
+#: lib/vutuv_web/components/ui.ex:4392
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Eintrag löschen"
 
-#: lib/vutuv_web/components/ui.ex:1794
-#: lib/vutuv_web/components/ui.ex:1804
+#: lib/vutuv_web/components/ui.ex:1806
+#: lib/vutuv_web/components/ui.ex:1816
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr "Optionen"
@@ -2026,12 +2025,12 @@ msgstr "Titelbild hinzufügen"
 msgid "Add cover photo"
 msgstr "Titelbild hinzufügen"
 
-#: lib/vutuv_web/components/ui.ex:3384
+#: lib/vutuv_web/components/ui.ex:3396
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr "April"
 
-#: lib/vutuv_web/components/ui.ex:3388
+#: lib/vutuv_web/components/ui.ex:3400
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr "August"
@@ -2056,37 +2055,37 @@ msgstr "Titelbild"
 msgid "Cover photo of %{name}"
 msgstr "Titelbild von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:3392
+#: lib/vutuv_web/components/ui.ex:3404
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr "Dezember"
 
-#: lib/vutuv_web/components/ui.ex:3382
+#: lib/vutuv_web/components/ui.ex:3394
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr "Februar"
 
-#: lib/vutuv_web/components/ui.ex:3381
+#: lib/vutuv_web/components/ui.ex:3393
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr "Januar"
 
-#: lib/vutuv_web/components/ui.ex:3387
+#: lib/vutuv_web/components/ui.ex:3399
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr "Juli"
 
-#: lib/vutuv_web/components/ui.ex:3386
+#: lib/vutuv_web/components/ui.ex:3398
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr "Juni"
 
-#: lib/vutuv_web/components/ui.ex:3383
+#: lib/vutuv_web/components/ui.ex:3395
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr "März"
 
-#: lib/vutuv_web/components/ui.ex:3385
+#: lib/vutuv_web/components/ui.ex:3397
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr "Mai"
@@ -2101,17 +2100,17 @@ msgstr "Mitglied seit %{month} %{year}"
 msgid "Member since %{year}"
 msgstr "Mitglied seit %{year}"
 
-#: lib/vutuv_web/components/ui.ex:3391
+#: lib/vutuv_web/components/ui.ex:3403
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr "November"
 
-#: lib/vutuv_web/components/ui.ex:3390
+#: lib/vutuv_web/components/ui.ex:3402
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr "Oktober"
 
-#: lib/vutuv_web/components/ui.ex:3389
+#: lib/vutuv_web/components/ui.ex:3401
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr "September"
@@ -2211,7 +2210,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3216
+#: lib/vutuv_web/live/post_live/feed.ex:3239
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2252,7 +2251,6 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/gettext_extraction_anchors.ex:109
 #: lib/vutuv_web/live/admin/dashboard_live.ex:172
 #: lib/vutuv_web/live/fediverse_account_live.ex:407
-#: lib/vutuv_web/live/notification_live/index.ex:1130
 #: lib/vutuv_web/live/organization_live/show.ex:700
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:348
@@ -2388,7 +2386,7 @@ msgstr "Personen, die Ihnen nicht folgen"
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
 
-#: lib/vutuv_web/components/ui.ex:3462
+#: lib/vutuv_web/components/ui.ex:3474
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
@@ -2426,7 +2424,7 @@ msgstr "Alle Beiträge"
 
 #: lib/vutuv_web/components/post_components.ex:2028
 #: lib/vutuv_web/components/post_components.ex:5593
-#: lib/vutuv_web/components/ui.ex:3938
+#: lib/vutuv_web/components/ui.ex:3950
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2445,8 +2443,8 @@ msgstr "Lesezeichen"
 
 #: lib/vutuv_web/components/post_components.ex:1981
 #: lib/vutuv_web/components/post_components.ex:5831
-#: lib/vutuv_web/components/ui.ex:3924
-#: lib/vutuv_web/live/notification_live/index.ex:1276
+#: lib/vutuv_web/components/ui.ex:3936
+#: lib/vutuv_web/live/notification_live/index.ex:1511
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2454,7 +2452,6 @@ msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1144
 #: lib/vutuv_web/components/post_components.ex:5841
-#: lib/vutuv_web/live/notification_live/index.ex:1209
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
 #: lib/vutuv_web/live/shell_live.ex:1312
@@ -2517,9 +2514,9 @@ msgstr "Gefällt mir entfernen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:498
 #: lib/vutuv_web/components/post_components.ex:2663
-#: lib/vutuv_web/components/ui.ex:2831
-#: lib/vutuv_web/components/ui.ex:2831
-#: lib/vutuv_web/components/ui.ex:2907
+#: lib/vutuv_web/components/ui.ex:2843
+#: lib/vutuv_web/components/ui.ex:2843
+#: lib/vutuv_web/components/ui.ex:2919
 #: lib/vutuv_web/live/organization_live/following.ex:384
 #: lib/vutuv_web/live/organization_live/following.ex:468
 #: lib/vutuv_web/live/organization_live/show.ex:611
@@ -2542,7 +2539,7 @@ msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
 #: lib/vutuv_web/components/post_components.ex:417
-#: lib/vutuv_web/live/notification_live/index.ex:1210
+#: lib/vutuv_web/live/notification_live/index.ex:1341
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
@@ -2550,7 +2547,8 @@ msgstr "Antworten"
 #: lib/vutuv_web/components/post_components.ex:1994
 #: lib/vutuv_web/components/post_components.ex:5868
 #: lib/vutuv_web/components/post_components.ex:5869
-#: lib/vutuv_web/live/notification_live/index.ex:1273
+#: lib/vutuv_web/live/notification_live/index.ex:993
+#: lib/vutuv_web/live/notification_live/index.ex:1508
 #: lib/vutuv_web/live/post_live/reply.ex:46
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2597,89 +2595,89 @@ msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
 
-#: lib/vutuv_web/live/message_live/index.ex:603
+#: lib/vutuv_web/live/message_live/index.ex:613
 #, elixir-autogen, elixir-format
 msgid "%{names} are typing…"
 msgstr "%{names} schreiben…"
 
-#: lib/vutuv_web/live/message_live/index.ex:602
+#: lib/vutuv_web/live/message_live/index.ex:612
 #, elixir-autogen, elixir-format
 msgid "%{name} is typing…"
 msgstr "%{name} schreibt…"
 
-#: lib/vutuv_web/live/message_live/index.ex:914
+#: lib/vutuv_web/live/message_live/index.ex:924
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr "@%{slug} hat Ihre Nachrichtenanfrage noch nicht angenommen."
 
-#: lib/vutuv_web/live/message_live/index.ex:865
+#: lib/vutuv_web/live/message_live/index.ex:875
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to message you."
 msgstr "@%{slug} möchte Ihnen Nachrichten schicken."
 
-#: lib/vutuv_web/live/message_live/index.ex:591
+#: lib/vutuv_web/live/message_live/index.ex:601
 #, elixir-autogen, elixir-format
 msgid "Accept"
 msgstr "Annehmen"
 
-#: lib/vutuv_web/live/message_live/index.ex:728
+#: lib/vutuv_web/live/message_live/index.ex:738
 #, elixir-autogen, elixir-format
 msgid "Back to conversations"
 msgstr "Zurück zu den Unterhaltungen"
 
-#: lib/vutuv_web/live/message_live/index.ex:593
+#: lib/vutuv_web/live/message_live/index.ex:603
 #, elixir-autogen, elixir-format
 msgid "Decline"
 msgstr "Ablehnen"
 
-#: lib/vutuv_web/live/message_live/index.ex:534
+#: lib/vutuv_web/live/message_live/index.ex:544
 #, elixir-autogen, elixir-format
 msgid "Deleted account"
 msgstr "Gelöschtes Konto"
 
-#: lib/vutuv_web/live/message_live/index.ex:774
+#: lib/vutuv_web/live/message_live/index.ex:784
 #, elixir-autogen, elixir-format
 msgid "Load older messages"
 msgstr "Ältere Nachrichten laden"
 
 #: lib/vutuv_web/controllers/admin/tag_member_controller.ex:55
-#: lib/vutuv_web/live/message_live/index.ex:132
+#: lib/vutuv_web/live/message_live/index.ex:142
 #, elixir-autogen, elixir-format
 msgid "Member not found."
 msgstr "Mitglied nicht gefunden."
 
-#: lib/vutuv_web/live/message_live/index.ex:707
+#: lib/vutuv_web/live/message_live/index.ex:717
 #, elixir-autogen, elixir-format
 msgid "No conversations yet."
 msgstr "Noch keine Unterhaltungen."
 
-#: lib/vutuv_web/components/ui.ex:3154
-#: lib/vutuv_web/live/message_live/index.ex:750
+#: lib/vutuv_web/components/ui.ex:3166
+#: lib/vutuv_web/live/message_live/index.ex:760
 #, elixir-autogen, elixir-format
 msgid "Online"
 msgstr "Online"
 
-#: lib/vutuv_web/live/message_live/index.ex:656
+#: lib/vutuv_web/live/message_live/index.ex:666
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr "Anfragen"
 
-#: lib/vutuv_web/live/message_live/index.ex:923
+#: lib/vutuv_web/live/message_live/index.ex:933
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr "Wählen Sie eine Unterhaltung aus."
 
-#: lib/vutuv_web/live/message_live/index.ex:147
+#: lib/vutuv_web/live/message_live/index.ex:157
 #, elixir-autogen, elixir-format
 msgid "This member cannot receive messages."
 msgstr "Dieses Mitglied kann keine Nachrichten empfangen."
 
-#: lib/vutuv_web/live/message_live/index.ex:239
+#: lib/vutuv_web/live/message_live/index.ex:249
 #, elixir-autogen, elixir-format
 msgid "This message could not be sent."
 msgstr "Diese Nachricht konnte nicht gesendet werden."
 
-#: lib/vutuv_web/live/message_live/index.ex:142
+#: lib/vutuv_web/live/message_live/index.ex:152
 #, elixir-autogen, elixir-format
 msgid "Too many new conversations. Please try again later."
 msgstr "Zu viele neue Unterhaltungen. Bitte versuchen Sie es später erneut."
@@ -2742,7 +2740,7 @@ msgstr "Eine neue PIN ist unterwegs zu Ihrer E-Mail-Adresse."
 msgid "Okay, let's start over."
 msgstr "Alles klar, fangen wir neu an."
 
-#: lib/vutuv_web/components/ui.ex:850
+#: lib/vutuv_web/components/ui.ex:862
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr "PIN erneut senden"
@@ -2753,7 +2751,7 @@ msgstr "PIN erneut senden"
 msgid "Too many PIN requests. Please try again later."
 msgstr "Zu viele PIN-Anfragen. Bitte versuchen Sie es später erneut."
 
-#: lib/vutuv_web/components/ui.ex:871
+#: lib/vutuv_web/components/ui.ex:883
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr "Andere E-Mail-Adresse verwenden"
@@ -2803,8 +2801,8 @@ msgstr "Berufserfahrung hinzufügen"
 msgid "Write your first post"
 msgstr "Ersten Beitrag schreiben"
 
-#: lib/vutuv_web/components/ui.ex:4104
-#: lib/vutuv_web/components/ui.ex:4541
+#: lib/vutuv_web/components/ui.ex:4116
+#: lib/vutuv_web/components/ui.ex:4553
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:109
@@ -2850,13 +2848,12 @@ msgstr[1] "+%{formatted} weitere Tags"
 #: lib/vutuv_web/agent_docs/markdown.ex:633
 #: lib/vutuv_web/agent_docs/text.ex:597
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:1208
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
 msgstr "Vernetzungen"
 
-#: lib/vutuv_web/components/ui.ex:1392
+#: lib/vutuv_web/components/ui.ex:1404
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr "Markdown"
@@ -2866,7 +2863,7 @@ msgstr "Markdown"
 msgid "No connections yet."
 msgstr "Noch keine Vernetzungen."
 
-#: lib/vutuv_web/components/ui.ex:1408
+#: lib/vutuv_web/components/ui.ex:1420
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr "Andere Formate"
@@ -2876,7 +2873,7 @@ msgstr "Andere Formate"
 msgid "People who aren't my connections"
 msgstr "Personen, mit denen ich nicht vernetzt bin"
 
-#: lib/vutuv_web/components/ui.ex:1393
+#: lib/vutuv_web/components/ui.ex:1405
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr "Nur Text"
@@ -2899,29 +2896,29 @@ msgstr[1] "Vernetzungen"
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
 
-#: lib/vutuv_web/live/message_live/index.ex:708
+#: lib/vutuv_web/live/message_live/index.ex:718
 #, elixir-autogen, elixir-format
 msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
 
 #: lib/vutuv_web/components/organization_components.ex:259
-#: lib/vutuv_web/live/notification_live/index.ex:1288
+#: lib/vutuv_web/live/notification_live/index.ex:1524
 #: lib/vutuv_web/live/organization_live/activity.ex:104
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr "Aktivität"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1279
+#: lib/vutuv_web/live/notification_live/index.ex:1515
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr "Vernetzung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1272
+#: lib/vutuv_web/live/notification_live/index.ex:1507
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr "Empfehlung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1271
+#: lib/vutuv_web/live/notification_live/index.ex:1506
 #: lib/vutuv_web/templates/user/show.html.heex:965
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -3074,7 +3071,7 @@ msgstr ""
 msgid "Hidden. You can settle this yourself - see below."
 msgstr "Verborgen. Sie können das selbst klären, siehe unten."
 
-#: lib/vutuv_web/live/message_live/index.ex:803
+#: lib/vutuv_web/live/message_live/index.ex:813
 #, elixir-autogen, elixir-format
 msgid "Hidden: reported, under review"
 msgstr "Verborgen: gemeldet, wird geprüft"
@@ -3086,7 +3083,7 @@ msgstr "Familienfreundlich bleiben"
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1280
+#: lib/vutuv_web/live/notification_live/index.ex:1516
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3228,7 +3225,7 @@ msgstr ""
 msgid "Private message"
 msgstr "Private Nachricht"
 
-#: lib/vutuv_web/components/ui.ex:4858
+#: lib/vutuv_web/components/ui.ex:4870
 #: lib/vutuv_web/live/shell_live.ex:1125
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3283,8 +3280,8 @@ msgstr "Meldung abgelehnt; der Inhalt ist wieder sichtbar."
 msgid "Report this content"
 msgstr "Diesen Inhalt melden"
 
-#: lib/vutuv_web/live/message_live/index.ex:821
-#: lib/vutuv_web/live/message_live/index.ex:822
+#: lib/vutuv_web/live/message_live/index.ex:831
+#: lib/vutuv_web/live/message_live/index.ex:832
 #, elixir-autogen, elixir-format
 msgid "Report this message"
 msgstr "Diese Nachricht melden"
@@ -3341,7 +3338,7 @@ msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 "Meldungen sind anonym; wir verraten nie, wer gemeldet hat. Unsere Regeln:"
 
-#: lib/vutuv_web/components/ui.ex:3811
+#: lib/vutuv_web/components/ui.ex:3823
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3782,7 +3779,7 @@ msgstr "Besitzer hat den Inhalt bearbeitet"
 msgid "Report filed"
 msgstr "Meldung eingegangen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1282
+#: lib/vutuv_web/live/notification_live/index.ex:1518
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr "Schutz nach Meldung"
@@ -4056,6 +4053,7 @@ msgstr "Beitragsarchiv von %{name}"
 #: lib/vutuv_web/agent_docs/text.ex:137
 #: lib/vutuv_web/live/admin/screenshot_live.ex:380
 #: lib/vutuv_web/live/admin/screenshot_live.ex:389
+#: lib/vutuv_web/live/notification_live/index.ex:1637
 #: lib/vutuv_web/templates/post/show.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "Post by %{name}"
@@ -4489,12 +4487,12 @@ msgstr "Buchbar bis einschließlich %{last}."
 msgid "Bookings are open through %{last}. Next available day: %{day}"
 msgstr "Buchbar bis einschließlich %{last}. Nächster freier Tag: %{day}"
 
-#: lib/vutuv_web/components/ui.ex:3414
+#: lib/vutuv_web/components/ui.ex:3426
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr "Fr"
 
-#: lib/vutuv_web/components/ui.ex:3410
+#: lib/vutuv_web/components/ui.ex:3422
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr "Mo"
@@ -4506,27 +4504,27 @@ msgstr ""
 "Eine Anzeige pro Kalendertag: Wählen Sie einen freien Tag im Kalender; "
 "durchgestrichene Tage sind bereits vergeben."
 
-#: lib/vutuv_web/components/ui.ex:3415
+#: lib/vutuv_web/components/ui.ex:3427
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr "Sa"
 
-#: lib/vutuv_web/components/ui.ex:3416
+#: lib/vutuv_web/components/ui.ex:3428
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr "So"
 
-#: lib/vutuv_web/components/ui.ex:3413
+#: lib/vutuv_web/components/ui.ex:3425
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr "Do"
 
-#: lib/vutuv_web/components/ui.ex:3411
+#: lib/vutuv_web/components/ui.ex:3423
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr "Di"
 
-#: lib/vutuv_web/components/ui.ex:3412
+#: lib/vutuv_web/components/ui.ex:3424
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr "Mi"
@@ -4719,12 +4717,12 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3221
+#: lib/vutuv_web/live/post_live/feed.ex:3244
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
 
-#: lib/vutuv_web/live/message_live/index.ex:711
+#: lib/vutuv_web/live/message_live/index.ex:721
 #, elixir-autogen, elixir-format
 msgid "Find members"
 msgstr "Mitglieder finden"
@@ -4778,7 +4776,8 @@ msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 #: lib/vutuv_web/agent_docs/markdown.ex:444
 #: lib/vutuv_web/agent_docs/text.ex:463
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/live/notification_live/index.ex:1131
+#: lib/vutuv_web/live/notification_live/index.ex:646
+#: lib/vutuv_web/live/notification_live/index.ex:1343
 #: lib/vutuv_web/live/organization_live/show.ex:787
 #: lib/vutuv_web/live/post_live/saved.ex:523
 #: lib/vutuv_web/live/search_live.ex:346
@@ -4804,7 +4803,7 @@ msgstr "Ähnliche Namen"
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
-#: lib/vutuv_web/live/notification_live/index.ex:1129
+#: lib/vutuv_web/live/notification_live/index.ex:1340
 #: lib/vutuv_web/live/search_live.ex:345
 #: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
@@ -5652,7 +5651,7 @@ msgstr "Fußzeilen-Navigation"
 #: lib/vutuv_web/components/post_components.ex:3727
 #: lib/vutuv_web/components/post_components.ex:3782
 #: lib/vutuv_web/components/post_components.ex:4190
-#: lib/vutuv_web/live/notification_live/index.ex:785
+#: lib/vutuv_web/live/notification_live/index.ex:1072
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5719,7 +5718,7 @@ msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 "Laden Sie alles herunter, was vutuv über Sie speichert, als eine Datei."
 
-#: lib/vutuv_web/components/ui.ex:4896
+#: lib/vutuv_web/components/ui.ex:4908
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5781,7 +5780,7 @@ msgstr "Ansehen"
 msgid "Your name"
 msgstr "Ihr Name"
 
-#: lib/vutuv_web/live/notification_live/index.ex:622
+#: lib/vutuv_web/live/notification_live/index.ex:1631
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr "Ihr Beitrag"
@@ -5876,7 +5875,6 @@ msgid "Apps & API"
 msgstr "Apps & API-Zugang"
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:1211
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -5956,7 +5954,7 @@ msgstr "Wenn jemand beginnt, Ihnen zu folgen."
 msgid "@handle"
 msgstr "@handle"
 
-#: lib/vutuv_web/live/message_live/index.ex:766
+#: lib/vutuv_web/live/message_live/index.ex:776
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}"
 msgstr "@%{slug} blockieren"
@@ -6078,21 +6076,21 @@ msgid "Sort"
 msgstr "Sortieren"
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3471
+#: lib/vutuv_web/components/ui.ex:3483
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "vor %{count} Tag"
 msgstr[1] "vor %{count} Tagen"
 
-#: lib/vutuv_web/components/ui.ex:3470
+#: lib/vutuv_web/components/ui.ex:3482
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "vor %{count} Stunde"
 msgstr[1] "vor %{count} Stunden"
 
-#: lib/vutuv_web/components/ui.ex:3469
+#: lib/vutuv_web/components/ui.ex:3481
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -6161,7 +6159,7 @@ msgstr ""
 "Das ist die erste Anmeldung, die wir von diesem Gerät oder Browser gesehen "
 "haben."
 
-#: lib/vutuv_web/components/ui.ex:3468
+#: lib/vutuv_web/components/ui.ex:3480
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "gerade eben"
@@ -6313,7 +6311,7 @@ msgstr "Kurzbeschreibung hinzufügen"
 msgid "Tagline"
 msgstr "Kurzbeschreibung"
 
-#: lib/vutuv_web/components/ui.ex:468
+#: lib/vutuv_web/components/ui.ex:480
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:915
@@ -6506,9 +6504,9 @@ msgstr "Nach unten"
 msgid "Move up"
 msgstr "Nach oben"
 
-#: lib/vutuv_web/components/ui.ex:2113
-#: lib/vutuv_web/components/ui.ex:2122
-#: lib/vutuv_web/components/ui.ex:2601
+#: lib/vutuv_web/components/ui.ex:2125
+#: lib/vutuv_web/components/ui.ex:2134
+#: lib/vutuv_web/components/ui.ex:2613
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr "Empfehlung zurücknehmen"
@@ -6573,11 +6571,11 @@ msgstr "Mitglieder, die %{name} für %{tag} empfohlen haben"
 msgid "No endorsements yet."
 msgstr "Noch keine Empfehlungen."
 
-#: lib/vutuv_web/components/ui.ex:2554
-#: lib/vutuv_web/live/notification_live/index.ex:685
-#: lib/vutuv_web/live/notification_live/index.ex:700
-#: lib/vutuv_web/live/notification_live/index.ex:1013
-#: lib/vutuv_web/live/notification_live/index.ex:1015
+#: lib/vutuv_web/components/ui.ex:2566
+#: lib/vutuv_web/live/notification_live/index.ex:716
+#: lib/vutuv_web/live/notification_live/index.ex:731
+#: lib/vutuv_web/live/notification_live/index.ex:1225
+#: lib/vutuv_web/live/notification_live/index.ex:1227
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
@@ -6895,7 +6893,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2643
 #: lib/vutuv_web/components/post_components.ex:3652
-#: lib/vutuv_web/components/ui.ex:2979
+#: lib/vutuv_web/components/ui.ex:2991
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/live/organization_live/following.ex:377
 #: lib/vutuv_web/live/organization_live/following.ex:461
@@ -6923,7 +6921,7 @@ msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
 #: lib/vutuv_web/components/post_components.ex:3652
-#: lib/vutuv_web/components/ui.ex:2978
+#: lib/vutuv_web/components/ui.ex:2990
 #: lib/vutuv_web/live/fediverse_account_live.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:377
 #: lib/vutuv_web/live/organization_live/following.ex:461
@@ -7546,13 +7544,13 @@ msgstr "Ihre Mitglieder werden zu dieser hinzugefügt (Vereinigung)."
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr "Seite %{page} von %{pages}, %{total} gesamt"
 
-#: lib/vutuv_web/components/ui.ex:3880
+#: lib/vutuv_web/components/ui.ex:3892
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Zurück"
 
-#: lib/vutuv_web/components/ui.ex:3892
+#: lib/vutuv_web/components/ui.ex:3904
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7746,7 +7744,7 @@ msgstr ""
 "der Versand läuft weiter."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3487
+#: lib/vutuv_web/live/post_live/feed.ex:3510
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #, elixir-autogen
 msgid "Done"
@@ -8052,13 +8050,13 @@ msgstr "Neue Mitglieder"
 #: lib/vutuv_web/components/job_components.ex:219
 #: lib/vutuv_web/live/admin/dashboard_live.ex:304
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:468
-#: lib/vutuv_web/live/notification_live/index.ex:1158
+#: lib/vutuv_web/live/notification_live/index.ex:1378
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Heute"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:308
-#: lib/vutuv_web/live/notification_live/index.ex:1161
+#: lib/vutuv_web/live/notification_live/index.ex:1381
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr "Gestern"
@@ -8356,7 +8354,7 @@ msgstr "PIN abgelaufen"
 msgid "PIN registered"
 msgstr "PIN-registriert"
 
-#: lib/vutuv_web/components/ui.ex:3883
+#: lib/vutuv_web/components/ui.ex:3895
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr "Seite %{page} von %{pages}"
@@ -8495,7 +8493,7 @@ msgstr "Abschluss"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:4872
+#: lib/vutuv_web/components/ui.ex:4884
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8584,7 +8582,7 @@ msgstr "%{items} importiert."
 msgid "Nothing new to import."
 msgstr "Nichts Neues zu importieren."
 
-#: lib/vutuv_web/components/ui.ex:4900
+#: lib/vutuv_web/components/ui.ex:4912
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8681,7 +8679,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 
-#: lib/vutuv_web/components/ui.ex:4156
+#: lib/vutuv_web/components/ui.ex:4168
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8775,7 +8773,7 @@ msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 "Ziehen Sie Ihre ZIP-Datei hierher oder klicken Sie, um eine auszuwählen."
 
-#: lib/vutuv_web/components/ui.ex:4860
+#: lib/vutuv_web/components/ui.ex:4872
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
@@ -8925,7 +8923,7 @@ msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 "Die Seite %{letter} des Mitgliederverzeichnisses, sortiert nach Nachnamen."
 
-#: lib/vutuv_web/components/ui.ex:1410
+#: lib/vutuv_web/components/ui.ex:1422
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -9033,7 +9031,7 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/agent_docs/text.ex:586
 #: lib/vutuv_web/agent_docs/text.ex:590
 #: lib/vutuv_web/components/organization_components.ex:276
-#: lib/vutuv_web/components/ui.ex:1611
+#: lib/vutuv_web/components/ui.ex:1623
 #: lib/vutuv_web/components/ui.ex:5032
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:357
@@ -9196,7 +9194,7 @@ msgstr ""
 "Ihres Browsers (Strg+P oder Cmd+P) und wählen Sie \"Als PDF speichern\", um "
 "eine PDF-Datei zu erhalten."
 
-#: lib/vutuv_web/components/ui.ex:1700
+#: lib/vutuv_web/components/ui.ex:1712
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr "Lebenslauf-Download"
@@ -9234,7 +9232,7 @@ msgstr "Jeder Download enthält genau die ausgewählten Teile."
 msgid "Header"
 msgstr "Kopfzeile"
 
-#: lib/vutuv_web/components/ui.ex:1710
+#: lib/vutuv_web/components/ui.ex:1722
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -9272,7 +9270,7 @@ msgstr ""
 "Besuchers enthält nur, was er dort ohnehin sehen kann, und private E-Mail-"
 "Adressen erscheinen nur in Ihrem eigenen."
 
-#: lib/vutuv_web/components/ui.ex:1702
+#: lib/vutuv_web/components/ui.ex:1714
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -9447,8 +9445,8 @@ msgstr "Dieses Tag kann nur von einem Admin entfernt werden."
 msgid "Yes"
 msgstr "Ja"
 
-#: lib/vutuv_web/components/ui.ex:2157
-#: lib/vutuv_web/components/ui.ex:2158
+#: lib/vutuv_web/components/ui.ex:2169
+#: lib/vutuv_web/components/ui.ex:2170
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -10028,7 +10026,7 @@ msgstr "Zertifikate"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:4876
+#: lib/vutuv_web/components/ui.ex:4888
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -10231,13 +10229,13 @@ msgstr "Dauerhafter Profillink"
 msgid "Dismiss"
 msgstr "Schließen"
 
-#: lib/vutuv_web/components/ui.ex:3584
+#: lib/vutuv_web/components/ui.ex:3596
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Kopiert"
 
-#: lib/vutuv_web/components/ui.ex:3583
-#: lib/vutuv_web/components/ui.ex:3591
+#: lib/vutuv_web/components/ui.ex:3595
+#: lib/vutuv_web/components/ui.ex:3603
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Kopieren"
@@ -10431,17 +10429,17 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr "Authenticator-App ausgeschaltet."
 
-#: lib/vutuv_web/components/ui.ex:456
+#: lib/vutuv_web/components/ui.ex:468
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr "Fett"
 
-#: lib/vutuv_web/components/ui.ex:508
+#: lib/vutuv_web/components/ui.ex:520
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr "Aufzählung"
 
-#: lib/vutuv_web/components/ui.ex:511
+#: lib/vutuv_web/components/ui.ex:523
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr "Codeblock"
@@ -10462,8 +10460,8 @@ msgstr ""
 msgid "Formatting"
 msgstr "Formatierung"
 
-#: lib/vutuv_web/components/ui.ex:575
-#: lib/vutuv_web/components/ui.ex:576
+#: lib/vutuv_web/components/ui.ex:587
+#: lib/vutuv_web/components/ui.ex:588
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr "Vollbild"
@@ -10478,22 +10476,24 @@ msgstr "Neue Liste erstellen"
 msgid "Generate code list"
 msgstr "Kennwortliste erstellen"
 
-#: lib/vutuv_web/components/ui.ex:506
+#: lib/vutuv_web/components/ui.ex:461
+#: lib/vutuv_web/components/ui.ex:518
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr "Überschrift 1"
 
-#: lib/vutuv_web/components/ui.ex:507
+#: lib/vutuv_web/components/ui.ex:464
+#: lib/vutuv_web/components/ui.ex:519
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr "Überschrift 2"
 
-#: lib/vutuv_web/components/ui.ex:465
+#: lib/vutuv_web/components/ui.ex:477
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr "Inline-Code"
 
-#: lib/vutuv_web/components/ui.ex:459
+#: lib/vutuv_web/components/ui.ex:471
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr "Kursiv"
@@ -10514,7 +10514,7 @@ msgstr "Anmelde-Codes"
 msgid "Not set up."
 msgstr "Nicht eingerichtet."
 
-#: lib/vutuv_web/components/ui.ex:509
+#: lib/vutuv_web/components/ui.ex:521
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr "Nummerierte Liste"
@@ -10531,7 +10531,7 @@ msgstr ""
 "Drucken Sie diese Seite aus oder schreiben Sie die Codes ab. "
 "Durchgestrichene Codes wurden bereits verwendet."
 
-#: lib/vutuv_web/components/ui.ex:510
+#: lib/vutuv_web/components/ui.ex:522
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr "Zitat"
@@ -10556,7 +10556,7 @@ msgstr ""
 msgid "Set up"
 msgstr "Einrichten"
 
-#: lib/vutuv_web/components/ui.ex:462
+#: lib/vutuv_web/components/ui.ex:474
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr "Durchgestrichen"
@@ -10677,6 +10677,7 @@ msgid_plural "%{count} stars"
 msgstr[0] "%{count} Stern"
 msgstr[1] "%{count} Sterne"
 
+#: lib/vutuv_web/live/notification_live/index.ex:1429
 #: lib/vutuv_web/live/organization_live/show.ex:638
 #: lib/vutuv_web/views/user_html.ex:950
 #: lib/vutuv_web/views/user_html.ex:1126
@@ -11653,12 +11654,12 @@ msgstr "Stellen Sie diese Datei bereit unter:"
 msgid "State / region (optional)"
 msgstr "Bundesland / Region (optional)"
 
-#: lib/vutuv_web/components/ui.ex:4210
+#: lib/vutuv_web/components/ui.ex:4222
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr "Dieser Dateityp ist nicht erlaubt."
 
-#: lib/vutuv_web/components/ui.ex:4212
+#: lib/vutuv_web/components/ui.ex:4224
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr "Der Upload ist fehlgeschlagen."
@@ -12092,7 +12093,7 @@ msgstr ""
 "Der Linktext ist beliebig. Ein verstecktes <link rel=\"me\"> im Seitenkopf "
 "funktioniert ebenfalls."
 
-#: lib/vutuv_web/components/ui.ex:1073
+#: lib/vutuv_web/components/ui.ex:1085
 #: lib/vutuv_web/live/section_reorder_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -12370,7 +12371,7 @@ msgstr "Organisationsseite"
 msgid "Organization pages"
 msgstr "Organisationsseiten"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1283
+#: lib/vutuv_web/live/notification_live/index.ex:1519
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr "Organisationsrolle"
@@ -13894,7 +13895,7 @@ msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 T
 msgid "Image awaiting review, visible only to you"
 msgstr "Bild wird geprüft, nur für Sie sichtbar"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1281
+#: lib/vutuv_web/live/notification_live/index.ex:1517
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13981,7 +13982,7 @@ msgstr[1] "%{formatted} Beiträge erwähnen aktuell %{handle} und werden beim Um
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr "Beim Ändern werden alle Erwähnungen Ihres alten Handles in Beiträgen automatisch auf den neuen umgeschrieben und die Verfasser dieser Beiträge benachrichtigt. Ihre alte Profiladresse funktioniert dann nicht mehr."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1284
+#: lib/vutuv_web/live/notification_live/index.ex:1520
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr "Handle-Änderung"
@@ -13998,27 +13999,27 @@ msgstr[1] "Wir haben %{formatted} Beiträge aktualisiert, die Ihren alten Handle
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "hat den Handle von @%{old} auf @%{new} geändert."
 
-#: lib/vutuv_web/components/ui.ex:485
+#: lib/vutuv_web/components/ui.ex:497
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr "Zentriert"
 
-#: lib/vutuv_web/components/ui.ex:482
+#: lib/vutuv_web/components/ui.ex:494
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr "Linksbündig (Text umfließt)"
 
-#: lib/vutuv_web/components/ui.ex:488
+#: lib/vutuv_web/components/ui.ex:500
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr "Rechtsbündig (Text umfließt)"
 
-#: lib/vutuv_web/components/ui.ex:479
+#: lib/vutuv_web/components/ui.ex:491
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr "Volle Breite"
 
-#: lib/vutuv_web/components/ui.ex:512
+#: lib/vutuv_web/components/ui.ex:524
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr "Bild einfügen"
@@ -14085,7 +14086,7 @@ msgstr ""
 "Personen tauchen in Ihren Vorschlägen auf. Einem Tag folgen Sie auf seiner "
 "Seite."
 
-#: lib/vutuv_web/components/ui.ex:4952
+#: lib/vutuv_web/components/ui.ex:4964
 #: lib/vutuv_web/controllers/settings_controller.ex:634
 #: lib/vutuv_web/live/post_live/feed.ex:720
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -14162,7 +14163,7 @@ msgstr "Messenger wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:63
-#: lib/vutuv_web/components/ui.ex:4919
+#: lib/vutuv_web/components/ui.ex:4931
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -14190,19 +14191,19 @@ msgstr "Messenger von %{name}"
 msgid "Select a messenger"
 msgstr "Messenger auswählen"
 
-#: lib/vutuv_web/components/ui.ex:4295
+#: lib/vutuv_web/components/ui.ex:4307
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] "Meinen Follower darüber informieren"
 msgstr[1] "Meine %{formatted} Follower darüber informieren"
 
-#: lib/vutuv_web/components/ui.ex:4305
+#: lib/vutuv_web/components/ui.ex:4317
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1285
+#: lib/vutuv_web/live/notification_live/index.ex:1521
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr "Lebenslauf-Update"
@@ -14373,45 +14374,40 @@ msgstr "Mit Qualifikation: %{name}"
 msgid "Publisher:"
 msgstr "Verlag:"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1150
+#: lib/vutuv_web/live/notification_live/index.ex:1370
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] "%{formatted} neue Mitteilung"
 msgstr[1] "%{formatted} neue Mitteilungen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1164
+#: lib/vutuv_web/live/notification_live/index.ex:1384
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr "%{day}. %{month} %{year}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:454
+#: lib/vutuv_web/live/notification_live/index.ex:545
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr "Zurückfolgen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:469
-#, elixir-autogen, elixir-format
-msgid "Last 30 days"
-msgstr "Letzte 30 Tage"
-
-#: lib/vutuv_web/live/notification_live/index.ex:1116
-#: lib/vutuv_web/live/notification_live/index.ex:1382
+#: lib/vutuv_web/live/notification_live/index.ex:1327
+#: lib/vutuv_web/live/notification_live/index.ex:1700
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "und"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1302
+#: lib/vutuv_web/live/notification_live/index.ex:1608
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr "sind jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1299
+#: lib/vutuv_web/live/notification_live/index.ex:1605
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr "folgen Ihnen jetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1308
+#: lib/vutuv_web/live/notification_live/index.ex:1614
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
@@ -14421,12 +14417,12 @@ msgstr "hat Sie für %{tags} empfohlen."
 msgid "by:"
 msgstr "von:"
 
-#: lib/vutuv_web/components/ui.ex:2291
+#: lib/vutuv_web/components/ui.ex:2303
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr "Empfohlen von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:2295
+#: lib/vutuv_web/components/ui.ex:2307
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -14670,7 +14666,7 @@ msgstr ""
 "familienfreundlich genug für ein Arbeitsumfeld. Sie kann sich irren, "
 "antworten Sie in dem Fall einfach auf unsere E-Mail."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1274
+#: lib/vutuv_web/live/notification_live/index.ex:1509
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr "Thread-Antwort"
@@ -14698,7 +14694,7 @@ msgstr "Unterhaltung"
 msgid "Only part of this long conversation is shown."
 msgstr "Von dieser langen Unterhaltung wird nur ein Teil angezeigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1275
+#: lib/vutuv_web/live/notification_live/index.ex:1510
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr "Erwähnung"
@@ -14964,6 +14960,8 @@ msgstr "Sie können nur alle %{days} Tage umziehen."
 msgid "as an account alias."
 msgstr "als Konto-Alias hinzu."
 
+#: lib/vutuv_web/live/notification_live/index.ex:1437
+#: lib/vutuv_web/live/notification_live/index.ex:1682
 #: lib/vutuv_web/templates/user_tag/show.html.heex:24
 #, elixir-autogen, elixir-format
 msgid "%{formatted} endorsement"
@@ -15001,7 +14999,7 @@ msgstr "Blenden Sie Beiträge aus Ihrem Feed aus, die ein Tag tragen oder ein Wo
 msgid "Match whole words only (word/phrase)"
 msgstr "Nur ganze Wörter treffen (Wort/Phrase)"
 
-#: lib/vutuv_web/components/ui.ex:4933
+#: lib/vutuv_web/components/ui.ex:4945
 #: lib/vutuv_web/controllers/settings_controller.ex:700
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -15051,7 +15049,7 @@ msgstr "Diese Ausbildung wird jetzt oben in Ihrem Profil angezeigt."
 msgid "Thread replies"
 msgstr "Thread-Antworten"
 
-#: lib/vutuv_web/live/notification_live/index.ex:663
+#: lib/vutuv_web/live/notification_live/index.ex:1022
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr "Thread-Benachrichtigungen abschalten"
@@ -15102,7 +15100,7 @@ msgstr "Sie haben noch nichts stummgeschaltet."
 msgid "You have reached the maximum of %{count} filters."
 msgstr "Sie haben das Maximum von %{count} Filtern erreicht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:658
+#: lib/vutuv_web/live/notification_live/index.ex:1017
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr "Sie haben in diesem Thread geschrieben."
@@ -15636,67 +15634,67 @@ msgstr "Ihr Server"
 msgid "moved to %{address}"
 msgstr "umgezogen nach %{address}"
 
-#: lib/vutuv_web/components/ui.ex:4861
+#: lib/vutuv_web/components/ui.ex:4873
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr "Name, Foto, Titelbild, Kurzbeschreibung"
 
-#: lib/vutuv_web/components/ui.ex:4866
+#: lib/vutuv_web/components/ui.ex:4878
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr "handle spitzname nutzername umbenennen slug profiladresse url erwähnung"
 
-#: lib/vutuv_web/components/ui.ex:4869
+#: lib/vutuv_web/components/ui.ex:4881
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr "Die Stationen in Ihrem Lebenslauf"
 
-#: lib/vutuv_web/components/ui.ex:4870
+#: lib/vutuv_web/components/ui.ex:4882
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr "lebenslauf cv karriere beruf arbeitgeber position stelle job firma"
 
-#: lib/vutuv_web/components/ui.ex:4873
+#: lib/vutuv_web/components/ui.ex:4885
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr "Schulen, Hochschulen, Abschlüsse"
 
-#: lib/vutuv_web/components/ui.ex:4874
+#: lib/vutuv_web/components/ui.ex:4886
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr "lebenslauf studium schule universität hochschule abschluss ausbildung"
 
-#: lib/vutuv_web/components/ui.ex:4877
+#: lib/vutuv_web/components/ui.ex:4889
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr "Nachweise, mit Belegdokumenten"
 
-#: lib/vutuv_web/components/ui.ex:4878
+#: lib/vutuv_web/components/ui.ex:4890
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr "zertifikat lizenz urkunde diplom nachweis beleg auszeichnung dokument"
 
-#: lib/vutuv_web/components/ui.ex:4885
+#: lib/vutuv_web/components/ui.ex:4897
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr "Sprachkenntnisse"
 
-#: lib/vutuv_web/components/ui.ex:4886
+#: lib/vutuv_web/components/ui.ex:4898
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr "Die Sprachen, die Sie sprechen"
 
-#: lib/vutuv_web/components/ui.ex:4887
+#: lib/vutuv_web/components/ui.ex:4899
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr "sprache sprachen sprechen fließend muttersprache verhandlungssicher"
 
-#: lib/vutuv_web/components/ui.ex:4890
+#: lib/vutuv_web/components/ui.ex:4902
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr "Die Themen, für die Sie bekannt sind"
 
-#: lib/vutuv_web/components/ui.ex:4891
+#: lib/vutuv_web/components/ui.ex:4903
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr "fähigkeit kenntnis thema stichwort schlagwort expertise empfehlung"
@@ -15711,107 +15709,107 @@ msgstr "Organisationsseiten, die Sie verwalten"
 msgid "company employer firm business organisation page"
 msgstr "firma unternehmen arbeitgeber betrieb organisation seite"
 
-#: lib/vutuv_web/components/ui.ex:4894
+#: lib/vutuv_web/components/ui.ex:4906
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr "Kontaktdaten"
 
-#: lib/vutuv_web/components/ui.ex:4897
+#: lib/vutuv_web/components/ui.ex:4909
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr "Wo wir Sie erreichen, und welche Adresse öffentlich ist"
 
-#: lib/vutuv_web/components/ui.ex:4898
+#: lib/vutuv_web/components/ui.ex:4910
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr "mail e-mail email adresse hauptadresse primär"
 
-#: lib/vutuv_web/components/ui.ex:4901
+#: lib/vutuv_web/components/ui.ex:4913
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr "Festnetz, Mobil, Fax"
 
-#: lib/vutuv_web/components/ui.ex:4902
+#: lib/vutuv_web/components/ui.ex:4914
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr "telefon handy mobil festnetz fax nummer rufnummer"
 
-#: lib/vutuv_web/components/ui.ex:4905
+#: lib/vutuv_web/components/ui.ex:4917
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr "Postanschriften auf Ihrem Profil"
 
-#: lib/vutuv_web/components/ui.ex:4906
+#: lib/vutuv_web/components/ui.ex:4918
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr "straße stadt ort postleitzahl plz land anschrift karte"
 
-#: lib/vutuv_web/components/ui.ex:4908
+#: lib/vutuv_web/components/ui.ex:4920
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr "Webseiten & Links"
 
-#: lib/vutuv_web/components/ui.ex:4909
+#: lib/vutuv_web/components/ui.ex:4921
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr "Ihre Homepage und weitere Links"
 
-#: lib/vutuv_web/components/ui.ex:4910
+#: lib/vutuv_web/components/ui.ex:4922
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr "url webseite website homepage blog link verifizieren bestätigen rel=me"
 
-#: lib/vutuv_web/components/ui.ex:4912
+#: lib/vutuv_web/components/ui.ex:4924
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr "Social-Media-Profile"
 
-#: lib/vutuv_web/components/ui.ex:4913
+#: lib/vutuv_web/components/ui.ex:4925
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr "Mastodon, Bluesky, GitHub und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:4915
+#: lib/vutuv_web/components/ui.ex:4927
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr "mastodon bluesky github gitlab codeberg linkedin x twitter instagram soziale netzwerke"
 
-#: lib/vutuv_web/components/ui.ex:4920
+#: lib/vutuv_web/components/ui.ex:4932
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr "Signal, Threema, Matrix und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:4921
+#: lib/vutuv_web/components/ui.ex:4933
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr "signal threema matrix xmpp telegram whatsapp chat messenger nachrichten"
 
-#: lib/vutuv_web/components/ui.ex:4924
+#: lib/vutuv_web/components/ui.ex:4936
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr "Mitteilungen & Feed"
 
-#: lib/vutuv_web/components/ui.ex:4927
+#: lib/vutuv_web/components/ui.ex:4939
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr "Welche E-Mails wir schicken, und was die Glocke meldet"
 
-#: lib/vutuv_web/components/ui.ex:4934
+#: lib/vutuv_web/components/ui.ex:4946
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr "Beiträge aus Ihrem Feed heraushalten"
 
-#: lib/vutuv_web/components/ui.ex:4935
+#: lib/vutuv_web/components/ui.ex:4947
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr "stummschalten ausblenden verbergen filter wort begriff tag feed blockieren"
 
-#: lib/vutuv_web/components/ui.ex:4953
+#: lib/vutuv_web/components/ui.ex:4965
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr "Themen, deren Beiträge in Ihrem Feed landen"
 
-#: lib/vutuv_web/components/ui.ex:4954
+#: lib/vutuv_web/components/ui.ex:4966
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr "tag thema abonnieren folgen feed"
@@ -16004,7 +16002,8 @@ msgstr ""
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
 #: lib/vutuv_web/components/post_components.ex:5786
-#: lib/vutuv_web/live/notification_live/index.ex:1357
+#: lib/vutuv_web/live/notification_live/index.ex:1425
+#: lib/vutuv_web/live/notification_live/index.ex:1657
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
@@ -16012,7 +16011,8 @@ msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
 #: lib/vutuv_web/components/post_components.ex:5790
-#: lib/vutuv_web/live/notification_live/index.ex:1355
+#: lib/vutuv_web/live/notification_live/index.ex:1422
+#: lib/vutuv_web/live/notification_live/index.ex:1655
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
@@ -16069,7 +16069,7 @@ msgstr "Vom Mitglied entfernt"
 msgid "Replies from other networks"
 msgstr "Antworten aus anderen Netzwerken"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1277
+#: lib/vutuv_web/live/notification_live/index.ex:1512
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr "Antwort aus einem anderen Netzwerk"
@@ -16090,7 +16090,7 @@ msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
 #: lib/vutuv_web/components/post_components.ex:1387
-#: lib/vutuv_web/live/notification_live/index.ex:911
+#: lib/vutuv_web/live/notification_live/index.ex:1120
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr "Nur an Sie gesendet, für niemanden sonst sichtbar"
@@ -16897,7 +16897,7 @@ msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1294
 #: lib/vutuv_web/agent_docs/text.ex:807
-#: lib/vutuv_web/components/ui.ex:3033
+#: lib/vutuv_web/components/ui.ex:3045
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Original herunterladen"
@@ -16922,7 +16922,7 @@ msgstr "Volle Auflösung, direkt aus dem Beitrag."
 msgid "Just the picture"
 msgstr "Nur das Bild"
 
-#: lib/vutuv_web/components/ui.ex:3032
+#: lib/vutuv_web/components/ui.ex:3044
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Nächstes Foto"
@@ -16960,7 +16960,7 @@ msgstr "Foto-Einstellungen"
 msgid "Photos:"
 msgstr "Fotos:"
 
-#: lib/vutuv_web/components/ui.ex:3031
+#: lib/vutuv_web/components/ui.ex:3043
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
@@ -17137,7 +17137,8 @@ msgstr "Fediverse-Reaktionen"
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1278
+#: lib/vutuv_web/live/notification_live/index.ex:1513
+#: lib/vutuv_web/live/notification_live/index.ex:1514
 #, elixir-autogen, elixir-format
 msgid "Reaction from another network"
 msgstr "Reaktion aus einem anderen Netzwerk"
@@ -17980,7 +17981,7 @@ msgstr "Ihr Benutzername ist hier Ihre öffentliche Identität. Er ändert sich 
 msgid "Your username is your public identity here. It changes only once you confirm with your passkey or a valid code below."
 msgstr "Ihr Benutzername ist hier Ihre öffentliche Identität. Er ändert sich erst, wenn Sie unten mit Ihrem Passkey oder einem gültigen Code bestätigen."
 
-#: lib/vutuv_web/components/ui.ex:610
+#: lib/vutuv_web/components/ui.ex:622
 #, elixir-autogen, elixir-format
 msgid "Markdown help"
 msgstr "Markdown-Hilfe"
@@ -18431,7 +18432,7 @@ msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
 "Noch nichts von vutuv. Folgen Sie Menschen hier, um diesen Tab zu füllen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:925
+#: lib/vutuv_web/live/notification_live/index.ex:1134
 #, elixir-autogen, elixir-format
 msgid "View the conversation"
 msgstr "Unterhaltung ansehen"
@@ -18509,8 +18510,8 @@ msgstr "Mehr von %{name}"
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr "Das ist die Kopie, die vutuv von einem auf %{host} veröffentlichten Beitrag hat. Sie bleibt erhalten, solange hier jemand diesem Konto folgt."
 
-#: lib/vutuv_web/components/ui.ex:1462
-#: lib/vutuv_web/components/ui.ex:1463
+#: lib/vutuv_web/components/ui.ex:1474
+#: lib/vutuv_web/components/ui.ex:1475
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr "Diesen Feed in Ihrem RSS-Reader abonnieren"
@@ -18912,7 +18913,7 @@ msgstr "Arbeitszeugnis aktualisiert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:4880
+#: lib/vutuv_web/components/ui.ex:4892
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -18957,7 +18958,7 @@ msgstr "Ausstellungsdatum"
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3239
+#: lib/vutuv_web/live/post_live/feed.ex:3262
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -19108,7 +19109,7 @@ msgstr "In der Warteschlange, Ihres ist als Nächstes dran."
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr "Sie haben den Text nach dieser Prüfung geändert. Sie beschreibt die frühere Fassung."
 
-#: lib/vutuv_web/components/ui.ex:4881
+#: lib/vutuv_web/components/ui.ex:4893
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr "Ihre Arbeitszeugnisse, privat bis Sie sie veröffentlichen"
@@ -19119,7 +19120,7 @@ msgstr "Ihre Arbeitszeugnisse, privat bis Sie sie veröffentlichen"
 msgid "Zwischenzeugnis"
 msgstr "Zwischenzeugnis"
 
-#: lib/vutuv_web/components/ui.ex:4883
+#: lib/vutuv_web/components/ui.ex:4895
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr "arbeitszeugnis zeugnis referenz beurteilung arbeitgeber bewertung prüfung"
@@ -19307,7 +19308,7 @@ msgstr "Arbeitszeugnis geändert"
 msgid "Employment reference deleted"
 msgstr "Arbeitszeugnis gelöscht"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1287
+#: lib/vutuv_web/live/notification_live/index.ex:1523
 #, elixir-autogen, elixir-format
 msgid "Employment reference review"
 msgstr "Zeugnisprüfung"
@@ -19374,7 +19375,7 @@ msgstr "Datei hierher ziehen oder eine auswählen"
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr "PDF, JPG, PNG oder WebP, bis %{limit}"
 
-#: lib/vutuv_web/components/ui.ex:4196
+#: lib/vutuv_web/components/ui.ex:4208
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -19729,19 +19730,19 @@ msgstr "6-stellige PIN"
 msgid "Enter the PIN from the email"
 msgstr "PIN aus der E-Mail eingeben"
 
-#: lib/vutuv_web/components/ui.ex:842
+#: lib/vutuv_web/components/ui.ex:854
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 "Wenn Sie Ihrem vutuv-Konto weitere Adressen hinzugefügt haben, melden Sie "
 "sich stattdessen mit einer davon an."
 
-#: lib/vutuv_web/components/ui.ex:870
+#: lib/vutuv_web/components/ui.ex:882
 #, elixir-autogen, elixir-format
 msgid "Cancel registration"
 msgstr "Registrierung abbrechen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1083
+#: lib/vutuv_web/live/notification_live/index.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -19754,7 +19755,7 @@ msgstr ""
 msgid "Follow other members"
 msgstr "Anderen Mitgliedern folgen"
 
-#: lib/vutuv_web/components/ui.ex:825
+#: lib/vutuv_web/components/ui.ex:837
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
@@ -19783,7 +19784,7 @@ msgstr ""
 "Anteile bezogen auf die %{answered} Mitglieder mit Angabe. %{unanswered} ohne "
 "Angabe."
 
-#: lib/vutuv_web/components/ui.ex:4862
+#: lib/vutuv_web/components/ui.ex:4874
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr "avatar profilbild portrait foto bild geburtstag geburtsdatum geschlecht über mich"
@@ -20737,8 +20738,8 @@ msgstr "Zu viele Versuche. Bitte versuchen Sie es später erneut."
 msgid "New message from %{sender} on vutuv"
 msgstr "Neue Nachricht von %{sender} auf vutuv"
 
-#: lib/vutuv_web/live/message_live/index.ex:160
 #: lib/vutuv_web/live/message_live/index.ex:170
+#: lib/vutuv_web/live/message_live/index.ex:180
 #, elixir-autogen, elixir-format
 msgid "This page cannot receive messages."
 msgstr "Diese Organisation kann keine Nachrichten empfangen."
@@ -20876,22 +20877,22 @@ msgstr "Neu registrieren"
 msgid "The PIN has expired."
 msgstr "Die PIN ist abgelaufen."
 
-#: lib/vutuv_web/components/ui.ex:946
+#: lib/vutuv_web/components/ui.ex:958
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr "Die PIN ist noch eine Minute gültig."
 
-#: lib/vutuv_web/components/ui.ex:948
+#: lib/vutuv_web/components/ui.ex:960
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr "Die PIN ist noch eine Sekunde gültig."
 
-#: lib/vutuv_web/components/ui.ex:947
+#: lib/vutuv_web/components/ui.ex:959
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr "Die PIN ist noch {n} Minuten gültig."
 
-#: lib/vutuv_web/components/ui.ex:949
+#: lib/vutuv_web/components/ui.ex:961
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr "Die PIN ist noch {n} Sekunden gültig."
@@ -21377,7 +21378,7 @@ msgid "Feed language settings reset to the site defaults."
 msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
 
 #: lib/vutuv_web/components/post_components.ex:4755
-#: lib/vutuv_web/components/ui.ex:4945
+#: lib/vutuv_web/components/ui.ex:4957
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -22105,7 +22106,7 @@ msgstr "Wenn etwas eintrifft, während vutuv in einem Tab offen ist, den Sie ger
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr "Sie haben Browser-Benachrichtigungen eingeschaltet. Dieser Browser wurde noch nicht um Erlaubnis gebeten."
 
-#: lib/vutuv_web/components/ui.ex:4929
+#: lib/vutuv_web/components/ui.ex:4941
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr "e-mail email mail abbestellen abmelden newsletter glocke benachrichtigung weniger ruhe browser desktop popup push hinweis mitteilung"
@@ -22156,7 +22157,7 @@ msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public po
 msgstr ""
 "Folgen Sie #%{tag} von Mastodon oder einer anderen Fediverse-App aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3400
+#: lib/vutuv_web/live/post_live/feed.ex:3423
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Andere Mitglieder begrüßen"
@@ -22166,43 +22167,43 @@ msgstr "Andere Mitglieder begrüßen"
 msgid "New here"
 msgstr "Neu dabei"
 
-#: lib/vutuv_web/components/ui.ex:1631
+#: lib/vutuv_web/components/ui.ex:1643
 #, elixir-autogen, elixir-format
 msgid "New public posts arrive in any feed reader. No account needed either."
 msgstr "Neue öffentliche Beiträge landen in jedem Feed-Reader. Auch dafür brauchen Sie kein Konto."
 
-#: lib/vutuv_web/components/ui.ex:1627
+#: lib/vutuv_web/components/ui.ex:1639
 #, elixir-autogen, elixir-format
 msgid "Or with an RSS reader"
 msgstr "Oder mit einem RSS-Reader"
 
-#: lib/vutuv_web/components/ui.ex:1507
-#: lib/vutuv_web/components/ui.ex:1576
+#: lib/vutuv_web/components/ui.ex:1519
+#: lib/vutuv_web/components/ui.ex:1588
 #, elixir-autogen, elixir-format
 msgid "Subscribe"
 msgstr "Abonnieren"
 
-#: lib/vutuv_web/components/ui.ex:1628
+#: lib/vutuv_web/components/ui.ex:1640
 #, elixir-autogen, elixir-format
 msgid "With an RSS reader"
 msgstr "Mit einem RSS-Reader"
 
-#: lib/vutuv_web/components/ui.ex:1588
+#: lib/vutuv_web/components/ui.ex:1600
 #, elixir-autogen, elixir-format
 msgid "Create a free account"
 msgstr "Kostenloses Konto erstellen"
 
-#: lib/vutuv_web/components/ui.ex:1603
+#: lib/vutuv_web/components/ui.ex:1615
 #, elixir-autogen, elixir-format
 msgid "No vutuv account? These ways work too:"
 msgstr "Kein vutuv-Konto? Das geht auch:"
 
-#: lib/vutuv_web/components/ui.ex:1581
+#: lib/vutuv_web/components/ui.ex:1593
 #, elixir-autogen, elixir-format
 msgid "The best way: follow %{name} here. New posts land in your feed, and you can reply and join in."
 msgstr "Der beste Weg: Folgen Sie %{name} hier. Neue Beiträge landen in Ihrem Feed, und Sie können antworten und mitreden."
 
-#: lib/vutuv_web/components/ui.ex:1579
+#: lib/vutuv_web/components/ui.ex:1591
 #, elixir-autogen, elixir-format
 msgid "With a vutuv account"
 msgstr "Mit einem vutuv-Konto"
@@ -22337,12 +22338,12 @@ msgstr "Wird in Ihrem Feed ausgeblendet."
 msgid "Shown in the language it was written in."
 msgstr "Wird in der Sprache gezeigt, in der es geschrieben wurde."
 
-#: lib/vutuv_web/components/ui.ex:4946
+#: lib/vutuv_web/components/ui.ex:4958
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr "Welche Sprachen Sie erreichen und was mit dem Rest geschieht"
 
-#: lib/vutuv_web/components/ui.ex:4948
+#: lib/vutuv_web/components/ui.ex:4960
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr ""
@@ -22485,7 +22486,7 @@ msgstr "Keine bezahlten Premium-Accounts."
 msgid "Your LinkedIn profile can come along."
 msgstr "Ihr LinkedIn-Profil kann mitkommen."
 
-#: lib/vutuv_web/components/ui.ex:1143
+#: lib/vutuv_web/components/ui.ex:1155
 #, elixir-autogen, elixir-format
 msgid "Being checked"
 msgstr "Wird geprüft"
@@ -22750,7 +22751,7 @@ msgstr "Beiträge mit einem dieser Tags werden genauso zugeklappt."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Beiträge mit einem dieser Wörter werden auf eine Zeile zugeklappt — nicht gelöscht, und mit einem Weg, sie doch zu lesen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3426
+#: lib/vutuv_web/live/post_live/feed.ex:3449
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Weggelegt:"
@@ -22827,9 +22828,10 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "und 1 weiterer"
 msgstr[1] "und %{formatted} weitere"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3036
-#: lib/vutuv_web/live/post_live/feed.ex:3474
-#: lib/vutuv_web/live/post_live/feed.ex:3479
+#: lib/vutuv_web/live/post_live/feed.ex:3048
+#: lib/vutuv_web/live/post_live/feed.ex:3075
+#: lib/vutuv_web/live/post_live/feed.ex:3497
+#: lib/vutuv_web/live/post_live/feed.ex:3502
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -22877,7 +22879,7 @@ msgstr ""
 "Ihre Organisationsseite wurde aktualisiert, aber dieses Bild konnte nicht als "
 "Logo verwendet werden. Bitte wählen Sie ein anderes."
 
-#: lib/vutuv_web/components/ui.ex:4202
+#: lib/vutuv_web/components/ui.ex:4214
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -22898,7 +22900,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} Beitrag am %{day}"
 msgstr[1] "%{count} Beiträge am %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3196
+#: lib/vutuv_web/live/post_live/feed.ex:3219
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Zurück zu jetzt"
@@ -22908,7 +22910,7 @@ msgstr "Zurück zu jetzt"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Voller Monat: die Färbung zählt mindestens so viel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3242
+#: lib/vutuv_web/live/post_live/feed.ex:3265
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22930,7 +22932,7 @@ msgstr "Nächster Monat"
 msgid "Next year"
 msgstr "Nächstes Jahr"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3192
+#: lib/vutuv_web/live/post_live/feed.ex:3215
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Am %{day} ist nichts in Ihrem Feed angekommen."
@@ -23075,7 +23077,7 @@ msgstr "Bleibt das Account-Feld leer, gilt die Regel für alle; %{example} grenz
 msgid "Only these accounts (empty = all) …"
 msgstr "Nur diese Accounts (leer = alle) …"
 
-#: lib/vutuv_web/components/ui.ex:3325
+#: lib/vutuv_web/components/ui.ex:3337
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr "nur %{account}"
@@ -23087,55 +23089,55 @@ msgctxt "filter rule"
 msgid "Hide"
 msgstr "Ausblenden"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1356
+#: lib/vutuv_web/live/notification_live/index.ex:1656
 #, elixir-autogen, elixir-format
 msgid "%{formatted} share"
 msgid_plural "%{formatted} shares"
 msgstr[0] "%{formatted} Mal geteilt"
 msgstr[1] "%{formatted} Mal geteilt"
 
-#: lib/vutuv_web/live/notification_live/index.ex:828
+#: lib/vutuv_web/live/notification_live/index.ex:818
 #, elixir-autogen, elixir-format
 msgid "Post without text"
 msgstr "Beitrag ohne Text"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1331
+#: lib/vutuv_web/live/notification_live/index.ex:1563
 #, elixir-autogen, elixir-format
 msgid "likes this."
 msgid_plural "like this."
 msgstr[0] "gefällt das."
 msgstr[1] "gefällt das."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1337
+#: lib/vutuv_web/live/notification_live/index.ex:1569
 #, elixir-autogen, elixir-format
 msgid "reacted to this."
 msgid_plural "reacted to this."
 msgstr[0] "hat darauf reagiert."
 msgstr[1] "haben darauf reagiert."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1322
+#: lib/vutuv_web/live/notification_live/index.ex:1571
 #, elixir-autogen, elixir-format
 msgid "replied."
 msgstr "hat geantwortet."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1334
+#: lib/vutuv_web/live/notification_live/index.ex:1566
 #, elixir-autogen, elixir-format
 msgid "shared this."
 msgid_plural "shared this."
 msgstr[0] "hat das geteilt."
 msgstr[1] "haben das geteilt."
 
-#: lib/vutuv_web/components/ui.ex:554
+#: lib/vutuv_web/components/ui.ex:566
 #, elixir-autogen, elixir-format
 msgid "Editor view"
 msgstr "Ansicht"
 
-#: lib/vutuv_web/components/ui.ex:502
+#: lib/vutuv_web/components/ui.ex:514
 #, elixir-autogen, elixir-format
 msgid "Insert a block"
 msgstr "Block einfügen"
 
-#: lib/vutuv_web/components/ui.ex:514
+#: lib/vutuv_web/components/ui.ex:526
 #, elixir-autogen, elixir-format
 msgid "Nothing matches."
 msgstr "Nichts gefunden."
@@ -23319,7 +23321,7 @@ msgstr "Von diesem Beitrag bleibt nichts übrig."
 msgid "Replace with"
 msgstr "Ersetzen durch"
 
-#: lib/vutuv_web/components/ui.ex:4938
+#: lib/vutuv_web/components/ui.ex:4950
 #, elixir-autogen, elixir-format
 msgid "Rewrite what an account's posts say, for you alone"
 msgstr "Text in den Beiträgen eines Kontos umschreiben, nur für Sie"
@@ -23337,7 +23339,7 @@ msgstr "Regeln, die den Text der Beiträge eines Kontos umschreiben, bevor Sie i
 #: lib/vutuv_web/components/post_components.ex:1366
 #: lib/vutuv_web/components/post_components.ex:2671
 #: lib/vutuv_web/components/post_components.ex:3658
-#: lib/vutuv_web/components/ui.ex:4937
+#: lib/vutuv_web/components/ui.ex:4949
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
 #: lib/vutuv_web/live/post_rewrites_live.ex:264
@@ -23393,7 +23395,7 @@ msgstr "Ihre gespeicherten Regeln ändern diesen Beitrag von %{who} wie gezeigt.
 msgid "\\1 puts back what the first (…) group matched, \\0 the whole match."
 msgstr "\\1 setzt ein, was die erste (…)-Gruppe getroffen hat, \\0 den ganzen Treffer."
 
-#: lib/vutuv_web/components/ui.ex:4939
+#: lib/vutuv_web/components/ui.ex:4951
 #, elixir-autogen, elixir-format
 msgid "regex regular expression rewrite replace footer signature strip"
 msgstr "regex regulärer ausdruck umschreiben ersetzen fußzeile signatur entfernen suchen"
@@ -23403,13 +23405,12 @@ msgstr "regex regulärer ausdruck umschreiben ersetzen fußzeile signatur entfer
 msgid "For members on a slow connection, data-saving mode shows pictures and screenshots in a stronger compression and leaves out a few luxuries, such as the richer editor. Any picture loads in full quality with one tap, and you can switch the mode off at any time."
 msgstr "Für Mitglieder mit langsamer Internetanbindung zeigt der Datensparmodus Bilder und Screenshots stärker komprimiert und verzichtet auf einige Luxusfeatures, zum Beispiel den besseren Editor. Jedes Bild lässt sich mit einem Tipp in voller Qualität laden, und der Modus ist jederzeit abschaltbar."
 
-#: lib/vutuv_web/components/ui.ex:1193
-#: lib/vutuv_web/components/ui.ex:1194
+#: lib/vutuv_web/components/ui.ex:1205
+#: lib/vutuv_web/components/ui.ex:1206
 #, elixir-autogen, elixir-format
 msgid "Load this picture in full quality"
 msgstr "Dieses Bild in voller Qualität laden"
 
-#: lib/vutuv_web/components/ui.ex:4962
 #: lib/vutuv_web/components/ui.ex:5007
 #, elixir-autogen, elixir-format
 msgid "Smaller pictures and a plain composer on a slow connection"
@@ -23420,7 +23421,6 @@ msgstr "Kleinere Bilder und ein einfacher Editor bei langsamer Verbindung"
 msgid "That endorsement is not possible."
 msgstr "Diese Empfehlung ist nicht möglich."
 
-#: lib/vutuv_web/components/ui.ex:4964
 #: lib/vutuv_web/components/ui.ex:5009
 #, elixir-autogen, elixir-format
 msgid "bandwidth slow internet mobile data saving saver volume metered compression pictures images screenshots editor langsam daten sparen datensparmodus volumen schmalband komprimierung bilder"
@@ -23430,3 +23430,69 @@ msgstr "bandbreite langsam internet mobil daten sparen datensparmodus volumen sc
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr "Darstellung"
+
+#: lib/vutuv_web/live/notification_live/index.ex:1433
+#, elixir-autogen, elixir-format
+msgid "%{formatted} connection"
+msgid_plural "%{formatted} connections"
+msgstr[0] "%{formatted} Vernetzung"
+msgstr[1] "%{formatted} Vernetzungen"
+
+#: lib/vutuv_web/live/notification_live/index.ex:1674
+#, elixir-autogen, elixir-format
+msgid "%{formatted} new connection"
+msgid_plural "%{formatted} new connections"
+msgstr[0] "%{formatted} neue Vernetzung"
+msgstr[1] "%{formatted} neue Vernetzungen"
+
+#: lib/vutuv_web/live/notification_live/index.ex:1678
+#, elixir-autogen, elixir-format
+msgid "%{formatted} new follower"
+msgid_plural "%{formatted} new followers"
+msgstr[0] "%{formatted} neuer Follower"
+msgstr[1] "%{formatted} neue Follower"
+
+#: lib/vutuv_web/live/notification_live/index.ex:1442
+#, elixir-autogen, elixir-format
+msgid "Last 30 days: %{parts}"
+msgstr "Letzte 30 Tage: %{parts}"
+
+#: lib/vutuv_web/live/notification_live/index.ex:1003
+#, elixir-autogen, elixir-format
+msgid "Less"
+msgstr "Weniger"
+
+#: lib/vutuv_web/live/notification_live/index.ex:1342
+#, elixir-autogen, elixir-format
+msgid "Reactions"
+msgstr "Reaktionen"
+
+#: lib/vutuv_web/live/notification_live/index.ex:511
+#, elixir-autogen, elixir-format
+msgid "Seen before"
+msgstr "Bereits gesehen"
+
+#: lib/vutuv_web/live/notification_live/index.ex:623
+#, elixir-autogen, elixir-format
+msgid "Show %{formatted} more"
+msgstr "%{formatted} weitere anzeigen"
+
+#: lib/vutuv_web/live/notification_live/index.ex:825
+#, elixir-autogen, elixir-format
+msgid "The post is no longer available."
+msgstr "Der Beitrag ist nicht mehr verfügbar."
+
+#: lib/vutuv_web/live/notification_live/index.ex:1634
+#, elixir-autogen, elixir-format
+msgid "Thread by %{name}"
+msgstr "Thread von %{name}"
+
+#: lib/vutuv_web/live/notification_live/index.ex:1573
+#, elixir-autogen, elixir-format
+msgid "mentioned you."
+msgstr "hat Sie erwähnt."
+
+#: lib/vutuv_web/live/notification_live/index.ex:1572
+#, elixir-autogen, elixir-format
+msgid "replied in the thread."
+msgstr "hat im Thread geantwortet."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -17,8 +17,8 @@ msgstr ""
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4586
-#: lib/vutuv_web/components/ui.ex:4591
+#: lib/vutuv_web/components/ui.ex:4598
+#: lib/vutuv_web/components/ui.ex:4603
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
 #: lib/vutuv_web/live/organization_live/domains.ex:267
@@ -64,7 +64,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/text.ex:71
-#: lib/vutuv_web/components/ui.ex:4904
+#: lib/vutuv_web/components/ui.ex:4916
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -77,14 +77,14 @@ msgstr ""
 msgid "Addresses"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1594
+#: lib/vutuv_web/components/ui.ex:1606
 #: lib/vutuv_web/templates/page/index.html.heex:325
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4377
-#: lib/vutuv_web/components/ui.ex:4476
+#: lib/vutuv_web/components/ui.ex:4389
+#: lib/vutuv_web/components/ui.ex:4488
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -112,7 +112,7 @@ msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:104
-#: lib/vutuv_web/components/ui.ex:4371
+#: lib/vutuv_web/components/ui.ex:4383
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
 #: lib/vutuv_web/live/admin/user_delete_live.ex:202
@@ -163,7 +163,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3635
-#: lib/vutuv_web/components/ui.ex:4478
+#: lib/vutuv_web/components/ui.ex:4490
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:657
@@ -211,7 +211,7 @@ msgid "Download"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3600
-#: lib/vutuv_web/components/ui.ex:4469
+#: lib/vutuv_web/components/ui.ex:4481
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
@@ -285,7 +285,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:4868
+#: lib/vutuv_web/components/ui.ex:4880
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -315,7 +315,6 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:595
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
-#: lib/vutuv_web/live/notification_live/index.ex:1207
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:27
@@ -326,8 +325,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:632
 #: lib/vutuv_web/agent_docs/text.ex:596
 #: lib/vutuv_web/components/fediverse_components.ex:468
-#: lib/vutuv_web/components/ui.ex:2871
-#: lib/vutuv_web/components/ui.ex:2906
+#: lib/vutuv_web/components/ui.ex:2883
+#: lib/vutuv_web/components/ui.ex:2918
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:608
@@ -454,7 +453,7 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1132
+#: lib/vutuv_web/live/notification_live/index.ex:1344
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:193
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:201
 #, elixir-autogen
@@ -474,7 +473,7 @@ msgid "Name"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:723
-#: lib/vutuv_web/live/notification_live/index.ex:743
+#: lib/vutuv_web/live/notification_live/index.ex:774
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
@@ -613,7 +612,7 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4370
+#: lib/vutuv_web/components/ui.ex:4382
 #: lib/vutuv_web/live/organization_live/edit.ex:367
 #: lib/vutuv_web/live/post_live/composer.ex:1937
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -788,13 +787,13 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4864
+#: lib/vutuv_web/components/ui.ex:4876
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:832
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
 #: lib/vutuv_web/live/directory_search_live.ex:134
-#: lib/vutuv_web/live/notification_live/index.ex:1286
+#: lib/vutuv_web/live/notification_live/index.ex:1522
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:51
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -840,7 +839,7 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1401
+#: lib/vutuv_web/components/ui.ex:1413
 #: lib/vutuv_web/views/user_html.ex:562
 #: lib/vutuv_web/views/user_html.ex:563
 #: lib/vutuv_web/views/user_html.ex:577
@@ -848,7 +847,7 @@ msgstr ""
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4539
+#: lib/vutuv_web/components/ui.ex:4551
 #: lib/vutuv_web/templates/user/show.html.heex:981
 #: lib/vutuv_web/templates/user/show.html.heex:1004
 #, elixir-autogen
@@ -1375,7 +1374,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:522
 #: lib/vutuv_web/agent_docs/text.ex:768
-#: lib/vutuv_web/components/ui.ex:4889
+#: lib/vutuv_web/components/ui.ex:4901
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1616,7 +1615,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3030
+#: lib/vutuv_web/components/ui.ex:3042
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:477
 #: lib/vutuv_web/live/admin/organization_live.ex:296
@@ -1673,20 +1672,20 @@ msgstr ""
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2113
-#: lib/vutuv_web/components/ui.ex:2122
-#: lib/vutuv_web/components/ui.ex:2600
+#: lib/vutuv_web/components/ui.ex:2125
+#: lib/vutuv_web/components/ui.ex:2134
+#: lib/vutuv_web/components/ui.ex:2612
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:244
-#: lib/vutuv_web/components/ui.ex:2836
-#: lib/vutuv_web/components/ui.ex:2836
-#: lib/vutuv_web/components/ui.ex:2853
-#: lib/vutuv_web/components/ui.ex:2862
-#: lib/vutuv_web/components/ui.ex:2878
-#: lib/vutuv_web/components/ui.ex:2940
+#: lib/vutuv_web/components/ui.ex:2848
+#: lib/vutuv_web/components/ui.ex:2848
+#: lib/vutuv_web/components/ui.ex:2865
+#: lib/vutuv_web/components/ui.ex:2874
+#: lib/vutuv_web/components/ui.ex:2890
+#: lib/vutuv_web/components/ui.ex:2952
 #: lib/vutuv_web/live/fediverse_account_live.ex:400
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:312
@@ -1724,7 +1723,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
 #: lib/vutuv_web/live/admin/user_delete_live.ex:143
 #: lib/vutuv_web/live/admin/user_live.ex:154
-#: lib/vutuv_web/live/message_live/index.ex:538
+#: lib/vutuv_web/live/message_live/index.ex:548
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:32
 #: lib/vutuv_web/templates/admin/account/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:28
@@ -1743,7 +1742,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/page_controller.ex:228
 #: lib/vutuv_web/live/message_live/index.ex:49
-#: lib/vutuv_web/live/message_live/index.ex:624
+#: lib/vutuv_web/live/message_live/index.ex:634
 #: lib/vutuv_web/live/shell_live.ex:1249
 #: lib/vutuv_web/live/shell_live.ex:1427
 #: lib/vutuv_web/templates/layout/app.html.heex:152
@@ -1758,7 +1757,7 @@ msgid "Network"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:459
-#: lib/vutuv_web/components/ui.ex:4588
+#: lib/vutuv_web/components/ui.ex:4600
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
@@ -1768,16 +1767,16 @@ msgstr ""
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:437
+#: lib/vutuv_web/live/notification_live/index.ex:528
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr ""
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:4926
+#: lib/vutuv_web/components/ui.ex:4938
 #: lib/vutuv_web/controllers/page_controller.ex:229
-#: lib/vutuv_web/live/notification_live/index.ex:147
-#: lib/vutuv_web/live/notification_live/index.ex:385
+#: lib/vutuv_web/live/notification_live/index.ex:156
+#: lib/vutuv_web/live/notification_live/index.ex:450
 #: lib/vutuv_web/live/shell_live.ex:1261
 #: lib/vutuv_web/templates/layout/app.html.heex:153
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
@@ -1800,7 +1799,7 @@ msgid "Pardon us! Something went wrong."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:902
+#: lib/vutuv_web/live/message_live/index.ex:912
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
@@ -1874,8 +1873,8 @@ msgstr ""
 msgid "Who to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:891
-#: lib/vutuv_web/live/message_live/index.ex:892
+#: lib/vutuv_web/live/message_live/index.ex:901
+#: lib/vutuv_web/live/message_live/index.ex:902
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr ""
@@ -1920,14 +1919,14 @@ msgstr ""
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3871
-#: lib/vutuv_web/components/ui.ex:4016
+#: lib/vutuv_web/components/ui.ex:3883
+#: lib/vutuv_web/components/ui.ex:4028
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4613
+#: lib/vutuv_web/components/ui.ex:4625
 #: lib/vutuv_web/live/organization_live/activity.ex:151
 #: lib/vutuv_web/live/organization_live/feed.ex:209
 #: lib/vutuv_web/live/organization_live/show.ex:777
@@ -1940,13 +1939,13 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4380
+#: lib/vutuv_web/components/ui.ex:4392
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1794
-#: lib/vutuv_web/components/ui.ex:1804
+#: lib/vutuv_web/components/ui.ex:1806
+#: lib/vutuv_web/components/ui.ex:1816
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr ""
@@ -1985,12 +1984,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3384
+#: lib/vutuv_web/components/ui.ex:3396
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3388
+#: lib/vutuv_web/components/ui.ex:3400
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -2015,37 +2014,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3392
+#: lib/vutuv_web/components/ui.ex:3404
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3382
+#: lib/vutuv_web/components/ui.ex:3394
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3381
+#: lib/vutuv_web/components/ui.ex:3393
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3387
+#: lib/vutuv_web/components/ui.ex:3399
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3386
+#: lib/vutuv_web/components/ui.ex:3398
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3383
+#: lib/vutuv_web/components/ui.ex:3395
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3385
+#: lib/vutuv_web/components/ui.ex:3397
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2060,17 +2059,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3391
+#: lib/vutuv_web/components/ui.ex:3403
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3390
+#: lib/vutuv_web/components/ui.ex:3402
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3389
+#: lib/vutuv_web/components/ui.ex:3401
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2170,7 +2169,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3216
+#: lib/vutuv_web/live/post_live/feed.ex:3239
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2209,7 +2208,6 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:109
 #: lib/vutuv_web/live/admin/dashboard_live.ex:172
 #: lib/vutuv_web/live/fediverse_account_live.ex:407
-#: lib/vutuv_web/live/notification_live/index.ex:1130
 #: lib/vutuv_web/live/organization_live/show.ex:700
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:348
@@ -2343,7 +2341,7 @@ msgstr ""
 msgid "people you don't follow"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3462
+#: lib/vutuv_web/components/ui.ex:3474
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
@@ -2381,7 +2379,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2028
 #: lib/vutuv_web/components/post_components.ex:5593
-#: lib/vutuv_web/components/ui.ex:3938
+#: lib/vutuv_web/components/ui.ex:3950
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2400,8 +2398,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1981
 #: lib/vutuv_web/components/post_components.ex:5831
-#: lib/vutuv_web/components/ui.ex:3924
-#: lib/vutuv_web/live/notification_live/index.ex:1276
+#: lib/vutuv_web/components/ui.ex:3936
+#: lib/vutuv_web/live/notification_live/index.ex:1511
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2409,7 +2407,6 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1144
 #: lib/vutuv_web/components/post_components.ex:5841
-#: lib/vutuv_web/live/notification_live/index.ex:1209
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
 #: lib/vutuv_web/live/shell_live.ex:1312
@@ -2472,9 +2469,9 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:498
 #: lib/vutuv_web/components/post_components.ex:2663
-#: lib/vutuv_web/components/ui.ex:2831
-#: lib/vutuv_web/components/ui.ex:2831
-#: lib/vutuv_web/components/ui.ex:2907
+#: lib/vutuv_web/components/ui.ex:2843
+#: lib/vutuv_web/components/ui.ex:2843
+#: lib/vutuv_web/components/ui.ex:2919
 #: lib/vutuv_web/live/organization_live/following.ex:384
 #: lib/vutuv_web/live/organization_live/following.ex:468
 #: lib/vutuv_web/live/organization_live/show.ex:611
@@ -2497,7 +2494,7 @@ msgid "Only public posts can be answered."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:417
-#: lib/vutuv_web/live/notification_live/index.ex:1210
+#: lib/vutuv_web/live/notification_live/index.ex:1341
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
@@ -2505,7 +2502,8 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1994
 #: lib/vutuv_web/components/post_components.ex:5868
 #: lib/vutuv_web/components/post_components.ex:5869
-#: lib/vutuv_web/live/notification_live/index.ex:1273
+#: lib/vutuv_web/live/notification_live/index.ex:993
+#: lib/vutuv_web/live/notification_live/index.ex:1508
 #: lib/vutuv_web/live/post_live/reply.ex:46
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2552,89 +2550,89 @@ msgstr ""
 msgid "Replying to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:603
+#: lib/vutuv_web/live/message_live/index.ex:613
 #, elixir-autogen, elixir-format
 msgid "%{names} are typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:602
+#: lib/vutuv_web/live/message_live/index.ex:612
 #, elixir-autogen, elixir-format
 msgid "%{name} is typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:914
+#: lib/vutuv_web/live/message_live/index.ex:924
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:865
+#: lib/vutuv_web/live/message_live/index.ex:875
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to message you."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:591
+#: lib/vutuv_web/live/message_live/index.ex:601
 #, elixir-autogen, elixir-format
 msgid "Accept"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:728
+#: lib/vutuv_web/live/message_live/index.ex:738
 #, elixir-autogen, elixir-format
 msgid "Back to conversations"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:593
+#: lib/vutuv_web/live/message_live/index.ex:603
 #, elixir-autogen, elixir-format
 msgid "Decline"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:534
+#: lib/vutuv_web/live/message_live/index.ex:544
 #, elixir-autogen, elixir-format
 msgid "Deleted account"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:774
+#: lib/vutuv_web/live/message_live/index.ex:784
 #, elixir-autogen, elixir-format
 msgid "Load older messages"
 msgstr ""
 
 #: lib/vutuv_web/controllers/admin/tag_member_controller.ex:55
-#: lib/vutuv_web/live/message_live/index.ex:132
+#: lib/vutuv_web/live/message_live/index.ex:142
 #, elixir-autogen, elixir-format
 msgid "Member not found."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:707
+#: lib/vutuv_web/live/message_live/index.ex:717
 #, elixir-autogen, elixir-format
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3154
-#: lib/vutuv_web/live/message_live/index.ex:750
+#: lib/vutuv_web/components/ui.ex:3166
+#: lib/vutuv_web/live/message_live/index.ex:760
 #, elixir-autogen, elixir-format
 msgid "Online"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:656
+#: lib/vutuv_web/live/message_live/index.ex:666
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:923
+#: lib/vutuv_web/live/message_live/index.ex:933
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:147
+#: lib/vutuv_web/live/message_live/index.ex:157
 #, elixir-autogen, elixir-format
 msgid "This member cannot receive messages."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:239
+#: lib/vutuv_web/live/message_live/index.ex:249
 #, elixir-autogen, elixir-format
 msgid "This message could not be sent."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:142
+#: lib/vutuv_web/live/message_live/index.ex:152
 #, elixir-autogen, elixir-format
 msgid "Too many new conversations. Please try again later."
 msgstr ""
@@ -2695,7 +2693,7 @@ msgstr ""
 msgid "Okay, let's start over."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:850
+#: lib/vutuv_web/components/ui.ex:862
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr ""
@@ -2706,7 +2704,7 @@ msgstr ""
 msgid "Too many PIN requests. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:871
+#: lib/vutuv_web/components/ui.ex:883
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr ""
@@ -2756,8 +2754,8 @@ msgstr ""
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4104
-#: lib/vutuv_web/components/ui.ex:4541
+#: lib/vutuv_web/components/ui.ex:4116
+#: lib/vutuv_web/components/ui.ex:4553
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:109
@@ -2803,13 +2801,12 @@ msgstr[1] ""
 #: lib/vutuv_web/agent_docs/markdown.ex:633
 #: lib/vutuv_web/agent_docs/text.ex:597
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:1208
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1392
+#: lib/vutuv_web/components/ui.ex:1404
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2819,7 +2816,7 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1408
+#: lib/vutuv_web/components/ui.ex:1420
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
@@ -2829,7 +2826,7 @@ msgstr ""
 msgid "People who aren't my connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1393
+#: lib/vutuv_web/components/ui.ex:1405
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -2852,29 +2849,29 @@ msgstr[1] ""
 msgid "people who aren't your connections"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:708
+#: lib/vutuv_web/live/message_live/index.ex:718
 #, elixir-autogen, elixir-format
 msgid "Open someone's profile to message them."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:259
-#: lib/vutuv_web/live/notification_live/index.ex:1288
+#: lib/vutuv_web/live/notification_live/index.ex:1524
 #: lib/vutuv_web/live/organization_live/activity.ex:104
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1279
+#: lib/vutuv_web/live/notification_live/index.ex:1515
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1272
+#: lib/vutuv_web/live/notification_live/index.ex:1507
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1271
+#: lib/vutuv_web/live/notification_live/index.ex:1506
 #: lib/vutuv_web/templates/user/show.html.heex:965
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -3018,7 +3015,7 @@ msgstr ""
 msgid "Hidden. You can settle this yourself - see below."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:803
+#: lib/vutuv_web/live/message_live/index.ex:813
 #, elixir-autogen, elixir-format
 msgid "Hidden: reported, under review"
 msgstr ""
@@ -3030,7 +3027,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1280
+#: lib/vutuv_web/live/notification_live/index.ex:1516
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3159,7 +3156,7 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4858
+#: lib/vutuv_web/components/ui.ex:4870
 #: lib/vutuv_web/live/shell_live.ex:1125
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3214,8 +3211,8 @@ msgstr ""
 msgid "Report this content"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:821
-#: lib/vutuv_web/live/message_live/index.ex:822
+#: lib/vutuv_web/live/message_live/index.ex:831
+#: lib/vutuv_web/live/message_live/index.ex:832
 #, elixir-autogen, elixir-format
 msgid "Report this message"
 msgstr ""
@@ -3269,7 +3266,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3811
+#: lib/vutuv_web/components/ui.ex:3823
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3677,7 +3674,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1282
+#: lib/vutuv_web/live/notification_live/index.ex:1518
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3932,6 +3929,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:137
 #: lib/vutuv_web/live/admin/screenshot_live.ex:380
 #: lib/vutuv_web/live/admin/screenshot_live.ex:389
+#: lib/vutuv_web/live/notification_live/index.ex:1637
 #: lib/vutuv_web/templates/post/show.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "Post by %{name}"
@@ -4343,12 +4341,12 @@ msgstr ""
 msgid "Bookings are open through %{last}. Next available day: %{day}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3414
+#: lib/vutuv_web/components/ui.ex:3426
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3410
+#: lib/vutuv_web/components/ui.ex:3422
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr ""
@@ -4358,27 +4356,27 @@ msgstr ""
 msgid "One ad per calendar day: pick a free day in the calendar; struck-through days are already booked."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3415
+#: lib/vutuv_web/components/ui.ex:3427
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3416
+#: lib/vutuv_web/components/ui.ex:3428
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3413
+#: lib/vutuv_web/components/ui.ex:3425
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3411
+#: lib/vutuv_web/components/ui.ex:3423
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3412
+#: lib/vutuv_web/components/ui.ex:3424
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr ""
@@ -4552,12 +4550,12 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3221
+#: lib/vutuv_web/live/post_live/feed.ex:3244
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:711
+#: lib/vutuv_web/live/message_live/index.ex:721
 #, elixir-autogen, elixir-format
 msgid "Find members"
 msgstr ""
@@ -4609,7 +4607,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:444
 #: lib/vutuv_web/agent_docs/text.ex:463
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/live/notification_live/index.ex:1131
+#: lib/vutuv_web/live/notification_live/index.ex:646
+#: lib/vutuv_web/live/notification_live/index.ex:1343
 #: lib/vutuv_web/live/organization_live/show.ex:787
 #: lib/vutuv_web/live/post_live/saved.ex:523
 #: lib/vutuv_web/live/search_live.ex:346
@@ -4633,7 +4632,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
-#: lib/vutuv_web/live/notification_live/index.ex:1129
+#: lib/vutuv_web/live/notification_live/index.ex:1340
 #: lib/vutuv_web/live/search_live.ex:345
 #: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
@@ -5431,7 +5430,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:3727
 #: lib/vutuv_web/components/post_components.ex:3782
 #: lib/vutuv_web/components/post_components.ex:4190
-#: lib/vutuv_web/live/notification_live/index.ex:785
+#: lib/vutuv_web/live/notification_live/index.ex:1072
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5497,7 +5496,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4896
+#: lib/vutuv_web/components/ui.ex:4908
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5559,7 +5558,7 @@ msgstr ""
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:622
+#: lib/vutuv_web/live/notification_live/index.ex:1631
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
@@ -5652,7 +5651,6 @@ msgid "Apps & API"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:1211
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -5730,7 +5728,7 @@ msgstr ""
 msgid "@handle"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:766
+#: lib/vutuv_web/live/message_live/index.ex:776
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}"
 msgstr ""
@@ -5850,21 +5848,21 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3471
+#: lib/vutuv_web/components/ui.ex:3483
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3470
+#: lib/vutuv_web/components/ui.ex:3482
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3469
+#: lib/vutuv_web/components/ui.ex:3481
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -5931,7 +5929,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3468
+#: lib/vutuv_web/components/ui.ex:3480
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -6073,7 +6071,7 @@ msgstr ""
 msgid "Tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:468
+#: lib/vutuv_web/components/ui.ex:480
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:915
@@ -6260,9 +6258,9 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2113
-#: lib/vutuv_web/components/ui.ex:2122
-#: lib/vutuv_web/components/ui.ex:2601
+#: lib/vutuv_web/components/ui.ex:2125
+#: lib/vutuv_web/components/ui.ex:2134
+#: lib/vutuv_web/components/ui.ex:2613
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6323,11 +6321,11 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2554
-#: lib/vutuv_web/live/notification_live/index.ex:685
-#: lib/vutuv_web/live/notification_live/index.ex:700
-#: lib/vutuv_web/live/notification_live/index.ex:1013
-#: lib/vutuv_web/live/notification_live/index.ex:1015
+#: lib/vutuv_web/components/ui.ex:2566
+#: lib/vutuv_web/live/notification_live/index.ex:716
+#: lib/vutuv_web/live/notification_live/index.ex:731
+#: lib/vutuv_web/live/notification_live/index.ex:1225
+#: lib/vutuv_web/live/notification_live/index.ex:1227
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
@@ -6620,7 +6618,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2643
 #: lib/vutuv_web/components/post_components.ex:3652
-#: lib/vutuv_web/components/ui.ex:2979
+#: lib/vutuv_web/components/ui.ex:2991
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/live/organization_live/following.ex:377
 #: lib/vutuv_web/live/organization_live/following.ex:461
@@ -6648,7 +6646,7 @@ msgid "Remove this connection? You will stop following them."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3652
-#: lib/vutuv_web/components/ui.ex:2978
+#: lib/vutuv_web/components/ui.ex:2990
 #: lib/vutuv_web/live/fediverse_account_live.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:377
 #: lib/vutuv_web/live/organization_live/following.ex:461
@@ -7248,13 +7246,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3880
+#: lib/vutuv_web/components/ui.ex:3892
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3892
+#: lib/vutuv_web/components/ui.ex:3904
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7438,7 +7436,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3487
+#: lib/vutuv_web/live/post_live/feed.ex:3510
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #, elixir-autogen
 msgid "Done"
@@ -7722,13 +7720,13 @@ msgstr ""
 #: lib/vutuv_web/components/job_components.ex:219
 #: lib/vutuv_web/live/admin/dashboard_live.ex:304
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:468
-#: lib/vutuv_web/live/notification_live/index.ex:1158
+#: lib/vutuv_web/live/notification_live/index.ex:1378
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:308
-#: lib/vutuv_web/live/notification_live/index.ex:1161
+#: lib/vutuv_web/live/notification_live/index.ex:1381
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -8003,7 +8001,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3883
+#: lib/vutuv_web/components/ui.ex:3895
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8133,7 +8131,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:4872
+#: lib/vutuv_web/components/ui.ex:4884
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8217,7 +8215,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4900
+#: lib/vutuv_web/components/ui.ex:4912
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8311,7 +8309,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4156
+#: lib/vutuv_web/components/ui.ex:4168
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8386,7 +8384,7 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4860
+#: lib/vutuv_web/components/ui.ex:4872
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
@@ -8523,7 +8521,7 @@ msgstr[1] ""
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1410
+#: lib/vutuv_web/components/ui.ex:1422
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -8619,7 +8617,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:586
 #: lib/vutuv_web/agent_docs/text.ex:590
 #: lib/vutuv_web/components/organization_components.ex:276
-#: lib/vutuv_web/components/ui.ex:1611
+#: lib/vutuv_web/components/ui.ex:1623
 #: lib/vutuv_web/components/ui.ex:5032
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:357
@@ -8770,7 +8768,7 @@ msgstr ""
 msgid "This is the print view of this CV. Use your browser's print dialog (Ctrl+P or Cmd+P) and choose \"Save as PDF\" to get a PDF file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1700
+#: lib/vutuv_web/components/ui.ex:1712
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr ""
@@ -8808,7 +8806,7 @@ msgstr ""
 msgid "Header"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1710
+#: lib/vutuv_web/components/ui.ex:1722
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -8840,7 +8838,7 @@ msgstr ""
 msgid "The CV is public, on your profile: a visitor's download contains only what they can see there anyway, and private email addresses appear only in your own."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1702
+#: lib/vutuv_web/components/ui.ex:1714
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -8994,8 +8992,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2157
-#: lib/vutuv_web/components/ui.ex:2158
+#: lib/vutuv_web/components/ui.ex:2169
+#: lib/vutuv_web/components/ui.ex:2170
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9564,7 +9562,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:4876
+#: lib/vutuv_web/components/ui.ex:4888
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -9760,13 +9758,13 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3584
+#: lib/vutuv_web/components/ui.ex:3596
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3583
-#: lib/vutuv_web/components/ui.ex:3591
+#: lib/vutuv_web/components/ui.ex:3595
+#: lib/vutuv_web/components/ui.ex:3603
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -9940,17 +9938,17 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:456
+#: lib/vutuv_web/components/ui.ex:468
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:508
+#: lib/vutuv_web/components/ui.ex:520
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:511
+#: lib/vutuv_web/components/ui.ex:523
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr ""
@@ -9970,8 +9968,8 @@ msgstr ""
 msgid "Formatting"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:575
-#: lib/vutuv_web/components/ui.ex:576
+#: lib/vutuv_web/components/ui.ex:587
+#: lib/vutuv_web/components/ui.ex:588
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr ""
@@ -9986,22 +9984,24 @@ msgstr ""
 msgid "Generate code list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:506
+#: lib/vutuv_web/components/ui.ex:461
+#: lib/vutuv_web/components/ui.ex:518
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:507
+#: lib/vutuv_web/components/ui.ex:464
+#: lib/vutuv_web/components/ui.ex:519
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:465
+#: lib/vutuv_web/components/ui.ex:477
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:459
+#: lib/vutuv_web/components/ui.ex:471
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr ""
@@ -10022,7 +10022,7 @@ msgstr ""
 msgid "Not set up."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:509
+#: lib/vutuv_web/components/ui.ex:521
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr ""
@@ -10037,7 +10037,7 @@ msgstr ""
 msgid "Print this page or write the codes down. Crossed-out codes have been used."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:510
+#: lib/vutuv_web/components/ui.ex:522
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr ""
@@ -10058,7 +10058,7 @@ msgstr ""
 msgid "Set up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:462
+#: lib/vutuv_web/components/ui.ex:474
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr ""
@@ -10165,6 +10165,7 @@ msgid_plural "%{count} stars"
 msgstr[0] ""
 msgstr[1] ""
 
+#: lib/vutuv_web/live/notification_live/index.ex:1429
 #: lib/vutuv_web/live/organization_live/show.ex:638
 #: lib/vutuv_web/views/user_html.ex:950
 #: lib/vutuv_web/views/user_html.ex:1126
@@ -11062,12 +11063,12 @@ msgstr ""
 msgid "State / region (optional)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4210
+#: lib/vutuv_web/components/ui.ex:4222
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4212
+#: lib/vutuv_web/components/ui.ex:4224
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr ""
@@ -11487,7 +11488,7 @@ msgstr ""
 msgid "The link text can be anything. A hidden <link rel=\"me\"> in the page head works too."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1073
+#: lib/vutuv_web/components/ui.ex:1085
 #: lib/vutuv_web/live/section_reorder_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -11742,7 +11743,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1283
+#: lib/vutuv_web/live/notification_live/index.ex:1519
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -13239,7 +13240,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1281
+#: lib/vutuv_web/live/notification_live/index.ex:1517
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13326,7 +13327,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1284
+#: lib/vutuv_web/live/notification_live/index.ex:1520
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13343,27 +13344,27 @@ msgstr[1] ""
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:485
+#: lib/vutuv_web/components/ui.ex:497
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:482
+#: lib/vutuv_web/components/ui.ex:494
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:488
+#: lib/vutuv_web/components/ui.ex:500
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:479
+#: lib/vutuv_web/components/ui.ex:491
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:512
+#: lib/vutuv_web/components/ui.ex:524
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr ""
@@ -13425,7 +13426,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4952
+#: lib/vutuv_web/components/ui.ex:4964
 #: lib/vutuv_web/controllers/settings_controller.ex:634
 #: lib/vutuv_web/live/post_live/feed.ex:720
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13500,7 +13501,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:63
-#: lib/vutuv_web/components/ui.ex:4919
+#: lib/vutuv_web/components/ui.ex:4931
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13528,19 +13529,19 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4295
+#: lib/vutuv_web/components/ui.ex:4307
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:4305
+#: lib/vutuv_web/components/ui.ex:4317
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1285
+#: lib/vutuv_web/live/notification_live/index.ex:1521
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
@@ -13711,45 +13712,40 @@ msgstr ""
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1150
+#: lib/vutuv_web/live/notification_live/index.ex:1370
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1164
+#: lib/vutuv_web/live/notification_live/index.ex:1384
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:454
+#: lib/vutuv_web/live/notification_live/index.ex:545
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:469
-#, elixir-autogen, elixir-format
-msgid "Last 30 days"
-msgstr ""
-
-#: lib/vutuv_web/live/notification_live/index.ex:1116
-#: lib/vutuv_web/live/notification_live/index.ex:1382
+#: lib/vutuv_web/live/notification_live/index.ex:1327
+#: lib/vutuv_web/live/notification_live/index.ex:1700
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1302
+#: lib/vutuv_web/live/notification_live/index.ex:1608
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1299
+#: lib/vutuv_web/live/notification_live/index.ex:1605
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1308
+#: lib/vutuv_web/live/notification_live/index.ex:1614
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
@@ -13759,12 +13755,12 @@ msgstr ""
 msgid "by:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2291
+#: lib/vutuv_web/components/ui.ex:2303
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2295
+#: lib/vutuv_web/components/ui.ex:2307
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -13993,7 +13989,7 @@ msgstr ""
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1274
+#: lib/vutuv_web/live/notification_live/index.ex:1509
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
@@ -14021,7 +14017,7 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1275
+#: lib/vutuv_web/live/notification_live/index.ex:1510
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
@@ -14280,6 +14276,8 @@ msgstr ""
 msgid "as an account alias."
 msgstr ""
 
+#: lib/vutuv_web/live/notification_live/index.ex:1437
+#: lib/vutuv_web/live/notification_live/index.ex:1682
 #: lib/vutuv_web/templates/user_tag/show.html.heex:24
 #, elixir-autogen, elixir-format
 msgid "%{formatted} endorsement"
@@ -14317,7 +14315,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4933
+#: lib/vutuv_web/components/ui.ex:4945
 #: lib/vutuv_web/controllers/settings_controller.ex:700
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -14365,7 +14363,7 @@ msgstr ""
 msgid "Thread replies"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:663
+#: lib/vutuv_web/live/notification_live/index.ex:1022
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr ""
@@ -14416,7 +14414,7 @@ msgstr ""
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:658
+#: lib/vutuv_web/live/notification_live/index.ex:1017
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr ""
@@ -14950,67 +14948,67 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4861
+#: lib/vutuv_web/components/ui.ex:4873
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4866
+#: lib/vutuv_web/components/ui.ex:4878
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4869
+#: lib/vutuv_web/components/ui.ex:4881
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4870
+#: lib/vutuv_web/components/ui.ex:4882
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4873
+#: lib/vutuv_web/components/ui.ex:4885
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4874
+#: lib/vutuv_web/components/ui.ex:4886
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4877
+#: lib/vutuv_web/components/ui.ex:4889
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4878
+#: lib/vutuv_web/components/ui.ex:4890
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4885
+#: lib/vutuv_web/components/ui.ex:4897
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4886
+#: lib/vutuv_web/components/ui.ex:4898
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4887
+#: lib/vutuv_web/components/ui.ex:4899
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4890
+#: lib/vutuv_web/components/ui.ex:4902
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4891
+#: lib/vutuv_web/components/ui.ex:4903
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
@@ -15025,107 +15023,107 @@ msgstr ""
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4894
+#: lib/vutuv_web/components/ui.ex:4906
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4897
+#: lib/vutuv_web/components/ui.ex:4909
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4898
+#: lib/vutuv_web/components/ui.ex:4910
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4901
+#: lib/vutuv_web/components/ui.ex:4913
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4902
+#: lib/vutuv_web/components/ui.ex:4914
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4905
+#: lib/vutuv_web/components/ui.ex:4917
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4906
+#: lib/vutuv_web/components/ui.ex:4918
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4908
+#: lib/vutuv_web/components/ui.ex:4920
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4909
+#: lib/vutuv_web/components/ui.ex:4921
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4910
+#: lib/vutuv_web/components/ui.ex:4922
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4912
+#: lib/vutuv_web/components/ui.ex:4924
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4913
+#: lib/vutuv_web/components/ui.ex:4925
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4915
+#: lib/vutuv_web/components/ui.ex:4927
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4920
+#: lib/vutuv_web/components/ui.ex:4932
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4921
+#: lib/vutuv_web/components/ui.ex:4933
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4924
+#: lib/vutuv_web/components/ui.ex:4936
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4927
+#: lib/vutuv_web/components/ui.ex:4939
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4934
+#: lib/vutuv_web/components/ui.ex:4946
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4935
+#: lib/vutuv_web/components/ui.ex:4947
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4953
+#: lib/vutuv_web/components/ui.ex:4965
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4954
+#: lib/vutuv_web/components/ui.ex:4966
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
@@ -15304,7 +15302,8 @@ msgid "Your public posts are copied to other servers. Once a copy is there we ca
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:5786
-#: lib/vutuv_web/live/notification_live/index.ex:1357
+#: lib/vutuv_web/live/notification_live/index.ex:1425
+#: lib/vutuv_web/live/notification_live/index.ex:1657
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
@@ -15312,7 +15311,8 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/components/post_components.ex:5790
-#: lib/vutuv_web/live/notification_live/index.ex:1355
+#: lib/vutuv_web/live/notification_live/index.ex:1422
+#: lib/vutuv_web/live/notification_live/index.ex:1655
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
@@ -15369,7 +15369,7 @@ msgstr ""
 msgid "Replies from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1277
+#: lib/vutuv_web/live/notification_live/index.ex:1512
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr ""
@@ -15390,7 +15390,7 @@ msgid "Reported as not appropriate"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1387
-#: lib/vutuv_web/live/notification_live/index.ex:911
+#: lib/vutuv_web/live/notification_live/index.ex:1120
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr ""
@@ -16187,7 +16187,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1294
 #: lib/vutuv_web/agent_docs/text.ex:807
-#: lib/vutuv_web/components/ui.ex:3033
+#: lib/vutuv_web/components/ui.ex:3045
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16212,7 +16212,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3032
+#: lib/vutuv_web/components/ui.ex:3044
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16250,7 +16250,7 @@ msgstr ""
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3031
+#: lib/vutuv_web/components/ui.ex:3043
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr ""
@@ -16427,7 +16427,8 @@ msgstr ""
 msgid "From other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1278
+#: lib/vutuv_web/live/notification_live/index.ex:1513
+#: lib/vutuv_web/live/notification_live/index.ex:1514
 #, elixir-autogen, elixir-format
 msgid "Reaction from another network"
 msgstr ""
@@ -17248,7 +17249,7 @@ msgstr ""
 msgid "Your username is your public identity here. It changes only once you confirm with your passkey or a valid code below."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:610
+#: lib/vutuv_web/components/ui.ex:622
 #, elixir-autogen, elixir-format
 msgid "Markdown help"
 msgstr ""
@@ -17696,7 +17697,7 @@ msgstr ""
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:925
+#: lib/vutuv_web/live/notification_live/index.ex:1134
 #, elixir-autogen, elixir-format
 msgid "View the conversation"
 msgstr ""
@@ -17774,8 +17775,8 @@ msgstr ""
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1462
-#: lib/vutuv_web/components/ui.ex:1463
+#: lib/vutuv_web/components/ui.ex:1474
+#: lib/vutuv_web/components/ui.ex:1475
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr ""
@@ -18175,7 +18176,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:4880
+#: lib/vutuv_web/components/ui.ex:4892
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -18220,7 +18221,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3239
+#: lib/vutuv_web/live/post_live/feed.ex:3262
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -18371,7 +18372,7 @@ msgstr ""
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4881
+#: lib/vutuv_web/components/ui.ex:4893
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
@@ -18382,7 +18383,7 @@ msgstr ""
 msgid "Zwischenzeugnis"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4883
+#: lib/vutuv_web/components/ui.ex:4895
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -18570,7 +18571,7 @@ msgstr ""
 msgid "Employment reference deleted"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1287
+#: lib/vutuv_web/live/notification_live/index.ex:1523
 #, elixir-autogen, elixir-format
 msgid "Employment reference review"
 msgstr ""
@@ -18637,7 +18638,7 @@ msgstr ""
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4196
+#: lib/vutuv_web/components/ui.ex:4208
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -18983,17 +18984,17 @@ msgstr ""
 msgid "Enter the PIN from the email"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:842
+#: lib/vutuv_web/components/ui.ex:854
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:870
+#: lib/vutuv_web/components/ui.ex:882
 #, elixir-autogen, elixir-format
 msgid "Cancel registration"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1083
+#: lib/vutuv_web/live/notification_live/index.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -19003,7 +19004,7 @@ msgstr ""
 msgid "Follow other members"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:825
+#: lib/vutuv_web/components/ui.ex:837
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
@@ -19028,7 +19029,7 @@ msgstr ""
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4862
+#: lib/vutuv_web/components/ui.ex:4874
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
@@ -19982,8 +19983,8 @@ msgstr ""
 msgid "New message from %{sender} on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:160
 #: lib/vutuv_web/live/message_live/index.ex:170
+#: lib/vutuv_web/live/message_live/index.ex:180
 #, elixir-autogen, elixir-format
 msgid "This page cannot receive messages."
 msgstr ""
@@ -20121,22 +20122,22 @@ msgstr ""
 msgid "The PIN has expired."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:946
+#: lib/vutuv_web/components/ui.ex:958
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:948
+#: lib/vutuv_web/components/ui.ex:960
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:947
+#: lib/vutuv_web/components/ui.ex:959
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:949
+#: lib/vutuv_web/components/ui.ex:961
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr ""
@@ -20603,7 +20604,7 @@ msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:4755
-#: lib/vutuv_web/components/ui.ex:4945
+#: lib/vutuv_web/components/ui.ex:4957
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -21331,7 +21332,7 @@ msgstr ""
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4929
+#: lib/vutuv_web/components/ui.ex:4941
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
@@ -21381,7 +21382,7 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3400
+#: lib/vutuv_web/live/post_live/feed.ex:3423
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
@@ -21391,43 +21392,43 @@ msgstr ""
 msgid "New here"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1631
+#: lib/vutuv_web/components/ui.ex:1643
 #, elixir-autogen, elixir-format
 msgid "New public posts arrive in any feed reader. No account needed either."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1627
+#: lib/vutuv_web/components/ui.ex:1639
 #, elixir-autogen, elixir-format
 msgid "Or with an RSS reader"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1507
-#: lib/vutuv_web/components/ui.ex:1576
+#: lib/vutuv_web/components/ui.ex:1519
+#: lib/vutuv_web/components/ui.ex:1588
 #, elixir-autogen, elixir-format
 msgid "Subscribe"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1628
+#: lib/vutuv_web/components/ui.ex:1640
 #, elixir-autogen, elixir-format
 msgid "With an RSS reader"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1588
+#: lib/vutuv_web/components/ui.ex:1600
 #, elixir-autogen, elixir-format
 msgid "Create a free account"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1603
+#: lib/vutuv_web/components/ui.ex:1615
 #, elixir-autogen, elixir-format
 msgid "No vutuv account? These ways work too:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1581
+#: lib/vutuv_web/components/ui.ex:1593
 #, elixir-autogen, elixir-format
 msgid "The best way: follow %{name} here. New posts land in your feed, and you can reply and join in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1579
+#: lib/vutuv_web/components/ui.ex:1591
 #, elixir-autogen, elixir-format
 msgid "With a vutuv account"
 msgstr ""
@@ -21552,12 +21553,12 @@ msgstr ""
 msgid "Shown in the language it was written in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4946
+#: lib/vutuv_web/components/ui.ex:4958
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4948
+#: lib/vutuv_web/components/ui.ex:4960
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr ""
@@ -21685,7 +21686,7 @@ msgstr ""
 msgid "Your LinkedIn profile can come along."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1143
+#: lib/vutuv_web/components/ui.ex:1155
 #, elixir-autogen, elixir-format
 msgid "Being checked"
 msgstr ""
@@ -21950,7 +21951,7 @@ msgstr ""
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3426
+#: lib/vutuv_web/live/post_live/feed.ex:3449
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
@@ -22027,9 +22028,10 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3036
-#: lib/vutuv_web/live/post_live/feed.ex:3474
-#: lib/vutuv_web/live/post_live/feed.ex:3479
+#: lib/vutuv_web/live/post_live/feed.ex:3048
+#: lib/vutuv_web/live/post_live/feed.ex:3075
+#: lib/vutuv_web/live/post_live/feed.ex:3497
+#: lib/vutuv_web/live/post_live/feed.ex:3502
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -22073,7 +22075,7 @@ msgstr ""
 msgid "Your organization page was updated, but that picture could not be used as a logo. Please pick another one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4202
+#: lib/vutuv_web/components/ui.ex:4214
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -22094,7 +22096,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3196
+#: lib/vutuv_web/live/post_live/feed.ex:3219
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr ""
@@ -22104,7 +22106,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3242
+#: lib/vutuv_web/live/post_live/feed.ex:3265
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22126,7 +22128,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3192
+#: lib/vutuv_web/live/post_live/feed.ex:3215
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -22271,7 +22273,7 @@ msgstr ""
 msgid "Only these accounts (empty = all) …"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3325
+#: lib/vutuv_web/components/ui.ex:3337
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr ""
@@ -22283,55 +22285,55 @@ msgctxt "filter rule"
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1356
+#: lib/vutuv_web/live/notification_live/index.ex:1656
 #, elixir-autogen, elixir-format
 msgid "%{formatted} share"
 msgid_plural "%{formatted} shares"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:828
+#: lib/vutuv_web/live/notification_live/index.ex:818
 #, elixir-autogen, elixir-format
 msgid "Post without text"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1331
+#: lib/vutuv_web/live/notification_live/index.ex:1563
 #, elixir-autogen, elixir-format
 msgid "likes this."
 msgid_plural "like this."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1337
+#: lib/vutuv_web/live/notification_live/index.ex:1569
 #, elixir-autogen, elixir-format
 msgid "reacted to this."
 msgid_plural "reacted to this."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1322
+#: lib/vutuv_web/live/notification_live/index.ex:1571
 #, elixir-autogen, elixir-format
 msgid "replied."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1334
+#: lib/vutuv_web/live/notification_live/index.ex:1566
 #, elixir-autogen, elixir-format
 msgid "shared this."
 msgid_plural "shared this."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:554
+#: lib/vutuv_web/components/ui.ex:566
 #, elixir-autogen, elixir-format
 msgid "Editor view"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:502
+#: lib/vutuv_web/components/ui.ex:514
 #, elixir-autogen, elixir-format
 msgid "Insert a block"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:514
+#: lib/vutuv_web/components/ui.ex:526
 #, elixir-autogen, elixir-format
 msgid "Nothing matches."
 msgstr ""
@@ -22515,7 +22517,7 @@ msgstr ""
 msgid "Replace with"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4938
+#: lib/vutuv_web/components/ui.ex:4950
 #, elixir-autogen, elixir-format
 msgid "Rewrite what an account's posts say, for you alone"
 msgstr ""
@@ -22533,7 +22535,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1366
 #: lib/vutuv_web/components/post_components.ex:2671
 #: lib/vutuv_web/components/post_components.ex:3658
-#: lib/vutuv_web/components/ui.ex:4937
+#: lib/vutuv_web/components/ui.ex:4949
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
 #: lib/vutuv_web/live/post_rewrites_live.ex:264
@@ -22589,7 +22591,7 @@ msgstr ""
 msgid "\\1 puts back what the first (…) group matched, \\0 the whole match."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4939
+#: lib/vutuv_web/components/ui.ex:4951
 #, elixir-autogen, elixir-format
 msgid "regex regular expression rewrite replace footer signature strip"
 msgstr ""
@@ -22599,13 +22601,12 @@ msgstr ""
 msgid "For members on a slow connection, data-saving mode shows pictures and screenshots in a stronger compression and leaves out a few luxuries, such as the richer editor. Any picture loads in full quality with one tap, and you can switch the mode off at any time."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1193
-#: lib/vutuv_web/components/ui.ex:1194
+#: lib/vutuv_web/components/ui.ex:1205
+#: lib/vutuv_web/components/ui.ex:1206
 #, elixir-autogen, elixir-format
 msgid "Load this picture in full quality"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4962
 #: lib/vutuv_web/components/ui.ex:5007
 #, elixir-autogen, elixir-format
 msgid "Smaller pictures and a plain composer on a slow connection"
@@ -22616,7 +22617,6 @@ msgstr ""
 msgid "That endorsement is not possible."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4964
 #: lib/vutuv_web/components/ui.ex:5009
 #, elixir-autogen, elixir-format
 msgid "bandwidth slow internet mobile data saving saver volume metered compression pictures images screenshots editor langsam daten sparen datensparmodus volumen schmalband komprimierung bilder"
@@ -22625,4 +22625,70 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4994
 #, elixir-autogen, elixir-format
 msgid "Appearance"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1433
+#, elixir-autogen, elixir-format
+msgid "%{formatted} connection"
+msgid_plural "%{formatted} connections"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1674
+#, elixir-autogen, elixir-format
+msgid "%{formatted} new connection"
+msgid_plural "%{formatted} new connections"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1678
+#, elixir-autogen, elixir-format
+msgid "%{formatted} new follower"
+msgid_plural "%{formatted} new followers"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1442
+#, elixir-autogen, elixir-format
+msgid "Last 30 days: %{parts}"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1003
+#, elixir-autogen, elixir-format
+msgid "Less"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1342
+#, elixir-autogen, elixir-format
+msgid "Reactions"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:511
+#, elixir-autogen, elixir-format
+msgid "Seen before"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:623
+#, elixir-autogen, elixir-format
+msgid "Show %{formatted} more"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:825
+#, elixir-autogen, elixir-format
+msgid "The post is no longer available."
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1634
+#, elixir-autogen, elixir-format
+msgid "Thread by %{name}"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1573
+#, elixir-autogen, elixir-format
+msgid "mentioned you."
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1572
+#, elixir-autogen, elixir-format
+msgid "replied in the thread."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -15,8 +15,8 @@ msgstr "Language: en\n"
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4586
-#: lib/vutuv_web/components/ui.ex:4591
+#: lib/vutuv_web/components/ui.ex:4598
+#: lib/vutuv_web/components/ui.ex:4603
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
 #: lib/vutuv_web/live/organization_live/domains.ex:267
@@ -62,7 +62,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/text.ex:71
-#: lib/vutuv_web/components/ui.ex:4904
+#: lib/vutuv_web/components/ui.ex:4916
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -75,14 +75,14 @@ msgstr ""
 msgid "Addresses"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1594
+#: lib/vutuv_web/components/ui.ex:1606
 #: lib/vutuv_web/templates/page/index.html.heex:325
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4377
-#: lib/vutuv_web/components/ui.ex:4476
+#: lib/vutuv_web/components/ui.ex:4389
+#: lib/vutuv_web/components/ui.ex:4488
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -110,7 +110,7 @@ msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:104
-#: lib/vutuv_web/components/ui.ex:4371
+#: lib/vutuv_web/components/ui.ex:4383
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
 #: lib/vutuv_web/live/admin/user_delete_live.ex:202
@@ -161,7 +161,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3635
-#: lib/vutuv_web/components/ui.ex:4478
+#: lib/vutuv_web/components/ui.ex:4490
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:657
@@ -209,7 +209,7 @@ msgid "Download"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3600
-#: lib/vutuv_web/components/ui.ex:4469
+#: lib/vutuv_web/components/ui.ex:4481
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
@@ -283,7 +283,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:4868
+#: lib/vutuv_web/components/ui.ex:4880
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -313,7 +313,6 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:595
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
-#: lib/vutuv_web/live/notification_live/index.ex:1207
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:27
@@ -324,8 +323,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:632
 #: lib/vutuv_web/agent_docs/text.ex:596
 #: lib/vutuv_web/components/fediverse_components.ex:468
-#: lib/vutuv_web/components/ui.ex:2871
-#: lib/vutuv_web/components/ui.ex:2906
+#: lib/vutuv_web/components/ui.ex:2883
+#: lib/vutuv_web/components/ui.ex:2918
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:608
@@ -452,7 +451,7 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1132
+#: lib/vutuv_web/live/notification_live/index.ex:1344
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:193
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:201
 #, elixir-autogen
@@ -472,7 +471,7 @@ msgid "Name"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:723
-#: lib/vutuv_web/live/notification_live/index.ex:743
+#: lib/vutuv_web/live/notification_live/index.ex:774
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
@@ -611,7 +610,7 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4370
+#: lib/vutuv_web/components/ui.ex:4382
 #: lib/vutuv_web/live/organization_live/edit.ex:367
 #: lib/vutuv_web/live/post_live/composer.ex:1937
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -786,13 +785,13 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4864
+#: lib/vutuv_web/components/ui.ex:4876
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:832
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
 #: lib/vutuv_web/live/directory_search_live.ex:134
-#: lib/vutuv_web/live/notification_live/index.ex:1286
+#: lib/vutuv_web/live/notification_live/index.ex:1522
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:51
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -838,7 +837,7 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1401
+#: lib/vutuv_web/components/ui.ex:1413
 #: lib/vutuv_web/views/user_html.ex:562
 #: lib/vutuv_web/views/user_html.ex:563
 #: lib/vutuv_web/views/user_html.ex:577
@@ -846,7 +845,7 @@ msgstr ""
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4539
+#: lib/vutuv_web/components/ui.ex:4551
 #: lib/vutuv_web/templates/user/show.html.heex:981
 #: lib/vutuv_web/templates/user/show.html.heex:1004
 #, elixir-autogen
@@ -1373,7 +1372,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:522
 #: lib/vutuv_web/agent_docs/text.ex:768
-#: lib/vutuv_web/components/ui.ex:4889
+#: lib/vutuv_web/components/ui.ex:4901
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1614,7 +1613,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3030
+#: lib/vutuv_web/components/ui.ex:3042
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:477
 #: lib/vutuv_web/live/admin/organization_live.ex:296
@@ -1671,20 +1670,20 @@ msgstr ""
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2113
-#: lib/vutuv_web/components/ui.ex:2122
-#: lib/vutuv_web/components/ui.ex:2600
+#: lib/vutuv_web/components/ui.ex:2125
+#: lib/vutuv_web/components/ui.ex:2134
+#: lib/vutuv_web/components/ui.ex:2612
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:244
-#: lib/vutuv_web/components/ui.ex:2836
-#: lib/vutuv_web/components/ui.ex:2836
-#: lib/vutuv_web/components/ui.ex:2853
-#: lib/vutuv_web/components/ui.ex:2862
-#: lib/vutuv_web/components/ui.ex:2878
-#: lib/vutuv_web/components/ui.ex:2940
+#: lib/vutuv_web/components/ui.ex:2848
+#: lib/vutuv_web/components/ui.ex:2848
+#: lib/vutuv_web/components/ui.ex:2865
+#: lib/vutuv_web/components/ui.ex:2874
+#: lib/vutuv_web/components/ui.ex:2890
+#: lib/vutuv_web/components/ui.ex:2952
 #: lib/vutuv_web/live/fediverse_account_live.ex:400
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:312
@@ -1722,7 +1721,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
 #: lib/vutuv_web/live/admin/user_delete_live.ex:143
 #: lib/vutuv_web/live/admin/user_live.ex:154
-#: lib/vutuv_web/live/message_live/index.ex:538
+#: lib/vutuv_web/live/message_live/index.ex:548
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:32
 #: lib/vutuv_web/templates/admin/account/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:28
@@ -1741,7 +1740,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/page_controller.ex:228
 #: lib/vutuv_web/live/message_live/index.ex:49
-#: lib/vutuv_web/live/message_live/index.ex:624
+#: lib/vutuv_web/live/message_live/index.ex:634
 #: lib/vutuv_web/live/shell_live.ex:1249
 #: lib/vutuv_web/live/shell_live.ex:1427
 #: lib/vutuv_web/templates/layout/app.html.heex:152
@@ -1756,7 +1755,7 @@ msgid "Network"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:459
-#: lib/vutuv_web/components/ui.ex:4588
+#: lib/vutuv_web/components/ui.ex:4600
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
@@ -1766,16 +1765,16 @@ msgstr ""
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:437
+#: lib/vutuv_web/live/notification_live/index.ex:528
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr ""
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:4926
+#: lib/vutuv_web/components/ui.ex:4938
 #: lib/vutuv_web/controllers/page_controller.ex:229
-#: lib/vutuv_web/live/notification_live/index.ex:147
-#: lib/vutuv_web/live/notification_live/index.ex:385
+#: lib/vutuv_web/live/notification_live/index.ex:156
+#: lib/vutuv_web/live/notification_live/index.ex:450
 #: lib/vutuv_web/live/shell_live.ex:1261
 #: lib/vutuv_web/templates/layout/app.html.heex:153
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
@@ -1798,7 +1797,7 @@ msgid "Pardon us! Something went wrong."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:902
+#: lib/vutuv_web/live/message_live/index.ex:912
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
@@ -1872,8 +1871,8 @@ msgstr ""
 msgid "Who to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:891
-#: lib/vutuv_web/live/message_live/index.ex:892
+#: lib/vutuv_web/live/message_live/index.ex:901
+#: lib/vutuv_web/live/message_live/index.ex:902
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr ""
@@ -1918,14 +1917,14 @@ msgstr ""
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3871
-#: lib/vutuv_web/components/ui.ex:4016
+#: lib/vutuv_web/components/ui.ex:3883
+#: lib/vutuv_web/components/ui.ex:4028
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4613
+#: lib/vutuv_web/components/ui.ex:4625
 #: lib/vutuv_web/live/organization_live/activity.ex:151
 #: lib/vutuv_web/live/organization_live/feed.ex:209
 #: lib/vutuv_web/live/organization_live/show.ex:777
@@ -1938,13 +1937,13 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4380
+#: lib/vutuv_web/components/ui.ex:4392
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1794
-#: lib/vutuv_web/components/ui.ex:1804
+#: lib/vutuv_web/components/ui.ex:1806
+#: lib/vutuv_web/components/ui.ex:1816
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr ""
@@ -1983,12 +1982,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3384
+#: lib/vutuv_web/components/ui.ex:3396
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3388
+#: lib/vutuv_web/components/ui.ex:3400
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -2013,37 +2012,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3392
+#: lib/vutuv_web/components/ui.ex:3404
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3382
+#: lib/vutuv_web/components/ui.ex:3394
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3381
+#: lib/vutuv_web/components/ui.ex:3393
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3387
+#: lib/vutuv_web/components/ui.ex:3399
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3386
+#: lib/vutuv_web/components/ui.ex:3398
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3383
+#: lib/vutuv_web/components/ui.ex:3395
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3385
+#: lib/vutuv_web/components/ui.ex:3397
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2058,17 +2057,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3391
+#: lib/vutuv_web/components/ui.ex:3403
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3390
+#: lib/vutuv_web/components/ui.ex:3402
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3389
+#: lib/vutuv_web/components/ui.ex:3401
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2168,7 +2167,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3216
+#: lib/vutuv_web/live/post_live/feed.ex:3239
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2207,7 +2206,6 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:109
 #: lib/vutuv_web/live/admin/dashboard_live.ex:172
 #: lib/vutuv_web/live/fediverse_account_live.ex:407
-#: lib/vutuv_web/live/notification_live/index.ex:1130
 #: lib/vutuv_web/live/organization_live/show.ex:700
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:348
@@ -2341,7 +2339,7 @@ msgstr ""
 msgid "people you don't follow"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3462
+#: lib/vutuv_web/components/ui.ex:3474
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
@@ -2379,7 +2377,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2028
 #: lib/vutuv_web/components/post_components.ex:5593
-#: lib/vutuv_web/components/ui.ex:3938
+#: lib/vutuv_web/components/ui.ex:3950
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2398,8 +2396,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1981
 #: lib/vutuv_web/components/post_components.ex:5831
-#: lib/vutuv_web/components/ui.ex:3924
-#: lib/vutuv_web/live/notification_live/index.ex:1276
+#: lib/vutuv_web/components/ui.ex:3936
+#: lib/vutuv_web/live/notification_live/index.ex:1511
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2407,7 +2405,6 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1144
 #: lib/vutuv_web/components/post_components.ex:5841
-#: lib/vutuv_web/live/notification_live/index.ex:1209
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
 #: lib/vutuv_web/live/shell_live.ex:1312
@@ -2470,9 +2467,9 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:498
 #: lib/vutuv_web/components/post_components.ex:2663
-#: lib/vutuv_web/components/ui.ex:2831
-#: lib/vutuv_web/components/ui.ex:2831
-#: lib/vutuv_web/components/ui.ex:2907
+#: lib/vutuv_web/components/ui.ex:2843
+#: lib/vutuv_web/components/ui.ex:2843
+#: lib/vutuv_web/components/ui.ex:2919
 #: lib/vutuv_web/live/organization_live/following.ex:384
 #: lib/vutuv_web/live/organization_live/following.ex:468
 #: lib/vutuv_web/live/organization_live/show.ex:611
@@ -2495,7 +2492,7 @@ msgid "Only public posts can be answered."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:417
-#: lib/vutuv_web/live/notification_live/index.ex:1210
+#: lib/vutuv_web/live/notification_live/index.ex:1341
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
@@ -2503,7 +2500,8 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1994
 #: lib/vutuv_web/components/post_components.ex:5868
 #: lib/vutuv_web/components/post_components.ex:5869
-#: lib/vutuv_web/live/notification_live/index.ex:1273
+#: lib/vutuv_web/live/notification_live/index.ex:993
+#: lib/vutuv_web/live/notification_live/index.ex:1508
 #: lib/vutuv_web/live/post_live/reply.ex:46
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2550,89 +2548,89 @@ msgstr ""
 msgid "Replying to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:603
+#: lib/vutuv_web/live/message_live/index.ex:613
 #, elixir-autogen, elixir-format
 msgid "%{names} are typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:602
+#: lib/vutuv_web/live/message_live/index.ex:612
 #, elixir-autogen, elixir-format
 msgid "%{name} is typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:914
+#: lib/vutuv_web/live/message_live/index.ex:924
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:865
+#: lib/vutuv_web/live/message_live/index.ex:875
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to message you."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:591
+#: lib/vutuv_web/live/message_live/index.ex:601
 #, elixir-autogen, elixir-format
 msgid "Accept"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:728
+#: lib/vutuv_web/live/message_live/index.ex:738
 #, elixir-autogen, elixir-format
 msgid "Back to conversations"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:593
+#: lib/vutuv_web/live/message_live/index.ex:603
 #, elixir-autogen, elixir-format
 msgid "Decline"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:534
+#: lib/vutuv_web/live/message_live/index.ex:544
 #, elixir-autogen, elixir-format
 msgid "Deleted account"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:774
+#: lib/vutuv_web/live/message_live/index.ex:784
 #, elixir-autogen, elixir-format
 msgid "Load older messages"
 msgstr ""
 
 #: lib/vutuv_web/controllers/admin/tag_member_controller.ex:55
-#: lib/vutuv_web/live/message_live/index.ex:132
+#: lib/vutuv_web/live/message_live/index.ex:142
 #, elixir-autogen, elixir-format
 msgid "Member not found."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:707
+#: lib/vutuv_web/live/message_live/index.ex:717
 #, elixir-autogen, elixir-format
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3154
-#: lib/vutuv_web/live/message_live/index.ex:750
+#: lib/vutuv_web/components/ui.ex:3166
+#: lib/vutuv_web/live/message_live/index.ex:760
 #, elixir-autogen, elixir-format
 msgid "Online"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:656
+#: lib/vutuv_web/live/message_live/index.ex:666
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:923
+#: lib/vutuv_web/live/message_live/index.ex:933
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:147
+#: lib/vutuv_web/live/message_live/index.ex:157
 #, elixir-autogen, elixir-format
 msgid "This member cannot receive messages."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:239
+#: lib/vutuv_web/live/message_live/index.ex:249
 #, elixir-autogen, elixir-format
 msgid "This message could not be sent."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:142
+#: lib/vutuv_web/live/message_live/index.ex:152
 #, elixir-autogen, elixir-format
 msgid "Too many new conversations. Please try again later."
 msgstr ""
@@ -2693,7 +2691,7 @@ msgstr ""
 msgid "Okay, let's start over."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:850
+#: lib/vutuv_web/components/ui.ex:862
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr ""
@@ -2704,7 +2702,7 @@ msgstr ""
 msgid "Too many PIN requests. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:871
+#: lib/vutuv_web/components/ui.ex:883
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr ""
@@ -2754,8 +2752,8 @@ msgstr ""
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4104
-#: lib/vutuv_web/components/ui.ex:4541
+#: lib/vutuv_web/components/ui.ex:4116
+#: lib/vutuv_web/components/ui.ex:4553
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:109
@@ -2801,13 +2799,12 @@ msgstr[1] ""
 #: lib/vutuv_web/agent_docs/markdown.ex:633
 #: lib/vutuv_web/agent_docs/text.ex:597
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:1208
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1392
+#: lib/vutuv_web/components/ui.ex:1404
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2817,7 +2814,7 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1408
+#: lib/vutuv_web/components/ui.ex:1420
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
@@ -2827,7 +2824,7 @@ msgstr ""
 msgid "People who aren't my connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1393
+#: lib/vutuv_web/components/ui.ex:1405
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -2850,29 +2847,29 @@ msgstr[1] ""
 msgid "people who aren't your connections"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:708
+#: lib/vutuv_web/live/message_live/index.ex:718
 #, elixir-autogen, elixir-format
 msgid "Open someone's profile to message them."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:259
-#: lib/vutuv_web/live/notification_live/index.ex:1288
+#: lib/vutuv_web/live/notification_live/index.ex:1524
 #: lib/vutuv_web/live/organization_live/activity.ex:104
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1279
+#: lib/vutuv_web/live/notification_live/index.ex:1515
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1272
+#: lib/vutuv_web/live/notification_live/index.ex:1507
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1271
+#: lib/vutuv_web/live/notification_live/index.ex:1506
 #: lib/vutuv_web/templates/user/show.html.heex:965
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -3016,7 +3013,7 @@ msgstr ""
 msgid "Hidden. You can settle this yourself - see below."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:803
+#: lib/vutuv_web/live/message_live/index.ex:813
 #, elixir-autogen, elixir-format
 msgid "Hidden: reported, under review"
 msgstr ""
@@ -3028,7 +3025,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1280
+#: lib/vutuv_web/live/notification_live/index.ex:1516
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3157,7 +3154,7 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4858
+#: lib/vutuv_web/components/ui.ex:4870
 #: lib/vutuv_web/live/shell_live.ex:1125
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3212,8 +3209,8 @@ msgstr ""
 msgid "Report this content"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:821
-#: lib/vutuv_web/live/message_live/index.ex:822
+#: lib/vutuv_web/live/message_live/index.ex:831
+#: lib/vutuv_web/live/message_live/index.ex:832
 #, elixir-autogen, elixir-format
 msgid "Report this message"
 msgstr ""
@@ -3267,7 +3264,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3811
+#: lib/vutuv_web/components/ui.ex:3823
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3675,7 +3672,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1282
+#: lib/vutuv_web/live/notification_live/index.ex:1518
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3930,6 +3927,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:137
 #: lib/vutuv_web/live/admin/screenshot_live.ex:380
 #: lib/vutuv_web/live/admin/screenshot_live.ex:389
+#: lib/vutuv_web/live/notification_live/index.ex:1637
 #: lib/vutuv_web/templates/post/show.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "Post by %{name}"
@@ -4341,12 +4339,12 @@ msgstr ""
 msgid "Bookings are open through %{last}. Next available day: %{day}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3414
+#: lib/vutuv_web/components/ui.ex:3426
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3410
+#: lib/vutuv_web/components/ui.ex:3422
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr ""
@@ -4356,27 +4354,27 @@ msgstr ""
 msgid "One ad per calendar day: pick a free day in the calendar; struck-through days are already booked."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3415
+#: lib/vutuv_web/components/ui.ex:3427
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3416
+#: lib/vutuv_web/components/ui.ex:3428
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3413
+#: lib/vutuv_web/components/ui.ex:3425
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3411
+#: lib/vutuv_web/components/ui.ex:3423
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3412
+#: lib/vutuv_web/components/ui.ex:3424
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr ""
@@ -4550,12 +4548,12 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3221
+#: lib/vutuv_web/live/post_live/feed.ex:3244
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:711
+#: lib/vutuv_web/live/message_live/index.ex:721
 #, elixir-autogen, elixir-format
 msgid "Find members"
 msgstr ""
@@ -4607,7 +4605,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:444
 #: lib/vutuv_web/agent_docs/text.ex:463
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/live/notification_live/index.ex:1131
+#: lib/vutuv_web/live/notification_live/index.ex:646
+#: lib/vutuv_web/live/notification_live/index.ex:1343
 #: lib/vutuv_web/live/organization_live/show.ex:787
 #: lib/vutuv_web/live/post_live/saved.ex:523
 #: lib/vutuv_web/live/search_live.ex:346
@@ -4631,7 +4630,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
-#: lib/vutuv_web/live/notification_live/index.ex:1129
+#: lib/vutuv_web/live/notification_live/index.ex:1340
 #: lib/vutuv_web/live/search_live.ex:345
 #: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
@@ -5429,7 +5428,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:3727
 #: lib/vutuv_web/components/post_components.ex:3782
 #: lib/vutuv_web/components/post_components.ex:4190
-#: lib/vutuv_web/live/notification_live/index.ex:785
+#: lib/vutuv_web/live/notification_live/index.ex:1072
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5495,7 +5494,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4896
+#: lib/vutuv_web/components/ui.ex:4908
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5557,7 +5556,7 @@ msgstr ""
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:622
+#: lib/vutuv_web/live/notification_live/index.ex:1631
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
@@ -5650,7 +5649,6 @@ msgid "Apps & API"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:1211
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -5728,7 +5726,7 @@ msgstr ""
 msgid "@handle"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:766
+#: lib/vutuv_web/live/message_live/index.ex:776
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}"
 msgstr ""
@@ -5848,21 +5846,21 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3471
+#: lib/vutuv_web/components/ui.ex:3483
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3470
+#: lib/vutuv_web/components/ui.ex:3482
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3469
+#: lib/vutuv_web/components/ui.ex:3481
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -5929,7 +5927,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3468
+#: lib/vutuv_web/components/ui.ex:3480
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -6071,7 +6069,7 @@ msgstr ""
 msgid "Tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:468
+#: lib/vutuv_web/components/ui.ex:480
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:915
@@ -6258,9 +6256,9 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2113
-#: lib/vutuv_web/components/ui.ex:2122
-#: lib/vutuv_web/components/ui.ex:2601
+#: lib/vutuv_web/components/ui.ex:2125
+#: lib/vutuv_web/components/ui.ex:2134
+#: lib/vutuv_web/components/ui.ex:2613
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6321,11 +6319,11 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2554
-#: lib/vutuv_web/live/notification_live/index.ex:685
-#: lib/vutuv_web/live/notification_live/index.ex:700
-#: lib/vutuv_web/live/notification_live/index.ex:1013
-#: lib/vutuv_web/live/notification_live/index.ex:1015
+#: lib/vutuv_web/components/ui.ex:2566
+#: lib/vutuv_web/live/notification_live/index.ex:716
+#: lib/vutuv_web/live/notification_live/index.ex:731
+#: lib/vutuv_web/live/notification_live/index.ex:1225
+#: lib/vutuv_web/live/notification_live/index.ex:1227
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
@@ -6618,7 +6616,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2643
 #: lib/vutuv_web/components/post_components.ex:3652
-#: lib/vutuv_web/components/ui.ex:2979
+#: lib/vutuv_web/components/ui.ex:2991
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/live/organization_live/following.ex:377
 #: lib/vutuv_web/live/organization_live/following.ex:461
@@ -6646,7 +6644,7 @@ msgid "Remove this connection? You will stop following them."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3652
-#: lib/vutuv_web/components/ui.ex:2978
+#: lib/vutuv_web/components/ui.ex:2990
 #: lib/vutuv_web/live/fediverse_account_live.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:377
 #: lib/vutuv_web/live/organization_live/following.ex:461
@@ -7246,13 +7244,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3880
+#: lib/vutuv_web/components/ui.ex:3892
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3892
+#: lib/vutuv_web/components/ui.ex:3904
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7436,7 +7434,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3487
+#: lib/vutuv_web/live/post_live/feed.ex:3510
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #, elixir-autogen
 msgid "Done"
@@ -7720,13 +7718,13 @@ msgstr ""
 #: lib/vutuv_web/components/job_components.ex:219
 #: lib/vutuv_web/live/admin/dashboard_live.ex:304
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:468
-#: lib/vutuv_web/live/notification_live/index.ex:1158
+#: lib/vutuv_web/live/notification_live/index.ex:1378
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:308
-#: lib/vutuv_web/live/notification_live/index.ex:1161
+#: lib/vutuv_web/live/notification_live/index.ex:1381
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -8001,7 +7999,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3883
+#: lib/vutuv_web/components/ui.ex:3895
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8131,7 +8129,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:4872
+#: lib/vutuv_web/components/ui.ex:4884
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8215,7 +8213,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4900
+#: lib/vutuv_web/components/ui.ex:4912
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8309,7 +8307,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4156
+#: lib/vutuv_web/components/ui.ex:4168
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8384,7 +8382,7 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4860
+#: lib/vutuv_web/components/ui.ex:4872
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
@@ -8521,7 +8519,7 @@ msgstr[1] ""
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1410
+#: lib/vutuv_web/components/ui.ex:1422
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -8617,7 +8615,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:586
 #: lib/vutuv_web/agent_docs/text.ex:590
 #: lib/vutuv_web/components/organization_components.ex:276
-#: lib/vutuv_web/components/ui.ex:1611
+#: lib/vutuv_web/components/ui.ex:1623
 #: lib/vutuv_web/components/ui.ex:5032
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:357
@@ -8768,7 +8766,7 @@ msgstr ""
 msgid "This is the print view of this CV. Use your browser's print dialog (Ctrl+P or Cmd+P) and choose \"Save as PDF\" to get a PDF file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1700
+#: lib/vutuv_web/components/ui.ex:1712
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr ""
@@ -8806,7 +8804,7 @@ msgstr ""
 msgid "Header"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1710
+#: lib/vutuv_web/components/ui.ex:1722
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -8838,7 +8836,7 @@ msgstr ""
 msgid "The CV is public, on your profile: a visitor's download contains only what they can see there anyway, and private email addresses appear only in your own."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1702
+#: lib/vutuv_web/components/ui.ex:1714
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -8992,8 +8990,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2157
-#: lib/vutuv_web/components/ui.ex:2158
+#: lib/vutuv_web/components/ui.ex:2169
+#: lib/vutuv_web/components/ui.ex:2170
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9562,7 +9560,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:4876
+#: lib/vutuv_web/components/ui.ex:4888
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -9758,13 +9756,13 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3584
+#: lib/vutuv_web/components/ui.ex:3596
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3583
-#: lib/vutuv_web/components/ui.ex:3591
+#: lib/vutuv_web/components/ui.ex:3595
+#: lib/vutuv_web/components/ui.ex:3603
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -9938,17 +9936,17 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:456
+#: lib/vutuv_web/components/ui.ex:468
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:508
+#: lib/vutuv_web/components/ui.ex:520
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:511
+#: lib/vutuv_web/components/ui.ex:523
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr ""
@@ -9968,8 +9966,8 @@ msgstr ""
 msgid "Formatting"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:575
-#: lib/vutuv_web/components/ui.ex:576
+#: lib/vutuv_web/components/ui.ex:587
+#: lib/vutuv_web/components/ui.ex:588
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr ""
@@ -9984,22 +9982,24 @@ msgstr ""
 msgid "Generate code list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:506
+#: lib/vutuv_web/components/ui.ex:461
+#: lib/vutuv_web/components/ui.ex:518
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:507
+#: lib/vutuv_web/components/ui.ex:464
+#: lib/vutuv_web/components/ui.ex:519
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:465
+#: lib/vutuv_web/components/ui.ex:477
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:459
+#: lib/vutuv_web/components/ui.ex:471
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr ""
@@ -10020,7 +10020,7 @@ msgstr ""
 msgid "Not set up."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:509
+#: lib/vutuv_web/components/ui.ex:521
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr ""
@@ -10035,7 +10035,7 @@ msgstr ""
 msgid "Print this page or write the codes down. Crossed-out codes have been used."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:510
+#: lib/vutuv_web/components/ui.ex:522
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr ""
@@ -10056,7 +10056,7 @@ msgstr ""
 msgid "Set up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:462
+#: lib/vutuv_web/components/ui.ex:474
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr ""
@@ -10163,6 +10163,7 @@ msgid_plural "%{count} stars"
 msgstr[0] ""
 msgstr[1] ""
 
+#: lib/vutuv_web/live/notification_live/index.ex:1429
 #: lib/vutuv_web/live/organization_live/show.ex:638
 #: lib/vutuv_web/views/user_html.ex:950
 #: lib/vutuv_web/views/user_html.ex:1126
@@ -11060,12 +11061,12 @@ msgstr ""
 msgid "State / region (optional)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4210
+#: lib/vutuv_web/components/ui.ex:4222
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4212
+#: lib/vutuv_web/components/ui.ex:4224
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr ""
@@ -11485,7 +11486,7 @@ msgstr ""
 msgid "The link text can be anything. A hidden <link rel=\"me\"> in the page head works too."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1073
+#: lib/vutuv_web/components/ui.ex:1085
 #: lib/vutuv_web/live/section_reorder_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -11740,7 +11741,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1283
+#: lib/vutuv_web/live/notification_live/index.ex:1519
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -13237,7 +13238,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1281
+#: lib/vutuv_web/live/notification_live/index.ex:1517
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13324,7 +13325,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1284
+#: lib/vutuv_web/live/notification_live/index.ex:1520
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13341,27 +13342,27 @@ msgstr[1] ""
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:485
+#: lib/vutuv_web/components/ui.ex:497
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:482
+#: lib/vutuv_web/components/ui.ex:494
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:488
+#: lib/vutuv_web/components/ui.ex:500
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:479
+#: lib/vutuv_web/components/ui.ex:491
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:512
+#: lib/vutuv_web/components/ui.ex:524
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr ""
@@ -13423,7 +13424,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4952
+#: lib/vutuv_web/components/ui.ex:4964
 #: lib/vutuv_web/controllers/settings_controller.ex:634
 #: lib/vutuv_web/live/post_live/feed.ex:720
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13498,7 +13499,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:63
-#: lib/vutuv_web/components/ui.ex:4919
+#: lib/vutuv_web/components/ui.ex:4931
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13526,19 +13527,19 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4295
+#: lib/vutuv_web/components/ui.ex:4307
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:4305
+#: lib/vutuv_web/components/ui.ex:4317
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1285
+#: lib/vutuv_web/live/notification_live/index.ex:1521
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
@@ -13709,45 +13710,40 @@ msgstr ""
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1150
+#: lib/vutuv_web/live/notification_live/index.ex:1370
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1164
+#: lib/vutuv_web/live/notification_live/index.ex:1384
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:454
+#: lib/vutuv_web/live/notification_live/index.ex:545
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:469
-#, elixir-autogen, elixir-format
-msgid "Last 30 days"
-msgstr ""
-
-#: lib/vutuv_web/live/notification_live/index.ex:1116
-#: lib/vutuv_web/live/notification_live/index.ex:1382
+#: lib/vutuv_web/live/notification_live/index.ex:1327
+#: lib/vutuv_web/live/notification_live/index.ex:1700
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1302
+#: lib/vutuv_web/live/notification_live/index.ex:1608
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1299
+#: lib/vutuv_web/live/notification_live/index.ex:1605
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1308
+#: lib/vutuv_web/live/notification_live/index.ex:1614
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
@@ -13757,12 +13753,12 @@ msgstr ""
 msgid "by:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2291
+#: lib/vutuv_web/components/ui.ex:2303
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2295
+#: lib/vutuv_web/components/ui.ex:2307
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -13991,7 +13987,7 @@ msgstr ""
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1274
+#: lib/vutuv_web/live/notification_live/index.ex:1509
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
@@ -14019,7 +14015,7 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1275
+#: lib/vutuv_web/live/notification_live/index.ex:1510
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
@@ -14278,6 +14274,8 @@ msgstr ""
 msgid "as an account alias."
 msgstr ""
 
+#: lib/vutuv_web/live/notification_live/index.ex:1437
+#: lib/vutuv_web/live/notification_live/index.ex:1682
 #: lib/vutuv_web/templates/user_tag/show.html.heex:24
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} endorsement"
@@ -14315,7 +14313,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4933
+#: lib/vutuv_web/components/ui.ex:4945
 #: lib/vutuv_web/controllers/settings_controller.ex:700
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -14363,7 +14361,7 @@ msgstr ""
 msgid "Thread replies"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:663
+#: lib/vutuv_web/live/notification_live/index.ex:1022
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr ""
@@ -14414,7 +14412,7 @@ msgstr ""
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:658
+#: lib/vutuv_web/live/notification_live/index.ex:1017
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr ""
@@ -14948,67 +14946,67 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4861
+#: lib/vutuv_web/components/ui.ex:4873
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4866
+#: lib/vutuv_web/components/ui.ex:4878
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4869
+#: lib/vutuv_web/components/ui.ex:4881
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4870
+#: lib/vutuv_web/components/ui.ex:4882
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4873
+#: lib/vutuv_web/components/ui.ex:4885
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4874
+#: lib/vutuv_web/components/ui.ex:4886
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4877
+#: lib/vutuv_web/components/ui.ex:4889
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4878
+#: lib/vutuv_web/components/ui.ex:4890
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4885
+#: lib/vutuv_web/components/ui.ex:4897
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4886
+#: lib/vutuv_web/components/ui.ex:4898
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4887
+#: lib/vutuv_web/components/ui.ex:4899
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4890
+#: lib/vutuv_web/components/ui.ex:4902
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4891
+#: lib/vutuv_web/components/ui.ex:4903
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
@@ -15023,107 +15021,107 @@ msgstr ""
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4894
+#: lib/vutuv_web/components/ui.ex:4906
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4897
+#: lib/vutuv_web/components/ui.ex:4909
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4898
+#: lib/vutuv_web/components/ui.ex:4910
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4901
+#: lib/vutuv_web/components/ui.ex:4913
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4902
+#: lib/vutuv_web/components/ui.ex:4914
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4905
+#: lib/vutuv_web/components/ui.ex:4917
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4906
+#: lib/vutuv_web/components/ui.ex:4918
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4908
+#: lib/vutuv_web/components/ui.ex:4920
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4909
+#: lib/vutuv_web/components/ui.ex:4921
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4910
+#: lib/vutuv_web/components/ui.ex:4922
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4912
+#: lib/vutuv_web/components/ui.ex:4924
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4913
+#: lib/vutuv_web/components/ui.ex:4925
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4915
+#: lib/vutuv_web/components/ui.ex:4927
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4920
+#: lib/vutuv_web/components/ui.ex:4932
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4921
+#: lib/vutuv_web/components/ui.ex:4933
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4924
+#: lib/vutuv_web/components/ui.ex:4936
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4927
+#: lib/vutuv_web/components/ui.ex:4939
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4934
+#: lib/vutuv_web/components/ui.ex:4946
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4935
+#: lib/vutuv_web/components/ui.ex:4947
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4953
+#: lib/vutuv_web/components/ui.ex:4965
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4954
+#: lib/vutuv_web/components/ui.ex:4966
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
@@ -15302,7 +15300,8 @@ msgid "Your public posts are copied to other servers. Once a copy is there we ca
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:5786
-#: lib/vutuv_web/live/notification_live/index.ex:1357
+#: lib/vutuv_web/live/notification_live/index.ex:1425
+#: lib/vutuv_web/live/notification_live/index.ex:1657
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
@@ -15310,7 +15309,8 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/components/post_components.ex:5790
-#: lib/vutuv_web/live/notification_live/index.ex:1355
+#: lib/vutuv_web/live/notification_live/index.ex:1422
+#: lib/vutuv_web/live/notification_live/index.ex:1655
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
@@ -15367,7 +15367,7 @@ msgstr ""
 msgid "Replies from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1277
+#: lib/vutuv_web/live/notification_live/index.ex:1512
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr ""
@@ -15388,7 +15388,7 @@ msgid "Reported as not appropriate"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1387
-#: lib/vutuv_web/live/notification_live/index.ex:911
+#: lib/vutuv_web/live/notification_live/index.ex:1120
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr ""
@@ -16185,7 +16185,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1294
 #: lib/vutuv_web/agent_docs/text.ex:807
-#: lib/vutuv_web/components/ui.ex:3033
+#: lib/vutuv_web/components/ui.ex:3045
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16210,7 +16210,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3032
+#: lib/vutuv_web/components/ui.ex:3044
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16248,7 +16248,7 @@ msgstr ""
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3031
+#: lib/vutuv_web/components/ui.ex:3043
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous photo"
 msgstr ""
@@ -16425,7 +16425,8 @@ msgstr ""
 msgid "From other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1278
+#: lib/vutuv_web/live/notification_live/index.ex:1513
+#: lib/vutuv_web/live/notification_live/index.ex:1514
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reaction from another network"
 msgstr ""
@@ -17246,7 +17247,7 @@ msgstr ""
 msgid "Your username is your public identity here. It changes only once you confirm with your passkey or a valid code below."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:610
+#: lib/vutuv_web/components/ui.ex:622
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Markdown help"
 msgstr ""
@@ -17694,7 +17695,7 @@ msgstr ""
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:925
+#: lib/vutuv_web/live/notification_live/index.ex:1134
 #, elixir-autogen, elixir-format
 msgid "View the conversation"
 msgstr ""
@@ -17772,8 +17773,8 @@ msgstr ""
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1462
-#: lib/vutuv_web/components/ui.ex:1463
+#: lib/vutuv_web/components/ui.ex:1474
+#: lib/vutuv_web/components/ui.ex:1475
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr ""
@@ -18173,7 +18174,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:4880
+#: lib/vutuv_web/components/ui.ex:4892
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -18218,7 +18219,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3239
+#: lib/vutuv_web/live/post_live/feed.ex:3262
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Loading…"
@@ -18369,7 +18370,7 @@ msgstr ""
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4881
+#: lib/vutuv_web/components/ui.ex:4893
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
@@ -18380,7 +18381,7 @@ msgstr ""
 msgid "Zwischenzeugnis"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4883
+#: lib/vutuv_web/components/ui.ex:4895
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -18568,7 +18569,7 @@ msgstr ""
 msgid "Employment reference deleted"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1287
+#: lib/vutuv_web/live/notification_live/index.ex:1523
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employment reference review"
 msgstr ""
@@ -18635,7 +18636,7 @@ msgstr ""
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4196
+#: lib/vutuv_web/components/ui.ex:4208
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -18981,17 +18982,17 @@ msgstr ""
 msgid "Enter the PIN from the email"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:842
+#: lib/vutuv_web/components/ui.ex:854
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:870
+#: lib/vutuv_web/components/ui.ex:882
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cancel registration"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1083
+#: lib/vutuv_web/live/notification_live/index.ex:1294
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -19001,7 +19002,7 @@ msgstr ""
 msgid "Follow other members"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:825
+#: lib/vutuv_web/components/ui.ex:837
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
@@ -19026,7 +19027,7 @@ msgstr ""
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4862
+#: lib/vutuv_web/components/ui.ex:4874
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
@@ -19980,8 +19981,8 @@ msgstr ""
 msgid "New message from %{sender} on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:160
 #: lib/vutuv_web/live/message_live/index.ex:170
+#: lib/vutuv_web/live/message_live/index.ex:180
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This page cannot receive messages."
 msgstr ""
@@ -20119,22 +20120,22 @@ msgstr ""
 msgid "The PIN has expired."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:946
+#: lib/vutuv_web/components/ui.ex:958
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:948
+#: lib/vutuv_web/components/ui.ex:960
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:947
+#: lib/vutuv_web/components/ui.ex:959
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:949
+#: lib/vutuv_web/components/ui.ex:961
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr ""
@@ -20601,7 +20602,7 @@ msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:4755
-#: lib/vutuv_web/components/ui.ex:4945
+#: lib/vutuv_web/components/ui.ex:4957
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -21329,7 +21330,7 @@ msgstr ""
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4929
+#: lib/vutuv_web/components/ui.ex:4941
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
@@ -21379,7 +21380,7 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3400
+#: lib/vutuv_web/live/post_live/feed.ex:3423
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
@@ -21389,43 +21390,43 @@ msgstr ""
 msgid "New here"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1631
+#: lib/vutuv_web/components/ui.ex:1643
 #, elixir-autogen, elixir-format
 msgid "New public posts arrive in any feed reader. No account needed either."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1627
+#: lib/vutuv_web/components/ui.ex:1639
 #, elixir-autogen, elixir-format
 msgid "Or with an RSS reader"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1507
-#: lib/vutuv_web/components/ui.ex:1576
+#: lib/vutuv_web/components/ui.ex:1519
+#: lib/vutuv_web/components/ui.ex:1588
 #, elixir-autogen, elixir-format
 msgid "Subscribe"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1628
+#: lib/vutuv_web/components/ui.ex:1640
 #, elixir-autogen, elixir-format
 msgid "With an RSS reader"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1588
+#: lib/vutuv_web/components/ui.ex:1600
 #, elixir-autogen, elixir-format
 msgid "Create a free account"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1603
+#: lib/vutuv_web/components/ui.ex:1615
 #, elixir-autogen, elixir-format
 msgid "No vutuv account? These ways work too:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1581
+#: lib/vutuv_web/components/ui.ex:1593
 #, elixir-autogen, elixir-format
 msgid "The best way: follow %{name} here. New posts land in your feed, and you can reply and join in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1579
+#: lib/vutuv_web/components/ui.ex:1591
 #, elixir-autogen, elixir-format
 msgid "With a vutuv account"
 msgstr ""
@@ -21550,12 +21551,12 @@ msgstr ""
 msgid "Shown in the language it was written in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4946
+#: lib/vutuv_web/components/ui.ex:4958
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4948
+#: lib/vutuv_web/components/ui.ex:4960
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr ""
@@ -21683,7 +21684,7 @@ msgstr ""
 msgid "Your LinkedIn profile can come along."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1143
+#: lib/vutuv_web/components/ui.ex:1155
 #, elixir-autogen, elixir-format
 msgid "Being checked"
 msgstr ""
@@ -21948,7 +21949,7 @@ msgstr "Posts carrying one of these tags are folded the same way."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3426
+#: lib/vutuv_web/live/post_live/feed.ex:3449
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
@@ -22025,9 +22026,10 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3036
-#: lib/vutuv_web/live/post_live/feed.ex:3474
-#: lib/vutuv_web/live/post_live/feed.ex:3479
+#: lib/vutuv_web/live/post_live/feed.ex:3048
+#: lib/vutuv_web/live/post_live/feed.ex:3075
+#: lib/vutuv_web/live/post_live/feed.ex:3497
+#: lib/vutuv_web/live/post_live/feed.ex:3502
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -22071,7 +22073,7 @@ msgstr ""
 msgid "Your organization page was updated, but that picture could not be used as a logo. Please pick another one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4202
+#: lib/vutuv_web/components/ui.ex:4214
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -22092,7 +22094,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3196
+#: lib/vutuv_web/live/post_live/feed.ex:3219
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to now"
 msgstr ""
@@ -22102,7 +22104,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3242
+#: lib/vutuv_web/live/post_live/feed.ex:3265
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22124,7 +22126,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3192
+#: lib/vutuv_web/live/post_live/feed.ex:3215
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -22269,7 +22271,7 @@ msgstr ""
 msgid "Only these accounts (empty = all) …"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3325
+#: lib/vutuv_web/components/ui.ex:3337
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr ""
@@ -22281,55 +22283,55 @@ msgctxt "filter rule"
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1356
+#: lib/vutuv_web/live/notification_live/index.ex:1656
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} share"
 msgid_plural "%{formatted} shares"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:828
+#: lib/vutuv_web/live/notification_live/index.ex:818
 #, elixir-autogen, elixir-format
 msgid "Post without text"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1331
+#: lib/vutuv_web/live/notification_live/index.ex:1563
 #, elixir-autogen, elixir-format
 msgid "likes this."
 msgid_plural "like this."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1337
+#: lib/vutuv_web/live/notification_live/index.ex:1569
 #, elixir-autogen, elixir-format
 msgid "reacted to this."
 msgid_plural "reacted to this."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1322
+#: lib/vutuv_web/live/notification_live/index.ex:1571
 #, elixir-autogen, elixir-format
 msgid "replied."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1334
+#: lib/vutuv_web/live/notification_live/index.ex:1566
 #, elixir-autogen, elixir-format
 msgid "shared this."
 msgid_plural "shared this."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:554
+#: lib/vutuv_web/components/ui.ex:566
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Editor view"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:502
+#: lib/vutuv_web/components/ui.ex:514
 #, elixir-autogen, elixir-format
 msgid "Insert a block"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:514
+#: lib/vutuv_web/components/ui.ex:526
 #, elixir-autogen, elixir-format
 msgid "Nothing matches."
 msgstr ""
@@ -22513,7 +22515,7 @@ msgstr ""
 msgid "Replace with"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4938
+#: lib/vutuv_web/components/ui.ex:4950
 #, elixir-autogen, elixir-format
 msgid "Rewrite what an account's posts say, for you alone"
 msgstr ""
@@ -22531,7 +22533,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1366
 #: lib/vutuv_web/components/post_components.ex:2671
 #: lib/vutuv_web/components/post_components.ex:3658
-#: lib/vutuv_web/components/ui.ex:4937
+#: lib/vutuv_web/components/ui.ex:4949
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
 #: lib/vutuv_web/live/post_rewrites_live.ex:264
@@ -22587,7 +22589,7 @@ msgstr ""
 msgid "\\1 puts back what the first (…) group matched, \\0 the whole match."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4939
+#: lib/vutuv_web/components/ui.ex:4951
 #, elixir-autogen, elixir-format
 msgid "regex regular expression rewrite replace footer signature strip"
 msgstr ""
@@ -22597,13 +22599,12 @@ msgstr ""
 msgid "For members on a slow connection, data-saving mode shows pictures and screenshots in a stronger compression and leaves out a few luxuries, such as the richer editor. Any picture loads in full quality with one tap, and you can switch the mode off at any time."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1193
-#: lib/vutuv_web/components/ui.ex:1194
+#: lib/vutuv_web/components/ui.ex:1205
+#: lib/vutuv_web/components/ui.ex:1206
 #, elixir-autogen, elixir-format
 msgid "Load this picture in full quality"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4962
 #: lib/vutuv_web/components/ui.ex:5007
 #, elixir-autogen, elixir-format
 msgid "Smaller pictures and a plain composer on a slow connection"
@@ -22614,7 +22615,6 @@ msgstr ""
 msgid "That endorsement is not possible."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4964
 #: lib/vutuv_web/components/ui.ex:5009
 #, elixir-autogen, elixir-format
 msgid "bandwidth slow internet mobile data saving saver volume metered compression pictures images screenshots editor langsam daten sparen datensparmodus volumen schmalband komprimierung bilder"
@@ -22623,4 +22623,70 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4994
 #, elixir-autogen, elixir-format
 msgid "Appearance"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1433
+#, elixir-autogen, elixir-format, fuzzy
+msgid "%{formatted} connection"
+msgid_plural "%{formatted} connections"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1674
+#, elixir-autogen, elixir-format, fuzzy
+msgid "%{formatted} new connection"
+msgid_plural "%{formatted} new connections"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1678
+#, elixir-autogen, elixir-format, fuzzy
+msgid "%{formatted} new follower"
+msgid_plural "%{formatted} new followers"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1442
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Last 30 days: %{parts}"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1003
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Less"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1342
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Reactions"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:511
+#, elixir-autogen, elixir-format
+msgid "Seen before"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:623
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Show %{formatted} more"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:825
+#, elixir-autogen, elixir-format, fuzzy
+msgid "The post is no longer available."
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1634
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Thread by %{name}"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1573
+#, elixir-autogen, elixir-format, fuzzy
+msgid "mentioned you."
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1572
+#, elixir-autogen, elixir-format
+msgid "replied in the thread."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -17,8 +17,8 @@ msgstr ""
 msgid "About us"
 msgstr "Note legali"
 
-#: lib/vutuv_web/components/ui.ex:4586
-#: lib/vutuv_web/components/ui.ex:4591
+#: lib/vutuv_web/components/ui.ex:4598
+#: lib/vutuv_web/components/ui.ex:4603
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
 #: lib/vutuv_web/live/organization_live/domains.ex:267
@@ -64,7 +64,7 @@ msgstr "Indirizzo aggiornato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/text.ex:71
-#: lib/vutuv_web/components/ui.ex:4904
+#: lib/vutuv_web/components/ui.ex:4916
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -77,14 +77,14 @@ msgstr "Indirizzo aggiornato."
 msgid "Addresses"
 msgstr "Indirizzi"
 
-#: lib/vutuv_web/components/ui.ex:1594
+#: lib/vutuv_web/components/ui.ex:1606
 #: lib/vutuv_web/templates/page/index.html.heex:325
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr "È già iscritto? Acceda qui."
 
-#: lib/vutuv_web/components/ui.ex:4377
-#: lib/vutuv_web/components/ui.ex:4476
+#: lib/vutuv_web/components/ui.ex:4389
+#: lib/vutuv_web/components/ui.ex:4488
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -112,7 +112,7 @@ msgid "Birthday"
 msgstr "Compleanno"
 
 #: lib/vutuv_web/components/saved_search_components.ex:104
-#: lib/vutuv_web/components/ui.ex:4371
+#: lib/vutuv_web/components/ui.ex:4383
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
 #: lib/vutuv_web/live/admin/user_delete_live.ex:202
@@ -163,7 +163,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr "Non è stato possibile ricambiare il follow a %{name}."
 
 #: lib/vutuv_web/components/post_components.ex:3635
-#: lib/vutuv_web/components/ui.ex:4478
+#: lib/vutuv_web/components/ui.ex:4490
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:657
@@ -211,7 +211,7 @@ msgid "Download"
 msgstr "Scarica"
 
 #: lib/vutuv_web/components/post_components.ex:3600
-#: lib/vutuv_web/components/ui.ex:4469
+#: lib/vutuv_web/components/ui.ex:4481
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
@@ -285,7 +285,7 @@ msgstr "Inserisca il Suo indirizzo e-mail"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:4868
+#: lib/vutuv_web/components/ui.ex:4880
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -315,7 +315,6 @@ msgstr "Nome"
 #: lib/vutuv_web/agent_docs/text.ex:595
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
-#: lib/vutuv_web/live/notification_live/index.ex:1207
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:27
@@ -326,8 +325,8 @@ msgstr "Follower"
 #: lib/vutuv_web/agent_docs/markdown.ex:632
 #: lib/vutuv_web/agent_docs/text.ex:596
 #: lib/vutuv_web/components/fediverse_components.ex:468
-#: lib/vutuv_web/components/ui.ex:2871
-#: lib/vutuv_web/components/ui.ex:2906
+#: lib/vutuv_web/components/ui.ex:2883
+#: lib/vutuv_web/components/ui.ex:2918
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:608
@@ -456,7 +455,7 @@ msgstr "Accedi"
 msgid "Middle Name"
 msgstr "Secondo nome"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1132
+#: lib/vutuv_web/live/notification_live/index.ex:1344
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:193
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:201
 #, elixir-autogen
@@ -476,7 +475,7 @@ msgid "Name"
 msgstr "Nome"
 
 #: lib/vutuv_web/components/post_components.ex:723
-#: lib/vutuv_web/live/notification_live/index.ex:743
+#: lib/vutuv_web/live/notification_live/index.ex:774
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
@@ -615,7 +614,7 @@ msgstr "Piattaforma"
 msgid "Public"
 msgstr "Pubblico"
 
-#: lib/vutuv_web/components/ui.ex:4370
+#: lib/vutuv_web/components/ui.ex:4382
 #: lib/vutuv_web/live/organization_live/edit.ex:367
 #: lib/vutuv_web/live/post_live/composer.ex:1937
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -790,13 +789,13 @@ msgstr "Utente aggiornato."
 msgid "User verified successfully."
 msgstr "Utente verificato."
 
-#: lib/vutuv_web/components/ui.ex:4864
+#: lib/vutuv_web/components/ui.ex:4876
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:832
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
 #: lib/vutuv_web/live/directory_search_live.ex:134
-#: lib/vutuv_web/live/notification_live/index.ex:1286
+#: lib/vutuv_web/live/notification_live/index.ex:1522
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:51
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -842,7 +841,7 @@ msgstr "Nome utente"
 msgid "Users"
 msgstr "Utenti"
 
-#: lib/vutuv_web/components/ui.ex:1401
+#: lib/vutuv_web/components/ui.ex:1413
 #: lib/vutuv_web/views/user_html.ex:562
 #: lib/vutuv_web/views/user_html.ex:563
 #: lib/vutuv_web/views/user_html.ex:577
@@ -850,7 +849,7 @@ msgstr "Utenti"
 msgid "vCard"
 msgstr "vCard"
 
-#: lib/vutuv_web/components/ui.ex:4539
+#: lib/vutuv_web/components/ui.ex:4551
 #: lib/vutuv_web/templates/user/show.html.heex:981
 #: lib/vutuv_web/templates/user/show.html.heex:1004
 #, elixir-autogen
@@ -1401,7 +1400,7 @@ msgstr "URL dei tag"
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:522
 #: lib/vutuv_web/agent_docs/text.ex:768
-#: lib/vutuv_web/components/ui.ex:4889
+#: lib/vutuv_web/components/ui.ex:4901
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1647,7 +1646,7 @@ msgstr "Torna alla pagina iniziale"
 msgid "Check your inbox"
 msgstr "Controlli la Sua casella di posta"
 
-#: lib/vutuv_web/components/ui.ex:3030
+#: lib/vutuv_web/components/ui.ex:3042
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:477
 #: lib/vutuv_web/live/admin/organization_live.ex:296
@@ -1704,20 +1703,20 @@ msgstr "Elimina il mio account"
 msgid "Edit profile"
 msgstr "Modifica profilo"
 
-#: lib/vutuv_web/components/ui.ex:2113
-#: lib/vutuv_web/components/ui.ex:2122
-#: lib/vutuv_web/components/ui.ex:2600
+#: lib/vutuv_web/components/ui.ex:2125
+#: lib/vutuv_web/components/ui.ex:2134
+#: lib/vutuv_web/components/ui.ex:2612
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr "Conferma"
 
 #: lib/vutuv_web/components/fediverse_components.ex:244
-#: lib/vutuv_web/components/ui.ex:2836
-#: lib/vutuv_web/components/ui.ex:2836
-#: lib/vutuv_web/components/ui.ex:2853
-#: lib/vutuv_web/components/ui.ex:2862
-#: lib/vutuv_web/components/ui.ex:2878
-#: lib/vutuv_web/components/ui.ex:2940
+#: lib/vutuv_web/components/ui.ex:2848
+#: lib/vutuv_web/components/ui.ex:2848
+#: lib/vutuv_web/components/ui.ex:2865
+#: lib/vutuv_web/components/ui.ex:2874
+#: lib/vutuv_web/components/ui.ex:2890
+#: lib/vutuv_web/components/ui.ex:2952
 #: lib/vutuv_web/live/fediverse_account_live.ex:400
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:312
@@ -1757,7 +1756,7 @@ msgstr "Esci"
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
 #: lib/vutuv_web/live/admin/user_delete_live.ex:143
 #: lib/vutuv_web/live/admin/user_live.ex:154
-#: lib/vutuv_web/live/message_live/index.ex:538
+#: lib/vutuv_web/live/message_live/index.ex:548
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:32
 #: lib/vutuv_web/templates/admin/account/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:28
@@ -1776,7 +1775,7 @@ msgstr "Messaggio"
 
 #: lib/vutuv_web/controllers/page_controller.ex:228
 #: lib/vutuv_web/live/message_live/index.ex:49
-#: lib/vutuv_web/live/message_live/index.ex:624
+#: lib/vutuv_web/live/message_live/index.ex:634
 #: lib/vutuv_web/live/shell_live.ex:1249
 #: lib/vutuv_web/live/shell_live.ex:1427
 #: lib/vutuv_web/templates/layout/app.html.heex:152
@@ -1791,7 +1790,7 @@ msgid "Network"
 msgstr "Rete"
 
 #: lib/vutuv_web/components/post_components.ex:459
-#: lib/vutuv_web/components/ui.ex:4588
+#: lib/vutuv_web/components/ui.ex:4600
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
@@ -1801,16 +1800,16 @@ msgstr "Rete"
 msgid "Nothing here yet."
 msgstr "Qui non c'è ancora nulla."
 
-#: lib/vutuv_web/live/notification_live/index.ex:437
+#: lib/vutuv_web/live/notification_live/index.ex:528
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr "Ancora nessuna novità."
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:4926
+#: lib/vutuv_web/components/ui.ex:4938
 #: lib/vutuv_web/controllers/page_controller.ex:229
-#: lib/vutuv_web/live/notification_live/index.ex:147
-#: lib/vutuv_web/live/notification_live/index.ex:385
+#: lib/vutuv_web/live/notification_live/index.ex:156
+#: lib/vutuv_web/live/notification_live/index.ex:450
 #: lib/vutuv_web/live/shell_live.ex:1261
 #: lib/vutuv_web/templates/layout/app.html.heex:153
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
@@ -1833,7 +1832,7 @@ msgid "Pardon us! Something went wrong."
 msgstr "Ci scusi, qualcosa è andato storto."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:902
+#: lib/vutuv_web/live/message_live/index.ex:912
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
@@ -1913,8 +1912,8 @@ msgstr ""
 msgid "Who to follow"
 msgstr "Chi seguire"
 
-#: lib/vutuv_web/live/message_live/index.ex:891
-#: lib/vutuv_web/live/message_live/index.ex:892
+#: lib/vutuv_web/live/message_live/index.ex:901
+#: lib/vutuv_web/live/message_live/index.ex:902
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr "Scriva un messaggio…"
@@ -1959,14 +1958,14 @@ msgstr "ora è collegato con Lei."
 msgid "started following you."
 msgstr "ha iniziato a seguirla."
 
-#: lib/vutuv_web/components/ui.ex:3871
-#: lib/vutuv_web/components/ui.ex:4016
+#: lib/vutuv_web/components/ui.ex:3883
+#: lib/vutuv_web/components/ui.ex:4028
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr "Paginazione"
 
-#: lib/vutuv_web/components/ui.ex:4613
+#: lib/vutuv_web/components/ui.ex:4625
 #: lib/vutuv_web/live/organization_live/activity.ex:151
 #: lib/vutuv_web/live/organization_live/feed.ex:209
 #: lib/vutuv_web/live/organization_live/show.ex:777
@@ -1981,13 +1980,13 @@ msgstr ""
 "L'indirizzo non può essere modificato. Per usarne un altro, lo aggiunga come"
 " nuovo indirizzo e-mail ed elimini questo."
 
-#: lib/vutuv_web/components/ui.ex:4380
+#: lib/vutuv_web/components/ui.ex:4392
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Elimina voce"
 
-#: lib/vutuv_web/components/ui.ex:1794
-#: lib/vutuv_web/components/ui.ex:1804
+#: lib/vutuv_web/components/ui.ex:1806
+#: lib/vutuv_web/components/ui.ex:1816
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr "Opzioni"
@@ -2026,12 +2025,12 @@ msgstr "Aggiungi un'immagine di copertina"
 msgid "Add cover photo"
 msgstr "Aggiungi immagine di copertina"
 
-#: lib/vutuv_web/components/ui.ex:3384
+#: lib/vutuv_web/components/ui.ex:3396
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr "Aprile"
 
-#: lib/vutuv_web/components/ui.ex:3388
+#: lib/vutuv_web/components/ui.ex:3400
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr "Agosto"
@@ -2056,37 +2055,37 @@ msgstr "Immagine di copertina"
 msgid "Cover photo of %{name}"
 msgstr "Immagine di copertina di %{name}"
 
-#: lib/vutuv_web/components/ui.ex:3392
+#: lib/vutuv_web/components/ui.ex:3404
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr "Dicembre"
 
-#: lib/vutuv_web/components/ui.ex:3382
+#: lib/vutuv_web/components/ui.ex:3394
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr "Febbraio"
 
-#: lib/vutuv_web/components/ui.ex:3381
+#: lib/vutuv_web/components/ui.ex:3393
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr "Gennaio"
 
-#: lib/vutuv_web/components/ui.ex:3387
+#: lib/vutuv_web/components/ui.ex:3399
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr "Luglio"
 
-#: lib/vutuv_web/components/ui.ex:3386
+#: lib/vutuv_web/components/ui.ex:3398
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr "Giugno"
 
-#: lib/vutuv_web/components/ui.ex:3383
+#: lib/vutuv_web/components/ui.ex:3395
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr "Marzo"
 
-#: lib/vutuv_web/components/ui.ex:3385
+#: lib/vutuv_web/components/ui.ex:3397
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr "Maggio"
@@ -2101,17 +2100,17 @@ msgstr "Membro da %{month} %{year}"
 msgid "Member since %{year}"
 msgstr "Membro dal %{year}"
 
-#: lib/vutuv_web/components/ui.ex:3391
+#: lib/vutuv_web/components/ui.ex:3403
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr "Novembre"
 
-#: lib/vutuv_web/components/ui.ex:3390
+#: lib/vutuv_web/components/ui.ex:3402
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr "Ottobre"
 
-#: lib/vutuv_web/components/ui.ex:3389
+#: lib/vutuv_web/components/ui.ex:3401
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr "Settembre"
@@ -2213,7 +2212,7 @@ msgstr "Visitatori non connessi"
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3216
+#: lib/vutuv_web/live/post_live/feed.ex:3239
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2254,7 +2253,6 @@ msgstr "Post eliminato."
 #: lib/vutuv_web/gettext_extraction_anchors.ex:109
 #: lib/vutuv_web/live/admin/dashboard_live.ex:172
 #: lib/vutuv_web/live/fediverse_account_live.ex:407
-#: lib/vutuv_web/live/notification_live/index.ex:1130
 #: lib/vutuv_web/live/organization_live/show.ex:700
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:348
@@ -2390,7 +2388,7 @@ msgstr "persone che non La seguono"
 msgid "people you don't follow"
 msgstr "persone che non segue"
 
-#: lib/vutuv_web/components/ui.ex:3462
+#: lib/vutuv_web/components/ui.ex:3474
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
@@ -2428,7 +2426,7 @@ msgstr "Tutti i post"
 
 #: lib/vutuv_web/components/post_components.ex:2028
 #: lib/vutuv_web/components/post_components.ex:5593
-#: lib/vutuv_web/components/ui.ex:3938
+#: lib/vutuv_web/components/ui.ex:3950
 #: lib/vutuv_web/views/user_html.ex:461
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2447,8 +2445,8 @@ msgstr "Salvati"
 
 #: lib/vutuv_web/components/post_components.ex:1981
 #: lib/vutuv_web/components/post_components.ex:5831
-#: lib/vutuv_web/components/ui.ex:3924
-#: lib/vutuv_web/live/notification_live/index.ex:1276
+#: lib/vutuv_web/components/ui.ex:3936
+#: lib/vutuv_web/live/notification_live/index.ex:1511
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2456,7 +2454,6 @@ msgstr "Mi piace"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1144
 #: lib/vutuv_web/components/post_components.ex:5841
-#: lib/vutuv_web/live/notification_live/index.ex:1209
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
 #: lib/vutuv_web/live/shell_live.ex:1312
@@ -2519,9 +2516,9 @@ msgstr "Togli Mi piace"
 
 #: lib/vutuv_web/components/fediverse_components.ex:498
 #: lib/vutuv_web/components/post_components.ex:2663
-#: lib/vutuv_web/components/ui.ex:2831
-#: lib/vutuv_web/components/ui.ex:2831
-#: lib/vutuv_web/components/ui.ex:2907
+#: lib/vutuv_web/components/ui.ex:2843
+#: lib/vutuv_web/components/ui.ex:2843
+#: lib/vutuv_web/components/ui.ex:2919
 #: lib/vutuv_web/live/organization_live/following.ex:384
 #: lib/vutuv_web/live/organization_live/following.ex:468
 #: lib/vutuv_web/live/organization_live/show.ex:611
@@ -2544,7 +2541,7 @@ msgid "Only public posts can be answered."
 msgstr "Solo ai post pubblici si può rispondere."
 
 #: lib/vutuv_web/components/post_components.ex:417
-#: lib/vutuv_web/live/notification_live/index.ex:1210
+#: lib/vutuv_web/live/notification_live/index.ex:1341
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Risposte"
@@ -2552,7 +2549,8 @@ msgstr "Risposte"
 #: lib/vutuv_web/components/post_components.ex:1994
 #: lib/vutuv_web/components/post_components.ex:5868
 #: lib/vutuv_web/components/post_components.ex:5869
-#: lib/vutuv_web/live/notification_live/index.ex:1273
+#: lib/vutuv_web/live/notification_live/index.ex:993
+#: lib/vutuv_web/live/notification_live/index.ex:1508
 #: lib/vutuv_web/live/post_live/reply.ex:46
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2604,89 +2602,89 @@ msgstr "Risposta a un post di %{handle} ora eliminato"
 msgid "Replying to %{handle}"
 msgstr "In risposta a %{handle}"
 
-#: lib/vutuv_web/live/message_live/index.ex:603
+#: lib/vutuv_web/live/message_live/index.ex:613
 #, elixir-autogen, elixir-format
 msgid "%{names} are typing…"
 msgstr "%{names} stanno scrivendo…"
 
-#: lib/vutuv_web/live/message_live/index.ex:602
+#: lib/vutuv_web/live/message_live/index.ex:612
 #, elixir-autogen, elixir-format
 msgid "%{name} is typing…"
 msgstr "%{name} sta scrivendo…"
 
-#: lib/vutuv_web/live/message_live/index.ex:914
+#: lib/vutuv_web/live/message_live/index.ex:924
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr "@%{slug} non ha ancora accettato la Sua richiesta di messaggio."
 
-#: lib/vutuv_web/live/message_live/index.ex:865
+#: lib/vutuv_web/live/message_live/index.ex:875
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to message you."
 msgstr "@%{slug} Le vuole scrivere."
 
-#: lib/vutuv_web/live/message_live/index.ex:591
+#: lib/vutuv_web/live/message_live/index.ex:601
 #, elixir-autogen, elixir-format
 msgid "Accept"
 msgstr "Accetta"
 
-#: lib/vutuv_web/live/message_live/index.ex:728
+#: lib/vutuv_web/live/message_live/index.ex:738
 #, elixir-autogen, elixir-format
 msgid "Back to conversations"
 msgstr "Torna alle conversazioni"
 
-#: lib/vutuv_web/live/message_live/index.ex:593
+#: lib/vutuv_web/live/message_live/index.ex:603
 #, elixir-autogen, elixir-format
 msgid "Decline"
 msgstr "Rifiuta"
 
-#: lib/vutuv_web/live/message_live/index.ex:534
+#: lib/vutuv_web/live/message_live/index.ex:544
 #, elixir-autogen, elixir-format
 msgid "Deleted account"
 msgstr "Account eliminato"
 
-#: lib/vutuv_web/live/message_live/index.ex:774
+#: lib/vutuv_web/live/message_live/index.ex:784
 #, elixir-autogen, elixir-format
 msgid "Load older messages"
 msgstr "Carica i messaggi precedenti"
 
 #: lib/vutuv_web/controllers/admin/tag_member_controller.ex:55
-#: lib/vutuv_web/live/message_live/index.ex:132
+#: lib/vutuv_web/live/message_live/index.ex:142
 #, elixir-autogen, elixir-format
 msgid "Member not found."
 msgstr "Membro non trovato."
 
-#: lib/vutuv_web/live/message_live/index.ex:707
+#: lib/vutuv_web/live/message_live/index.ex:717
 #, elixir-autogen, elixir-format
 msgid "No conversations yet."
 msgstr "Ancora nessuna conversazione."
 
-#: lib/vutuv_web/components/ui.ex:3154
-#: lib/vutuv_web/live/message_live/index.ex:750
+#: lib/vutuv_web/components/ui.ex:3166
+#: lib/vutuv_web/live/message_live/index.ex:760
 #, elixir-autogen, elixir-format
 msgid "Online"
 msgstr "Online"
 
-#: lib/vutuv_web/live/message_live/index.ex:656
+#: lib/vutuv_web/live/message_live/index.ex:666
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr "Richieste"
 
-#: lib/vutuv_web/live/message_live/index.ex:923
+#: lib/vutuv_web/live/message_live/index.ex:933
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr "Selezioni una conversazione."
 
-#: lib/vutuv_web/live/message_live/index.ex:147
+#: lib/vutuv_web/live/message_live/index.ex:157
 #, elixir-autogen, elixir-format
 msgid "This member cannot receive messages."
 msgstr "Questo membro non può ricevere messaggi."
 
-#: lib/vutuv_web/live/message_live/index.ex:239
+#: lib/vutuv_web/live/message_live/index.ex:249
 #, elixir-autogen, elixir-format
 msgid "This message could not be sent."
 msgstr "Non è stato possibile inviare il messaggio."
 
-#: lib/vutuv_web/live/message_live/index.ex:142
+#: lib/vutuv_web/live/message_live/index.ex:152
 #, elixir-autogen, elixir-format
 msgid "Too many new conversations. Please try again later."
 msgstr "Troppe nuove conversazioni. Riprovi più tardi."
@@ -2749,7 +2747,7 @@ msgstr "Un nuovo PIN è in arrivo nella Sua casella di posta."
 msgid "Okay, let's start over."
 msgstr "Va bene, ricominciamo."
 
-#: lib/vutuv_web/components/ui.ex:850
+#: lib/vutuv_web/components/ui.ex:862
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr "Invia di nuovo il PIN"
@@ -2760,7 +2758,7 @@ msgstr "Invia di nuovo il PIN"
 msgid "Too many PIN requests. Please try again later."
 msgstr "Troppe richieste di PIN. Riprovi più tardi."
 
-#: lib/vutuv_web/components/ui.ex:871
+#: lib/vutuv_web/components/ui.ex:883
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr "Usa un altro indirizzo e-mail"
@@ -2810,8 +2808,8 @@ msgstr "Aggiungi un'esperienza lavorativa"
 msgid "Write your first post"
 msgstr "Scriva il Suo primo post"
 
-#: lib/vutuv_web/components/ui.ex:4104
-#: lib/vutuv_web/components/ui.ex:4541
+#: lib/vutuv_web/components/ui.ex:4116
+#: lib/vutuv_web/components/ui.ex:4553
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:109
@@ -2857,13 +2855,12 @@ msgstr[1] "+%{formatted} altri tag"
 #: lib/vutuv_web/agent_docs/markdown.ex:633
 #: lib/vutuv_web/agent_docs/text.ex:597
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:1208
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
 msgstr "Collegamenti"
 
-#: lib/vutuv_web/components/ui.ex:1392
+#: lib/vutuv_web/components/ui.ex:1404
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr "Markdown"
@@ -2873,7 +2870,7 @@ msgstr "Markdown"
 msgid "No connections yet."
 msgstr "Ancora nessun collegamento."
 
-#: lib/vutuv_web/components/ui.ex:1408
+#: lib/vutuv_web/components/ui.ex:1420
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr "Altri formati"
@@ -2883,7 +2880,7 @@ msgstr "Altri formati"
 msgid "People who aren't my connections"
 msgstr "Persone che non sono miei collegamenti"
 
-#: lib/vutuv_web/components/ui.ex:1393
+#: lib/vutuv_web/components/ui.ex:1405
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr "Solo testo"
@@ -2906,29 +2903,29 @@ msgstr[1] "collegamenti"
 msgid "people who aren't your connections"
 msgstr "persone che non sono Suoi collegamenti"
 
-#: lib/vutuv_web/live/message_live/index.ex:708
+#: lib/vutuv_web/live/message_live/index.ex:718
 #, elixir-autogen, elixir-format
 msgid "Open someone's profile to message them."
 msgstr "Apra il profilo di una persona per scriverle."
 
 #: lib/vutuv_web/components/organization_components.ex:259
-#: lib/vutuv_web/live/notification_live/index.ex:1288
+#: lib/vutuv_web/live/notification_live/index.ex:1524
 #: lib/vutuv_web/live/organization_live/activity.ex:104
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr "Attività"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1279
+#: lib/vutuv_web/live/notification_live/index.ex:1515
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr "Collegamento"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1272
+#: lib/vutuv_web/live/notification_live/index.ex:1507
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr "Conferma"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1271
+#: lib/vutuv_web/live/notification_live/index.ex:1506
 #: lib/vutuv_web/templates/user/show.html.heex:965
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -3086,7 +3083,7 @@ msgstr ""
 msgid "Hidden. You can settle this yourself - see below."
 msgstr "Nascosto. Può risolvere da solo: veda qui sotto."
 
-#: lib/vutuv_web/live/message_live/index.ex:803
+#: lib/vutuv_web/live/message_live/index.ex:813
 #, elixir-autogen, elixir-format
 msgid "Hidden: reported, under review"
 msgstr "Nascosto: segnalato, in esame"
@@ -3098,7 +3095,7 @@ msgstr "Contenuti adatti a tutti"
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1280
+#: lib/vutuv_web/live/notification_live/index.ex:1516
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3237,7 +3234,7 @@ msgstr ""
 msgid "Private message"
 msgstr "Messaggio privato"
 
-#: lib/vutuv_web/components/ui.ex:4858
+#: lib/vutuv_web/components/ui.ex:4870
 #: lib/vutuv_web/live/shell_live.ex:1125
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3292,8 +3289,8 @@ msgstr "Segnalazione respinta; il contenuto è di nuovo visibile."
 msgid "Report this content"
 msgstr "Segnala questo contenuto"
 
-#: lib/vutuv_web/live/message_live/index.ex:821
-#: lib/vutuv_web/live/message_live/index.ex:822
+#: lib/vutuv_web/live/message_live/index.ex:831
+#: lib/vutuv_web/live/message_live/index.ex:832
 #, elixir-autogen, elixir-format
 msgid "Report this message"
 msgstr "Segnala questo messaggio"
@@ -3351,7 +3348,7 @@ msgstr ""
 "Le segnalazioni sono anonime; non diciamo mai chi ha segnalato. Le nostre "
 "regole:"
 
-#: lib/vutuv_web/components/ui.ex:3811
+#: lib/vutuv_web/components/ui.ex:3823
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3789,7 +3786,7 @@ msgstr "Il proprietario ha modificato il contenuto"
 msgid "Report filed"
 msgstr "Segnalazione inviata"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1282
+#: lib/vutuv_web/live/notification_live/index.ex:1518
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr "Protezione dopo la segnalazione"
@@ -4066,6 +4063,7 @@ msgstr "Archivio dei post di %{name}"
 #: lib/vutuv_web/agent_docs/text.ex:137
 #: lib/vutuv_web/live/admin/screenshot_live.ex:380
 #: lib/vutuv_web/live/admin/screenshot_live.ex:389
+#: lib/vutuv_web/live/notification_live/index.ex:1637
 #: lib/vutuv_web/templates/post/show.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "Post by %{name}"
@@ -4503,12 +4501,12 @@ msgstr ""
 "Le prenotazioni sono aperte fino al %{last}. Prossimo giorno disponibile: "
 "%{day}"
 
-#: lib/vutuv_web/components/ui.ex:3414
+#: lib/vutuv_web/components/ui.ex:3426
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr "Ve"
 
-#: lib/vutuv_web/components/ui.ex:3410
+#: lib/vutuv_web/components/ui.ex:3422
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr "Lu"
@@ -4520,27 +4518,27 @@ msgstr ""
 "Una pubblicità al giorno: scelga un giorno libero nel calendario; i giorni "
 "barrati sono già prenotati."
 
-#: lib/vutuv_web/components/ui.ex:3415
+#: lib/vutuv_web/components/ui.ex:3427
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr "Sa"
 
-#: lib/vutuv_web/components/ui.ex:3416
+#: lib/vutuv_web/components/ui.ex:3428
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr "Do"
 
-#: lib/vutuv_web/components/ui.ex:3413
+#: lib/vutuv_web/components/ui.ex:3425
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr "Gi"
 
-#: lib/vutuv_web/components/ui.ex:3411
+#: lib/vutuv_web/components/ui.ex:3423
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr "Ma"
 
-#: lib/vutuv_web/components/ui.ex:3412
+#: lib/vutuv_web/components/ui.ex:3424
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr "Me"
@@ -4730,12 +4728,12 @@ msgstr "Non ha bloccato nessuno."
 msgid "You unblocked @%{slug}."
 msgstr "Ha sbloccato @%{slug}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3221
+#: lib/vutuv_web/live/post_live/feed.ex:3244
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Scopra persone da seguire"
 
-#: lib/vutuv_web/live/message_live/index.ex:711
+#: lib/vutuv_web/live/message_live/index.ex:721
 #, elixir-autogen, elixir-format
 msgid "Find members"
 msgstr "Trova membri"
@@ -4787,7 +4785,8 @@ msgstr "Non è una corrispondenza esatta, ma somiglia alla Sua ricerca."
 #: lib/vutuv_web/agent_docs/markdown.ex:444
 #: lib/vutuv_web/agent_docs/text.ex:463
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/live/notification_live/index.ex:1131
+#: lib/vutuv_web/live/notification_live/index.ex:646
+#: lib/vutuv_web/live/notification_live/index.ex:1343
 #: lib/vutuv_web/live/organization_live/show.ex:787
 #: lib/vutuv_web/live/post_live/saved.ex:523
 #: lib/vutuv_web/live/search_live.ex:346
@@ -4811,7 +4810,7 @@ msgstr "Nomi simili"
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
-#: lib/vutuv_web/live/notification_live/index.ex:1129
+#: lib/vutuv_web/live/notification_live/index.ex:1340
 #: lib/vutuv_web/live/search_live.ex:345
 #: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
@@ -5649,7 +5648,7 @@ msgstr "Navigazione a piè di pagina"
 #: lib/vutuv_web/components/post_components.ex:3727
 #: lib/vutuv_web/components/post_components.ex:3782
 #: lib/vutuv_web/components/post_components.ex:4190
-#: lib/vutuv_web/live/notification_live/index.ex:785
+#: lib/vutuv_web/live/notification_live/index.ex:1072
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5715,7 +5714,7 @@ msgstr "Modifica"
 msgid "Download everything vutuv stores about you, as one file."
 msgstr "Scarichi in un unico file tutto ciò che vutuv conserva su di Lei."
 
-#: lib/vutuv_web/components/ui.ex:4896
+#: lib/vutuv_web/components/ui.ex:4908
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5777,7 +5776,7 @@ msgstr "Vedi"
 msgid "Your name"
 msgstr "Il Suo nome"
 
-#: lib/vutuv_web/live/notification_live/index.ex:622
+#: lib/vutuv_web/live/notification_live/index.ex:1631
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr "Il Suo post"
@@ -5872,7 +5871,6 @@ msgid "Apps & API"
 msgstr "App e API"
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:1211
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -5952,7 +5950,7 @@ msgstr "Quando qualcuno inizia a seguirla."
 msgid "@handle"
 msgstr "@handle"
 
-#: lib/vutuv_web/live/message_live/index.ex:766
+#: lib/vutuv_web/live/message_live/index.ex:776
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}"
 msgstr "Blocca @%{slug}"
@@ -6073,21 +6071,21 @@ msgid "Sort"
 msgstr "Ordina"
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3471
+#: lib/vutuv_web/components/ui.ex:3483
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "%{count} giorno fa"
 msgstr[1] "%{count} giorni fa"
 
-#: lib/vutuv_web/components/ui.ex:3470
+#: lib/vutuv_web/components/ui.ex:3482
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "%{count} ora fa"
 msgstr[1] "%{count} ore fa"
 
-#: lib/vutuv_web/components/ui.ex:3469
+#: lib/vutuv_web/components/ui.ex:3481
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -6154,7 +6152,7 @@ msgstr "Questo dispositivo"
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr "È il primo accesso che vediamo da questo dispositivo o browser."
 
-#: lib/vutuv_web/components/ui.ex:3468
+#: lib/vutuv_web/components/ui.ex:3480
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "adesso"
@@ -6303,7 +6301,7 @@ msgstr "Aggiungi una descrizione breve"
 msgid "Tagline"
 msgstr "Descrizione breve"
 
-#: lib/vutuv_web/components/ui.ex:468
+#: lib/vutuv_web/components/ui.ex:480
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:915
@@ -6496,9 +6494,9 @@ msgstr "Sposta giù"
 msgid "Move up"
 msgstr "Sposta su"
 
-#: lib/vutuv_web/components/ui.ex:2113
-#: lib/vutuv_web/components/ui.ex:2122
-#: lib/vutuv_web/components/ui.ex:2601
+#: lib/vutuv_web/components/ui.ex:2125
+#: lib/vutuv_web/components/ui.ex:2134
+#: lib/vutuv_web/components/ui.ex:2613
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr "Ritira la conferma"
@@ -6563,11 +6561,11 @@ msgstr "Membri che hanno confermato %{name} per %{tag}"
 msgid "No endorsements yet."
 msgstr "Ancora nessuna conferma."
 
-#: lib/vutuv_web/components/ui.ex:2554
-#: lib/vutuv_web/live/notification_live/index.ex:685
-#: lib/vutuv_web/live/notification_live/index.ex:700
-#: lib/vutuv_web/live/notification_live/index.ex:1013
-#: lib/vutuv_web/live/notification_live/index.ex:1015
+#: lib/vutuv_web/components/ui.ex:2566
+#: lib/vutuv_web/live/notification_live/index.ex:716
+#: lib/vutuv_web/live/notification_live/index.ex:731
+#: lib/vutuv_web/live/notification_live/index.ex:1225
+#: lib/vutuv_web/live/notification_live/index.ex:1227
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr "e altri %{count}"
@@ -6887,7 +6885,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2643
 #: lib/vutuv_web/components/post_components.ex:3652
-#: lib/vutuv_web/components/ui.ex:2979
+#: lib/vutuv_web/components/ui.ex:2991
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/live/organization_live/following.ex:377
 #: lib/vutuv_web/live/organization_live/following.ex:461
@@ -6915,7 +6913,7 @@ msgid "Remove this connection? You will stop following them."
 msgstr "Rimuovere questo collegamento? Smetterà di seguire questa persona."
 
 #: lib/vutuv_web/components/post_components.ex:3652
-#: lib/vutuv_web/components/ui.ex:2978
+#: lib/vutuv_web/components/ui.ex:2990
 #: lib/vutuv_web/live/fediverse_account_live.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:377
 #: lib/vutuv_web/live/organization_live/following.ex:461
@@ -7537,13 +7535,13 @@ msgstr "I loro membri vengono aggiunti a questo (unione)."
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr "pagina %{page} di %{pages}, %{total} in totale"
 
-#: lib/vutuv_web/components/ui.ex:3880
+#: lib/vutuv_web/components/ui.ex:3892
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Precedente"
 
-#: lib/vutuv_web/components/ui.ex:3892
+#: lib/vutuv_web/components/ui.ex:3904
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7734,7 +7732,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr "Si aggiorna da sola. Può lasciare questa pagina: l'invio prosegue."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3487
+#: lib/vutuv_web/live/post_live/feed.ex:3510
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #, elixir-autogen
 msgid "Done"
@@ -8040,13 +8038,13 @@ msgstr "Nuovi membri"
 #: lib/vutuv_web/components/job_components.ex:219
 #: lib/vutuv_web/live/admin/dashboard_live.ex:304
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:468
-#: lib/vutuv_web/live/notification_live/index.ex:1158
+#: lib/vutuv_web/live/notification_live/index.ex:1378
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Oggi"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:308
-#: lib/vutuv_web/live/notification_live/index.ex:1161
+#: lib/vutuv_web/live/notification_live/index.ex:1381
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr "Ieri"
@@ -8345,7 +8343,7 @@ msgstr "PIN scaduto"
 msgid "PIN registered"
 msgstr "Registrato con PIN"
 
-#: lib/vutuv_web/components/ui.ex:3883
+#: lib/vutuv_web/components/ui.ex:3895
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr "Pagina %{page} di %{pages}"
@@ -8484,7 +8482,7 @@ msgstr "Titolo di studio"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:4872
+#: lib/vutuv_web/components/ui.ex:4884
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8572,7 +8570,7 @@ msgstr "Importati: %{items}."
 msgid "Nothing new to import."
 msgstr "Nulla di nuovo da importare."
 
-#: lib/vutuv_web/components/ui.ex:4900
+#: lib/vutuv_web/components/ui.ex:4912
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8668,7 +8666,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Troppe importazioni. Riprovi tra poco."
 
-#: lib/vutuv_web/components/ui.ex:4156
+#: lib/vutuv_web/components/ui.ex:4168
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8758,7 +8756,7 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr "Trascini qui il Suo file ZIP, oppure prema per sceglierne uno."
 
-#: lib/vutuv_web/components/ui.ex:4860
+#: lib/vutuv_web/components/ui.ex:4872
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
@@ -8902,7 +8900,7 @@ msgstr[1] "%{formatted} membri"
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr "La pagina %{letter} dell'elenco dei membri, ordinata per cognome."
 
-#: lib/vutuv_web/components/ui.ex:1410
+#: lib/vutuv_web/components/ui.ex:1422
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -9010,7 +9008,7 @@ msgstr "La scriva in Amministrazione › Pagine legali"
 #: lib/vutuv_web/agent_docs/text.ex:586
 #: lib/vutuv_web/agent_docs/text.ex:590
 #: lib/vutuv_web/components/organization_components.ex:276
-#: lib/vutuv_web/components/ui.ex:1611
+#: lib/vutuv_web/components/ui.ex:1623
 #: lib/vutuv_web/components/ui.ex:5032
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:357
@@ -9170,7 +9168,7 @@ msgstr ""
 "Questa è la versione di stampa del CV. Usi la finestra di stampa del browser"
 " (Ctrl+P o Cmd+P) e scelga \"Salva come PDF\" per ottenere un file PDF."
 
-#: lib/vutuv_web/components/ui.ex:1700
+#: lib/vutuv_web/components/ui.ex:1712
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr "Download del CV"
@@ -9208,7 +9206,7 @@ msgstr "Ogni download rispecchia le parti che ha selezionato."
 msgid "Header"
 msgstr "Intestazione"
 
-#: lib/vutuv_web/components/ui.ex:1710
+#: lib/vutuv_web/components/ui.ex:1722
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -9245,7 +9243,7 @@ msgstr ""
 "solo ciò che può già vedere lì, e gli indirizzi e-mail privati compaiono "
 "solo nel Suo."
 
-#: lib/vutuv_web/components/ui.ex:1702
+#: lib/vutuv_web/components/ui.ex:1714
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -9418,8 +9416,8 @@ msgstr "Questo tag può essere rimosso solo da un amministratore del sito."
 msgid "Yes"
 msgstr "Sì"
 
-#: lib/vutuv_web/components/ui.ex:2157
-#: lib/vutuv_web/components/ui.ex:2158
+#: lib/vutuv_web/components/ui.ex:2169
+#: lib/vutuv_web/components/ui.ex:2170
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9998,7 +9996,7 @@ msgstr "Certificati"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:4876
+#: lib/vutuv_web/components/ui.ex:4888
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -10201,13 +10199,13 @@ msgstr "Link permanente al profilo"
 msgid "Dismiss"
 msgstr "Chiudi"
 
-#: lib/vutuv_web/components/ui.ex:3584
+#: lib/vutuv_web/components/ui.ex:3596
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Copiato"
 
-#: lib/vutuv_web/components/ui.ex:3583
-#: lib/vutuv_web/components/ui.ex:3591
+#: lib/vutuv_web/components/ui.ex:3595
+#: lib/vutuv_web/components/ui.ex:3603
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Copia"
@@ -10399,17 +10397,17 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr "App di autenticazione disattivata."
 
-#: lib/vutuv_web/components/ui.ex:456
+#: lib/vutuv_web/components/ui.ex:468
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr "Grassetto"
 
-#: lib/vutuv_web/components/ui.ex:508
+#: lib/vutuv_web/components/ui.ex:520
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr "Elenco puntato"
 
-#: lib/vutuv_web/components/ui.ex:511
+#: lib/vutuv_web/components/ui.ex:523
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr "Blocco di codice"
@@ -10431,8 +10429,8 @@ msgstr ""
 msgid "Formatting"
 msgstr "Formattazione"
 
-#: lib/vutuv_web/components/ui.ex:575
-#: lib/vutuv_web/components/ui.ex:576
+#: lib/vutuv_web/components/ui.ex:587
+#: lib/vutuv_web/components/ui.ex:588
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr "Schermo intero"
@@ -10447,22 +10445,24 @@ msgstr "Genera un nuovo elenco"
 msgid "Generate code list"
 msgstr "Genera l'elenco dei codici"
 
-#: lib/vutuv_web/components/ui.ex:506
+#: lib/vutuv_web/components/ui.ex:461
+#: lib/vutuv_web/components/ui.ex:518
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr "Titolo 1"
 
-#: lib/vutuv_web/components/ui.ex:507
+#: lib/vutuv_web/components/ui.ex:464
+#: lib/vutuv_web/components/ui.ex:519
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr "Titolo 2"
 
-#: lib/vutuv_web/components/ui.ex:465
+#: lib/vutuv_web/components/ui.ex:477
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr "Codice in linea"
 
-#: lib/vutuv_web/components/ui.ex:459
+#: lib/vutuv_web/components/ui.ex:471
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr "Corsivo"
@@ -10483,7 +10483,7 @@ msgstr "Codici di accesso"
 msgid "Not set up."
 msgstr "Non configurata."
 
-#: lib/vutuv_web/components/ui.ex:509
+#: lib/vutuv_web/components/ui.ex:521
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr "Elenco numerato"
@@ -10500,7 +10500,7 @@ msgstr ""
 "Stampi questa pagina o annoti i codici. I codici barrati sono già stati "
 "usati."
 
-#: lib/vutuv_web/components/ui.ex:510
+#: lib/vutuv_web/components/ui.ex:522
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr "Citazione"
@@ -10526,7 +10526,7 @@ msgstr ""
 msgid "Set up"
 msgstr "Configura"
 
-#: lib/vutuv_web/components/ui.ex:462
+#: lib/vutuv_web/components/ui.ex:474
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr "Barrato"
@@ -10645,6 +10645,7 @@ msgid_plural "%{count} stars"
 msgstr[0] "%{count} stella"
 msgstr[1] "%{count} stelle"
 
+#: lib/vutuv_web/live/notification_live/index.ex:1429
 #: lib/vutuv_web/live/organization_live/show.ex:638
 #: lib/vutuv_web/views/user_html.ex:950
 #: lib/vutuv_web/views/user_html.ex:1126
@@ -11623,12 +11624,12 @@ msgstr "Pubblichi questo file all'indirizzo:"
 msgid "State / region (optional)"
 msgstr "Provincia / regione (facoltativo)"
 
-#: lib/vutuv_web/components/ui.ex:4210
+#: lib/vutuv_web/components/ui.ex:4222
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr "Questo tipo di file non è ammesso."
 
-#: lib/vutuv_web/components/ui.ex:4212
+#: lib/vutuv_web/components/ui.ex:4224
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr "Il caricamento non è riuscito."
@@ -12060,7 +12061,7 @@ msgstr ""
 "Il testo del link può essere qualsiasi. Va bene anche un <link rel=\"me\"> "
 "nascosto nell'head della pagina."
 
-#: lib/vutuv_web/components/ui.ex:1073
+#: lib/vutuv_web/components/ui.ex:1085
 #: lib/vutuv_web/live/section_reorder_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -12354,7 +12355,7 @@ msgstr "Pagina dell'organizzazione"
 msgid "Organization pages"
 msgstr "Pagine delle organizzazioni"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1283
+#: lib/vutuv_web/live/notification_live/index.ex:1519
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr "Ruolo nell'organizzazione"
@@ -13952,7 +13953,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr "Immagine in attesa di esame, visibile solo a Lei"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1281
+#: lib/vutuv_web/live/notification_live/index.ex:1517
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -14054,7 +14055,7 @@ msgstr ""
 "con quello nuovo e gli autori di quei post vengono avvisati. Il Suo vecchio "
 "indirizzo di profilo smette di funzionare."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1284
+#: lib/vutuv_web/live/notification_live/index.ex:1520
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr "Cambio di handle"
@@ -14075,27 +14076,27 @@ msgstr[1] ""
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "ha cambiato il proprio handle da @%{old} a @%{new}."
 
-#: lib/vutuv_web/components/ui.ex:485
+#: lib/vutuv_web/components/ui.ex:497
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr "Al centro"
 
-#: lib/vutuv_web/components/ui.ex:482
+#: lib/vutuv_web/components/ui.ex:494
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr "Allinea a sinistra"
 
-#: lib/vutuv_web/components/ui.ex:488
+#: lib/vutuv_web/components/ui.ex:500
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr "Allinea a destra"
 
-#: lib/vutuv_web/components/ui.ex:479
+#: lib/vutuv_web/components/ui.ex:491
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr "A tutta larghezza"
 
-#: lib/vutuv_web/components/ui.ex:512
+#: lib/vutuv_web/components/ui.ex:524
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr "Inserisci un'immagine"
@@ -14162,7 +14163,7 @@ msgstr ""
 "persone note per quel tag compaiono tra i Suoi suggerimenti. Segua un tag "
 "dalla sua pagina."
 
-#: lib/vutuv_web/components/ui.ex:4952
+#: lib/vutuv_web/components/ui.ex:4964
 #: lib/vutuv_web/controllers/settings_controller.ex:634
 #: lib/vutuv_web/live/post_live/feed.ex:720
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -14242,7 +14243,7 @@ msgstr "Messenger aggiornato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:63
-#: lib/vutuv_web/components/ui.ex:4919
+#: lib/vutuv_web/components/ui.ex:4931
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -14270,21 +14271,21 @@ msgstr "Messenger di %{name}"
 msgid "Select a messenger"
 msgstr "Selezioni un messenger"
 
-#: lib/vutuv_web/components/ui.ex:4295
+#: lib/vutuv_web/components/ui.ex:4307
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] "Avvisa il mio follower"
 msgstr[1] "Avvisa i miei %{formatted} follower"
 
-#: lib/vutuv_web/components/ui.ex:4305
+#: lib/vutuv_web/components/ui.ex:4317
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 "Vedono una notifica che rimanda a questa voce. Non viene inviata alcuna "
 "e-mail, e accade solo per una voce nuova."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1285
+#: lib/vutuv_web/live/notification_live/index.ex:1521
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr "Aggiornamento del CV"
@@ -14460,45 +14461,40 @@ msgstr "Con certificazione: %{name}"
 msgid "Publisher:"
 msgstr "Editore:"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1150
+#: lib/vutuv_web/live/notification_live/index.ex:1370
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] "%{formatted} nuova notifica"
 msgstr[1] "%{formatted} nuove notifiche"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1164
+#: lib/vutuv_web/live/notification_live/index.ex:1384
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr "%{day} %{month} %{year}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:454
+#: lib/vutuv_web/live/notification_live/index.ex:545
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr "Segui anche tu"
 
-#: lib/vutuv_web/live/notification_live/index.ex:469
-#, elixir-autogen, elixir-format
-msgid "Last 30 days"
-msgstr "Ultimi 30 giorni"
-
-#: lib/vutuv_web/live/notification_live/index.ex:1116
-#: lib/vutuv_web/live/notification_live/index.ex:1382
+#: lib/vutuv_web/live/notification_live/index.ex:1327
+#: lib/vutuv_web/live/notification_live/index.ex:1700
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "e"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1302
+#: lib/vutuv_web/live/notification_live/index.ex:1608
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr "ora sono collegati con Lei."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1299
+#: lib/vutuv_web/live/notification_live/index.ex:1605
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr "ora La seguono."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1308
+#: lib/vutuv_web/live/notification_live/index.ex:1614
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr "L'ha confermata per %{tags}."
@@ -14508,12 +14504,12 @@ msgstr "L'ha confermata per %{tags}."
 msgid "by:"
 msgstr "di:"
 
-#: lib/vutuv_web/components/ui.ex:2291
+#: lib/vutuv_web/components/ui.ex:2303
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr "Confermato da %{name}"
 
-#: lib/vutuv_web/components/ui.ex:2295
+#: lib/vutuv_web/components/ui.ex:2307
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -14759,7 +14755,7 @@ msgstr ""
 "non abbastanza adatta a un ambiente di lavoro. Può sbagliare, quindi "
 "risponda alla nostra e-mail se non è d'accordo."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1274
+#: lib/vutuv_web/live/notification_live/index.ex:1509
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr "Risposta in una discussione"
@@ -14787,7 +14783,7 @@ msgstr "Conversazione"
 msgid "Only part of this long conversation is shown."
 msgstr "Di questa lunga conversazione è mostrata solo una parte."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1275
+#: lib/vutuv_web/live/notification_live/index.ex:1510
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr "Menzione"
@@ -15082,6 +15078,8 @@ msgstr "Può spostarsi solo una volta ogni %{days} giorni."
 msgid "as an account alias."
 msgstr "come alias dell'account."
 
+#: lib/vutuv_web/live/notification_live/index.ex:1437
+#: lib/vutuv_web/live/notification_live/index.ex:1682
 #: lib/vutuv_web/templates/user_tag/show.html.heex:24
 #, elixir-autogen, elixir-format
 msgid "%{formatted} endorsement"
@@ -15124,7 +15122,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr "Corrispondenza solo su parole intere (parola o frase)"
 
-#: lib/vutuv_web/components/ui.ex:4933
+#: lib/vutuv_web/components/ui.ex:4945
 #: lib/vutuv_web/controllers/settings_controller.ex:700
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -15174,7 +15172,7 @@ msgstr "Questa formazione ora compare in cima al Suo profilo."
 msgid "Thread replies"
 msgstr "Risposte nelle discussioni"
 
-#: lib/vutuv_web/live/notification_live/index.ex:663
+#: lib/vutuv_web/live/notification_live/index.ex:1022
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr "Disattiva le notifiche delle discussioni"
@@ -15232,7 +15230,7 @@ msgstr "Non ha ancora silenziato nulla."
 msgid "You have reached the maximum of %{count} filters."
 msgstr "Ha raggiunto il massimo di %{count} filtri."
 
-#: lib/vutuv_web/live/notification_live/index.ex:658
+#: lib/vutuv_web/live/notification_live/index.ex:1017
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr "Ha scritto in questa discussione."
@@ -15828,68 +15826,68 @@ msgstr "Il Suo server"
 msgid "moved to %{address}"
 msgstr "spostato a %{address}"
 
-#: lib/vutuv_web/components/ui.ex:4861
+#: lib/vutuv_web/components/ui.ex:4873
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr "Nome, foto, immagine di copertina, descrizione breve"
 
-#: lib/vutuv_web/components/ui.ex:4866
+#: lib/vutuv_web/components/ui.ex:4878
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr "handle soprannome rinomina slug profilo indirizzo url menzione"
 
-#: lib/vutuv_web/components/ui.ex:4869
+#: lib/vutuv_web/components/ui.ex:4881
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr "Gli impieghi e i ruoli nel Suo CV"
 
-#: lib/vutuv_web/components/ui.ex:4870
+#: lib/vutuv_web/components/ui.ex:4882
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr "cv curriculum carriera datore di lavoro posizione qualifica azienda"
 
-#: lib/vutuv_web/components/ui.ex:4873
+#: lib/vutuv_web/components/ui.ex:4885
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr "Scuole, università, titoli di studio"
 
-#: lib/vutuv_web/components/ui.ex:4874
+#: lib/vutuv_web/components/ui.ex:4886
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr "cv curriculum studio studi scuola università laurea titolo"
 
-#: lib/vutuv_web/components/ui.ex:4877
+#: lib/vutuv_web/components/ui.ex:4889
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr "Credenziali, con documenti di prova"
 
-#: lib/vutuv_web/components/ui.ex:4878
+#: lib/vutuv_web/components/ui.ex:4890
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 "certificato abilitazione diploma credenziale riconoscimento prova documento"
 
-#: lib/vutuv_web/components/ui.ex:4885
+#: lib/vutuv_web/components/ui.ex:4897
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr "Competenze linguistiche"
 
-#: lib/vutuv_web/components/ui.ex:4886
+#: lib/vutuv_web/components/ui.ex:4898
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr "Le lingue che parla"
 
-#: lib/vutuv_web/components/ui.ex:4887
+#: lib/vutuv_web/components/ui.ex:4899
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr "lingua parlare parlata fluente madrelingua"
 
-#: lib/vutuv_web/components/ui.ex:4890
+#: lib/vutuv_web/components/ui.ex:4902
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr "Gli argomenti per cui è conosciuto"
 
-#: lib/vutuv_web/components/ui.ex:4891
+#: lib/vutuv_web/components/ui.ex:4903
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr "competenza argomento parola chiave esperienza conferma"
@@ -15904,108 +15902,108 @@ msgstr "Pagine aziendali che gestisce"
 msgid "company employer firm business organisation page"
 msgstr "azienda datore di lavoro impresa attività organizzazione pagina"
 
-#: lib/vutuv_web/components/ui.ex:4894
+#: lib/vutuv_web/components/ui.ex:4906
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr "Recapiti"
 
-#: lib/vutuv_web/components/ui.ex:4897
+#: lib/vutuv_web/components/ui.ex:4909
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr "Dove La raggiungiamo, e quale indirizzo è pubblico"
 
-#: lib/vutuv_web/components/ui.ex:4898
+#: lib/vutuv_web/components/ui.ex:4910
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr "posta e-mail indirizzo principale"
 
-#: lib/vutuv_web/components/ui.ex:4901
+#: lib/vutuv_web/components/ui.ex:4913
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr "Fisso, cellulare, fax"
 
-#: lib/vutuv_web/components/ui.ex:4902
+#: lib/vutuv_web/components/ui.ex:4914
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr "telefono cellulare fax numero"
 
-#: lib/vutuv_web/components/ui.ex:4905
+#: lib/vutuv_web/components/ui.ex:4917
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr "Indirizzi postali sul Suo profilo"
 
-#: lib/vutuv_web/components/ui.ex:4906
+#: lib/vutuv_web/components/ui.ex:4918
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr "via città cap paese posta mappa"
 
-#: lib/vutuv_web/components/ui.ex:4908
+#: lib/vutuv_web/components/ui.ex:4920
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr "Siti web e link"
 
-#: lib/vutuv_web/components/ui.ex:4909
+#: lib/vutuv_web/components/ui.ex:4921
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr "Il Suo sito e gli altri link"
 
-#: lib/vutuv_web/components/ui.ex:4910
+#: lib/vutuv_web/components/ui.ex:4922
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr "url sito web homepage blog link verifica rel=me"
 
-#: lib/vutuv_web/components/ui.ex:4912
+#: lib/vutuv_web/components/ui.ex:4924
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr "Profili sui social"
 
-#: lib/vutuv_web/components/ui.ex:4913
+#: lib/vutuv_web/components/ui.ex:4925
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr "Mastodon, Bluesky, GitHub e gli altri"
 
-#: lib/vutuv_web/components/ui.ex:4915
+#: lib/vutuv_web/components/ui.ex:4927
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 
-#: lib/vutuv_web/components/ui.ex:4920
+#: lib/vutuv_web/components/ui.ex:4932
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr "Signal, Threema, Matrix e gli altri"
 
-#: lib/vutuv_web/components/ui.ex:4921
+#: lib/vutuv_web/components/ui.ex:4933
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr "signal threema matrix xmpp telegram whatsapp chat messenger"
 
-#: lib/vutuv_web/components/ui.ex:4924
+#: lib/vutuv_web/components/ui.ex:4936
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr "Notifiche e feed"
 
-#: lib/vutuv_web/components/ui.ex:4927
+#: lib/vutuv_web/components/ui.ex:4939
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr "Quali e-mail inviamo, e cosa Le dice la campanella"
 
-#: lib/vutuv_web/components/ui.ex:4934
+#: lib/vutuv_web/components/ui.ex:4946
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr "Tenga dei post fuori dal Suo feed"
 
-#: lib/vutuv_web/components/ui.ex:4935
+#: lib/vutuv_web/components/ui.ex:4947
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr "silenzia blocca nascondi filtro parola chiave parola tag feed"
 
-#: lib/vutuv_web/components/ui.ex:4953
+#: lib/vutuv_web/components/ui.ex:4965
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr "Argomenti i cui post arrivano nel Suo feed"
 
-#: lib/vutuv_web/components/ui.ex:4954
+#: lib/vutuv_web/components/ui.ex:4966
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr "tag argomento iscriviti segui feed"
@@ -16211,7 +16209,8 @@ msgstr ""
 " richiesta rivolta a quei server, e non tutti la rispettano."
 
 #: lib/vutuv_web/components/post_components.ex:5786
-#: lib/vutuv_web/live/notification_live/index.ex:1357
+#: lib/vutuv_web/live/notification_live/index.ex:1425
+#: lib/vutuv_web/live/notification_live/index.ex:1657
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
@@ -16219,7 +16218,8 @@ msgstr[0] "%{formatted} risposta"
 msgstr[1] "%{formatted} risposte"
 
 #: lib/vutuv_web/components/post_components.ex:5790
-#: lib/vutuv_web/live/notification_live/index.ex:1355
+#: lib/vutuv_web/live/notification_live/index.ex:1422
+#: lib/vutuv_web/live/notification_live/index.ex:1655
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
@@ -16281,7 +16281,7 @@ msgstr "Rimossa dal membro"
 msgid "Replies from other networks"
 msgstr "Risposte da altre reti"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1277
+#: lib/vutuv_web/live/notification_live/index.ex:1512
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr "Risposta da un'altra rete"
@@ -16303,7 +16303,7 @@ msgid "Reported as not appropriate"
 msgstr "Segnalata come non appropriata"
 
 #: lib/vutuv_web/components/post_components.ex:1387
-#: lib/vutuv_web/live/notification_live/index.ex:911
+#: lib/vutuv_web/live/notification_live/index.ex:1120
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr "Inviata solo a Lei, non visibile a nessun altro"
@@ -17139,7 +17139,7 @@ msgstr "Descriva la foto per chi non può vederla"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1294
 #: lib/vutuv_web/agent_docs/text.ex:807
-#: lib/vutuv_web/components/ui.ex:3033
+#: lib/vutuv_web/components/ui.ex:3045
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Scarica l'originale"
@@ -17166,7 +17166,7 @@ msgstr "Risoluzione piena, direttamente dal post."
 msgid "Just the picture"
 msgstr "Solo l'immagine"
 
-#: lib/vutuv_web/components/ui.ex:3032
+#: lib/vutuv_web/components/ui.ex:3044
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Foto successiva"
@@ -17204,7 +17204,7 @@ msgstr "Opzioni della foto"
 msgid "Photos:"
 msgstr "Foto:"
 
-#: lib/vutuv_web/components/ui.ex:3031
+#: lib/vutuv_web/components/ui.ex:3043
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Foto precedente"
@@ -17407,7 +17407,8 @@ msgstr "Reazioni dal Fediverso"
 msgid "From other networks"
 msgstr "Da altre reti"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1278
+#: lib/vutuv_web/live/notification_live/index.ex:1513
+#: lib/vutuv_web/live/notification_live/index.ex:1514
 #, elixir-autogen, elixir-format
 msgid "Reaction from another network"
 msgstr "Reazione da un'altra rete"
@@ -18347,7 +18348,7 @@ msgstr ""
 "Il Suo nome utente è la Sua identità pubblica qui. Cambia solo dopo che avrà"
 " confermato con la Sua passkey o con un codice valido qui sotto."
 
-#: lib/vutuv_web/components/ui.ex:610
+#: lib/vutuv_web/components/ui.ex:622
 #, elixir-autogen, elixir-format
 msgid "Markdown help"
 msgstr "Guida a Markdown"
@@ -18839,7 +18840,7 @@ msgstr ""
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr "Ancora nulla da vutuv. Segua persone qui per riempire questa scheda."
 
-#: lib/vutuv_web/live/notification_live/index.ex:925
+#: lib/vutuv_web/live/notification_live/index.ex:1134
 #, elixir-autogen, elixir-format
 msgid "View the conversation"
 msgstr "Vedi la conversazione"
@@ -18921,8 +18922,8 @@ msgstr ""
 "Questa è la copia vutuv di un post pubblicato su %{host}. Viene conservata "
 "finché qualcuno qui segue il suo autore."
 
-#: lib/vutuv_web/components/ui.ex:1462
-#: lib/vutuv_web/components/ui.ex:1463
+#: lib/vutuv_web/components/ui.ex:1474
+#: lib/vutuv_web/components/ui.ex:1475
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr "Si iscriva a questo feed nel Suo lettore RSS"
@@ -19403,7 +19404,7 @@ msgstr "Attestato di lavoro aggiornato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:4880
+#: lib/vutuv_web/components/ui.ex:4892
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -19448,7 +19449,7 @@ msgstr "Rilasciato il"
 msgid "Label"
 msgstr "Etichetta"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3239
+#: lib/vutuv_web/live/post_live/feed.ex:3262
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -19608,7 +19609,7 @@ msgstr ""
 "Ha modificato il testo dopo questa analisi. L'analisi descrive la versione "
 "precedente."
 
-#: lib/vutuv_web/components/ui.ex:4881
+#: lib/vutuv_web/components/ui.ex:4893
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr "I Suoi Arbeitszeugnisse, privati finché non li pubblica"
@@ -19619,7 +19620,7 @@ msgstr "I Suoi Arbeitszeugnisse, privati finché non li pubblica"
 msgid "Zwischenzeugnis"
 msgstr "Zwischenzeugnis"
 
-#: lib/vutuv_web/components/ui.ex:4883
+#: lib/vutuv_web/components/ui.ex:4895
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -19825,7 +19826,7 @@ msgstr "Attestato di lavoro modificato"
 msgid "Employment reference deleted"
 msgstr "Attestato di lavoro eliminato"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1287
+#: lib/vutuv_web/live/notification_live/index.ex:1523
 #, elixir-autogen, elixir-format
 msgid "Employment reference review"
 msgstr "Analisi dell'attestato di lavoro"
@@ -19895,7 +19896,7 @@ msgstr "Trascini qui il file, oppure ne scelga uno"
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr "PDF, JPG, PNG o WebP, fino a %{limit}"
 
-#: lib/vutuv_web/components/ui.ex:4196
+#: lib/vutuv_web/components/ui.ex:4208
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -20299,19 +20300,19 @@ msgstr "PIN di 6 cifre"
 msgid "Enter the PIN from the email"
 msgstr "Inserisca il PIN che trova nell'e-mail"
 
-#: lib/vutuv_web/components/ui.ex:842
+#: lib/vutuv_web/components/ui.ex:854
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 "Se ha aggiunto altri indirizzi al Suo account vutuv, provi ad accedere con "
 "uno di quelli."
 
-#: lib/vutuv_web/components/ui.ex:870
+#: lib/vutuv_web/components/ui.ex:882
 #, elixir-autogen, elixir-format
 msgid "Cancel registration"
 msgstr "Annulla la registrazione"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1083
+#: lib/vutuv_web/live/notification_live/index.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -20323,7 +20324,7 @@ msgstr ""
 msgid "Follow other members"
 msgstr "Segua altri membri"
 
-#: lib/vutuv_web/components/ui.ex:825
+#: lib/vutuv_web/components/ui.ex:837
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
@@ -20352,7 +20353,7 @@ msgstr ""
 "Le percentuali si riferiscono ai %{answered} membri che hanno risposto. "
 "%{unanswered} non hanno risposto."
 
-#: lib/vutuv_web/components/ui.ex:4862
+#: lib/vutuv_web/components/ui.ex:4874
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr "immagine profilo ritratto foto compleanno genere su di me"
@@ -21398,8 +21399,8 @@ msgstr "Per ora troppi tentativi. Riprovi più tardi."
 msgid "New message from %{sender} on vutuv"
 msgstr "Nuovo messaggio da %{sender} su vutuv"
 
-#: lib/vutuv_web/live/message_live/index.ex:160
 #: lib/vutuv_web/live/message_live/index.ex:170
+#: lib/vutuv_web/live/message_live/index.ex:180
 #, elixir-autogen, elixir-format
 msgid "This page cannot receive messages."
 msgstr "Questa pagina non può ricevere messaggi."
@@ -21567,22 +21568,22 @@ msgstr "Si registri di nuovo"
 msgid "The PIN has expired."
 msgstr "Il PIN è scaduto."
 
-#: lib/vutuv_web/components/ui.ex:946
+#: lib/vutuv_web/components/ui.ex:958
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr "Il PIN è valido per un altro minuto."
 
-#: lib/vutuv_web/components/ui.ex:948
+#: lib/vutuv_web/components/ui.ex:960
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr "Il PIN è valido per un altro secondo."
 
-#: lib/vutuv_web/components/ui.ex:947
+#: lib/vutuv_web/components/ui.ex:959
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr "Il PIN è valido per altri {n} minuti."
 
-#: lib/vutuv_web/components/ui.ex:949
+#: lib/vutuv_web/components/ui.ex:961
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr "Il PIN è valido per altri {n} secondi."
@@ -22094,7 +22095,7 @@ msgstr ""
 "Impostazioni delle lingue del feed riportate ai valori predefiniti del sito."
 
 #: lib/vutuv_web/components/post_components.ex:4755
-#: lib/vutuv_web/components/ui.ex:4945
+#: lib/vutuv_web/components/ui.ex:4957
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -22912,7 +22913,7 @@ msgstr ""
 "Ha attivato le notifiche del browser. A questo browser non è ancora stato "
 "chiesto il permesso."
 
-#: lib/vutuv_web/components/ui.ex:4929
+#: lib/vutuv_web/components/ui.ex:4941
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
@@ -22968,7 +22969,7 @@ msgstr ""
 "Segua #%{tag} da Mastodon o da qualsiasi altra app del Fediverso e i suoi "
 "post pubblici arriveranno nella Sua cronologia. Non serve un account vutuv."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3400
+#: lib/vutuv_web/live/post_live/feed.ex:3423
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Saluti gli altri membri"
@@ -22978,47 +22979,47 @@ msgstr "Saluti gli altri membri"
 msgid "New here"
 msgstr "Nuovi qui"
 
-#: lib/vutuv_web/components/ui.ex:1631
+#: lib/vutuv_web/components/ui.ex:1643
 #, elixir-autogen, elixir-format
 msgid "New public posts arrive in any feed reader. No account needed either."
 msgstr ""
 "I nuovi post pubblici arrivano in qualsiasi lettore di feed. Anche qui non "
 "serve un account."
 
-#: lib/vutuv_web/components/ui.ex:1627
+#: lib/vutuv_web/components/ui.ex:1639
 #, elixir-autogen, elixir-format
 msgid "Or with an RSS reader"
 msgstr "Oppure con un lettore RSS"
 
-#: lib/vutuv_web/components/ui.ex:1507
-#: lib/vutuv_web/components/ui.ex:1576
+#: lib/vutuv_web/components/ui.ex:1519
+#: lib/vutuv_web/components/ui.ex:1588
 #, elixir-autogen, elixir-format
 msgid "Subscribe"
 msgstr "Iscriviti"
 
-#: lib/vutuv_web/components/ui.ex:1628
+#: lib/vutuv_web/components/ui.ex:1640
 #, elixir-autogen, elixir-format
 msgid "With an RSS reader"
 msgstr "Con un lettore RSS"
 
-#: lib/vutuv_web/components/ui.ex:1588
+#: lib/vutuv_web/components/ui.ex:1600
 #, elixir-autogen, elixir-format
 msgid "Create a free account"
 msgstr "Crei un account gratuito"
 
-#: lib/vutuv_web/components/ui.ex:1603
+#: lib/vutuv_web/components/ui.ex:1615
 #, elixir-autogen, elixir-format
 msgid "No vutuv account? These ways work too:"
 msgstr "Non ha un account vutuv? Funzionano anche questi modi:"
 
-#: lib/vutuv_web/components/ui.ex:1581
+#: lib/vutuv_web/components/ui.ex:1593
 #, elixir-autogen, elixir-format
 msgid "The best way: follow %{name} here. New posts land in your feed, and you can reply and join in."
 msgstr ""
 "Il modo migliore: segua %{name} qui. I nuovi post arrivano nel Suo feed, e "
 "può rispondere e partecipare."
 
-#: lib/vutuv_web/components/ui.ex:1579
+#: lib/vutuv_web/components/ui.ex:1591
 #, elixir-autogen, elixir-format
 msgid "With a vutuv account"
 msgstr "Con un account vutuv"
@@ -23146,12 +23147,12 @@ msgstr "Vengono nascosti dal Suo feed."
 msgid "Shown in the language it was written in."
 msgstr "Vengono mostrati nella lingua in cui sono stati scritti."
 
-#: lib/vutuv_web/components/ui.ex:4946
+#: lib/vutuv_web/components/ui.ex:4958
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr "Quali lingue arrivano fino a Lei e cosa succede al resto"
 
-#: lib/vutuv_web/components/ui.ex:4948
+#: lib/vutuv_web/components/ui.ex:4960
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr "lingua tradurre traduzione italiano tedesco inglese originale nascondere lingua straniera ordine priorità feed language translate sprache"
@@ -23285,7 +23286,7 @@ msgstr "Nessun account premium a pagamento."
 msgid "Your LinkedIn profile can come along."
 msgstr "Il suo profilo LinkedIn può venire con lei."
 
-#: lib/vutuv_web/components/ui.ex:1143
+#: lib/vutuv_web/components/ui.ex:1155
 #, elixir-autogen, elixir-format
 msgid "Being checked"
 msgstr "In verifica"
@@ -23550,7 +23551,7 @@ msgstr "I post con uno di questi tag vengono ridotti allo stesso modo."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "I post che contengono una di queste parole vengono ridotti a una riga — non eliminati, e con un modo per aprirli comunque."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3426
+#: lib/vutuv_web/live/post_live/feed.ex:3449
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Messe da parte:"
@@ -23627,9 +23628,10 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "e 1 altro"
 msgstr[1] "e altri %{formatted}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3036
-#: lib/vutuv_web/live/post_live/feed.ex:3474
-#: lib/vutuv_web/live/post_live/feed.ex:3479
+#: lib/vutuv_web/live/post_live/feed.ex:3048
+#: lib/vutuv_web/live/post_live/feed.ex:3075
+#: lib/vutuv_web/live/post_live/feed.ex:3497
+#: lib/vutuv_web/live/post_live/feed.ex:3502
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -23677,7 +23679,7 @@ msgstr ""
 "La pagina della Sua organizzazione è stata aggiornata, ma non è stato "
 "possibile usare quell'immagine come logo. Ne scelga un'altra."
 
-#: lib/vutuv_web/components/ui.ex:4202
+#: lib/vutuv_web/components/ui.ex:4214
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -23698,7 +23700,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} post il %{day}"
 msgstr[1] "%{count} post il %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3196
+#: lib/vutuv_web/live/post_live/feed.ex:3219
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Torna al presente"
@@ -23708,7 +23710,7 @@ msgstr "Torna al presente"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Mese intenso: la tonalità indica almeno questo valore."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3242
+#: lib/vutuv_web/live/post_live/feed.ex:3265
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -23730,7 +23732,7 @@ msgstr "Mese successivo"
 msgid "Next year"
 msgstr "Anno successivo"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3192
+#: lib/vutuv_web/live/post_live/feed.ex:3215
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Il %{day} non è arrivato nulla nel Suo feed."
@@ -23875,7 +23877,7 @@ msgstr "Lascia vuoto il campo degli account e la regola vale per tutti; %{exampl
 msgid "Only these accounts (empty = all) …"
 msgstr "Solo questi account (vuoto = tutti) …"
 
-#: lib/vutuv_web/components/ui.ex:3325
+#: lib/vutuv_web/components/ui.ex:3337
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr "solo %{account}"
@@ -23887,55 +23889,55 @@ msgctxt "filter rule"
 msgid "Hide"
 msgstr "Nascondi"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1356
+#: lib/vutuv_web/live/notification_live/index.ex:1656
 #, elixir-autogen, elixir-format
 msgid "%{formatted} share"
 msgid_plural "%{formatted} shares"
 msgstr[0] "%{formatted} condivisione"
 msgstr[1] "%{formatted} condivisioni"
 
-#: lib/vutuv_web/live/notification_live/index.ex:828
+#: lib/vutuv_web/live/notification_live/index.ex:818
 #, elixir-autogen, elixir-format
 msgid "Post without text"
 msgstr "Post senza testo"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1331
+#: lib/vutuv_web/live/notification_live/index.ex:1563
 #, elixir-autogen, elixir-format
 msgid "likes this."
 msgid_plural "like this."
 msgstr[0] "ha messo Mi piace."
 msgstr[1] "hanno messo Mi piace."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1337
+#: lib/vutuv_web/live/notification_live/index.ex:1569
 #, elixir-autogen, elixir-format
 msgid "reacted to this."
 msgid_plural "reacted to this."
 msgstr[0] "ha reagito."
 msgstr[1] "hanno reagito."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1322
+#: lib/vutuv_web/live/notification_live/index.ex:1571
 #, elixir-autogen, elixir-format
 msgid "replied."
 msgstr "ha risposto."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1334
+#: lib/vutuv_web/live/notification_live/index.ex:1566
 #, elixir-autogen, elixir-format
 msgid "shared this."
 msgid_plural "shared this."
 msgstr[0] "lo ha condiviso."
 msgstr[1] "lo hanno condiviso."
 
-#: lib/vutuv_web/components/ui.ex:554
+#: lib/vutuv_web/components/ui.ex:566
 #, elixir-autogen, elixir-format
 msgid "Editor view"
 msgstr "Vista"
 
-#: lib/vutuv_web/components/ui.ex:502
+#: lib/vutuv_web/components/ui.ex:514
 #, elixir-autogen, elixir-format
 msgid "Insert a block"
 msgstr "Inserisci un blocco"
 
-#: lib/vutuv_web/components/ui.ex:514
+#: lib/vutuv_web/components/ui.ex:526
 #, elixir-autogen, elixir-format
 msgid "Nothing matches."
 msgstr "Nessun risultato."
@@ -24119,7 +24121,7 @@ msgstr "Di questo post non resta nulla."
 msgid "Replace with"
 msgstr "Sostituisci con"
 
-#: lib/vutuv_web/components/ui.ex:4938
+#: lib/vutuv_web/components/ui.ex:4950
 #, elixir-autogen, elixir-format
 msgid "Rewrite what an account's posts say, for you alone"
 msgstr "Riscrivere il testo dei post di un account, solo per Lei"
@@ -24137,7 +24139,7 @@ msgstr "Regole che riscrivono il testo dei post di un account prima che Lei li l
 #: lib/vutuv_web/components/post_components.ex:1366
 #: lib/vutuv_web/components/post_components.ex:2671
 #: lib/vutuv_web/components/post_components.ex:3658
-#: lib/vutuv_web/components/ui.ex:4937
+#: lib/vutuv_web/components/ui.ex:4949
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
 #: lib/vutuv_web/live/post_rewrites_live.ex:264
@@ -24193,7 +24195,7 @@ msgstr "Le Sue regole salvate modificano questo post di %{who} come mostrato."
 msgid "\\1 puts back what the first (…) group matched, \\0 the whole match."
 msgstr "\\1 reinserisce ciò che ha trovato il primo gruppo (…), \\0 l'intera corrispondenza."
 
-#: lib/vutuv_web/components/ui.ex:4939
+#: lib/vutuv_web/components/ui.ex:4951
 #, elixir-autogen, elixir-format
 msgid "regex regular expression rewrite replace footer signature strip"
 msgstr "regex espressione regolare riscrivere sostituire piè di pagina firma rimuovere cerca"
@@ -24203,13 +24205,12 @@ msgstr "regex espressione regolare riscrivere sostituire piè di pagina firma ri
 msgid "For members on a slow connection, data-saving mode shows pictures and screenshots in a stronger compression and leaves out a few luxuries, such as the richer editor. Any picture loads in full quality with one tap, and you can switch the mode off at any time."
 msgstr "Per chi ha una connessione lenta, la modalità risparmio dati mostra foto e screenshot con una compressione più forte e rinuncia a qualche lusso, come l'editor avanzato. Ogni immagine si carica in piena qualità con un tocco, e la modalità si può disattivare in qualsiasi momento."
 
-#: lib/vutuv_web/components/ui.ex:1193
-#: lib/vutuv_web/components/ui.ex:1194
+#: lib/vutuv_web/components/ui.ex:1205
+#: lib/vutuv_web/components/ui.ex:1206
 #, elixir-autogen, elixir-format
 msgid "Load this picture in full quality"
 msgstr "Carica questa immagine in piena qualità"
 
-#: lib/vutuv_web/components/ui.ex:4962
 #: lib/vutuv_web/components/ui.ex:5007
 #, elixir-autogen, elixir-format
 msgid "Smaller pictures and a plain composer on a slow connection"
@@ -24220,7 +24221,6 @@ msgstr "Immagini più piccole e un editor semplice con una connessione lenta"
 msgid "That endorsement is not possible."
 msgstr "Questa conferma non è possibile."
 
-#: lib/vutuv_web/components/ui.ex:4964
 #: lib/vutuv_web/components/ui.ex:5009
 #, elixir-autogen, elixir-format
 msgid "bandwidth slow internet mobile data saving saver volume metered compression pictures images screenshots editor langsam daten sparen datensparmodus volumen schmalband komprimierung bilder"
@@ -24230,3 +24230,69 @@ msgstr "banda lento internet mobile risparmio dati volume compressione immagini 
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr "Aspetto"
+
+#: lib/vutuv_web/live/notification_live/index.ex:1433
+#, elixir-autogen, elixir-format, fuzzy
+msgid "%{formatted} connection"
+msgid_plural "%{formatted} connections"
+msgstr[0] "%{formatted} nuovo"
+msgstr[1] "%{formatted} nuovi"
+
+#: lib/vutuv_web/live/notification_live/index.ex:1674
+#, elixir-autogen, elixir-format, fuzzy
+msgid "%{formatted} new connection"
+msgid_plural "%{formatted} new connections"
+msgstr[0] "%{formatted} nuovo"
+msgstr[1] "%{formatted} nuovi"
+
+#: lib/vutuv_web/live/notification_live/index.ex:1678
+#, elixir-autogen, elixir-format, fuzzy
+msgid "%{formatted} new follower"
+msgid_plural "%{formatted} new followers"
+msgstr[0] "%{formatted} follower"
+msgstr[1] "%{formatted} follower"
+
+#: lib/vutuv_web/live/notification_live/index.ex:1442
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Last 30 days: %{parts}"
+msgstr "Ultimi 30 giorni"
+
+#: lib/vutuv_web/live/notification_live/index.ex:1003
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Less"
+msgstr "Meno"
+
+#: lib/vutuv_web/live/notification_live/index.ex:1342
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Reactions"
+msgstr "Sezione"
+
+#: lib/vutuv_web/live/notification_live/index.ex:511
+#, elixir-autogen, elixir-format
+msgid "Seen before"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:623
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Show %{formatted} more"
+msgstr "Mostra %{formatted} altra risposta"
+
+#: lib/vutuv_web/live/notification_live/index.ex:825
+#, elixir-autogen, elixir-format, fuzzy
+msgid "The post is no longer available."
+msgstr "Questa posizione non è più disponibile."
+
+#: lib/vutuv_web/live/notification_live/index.ex:1634
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Thread by %{name}"
+msgstr "Piace a %{name}"
+
+#: lib/vutuv_web/live/notification_live/index.ex:1573
+#, elixir-autogen, elixir-format, fuzzy
+msgid "mentioned you."
+msgstr "L'ha menzionata in un post."
+
+#: lib/vutuv_web/live/notification_live/index.ex:1572
+#, elixir-autogen, elixir-format
+msgid "replied in the thread."
+msgstr ""

--- a/test/vutuv_web/live/notification_live_test.exs
+++ b/test/vutuv_web/live/notification_live_test.exs
@@ -107,7 +107,17 @@ defmodule VutuvWeb.NotificationLiveTest do
       assert html =~ "started following you"
 
       assert render(live) =~ "endorsed you for Phoenix"
-      assert has_element?(live, ~s([data-notification-row][data-kind="follower"]))
+
+      # Both people events sit as lines inside the day's one people card.
+      assert has_element?(
+               live,
+               ~s([data-notification-row][data-kind="people"] [data-event-kind="follower"])
+             )
+
+      assert has_element?(
+               live,
+               ~s([data-notification-row][data-kind="people"] [data-event-kind="endorsement"])
+             )
 
       # The actor's name links to their profile.
       assert render(live) =~ ~s(href="/#{follower.username}")
@@ -127,7 +137,7 @@ defmodule VutuvWeb.NotificationLiveTest do
       assert render(live) =~ ~r/<time[^>]*datetime="\d{4}-\d{2}-\d{2}T[^"]*Z"/
     end
 
-    test "a derived row shows the actor's real avatar when they have one", %{conn: conn} do
+    test "a people card shows the actor's real avatar when they have one", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
       follower =
@@ -154,7 +164,7 @@ defmodule VutuvWeb.NotificationLiveTest do
       assert has_element?(live, ~s([data-presence-user-id="#{follower.id}"]))
     end
 
-    test "a picture-less actor still gets the presence dot on the kind glyph", %{conn: conn} do
+    test "a picture-less actor still gets the presence dot", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
       follower = insert(:user, first_name: "Ada", last_name: "Lovelace")
@@ -178,14 +188,14 @@ defmodule VutuvWeb.NotificationLiveTest do
       assert render(live) =~ "🤝"
     end
 
-    test "a same-day mutual follow shows only the connection row, not a follower double", %{
+    test "a same-day mutual follow shows only the connection line, not a follower double", %{
       conn: conn
     } do
       {conn, user} = create_and_login_user(conn)
 
       # The mutual follow derives both a follower and a connection event with
       # the same actor on the same day; "is now connected" implies "follows
-      # you", so the follower row would be redundant noise.
+      # you", so the follower line would be redundant noise.
       connect!(user, insert(:user, first_name: "Wojtek", last_name: "Mach"))
       # An unrelated one-way follower on the same day still shows.
       insert(:follow, follower: insert(:user, first_name: "Grace"), followee: user)
@@ -193,25 +203,51 @@ defmodule VutuvWeb.NotificationLiveTest do
       {:ok, live, _html} = live(conn, ~p"/notifications")
       html = render(live)
 
-      assert length(row_ids(html, "connection")) == 1
-      assert [_] = row_ids(html, "follower")
-      # The follower row names Grace, not the already-connected Wojtek.
-      assert has_element?(live, ~s([data-notification-row][data-kind="follower"]), "Grace")
-      refute has_element?(live, ~s([data-notification-row][data-kind="follower"]), "Wojtek")
+      assert length(lines(html, "connection")) == 1
+      assert [_] = lines(html, "follower")
+      # The follower line names Grace, not the already-connected Wojtek.
+      assert has_element?(live, ~s([data-event-kind="follower"]), "Grace")
+      refute has_element?(live, ~s([data-event-kind="follower"]), "Wojtek")
     end
 
-    test "a reply notification links to the parent post's thread", %{conn: conn} do
+    test "the people card's head counts the day's people events", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
-      parent = insert(:post, user: user)
+      connect!(user, insert(:user, first_name: "Wojtek"))
+      insert(:follow, follower: insert(:user, first_name: "Grace"), followee: user)
+      insert(:follow, follower: insert(:user, first_name: "Ada"), followee: user)
+      user_tag = insert(:user_tag, user: user, tag: insert(:tag, name: "Elixir"))
+      insert(:user_tag_endorsement, user: insert(:user), user_tag: user_tag)
+
+      {:ok, live, _html} = live(conn, ~p"/notifications")
+
+      # One card for the day's people, and its head is the tally: the reader
+      # knows what happened before reading a single line.
+      assert length(rows(render(live), "people")) == 1
+      assert has_element?(live, ~s([data-kind="people"] [data-card-title]), "1 new connection")
+      assert has_element?(live, ~s([data-kind="people"] [data-card-title]), "2 new followers")
+      assert has_element?(live, ~s([data-kind="people"] [data-card-title]), "1 endorsement")
+    end
+
+    test "a reply card is headed by the parent post and opens its thread", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      parent = insert(:post, user: user, body: "Which editor do you swear by?")
       insert(:post_reply, post: insert(:post), parent_post: parent, parent_author: user)
 
       {:ok, live, _html} = live(conn, ~p"/notifications")
 
-      assert render(live) =~ ~s(href="/#{user.username}/posts/#{parent.id}")
+      assert has_element?(
+               live,
+               ~s([data-post-card][href="/#{user.username}/posts/#{parent.id}"]),
+               "Which editor do you swear by?"
+             )
+
+      # The head says whose post this is: the reader's own.
+      assert has_element?(live, ~s([data-kind="post"] [data-card-eyebrow]), "Your post")
     end
 
-    test "a like is shown and links to the liked post", %{conn: conn} do
+    test "a like is a line under the liked post's card", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
       post = insert(:post, user: user)
@@ -221,29 +257,14 @@ defmodule VutuvWeb.NotificationLiveTest do
       {:ok, live, _html} = live(conn, ~p"/notifications")
       html = render(live)
 
-      assert html =~ "liked your post"
+      # The card's head already names the post, so the line only says who and
+      # what.
+      assert html =~ "Fanny First"
+      assert has_element?(live, ~s([data-event-kind="like"]), "likes this.")
       assert html =~ ~s(href="/#{user.username}/posts/#{post.id}")
     end
 
-    test "a like notification previews the liked post's body", %{conn: conn} do
-      {conn, user} = create_and_login_user(conn)
-
-      post = insert(:post, user: user, body: "Ship the redesign on Friday")
-      :ok = Vutuv.Posts.like_post(insert(:user), post)
-
-      {:ok, live, _html} = live(conn, ~p"/notifications")
-
-      assert has_element?(live, ~s([data-post-preview]), "Ship the redesign on Friday")
-
-      assert has_element?(
-               live,
-               ~s([data-post-preview] a[href="/#{user.username}/posts/#{post.id}"])
-             )
-    end
-
-    test "a quoted post is formatted like a feed post, not shown as Markdown source", %{
-      conn: conn
-    } do
+    test "the card head quotes the liked post's body as a plain two-line teaser", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
       post =
@@ -257,31 +278,19 @@ defmodule VutuvWeb.NotificationLiveTest do
       {:ok, live, _html} = live(conn, ~p"/notifications")
       html = render(live)
 
-      assert html =~ "<strong>Ship it</strong>"
-      assert html =~ "<li>"
+      # Plain text: no Markdown markers, no rendered markup — the formatted
+      # quote belongs to a reply line, which the reader opens on purpose.
+      assert has_element?(live, ~s([data-post-card]), "Ship it on Friday")
       refute html =~ "**Ship it**"
-      # The same body recipe the feed uses, so the quote reads like a post.
-      assert has_element?(live, ~s([data-post-preview] .markdown.markdown--post))
+      refute has_element?(live, ~s([data-post-preview]))
+
+      assert has_element?(
+               live,
+               ~s([data-post-card][href="/#{user.username}/posts/#{post.id}"])
+             )
     end
 
-    test "a @mention in a quoted post links to that member", %{conn: conn} do
-      {conn, user} = create_and_login_user(conn)
-      # The factory's `user-<n>` handle carries a hyphen, which a real handle
-      # never may (`Vutuv.Handles.format/0`) and a mention therefore never
-      # matches, so this needs a handle-shaped one.
-      colleague = insert(:user, username: "quoted_colleague")
-
-      post = insert(:post, user: user, body: "Thanks @#{colleague.username}!")
-      :ok = Vutuv.Posts.like_post(insert(:user), post)
-
-      {:ok, live, _html} = live(conn, ~p"/notifications")
-
-      # The mention keeps its own target, so the quote cannot be one big link:
-      # the permalink is a stretched link underneath the body instead.
-      assert has_element?(live, ~s([data-post-preview] a[href="/#{colleague.username}"]))
-    end
-
-    test "a post that is nothing but an inline image shows no quote", %{conn: conn} do
+    test "a post that is nothing but an inline image is named as textless", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
       post = insert(:post, user: user, body: "![a cat](/post_images/cat.jpg)")
@@ -289,11 +298,13 @@ defmodule VutuvWeb.NotificationLiveTest do
 
       {:ok, live, _html} = live(conn, ~p"/notifications")
 
-      assert render(live) =~ "liked your post"
-      refute has_element?(live, ~s([data-post-preview]))
+      assert render(live) =~ "likes this."
+      assert has_element?(live, ~s([data-post-card-textless]), "Post without text")
     end
 
-    test "two likes of the same post on the same day merge into one row", %{conn: conn} do
+    test "two likes of the same post on the same day merge into one line of one card", %{
+      conn: conn
+    } do
       {conn, user} = create_and_login_user(conn)
 
       post = insert(:post, user: user, body: "Grouped post body")
@@ -303,14 +314,16 @@ defmodule VutuvWeb.NotificationLiveTest do
       {:ok, live, _html} = live(conn, ~p"/notifications")
       html = render(live)
 
-      # One row names both likers; the post is quoted once, not per like.
-      assert length(row_ids(html, "like")) == 1
+      # One card, one like line naming both; the post is quoted once, not per like.
+      assert length(rows(html, "post")) == 1
+      assert length(lines(html, "like")) == 1
       assert html =~ "Anna Arnold"
       assert html =~ "Ben Otto"
+      assert html =~ "like this."
       assert length(String.split(html, "Grouped post body")) - 1 == 1
     end
 
-    test "likes of different posts stay separate rows", %{conn: conn} do
+    test "likes of different posts stay separate cards", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
       :ok = Vutuv.Posts.like_post(insert(:user), insert(:post, user: user, body: "First post"))
@@ -318,10 +331,27 @@ defmodule VutuvWeb.NotificationLiveTest do
 
       {:ok, live, _html} = live(conn, ~p"/notifications")
 
-      assert length(row_ids(render(live), "like")) == 2
+      assert length(rows(render(live), "post")) == 2
     end
 
-    test "several followers on one day merge into one row with an overflow link", %{conn: conn} do
+    test "a local like and a like from another network share one line", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = create_post!(user, %{body: "liked on both sides"})
+      :ok = Vutuv.Posts.like_post(insert(:user, first_name: "Anna", last_name: "Arnold"), post)
+      remote_reaction!(post, "alice", "like")
+
+      html = render_the_page(conn)
+
+      # One post, one like line: where a like came from is a globe on the name,
+      # not a second line saying the same thing.
+      assert length(rows(html, "post")) == 1
+      assert length(lines(html, "like")) == 1
+      assert html =~ "Anna Arnold"
+      assert html =~ "@alice@social.example"
+      assert html =~ "2 likes"
+    end
+
+    test "several followers on one day merge into one line with an overflow link", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
       insert(:follow,
@@ -347,15 +377,15 @@ defmodule VutuvWeb.NotificationLiveTest do
       {:ok, live, _html} = live(conn, ~p"/notifications")
       html = render(live)
 
-      # One grouped row: two names spelled out, the rest counted, plural verb.
-      assert length(row_ids(html, "follower")) == 1
+      # One grouped line: two names spelled out, the rest counted, plural verb.
+      assert length(lines(html, "follower")) == 1
       assert html =~ "and 2 more"
       assert html =~ "are now following you."
       # The overflow leads to the member's own followers list.
       assert has_element?(live, ~s(a[href="/#{user.username}/followers"]), "and 2 more")
     end
 
-    test "one endorser's same-day endorsements merge into one row naming every tag", %{
+    test "one endorser's same-day endorsements merge into one line naming every tag", %{
       conn: conn
     } do
       {conn, user} = create_and_login_user(conn)
@@ -370,11 +400,11 @@ defmodule VutuvWeb.NotificationLiveTest do
       {:ok, live, _html} = live(conn, ~p"/notifications")
       html = render(live)
 
-      assert length(row_ids(html, "endorsement")) == 1
+      assert length(lines(html, "endorsement")) == 1
       assert html =~ "endorsed you for Elixir and Phoenix."
     end
 
-    test "different endorsers stay separate rows", %{conn: conn} do
+    test "different endorsers stay separate lines", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
       for _ <- 1..2 do
@@ -384,10 +414,10 @@ defmodule VutuvWeb.NotificationLiveTest do
 
       {:ok, live, _html} = live(conn, ~p"/notifications")
 
-      assert length(row_ids(render(live), "endorsement")) == 2
+      assert length(lines(render(live), "endorsement")) == 2
     end
 
-    test "rows sit under Berlin-day section headings", %{conn: conn} do
+    test "cards sit under Berlin-day section headings", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
       # One event today, one on a fixed historic day.
@@ -402,50 +432,72 @@ defmodule VutuvWeb.NotificationLiveTest do
       assert html =~ "November 24, 2016"
     end
 
-    test "a reply notification previews both the parent post and the reply", %{conn: conn} do
+    test "a reply line carries the reply's text and opens to the formatted quote", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
-      replier = insert(:user)
+      replier = insert(:user, first_name: "Joe", last_name: "Armstrong")
       parent = insert(:post, user: user, body: "Which editor do you swear by?")
-      reply = insert(:post, user: replier, body: "Neovim, without a doubt.")
+
+      reply =
+        insert(:post, user: replier, body: "**Neovim**, without a doubt.\n\n- fast\n- everywhere")
 
       insert(:post_reply, post: reply, parent_post: parent, parent_author: user)
 
       {:ok, live, _html} = live(conn, ~p"/notifications")
 
-      assert has_element?(
-               live,
-               ~s([data-post-preview][href="/#{user.username}/posts/#{parent.id}"]),
-               "Which editor do you swear by?"
-             )
+      # Collapsed: who, what, and the reply's words on one clamped line — plain
+      # text, so the markers stay out of it.
+      assert has_element?(live, ~s([data-event-kind="reply"]), "Joe Armstrong")
+      assert has_element?(live, ~s([data-event-kind="reply"]), "replied.")
+      assert has_element?(live, ~s([data-event-kind="reply"] [data-reply-teaser]), "Neovim")
+      refute render(live) =~ "**Neovim**"
+      refute has_element?(live, ~s([data-reply-preview]))
 
-      assert has_element?(live, ~s([data-reply-preview]), "Neovim, without a doubt.")
+      # Opened: the reply formatted the way /feed formats a post, its permalink
+      # under it as the stretched link, and a Reply link for the answer.
+      live |> element(~s([data-event-kind="reply"] [data-line-toggle])) |> render_click()
+
+      html = render(live)
+      assert html =~ "<strong>Neovim</strong>"
+      assert html =~ "<li>"
+      assert has_element?(live, ~s([data-reply-preview] .markdown.markdown--post))
 
       assert has_element?(
                live,
                ~s([data-reply-preview] a[href="/#{replier.username}/posts/#{reply.id}"])
              )
+
+      assert has_element?(
+               live,
+               ~s([data-event-kind="reply"] a[data-reply-link][href="/#{replier.username}/posts/#{reply.id}"]),
+               "Reply"
+             )
+
+      # And it folds again.
+      live |> element(~s([data-event-kind="reply"] [data-line-toggle])) |> render_click()
+      refute has_element?(live, ~s([data-reply-preview]))
     end
 
-    test "the one-line context above a reply drops the Markdown markers", %{conn: conn} do
+    test "a @mention in an opened reply links to that member", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
+      # The factory's `user-<n>` handle carries a hyphen, which a real handle
+      # never may (`Vutuv.Handles.format/0`) and a mention therefore never
+      # matches, so this needs a handle-shaped one.
+      colleague = insert(:user, username: "quoted_colleague")
 
-      replier = insert(:user)
-      parent = insert(:post, user: user, body: "**Which editor** do you swear by?")
-      reply = insert(:post, user: replier, body: "Neovim, without a doubt.")
-
+      parent = insert(:post, user: user, body: "Who helped?")
+      reply = insert(:post, user: insert(:user), body: "Thanks @#{colleague.username}!")
       insert(:post_reply, post: reply, parent_post: parent, parent_author: user)
 
       {:ok, live, _html} = live(conn, ~p"/notifications")
-      html = render(live)
+      live |> element(~s([data-event-kind="reply"] [data-line-toggle])) |> render_click()
 
-      # A breadcrumb stays one plain line (it is inside the row's own link, so
-      # it cannot carry links of its own) — but it must not show the markers.
-      assert has_element?(live, ~s([data-post-preview]), "Which editor do you swear by?")
-      refute html =~ "**Which editor**"
+      # The mention keeps its own target, so the quote cannot be one big link:
+      # the permalink is a stretched link underneath the body instead.
+      assert has_element?(live, ~s([data-reply-preview] a[href="/#{colleague.username}"]))
     end
 
-    test "an answer to someone else in my thread renders as a thread row linking the reply", %{
+    test "an answer to someone else in my thread is a thread line under the root's card", %{
       conn: conn
     } do
       {conn, user} = create_and_login_user(conn)
@@ -461,14 +513,21 @@ defmodule VutuvWeb.NotificationLiveTest do
       {:ok, live, _html} = live(conn, ~p"/notifications")
       html = render(live)
 
-      assert length(row_ids(html, "thread")) == 1
-      assert html =~ "Joe Armstrong"
-      assert html =~ "replied in a thread you posted in."
+      # The root's card holds both the direct answer and the deeper one.
+      assert length(rows(html, "post")) == 1
+      assert length(lines(html, "thread")) == 1
+      assert length(lines(html, "reply")) == 1
+      assert has_element?(live, ~s([data-post-card]), "The root question")
+      assert has_element?(live, ~s([data-event-kind="thread"]), "Joe Armstrong")
+      assert has_element?(live, ~s([data-event-kind="thread"]), "replied in the thread.")
 
-      # The row quotes the reply and links to its permalink. The quote is a
-      # formatted block with a stretched link, so the href sits on the inner
-      # <a>, not on the element carrying the marker.
-      assert has_element?(live, ~s([data-reply-preview]), "The answer I used to miss")
+      assert has_element?(
+               live,
+               ~s([data-event-kind="thread"] [data-reply-teaser]),
+               "The answer I used to miss"
+             )
+
+      live |> element(~s([data-event-kind="thread"] [data-line-toggle])) |> render_click()
 
       assert has_element?(
                live,
@@ -476,7 +535,9 @@ defmodule VutuvWeb.NotificationLiveTest do
              )
     end
 
-    test "several same-day answers in one thread merge into one thread row", %{conn: conn} do
+    test "every answer in a thread keeps its own line, because each carries its own words", %{
+      conn: conn
+    } do
       {conn, user} = create_and_login_user(conn)
 
       root = insert(:post, user: user, body: "The root question")
@@ -499,18 +560,46 @@ defmodule VutuvWeb.NotificationLiveTest do
       {:ok, live, _html} = live(conn, ~p"/notifications")
       html = render(live)
 
-      # One grouped row names both answerers; the direct reply row stays its own.
-      assert length(row_ids(html, "thread")) == 1
+      assert length(rows(html, "post")) == 1
+      assert length(lines(html, "thread")) == 2
+      assert length(lines(html, "reply")) == 1
       assert html =~ "Anna Arnold"
       assert html =~ "Ben Otto"
-      assert length(row_ids(html, "reply")) == 1
     end
 
-    test "only the day's first thread row carries the opt-out hint (issue #1025)", %{conn: conn} do
+    test "a thread rooted in somebody else's post says whose thread it is", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      host = insert(:user, first_name: "Grace", last_name: "Hopper")
+      # No apostrophe in the body: the teaser typesets `'` as `’`, and this
+      # test is about whose thread it is, not about quotes.
+      root = create_post!(host, %{body: "The root question Grace asked"})
+      {:ok, mine} = Vutuv.Posts.create_reply(user, root, %{body: "My answer"})
+      # Participation has to predate the answer, and both land in the same
+      # second here.
+      backdate_reply(mine, NaiveDateTime.add(NaiveDateTime.utc_now(:second), -60))
+
+      {:ok, _} =
+        Vutuv.Posts.create_reply(insert(:user, first_name: "Joe"), root, %{
+          body: "What Joe answered"
+        })
+
+      {:ok, live, _html} = live(conn, ~p"/notifications")
+
+      assert has_element?(
+               live,
+               ~s([data-kind="post"] [data-card-eyebrow]),
+               "Thread by Grace Hopper"
+             )
+
+      assert has_element?(live, ~s([data-post-card]), "The root question Grace asked")
+    end
+
+    test "only the day's first thread line carries the opt-out hint (issue #1025)", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
       # Two separate threads the member rooted, each answered by a third party
-      # to the first replier - two distinct thread rows on the same day.
+      # to the first replier - two distinct thread cards on the same day.
       for body <- ["Thread one", "Thread two"] do
         root = insert(:post, user: user, body: body)
         {:ok, first} = Vutuv.Posts.create_reply(insert(:user), root, %{body: "First answer"})
@@ -519,7 +608,7 @@ defmodule VutuvWeb.NotificationLiveTest do
 
       {:ok, live, html} = live(conn, ~p"/notifications")
 
-      assert length(row_ids(html, "thread")) == 2
+      assert length(lines(html, "thread")) == 2
       # Exactly one hint for the day, linking to the notification settings.
       assert length(Regex.scan(~r/data-thread-hint/, html)) == 1
       assert has_element?(live, ~s([data-thread-hint] a[href="/settings/notifications"]))
@@ -531,16 +620,16 @@ defmodule VutuvWeb.NotificationLiveTest do
              )
     end
 
-    test "the posts filter tab keeps thread rows", %{conn: conn} do
+    test "the replies filter keeps thread lines", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
       root = insert(:post, user: user, body: "The root question")
       {:ok, first} = Vutuv.Posts.create_reply(insert(:user), root, %{body: "First answer"})
       {:ok, _} = Vutuv.Posts.create_reply(insert(:user), first, %{body: "Deeper answer"})
 
-      {:ok, live, _html} = live(conn, ~p"/notifications?filter=posts")
+      {:ok, live, _html} = live(conn, ~p"/notifications?filter=replies")
 
-      assert length(row_ids(render(live), "thread")) == 1
+      assert length(lines(render(live), "thread")) == 1
     end
 
     test "a reply hidden from the recipient is not quoted", %{conn: conn} do
@@ -557,62 +646,58 @@ defmodule VutuvWeb.NotificationLiveTest do
 
       assert render(live) =~ "Public question"
       refute render(live) =~ "Secret answer"
-      refute has_element?(live, ~s([data-reply-preview]))
+      refute has_element?(live, ~s([data-reply-teaser]))
+      refute has_element?(live, ~s([data-line-toggle]))
     end
 
-    test "the post preview keeps only the first five lines by default", %{conn: conn} do
+    test "an opened quote keeps only the first five lines by default", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
       body = Enum.map_join(1..7, "\n", &"Line #{&1}")
-      post = insert(:post, user: user, body: body)
-      :ok = Vutuv.Posts.like_post(insert(:user), post)
+      reply_with_body!(user, body)
 
       {:ok, live, _html} = live(conn, ~p"/notifications")
+      live |> element(~s([data-event-kind="reply"] [data-line-toggle])) |> render_click()
       html = render(live)
 
-      assert html =~ "Line 1"
-      assert html =~ "Line 5"
+      assert has_element?(live, ~s([data-reply-preview]), "Line 5")
       refute html =~ "Line 6"
       # The shipped default needs no inline override: the .notif-clamp
       # stylesheet fallback already says 5.
-      assert has_element?(live, ~s([data-post-preview] .notif-clamp))
+      assert has_element?(live, ~s([data-reply-preview] .notif-clamp))
       refute html =~ "--notif-clamp"
     end
 
-    test "a quote is wired to reveal the truncation ellipsis", %{conn: conn} do
+    test "an opened quote is wired to reveal the truncation ellipsis", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
-      body = Enum.map_join(1..7, "\n", &"Line #{&1}")
-      post = insert(:post, user: user, body: body)
-      :ok = Vutuv.Posts.like_post(insert(:user), post)
+      reply_with_body!(user, Enum.map_join(1..7, "\n", &"Line #{&1}"))
 
       {:ok, live, _html} = live(conn, ~p"/notifications")
+      live |> element(~s([data-event-kind="reply"] [data-line-toggle])) |> render_click()
 
       # The server cuts the quote to the reader's line budget, but whether those
       # lines still overflow the box depends on column width and font — only the
       # browser knows. The quote therefore carries the same two markers the
       # feed's post previews use: app.js measures `[data-clamp-body]` and puts
       # `is-clamped` on `[data-post-preview]`, which is what paints the "…"
-      # (the shared excerpt-clamp rules in components.css). The hook re-measures
-      # after a patch, since rows stream in.
+      # (the shared excerpt-clamp rules in components.css).
       assert has_element?(live, ~s([data-post-preview][phx-hook="PostPreviewClamp"]))
       assert has_element?(live, ~s([data-post-preview] .notif-clamp[data-clamp-body]))
     end
 
-    test "the reader's own line count cuts the quote, server-side and in the CSS clamp", %{
-      conn: conn
-    } do
+    test "the reader's own line count cuts the opened quote, server-side and in the CSS clamp",
+         %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       {:ok, _user} = Vutuv.Accounts.update_user(user, %{"notification_post_lines" => "2"})
 
-      body = Enum.map_join(1..7, "\n", &"Line #{&1}")
-      post = insert(:post, user: user, body: body)
-      :ok = Vutuv.Posts.like_post(insert(:user), post)
+      reply_with_body!(user, Enum.map_join(1..7, "\n", &"Line #{&1}"))
 
       {:ok, live, _html} = live(conn, ~p"/notifications")
+      live |> element(~s([data-event-kind="reply"] [data-line-toggle])) |> render_click()
       html = render(live)
 
-      assert html =~ "Line 2"
+      assert has_element?(live, ~s([data-reply-preview]), "Line 2")
       refute html =~ "Line 3"
       assert html =~ "--notif-clamp:2"
     end
@@ -621,19 +706,18 @@ defmodule VutuvWeb.NotificationLiveTest do
       {conn, user} = create_and_login_user(conn)
       with_installation_defaults(%{notification_post_lines: 3})
 
-      body = Enum.map_join(1..7, "\n", &"Line #{&1}")
-      post = insert(:post, user: user, body: body)
-      :ok = Vutuv.Posts.like_post(insert(:user), post)
+      reply_with_body!(user, Enum.map_join(1..7, "\n", &"Line #{&1}"))
 
       {:ok, live, _html} = live(conn, ~p"/notifications")
+      live |> element(~s([data-event-kind="reply"] [data-line-toggle])) |> render_click()
       html = render(live)
 
-      assert html =~ "Line 3"
+      assert has_element?(live, ~s([data-reply-preview]), "Line 3")
       refute html =~ "Line 4"
       assert html =~ "--notif-clamp:3"
     end
 
-    test "a like on a bodyless (photo-only) post shows no preview", %{conn: conn} do
+    test "a like on a bodyless (photo-only) post names the post as textless", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
       post = insert(:post, user: user, body: "")
@@ -641,21 +725,21 @@ defmodule VutuvWeb.NotificationLiveTest do
 
       {:ok, live, _html} = live(conn, ~p"/notifications")
 
-      assert render(live) =~ "liked your post"
-      refute has_element?(live, ~s([data-post-preview]))
+      assert render(live) =~ "likes this."
+      assert has_element?(live, ~s([data-post-card-textless]))
     end
 
-    test "non-post notifications carry no preview", %{conn: conn} do
+    test "non-post notifications carry no post card", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       insert(:follow, follower: insert(:user), followee: user)
 
       {:ok, live, _html} = live(conn, ~p"/notifications")
 
       assert render(live) =~ "started following you"
-      refute has_element?(live, ~s([data-post-preview]))
+      refute has_element?(live, ~s([data-post-card]))
     end
 
-    test "a like arriving live carries its post preview", %{conn: conn} do
+    test "a like arriving live brings its post card", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       post = insert(:post, user: user, body: "Live-quoted post body")
 
@@ -665,25 +749,27 @@ defmodule VutuvWeb.NotificationLiveTest do
       Vutuv.Activity.notify_like(user.id, fan, post.id)
       _ = :sys.get_state(live.pid)
 
-      assert has_element?(live, ~s([data-post-preview]), "Live-quoted post body")
+      assert has_element?(live, ~s([data-post-card]), "Live-quoted post body")
+      assert has_element?(live, ~s([data-event-kind="like"]), "Fanny First")
     end
 
-    test "a live like merges into the derived same-day row for the same post", %{conn: conn} do
+    test "a live like merges into the derived same-day card for the same post", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
       post = insert(:post, user: user, body: "Merged live post")
       :ok = Vutuv.Posts.like_post(insert(:user, first_name: "Anna", last_name: "Arnold"), post)
 
       {:ok, live, _html} = live(conn, ~p"/notifications")
-      assert length(row_ids(render(live), "like")) == 1
+      assert length(rows(render(live), "post")) == 1
 
       fan = insert(:user, first_name: "Fanny", last_name: "First")
       Vutuv.Activity.notify_like(user.id, fan, post.id)
       _ = :sys.get_state(live.pid)
 
       html = render(live)
-      # Still one row for the post - now naming both likers.
-      assert length(row_ids(html, "like")) == 1
+      # Still one card and one like line for the post - now naming both likers.
+      assert length(rows(html, "post")) == 1
+      assert length(lines(html, "like")) == 1
       assert html =~ "Anna Arnold"
       assert html =~ "Fanny First"
     end
@@ -699,7 +785,7 @@ defmodule VutuvWeb.NotificationLiveTest do
       assert render(live) =~ "Connection"
     end
 
-    test "shows a reply as a reply event, but not a self-reply", %{conn: conn} do
+    test "shows a reply as a reply line, but not a self-reply", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
       replier = insert(:user, first_name: "Joe", last_name: "Armstrong")
@@ -719,19 +805,19 @@ defmodule VutuvWeb.NotificationLiveTest do
 
       {:ok, live, _html} = live(conn, ~p"/notifications")
 
-      assert render(live) =~ "replied to your post"
+      assert render(live) =~ "replied."
       assert render(live) =~ "Joe Armstrong"
-      # The self-reply derives no row.
-      assert length(row_ids(render(live), "reply")) == 1
+      # The self-reply derives no line.
+      assert length(lines(render(live), "reply")) == 1
     end
 
     # Every confirmed account carries its own username welcome note, so an
     # utterly empty feed no longer exists; the empty state now belongs to a
-    # filter tab with nothing in it.
-    test "shows the empty state for a filter tab with nothing in it", %{conn: conn} do
+    # filter with nothing in it.
+    test "shows the empty state for a filter with nothing in it", %{conn: conn} do
       {conn, _user} = create_and_login_user(conn)
 
-      {:ok, live, _html} = live(conn, ~p"/notifications?filter=posts")
+      {:ok, live, _html} = live(conn, ~p"/notifications?filter=replies")
 
       assert render(live) =~ "Nothing new yet."
       refute has_element?(live, ~s([data-notification-row]))
@@ -767,9 +853,10 @@ defmodule VutuvWeb.NotificationLiveTest do
       {:ok, live, _html} = live(conn, ~p"/notifications")
       html = render(live)
 
-      # The fresh like is highlighted, the long-seen follower row is not.
-      assert has_element?(live, ~s([data-notification-row][data-kind="like"][data-unread]))
-      refute has_element?(live, ~s([data-notification-row][data-kind="follower"][data-unread]))
+      # The fresh like is highlighted, card and line; the long-seen people card is not.
+      assert has_element?(live, ~s([data-notification-row][data-kind="post"][data-unread]))
+      assert has_element?(live, ~s([data-event-kind="like"][data-unread]))
+      refute has_element?(live, ~s([data-notification-row][data-kind="people"][data-unread]))
       # The header counts what is new since the last visit.
       assert html =~ "1 new notification"
       # And the visit still clears the badge for next time.
@@ -777,7 +864,7 @@ defmodule VutuvWeb.NotificationLiveTest do
     end
 
     test "a reply I already answered is listed but not marked unread", %{conn: conn} do
-      # The row stays - the page is the log of what happened - but answering the
+      # The line stays - the page is the log of what happened - but answering the
       # reply out in the feed already settled it, so it must not read as new
       # here either, or the page and the bell badge would tell two stories.
       {conn, user} = create_and_login_user(conn)
@@ -792,8 +879,127 @@ defmodule VutuvWeb.NotificationLiveTest do
 
       {:ok, live, _html} = live(conn, ~p"/notifications")
 
-      assert has_element?(live, ~s([data-notification-row][data-kind="reply"]))
-      refute has_element?(live, ~s([data-notification-row][data-kind="reply"][data-unread]))
+      assert has_element?(live, ~s([data-event-kind="reply"]))
+      refute has_element?(live, ~s([data-event-kind="reply"][data-unread]))
+      refute has_element?(live, ~s([data-notification-row][data-kind="post"][data-unread]))
+    end
+
+    test "within a day, cards with unanswered replies come first and a rule marks the seen ones",
+         %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      backdate_welcome_note(user, ~N[2016-11-24 12:00:00])
+      # Everything below is newer than the marker; what settles a card is the
+      # per-post engagement, not the clock.
+      set_read_marker(user, ~N[2016-11-25 00:00:00])
+
+      liked = insert(:post, user: user, body: "The liked one")
+      :ok = Vutuv.Posts.like_post(insert(:user), liked)
+
+      answered = insert(:post, user: user, body: "The answered one")
+      answer = insert(:post, user: insert(:user), body: "an answer I saw")
+      insert(:post_reply, post: answer, parent_post: answered, parent_author: user)
+      {:ok, _} = Vutuv.Posts.create_reply(user, answer, %{body: "Thanks!"})
+
+      # Oldest of the three, yet its unanswered reply puts it on top.
+      open = insert(:post, user: user, body: "The open one")
+      backdate_post(open, NaiveDateTime.add(NaiveDateTime.utc_now(:second), -3600))
+      pending = insert(:post, user: insert(:user), body: "a reply waiting for me")
+      insert(:post_reply, post: pending, parent_post: open, parent_author: user)
+      backdate_reply(pending, NaiveDateTime.add(NaiveDateTime.utc_now(:second), -3600))
+
+      html = render_the_page(conn)
+
+      assert at(html, "The open one") < at(html, "The liked one")
+      assert at(html, "The liked one") < at(html, "The answered one")
+      # One rule, between the last new card and the first seen one.
+      assert length(Regex.scan(~r/data-seen-rule/, html)) == 1
+      assert at(html, "The liked one") < at(html, "data-seen-rule")
+      assert at(html, "data-seen-rule") < at(html, "The answered one")
+    end
+
+    test "no seen-rule when nothing on the page is new", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      :ok = Vutuv.Posts.like_post(insert(:user), insert(:post, user: user, body: "old news"))
+      set_read_marker(user, NaiveDateTime.add(NaiveDateTime.utc_now(:second), 60))
+
+      refute render_the_page(conn) =~ "data-seen-rule"
+    end
+
+    test "a card shows four lines and folds the rest behind a count", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = insert(:post, user: user, body: "Much discussed")
+
+      for i <- 1..6 do
+        reply = insert(:post, user: insert(:user), body: "Answer number #{i}")
+        insert(:post_reply, post: reply, parent_post: post, parent_author: user)
+      end
+
+      {:ok, live, _html} = live(conn, ~p"/notifications")
+
+      assert length(lines(render(live), "reply")) == 4
+      assert has_element?(live, ~s([data-card-more]), "Show 2 more")
+
+      live |> element(~s([data-card-more])) |> render_click()
+
+      assert length(lines(render(live), "reply")) == 6
+      refute has_element?(live, ~s([data-card-more]))
+    end
+
+    test "the card's head counts likes, shares and replies from both sides", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = create_post!(user, %{body: "counted"})
+      :ok = Vutuv.Posts.like_post(insert(:user), post)
+      remote_reaction!(post, "alice", "like")
+      remote_reaction!(post, "bob", "announce")
+      remote_note!(post, "carol", "a remote answer")
+
+      insert(:post_reply,
+        post: insert(:post, user: insert(:user)),
+        parent_post: post,
+        parent_author: user
+      )
+
+      html = render_the_page(conn)
+
+      assert html =~ "2 likes"
+      assert html =~ "1 share"
+      assert html =~ "2 replies"
+    end
+
+    test "the filter chips count what is new since the last visit", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      backdate_welcome_note(user, ~N[2016-11-24 12:00:00])
+      set_read_marker(user, ~N[2016-11-25 00:00:00])
+
+      post = insert(:post, user: user)
+      :ok = Vutuv.Posts.like_post(insert(:user), post)
+      :ok = Vutuv.Posts.like_post(insert(:user), post)
+
+      insert(:post_reply,
+        post: insert(:post, user: insert(:user)),
+        parent_post: post,
+        parent_author: user
+      )
+
+      insert(:follow, follower: insert(:user), followee: user)
+
+      {:ok, live, _html} = live(conn, ~p"/notifications")
+
+      assert has_element?(live, ~s([data-filter-tab="all"] [data-filter-count]), "4")
+      assert has_element?(live, ~s([data-filter-tab="replies"] [data-filter-count]), "1")
+      assert has_element?(live, ~s([data-filter-tab="reactions"] [data-filter-count]), "2")
+      assert has_element?(live, ~s([data-filter-tab="people"] [data-filter-count]), "1")
+      refute has_element?(live, ~s([data-filter-tab="other"] [data-filter-count]))
+    end
+
+    test "chips carry no counts when nothing is new", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      insert(:follow, follower: insert(:user), followee: user)
+      set_read_marker(user, NaiveDateTime.add(NaiveDateTime.utc_now(:second), 60))
+
+      {:ok, live, _html} = live(conn, ~p"/notifications")
+
+      refute has_element?(live, ~s([data-filter-count]))
     end
 
     test "redirects a logged-out visitor to the login", %{conn: conn} do
@@ -817,6 +1023,78 @@ defmodule VutuvWeb.NotificationLiveTest do
       # The grouped plural sentence and the folded overflow, both German.
       assert body =~ "folgen Ihnen jetzt."
       assert body =~ "und 1 weitere"
+    end
+
+    test "the card vocabulary is written German, not fuzzy-filled from something else", %{
+      conn: conn
+    } do
+      # `gettext.extract --merge` fills a brand-new msgid with the translation of
+      # whatever looked similar and nothing fails the build, so the German of
+      # every new string on this page is asserted by name, the short ones first.
+      {conn, user} = create_and_login_user(conn)
+      backdate_welcome_note(user, ~N[2016-11-24 12:00:00])
+      set_read_marker(user, ~N[2016-11-25 00:00:00])
+
+      host = insert(:user, first_name: "Grace", last_name: "Hopper")
+      root = create_post!(host, %{body: "Grace fragt"})
+      {:ok, mine} = Vutuv.Posts.create_reply(user, root, %{body: "Meine Antwort"})
+      backdate_reply(mine, NaiveDateTime.add(NaiveDateTime.utc_now(:second), -60))
+      {:ok, _} = Vutuv.Posts.create_reply(insert(:user), root, %{body: "Joes Antwort"})
+
+      mine = create_post!(user, %{body: "Mein Beitrag"})
+      :ok = Vutuv.Posts.like_post(insert(:user), mine)
+
+      insert(:post_reply,
+        post: insert(:post, user: insert(:user)),
+        parent_post: mine,
+        parent_author: user
+      )
+
+      answered = create_post!(user, %{body: "Beantwortet"})
+      answer = insert(:post, user: insert(:user), body: "gesehen")
+      insert(:post_reply, post: answer, parent_post: answered, parent_author: user)
+      {:ok, _} = Vutuv.Posts.create_reply(user, answer, %{body: "Danke!"})
+      # A like on a card of its own: `mine`'s like line sits behind its fold,
+      # and a like on `answered` would make that card new again.
+      :ok = Vutuv.Posts.like_post(insert(:user), create_post!(user, %{body: "Nur gelikt"}))
+
+      create_post!(insert(:activated_user), %{body: "Hallo @#{user.username}"})
+
+      for i <- 1..6 do
+        reply = insert(:post, user: insert(:user), body: "Antwort #{i}")
+        insert(:post_reply, post: reply, parent_post: mine, parent_author: user)
+      end
+
+      connect!(user, insert(:user))
+      insert(:follow, follower: insert(:user), followee: user)
+
+      {:ok, live, _html} =
+        conn
+        |> recycle()
+        |> put_req_header("accept-language", "de-DE,de;q=0.9")
+        |> live(~p"/notifications")
+
+      html = render(live)
+
+      assert html =~ "Ihr Beitrag"
+      assert html =~ "Thread von Grace Hopper"
+      assert html =~ "hat im Thread geantwortet."
+      assert html =~ "hat Sie erwähnt."
+      assert html =~ "gefällt das."
+      assert html =~ "hat geantwortet."
+      assert html =~ "Personen"
+      assert html =~ "1 neue Vernetzung"
+      assert html =~ "1 neuer Follower"
+      assert html =~ "Bereits gesehen"
+      # `mine` holds seven answers and a like: four lines shown, four folded.
+      assert html =~ "4 weitere anzeigen"
+      assert has_element?(live, ~s([data-filter-tab="replies"]), "Antworten")
+      assert has_element?(live, ~s([data-filter-tab="reactions"]), "Reaktionen")
+      assert has_element?(live, ~s([data-filter-tab="people"]), "Personen")
+      assert has_element?(live, ~s([data-filter-tab="other"]), "Mehr")
+
+      live |> element(~s([data-event-kind="thread"] [data-line-toggle])) |> render_click()
+      assert has_element?(live, ~s(a[data-reply-link]), "Antworten")
     end
 
     test "a new follower appears live without a reload", %{conn: conn} do
@@ -870,8 +1148,10 @@ defmodule VutuvWeb.NotificationLiveTest do
     end
   end
 
-  describe "mention rows" do
-    test "a post naming the reader renders a mention row linking that post", %{conn: conn} do
+  describe "mention lines" do
+    test "a post naming the reader is a card headed by that post, under its author", %{
+      conn: conn
+    } do
       {conn, user} = create_and_login_user(conn)
       author = insert(:activated_user, first_name: "Joe", last_name: "Armstrong")
 
@@ -881,53 +1161,55 @@ defmodule VutuvWeb.NotificationLiveTest do
       {:ok, live, _html} = live(conn, ~p"/notifications")
       html = render(live)
 
-      assert length(row_ids(html, "mention")) == 1
-      assert html =~ "Joe Armstrong"
-      assert html =~ "mentioned you in a post."
+      assert length(lines(html, "mention")) == 1
+      assert has_element?(live, ~s([data-event-kind="mention"]), "Joe Armstrong")
+      assert has_element?(live, ~s([data-event-kind="mention"]), "mentioned you.")
 
-      # The quoted post and the row both open the permalink under the *author*
-      # — it is their post, not the reader's, which is what sets this kind
-      # apart from a reply or a like.
-      assert has_element?(live, ~s([data-post-preview]), "they know it")
+      # The head names the post and opens the permalink under the *author* — it
+      # is their post, not the reader's, which is what sets this kind apart from
+      # a reply or a like — and the eyebrow says so.
+      assert has_element?(live, ~s([data-post-card]), "they know it")
 
       assert has_element?(
                live,
-               ~s([data-post-preview] a[href="/#{author.username}/posts/#{post.id}"])
+               ~s([data-post-card][href="/#{author.username}/posts/#{post.id}"])
              )
+
+      assert has_element?(live, ~s([data-card-eyebrow]), "Post by Joe Armstrong")
+
+      # The head IS the quote here, so the line has nothing to unfold.
+      refute has_element?(live, ~s([data-event-kind="mention"] [data-line-toggle]))
     end
 
-    test "the posts filter tab keeps mention rows", %{conn: conn} do
+    test "the replies filter keeps mention lines", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       create_post!(insert(:activated_user), %{body: "Hello @#{user.username}."})
 
-      {:ok, live, _html} = live(conn, ~p"/notifications?filter=posts")
+      {:ok, live, _html} = live(conn, ~p"/notifications?filter=replies")
 
-      assert length(row_ids(render(live), "mention")) == 1
+      assert length(lines(render(live), "mention")) == 1
     end
   end
 
   describe "replies from other networks (#1069)" do
-    defp remote_note!(post, name, text) do
-      Vutuv.Repo.insert!(%Vutuv.Fediverse.Note{
-        post_id: post.id,
-        object_uri:
-          "https://social.example/users/#{name}/statuses/#{System.unique_integer([:positive])}",
-        actor_uri: "https://social.example/users/#{name}",
-        handle: name,
-        display_name: String.capitalize(name),
-        content_text: text,
-        audience: "public",
-        received_at: DateTime.utc_now(:second),
-        expires_at: DateTime.add(DateTime.utc_now(:second), 30, :day)
-      })
-    end
-
-    test "the quoted reply opens the conversation, anchored at that reply", %{conn: conn} do
+    test "the line carries the reply's words and opens to the conversation, anchored at it", %{
+      conn: conn
+    } do
       {conn, user} = create_and_login_user(conn)
       post = create_post!(user, %{body: "why are the trains late"})
       note = remote_note!(post, "ba_eh", "the delays come down to two factors")
 
       {:ok, live, _html} = live(conn, ~p"/notifications")
+
+      assert has_element?(
+               live,
+               ~s([data-event-kind="fediverse_reply"] [data-reply-teaser]),
+               "the delays come down to two factors"
+             )
+
+      live
+      |> element(~s([data-event-kind="fediverse_reply"] [data-line-toggle]))
+      |> render_click()
 
       # The quote is what the reader reaches for, so it has to be the link — a
       # readable block of somebody's words that does nothing on tap reads as a
@@ -954,23 +1236,15 @@ defmodule VutuvWeb.NotificationLiveTest do
         |> put_req_header("accept-language", "de-DE,de;q=0.9")
         |> live(~p"/notifications")
 
+      live
+      |> element(~s([data-event-kind="fediverse_reply"] [data-line-toggle]))
+      |> render_click()
+
       assert render(live) =~ ~s(aria-label="Unterhaltung ansehen")
     end
   end
 
   describe "reactions from other networks (#1068)" do
-    # Written straight to the table: the inbox gates are the Fediverse tests'
-    # business, this is about the row the reader gets.
-    defp remote_reaction!(post, name, kind) do
-      Vutuv.Repo.insert!(%Vutuv.Fediverse.Reaction{
-        post_id: post.id,
-        actor_uri: "https://social.example/users/#{name}",
-        handle: name,
-        kind: kind,
-        received_at: DateTime.utc_now(:second)
-      })
-    end
-
     test "a boost names the account and says what they did", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       post = create_post!(user, %{body: "went out into the world"})
@@ -979,7 +1253,7 @@ defmodule VutuvWeb.NotificationLiveTest do
       {:ok, live, _html} = live(conn, ~p"/notifications")
       html = render(live)
 
-      assert length(row_ids(html, "fediverse_post")) == 1
+      assert length(rows(html, "post")) == 1
       assert html =~ "@alice@social.example"
       assert html =~ "shared this."
       # It opens the reader's own post, where the line naming them sits — not
@@ -994,8 +1268,23 @@ defmodule VutuvWeb.NotificationLiveTest do
 
       html = render_the_page(conn)
 
-      assert length(row_ids(html, "fediverse_post")) == 1
-      assert event_kinds(html) == ["fediverse_reaction"]
+      assert length(rows(html, "post")) == 1
+      assert event_kinds(html) == ["share"]
+      # A like or share line names three before folding — where a people line
+      # names two — so three sharers are all spelled out.
+      for name <- ~w(alice bob carol), do: assert(html =~ "@#{name}@social.example")
+      refute html =~ "and 1 more"
+      assert html =~ "shared this."
+    end
+
+    test "a fourth sharer folds into the count", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = create_post!(user, %{body: "much shared"})
+      for name <- ~w(alice bob carol dave), do: remote_reaction!(post, name, "announce")
+
+      html = render_the_page(conn)
+
+      assert length(lines(html, "share")) == 1
       assert html =~ "and 1 more"
     end
 
@@ -1020,23 +1309,19 @@ defmodule VutuvWeb.NotificationLiveTest do
       assert has_element?(live, ~s(a[href="https://social.example/users/alice"]))
     end
 
-    test "the posts filter tab keeps them", %{conn: conn} do
+    test "the reactions filter keeps them", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       remote_reaction!(create_post!(user, %{body: "filtered"}), "alice", "like")
 
-      {:ok, live, _html} = live(conn, ~p"/notifications?filter=posts")
+      {:ok, live, _html} = live(conn, ~p"/notifications?filter=reactions")
 
-      assert length(row_ids(render(live), "fediverse_post")) == 1
-    end
-
-    defp render_the_page(conn) do
-      {:ok, live, _html} = live(conn, ~p"/notifications")
-      render(live)
+      assert length(rows(render(live), "post")) == 1
     end
   end
 
-  describe "one card per post, for everything the fediverse sends back" do
+  describe "one card per post, for everything that came back about it" do
     alias Vutuv.Posts.PostImage
+    alias Vutuv.Posts.PostScreenshot
 
     test "a favourite, a boost and a reply to one post share one card", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
@@ -1048,11 +1333,10 @@ defmodule VutuvWeb.NotificationLiveTest do
       html = render_the_page(conn)
 
       # One post, one card — the three verbs are three lines inside it, not
-      # three cards asking the reader which post each one meant.
-      assert length(row_ids(html, "fediverse_post")) == 1
-
-      assert Enum.sort(event_kinds(html)) ==
-               ~w(fediverse_reaction fediverse_reaction fediverse_reply)
+      # three cards asking the reader which post each one meant. Replies lead,
+      # because each carries its own words.
+      assert length(rows(html, "post")) == 1
+      assert event_kinds(html) == ~w(fediverse_reply like share)
 
       assert html =~ "likes this."
       assert html =~ "shared this."
@@ -1067,7 +1351,7 @@ defmodule VutuvWeb.NotificationLiveTest do
 
       html = render_the_page(conn)
 
-      assert length(row_ids(html, "fediverse_post")) == 2
+      assert length(rows(html, "post")) == 2
       assert html =~ "the first one"
       assert html =~ "the second one"
     end
@@ -1095,12 +1379,13 @@ defmodule VutuvWeb.NotificationLiveTest do
         for position <- 0..2,
             do: insert(:post_image, post: post, user: user, position: position)
 
-      remote_reaction!(post, "alice", "like")
+      :ok = Vutuv.Posts.like_post(insert(:user), post)
 
       html = render_the_page(conn)
 
       # Two thumbnails, then a count: the card's right edge has to sit in the
-      # same place whether a post carries two pictures or twenty.
+      # same place whether a post carries two pictures or twenty. A local like
+      # earns the pictures exactly as a remote one does.
       assert html =~ PostImage.url(first, "thumb")
       assert html =~ PostImage.url(second, "thumb")
       refute html =~ PostImage.url(third, "thumb")
@@ -1128,6 +1413,40 @@ defmodule VutuvWeb.NotificationLiveTest do
       # The image proxy 404s on an unreleased picture, so a card that linked to
       # one would draw a broken thumbnail on the reader's own notifications.
       refute render_the_page(conn) =~ "/post_images/"
+    end
+
+    test "a link post's ready screenshot rides the card where the pictures would", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = create_post!(user, %{body: "Check https://example.com/page"})
+
+      Vutuv.Repo.insert!(%PostScreenshot{
+        post_id: post.id,
+        url: "https://example.com/page",
+        status: "ready",
+        screenshot: "0123456789ab.avif",
+        moderation: "approved"
+      })
+
+      :ok = Vutuv.Posts.like_post(insert(:user), post)
+
+      html = render_the_page(conn)
+
+      assert html =~ "data-post-card-screenshot"
+    end
+
+    test "a pending screenshot shows nothing", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = create_post!(user, %{body: "Check https://example.com/page"})
+
+      Vutuv.Repo.insert!(%PostScreenshot{
+        post_id: post.id,
+        url: "https://example.com/page",
+        status: "pending"
+      })
+
+      :ok = Vutuv.Posts.like_post(insert(:user), post)
+
+      refute render_the_page(conn) =~ "data-post-card-screenshot"
     end
 
     test "a post with no text says so instead of showing an empty line", %{conn: conn} do
@@ -1184,7 +1503,9 @@ defmodule VutuvWeb.NotificationLiveTest do
       assert html =~ "1 reply"
     end
 
-    test "a private reply keeps its warning inside the card", %{conn: conn} do
+    test "a private reply carries its warning on the line, before the reader opens it", %{
+      conn: conn
+    } do
       {conn, user} = create_and_login_user(conn)
       post = create_post!(user, %{body: "why are the trains late"})
 
@@ -1196,8 +1517,8 @@ defmodule VutuvWeb.NotificationLiveTest do
       {:ok, live, _html} = live(conn, ~p"/notifications")
 
       # The member has to know the reply is private *before* they answer it, so
-      # the notice cannot be a casualty of moving the row into a card.
-      assert has_element?(live, "[data-remote-private]")
+      # the notice cannot wait behind the toggle.
+      assert has_element?(live, ~s([data-event-kind="fediverse_reply"] [data-remote-private]))
     end
 
     test "unread reactions keep their own marker per line", %{conn: conn} do
@@ -1210,13 +1531,13 @@ defmodule VutuvWeb.NotificationLiveTest do
 
       html = render_the_page(conn)
 
-      assert html =~ ~s(data-unread="true")
+      assert html =~ ~s(data-event-kind="like" data-unread="true")
     end
   end
 
   describe "pagination" do
-    # The page size is 50 raw events; a day's followers group into ONE row, so
-    # the rows are counted through the grouped row's overflow label ("and N
+    # The page size is 50 raw events; a day's followers group into ONE line, so
+    # the events are counted through the grouped line's overflow label ("and N
     # more") rather than by counting <article>s.
     test "a long feed is split into numbered pages the reader can patch between", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
@@ -1228,7 +1549,7 @@ defmodule VutuvWeb.NotificationLiveTest do
       assert has_element?(live, ~s(nav[aria-label="Pagination"] a[href="/notifications?page=2"]))
       assert has_element?(live, ~s(nav[aria-label="Pagination"] a[href="/notifications?page=3"]))
       refute has_element?(live, ~s(nav[aria-label="Pagination"] a[href="/notifications?page=4"]))
-      # 50 raw events in one grouped row: 2 named + 48 counted.
+      # 50 raw events in one grouped line: 2 named + 48 counted.
       assert render(live) =~ "and 48 more"
 
       live |> element(~s(a[href="/notifications?page=2"])) |> render_click()
@@ -1239,7 +1560,7 @@ defmodule VutuvWeb.NotificationLiveTest do
 
       live |> element(~s(a[href="/notifications?page=3"])) |> render_click()
 
-      # The last page holds the leftover 2 events, so its grouped row names
+      # The last page holds the leftover 2 events, so its grouped line names
       # both actors and has no overflow link at all.
       refute render(live) =~ "and 48 more"
       assert has_element?(live, ~s(nav[aria-label="Pagination"] span[aria-current="page"]), "3")
@@ -1272,24 +1593,24 @@ defmodule VutuvWeb.NotificationLiveTest do
       refute has_element?(live, ~s(nav a[href="/notifications?page=1"]))
     end
 
-    test "paging inside a filter tab keeps the filter", %{conn: conn} do
+    test "paging inside a filter keeps the filter", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       post = insert(:post, user: user)
       for _ <- 1..60, do: :ok = Vutuv.Posts.like_post(insert(:user), post)
-      # People events the "posts" tab must leave out of both list and count.
+      # People events the "reactions" filter must leave out of both list and count.
       for _ <- 1..60, do: insert(:follow, follower: insert(:user), followee: user)
 
-      {:ok, live, _html} = live(conn, ~p"/notifications?filter=posts")
+      {:ok, live, _html} = live(conn, ~p"/notifications?filter=reactions")
 
-      assert has_element?(live, ~s(a[href="/notifications?filter=posts&page=2"]))
+      assert has_element?(live, ~s(a[href="/notifications?filter=reactions&page=2"]))
       refute has_element?(live, ~s(nav[aria-label="Pagination"] a[href="/notifications?page=2"]))
 
-      live |> element(~s(a[href="/notifications?filter=posts&page=2"])) |> render_click()
+      live |> element(~s(a[href="/notifications?filter=reactions&page=2"])) |> render_click()
 
-      # 60 likes = 50 + 10, so the second page of THIS tab holds 10 likes and
-      # none of the 60 followers.
+      # 60 likes = 50 + 10, so the second page of THIS filter holds 10 likes
+      # (three named, seven folded) and none of the 60 followers.
       html = render(live)
-      assert html =~ "and 8 more"
+      assert html =~ "and 7 more"
       refute html =~ "started following you"
     end
 
@@ -1312,19 +1633,45 @@ defmodule VutuvWeb.NotificationLiveTest do
     end
   end
 
-  describe "filter tabs" do
-    test "?filter=posts keeps replies and likes, drops people events", %{conn: conn} do
+  describe "filter chips" do
+    test "?filter=reactions keeps likes, drops replies and people events", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
       insert(:follow, follower: insert(:user, first_name: "Grace"), followee: user)
       post = insert(:post, user: user, body: "Filterable post")
       :ok = Vutuv.Posts.like_post(insert(:user, first_name: "Fanny"), post)
 
-      {:ok, live, _html} = live(conn, ~p"/notifications?filter=posts")
+      insert(:post_reply,
+        post: insert(:post, user: insert(:user)),
+        parent_post: post,
+        parent_author: user
+      )
+
+      {:ok, live, _html} = live(conn, ~p"/notifications?filter=reactions")
 
       html = render(live)
-      assert html =~ "liked your post"
+      assert html =~ "likes this."
+      refute html =~ "replied."
       refute html =~ "started following you"
+    end
+
+    test "?filter=replies keeps replies, drops likes", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      post = insert(:post, user: user, body: "Filterable post")
+      :ok = Vutuv.Posts.like_post(insert(:user, first_name: "Fanny"), post)
+
+      insert(:post_reply,
+        post: insert(:post, user: insert(:user)),
+        parent_post: post,
+        parent_author: user
+      )
+
+      {:ok, live, _html} = live(conn, ~p"/notifications?filter=replies")
+
+      html = render(live)
+      assert html =~ "replied."
+      refute html =~ "likes this."
     end
 
     test "?filter=people keeps follower events, drops post events", %{conn: conn} do
@@ -1338,10 +1685,10 @@ defmodule VutuvWeb.NotificationLiveTest do
 
       html = render(live)
       assert html =~ "started following you"
-      refute html =~ "liked your post"
+      refute html =~ "likes this."
     end
 
-    test "the tabs patch the filter without a reload", %{conn: conn} do
+    test "the chips patch the filter without a reload", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       insert(:follow, follower: insert(:user, first_name: "Grace"), followee: user)
 
@@ -1349,19 +1696,19 @@ defmodule VutuvWeb.NotificationLiveTest do
       assert has_element?(live, ~s([data-filter-tab="all"][aria-current="page"]))
 
       live
-      |> element(~s([data-filter-tab="posts"]))
+      |> element(~s([data-filter-tab="reactions"]))
       |> render_click()
 
-      assert_patch(live, ~p"/notifications?filter=posts")
+      assert_patch(live, ~p"/notifications?filter=reactions")
       refute render(live) =~ "started following you"
     end
 
-    # A tab switch reloads the whole list, so on a slow line nothing in the DOM
+    # A chip switch reloads the whole list, so on a slow line nothing in the DOM
     # moves between the press and a page of rows arriving — a control that
     # reads as dead. The press paints itself instead, which is CSS on
     # LiveView's own `phx-click-loading` (`assets/css/app.css`) and cannot be
     # asserted here. What this pins is the markup that paint silently needs.
-    test "the tabs and the list sit inside one scope", %{conn: conn} do
+    test "the chips and the list sit inside one scope", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       insert(:follow, follower: insert(:user, first_name: "Grace"), followee: user)
 
@@ -1370,7 +1717,7 @@ defmodule VutuvWeb.NotificationLiveTest do
       # `[data-filter-scope]:has([data-filter-tab].phx-click-loading)
       # [data-filter-list]` — move either marker out of that container and the
       # feedback dies with every other test still green.
-      assert has_element?(live, ~s([data-filter-scope] [data-filter-tab="posts"]))
+      assert has_element?(live, ~s([data-filter-scope] [data-filter-tab="replies"]))
       assert has_element?(live, ~s([data-filter-scope] [data-filter-list]))
 
       # And the bar names which of the app's two tab looks the paint wears; the
@@ -1387,11 +1734,11 @@ defmodule VutuvWeb.NotificationLiveTest do
       Vutuv.Activity.notify_like(user.id, insert(:user, first_name: "Fanny"), post.id)
       _ = :sys.get_state(live.pid)
 
-      refute render(live) =~ "liked your post"
+      refute render(live) =~ "likes this."
     end
   end
 
-  describe "the desktop rail" do
+  describe "the rail and the summary line" do
     test "suggests following back a recent follower and follows on click", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       follower = insert(:user, first_name: "Grace", last_name: "Hopper")
@@ -1419,16 +1766,19 @@ defmodule VutuvWeb.NotificationLiveTest do
       refute has_element?(live, "#follow-back")
     end
 
-    test "summarizes the last 30 days of activity", %{conn: conn} do
+    test "summarizes the last 30 days in one line under the title", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       insert(:follow, follower: insert(:user), followee: user)
+      :ok = Vutuv.Posts.like_post(insert(:user), insert(:post, user: user))
 
       {:ok, live, _html} = live(conn, ~p"/notifications")
 
-      assert has_element?(live, "#activity-summary", "Follower")
+      assert has_element?(live, "#activity-summary", "Last 30 days")
+      assert has_element?(live, "#activity-summary", "1 follower")
+      assert has_element?(live, "#activity-summary", "1 like")
     end
 
-    test "shows no summary card when the window is empty", %{conn: conn} do
+    test "shows no summary line when the window is empty", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       old = insert(:follow, follower: insert(:user), followee: user)
       backdate_follow(old, ~N[2016-11-24 12:00:00])
@@ -1446,24 +1796,73 @@ defmodule VutuvWeb.NotificationLiveTest do
       :ok = Vutuv.Posts.like_post(insert(:user), post)
 
       {:ok, live, _html} = live(conn, ~p"/notifications")
-      assert has_element?(live, ~s([data-post-preview]), "Ship the redesign on Friday")
+      assert has_element?(live, ~s([data-post-card]), "Ship the redesign on Friday")
 
       send(live.pid, :day_changed)
       _ = :sys.get_state(live.pid)
-      assert has_element?(live, ~s([data-post-preview]), "Ship the redesign on Friday")
+      assert has_element?(live, ~s([data-post-card]), "Ship the redesign on Friday")
     end
   end
 
-  # Grouped rows carry `id="notification-<kind>-..."` plus a data-kind marker.
-  defp row_ids(html, kind) do
-    Regex.scan(~r/data-kind="#{kind}"/, html)
+  # ── helpers ──
+
+  # Written straight to the table: the inbox gates are the Fediverse tests'
+  # business, this is about the line the reader gets.
+  defp remote_reaction!(post, name, kind) do
+    Vutuv.Repo.insert!(%Vutuv.Fediverse.Reaction{
+      post_id: post.id,
+      actor_uri: "https://social.example/users/#{name}",
+      handle: name,
+      kind: kind,
+      received_at: DateTime.utc_now(:second)
+    })
   end
 
-  # The lines inside a post card, one per merged event.
+  defp remote_note!(post, name, text) do
+    Vutuv.Repo.insert!(%Vutuv.Fediverse.Note{
+      post_id: post.id,
+      object_uri:
+        "https://social.example/users/#{name}/statuses/#{System.unique_integer([:positive])}",
+      actor_uri: "https://social.example/users/#{name}",
+      handle: name,
+      display_name: String.capitalize(name),
+      content_text: text,
+      audience: "public",
+      received_at: DateTime.utc_now(:second),
+      expires_at: DateTime.add(DateTime.utc_now(:second), 30, :day)
+    })
+  end
+
+  # One reply to a fresh post of `user`'s, with `body` as the reply's text.
+  defp reply_with_body!(user, body) do
+    parent = insert(:post, user: user, body: "The question")
+    reply = insert(:post, user: insert(:user), body: body)
+    insert(:post_reply, post: reply, parent_post: parent, parent_author: user)
+    reply
+  end
+
+  defp render_the_page(conn) do
+    {:ok, live, _html} = live(conn, ~p"/notifications")
+    render(live)
+  end
+
+  # Cards and single rows carry `data-kind`; the lines inside a card carry
+  # `data-event-kind`, so counting one never counts the other.
+  defp rows(html, kind), do: Regex.scan(~r/data-kind="#{kind}"/, html)
+  defp lines(html, kind), do: Regex.scan(~r/data-event-kind="#{kind}"/, html)
+
+  # The lines inside the cards, one per merged event, in document order.
   defp event_kinds(html) do
     ~r/data-event-kind="([a-z_]+)"/
     |> Regex.scan(html)
     |> Enum.map(fn [_, kind] -> kind end)
+  end
+
+  # Source-order position of `needle`, so a test can pin that one piece of
+  # markup comes before another.
+  defp at(html, needle) do
+    assert {start, _length} = :binary.match(html, needle)
+    start
   end
 
   defp backdate_follow(%Vutuv.Social.Follow{id: id}, at) do
@@ -1471,6 +1870,23 @@ defmodule VutuvWeb.NotificationLiveTest do
 
     Vutuv.Repo.update_all(
       from(c in Vutuv.Social.Follow, where: c.id == ^id),
+      set: [inserted_at: at]
+    )
+  end
+
+  defp backdate_post(%Vutuv.Posts.Post{id: id}, at) do
+    import Ecto.Query
+
+    Vutuv.Repo.update_all(from(p in Vutuv.Posts.Post, where: p.id == ^id), set: [inserted_at: at])
+  end
+
+  # A reply event is timestamped by its post_replies row, so an old answer
+  # needs that row backdated, not only the reply post.
+  defp backdate_reply(%Vutuv.Posts.Post{id: id}, at) do
+    import Ecto.Query
+
+    Vutuv.Repo.update_all(
+      from(r in Vutuv.Posts.PostReply, where: r.post_id == ^id),
       set: [inserted_at: at]
     )
   end


### PR DESCRIPTION
On a real day the notifications page showed 39 events about 11 posts, and the busiest post appeared three times, every reply repeating its "Your post" quote above its own text. Ten replies were ten screens on a phone.

`/notifications` now groups by subject: one card per post (two-line teaser, its photos or link screenshot on the right, one line per verb; replies keep their words, likes and shares merge, local and fediverse together), one people card per day. Cards with unanswered replies come first, a "Seen before" rule marks the transition, the filter chips count what is new in one query, and a reply's formatted quote renders only when its line is unfolded.

Entry point: `VutuvWeb.NotificationLive.Index`, with `Groups.post_id_of/1` as the one owner of "which post is this about". Hot deploy, no migration.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01UfqkNaPwdq2RexgFcfoLER
