### PR TITLE
Posts arriving behind the feed's pill skipped the reader's own rules

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -3289,6 +3289,16 @@ defmodule Vutuv.Posts do
 
   Costs one decorate pass on a single row, so quoting the arrival is no more
   work than the boolean this replaced plus that pass.
+
+  The entry comes back with the post **as it was written**. A caller that shows
+  or quotes it owes it the reader's own two passes, in this order: their
+  search-and-replace rules (`Vutuv.PostRewrites.rewrite_entry/3`), then their
+  content filters. Two functions discharge that, and a third caller should
+  reach for one of them rather than spelling it again: `for_reader/2` in the
+  feed, which STAMPS the filter answer onto the entry so the row can fold to a
+  placeholder the reader may open, and `VutuvWeb.PostTeaser.quote_for/4`, which
+  REFUSES to quote a muted post at all. Both existing callers once skipped a
+  pass and showed a line no other surface in the app would have shown.
   """
   def newest_source_entry(%User{} = viewer, source, %NaiveDateTime{} = since)
       when source in [:vutuv, :fediverse] do

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -672,16 +672,30 @@ defmodule VutuvWeb.PostLive.Feed do
   # post this reader's own filters hide. The row below it folds to a placeholder
   # (`hidden_by_filter?/2`) while the pill above it read the muted words out —
   # and a teaser is the one place they cannot scroll past them (issue #940).
-  # Both read the same `:filtered_by` stamp, so the two cannot disagree.
-  defp newest_quote([%{filtered_by: pattern} | _rest]) when is_binary(pattern), do: nil
-
+  # It refuses before reading anything: `who/1` can fall back to a query and
+  # `text/1` runs the whole line through the Markdown renderer, and neither is
+  # work a muted post should cost.
   defp newest_quote([newest | _rest]) do
+    if muted_quote?(newest), do: nil, else: quoted_pair(newest)
+  end
+
+  defp quoted_pair(newest) do
     case {PostTeaser.who(newest), PostTeaser.text(newest)} do
       {nil, _text} -> nil
       {_who, nil} -> nil
       {who, text} -> %{who: who, text: text}
     end
   end
+
+  # Whether quoting this post would read the reader's own muted words back to
+  # them: the one spelling of the `:filtered_by` stamp, shared by the pill
+  # above, the rail's "not read yet" card (`unread_body/1`) and the timeline row
+  # (`hidden_by_filter?/2`), so no two of them can read the stamp differently.
+  # What they then DO differs, and deliberately: the pill gives its quote up
+  # entirely, the rail skips that post and lists the next, the row folds to a
+  # placeholder the reader can open. Only the rail's count stays whole either
+  # way — it counts what is waiting, not what it may quote.
+  defp muted_quote?(entry), do: is_binary(entry[:filtered_by])
 
   # Write an arrangement change through and keep the socket's copy in step. The
   # column is the truth here and the assign is a copy of it, so both move
@@ -838,7 +852,8 @@ defmodule VutuvWeb.PostLive.Feed do
   attr(:click, :any, required: true)
 
   defp unread_body(assigns) do
-    assigns = assign(assigns, :shown, Enum.take(assigns.entries, @unread_shown))
+    shown = assigns.entries |> Enum.reject(&muted_quote?/1) |> Enum.take(@unread_shown)
+    assigns = assign(assigns, :shown, shown)
 
     ~H"""
     <div id="unread-posts">
@@ -2143,9 +2158,12 @@ defmodule VutuvWeb.PostLive.Feed do
   defp queue_remote_arrival(%{assigns: %{feed_filter: :vutuv}} = socket, _at), do: socket
 
   defp queue_remote_arrival(socket, at) do
-    case Posts.newest_source_entry(socket.assigns.current_user, :fediverse, at) do
-      nil -> socket
-      entry -> if known_entry?(socket, entry), do: socket, else: queue(socket, entry)
+    entry = Posts.newest_source_entry(socket.assigns.current_user, :fediverse, at)
+
+    cond do
+      is_nil(entry) -> socket
+      known_entry?(socket, entry) -> socket
+      true -> queue(socket, for_reader(entry, socket))
     end
   end
 
@@ -2581,11 +2599,13 @@ defmodule VutuvWeb.PostLive.Feed do
         {:noreply, socket}
 
       true ->
-        # `mark_one/3` and not `decorate/3`: nothing here is streamed, and the
+        # `for_reader/2` and not `decorate/3`: nothing here is streamed, and the
         # pill only reads the author and the opening line. Decorating would buy
         # a follow edge and an engagement count per arrival, two queries, for a
         # card that is never drawn — including the ones the cap throws away.
-        {:noreply, count_away(socket, mark_one(entry, socket.assigns.content_filters, user.id))}
+        # The reader's own two passes are not that: they run on the sets the
+        # mount compiled, and the pill quotes what they leave.
+        {:noreply, count_away(socket, for_reader(entry, socket))}
     end
   end
 
@@ -2613,7 +2633,7 @@ defmodule VutuvWeb.PostLive.Feed do
          |> load_source_filter(:all)}
 
       actor_id == user.id ->
-        decorated = decorate(entry, user, socket)
+        decorated = decorate(entry, socket)
 
         {:noreply,
          socket
@@ -2639,7 +2659,7 @@ defmodule VutuvWeb.PostLive.Feed do
       # either: the pill's whole promise is that clicking it shows those posts
       # right here.
       view_accepts?(socket, entry, actor_id) ->
-        {:noreply, queue(socket, decorate(entry, user, socket))}
+        {:noreply, queue(socket, decorate(entry, socket))}
 
       # It belongs to a source this reader has switched off in the band, so it
       # is not news for them at all: the switch is the answer, and queueing it
@@ -2679,24 +2699,52 @@ defmodule VutuvWeb.PostLive.Feed do
   # dropped before either query runs. A live-arrived reply nests only its direct
   # parent (one level, whose bar self-loads); the full visible chain reassembles
   # on the next reload / "Load more" (which run through `collapse_threads/1`).
-  defp decorate(entry, user, socket) do
+  defp decorate(entry, socket) do
+    user_id = socket.assigns.current_user.id
+
     entry
-    |> Map.put(:viewer_follow, Social.follow_edge(user.id, entry.post.user_id))
-    |> Map.put(:engagement, Posts.post_engagement(entry.post.id, user.id))
-    |> PostRewrites.rewrite_entry(socket.assigns.post_rewrites, user.id)
-    |> mark_one(socket.assigns.content_filters, user.id)
+    |> Map.put(:viewer_follow, Social.follow_edge(user_id, entry.post.user_id))
+    |> Map.put(:engagement, Posts.post_engagement(entry.post.id, user_id))
+    |> for_reader(socket)
   end
 
-  # Everything a page of entries goes through before it is streamed — the one
-  # place the order is decided: the reader's search-and-replace rules run
-  # BEFORE their content filters, so a filter reads the text the card shows.
-  # Mount, load-more and the source and day reloads all come through here;
-  # a live arrival takes the same two steps in `decorate/3`.
+  # The passes that turn posts into *this reader's* copy of them, and the one
+  # place their order is decided: the reader's search-and-replace rules run
+  # BEFORE their content filters, so a filter reads the text the card will
+  # show.
+  #
+  # Every entry the page draws owes them, whichever door it came in by — and
+  # each door that spelled them for itself has forgotten one. A cached post
+  # from another network has no author here, so it takes no other step of
+  # `decorate/3` and used to be streamed raw: the footer a rule deletes on
+  # every reload stayed on the card that arrived behind the pill, and a filter
+  # that hides that post let it through and quoted it in the pill besides.
+  defp reader_passes(entries, rewrites, filters, viewer_id) do
+    entries
+    |> Enum.map(&PostRewrites.rewrite_entry(&1, rewrites, viewer_id))
+    |> mark_filtered(filters, viewer_id)
+  end
+
+  # One arrival's worth of the same, reading the sets the mount compiled. The
+  # three doors a single entry comes in by (`decorate/3` for the reader's own
+  # post, `queue_remote_arrival/2` for one from another network, and the
+  # travelling reader's `insert_while_travelling/3`) all end here.
+  defp for_reader(entry, socket) do
+    [entry]
+    |> reader_passes(
+      socket.assigns.post_rewrites,
+      socket.assigns.content_filters,
+      socket.assigns.current_user.id
+    )
+    |> hd()
+  end
+
+  # Everything a page of entries goes through before it is streamed. Mount,
+  # load-more and the source and day reloads all come through here.
   defp prepare_entries(entries, user, rewrites, filters) do
     entries
     |> with_engagement(user)
-    |> Enum.map(&PostRewrites.rewrite_entry(&1, rewrites, user.id))
-    |> mark_filtered(filters, user.id)
+    |> reader_passes(rewrites, filters, user.id)
   end
 
   # Content filters (issue #940): stamp each entry with the pattern that hides it
@@ -2727,7 +2775,7 @@ defmodule VutuvWeb.PostLive.Feed do
   # branch on, so the placeholder and the card it stands in for cannot both show
   # (or both vanish).
   defp hidden_by_filter?(entry, revealed),
-    do: entry[:filtered_by] != nil and filter_key(entry) not in revealed
+    do: muted_quote?(entry) and filter_key(entry) not in revealed
 
   # A reported or muted cached post leaves the feed in the same round trip, so
   # the reader never looks at a row that is no longer theirs to see.

--- a/lib/vutuv_web/live/shell_live.ex
+++ b/lib/vutuv_web/live/shell_live.ex
@@ -44,6 +44,7 @@ defmodule VutuvWeb.ShellLive do
   alias Vutuv.DayClock
   alias Vutuv.Organizations
   alias Vutuv.PeopleCounter
+  alias Vutuv.PostRewrites
   alias Vutuv.Posts
   alias Vutuv.Prefs
   alias Vutuv.Social
@@ -240,13 +241,14 @@ defmodule VutuvWeb.ShellLive do
     # The browser tab's teaser (issue #1681). `tab_hidden?` is what the hook
     # reports and starts false, so nothing is spent on a tab that has not said
     # it is in the background; `teaser` holds the open window, `teaser_quiet_until`
-    # the silence after it, and `teaser_filters` this member's compiled content
-    # filters once something is actually quoted.
+    # the silence after it, and `teaser_rules` this member's compiled
+    # search-and-replace rules and content filters once something is actually
+    # quoted.
     |> assign(:current_user, nil)
     |> assign(:tab_hidden?, false)
     |> assign(:teaser, nil)
     |> assign(:teaser_quiet_until, nil)
-    |> assign(:teaser_filters, nil)
+    |> assign(:teaser_rules, nil)
     |> assign(:presence_hidden_ids, MapSet.new())
     |> assign(:messages_count, 0)
     |> assign(:notifications_count, 0)
@@ -799,16 +801,24 @@ defmodule VutuvWeb.ShellLive do
   # the release before this one carries none (the blue/green window), and that
   # skips the teaser rather than quoting whatever happens to sit on top.
   defp open_teaser(socket, source, at) do
-    {socket, filters} = teaser_filters(socket)
     user = socket.assigns.current_user
 
-    frames =
-      case Posts.newest_source_entry(user, source, at) do
-        nil -> []
-        entry -> entry |> PostTeaser.quote_for(filters, user.id) |> PostTeaser.title_frames()
-      end
+    case Posts.newest_source_entry(user, source, at) do
+      nil ->
+        push_teaser(socket, [])
 
-    push_teaser(socket, frames)
+      entry ->
+        # Compiled here and not above the case: an arrival this member's own
+        # sources answer nothing for is the common outcome, and it should not
+        # pay for two queries. `quote_for/4` owns what happens to the entry —
+        # it comes back from the sources as it was written.
+        {socket, {rewrites, filters}} = teaser_rules(socket)
+
+        push_teaser(
+          socket,
+          entry |> PostTeaser.quote_for(rewrites, filters, user.id) |> PostTeaser.title_frames()
+        )
+    end
   end
 
   defp push_teaser(socket, []), do: {:off, arm_quiet(socket, 0)}
@@ -846,15 +856,18 @@ defmodule VutuvWeb.ShellLive do
     )
   end
 
-  # Compiled once per socket, and only when a teaser is actually attempted: the
-  # vast majority of shells never raise one, and the query would otherwise ride
-  # every page load site-wide.
-  defp teaser_filters(%{assigns: %{teaser_filters: nil}} = socket) do
-    compiled = ContentFilters.compile_for(socket.assigns.current_user)
-    {assign(socket, :teaser_filters, compiled), compiled}
+  # This reader's rewrite rules and content filters, compiled once per socket
+  # and only when a teaser is actually quoted: the vast majority of shells never
+  # raise one, and the two queries would otherwise ride every page load
+  # site-wide. One assign for the pair, because they are only ever wanted
+  # together — the quote applies both or neither.
+  defp teaser_rules(%{assigns: %{teaser_rules: nil}} = socket) do
+    user = socket.assigns.current_user
+    compiled = {PostRewrites.compile_for(user), ContentFilters.compile_for(user)}
+    {assign(socket, :teaser_rules, compiled), compiled}
   end
 
-  defp teaser_filters(socket), do: {socket, socket.assigns.teaser_filters}
+  defp teaser_rules(socket), do: {socket, socket.assigns.teaser_rules}
 
   defp arm_quiet(socket, window_ms),
     do: assign(socket, :teaser_quiet_until, now_ms() + window_ms + teaser_cooldown_ms())

--- a/lib/vutuv_web/post_teaser.ex
+++ b/lib/vutuv_web/post_teaser.ex
@@ -56,6 +56,12 @@ defmodule VutuvWeb.PostTeaser do
   window sits behind something else (issue #1681). Both ask the same three
   questions, so all three answers live here instead of twice.
 
+  The feed's "new posts" pill is the exception, and reads as one on purpose: it
+  quotes an entry it has already put through the reader's passes on its way
+  into the stream, so it asks `who/1` and `text/1` here and reads the filter
+  answer off the stamp the row carries. `quote_for/4` is for a surface holding
+  an entry straight from `Vutuv.Posts.newest_source_entry/3`.
+
   `title_frames/1` is the browser tab's half and belongs here for the same
   reason: it cuts the quote the two surfaces share, and where it cuts is a
   decision about how a tab strip reads, not about the feed.
@@ -66,6 +72,7 @@ defmodule VutuvWeb.PostTeaser do
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Identity
   alias Vutuv.Mentions
+  alias Vutuv.PostRewrites
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias VutuvWeb.Markdown
@@ -163,15 +170,25 @@ defmodule VutuvWeb.PostTeaser do
     do: "#{Identity.display_name(Posts.author(post))} · #{Date.to_iso8601(post.published_on)}"
 
   @doc """
-  The quote for one feed entry — `%{who: …, text: …}` — or nil where this
-  reader has muted it.
+  The quote for one feed entry, as **this** reader would read it —
+  `%{who: …, text: …}` — or nil where they have muted it.
+
+  Their two passes over a post happen here, and in this order: their
+  search-and-replace rules (`rewrites`, compiled) rewrite the text, then their
+  content filters (`filters`, compiled) read what would be quoted. Reversed,
+  a filter would judge a line the reader was never going to see; skipped, the
+  tab strip reads out the footer a mirror puts under every post while every
+  other surface deletes it. The order is here rather than at the call site
+  because this module is what a surface asks for a quote.
 
   nil rather than a redacted line: the member silenced that word, and a teaser
   is the one place they cannot scroll past it. Both surfaces then fall back to
   the bare dot, which says *that* something landed without saying what.
   """
-  def quote_for(entry, compiled, viewer_id) do
-    if filtered_pattern(entry, compiled, viewer_id) do
+  def quote_for(entry, rewrites, filters, viewer_id) do
+    entry = PostRewrites.rewrite_entry(entry, rewrites, viewer_id)
+
+    if filtered_pattern(entry, filters, viewer_id) do
       nil
     else
       %{who: who(entry), text: text(entry)}

--- a/test/vutuv_web/live/browser_tab_teaser_test.exs
+++ b/test/vutuv_web/live/browser_tab_teaser_test.exs
@@ -220,6 +220,37 @@ defmodule VutuvWeb.BrowserTabTeaserTest do
     end
   end
 
+  describe "the reader's own rules" do
+    # The teaser quotes one line, so the rule under test has to change THAT
+    # line: a rule that deletes a footer two lines down would leave the title
+    # identical either way and prove nothing.
+    test "the title quotes the text this reader's rules rewrote", %{conn: conn} do
+      user = insert(:user)
+      account = remote_account(user, "golemde")
+
+      {:ok, _rule} =
+        Vutuv.PostRewrites.create_rule(user, "@golemde@social.example", %{
+          pattern: "Zahnbürste",
+          replacement: "Zahnputzstab"
+        })
+
+      view = tab(conn, user)
+
+      assert :ok =
+               Fediverse.record_remote_post(
+                 remote_note(account, "Dyson stellt Zahnbürste vor"),
+                 account.actor_uri
+               )
+
+      settle(view)
+
+      assert_push_event(view, "tab:teaser", %{frames: frames})
+      line = Enum.join(frames, " ")
+      assert line =~ "Zahnputzstab"
+      refute line =~ "Zahnbürste"
+    end
+  end
+
   describe "more than one inside the window" do
     test "the second arrival is counted, not quoted again", %{conn: conn} do
       user = insert(:user)

--- a/test/vutuv_web/live/feed_arrival_reader_passes_test.exs
+++ b/test/vutuv_web/live/feed_arrival_reader_passes_test.exs
@@ -1,0 +1,47 @@
+defmodule VutuvWeb.FeedArrivalReaderPassesTest do
+  @moduledoc """
+  A post that arrives while a page is open must be put through the reader's own
+  two passes before anything shows or quotes it: their search-and-replace rules
+  (`Vutuv.PostRewrites`), then their content filters.
+
+  `Vutuv.Posts.newest_source_entry/3` answers with the post as it was written,
+  and both of its callers once forgot a pass — the feed's pill streamed a
+  fediverse arrival raw, and the browser tab's teaser quoted un-rewritten text.
+  Each has one place that discharges the obligation now (`for_reader/2` in the
+  feed, `PostTeaser.quote_for/4` for anything that quotes), so this guards the
+  caller that comes third: a source read with no discharge beside it is the
+  shape of both bugs.
+
+  A source grep, deliberately: what it pins is that the obligation was *seen*,
+  which no runtime assertion can ask of a caller nobody has written yet. The
+  behaviour itself is covered by `feed_post_rewrites_test.exs`,
+  `feed_remote_posts_test.exs` and `browser_tab_teaser_test.exs`.
+  """
+  use ExUnit.Case, async: true
+
+  @source "newest_source_entry("
+  @discharges ["for_reader(", "PostTeaser.quote_for("]
+
+  test "every module reading an arrival discharges the reader's passes beside it" do
+    readers = Enum.filter(lib_files(), &(File.read!(&1) =~ @source))
+
+    # The context function that defines it is not a caller.
+    readers = readers -- ["lib/vutuv/posts.ex"]
+
+    offenders =
+      Enum.reject(readers, fn path ->
+        contents = File.read!(path)
+        Enum.any?(@discharges, &(contents =~ &1))
+      end)
+
+    assert readers != [], "nothing calls #{@source} any more — retire this test"
+
+    assert offenders == [],
+           "#{@source} answers with the post as it was written. Put the entry " <>
+             "through the reader's rewrite rules and content filters before you " <>
+             "show or quote it (#{Enum.join(@discharges, " / ")}). " <>
+             "Offending files: #{Enum.join(offenders, ", ")}"
+  end
+
+  defp lib_files, do: Path.wildcard("lib/**/*.ex")
+end

--- a/test/vutuv_web/live/feed_post_rewrites_test.exs
+++ b/test/vutuv_web/live/feed_post_rewrites_test.exs
@@ -102,4 +102,44 @@ defmodule VutuvWeb.FeedPostRewritesTest do
              ~s(a[href="/settings/rewrites/%40erika-rewrites?post=#{theirs.id}"])
            )
   end
+
+  test "rewrites a post that arrived live behind the pill, not only one the page load carried",
+       %{conn: conn} do
+    {conn, reader} = create_and_login_user(conn)
+    account = golem_account()
+    follow_remote(reader, account)
+
+    {:ok, _rule} = PostRewrites.create_rule(reader, @account, %{pattern: "^Gepostet in .*$"})
+
+    # The feed is open BEFORE the post exists, so the only way it reaches this
+    # page is the live arrival behind the pill.
+    {:ok, live, _html} = live(conn, ~p"/feed")
+    post = remote_post(account)
+    send(live.pid, {:remote_feed_arrival, %{at: ~N[2000-01-01 00:00:00]}})
+    render(live)
+
+    card = live |> element(~s([data-remote-post="#{post.id}"])) |> render()
+    assert card =~ "Dyson stellt Zahnbürste vor"
+    refute card =~ "Gepostet in"
+  end
+
+  test "rewrites a post that lands while the reader is on another day, before the pill quotes it",
+       %{conn: conn} do
+    {conn, reader} = create_and_login_user(conn)
+    author = insert(:activated_user, username: "erika-travel")
+    insert(:follow, follower: reader, followee: author)
+
+    {:ok, _} = PostRewrites.create_rule(reader, "@erika-travel", %{pattern: " -- Gruß Erika"})
+
+    # A day in the past is on screen, so the arrival is counted behind the pill
+    # and never drawn — the rail's card and the pill quote it from the waiting
+    # list alone.
+    {:ok, live, _html} = live(conn, ~p"/feed?day=1999-01-04")
+    post = insert(:post, user: author, body: "Hallo zusammen -- Gruß Erika")
+    send(live.pid, {:new_post, %{post_id: post.id, author_id: author.id}})
+
+    waiting = render(live)
+    assert waiting =~ "Hallo zusammen"
+    refute waiting =~ "Gruß Erika"
+  end
 end

--- a/test/vutuv_web/live/feed_remote_posts_test.exs
+++ b/test/vutuv_web/live/feed_remote_posts_test.exs
@@ -503,6 +503,24 @@ defmodule VutuvWeb.FeedRemotePostsTest do
     assert has_element?(view, "[data-remote-post='#{post.id}']")
   end
 
+  test "a muted word collapses a post that arrived live too, and the pill does not quote it",
+       %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+
+    {:ok, _filter} =
+      Vutuv.ContentFilters.create_filter(user, %{"kind" => "keyword", "pattern" => "thought"})
+
+    # Open before the post exists, so it can only reach this page behind the pill.
+    {:ok, view, _html} = live(conn, ~p"/feed")
+    post = cached_post(user)
+    send(view.pid, {:remote_feed_arrival, %{at: ~N[2000-01-01 00:00:00]}})
+    render(view)
+
+    assert has_element?(view, "[data-filtered-post]")
+    refute has_element?(view, "[data-remote-post='#{post.id}']")
+    refute render(view) =~ "A thought from over there."
+  end
+
   test "reporting deletes our copy and drops the row", %{conn: conn} do
     {conn, user} = create_and_login_user(conn)
     post = cached_post(user)


### PR DESCRIPTION
A post pulled in through the feed's "New:" pill looked different from the same post after a reload: the reader's own search-and-replace rules and content filters had not run on it. Fediverse posts are what the rules are written for and what arrives live, so the miss hit the main case while reading as "sometimes".

A single arrival enters `/feed` by three doors, and each spelled the reader's two passes for itself — one had both, one had only the filter, one had neither. All three now end in `for_reader/2`, which shares `reader_passes/4` with the page-load path; `VutuvWeb.PostTeaser.quote_for/4` owns the same order for anything that quotes.

Two more of the same family: the rail's "Not read yet" card read muted words out loud, and the browser tab title quoted the footer a rule deletes everywhere else.

Four calibrated regression tests plus a grep test for the next caller of `Posts.newest_source_entry/3`.

An AI agent wrote this text in my name. I know that is problematic.

https://claude.ai/code/session_018XmJSKBM4ksFwJodNFkJMR
