### PR TITLE
Fetch the feed's ten sources concurrently instead of one after another

### DIFF
--- a/lib/vutuv/feed_page.ex
+++ b/lib/vutuv/feed_page.ex
@@ -38,6 +38,58 @@ defmodule Vutuv.FeedPage do
   """
   def sort_entries(entries), do: Enum.sort_by(entries, & &1.at, {:desc, NaiveDateTime})
 
+  # How many sources may be in flight at once. They are independent reads of
+  # different tables, so running them one after the other only adds their
+  # latencies up: the newsfeed's ten sources cost 0.8 to 5.6 ms each and
+  # **31 ms in a row**, measured on a copy of production (2026-09-03), which was
+  # three quarters of the whole `/feed` dead render and, on the production
+  # machine, roughly 90 ms of it.
+  #
+  # Four rather than "all of them" because the number bounds how much of the
+  # **connection pool** one request may hold, and production runs a pool of ten
+  # (`POOL_SIZE`, `config/runtime.exs`). Concurrency does not increase the total
+  # connection-time a request costs — the same ten queries occupy the same ~31
+  # connection-milliseconds either way — it only shortens the span they are held
+  # over, so throughput is unchanged and latency is what improves. Ten in flight
+  # would still be safe by that argument and is not worth the shape of the
+  # failure it invites: one request able to empty the pool turns a slow query
+  # into a site-wide stall. Four takes about 60 % of the available saving and
+  # never holds more than 40 % of the pool.
+  #
+  # `timeout: :infinity` hands the deadline to Ecto, which has its own per-query
+  # timeout; a second one here would only cut a query short in a way the caller
+  # cannot tell from a crash. A raising source still brings the request down,
+  # exactly as it did when these ran in a row.
+  @max_concurrency 4
+
+  @doc """
+  Runs every source and returns what each one gave back, in the order the
+  sources were listed.
+
+  The one place a list of sources is turned into rows, so both paginators here
+  and the feed calendar's counter (`Vutuv.Posts.feed_activity_by_day/4`, which
+  merges nothing and only wants the lists) share the concurrency rule above
+  rather than each spelling out its own loop.
+
+  `$callers` travels into each task, which is what lets the Ecto SQL sandbox
+  find the test's connection — so these stay plain `Task`s rather than anything
+  supervised.
+  """
+  def fetch_sources(sources, fetch_n, cursor) when is_list(sources) do
+    sources
+    |> Task.async_stream(fn fetch -> fetch.(fetch_n, cursor) end,
+      max_concurrency: @max_concurrency,
+      timeout: :infinity
+    )
+    |> Enum.map(fn {:ok, items} -> items end)
+  end
+
+  # Both paginators want the sources merged into one list; the only difference
+  # is the cursor they pass on.
+  defp fetch_all(sources, fetch_n, cursor) do
+    sources |> fetch_sources(fetch_n, cursor) |> Enum.concat()
+  end
+
   @doc """
   An entry cut down to the two fields the paginators actually read — a **mark**.
 
@@ -63,7 +115,7 @@ defmodule Vutuv.FeedPage do
 
     candidates =
       sources
-      |> Enum.flat_map(fn fetch -> fetch.(fetch_n, cursor) end)
+      |> fetch_all(fetch_n, cursor)
       |> Enum.reject(&(&1.id in seen))
       |> sort_entries()
 
@@ -87,7 +139,7 @@ defmodule Vutuv.FeedPage do
 
     candidates =
       sources
-      |> Enum.flat_map(fn fetch -> fetch.(fetch_n, nil) end)
+      |> fetch_all(fetch_n, nil)
       |> sort_entries()
 
     %{

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2861,7 +2861,9 @@ defmodule Vutuv.Posts do
     cursor = %{at: last, ids: [], since: first}
 
     entries =
-      Enum.map(feed_sources(viewer, filter, :marks), fn fetch -> fetch.(cap, cursor) end)
+      viewer
+      |> feed_sources(filter, :marks)
+      |> Vutuv.FeedPage.fetch_sources(cap, cursor)
 
     # Truncation is a per-SOURCE fact, not a fact about their union: the cap is
     # each source's `LIMIT`, so nine sources of 400 rows each make 3,600

--- a/test/vutuv/feed_page_concurrency_test.exs
+++ b/test/vutuv/feed_page_concurrency_test.exs
@@ -53,7 +53,11 @@ defmodule Vutuv.FeedPageConcurrencyTest do
       # is itself the assertion: the failure travels out of the task.
       {pid, ref} = spawn_monitor(fn -> FeedPage.fetch_sources(sources, 5, nil) end)
 
-      assert_receive {:DOWN, ^ref, :process, ^pid, {%RuntimeError{message: "source down"}, _}}
+      # Generously, because the default 100 ms is a bet on scheduling: the whole
+      # suite runs twenty cases at once, and this failed there while passing
+      # alone. What is asserted is that the exit arrives at all, not how quickly.
+      assert_receive {:DOWN, ^ref, :process, ^pid, reason}, 5_000
+      assert {%RuntimeError{message: "source down"}, _stacktrace} = reason
     end
 
     test "each source is handed the fetch size and the cursor the caller passed" do

--- a/test/vutuv/feed_page_concurrency_test.exs
+++ b/test/vutuv/feed_page_concurrency_test.exs
@@ -1,0 +1,117 @@
+defmodule Vutuv.FeedPageConcurrencyTest do
+  @moduledoc """
+  The feed's sources are fetched concurrently (`Vutuv.FeedPage.fetch_sources/3`)
+  because running ten independent reads one after the other only added their
+  latencies up — 31 ms of the newsfeed's 45 ms dead render, measured on a copy
+  of production.
+
+  What that buys is latency; what it must not cost is a single row, a single
+  place in the order, or the ability of a source to fail loudly. Those three are
+  what this file pins, plus the one thing about a `Task` that would break a
+  source silently: it does not inherit the caller's process dictionary, which is
+  where the viewer's clock lives (`Vutuv.ViewerClock`).
+
+  Sources here are plain functions rather than real queries — the point is the
+  fetching rule, not what any particular source selects.
+  """
+  use ExUnit.Case, async: true
+
+  alias Vutuv.FeedPage
+
+  defp at(minutes_ago) do
+    NaiveDateTime.utc_now()
+    |> NaiveDateTime.truncate(:second)
+    |> NaiveDateTime.add(-minutes_ago * 60)
+  end
+
+  # A source that answers with the items it was built from, ignoring the cursor.
+  defp source(items), do: fn _fetch_n, _cursor -> items end
+
+  describe "fetching the sources" do
+    test "every source's rows come back, and in the order the sources were listed" do
+      sources = for n <- 1..10, do: source([%{id: "s#{n}", at: at(n)}])
+
+      assert FeedPage.fetch_sources(sources, 5, nil) ==
+               Enum.map(1..10, &[%{id: "s#{&1}", at: at(&1)}])
+    end
+
+    test "more sources than may run at once still all run" do
+      # Deliberately past the concurrency cap, so the stream has to work through
+      # several waves rather than one.
+      sources = for n <- 1..40, do: source([%{id: "s#{n}", at: at(1)}])
+
+      assert length(FeedPage.fetch_sources(sources, 5, nil)) == 40
+    end
+
+    test "a source that raises brings the fetch down rather than returning short" do
+      # The failure mode to avoid is a page that silently loses one source's
+      # rows: an exception in a task must reach the caller, not be swallowed
+      # into a shorter feed nobody can tell from a quiet day.
+      sources = [source([%{id: "a", at: at(1)}]), fn _n, _c -> raise "source down" end]
+
+      # In its own unlinked process, or the exit takes the test with it — which
+      # is itself the assertion: the failure travels out of the task.
+      {pid, ref} = spawn_monitor(fn -> FeedPage.fetch_sources(sources, 5, nil) end)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, {%RuntimeError{message: "source down"}, _}}
+    end
+
+    test "each source is handed the fetch size and the cursor the caller passed" do
+      cursor = %{at: at(5), ids: ["x"], since: nil}
+      spy = fn fetch_n, c -> [%{id: "#{fetch_n}/#{inspect(c.ids)}", at: at(1)}] end
+
+      assert [[%{id: "7/[\"x\"]"}]] = FeedPage.fetch_sources([spy], 7, cursor)
+    end
+  end
+
+  describe "paginate/3 over concurrent sources" do
+    test "merges newest first across sources and reports the next page" do
+      sources = [
+        source([%{id: "a", at: at(1)}, %{id: "d", at: at(4)}]),
+        source([%{id: "b", at: at(2)}, %{id: "e", at: at(5)}]),
+        source([%{id: "c", at: at(3)}])
+      ]
+
+      assert %{entries: entries, more?: true} = FeedPage.paginate(sources, 3, nil)
+      assert Enum.map(entries, & &1.id) == ~w(a b c)
+    end
+
+    test "items tying at the same second keep the source order they were listed in" do
+      # `Enum.sort_by/3` is stable, so a tie falls back to the order the fetch
+      # handed over — which is the order of the source list, and stays that way
+      # only because the fetch keeps its results ordered.
+      same = at(3)
+
+      sources = [
+        source([%{id: "first", at: same}]),
+        source([%{id: "second", at: same}]),
+        source([%{id: "third", at: same}])
+      ]
+
+      assert %{entries: entries} = FeedPage.paginate(sources, 3, nil)
+      assert Enum.map(entries, & &1.id) == ~w(first second third)
+    end
+  end
+
+  describe "the viewer's clock" do
+    test "is read by the caller, never inside a source" do
+      # A `Task` starts with an empty process dictionary, so a source that asked
+      # `Vutuv.ViewerClock` for the viewer's zone would quietly get the
+      # installation default instead — a feed grouped into the wrong days for
+      # everybody outside it, with nothing raising. No source does today; this
+      # is what says so out loud.
+      Vutuv.ViewerClock.put_viewer(%{time_zone: "Pacific/Auckland", date_region: "de"})
+      assert Vutuv.ViewerClock.zone() == "Pacific/Auckland"
+
+      [[seen]] =
+        FeedPage.fetch_sources(
+          [fn _n, _c -> [%{id: Vutuv.ViewerClock.zone(), at: at(1)}] end],
+          5,
+          nil
+        )
+
+      assert seen.id != "Pacific/Auckland",
+             "a source now reads the viewer clock; it must be read in the caller and passed in"
+    end
+  end
+end


### PR DESCRIPTION
A feed page is built from ten independent queries — own posts, organization posts, reposts, tags, replies, four fediverse sources — and `Vutuv.FeedPage.paginate/3` ran them in a row with `Enum.flat_map`. Measured on a copy of production, each costs 0.8 to 5.6 ms and together **31 ms**, three quarters of the whole `/feed` dead render.

They now run four at a time. Back-to-back on the same machine:

| | before | after |
|---|---|---|
| `/feed` median | 47.5 ms | **22.1 ms** |
| `feed_page(10)` median | 29.5 ms | **5.2 ms** |

Four, not ten, bounds how much of the connection pool (ten in production) one request may hold. The total connection-time is unchanged — only the span it is held over. The calendar's counter takes the same path.

The trap the tests pin: a `Task` does not inherit the process dictionary, and `Vutuv.ViewerClock` lives there.

Where: `lib/vutuv/feed_page.ex`.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_015uHLPurrJ61uaUE9G7d5xY
