### PR TITLE
Cap a catalogue answer and budget the domain check

### DIFF
--- a/lib/vutuv/audiobook_length.ex
+++ b/lib/vutuv/audiobook_length.ex
@@ -51,6 +51,20 @@ defmodule Vutuv.AudiobookLength do
   # length attached — so it is filtered out rather than trusted.
   @radio_play ~r/hörspiel/i
 
+  # 64 KB of answer, and bounded runs inside it. Measured on a body of opening
+  # `<record>` tags with no closer, the shape that makes each lazy run expand to
+  # the end of the subject before failing: 200 KB cost **13.6 s** unbounded and
+  # 7.4 s bounded at 65535, so the answer cap is the lever here, exactly as in
+  # `Vutuv.RemoteHtml`. This runs on a background task against a fixed catalogue
+  # host, so what it costs is a pinned worker rather than request latency — but
+  # the host is config-overridable and nothing else bounded this.
+  #
+  # A real answer is untouched: five records parse in 10 us either way.
+  @max_answer_bytes 64 * 1024
+  @field_body 8_192
+
+  @record ~r/<(?:\w+:)?record\b[^>]{0,1024}>.{0,#{@field_body}}?<\/(?:\w+:)?record>/s
+
   @doc "Where the SRU lookup goes; nil/blank switches the feature off."
   def endpoint, do: Application.get_env(:vutuv, :dnb_sru_url, "https://services.dnb.de/sru/dnb")
 
@@ -166,25 +180,44 @@ defmodule Vutuv.AudiobookLength do
     |> Keyword.merge(Application.get_env(:vutuv, @req_options_key, []))
     |> Req.get()
     |> case do
-      {:ok, %Req.Response{status: 200, body: xml}} when is_binary(xml) -> {:ok, xml}
+      {:ok, %Req.Response{status: 200, body: xml}} when is_binary(xml) -> {:ok, clamp(xml)}
       _other -> :error
     end
   end
 
+  # An SRU answer for a handful of records is a few hundred bytes (five MARC
+  # records measure 455), so 64 KB is a hundred times a real one — and it is the
+  # only thing bounding the regexes below, since the fetch above reads whatever
+  # arrives. A catalogue that answers with megabytes is not one we can use.
+  #
+  # Bytes, and `String.byte_slice/3` so the cut lands on a codepoint boundary;
+  # the guard skips the copy for every real answer.
+  defp clamp(xml) when byte_size(xml) <= @max_answer_bytes, do: xml
+  defp clamp(xml), do: String.byte_slice(xml, 0, @max_answer_bytes)
+
   # One record out of an SRU answer is a handful of MARC fields, so these read
   # the XML with targeted regexes rather than dragging in a parser: a miss
   # yields nil, the same answer as "the record does not say".
+  # Built per tag/code, so they carry the caller's literal — the values are our
+  # own MARC constants ("300", "a"), never anything a catalogue sends.
+  defp datafield_regex(tag) do
+    ~r/<(?:\w+:)?datafield[^>]{0,1024}tag="#{tag}".{0,#{@field_body}}?<\/(?:\w+:)?datafield>/s
+  end
+
+  defp subfield_regex(code) do
+    ~r/<(?:\w+:)?subfield[^>]{0,1024}code="#{code}">([^<]{0,#{@field_body}})</
+  end
+
   defp records(xml) do
-    Regex.scan(~r{<(?:\w+:)?record\b.*?</(?:\w+:)?record>}s, xml) |> Enum.map(&hd/1)
+    Regex.scan(@record, xml) |> Enum.map(&hd/1)
   end
 
   defp record_minutes(nil), do: nil
   defp record_minutes(record), do: record |> subfield("300", "a") |> parse_minutes()
 
   defp subfield(record, tag, code) do
-    with [field] <-
-           Regex.run(~r{<(?:\w+:)?datafield[^>]*tag="#{tag}".*?</(?:\w+:)?datafield>}s, record),
-         [_match, value] <- Regex.run(~r{<(?:\w+:)?subfield[^>]*code="#{code}">([^<]*)<}, field) do
+    with [field] <- Regex.run(datafield_regex(tag), record),
+         [_match, value] <- Regex.run(subfield_regex(code), field) do
       value
     else
       _nothing -> nil

--- a/lib/vutuv_web/live/organization_live/domains.ex
+++ b/lib/vutuv_web/live/organization_live/domains.ex
@@ -17,6 +17,7 @@ defmodule VutuvWeb.OrganizationLive.Domains do
   alias Vutuv.Organizations
   alias VutuvWeb.Live.InitAssigns
   alias VutuvWeb.OrganizationLive.ManageGate
+  alias VutuvWeb.RateLimit
   alias VutuvWeb.VerificationComponents
 
   @impl true
@@ -41,6 +42,26 @@ defmodule VutuvWeb.OrganizationLive.Domains do
 
       {:refused, socket} ->
         {:ok, socket}
+    end
+  end
+
+  defp verify_domain(socket, organization, id) do
+    case Organizations.get_domain(organization, id) do
+      nil ->
+        {:noreply, socket}
+
+      domain ->
+        case Organizations.check_domain(organization, domain) do
+          {:ok, _organization} ->
+            {:noreply,
+             socket
+             |> forget_report(id)
+             |> load_domains()
+             |> put_flash(:info, gettext("Domain verified."))}
+
+          {:error, report} ->
+            {:noreply, put_report(socket, id, report)}
+        end
     end
   end
 
@@ -102,22 +123,13 @@ defmodule VutuvWeb.OrganizationLive.Domains do
   def handle_event("verify", %{"id" => id}, socket) do
     organization = socket.assigns.organization
 
-    case Organizations.get_domain(organization, id) do
-      nil ->
-        {:noreply, socket}
-
-      domain ->
-        case Organizations.check_domain(organization, domain) do
-          {:ok, _organization} ->
-            {:noreply,
-             socket
-             |> forget_report(id)
-             |> load_domains()
-             |> put_flash(:info, gettext("Domain verified."))}
-
-          {:error, report} ->
-            {:noreply, put_report(socket, id, report)}
-        end
+    # Each press makes this server fetch or query a host somebody typed, and the
+    # domain can be swapped between presses for nothing — the same shape the
+    # link-verification budget exists for, reached from a socket instead.
+    if RateLimit.check_link_verify(socket.assigns.current_user) == :rate_limited do
+      {:noreply, put_flash(socket, :error, gettext("Too many attempts. Please try again later."))}
+    else
+      verify_domain(socket, organization, id)
     end
   end
 

--- a/lib/vutuv_web/rate_limit.ex
+++ b/lib/vutuv_web/rate_limit.ex
@@ -163,6 +163,17 @@ defmodule VutuvWeb.RateLimit do
     check(conn, :link_verify, user.id, limit: @probe_limit, window_ms: @probe_window_ms)
   end
 
+  @doc """
+  The socket-side twin, for the organization pages that press the very same
+  check over a LiveView (`Organizations.check_domain/2` reaches the same
+  `WebVerification.dns_check/4` and `well_known_check/4`).
+
+  It shares the bucket rather than taking one of its own, because it is the same
+  act — this server fetching or querying a host somebody typed — and keyed on
+  the member alone, since a LiveView has no conn to read a client address from.
+  """
+  def check_link_verify(user), do: check_link_verify(nil, user)
+
   defp identity_keys(_event, nil), do: []
   defp identity_keys(event, extra), do: [{event, :id, hash_identity(extra)}]
 

--- a/test/vutuv/audiobook_length_test.exs
+++ b/test/vutuv/audiobook_length_test.exs
@@ -109,6 +109,50 @@ defmodule Vutuv.AudiobookLengthTest do
     assert AudiobookLength.minutes(@isbn) == nil
   end
 
+  describe "a catalogue that answers with junk" do
+    # `Req.get` here reads the whole response — no `into:`, no `max_bytes` — and
+    # the MARC regexes ran over whatever arrived. On a body of opening `<record>`
+    # tags with no closer, each lazy run expands to the end of the subject before
+    # failing: measured 13.6 s on 200 KB. This is a background task against a
+    # fixed catalogue host, so the cost is a pinned worker rather than request
+    # latency, but the host is config-overridable and nothing bounded this.
+    #
+    # Reductions, not the clock: the suite runs twenty cases in parallel.
+    #
+    # Calibrated: this goes red only with BOTH guards out. At this size either
+    # one alone already holds — the cap keeps the runs off most of the body, and
+    # the runs are cheap enough for what is left. They are both kept because
+    # they answer different questions: the cap bounds a fetch that reads
+    # whatever a host sends, the bounds protect against a hostile body that fits
+    # UNDER the cap, which no amount of capping reaches.
+    test "a hostile answer is bounded work" do
+      hostile = String.duplicate("<record foo>", 40_000)
+
+      Application.put_env(:vutuv, :dnb_req_options,
+        plug: fn conn ->
+          conn
+          |> Plug.Conn.put_resp_content_type("text/xml")
+          |> Plug.Conn.send_resp(200, hostile)
+        end
+      )
+
+      review = %Vutuv.Posts.PostReview{
+        kind: "book",
+        identifier: "9783442541683",
+        title: "Egal",
+        creator: "Wer auch immer",
+        medium: "audiobook"
+      }
+
+      {reductions, result} =
+        Vutuv.WorkCounter.count_reductions(fn -> Vutuv.AudiobookLength.lookup(review) end)
+
+      # Nothing to find in junk, and it must not cost a second to say so.
+      refute result
+      assert reductions < 50_000_000, "a hostile answer cost #{reductions} reductions"
+    end
+  end
+
   describe "lookup/1 falling back to the work's other audio editions" do
     # Most reviews carry the PRINT ISBN, so the by-ISBN answer is empty and
     # the catalogue is searched by title + author instead. These records are


### PR DESCRIPTION
Not from the scan — two siblings of what #1957 closed, found by asking whether
those fixes had any.

**The audiobook-length lookup read a catalogue answer with no cap at all** (no
`into:`, no `max_bytes`) and ran two unbounded regexes over it: measured 13.6 s
on 200 KB of unclosed `<record>` tags. It runs on a background task against a
fixed catalogue host, so the cost is a pinned worker rather than request
latency — but the host is config-overridable and nothing bounded this. The
answer is capped at 64 KB (a real one, five MARC records, is 455 bytes) and both
runs are bounded.

**An organization's domain check presses the very functions #1957 budgeted** —
the same `dns_check/4` and `well_known_check/4`, reached over a socket instead
of a form, with the domain swappable between presses for nothing. It shares that
budget now, because it is the same act.

The regression test goes red only when *both* guards are removed, and says so:
either one suffices at that size, and they are kept for different reasons (the
cap bounds a fetch that reads whatever arrives, the bounds cover a hostile body
that fits under the cap).

https://claude.ai/code/session_01HpEBfNDHjPRmJ1Joe2923o
