### PR TITLE
A boost drew the post a second time, empty

### DIFF
--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -1415,6 +1415,17 @@ that second half the two cards render, no error is raised, and the browser's
 patch moves the shared body into whichever was rendered last — leaving the other
 a name with its hashtags and nothing under them.
 
+The **live** arrival is the third way in and owes the same rule, measured
+against the same set (`shown_keys/1`, that one plus the member posts on screen).
+It is keyed by the **event**, not by the subject: a post an account the reader
+follows boosts arrives as `boost-<id>`, while the same post reaching them
+through their follow of its author is `remote-<id>`, so a gate that compared ids
+called the boost new — and the reader got the empty card above, this time with a
+"Reposted by" line over it (reported 2026-09-03). It is first come, first served
+here as it is across a page boundary: the card on screen stays and the arrival
+is dropped rather than queued behind the pill, which within a single page is the
+tie `dedupe_remote/1` settles the other way round.
+
 Both ties above are decided **within a page**; across the boundary it is simply
 first come, first served, since the earlier page was already sent. So a note
 whose reshare row lands on the second page loses it to the woven-in copy above

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -1561,10 +1561,7 @@ defmodule VutuvWeb.PostLive.Feed do
     # can't see the ones already on screen. The higher card already carries the
     # complete follow-scoped roster, so dropping the older duplicate loses
     # nothing. Filter before the engagement batch so it queries only survivors.
-    shown =
-      socket.assigns.entries
-      |> shown_post_ids()
-      |> MapSet.union(seen_remote)
+    shown = shown_keys(socket.assigns.entries, seen_remote)
 
     fresh = Enum.reject(page.entries, &MapSet.member?(shown, dedupe_key(&1)))
 
@@ -2471,9 +2468,28 @@ defmodule VutuvWeb.PostLive.Feed do
   # which is the one thing `hidden` loses to (issue #880).
   defp pending_row?(entry, pending), do: Enum.any?(pending, &(&1.id == entry.id))
 
+  # Whether the page already holds this arrival — asked of the **subject**, not
+  # of the entry. An entry is keyed by the event that produced it, so a post an
+  # account the reader follows boosts arrives as `boost-<id>` while the same
+  # post reaching them through their follow of its author is `remote-<id>`: an
+  # id check calls the second one new and the reader gets two cards for one
+  # cached post. Those cards carry the same body id and the same action-bar
+  # LiveComponent, so the browser moves each into whichever rendered last and
+  # leaves the other a name with the hashtags under it and nothing in between
+  # (reported 2026-09-03) — the failure `shown_remote_keys/1` was written for
+  # one door along.
+  #
+  # An id is derived from the record, so equal ids mean the same subject and the
+  # key check answers the burst of deliveries that queues one row twice as well.
+  # Which of the two survives is first come, first served, as it is across a
+  # page boundary: the card on screen stays and the arrival is dropped rather
+  # than queued behind the pill. Within one page `dedupe_remote/1` decides it
+  # the other way (the direct entry wins over a passed-on one), so a boost that
+  # got here first keeps its banner until the next reload.
   defp known_entry?(socket, entry) do
-    ids = Enum.map(socket.assigns.entries ++ socket.assigns.pending_posts, & &1.id)
-    entry.id in ids
+    on_page = socket.assigns.entries ++ socket.assigns.pending_posts
+
+    MapSet.member?(shown_keys(on_page), dedupe_key(entry))
   end
 
   # Swap in the post's now-screenshot-carrying copy and re-stream the entry in
@@ -2946,6 +2962,21 @@ defmodule VutuvWeb.PostLive.Feed do
         into: MapSet.new(),
         do: Fediverse.subject_key(subject)
   end
+
+  # Everything the page already holds, in the keys `dedupe_key/1` answers in.
+  # Both doors an entry can come through measure it with this — an older page
+  # appended below (`append_older_page/2`) and an arrival queued on top
+  # (`known_entry?/2`) — because a subject that has a card must not get a second
+  # one whichever way the second one would have arrived.
+  #
+  # The remote half arrives as an argument where the caller already holds it:
+  # `append_older_page/2` has to build that set anyway, for `feed_page/2`'s
+  # `seen:`, and walking every on-screen entry twice is a walk that grows with
+  # each "Load more".
+  defp shown_keys(entries), do: shown_keys(entries, shown_remote_keys(entries))
+
+  defp shown_keys(entries, remote_keys),
+    do: entries |> shown_post_ids() |> MapSet.union(remote_keys)
 
   defp remote_key(entry), do: Fediverse.subject_key(entry_record(entry))
 

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -2160,8 +2160,19 @@ defmodule VutuvWeb.PostLive.Feed do
     cond do
       is_nil(entry) -> socket
       known_entry?(socket, entry) -> socket
-      true -> queue(socket, for_reader(entry, socket))
+      true -> place_arrival(socket, for_reader(entry, socket))
     end
+  end
+
+  # Where the arrival goes, which is the question `insert_entry/3` asks of every
+  # local one and this door used to skip: a row on top at now, the count alone
+  # while the reader is standing on a past day. What it costs to draw it there
+  # is not only a card belonging to another day sitting hidden in this day's
+  # stream — `queue/2` also says the timeline is no longer empty, which takes
+  # the day's own "nothing reached your feed on this day" card away and leaves
+  # the reader looking at a blank page.
+  defp place_arrival(socket, entry) do
+    if at_now?(socket.assigns), do: queue(socket, entry), else: count_away(socket, entry)
   end
 
   # A waiting post goes into the timeline **now**, hidden, and not when the

--- a/test/vutuv_web/live/feed_calendar_test.exs
+++ b/test/vutuv_web/live/feed_calendar_test.exs
@@ -626,6 +626,38 @@ defmodule VutuvWeb.FeedCalendarTest do
       assert has_element?(view, "#show-new-posts")
     end
 
+    test "and neither does one from the other network", %{conn: conn} do
+      # The fediverse door is its own (`queue_remote_arrival/2`), and it used to
+      # skip the `at_now?` split every local arrival goes through: the row was
+      # streamed into the open day hidden, and — worse — the day's own "nothing
+      # reached you on this day" card went with it, since drawing a row says the
+      # timeline is not empty. The reader was left looking at a blank page.
+      {conn, user} = create_and_login_user(conn)
+
+      account = Vutuv.MastodonHelpers.remote_account()
+
+      Repo.insert!(%Vutuv.Fediverse.Follow{
+        user_id: user.id,
+        remote_account_id: account.id,
+        state: "accepted",
+        follow_activity_id: "https://vutuv.test/#{user.id}/actor#follows/#{account.id}"
+      })
+
+      post =
+        Vutuv.MastodonHelpers.cached_post(account, content_text: "Von woanders, gerade eben.")
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "cal-day", %{"date" => iso(days_ago(3))})
+
+      # Naive UTC, the shape `Vutuv.Fediverse.nudge_feeds/2` really broadcasts.
+      send(view.pid, {:remote_feed_arrival, %{at: DateTime.to_naive(post.published_at)}})
+
+      refute timeline(view) =~ "Von woanders, gerade eben."
+      assert render(view) =~ "Nothing reached your feed on"
+      # Still counted, like every other arrival that reaches a travelling reader.
+      assert has_element?(view, "#show-new-posts")
+    end
+
     test "writing a post takes the reader home to see it", %{conn: conn} do
       # Text that vanishes on submit reads as a post that was lost, so the
       # viewer's own post is the one arrival that ends the trip.

--- a/test/vutuv_web/live/feed_duplicate_cards_test.exs
+++ b/test/vutuv_web/live/feed_duplicate_cards_test.exs
@@ -31,6 +31,11 @@ defmodule VutuvWeb.FeedDuplicateCardsTest do
   dropped out here at all, so the same set rides back down as `feed_page/2`'s
   `seen:`.
 
+  The **live arrival** is the third call, and it is keyed by the event rather
+  than by the subject — a boost of a post the reader already has a card for is
+  a different entry id — which is how the same empty card came back on
+  2026-09-03 with a "Reposted by" line over it.
+
   Not async: answering a note claims from `Vutuv.RateLimiter`, a shared ETS
   table the SQL sandbox does not roll back.
   """
@@ -43,6 +48,7 @@ defmodule VutuvWeb.FeedDuplicateCardsTest do
   alias Vutuv.Fediverse.Follow
   alias Vutuv.Fediverse.Note
   alias Vutuv.Fediverse.NoteRepost
+  alias Vutuv.Fediverse.PostBoost
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Posts
@@ -126,12 +132,7 @@ defmodule VutuvWeb.FeedDuplicateCardsTest do
   # `feed_page/2` calls (ten cards in the document, the rest in the fill), the
   # whole point of every test that uses it.
   defp two_pages!(user, remote) do
-    Repo.insert!(%Follow{
-      user_id: user.id,
-      remote_account_id: remote.remote_account_id,
-      state: "accepted",
-      follow_activity_id: "https://vutuv.test/#{user.id}/actor#follows/1"
-    })
+    follow_remote!(user, remote.remote_account_id)
 
     author = insert(:activated_user)
     follow!(user, author)
@@ -139,6 +140,32 @@ defmodule VutuvWeb.FeedDuplicateCardsTest do
     for i <- 1..12 do
       author |> create_post!(%{body: "Beitrag Nummer #{i}"}) |> backdate_post!(60 + i)
     end
+  end
+
+  # The reader following an account out there — what puts that account's own
+  # posts *and* the posts it boosts in their feed.
+  defp follow_remote!(user, account_id) do
+    Repo.insert!(%Follow{
+      user_id: user.id,
+      remote_account_id: account_id,
+      state: "accepted",
+      follow_activity_id: "https://vutuv.test/#{user.id}/actor#follows/#{account_id}"
+    })
+  end
+
+  # An account out there passing a cached post on, stamped now — the arrival
+  # that reaches an open feed over `{:remote_feed_arrival, …}`. The row comes
+  # back because the announcement has to carry *its* stamp: `newest_row/2` keeps
+  # the boost only while it is at least as new as the `at` the message names, so
+  # a fresh `utc_now` there would find nothing on any run where the second rolls
+  # over in between — and the test would pass with nothing having arrived.
+  defp boost!(account, %RemotePost{} = post) do
+    Repo.insert!(%PostBoost{
+      remote_account_id: account.id,
+      remote_post_id: post.id,
+      activity_id: "https://social.example/act/#{System.unique_integer([:positive])}",
+      announced_at: DateTime.utc_now(:second)
+    })
   end
 
   # How many cards a cached post got. `data-remote-post` rides every one of
@@ -323,5 +350,28 @@ defmodule VutuvWeb.FeedDuplicateCardsTest do
 
     assert cards_for(render(view), remote) == 1,
            "the fill must not draw a second card for a post already on screen"
+  end
+
+  test "a boost of a post already on screen arriving live", %{conn: conn} do
+    # The reported shape (2026-09-03). Two accounts out there: the reader
+    # follows the author, so the post is on screen when the second one boosts
+    # it two hours later — old enough that the boost, not the post, is what the
+    # arrival finds.
+    {conn, user} = reader(conn)
+
+    remote = cached_post("was da draussen steht", 7_200)
+    follow_remote!(user, remote.remote_account_id)
+
+    {:ok, view, html} = live(conn, ~p"/feed")
+    assert cards_for(html, remote) == 1
+
+    booster = remote_account()
+    follow_remote!(user, booster.id)
+    boost = boost!(booster, remote)
+
+    send(view.pid, {:remote_feed_arrival, %{at: DateTime.to_naive(boost.announced_at)}})
+
+    assert cards_for(render(view), remote) == 1,
+           "a boost must not draw a second card for a post already on screen"
   end
 end


### PR DESCRIPTION
A boost of a post already on screen drew a second card, and the reader saw a name with hashtags and nothing between them: two cards for one cached post share a body id (`remote-post-body-<id>`) and one action-bar LiveComponent, so the browser moves both into whichever rendered last.

The live-arrival gate in `VutuvWeb.PostLive.Feed` compared entry ids, and those name the *event* — `boost-<id>` against `remote-<id>` for the same post. `known_entry?/2` now asks for the subject instead, against the key set the appended page already used (pulled out as `shown_keys/1`, so both doors have one spelling).

Second fix in the same door: a fediverse arrival skipped the `at_now?` split every local arrival takes, so it streamed a hidden row into an open calendar day and took that day's "nothing reached your feed" card with it, leaving a blank page. It goes through `place_arrival/2` now.

Both tests were red before their fix. Smoke-tested on /feed and on an empty calendar day.

https://claude.ai/code/session_01KE2NaGdpqUG5idSC7Cf2v1
