### PR TITLE
Paginate the post archive at 25 instead of 250

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -5087,19 +5087,47 @@ defmodule Vutuv.Posts do
   `author_timeline_query/3`. Returns `{entries, total}` (entry shape as in
   `feed_page/2`).
   """
-  def author_posts_page(%User{} = author, viewer, params, period \\ nil, filter \\ :all) do
+  @author_posts_per_page 25
+
+  def author_posts_page(
+        %User{} = author,
+        viewer,
+        params,
+        period \\ nil,
+        filter \\ :all,
+        per_page \\ Vutuv.Pages.max_page_items()
+      ) do
     query = author |> author_timeline_query(viewer, filter) |> scope_period(period)
     total = Repo.aggregate(query, :count)
 
     entries =
       query
       |> order_by([t], desc: t.at, desc: t.ref_id)
-      |> Vutuv.Pages.paginate(params, total)
+      |> Vutuv.Pages.paginate(params, total, per_page)
       |> Repo.all()
       |> author_entries(author)
 
     {entries, total}
   end
+
+  @doc """
+  How many entries one page of the **HTML** archive (`/:slug/posts`) carries.
+
+  Its own number rather than the site-wide `Vutuv.Pages.max_page_items/0`,
+  which is 250: that figure was chosen for listing pages whose item is one row,
+  and here every item is a full post card — a reply nesting the post it answers
+  renders two. On a copy of production a member with 93 entries drew **258
+  cards** and the document came to 3.5 MB (measured 2026-09-03: 136 ms of
+  render locally, about 1.3 s on the production machine). The same page at this
+  size is 292 kB and 21 ms.
+
+  **The agent-format siblings and `/api/2.0` deliberately keep the site-wide
+  250.** Neither document carries a next-page pointer, so shrinking their page
+  would not paginate them, it would silently hand a reader of `/posts.json`
+  a quarter of the archive with a `total` saying otherwise — and a machine
+  fetching a snapshot would rather have it in one piece anyway.
+  """
+  def author_posts_per_page, do: @author_posts_per_page
 
   @organization_posts_per_page 10
 

--- a/lib/vutuv_web/controllers/post_controller.ex
+++ b/lib/vutuv_web/controllers/post_controller.ex
@@ -51,7 +51,14 @@ defmodule VutuvWeb.PostController do
         filter = if is_nil(period), do: Posts.normalize_post_filter(params["type"]), else: :all
 
         {posts, total} =
-          Posts.author_posts_page(author, conn.assigns[:current_user], params, period, filter)
+          Posts.author_posts_page(
+            author,
+            conn.assigns[:current_user],
+            params,
+            period,
+            filter,
+            Posts.author_posts_per_page()
+          )
 
         {noindex?, noai?} = PostDoc.robots_axes(author, false)
 
@@ -70,6 +77,14 @@ defmodule VutuvWeb.PostController do
           engagement: archive_engagement(posts, conn.assigns[:current_user]),
           total: total,
           post_filter: Atom.to_string(filter),
+          per_page: Posts.author_posts_per_page(),
+          # What every page link has to carry with it. Only the type filter:
+          # `conn.params` also holds the path segments (the slug, and the year /
+          # month / day of a scoped archive), and putting those in the query
+          # string would name the same thing twice — the links are relative to
+          # the current path, which already says it. Without this a reader
+          # paging through "Replies" landed back on "All" at page two.
+          page_query: page_query(filter),
           period_label: period_label,
           period_crumbs: period_crumbs(author, params, period_label),
           page_title: "#{VutuvWeb.UserHelpers.full_name(author)} · #{gettext("Posts")}"
@@ -120,6 +135,11 @@ defmodule VutuvWeb.PostController do
 
   # A reshare of a post from another network carries no local post at all.
   defp archive_post_ids(_entry), do: []
+
+  # The type filter is the only thing a page link carries; `:all` is the
+  # default the bare URL already means, so it is left off.
+  defp page_query(:all), do: %{}
+  defp page_query(filter), do: %{"type" => Atom.to_string(filter)}
 
   # With no explicit `ancestors` the card falls back to the one preloaded
   # parent, which carries an action bar of its own — so it belongs in the batch

--- a/lib/vutuv_web/templates/post/index.html.heex
+++ b/lib/vutuv_web/templates/post/index.html.heex
@@ -5,6 +5,20 @@
       <h1 class="text-2xl font-bold text-slate-800 dark:text-slate-100">
         {gettext("Posts by %{name}", name: full_name(@author))}
         <span :if={@period_label} class="font-normal text-slate-600 dark:text-slate-400">· {@period_label}</span>
+        <%!-- How much there is to page through, shown only once there is more
+        than one page: a pager offering "1 2 3 4" with no total says how far the
+        reader can go but not how far they have to. On a single page the number
+        is already on the screen, so it would only be noise. `%{formatted}`
+        rather than `%{count}`, which ngettext binds to the raw integer. --%>
+        <span
+          :if={@total > @per_page}
+          class="font-normal text-slate-600 dark:text-slate-400"
+          data-archive-total
+        >
+          · {ngettext("%{formatted} post", "%{formatted} posts", @total,
+            formatted: compact_count(@total)
+          )}
+        </span>
       </h1>
       <%!-- The page IS what the feed carries, so the pill belongs here — this
       is the one place it still stands alone, since a page about a single feed
@@ -79,6 +93,8 @@
       {post_filter_empty_text(@post_filter)}
     </p>
 
-    <.pager params={@conn.params} total={@total} />
+    <%!-- `per_page` must be the one the query used, or the page count and the
+    rows disagree; `query` is what keeps the type filter across a page turn. --%>
+    <.pager params={@conn.params} total={@total} per_page={@per_page} query={@page_query} />
   </div>
 </div>

--- a/test/vutuv_web/controllers/post_controller_test.exs
+++ b/test/vutuv_web/controllers/post_controller_test.exs
@@ -47,6 +47,13 @@ defmodule VutuvWeb.PostControllerTest do
     {drain_queries(ref, 0), result}
   end
 
+  # How many post bodies a rendered archive page carries. Counted by the id the
+  # card gives each body, so a nested parent card counts too — which is the
+  # point: what makes this page heavy is cards, not entries.
+  defp bodies_on(conn) do
+    length(Regex.scan(~r/id="post-body-post-/, conn.resp_body))
+  end
+
   defp drain_queries(ref, n) do
     receive do
       {^ref, :query} -> drain_queries(ref, n + 1)
@@ -1256,6 +1263,49 @@ defmodule VutuvWeb.PostControllerTest do
              "ten more posts cost #{wide - narrow} more queries (#{narrow} then #{wide}) — " <>
                "an action bar or a nested card is loading per post again instead of " <>
                "taking the batched map"
+    end
+
+    test "carries one page of posts, and the next page carries the rest", %{conn: conn} do
+      # 250 was the site-wide listing figure, meant for pages whose item is one
+      # row; here every item is a full post card, so a member with a real
+      # history shipped a multi-megabyte document (3.5 MB and 258 cards for 93
+      # entries, measured 2026-09-03).
+      per_page = Posts.author_posts_per_page()
+      user = insert_activated_user()
+
+      for n <- 1..(per_page + 3),
+          do: {:ok, _} = Posts.create_post(user, %{body: "archive post #{n}"})
+
+      first = get(conn, "/#{user.username}/posts")
+      second = get(conn, "/#{user.username}/posts?page=2")
+
+      assert bodies_on(first) == per_page
+      assert bodies_on(second) == 3
+
+      # Newest first, so the last three written open the archive and the three
+      # oldest close it — which is also what says the second page is a
+      # continuation rather than the same rows again.
+      assert html_response(first, 200) =~ "archive post #{per_page + 3}"
+      refute first.resp_body =~ "archive post 1<"
+      assert html_response(second, 200) =~ "archive post 1<"
+      refute second.resp_body =~ "archive post #{per_page + 3}"
+    end
+
+    test "a page link keeps the filter the reader is on", %{conn: conn} do
+      # Without this the reader paging through "Replies" landed back on "All"
+      # at page two, having asked for nothing of the sort.
+      user = insert_activated_user()
+      {:ok, parent} = Posts.create_post(user, %{body: "the post being answered"})
+
+      for n <- 1..(Posts.author_posts_per_page() + 1) do
+        {:ok, _} = Posts.create_reply(user, parent, %{body: "reply #{n}"})
+      end
+
+      conn = get(conn, "/#{user.username}/posts?type=replies")
+      html = html_response(conn, 200)
+
+      assert [_ | _] = links = Regex.scan(~r/href="\?[^"]*page=2[^"]*"/, html)
+      assert Enum.all?(links, fn [link] -> link =~ "type=replies" end), inspect(links)
     end
 
     test "lists the author's posts, visibility-filtered per viewer", %{conn: conn} do


### PR DESCRIPTION
250 items per page is the site-wide figure for listing pages whose item is one row. On `/:slug/posts` every item is a full post card, and a reply draws the card it answers — so 93 entries became **258 cards and a 3.5 MB document** (measured on a copy of production: 136 ms of render locally, about 1.3 s on the production machine).

| posts/page | HTML | render |
|---|---|---|
| 250 | 3,455,755 B | 136 ms |
| **25** | **293,271 B** | **16 ms** |

The agent-format siblings and `/api/2.0` deliberately keep 250: neither document carries a next-page pointer, so a smaller page would not paginate them, it would silently hand a reader of `/posts.json` a quarter of the archive with a `total` saying otherwise.

Two things the pager was missing, now that it actually shows up:

- it is handed the same page size the query used, or the page count and the rows disagree;
- **a page link keeps the type filter** — a reader paging through "Replies" landed back on "All" at page two.

The header now says how much there is to page through, shown only when there is more than one page.

Where: `VutuvWeb.PostController.index/2`, `Vutuv.Posts.author_posts_per_page/0`.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_015uHLPurrJ61uaUE9G7d5xY
