### PR TITLE
Show who a job posting would reach while the board is empty

### DIFF
--- a/docs/architecture/jobs.md
+++ b/docs/architecture/jobs.md
@@ -215,7 +215,34 @@ and the crawl path — the board is a shared-footer + top-bar nav link). PubSub
   are the anonymous public view — only `everyone`, `geo?` postings, each entry
   carrying the structured location / salary / tag fields
   (`JobPostingDoc.summary/1`) so agents filter client-side, cursor-paginated with
-  a `next` link. **No `JobPosting` JSON-LD on the list** (leaf pages only).
+  a `next` link. On an empty board the document adds `open_to_offers`
+  (`%{total:, people:}`) and `fields` from the same `Jobs.board_reach/1` the
+  page reads, with the anonymous viewer — the people entries are the shared
+  listing shape (`AgentDocs.person_entry/3`, as on the follow lists) plus the
+  availability. **No `JobPosting` JSON-LD on the list** (leaf pages only).
+- **An empty board is not a board (`Jobs.board_reach/1`).** With no posting at
+  all, the search form, the filter chips and the "no results" card do not
+  render: a box over an empty corpus promises a stock and disproves it in the
+  same view. In their place the board shows the side of the market this
+  installation *does* have, and **one function owns that answer** —
+  `Jobs.board_reach(viewer)` returns `%{count:, people:, fields:}` or `nil`
+  ("render the ordinary board"), so the page and its agent documents cannot show
+  different members or a different number of them. It composes
+  `Accounts.open_to_offers/2` (the members who set a #928 availability, under
+  the same three-way visibility and the same #938 exclusion list — both in SQL,
+  and `count(*) OVER ()` brings the total back with the rows, so one round trip
+  and no way for the headline number to disagree with what is under it; a test
+  pins that SQL gate to `User.employment_status_visible?/2`) and
+  `Tags.popular_member_tags/1` (the fields the most listed members carry). The
+  "Post a job" button renders logged out too, because whoever has a job to fill
+  is exactly who that page has to keep; `/jobs/new` sends them to the login page
+  with a line saying why. The reach block is for a visitor who arrived at the
+  **plain** board: with a filter active the ordinary "no matching positions" card
+  answers instead, which also keeps the everyday filtered-to-zero case from
+  paying for the corpus check. `JobPostingLive.Form` answers the same question
+  while a posting is being written: `Tags.member_counts_by_name/1` puts the
+  member count beside each typed tag, recomputed only when a tag field really
+  changed (`validate` fires on every keystroke of the whole form).
 - **Scoped sections.** `Jobs.list_organization_postings/2` and
   `Jobs.list_tag_postings/2` power the "Offene Stellen" sections on
   `/organizations/:slug` and `/tags/:slug` (the tag section links into the

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -5,7 +5,7 @@ defmodule Vutuv.Accounts do
   """
 
   import Ecto.Query
-  import Vutuv.Moderation.Query, only: [account_confirmed_row: 1]
+  import Vutuv.Moderation.Query, only: [account_confirmed_row: 1, account_hidden_row: 1]
   import Vutuv.SearchText, only: [contains: 1, name_ilike: 3, normalize_search: 1]
   require Logger
 
@@ -2053,21 +2053,27 @@ defmodule Vutuv.Accounts do
   # listed `example.com` matches `eu.example.com` but never `notexample.com`;
   # validated domains carry no LIKE wildcards, so no escaping is needed.
   defp on_exclusion_list?(owner_id, viewer_id) do
-    Repo.exists?(
-      from(x in ViewerExclusion,
-        left_join: e in Email,
-        on:
-          e.user_id == ^viewer_id and
-            fragment(
-              "(lower(split_part(?, '@', 2)) = ? OR lower(split_part(?, '@', 2)) LIKE '%.' || ?)",
-              e.value,
-              x.domain,
-              e.value,
-              x.domain
-            ),
-        where: x.user_id == ^owner_id,
-        where: x.excluded_user_id == ^viewer_id or not is_nil(e.id)
-      )
+    Repo.exists?(exclusion_rows(viewer_id, dynamic([x], x.user_id == ^owner_id)))
+  end
+
+  # The rows that put `viewer_id` on somebody's #938 list — the one spelling of
+  # that membership, so the domain(+subdomain) rule lives in a single place.
+  # `owner_match` says WHOSE list: a pinned id for the per-pair predicate
+  # above, a correlated `parent_as/1` for the listing in `open_to_offers/2`.
+  defp exclusion_rows(viewer_id, owner_match) do
+    from(x in ViewerExclusion,
+      left_join: e in Email,
+      on:
+        e.user_id == ^viewer_id and
+          fragment(
+            "(lower(split_part(?, '@', 2)) = ? OR lower(split_part(?, '@', 2)) LIKE '%.' || ?)",
+            e.value,
+            x.domain,
+            e.value,
+            x.domain
+          ),
+      where: ^owner_match,
+      where: x.excluded_user_id == ^viewer_id or not is_nil(e.id)
     )
   end
 
@@ -2091,6 +2097,94 @@ defmodule Vutuv.Accounts do
       employment_status: status_base and not hidden?,
       salary: salary_base and not hidden?
     }
+  end
+
+  # How many available members `open_to_offers/2` draws unless told otherwise.
+  # The empty job board passes its own (`Vutuv.Jobs.board_reach/1`); this is the
+  # default for anything else that wants a glance at the set.
+  @available_shown 6
+
+  @doc """
+  The members who said they are available — `%{people: [%User{}], total:
+  integer}`, freshest signal first. The same #928 availability the profile
+  badge carries, read as a **listing**.
+
+  `viewer` decides what is on it, exactly as on a profile: an anonymous visitor
+  (nil) sees only the members open to `everyone`, a signed-in one also the
+  `members` ones, nobody sees `hidden`, and the #938 exclusion list is
+  subtracted last. Both gates run in SQL rather than over the loaded rows: a
+  list asks the exclusion question once per candidate, and the per-pair
+  predicate `viewer_excluded?/2` would be two queries each. The gate is pinned
+  to `User.employment_status_visible?/2` by
+  `test/vutuv/accounts/open_to_offers_test.exs`, so the SQL spelling and the
+  struct predicate cannot drift into two different answers.
+
+  `total` counts the whole gated set, not the returned page, and comes back
+  from the same query as the rows (`count(*) OVER ()`) — one round trip, and no
+  way for the headline number to disagree with what is under it. A count that
+  ignored the exclusion list would tell an excluded visitor that somebody is
+  looking and then show them nobody.
+
+  Opts: `:limit` (default #{@available_shown}). The rows carry the listing
+  fields plus the two the availability line reads, so a card needs no second
+  query.
+  """
+  def open_to_offers(viewer, opts \\ []) do
+    fields = User.listing_fields() ++ ~w(employment_status desired_workplace_types)a
+
+    rows =
+      available(viewer)
+      |> order_by([candidate: u], desc_nulls_last: u.employment_status_set_at, desc: u.id)
+      |> limit(^Keyword.get(opts, :limit, @available_shown))
+      |> select([candidate: u], {struct(u, ^fields), fragment("count(*) OVER ()")})
+      |> Repo.all()
+
+    %{people: Enum.map(rows, &elem(&1, 0)), total: gated_total(rows)}
+  end
+
+  # The window count rides on every row, so an empty page carries none — and an
+  # empty page means an empty set.
+  defp gated_total([]), do: 0
+  defp gated_total([{_person, total} | _rest]), do: total
+
+  # The listed, confirmed members carrying a status this viewer may see.
+  defp available(viewer) do
+    from(u in User,
+      as: :candidate,
+      where: account_confirmed_row(u) and not account_hidden_row(u),
+      where: not is_nil(u.employment_status)
+    )
+    |> availability_visible(viewer)
+    |> availability_not_excluded(viewer)
+  end
+
+  # The #928 three-way gate as SQL. A legacy NULL falls back to the "members"
+  # rule, like `User.employment_status_visible?/2`.
+  defp availability_visible(query, nil),
+    do: where(query, [candidate: u], u.employment_status_visibility == "everyone")
+
+  defp availability_visible(query, %User{}),
+    do:
+      where(
+        query,
+        [candidate: u],
+        is_nil(u.employment_status_visibility) or u.employment_status_visibility != "hidden"
+      )
+
+  # `viewer_excluded?/2`'s two halves as correlated NOT EXISTS: the block that
+  # implies exclusion, and the #938 list itself through `exclusion_rows/2` — the
+  # set answer to the question that predicate asks one owner at a time.
+  defp availability_not_excluded(query, nil), do: query
+
+  defp availability_not_excluded(query, %User{id: viewer_id}) do
+    blocked =
+      from(b in Block,
+        where: b.blocker_id == parent_as(:candidate).id and b.blocked_id == ^viewer_id
+      )
+
+    listed = exclusion_rows(viewer_id, dynamic([x], x.user_id == parent_as(:candidate).id))
+
+    where(query, not exists(subquery(blocked)) and not exists(subquery(listed)))
   end
 
   # Avatar/cover files are written to disk only AFTER the row commits, so a

--- a/lib/vutuv/jobs.ex
+++ b/lib/vutuv/jobs.ex
@@ -31,6 +31,7 @@ defmodule Vutuv.Jobs do
   import Ecto.Query
   import Vutuv.SearchText, only: [cap: 1, contains: 1, escape_like: 1, normalize_search: 1]
 
+  alias Vutuv.Accounts
   alias Vutuv.Accounts.User
   alias Vutuv.BerlinTime
   alias Vutuv.Countries
@@ -49,6 +50,7 @@ defmodule Vutuv.Jobs do
   alias Vutuv.Pages
   alias Vutuv.Repo
   alias Vutuv.Salary
+  alias Vutuv.Tags
   alias Vutuv.Tags.Tag
   alias Vutuv.Tags.UserTag
 
@@ -865,6 +867,45 @@ defmodule Vutuv.Jobs do
     |> board_scope()
     |> apply_board_filters(filters, viewer)
     |> finish_board(limit, Keyword.get(opts, :cursor))
+  end
+
+  @doc """
+  Whether `viewer` would find no posting at all on the board — the corpus, not
+  the current page, so a filter that matches nothing does not answer true.
+
+  The board reads it to decide whether it is a board at all: with nothing to
+  search, a search form over four fields and a row of filter chips promise a
+  stock and prove in the same breath that there is none.
+  """
+  def board_empty?(viewer), do: not Repo.exists?(board_scope(viewer))
+
+  # How much of the reach below to show. Both figures live here rather than at
+  # the two call sites, because the HTML board and its agent-format sibling have
+  # to show the same two facts (`VutuvWeb.AgentDocs.JobBoardDoc`) and a number
+  # written twice is a number that drifts.
+  @reach_people 6
+  @reach_fields 12
+
+  @doc """
+  What the board shows in place of a listing when `viewer` would find no
+  posting at all: the members who said they are available (with how many there
+  are) and the fields the most members carry — `%{count:, people:, fields:}`.
+
+  `nil` on a board that has something to list, which is the caller's signal to
+  render the ordinary board. One home for the answer, so the page
+  (`VutuvWeb.JobBoardLive`) and its agent documents cannot show different
+  members or a different number of them.
+  """
+  def board_reach(viewer) do
+    if board_empty?(viewer) do
+      available = Accounts.open_to_offers(viewer, limit: @reach_people)
+
+      %{
+        count: available.total,
+        people: available.people,
+        fields: Tags.popular_member_tags(@reach_fields)
+      }
+    end
   end
 
   @doc """

--- a/lib/vutuv/search.ex
+++ b/lib/vutuv/search.ex
@@ -20,6 +20,7 @@ defmodule Vutuv.Search do
   alias Vutuv.Accounts.User
   alias Vutuv.Repo
   alias Vutuv.SearchText
+  alias Vutuv.Tags
   alias Vutuv.Tags.Tag
 
   @min_chars 3
@@ -586,27 +587,9 @@ defmodule Vutuv.Search do
 
   # How many members carry each found tag - the number that makes a tag chip
   # worth clicking.
-  defp tag_member_counts([]), do: %{}
-
-  defp tag_member_counts(tags) do
-    ids = Enum.map(tags, & &1.id)
-
-    # Count only members the tag page would actually show: activated and not
-    # moderation-hidden (Tag.recommended_users applies the same gate), so the
-    # chip's "N members" can't exceed what clicking it reveals.
-    Repo.all(
-      from(ut in Vutuv.Tags.UserTag,
-        join: u in User,
-        on: u.id == ut.user_id,
-        where:
-          ut.tag_id in ^ids and account_confirmed_row(u) and
-            not account_hidden_row(u),
-        group_by: ut.tag_id,
-        select: {ut.tag_id, count(ut.id)}
-      )
-    )
-    |> Map.new()
-  end
+  # The tag chips' "N members", counted the way the tag page lists: `Vutuv.Tags`
+  # owns that gate, so the chip and the page it leads to cannot drift apart.
+  defp tag_member_counts(tags), do: Tags.listed_member_counts(tags)
 
   # Posts are matched by Postgres full-text search over the body, which is
   # word-exact already; the `tag:` operator (issue #946) additionally filters

--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -10,6 +10,7 @@ defmodule Vutuv.Tags do
   """
 
   import Ecto.Query
+  import Vutuv.Moderation.Query, only: [account_confirmed_row: 1, account_hidden_row: 1]
 
   alias Vutuv.Accounts.User
   alias Vutuv.Keyset
@@ -125,7 +126,16 @@ defmodule Vutuv.Tags do
   """
   def canonical_tag_names([]), do: []
 
-  def canonical_tag_names(names) when is_list(names) do
+  def canonical_tag_names(names) when is_list(names),
+    do: names |> resolved_entries() |> Enum.map(&elem(&1, 1))
+
+  # `[{identity, display name}]` for the typed `names`, in typed order, with the
+  # duplicates resolution creates dropped. The identity is `{:tag, id}` for a
+  # name that resolves to a stored topic and `{:new, key}` for one about to
+  # become a tag — which is both what makes two spellings of one topic collapse
+  # and what a caller that has to look the topic up again reads
+  # (`member_counts_by_name/1`).
+  defp resolved_entries(names) do
     resolved = resolution_by_key(names)
 
     names
@@ -138,11 +148,10 @@ defmodule Vutuv.Tags do
       Map.get(resolved, key, {{:new, key}, name})
     end)
     |> Enum.uniq_by(&elem(&1, 0))
-    |> Enum.map(&elem(&1, 1))
   end
 
   # `{typed key => {identity, display name}}` for every name that matches a
-  # stored tag, both by lowercased name and by slug (the two things
+  # stored tag — the lookup behind `resolved_entries/1`, both by lowercased name and by slug (the two things
   # `Tag.find_by_value/1` matches on). The identity is the **canonical** tag's
   # id, which is what makes two different spellings of one topic collapse.
   defp resolution_by_key(names) do
@@ -455,6 +464,79 @@ defmodule Vutuv.Tags do
       select: struct(u, ^User.listing_fields())
     )
     |> Repo.all()
+  end
+
+  @doc """
+  How many **listed** members carry each of `tags` — `%{tag_id => count}`, tags
+  nobody holds simply absent.
+
+  Counts only members a tag page would actually show (confirmed, not
+  moderation-hidden), so a "N members" chip can never promise more than the
+  click delivers. That gate is the whole difference to `member_counts/1`, which
+  counts the rows themselves for the admin merge screen. A merge moves the
+  holders to the canonical tag (`Vutuv.Tags.Merge`), so counting by id needs no
+  alias folding.
+  """
+  def listed_member_counts([]), do: %{}
+
+  def listed_member_counts(tags) do
+    ids = Enum.map(tags, & &1.id)
+
+    from(ut in UserTag,
+      join: u in User,
+      on: u.id == ut.user_id,
+      where: ut.tag_id in ^ids and account_confirmed_row(u) and not account_hidden_row(u),
+      group_by: ut.tag_id,
+      select: {ut.tag_id, count(ut.id)}
+    )
+    |> Repo.all()
+    |> Map.new()
+  end
+
+  @doc """
+  The topics the most listed members carry — `[{%Tag{}, count}]`, biggest first.
+
+  What vutuv is about, said in the members' own words rather than an editor's:
+  the empty `/jobs` board offers it as the fields somebody hiring would find
+  here. Aliases are left out (an alias is another name for a topic already in
+  the list) and so are honor tags, which are admin-awarded badges rather than
+  something a member does.
+  """
+  def popular_member_tags(limit \\ 12) do
+    from(t in Tag.not_merged(),
+      join: ut in assoc(t, :user_tags),
+      join: u in User,
+      on: u.id == ut.user_id,
+      where: not t.honor? and account_confirmed_row(u) and not account_hidden_row(u),
+      group_by: t.id,
+      order_by: [desc: count(ut.id), asc: t.name],
+      limit: ^limit,
+      select: {t, count(ut.id)}
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  How many listed members carry each of the typed `names` — `[{name, count}]` in
+  typed order, a name nothing matches yet counting 0.
+
+  Resolution is `canonical_tag_names/1`'s: a spelling variant and an alternative
+  name both answer for the topic they name, and the duplicate that collapse
+  creates is dropped, so a poster who typed "ROR, Ruby on Rails" is told about
+  one topic rather than shown the same members twice.
+  """
+  def member_counts_by_name([]), do: []
+
+  def member_counts_by_name(names) when is_list(names) do
+    entries = resolved_entries(names)
+    counts = listed_member_counts(for {{:tag, id}, _name} <- entries, do: %Tag{id: id})
+
+    Enum.map(entries, fn {identity, name} ->
+      case identity do
+        {:tag, id} -> {name, Map.get(counts, id, 0)}
+        {:new, _key} -> {name, 0}
+      end
+    end)
   end
 
   @doc """

--- a/lib/vutuv_web/agent_docs/agent_docs.ex
+++ b/lib/vutuv_web/agent_docs/agent_docs.ex
@@ -310,6 +310,48 @@ defmodule VutuvWeb.AgentDocs do
   """
   def person_ref(identity), do: Vutuv.Identity.ref(identity)
 
+  @doc """
+  One person as a **listing entry**: the `person_ref/1` identity plus the muted
+  work line and, where the caller passes one, the tag sample the page shows
+  beside their name.
+
+  The shape the follower / following lists, the directory letter pages, the tag
+  page and the empty job board's available members all publish, so an agent
+  parses one thing wherever it meets a person in a list. `work_info_by_id` and
+  `tags_by_id` are the batched maps
+  (`VutuvWeb.UserHelpers.work_information_map/2` and `tag_summary_map/2`), so a
+  list of N people costs two queries rather than 2N. A caller with more to say
+  about a person merges its own keys onto the result — the job board adds the
+  availability it is about.
+  """
+  def person_entry(user, work_info_by_id, tags_by_id \\ %{}) do
+    user
+    |> person_ref()
+    |> Map.put(:work_info, blank_to_nil(work_info_by_id[user.id]))
+    |> put_tag_summary(tags_by_id[user.id])
+  end
+
+  # A member with no current job has an empty work line, and an absent fact is
+  # `null` in a document rather than "".
+  defp blank_to_nil(""), do: nil
+  defp blank_to_nil(value), do: value
+
+  # The tag sample, only where there is one: the connection and endorser lists
+  # show none, so their entries carry no `tags` key at all rather than an empty
+  # one.
+  defp put_tag_summary(person, nil), do: person
+  defp put_tag_summary(person, %{top: []}), do: person
+
+  defp put_tag_summary(person, %{top: top, total: total}) do
+    Map.put(person, :tags, %{
+      total: total,
+      top:
+        Enum.map(top, fn user_tag ->
+          %{name: user_tag.tag.name, url: abs_url("/tags/" <> user_tag.tag.slug)}
+        end)
+    })
+  end
+
   defp format_name(:md), do: :markdown
   defp format_name(:txt), do: :text
   defp format_name(:json), do: :json

--- a/lib/vutuv_web/agent_docs/job_board_doc.ex
+++ b/lib/vutuv_web/agent_docs/job_board_doc.ex
@@ -6,22 +6,74 @@ defmodule VutuvWeb.AgentDocs.JobBoardDoc do
   first, cursor-paginated. Each entry carries the structured location, salary
   and tag fields (`VutuvWeb.AgentDocs.JobPostingDoc.summary/1`) so an agent can
   filter client-side; a `next` link walks to the following page.
+
+  With no posting at all the HTML board shows the other side of the market
+  instead — the members who said they are available and the fields they carry —
+  so the document carries the same two facts under `open_to_offers` and
+  `fields`. An agent asked "is anybody hiring on vutuv?" then gets the honest
+  answer *and* the reason to look further, exactly like a reader.
   """
 
   use Gettext, backend: VutuvWeb.Gettext
 
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.AgentDocs.JobPostingDoc
+  alias VutuvWeb.UserHelpers
 
-  def build(postings, next_cursor \\ nil) do
+  # Tags per available member, the same glance the HTML board shows beside a
+  # name (`VutuvWeb.JobBoardLive`); the whole list is on their tag page.
+  @tags_shown 3
+
+  @doc """
+  The board document. `reach` is the empty-board companion (`%{count:, people:,
+  fields:}` from `Vutuv.Jobs`/`Vutuv.Accounts`, anonymous view) or nil on a
+  board that has postings.
+  """
+  def build(postings, next_cursor \\ nil, reach \\ nil) do
     AgentDocs.doc_meta("job_board", "/jobs")
     |> Map.merge(%{
       title: gettext("Jobs"),
-      description: gettext("Open positions on vutuv, newest first."),
+      description: description(reach),
       count: length(postings),
       next: next_url(next_cursor),
       postings: Enum.map(postings, &JobPostingDoc.summary/1)
     })
+    |> put_reach(reach)
+  end
+
+  defp description(nil), do: gettext("Open positions on vutuv, newest first.")
+
+  defp description(_reach),
+    do:
+      gettext(
+        "No posting yet. Yours would be the first, and it would stand at the top on its own."
+      )
+
+  defp put_reach(doc, nil), do: doc
+
+  defp put_reach(doc, %{count: count, people: people, fields: fields}) do
+    work_info = UserHelpers.work_information_map(people, 45)
+    tags = UserHelpers.tag_summary_map(people, @tags_shown)
+
+    Map.merge(doc, %{
+      open_to_offers: %{
+        total: count,
+        people: Enum.map(people, &person_entry(&1, work_info, tags))
+      },
+      fields:
+        Enum.map(fields, fn {tag, members} ->
+          %{name: tag.name, url: AgentDocs.abs_url("/tags/" <> tag.slug), members: members}
+        end)
+    })
+  end
+
+  # The shared listing shape (`AgentDocs.person_entry/3`) plus the availability
+  # this document is about. Only members whose status is open to `everyone`
+  # reach it — `Vutuv.Jobs.board_reach/1` is asked with a nil viewer.
+  defp person_entry(user, work_info, tags) do
+    AgentDocs.person_entry(user, work_info, tags)
+    |> Map.put(:employment_status, user.employment_status)
+    |> Map.put(:desired_workplace_types, user.desired_workplace_types)
   end
 
   defp next_url(nil), do: nil

--- a/lib/vutuv_web/agent_docs/list_docs.ex
+++ b/lib/vutuv_web/agent_docs/list_docs.ex
@@ -212,29 +212,6 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
     })
   end
 
-  defp person_entry(user, work_info_by_id, tags_by_id \\ %{}) do
-    user
-    |> AgentDocs.person_ref()
-    |> Map.put(:work_info, presence(work_info_by_id[user.id]))
-    |> maybe_put_tags(tags_by_id[user.id])
-  end
-
-  # The follower / following lists and the directory's letter pages pass a tag
-  # summary; the connection and tag-endorser lists leave it nil so their person
-  # entries are unchanged.
-  defp maybe_put_tags(person, nil), do: person
-  defp maybe_put_tags(person, %{top: []}), do: person
-
-  defp maybe_put_tags(person, %{top: top, total: total}) do
-    Map.put(person, :tags, %{
-      total: total,
-      top:
-        Enum.map(top, fn user_tag ->
-          %{name: user_tag.tag.name, url: AgentDocs.abs_url("/tags/" <> user_tag.tag.slug)}
-        end)
-    })
-  end
-
-  defp presence(""), do: nil
-  defp presence(value), do: value
+  defp person_entry(user, work_info_by_id, tags_by_id \\ %{}),
+    do: AgentDocs.person_entry(user, work_info_by_id, tags_by_id)
 end

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -296,13 +296,15 @@ defmodule VutuvWeb.AgentDocs.Markdown do
     |> join_blocks()
   end
 
-  # The public job board (/jobs) — a listing of posting summaries.
+  # The public job board (/jobs) — a listing of posting summaries, or, with no
+  # posting at all, the two blocks the HTML board shows in its place.
   def render(%{type: "job_board"} = doc) do
     [
       frontmatter(doc),
       "# #{doc.title}",
       doc.description,
       Enum.map_join(doc.postings, "\n\n", &job_summary/1),
+      board_reach(doc),
       doc.next && md_link(gettext("Next page"), doc.next)
     ]
     |> join_blocks()
@@ -1104,6 +1106,29 @@ defmodule VutuvWeb.AgentDocs.Markdown do
       true -> []
     end
   end
+
+  # The empty board's companion blocks (see `VutuvWeb.AgentDocs.JobBoardDoc`):
+  # the members who said they are available, and the fields members carry.
+  # Absent on a board with postings, where the doc carries neither key.
+  defp board_reach(%{open_to_offers: available, fields: fields}) do
+    [
+      "## #{gettext("Who you would reach")}",
+      ngettext(
+        "One member has said they are available.",
+        "%{formatted} members have said they are available.",
+        available.total,
+        formatted: to_string(available.total)
+      ),
+      Enum.map_join(available.people, "\n", &person_line/1),
+      "## #{gettext("What members here work on")}",
+      Enum.map_join(fields, "\n", fn field ->
+        "- #{md_link(field.name, field.url)} (#{field.members})"
+      end)
+    ]
+    |> join_blocks()
+  end
+
+  defp board_reach(_doc), do: nil
 
   defp person_line(person), do: "- #{person_text(person)}"
 

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -280,12 +280,14 @@ defmodule VutuvWeb.AgentDocs.Text do
     |> join_blocks()
   end
 
-  # The public job board (/jobs) — a listing of posting summaries.
+  # The public job board (/jobs) — a listing of posting summaries, or, with no
+  # posting at all, the two blocks the HTML board shows in its place.
   def render(%{type: "job_board"} = doc) do
     [
       heading(doc.title),
       doc.description,
       Enum.map_join(doc.postings, "\n\n", &job_summary/1),
+      board_reach(doc),
       doc.next && gettext("Next page: %{url}", url: doc.next),
       footer(doc)
     ]
@@ -747,6 +749,26 @@ defmodule VutuvWeb.AgentDocs.Text do
   defp thread_context_lines(post) do
     "  * #{post.published_on} #{post.author}: #{Markdown.entry_label(post)}\n    #{post.url}"
   end
+
+  # The empty board's companion blocks (see `VutuvWeb.AgentDocs.JobBoardDoc`):
+  # the members who said they are available, and the fields members carry.
+  defp board_reach(%{open_to_offers: available, fields: fields}) do
+    [
+      heading(gettext("Who you would reach")),
+      ngettext(
+        "One member has said they are available.",
+        "%{formatted} members have said they are available.",
+        available.total,
+        formatted: to_string(available.total)
+      ),
+      Enum.map(available.people, &person_line/1),
+      heading(gettext("What members here work on")),
+      Enum.map(fields, fn field -> "* #{field.name} (#{field.members})\n  #{field.url}" end)
+    ]
+    |> join_blocks()
+  end
+
+  defp board_reach(_doc), do: nil
 
   defp person_line(person, prefix \\ "* ") do
     work = if person.work_info, do: " — #{person.work_info}", else: ""

--- a/lib/vutuv_web/controllers/job_posting_controller.ex
+++ b/lib/vutuv_web/controllers/job_posting_controller.ex
@@ -42,7 +42,14 @@ defmodule VutuvWeb.JobPostingController do
 
     page = Jobs.agent_board_page(cursor: cursor)
     next = if page.more?, do: ApiV2.encode_cursor(page.cursor)
-    AgentDocs.send_doc(conn, format, JobBoardDoc.build(page.entries, next))
+
+    # What the HTML board shows in place of a search form when there is nothing
+    # to search (`VutuvWeb.JobBoardLive`), in the anonymous view. A page with
+    # entries proves the board is not empty, so only an empty one pays for the
+    # corpus check.
+    reach = if page.entries == [], do: Jobs.board_reach(nil)
+
+    AgentDocs.send_doc(conn, format, JobBoardDoc.build(page.entries, next, reach))
   end
 
   def show(conn, %{"slug" => slug}) do

--- a/lib/vutuv_web/live/job_board_live.ex
+++ b/lib/vutuv_web/live/job_board_live.ex
@@ -25,8 +25,10 @@ defmodule VutuvWeb.JobBoardLive do
   alias Vutuv.Jobs.JobPosting
   alias Vutuv.Salary
   alias Vutuv.Tags.Tag
+  alias Vutuv.Tags.UserTag
   alias VutuvWeb.ApiV2
   alias VutuvWeb.Live.InitAssigns
+  alias VutuvWeb.UserHelpers
 
   @impl true
   def mount(_params, session, socket) do
@@ -63,6 +65,58 @@ defmodule VutuvWeb.JobBoardLive do
     |> assign(:more?, page.more?)
     |> assign(:next_cursor, page.cursor && ApiV2.encode_cursor(page.cursor))
     |> assign_tag_suggestions(page.entries)
+    |> assign_reach()
+  end
+
+  # Tags per drawn member: enough to be curious about somebody, never their
+  # whole profile, which their tag page one tap away holds. How many members and
+  # how many fields the block shows belongs to `Jobs.board_reach/1`, which the
+  # agent documents read too.
+  @tags_per_seeker 3
+
+  # A board with nothing on it shows the other half of the market instead (see
+  # `render/1`). `nil` reach means "render the ordinary board", so the queries
+  # behind it never run on a board that has a stock.
+  defp assign_reach(socket) do
+    reach = board_reach(socket)
+
+    socket
+    |> assign(:reach, reach)
+    |> assign(:seekers, if(reach, do: seeker_rows(reach.people), else: []))
+  end
+
+  # The reach block replaces the board only for a visitor who arrived at the
+  # plain board. With a filter active they asked a question, and "no matching
+  # positions" plus a way to clear it is the answer — which also keeps the
+  # everyday filtered-to-zero case from paying for the corpus check.
+  defp board_reach(%{assigns: %{postings: []}} = socket) do
+    if any_filters?(socket.assigns.params),
+      do: nil,
+      else: Jobs.board_reach(socket.assigns.current_user)
+  end
+
+  defp board_reach(_socket), do: nil
+
+  # The available members as finished rows — member, their work line, a sample
+  # of their tags — assembled here so each batched query is asked once rather
+  # than per row in the markup. The row shape and its markup deliberately mirror
+  # the feed's "New here" card (`VutuvWeb.PostLive.Feed`), which samples its
+  # tags at random because a newcomer has no endorsements yet; these members do,
+  # so theirs are ranked (`tag_summary_map/2`).
+  defp seeker_rows(users) do
+    work = UserHelpers.work_information_map(users, 60)
+    tags = UserHelpers.tag_summary_map(users, @tags_per_seeker)
+
+    Enum.map(users, fn user ->
+      summary = Map.get(tags, user.id, %{top: [], total: 0})
+
+      %{
+        user: user,
+        work: Map.get(work, user.id, ""),
+        tags: summary.top,
+        more: summary.total - length(summary.top)
+      }
+    end)
   end
 
   # Tags to offer as one-tap additions to the filter (issue #951), drawn from
@@ -210,116 +264,224 @@ defmodule VutuvWeb.JobBoardLive do
         <div>
           <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">{gettext("Jobs")}</h1>
           <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
-            {gettext("Open positions on vutuv, newest first.")}
+            <%= if @reach do %>
+              {gettext("No posting yet. Yours would be the first, and it would stand at the top on its own.")}
+            <% else %>
+              {gettext("Open positions on vutuv, newest first.")}
+            <% end %>
           </p>
         </div>
-        <.button :if={@current_user} navigate={~p"/jobs/new"}>
+        <%!-- Shown logged out too, and deliberately: a visitor with a job to
+        fill is exactly who the empty board has to keep, and /jobs/new sends
+        them to the login page with a line saying why. --%>
+        <.button navigate={~p"/jobs/new"}>
           {gettext("Post a job")}
         </.button>
       </div>
 
-      <.search_form params={@params} filters={@filters} suggestions={@tag_suggestions} />
+      <.reach :if={@reach} reach={@reach} seekers={@seekers} />
 
-      <div id="job-filter-chips" class="mt-3 -mx-4 flex gap-2 overflow-x-auto px-4 pb-1 [scrollbar-width:none]">
-        <.link
-          :for={type <- [:onsite, :hybrid, :remote]}
-          navigate={~p"/jobs?#{toggle_param(@params, "workplace", Atom.to_string(type))}"}
-          class={filter_chip_class(active?(@params, "workplace", Atom.to_string(type)))}
-        >
-          {JobPosting.workplace_type_label(type)}
-        </.link>
+      <div :if={!@reach}>
+        <.search_form params={@params} filters={@filters} suggestions={@tag_suggestions} />
 
-        <.link
-          :if={@current_user}
-          navigate={~p"/jobs?#{toggle_param(@params, "my_tags", "1")}"}
-          class={filter_chip_class(active?(@params, "my_tags", "1"))}
-        >
-          {gettext("Matches my tags")}
-        </.link>
+        <div id="job-filter-chips" class="mt-3 -mx-4 flex gap-2 overflow-x-auto px-4 pb-1 [scrollbar-width:none]">
+          <.link
+            :for={type <- [:onsite, :hybrid, :remote]}
+            navigate={~p"/jobs?#{toggle_param(@params, "workplace", Atom.to_string(type))}"}
+            class={filter_chip_class(active?(@params, "workplace", Atom.to_string(type)))}
+          >
+            {JobPosting.workplace_type_label(type)}
+          </.link>
 
-        <.link
-          :if={@current_user && @has_salary_expectation?}
-          navigate={~p"/jobs?#{toggle_param(@params, "salary_min", "mine")}"}
-          class={filter_chip_class(active?(@params, "salary_min", "mine"))}
-        >
-          {gettext("From my salary expectation")}
-        </.link>
+          <.link
+            :if={@current_user}
+            navigate={~p"/jobs?#{toggle_param(@params, "my_tags", "1")}"}
+            class={filter_chip_class(active?(@params, "my_tags", "1"))}
+          >
+            {gettext("Matches my tags")}
+          </.link>
 
-        <.link
-          :if={any_filters?(@params)}
-          navigate={~p"/jobs"}
-          class={[
-            button_base(),
-            "whitespace-nowrap text-slate-600 underline decoration-dotted hover:text-slate-800 dark:text-slate-400"
-          ]}
-        >
-          {gettext("Clear filters")}
-        </.link>
-      </div>
+          <.link
+            :if={@current_user && @has_salary_expectation?}
+            navigate={~p"/jobs?#{toggle_param(@params, "salary_min", "mine")}"}
+            class={filter_chip_class(active?(@params, "salary_min", "mine"))}
+          >
+            {gettext("From my salary expectation")}
+          </.link>
 
-      <.save_search_control
-        :if={@current_user && any_filters?(@params)}
-        id="jobs-save-search"
-        show?={@show_save?}
-        saved?={@saved?}
-        class="mt-3"
-      />
+          <.link
+            :if={any_filters?(@params)}
+            navigate={~p"/jobs"}
+            class={[
+              button_base(),
+              "whitespace-nowrap text-slate-600 underline decoration-dotted hover:text-slate-800 dark:text-slate-400"
+            ]}
+          >
+            {gettext("Clear filters")}
+          </.link>
+        </div>
 
-      <%!-- Active tag filters as removable pills, and one-tap suggestions drawn
-      from the current results (issue #951). Each pill's ✕ drops just that tag;
-      the whole `tag` param is comma-separated and shareable. --%>
-      <div
-        :if={tag_slugs(@params) != [] or @tag_suggestions != []}
-        id="job-tag-filters"
-        class="mt-3 flex flex-wrap items-center gap-2 text-sm text-slate-600 dark:text-slate-400"
-      >
-        <span :if={tag_slugs(@params) != []} class="font-medium">{gettext("Tags")}:</span>
-        <.link
-          :for={slug <- tag_slugs(@params)}
-          navigate={~p"/jobs?#{drop_tag(@params, slug)}"}
-          data-active-tag={slug}
-          class="inline-flex items-center gap-1 rounded-lg bg-brand-50 px-2.5 py-1 font-medium text-brand-700 dark:bg-brand-900/40 dark:text-brand-100"
-        >
-          {slug} <span aria-hidden="true">✕</span>
-        </.link>
-
-        <span :if={tag_slugs(@params) != [] and @tag_suggestions != []} class="text-slate-400">·</span>
-
-        <.link
-          :for={tag <- @tag_suggestions}
-          navigate={~p"/jobs?#{add_tag(@params, tag.slug)}"}
-          data-suggest-tag={tag.slug}
-          class="inline-flex items-center gap-1 rounded-lg px-2.5 py-1 font-medium text-slate-600 ring-1 ring-slate-200 hover:bg-slate-50 hover:text-slate-800 dark:text-slate-300 dark:ring-slate-700 dark:hover:bg-slate-800"
-        >
-          <span aria-hidden="true">+</span> {tag.name}
-        </.link>
-      </div>
-
-      <div :if={@postings == []} class="mt-6 rounded-2xl bg-white p-8 text-center shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800">
-        <p class="text-sm text-slate-600 dark:text-slate-400">{empty_line(@params)}</p>
-        <.link
-          :if={not any_filters?(@params) && @current_user}
-          navigate={~p"/jobs/new"}
-          class="mt-3 inline-block text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
-        >
-          {gettext("Post the first one")}
-        </.link>
-      </div>
-
-      <div class="mt-6 grid gap-4 sm:grid-cols-2">
-        <.job_card
-          :for={posting <- @postings}
-          posting={posting}
-          viewer_tags={@viewer_tags}
-          engagement={@engagement[posting.id]}
+        <.save_search_control
+          :if={@current_user && any_filters?(@params)}
+          id="jobs-save-search"
+          show?={@show_save?}
+          saved?={@saved?}
+          class="mt-3"
         />
-      </div>
 
-      <div :if={@more?} class="mt-6 text-center">
-        <.button navigate={~p"/jobs?#{Map.put(@params, "cursor", @next_cursor)}"} variant="secondary">
-          {gettext("More jobs")}
-        </.button>
+        <%!-- Active tag filters as removable pills, and one-tap suggestions drawn
+        from the current results (issue #951). Each pill's ✕ drops just that tag;
+        the whole `tag` param is comma-separated and shareable. --%>
+        <div
+          :if={tag_slugs(@params) != [] or @tag_suggestions != []}
+          id="job-tag-filters"
+          class="mt-3 flex flex-wrap items-center gap-2 text-sm text-slate-600 dark:text-slate-400"
+        >
+          <span :if={tag_slugs(@params) != []} class="font-medium">{gettext("Tags")}:</span>
+          <.link
+            :for={slug <- tag_slugs(@params)}
+            navigate={~p"/jobs?#{drop_tag(@params, slug)}"}
+            data-active-tag={slug}
+            class="inline-flex items-center gap-1 rounded-lg bg-brand-50 px-2.5 py-1 font-medium text-brand-700 dark:bg-brand-900/40 dark:text-brand-100"
+          >
+            {slug} <span aria-hidden="true">✕</span>
+          </.link>
+
+          <span :if={tag_slugs(@params) != [] and @tag_suggestions != []} class="text-slate-400">·</span>
+
+          <.link
+            :for={tag <- @tag_suggestions}
+            navigate={~p"/jobs?#{add_tag(@params, tag.slug)}"}
+            data-suggest-tag={tag.slug}
+            class="inline-flex items-center gap-1 rounded-lg px-2.5 py-1 font-medium text-slate-600 ring-1 ring-slate-200 hover:bg-slate-50 hover:text-slate-800 dark:text-slate-300 dark:ring-slate-700 dark:hover:bg-slate-800"
+          >
+            <span aria-hidden="true">+</span> {tag.name}
+          </.link>
+        </div>
+
+        <div :if={@postings == []} class="mt-6 rounded-2xl bg-white p-8 text-center shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800">
+          <p class="text-sm text-slate-600 dark:text-slate-400">{empty_line(@params)}</p>
+          <.link
+            :if={not any_filters?(@params) && @current_user}
+            navigate={~p"/jobs/new"}
+            class="mt-3 inline-block text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+          >
+            {gettext("Post the first one")}
+          </.link>
+        </div>
+
+        <div class="mt-6 grid gap-4 sm:grid-cols-2">
+          <.job_card
+            :for={posting <- @postings}
+            posting={posting}
+            viewer_tags={@viewer_tags}
+            engagement={@engagement[posting.id]}
+          />
+        </div>
+
+        <div :if={@more?} class="mt-6 text-center">
+          <.button navigate={~p"/jobs?#{Map.put(@params, "cursor", @next_cursor)}"} variant="secondary">
+            {gettext("More jobs")}
+          </.button>
+        </div>
       </div>
+    </div>
+    """
+  end
+
+  @doc false
+  # What a board with nothing on it shows instead of a search form over an
+  # empty corpus: the other half of the market. The stock of postings is the
+  # side vutuv does not have yet, the members are the side it does — so the
+  # page answers the question somebody with a job to fill actually came with
+  # ("who is here?") rather than reporting that a table is empty.
+  #
+  # Both blocks render only when they have something, so a brand-new
+  # installation shows the heading and the button and nothing that reads as a
+  # gap.
+  attr(:reach, :map, required: true, doc: "`Vutuv.Jobs.board_reach/1`: count + fields")
+  attr(:seekers, :list, required: true, doc: "its members, decorated by `seeker_rows/1`")
+
+  defp reach(assigns) do
+    ~H"""
+    <div class="mt-6 space-y-6">
+      <.card :if={@seekers != []} class="space-y-4">
+        <div>
+          <.section_title>{gettext("Who you would reach")}</.section_title>
+          <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+            <%!-- `%{formatted}` rather than `%{count}`: ngettext binds the raw
+            integer to `count` and a `count:` binding does not override it, so
+            the grouped number needs a placeholder of its own. --%>
+            {ngettext(
+              "One member has said they are available.",
+              "%{formatted} members have said they are available.",
+              @reach.count,
+              formatted: delimited_count(@reach.count)
+            )}
+          </p>
+        </div>
+
+        <ul class="grid gap-4 sm:grid-cols-2">
+          <li :for={row <- @seekers} id={"seeker-#{row.user.id}"} class="flex items-start gap-3">
+            <.link href={~p"/#{row.user}"} class="shrink-0">
+              <.avatar
+                user={row.user}
+                size="sm"
+                alt={gettext("Profile picture of %{name}", name: UserHelpers.full_name(row.user))}
+              />
+            </.link>
+            <div class="min-w-0 flex-1">
+              <.link
+                href={~p"/#{row.user}"}
+                class="block truncate text-sm font-medium text-slate-800 hover:text-brand-700 dark:text-slate-100 dark:hover:text-brand-300"
+              >
+                {UserHelpers.full_name(row.user)}
+              </.link>
+              <.employment_status_badge
+                status={row.user.employment_status}
+                workplace={row.user.desired_workplace_types}
+                class="mt-1"
+              />
+              <p :if={row.work != ""} class="mb-0 mt-1 truncate text-xs text-slate-600 dark:text-slate-400">
+                {row.work}
+              </p>
+              <div :if={row.tags != []} class="mt-1.5 flex flex-wrap items-center gap-1">
+                <.chip :for={user_tag <- row.tags} size="sm" navigate={~p"/tags/#{UserTag.tag(user_tag)}"}>
+                  <span aria-hidden="true">#</span>{UserTag.truncated_name(user_tag)}
+                </.chip>
+                <.link
+                  :if={row.more > 0}
+                  navigate={~p"/#{row.user}/tags"}
+                  class="text-xs font-medium text-slate-600 hover:text-brand-700 dark:text-slate-400 dark:hover:text-brand-300"
+                >
+                  {ngettext("+1 more tag", "+%{formatted} more tags", row.more,
+                    formatted: compact_count(row.more)
+                  )}
+                </.link>
+              </div>
+            </div>
+          </li>
+        </ul>
+
+        <.card_footer_link href={~p"/system/members"}>
+          {gettext("All members")}
+        </.card_footer_link>
+      </.card>
+
+      <.card :if={@reach.fields != []} class="space-y-3">
+        <div>
+          <.section_title>{gettext("What members here work on")}</.section_title>
+          <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+            {gettext("The fields the most members carry, and how many of them do.")}
+          </p>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <.chip :for={{tag, count} <- @reach.fields} navigate={~p"/tags/#{tag}"}>
+            <span aria-hidden="true">#</span>{tag.name}
+            <span class="text-brand-600 dark:text-brand-300">{compact_count(count)}</span>
+          </.chip>
+        </div>
+      </.card>
     </div>
     """
   end

--- a/lib/vutuv_web/live/job_posting_live/form.ex
+++ b/lib/vutuv_web/live/job_posting_live/form.ex
@@ -46,6 +46,7 @@ defmodule VutuvWeb.JobPostingLive.Form do
   alias Vutuv.Languages
   alias Vutuv.Organizations
   alias Vutuv.Salary
+  alias Vutuv.Tags
 
   # How many search hits the box offers at once. Long enough that a two-letter
   # fragment still shows the country you meant, short enough to stay a list you
@@ -85,6 +86,7 @@ defmodule VutuvWeb.JobPostingLive.Form do
 
     socket
     |> base_assigns(posting, changeset)
+    |> assign_tag_reach("", "")
     |> assign(:required_tags, "")
     |> assign(:nice_tags, "")
     |> assign(:images, [])
@@ -94,10 +96,14 @@ defmodule VutuvWeb.JobPostingLive.Form do
     posting = Jobs.get_job_posting_by_slug(slug)
 
     if posting && Jobs.owner?(posting, socket.assigns.current_user) do
+      required = Jobs.tag_names(posting, :required)
+      nice = Jobs.tag_names(posting, :nice_to_have)
+
       socket
       |> base_assigns(posting, Jobs.change_job_posting(posting))
-      |> assign(:required_tags, Jobs.tag_names(posting, :required))
-      |> assign(:nice_tags, Jobs.tag_names(posting, :nice_to_have))
+      |> assign_tag_reach(required, nice)
+      |> assign(:required_tags, required)
+      |> assign(:nice_tags, nice)
       |> assign(:images, posting.images)
     else
       socket
@@ -133,6 +139,21 @@ defmodule VutuvWeb.JobPostingLive.Form do
     |> assign_country_matches()
   end
 
+  # How many members carry the tags the poster has typed so far — the one number
+  # that answers "is this posting worth writing here?" while they are still
+  # writing it. `validate` fires on every keystroke in the whole form, so the
+  # two queries behind it run only when a tag field really changed: it is called
+  # BEFORE the new strings are assigned, so the old ones are still there to
+  # compare against.
+  defp assign_tag_reach(socket, required, nice) do
+    if {required, nice} == {socket.assigns[:required_tags], socket.assigns[:nice_tags]} do
+      socket
+    else
+      names = Tags.parse_tag_names(required) ++ Tags.parse_tag_names(nice)
+      assign(socket, :tag_reach, Tags.member_counts_by_name(names))
+    end
+  end
+
   # The hits the search box offers: what the query finds, minus what is already
   # a pill. Offering a country you have picked would answer a tap with nothing
   # visibly happening.
@@ -157,11 +178,15 @@ defmodule VutuvWeb.JobPostingLive.Form do
       |> Jobs.change_job_posting(seed_remote_countries(params, socket.assigns.changeset))
       |> Map.put(:action, :validate)
 
+    required = params["required_tags"] || ""
+    nice = params["nice_to_have_tags"] || ""
+
     {:noreply,
      socket
      |> assign_form(changeset)
-     |> assign(:required_tags, params["required_tags"] || "")
-     |> assign(:nice_tags, params["nice_to_have_tags"] || "")}
+     |> assign_tag_reach(required, nice)
+     |> assign(:required_tags, required)
+     |> assign(:nice_tags, nice)}
   end
 
   def handle_event("country-search", %{"country_query" => query}, socket) do
@@ -736,6 +761,32 @@ defmodule VutuvWeb.JobPostingLive.Form do
               value={@nice_tags}
               field_class={input_class()}
             />
+          </div>
+          <%!-- What the tags typed so far are worth here: the members who carry
+          them. A posting is written before anybody can answer it, so this is
+          the only thing the form can honestly say about its audience — and a
+          zero is the useful half, because it says the field is spelled in a way
+          nobody here uses. --%>
+          <div :if={@tag_reach != []} id="job-tag-reach">
+            <p class="text-xs text-slate-600 dark:text-slate-400">
+              {gettext("Members carrying these tags:")}
+            </p>
+            <div class="mt-1.5 flex flex-wrap gap-2">
+              <%!-- The chips' own geometry (`chip_class/1`, so a padding or
+              radius change carries it along) in slate: these line up in a row
+              of tag chips without pretending to be tags. --%>
+              <span
+                :for={{name, count} <- @tag_reach}
+                data-tag-reach={name}
+                class={[
+                  chip_class("sm"),
+                  "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200"
+                ]}
+              >
+                {name}
+                <span class="text-slate-600 dark:text-slate-400">{delimited_count(count)}</span>
+              </span>
+            </div>
           </div>
         </.card>
 

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -100,10 +100,10 @@ msgstr "Avatar"
 msgid "Birthdate"
 msgstr "Geburtstag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:612
-#: lib/vutuv_web/agent_docs/markdown.ex:613
-#: lib/vutuv_web/agent_docs/text.ex:576
-#: lib/vutuv_web/agent_docs/text.ex:577
+#: lib/vutuv_web/agent_docs/markdown.ex:614
+#: lib/vutuv_web/agent_docs/markdown.ex:615
+#: lib/vutuv_web/agent_docs/text.ex:578
+#: lib/vutuv_web/agent_docs/text.ex:579
 #: lib/vutuv_web/templates/user/show.html.heex:1116
 #, elixir-autogen
 msgid "Birthday"
@@ -115,7 +115,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
 #: lib/vutuv_web/live/admin/user_delete_live.ex:202
-#: lib/vutuv_web/live/job_posting_live/form.ex:806
+#: lib/vutuv_web/live/job_posting_live/form.ex:852
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
 #: lib/vutuv_web/live/post_live/composer.ex:1901
@@ -178,7 +178,7 @@ msgstr "%{name} konnte nicht zurückgefolgt werden."
 msgid "Delete"
 msgstr "Löschen"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:685
+#: lib/vutuv_web/live/job_posting_live/form.ex:711
 #: lib/vutuv_web/live/organization_live/edit.ex:305
 #: lib/vutuv_web/live/organization_live/edit.ex:318
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
@@ -306,14 +306,14 @@ msgstr "Lebenslauf"
 msgid "Fax"
 msgstr "Fax"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:598
+#: lib/vutuv_web/agent_docs/markdown.ex:600
 #: lib/vutuv_web/templates/user/edit.html.heex:164
 #, elixir-autogen
 msgid "First Name"
 msgstr "Vorname"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:633
-#: lib/vutuv_web/agent_docs/text.ex:597
+#: lib/vutuv_web/agent_docs/markdown.ex:635
+#: lib/vutuv_web/agent_docs/text.ex:599
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
@@ -323,8 +323,8 @@ msgstr "Vorname"
 msgid "Followers"
 msgstr "Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:634
-#: lib/vutuv_web/agent_docs/text.ex:598
+#: lib/vutuv_web/agent_docs/markdown.ex:636
+#: lib/vutuv_web/agent_docs/text.ex:600
 #: lib/vutuv_web/components/fediverse_components.ex:468
 #: lib/vutuv_web/components/ui.ex:2964
 #: lib/vutuv_web/components/ui.ex:2999
@@ -380,7 +380,7 @@ msgstr "Stellenbezeichnung"
 msgid "Language"
 msgstr "Sprache"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:600
+#: lib/vutuv_web/agent_docs/markdown.ex:602
 #: lib/vutuv_web/templates/user/edit.html.heex:169
 #, elixir-autogen
 msgid "Last Name"
@@ -447,7 +447,7 @@ msgstr "Ausloggen"
 msgid "Log in"
 msgstr "Einloggen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:599
+#: lib/vutuv_web/agent_docs/markdown.ex:601
 #: lib/vutuv_web/templates/user/edit.html.heex:174
 #, elixir-autogen
 msgid "Middle Name"
@@ -484,7 +484,7 @@ msgstr "Name"
 msgid "New"
 msgstr "Neu"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:602
+#: lib/vutuv_web/agent_docs/markdown.ex:604
 #: lib/vutuv_web/templates/user/edit.html.heex:179
 #, elixir-autogen
 msgid "Nickname"
@@ -565,7 +565,7 @@ msgstr "Telefonnummer wurde gelöscht."
 msgid "Phone number updated successfully."
 msgstr "Telefonnummer wurde geändert."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:597
+#: lib/vutuv_web/agent_docs/markdown.ex:599
 #: lib/vutuv_web/templates/user/edit.html.heex:184
 #, elixir-autogen
 msgid "Prefix"
@@ -641,7 +641,7 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:219
 #: lib/vutuv_web/live/directory_search_live.ex:181
-#: lib/vutuv_web/live/job_board_live.ex:410
+#: lib/vutuv_web/live/job_board_live.ex:572
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
@@ -744,7 +744,7 @@ msgstr "Etwas ist schiefgelaufen"
 msgid "Submit a bugreport or a feature request."
 msgstr "Fehler auf der Seite melden."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:601
+#: lib/vutuv_web/agent_docs/markdown.ex:603
 #: lib/vutuv_web/templates/user/edit.html.heex:189
 #, elixir-autogen
 msgid "Suffix"
@@ -858,7 +858,7 @@ msgstr "Alle anzeigen"
 
 #: lib/vutuv_web/components/ui.ex:5097
 #: lib/vutuv_web/controllers/settings_controller.ex:171
-#: lib/vutuv_web/live/job_posting_live/form.ex:767
+#: lib/vutuv_web/live/job_posting_live/form.ex:813
 #: lib/vutuv_web/live/organization_live/edit.ex:339
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
@@ -1370,11 +1370,11 @@ msgid "Tag urls"
 msgstr "Tag-URLs"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
-#: lib/vutuv_web/agent_docs/markdown.ex:505
-#: lib/vutuv_web/agent_docs/markdown.ex:1123
+#: lib/vutuv_web/agent_docs/markdown.ex:507
+#: lib/vutuv_web/agent_docs/markdown.ex:1148
 #: lib/vutuv_web/agent_docs/text.ex:31
-#: lib/vutuv_web/agent_docs/text.ex:524
-#: lib/vutuv_web/agent_docs/text.ex:770
+#: lib/vutuv_web/agent_docs/text.ex:526
+#: lib/vutuv_web/agent_docs/text.ex:792
 #: lib/vutuv_web/components/ui.ex:4982
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
@@ -1385,8 +1385,8 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/cv/odt.ex:148
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:444
 #: lib/vutuv_web/live/cv_live.ex:323
-#: lib/vutuv_web/live/job_board_live.ex:276
-#: lib/vutuv_web/live/job_posting_live/form.ex:716
+#: lib/vutuv_web/live/job_board_live.ex:339
+#: lib/vutuv_web/live/job_posting_live/form.ex:742
 #: lib/vutuv_web/live/search_live.ex:347
 #: lib/vutuv_web/live/search_live.ex:818
 #: lib/vutuv_web/live/tag_new_live.ex:35
@@ -1566,8 +1566,8 @@ msgstr ""
 "Login-Link."
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:771
-#: lib/vutuv_web/live/job_board_live.ex:356
-#: lib/vutuv_web/live/job_posting_live/form.ex:548
+#: lib/vutuv_web/live/job_board_live.ex:518
+#: lib/vutuv_web/live/job_posting_live/form.ex:574
 #: lib/vutuv_web/live/organization_live/edit.ex:335
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
@@ -2100,7 +2100,7 @@ msgstr "September"
 msgid "Markdown is supported: bold, italics, links and lists."
 msgstr "Markdown wird unterstützt: Fett, Kursiv, Links und Listen."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:709
+#: lib/vutuv_web/live/job_posting_live/form.ex:735
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr "Bilder hinzufügen"
@@ -2143,7 +2143,7 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:162
 #: lib/vutuv_web/live/post_live/feed.ex:336
-#: lib/vutuv_web/live/post_live/feed.ex:3069
+#: lib/vutuv_web/live/post_live/feed.ex:3111
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1156
 #: lib/vutuv_web/live/shell_live.ex:1460
@@ -2189,7 +2189,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3385
+#: lib/vutuv_web/live/post_live/feed.ex:3427
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2284,7 +2284,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2310
+#: lib/vutuv_web/live/post_live/feed.ex:2318
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2413,7 +2413,7 @@ msgstr "Alle Beiträge"
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1161
+#: lib/vutuv_web/agent_docs/markdown.ex:1186
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
 #: lib/vutuv_web/live/shell_live.ex:1296
@@ -2433,7 +2433,7 @@ msgstr "Lesezeichen"
 msgid "Like"
 msgstr "Gefällt mir"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1160
+#: lib/vutuv_web/agent_docs/markdown.ex:1185
 #: lib/vutuv_web/components/post_components.ex:6038
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
@@ -2799,7 +2799,7 @@ msgid "Manage"
 msgstr "Verwalten"
 
 #: lib/vutuv_web/controllers/page_controller.ex:216
-#: lib/vutuv_web/live/post_live/feed.ex:2350
+#: lib/vutuv_web/live/post_live/feed.ex:2358
 #: lib/vutuv_web/templates/user/show.html.heex:507
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2820,6 +2820,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] "1 Vernetzung"
 msgstr[1] "%{formatted} Vernetzungen"
 
+#: lib/vutuv_web/live/job_board_live.ex:457
 #: lib/vutuv_web/live/post_live/feed.ex:1053
 #: lib/vutuv_web/templates/user/card_list.html.heex:51
 #, elixir-autogen, elixir-format
@@ -2828,8 +2829,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] "+1 weiteres Tag"
 msgstr[1] "+%{formatted} weitere Tags"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:635
-#: lib/vutuv_web/agent_docs/text.ex:599
+#: lib/vutuv_web/agent_docs/markdown.ex:637
+#: lib/vutuv_web/agent_docs/text.ex:601
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2981,8 +2982,8 @@ msgstr "Gibt es etwas, das unsere Admins wissen sollten? (optional)"
 msgid "Bullying or harassment"
 msgstr "Mobbing oder Belästigung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:345
-#: lib/vutuv_web/agent_docs/text.ex:326
+#: lib/vutuv_web/agent_docs/markdown.ex:347
+#: lib/vutuv_web/agent_docs/text.ex:328
 #: lib/vutuv_web/controllers/page_controller.ex:81
 #: lib/vutuv_web/templates/layout/app.html.heex:119
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3941,12 +3942,12 @@ msgstr "gemeldete Nachricht"
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:742
+#: lib/vutuv_web/agent_docs/markdown.ex:744
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr "%{count} Empfehlungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1282
+#: lib/vutuv_web/agent_docs/markdown.ex:1307
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} auf dieser Seite, weitere mit ?page=N"
@@ -3960,11 +3961,11 @@ msgstr "%{count} Beiträge von %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:91
 #: lib/vutuv_web/agent_docs/markdown.ex:204
 #: lib/vutuv_web/agent_docs/markdown.ex:218
-#: lib/vutuv_web/agent_docs/markdown.ex:1123
+#: lib/vutuv_web/agent_docs/markdown.ex:1148
 #: lib/vutuv_web/agent_docs/text.ex:86
 #: lib/vutuv_web/agent_docs/text.ex:187
 #: lib/vutuv_web/agent_docs/text.ex:201
-#: lib/vutuv_web/agent_docs/text.ex:770
+#: lib/vutuv_web/agent_docs/text.ex:792
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr "%{count} insgesamt"
@@ -3978,33 +3979,33 @@ msgstr "Follower von %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:158
 #: lib/vutuv_web/agent_docs/text.ex:112
 #: lib/vutuv_web/agent_docs/text.ex:144
-#: lib/vutuv_web/live/job_posting_live/form.ex:699
+#: lib/vutuv_web/live/job_posting_live/form.ex:725
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr "Bilder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1141
-#: lib/vutuv_web/agent_docs/text.ex:781
+#: lib/vutuv_web/agent_docs/markdown.ex:1166
+#: lib/vutuv_web/agent_docs/text.ex:803
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr "Antwort auf einen gelöschten Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1138
-#: lib/vutuv_web/agent_docs/text.ex:778
+#: lib/vutuv_web/agent_docs/markdown.ex:1163
+#: lib/vutuv_web/agent_docs/text.ex:800
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr "Antwort auf einen gelöschten Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1145
-#: lib/vutuv_web/agent_docs/markdown.ex:1375
-#: lib/vutuv_web/agent_docs/text.ex:784
-#: lib/vutuv_web/agent_docs/text.ex:840
+#: lib/vutuv_web/agent_docs/markdown.ex:1170
+#: lib/vutuv_web/agent_docs/markdown.ex:1400
+#: lib/vutuv_web/agent_docs/text.ex:806
+#: lib/vutuv_web/agent_docs/text.ex:862
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr "Antwort auf einen Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:570
-#: lib/vutuv_web/agent_docs/text.ex:562
+#: lib/vutuv_web/agent_docs/markdown.ex:572
+#: lib/vutuv_web/agent_docs/text.ex:564
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr "Mitglied seit"
@@ -4043,23 +4044,23 @@ msgstr "Beitrag von %{name}"
 msgid "Posts (%{count} total)"
 msgstr "Beiträge (insgesamt %{count})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:564
-#: lib/vutuv_web/agent_docs/text.ex:556
+#: lib/vutuv_web/agent_docs/markdown.ex:566
+#: lib/vutuv_web/agent_docs/text.ex:558
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr "Verifiziertes Profil: ja"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1092
+#: lib/vutuv_web/agent_docs/markdown.ex:1094
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr "repostet von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:954
+#: lib/vutuv_web/agent_docs/markdown.ex:956
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr "heute"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:955
+#: lib/vutuv_web/agent_docs/markdown.ex:957
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr "bis %{date}"
@@ -4137,8 +4138,8 @@ msgstr ""
 msgid "Billing name"
 msgstr "Name für die Rechnung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:359
-#: lib/vutuv_web/agent_docs/text.ex:334
+#: lib/vutuv_web/agent_docs/markdown.ex:361
+#: lib/vutuv_web/agent_docs/text.ex:336
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr "Online buchen (Login erforderlich): %{url}"
@@ -4162,7 +4163,7 @@ msgid "Booking requires a vutuv login."
 msgstr "Für die Buchung ist ein vutuv-Login erforderlich."
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
-#: lib/vutuv_web/live/job_posting_live/form.ex:542
+#: lib/vutuv_web/live/job_posting_live/form.ex:568
 #: lib/vutuv_web/live/organization_live/edit.ex:331
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
@@ -4191,8 +4192,8 @@ msgstr "Tag"
 msgid "Markdown is supported. At most %{max} characters."
 msgstr "Markdown wird unterstützt. Höchstens %{max} Zeichen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:349
-#: lib/vutuv_web/agent_docs/text.ex:330
+#: lib/vutuv_web/agent_docs/markdown.ex:351
+#: lib/vutuv_web/agent_docs/text.ex:332
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4208,8 +4209,8 @@ msgstr "Ein Tag. Eine Anzeige. Alle Besucher."
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr "Eine reine Textanzeige pro Kalendertag, gesehen von allen Besuchern."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:346
-#: lib/vutuv_web/agent_docs/text.ex:327
+#: lib/vutuv_web/agent_docs/markdown.ex:348
+#: lib/vutuv_web/agent_docs/text.ex:329
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4443,14 +4444,14 @@ msgstr "gebucht am"
 msgid "deleted account"
 msgstr "gelöschtes Konto"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:351
-#: lib/vutuv_web/agent_docs/text.ex:332
+#: lib/vutuv_web/agent_docs/markdown.ex:353
+#: lib/vutuv_web/agent_docs/text.ex:334
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr "Bereits gebucht"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:347
-#: lib/vutuv_web/agent_docs/text.ex:328
+#: lib/vutuv_web/agent_docs/markdown.ex:349
+#: lib/vutuv_web/agent_docs/text.ex:330
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr "Buchungszeitraum"
@@ -4695,7 +4696,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3390
+#: lib/vutuv_web/live/post_live/feed.ex:3432
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -4751,8 +4752,8 @@ msgstr "Keine Ergebnisse für \"%{query}\""
 msgid "Not an exact match, but sounds like your search."
 msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:446
-#: lib/vutuv_web/agent_docs/text.ex:465
+#: lib/vutuv_web/agent_docs/markdown.ex:448
+#: lib/vutuv_web/agent_docs/text.ex:467
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/notification_live/index.ex:657
 #: lib/vutuv_web/live/notification_live/index.ex:1350
@@ -4828,7 +4829,7 @@ msgstr "müller"
 msgid "searches first names only (last: for last names)"
 msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 
-#: lib/vutuv_web/live/job_board_live.ex:384
+#: lib/vutuv_web/live/job_board_live.ex:546
 #: lib/vutuv_web/live/tag_new_live.ex:47
 #: lib/vutuv_web/live/user_profile_live.ex:1358
 #: lib/vutuv_web/templates/user/show.html.heex:610
@@ -6367,8 +6368,8 @@ msgid_plural "%{count} years old"
 msgstr[0] "%{count} Jahr"
 msgstr[1] "%{count} Jahre"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:614
-#: lib/vutuv_web/agent_docs/text.ex:578
+#: lib/vutuv_web/agent_docs/markdown.ex:616
+#: lib/vutuv_web/agent_docs/text.ex:580
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr "Alter"
@@ -6442,7 +6443,7 @@ msgstr "Tagesbericht öffnen"
 msgid "Previous day"
 msgstr "Vorheriger Tag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1160
+#: lib/vutuv_web/agent_docs/markdown.ex:1185
 #: lib/vutuv_web/components/post_components.ex:421
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
@@ -6558,7 +6559,7 @@ msgstr "Noch keine Empfehlungen."
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1136
+#: lib/vutuv_web/agent_docs/markdown.ex:1161
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr "empfohlen am %{date}"
@@ -7066,7 +7067,7 @@ msgstr "Entwurf"
 
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:36
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:103
-#: lib/vutuv_web/live/job_posting_live/form.ex:318
+#: lib/vutuv_web/live/job_posting_live/form.ex:344
 #, elixir-autogen, elixir-format
 msgid "Draft saved."
 msgstr "Entwurf gespeichert."
@@ -7293,7 +7294,7 @@ msgstr "Zurücksetzen"
 msgid "Save audience"
 msgstr "Zielgruppe speichern"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:804
+#: lib/vutuv_web/live/job_posting_live/form.ex:850
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:16
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:11
 #, elixir-autogen, elixir-format
@@ -7722,7 +7723,7 @@ msgstr ""
 "der Versand läuft weiter."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3656
+#: lib/vutuv_web/live/post_live/feed.ex:3698
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #, elixir-autogen
 msgid "Done"
@@ -7803,17 +7804,17 @@ msgstr "Feed von %{name}"
 msgid "The vutuv newsfeed of %{name}"
 msgstr "Der vutuv-Newsfeed von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1287
+#: lib/vutuv_web/agent_docs/markdown.ex:1312
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr "Ihr Feed ist leer."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1290
+#: lib/vutuv_web/agent_docs/markdown.ex:1315
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr "%{count} Beiträge auf dieser Seite"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1297
+#: lib/vutuv_web/agent_docs/markdown.ex:1322
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "weitere Beiträge verfügbar, ?cursor=%{cursor} anhängen"
@@ -8199,6 +8200,7 @@ msgid "Admins"
 msgstr "Administratoren"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
+#: lib/vutuv_web/live/job_board_live.ex:467
 #: lib/vutuv_web/live/post_live/feed.ex:1062
 #, elixir-autogen, elixir-format
 msgid "All members"
@@ -8218,7 +8220,7 @@ msgstr "Prüfung ausstehend"
 #: lib/vutuv_web/live/account_activity_live.ex:189
 #: lib/vutuv_web/live/admin/activity_live.ex:231
 #: lib/vutuv_web/live/admin/user_live.ex:184
-#: lib/vutuv_web/live/job_board_live.ex:256
+#: lib/vutuv_web/live/job_board_live.ex:319
 #: lib/vutuv_web/live/tag_live/timeline.ex:365
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
@@ -9004,10 +9006,10 @@ msgstr "Die Seite wurde veröffentlicht."
 msgid "Write it under Admin › Legal pages"
 msgstr "Unter Admin › Rechtstexte verfassen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:624
-#: lib/vutuv_web/agent_docs/markdown.ex:628
-#: lib/vutuv_web/agent_docs/text.ex:588
-#: lib/vutuv_web/agent_docs/text.ex:592
+#: lib/vutuv_web/agent_docs/markdown.ex:626
+#: lib/vutuv_web/agent_docs/markdown.ex:630
+#: lib/vutuv_web/agent_docs/text.ex:590
+#: lib/vutuv_web/agent_docs/text.ex:594
 #: lib/vutuv_web/components/organization_components.ex:276
 #: lib/vutuv_web/components/ui.ex:1695
 #: lib/vutuv_web/components/ui.ex:5113
@@ -9142,13 +9144,13 @@ msgstr "Ihr Profil als Lebenslauf"
 msgid "Higher Education"
 msgstr "Studium"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:832
+#: lib/vutuv_web/agent_docs/markdown.ex:834
 #: lib/vutuv_web/views/education_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr "Schulbildung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:831
+#: lib/vutuv_web/agent_docs/markdown.ex:833
 #: lib/vutuv_web/views/education_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -9184,7 +9186,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] "Repostet von %{name} und %{formatted} weiteren"
 msgstr[1] "Repostet von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1095
+#: lib/vutuv_web/agent_docs/markdown.ex:1097
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr "repostet von %{name} und %{count} weiteren"
@@ -9436,8 +9438,8 @@ msgstr "Ehren-Tag"
 msgid "Honor tag (only site admins can assign it)"
 msgstr "Ehren-Tag (nur Admins können es vergeben)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:644
-#: lib/vutuv_web/agent_docs/text.ex:606
+#: lib/vutuv_web/agent_docs/markdown.ex:646
+#: lib/vutuv_web/agent_docs/text.ex:608
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr "Ehren-Tag"
@@ -9861,8 +9863,8 @@ msgstr "Walisisch"
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:566
-#: lib/vutuv_web/agent_docs/text.ex:558
+#: lib/vutuv_web/agent_docs/markdown.ex:568
+#: lib/vutuv_web/agent_docs/text.ex:560
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
@@ -9976,7 +9978,7 @@ msgstr[1] "%{count} Zertifikate oder Lizenzen"
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:948
+#: lib/vutuv_web/agent_docs/markdown.ex:950
 #: lib/vutuv_web/views/qualification_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -10056,7 +10058,7 @@ msgstr "Läuft nicht ab"
 msgid "Expired"
 msgstr "Abgelaufen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:923
+#: lib/vutuv_web/agent_docs/markdown.ex:925
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr "ID: %{id}"
@@ -10073,7 +10075,7 @@ msgstr "Ausgestellt"
 msgid "Issuer"
 msgstr "Aussteller"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:947
+#: lib/vutuv_web/agent_docs/markdown.ex:949
 #: lib/vutuv_web/views/qualification_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -10103,7 +10105,7 @@ msgstr "Nachweis"
 msgid "Verification link"
 msgstr "Nachweislink"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:921
+#: lib/vutuv_web/agent_docs/markdown.ex:923
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr "ausgestellt %{date}"
@@ -10118,7 +10120,7 @@ msgstr "z. B. AWS Solutions Architect – Associate"
 msgid "e.g. Amazon Web Services"
 msgstr "z. B. Amazon Web Services"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:922
+#: lib/vutuv_web/agent_docs/markdown.ex:924
 #: lib/vutuv_web/views/qualification_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "valid until %{date}"
@@ -10136,7 +10138,7 @@ msgstr ""
 msgid "Preferred"
 msgstr "Bevorzugt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:759
+#: lib/vutuv_web/agent_docs/markdown.ex:761
 #: lib/vutuv_web/live/section_reorder_live.ex:287
 #: lib/vutuv_web/views/language_html.ex:114
 #, elixir-autogen, elixir-format
@@ -10634,21 +10636,21 @@ msgstr ""
 " von einer gedruckten Kennwortliste an, eingegeben im normalen PIN-Feld. "
 "Ihre PIN per E-Mail funktioniert immer weiter."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:719
+#: lib/vutuv_web/agent_docs/markdown.ex:721
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] "%{count} Follower"
 msgstr[1] "%{count} Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:717
+#: lib/vutuv_web/agent_docs/markdown.ex:719
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] "%{count} Repository"
 msgstr[1] "%{count} Repositories"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:715
+#: lib/vutuv_web/agent_docs/markdown.ex:717
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10710,12 +10712,12 @@ msgstr ""
 "Wenn deaktiviert, zeigt die Social-Media-Karte Ihre Konten nur als einfache "
 "Links."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:733
+#: lib/vutuv_web/agent_docs/markdown.ex:735
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr "zuletzt aktiv %{date}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:720
+#: lib/vutuv_web/agent_docs/markdown.ex:722
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr "seit %{date}"
@@ -11330,7 +11332,7 @@ msgstr "Niemand"
 
 #: lib/vutuv/accounts/user.ex:1266
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
-#: lib/vutuv_web/live/job_posting_live/form.ex:772
+#: lib/vutuv_web/live/job_posting_live/form.ex:818
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr "Nur angemeldete Mitglieder"
@@ -11347,7 +11349,7 @@ msgstr "Wer kann Ihre Verfügbarkeit sehen?"
 msgid "Amount"
 msgstr "Betrag"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:668
+#: lib/vutuv_web/live/job_posting_live/form.ex:694
 #: lib/vutuv_web/templates/user/edit.html.heex:321
 #: lib/vutuv_web/templates/welcome/show.html.heex:131
 #, elixir-autogen, elixir-format
@@ -11376,7 +11378,7 @@ msgstr ""
 "Benachrichtigungen, indem Stellen darunter herausgefiltert werden. Lassen "
 "Sie den Betrag leer, um die Angabe zu entfernen."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:675
+#: lib/vutuv_web/live/job_posting_live/form.ex:701
 #: lib/vutuv_web/templates/user/edit.html.heex:317
 #: lib/vutuv_web/templates/welcome/show.html.heex:127
 #, elixir-autogen, elixir-format
@@ -11748,8 +11750,8 @@ msgstr "Alias hinzugefügt."
 msgid "Alias removed."
 msgstr "Alias entfernt."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:438
-#: lib/vutuv_web/agent_docs/text.ex:458
+#: lib/vutuv_web/agent_docs/markdown.ex:440
+#: lib/vutuv_web/agent_docs/text.ex:460
 #: lib/vutuv_web/live/organization_live/edit.ex:384
 #: lib/vutuv_web/live/organization_live/show.ex:923
 #: lib/vutuv_web/templates/tag/single_card.html.heex:14
@@ -11976,8 +11978,8 @@ msgstr "ausstehend"
 msgid "primary"
 msgstr "primär"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:459
-#: lib/vutuv_web/agent_docs/text.ex:478
+#: lib/vutuv_web/agent_docs/markdown.ex:461
+#: lib/vutuv_web/agent_docs/text.ex:480
 #: lib/vutuv_web/live/admin/organization_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -12106,8 +12108,8 @@ msgstr "Per Rück-Link verifizieren"
 msgid "Verify via file"
 msgstr "Per Datei verifizieren"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:968
-#: lib/vutuv_web/agent_docs/text.ex:734
+#: lib/vutuv_web/agent_docs/markdown.ex:970
+#: lib/vutuv_web/agent_docs/text.ex:736
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr "verifizierte Webseite"
@@ -12143,8 +12145,8 @@ msgstr "Verknüpft mit {name}"
 msgid "Remove link"
 msgstr "Verknüpfung entfernen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:450
-#: lib/vutuv_web/agent_docs/text.ex:469
+#: lib/vutuv_web/agent_docs/markdown.ex:452
+#: lib/vutuv_web/agent_docs/text.ex:471
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr "ehemalig"
@@ -12355,9 +12357,9 @@ msgstr "Organisationsrolle"
 msgid "Organization unfrozen."
 msgstr "Organisation wieder freigegeben."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:429
+#: lib/vutuv_web/agent_docs/markdown.ex:431
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
-#: lib/vutuv_web/agent_docs/text.ex:402
+#: lib/vutuv_web/agent_docs/text.ex:404
 #: lib/vutuv_web/components/ui.ex:5140
 #: lib/vutuv_web/controllers/settings_controller.ex:213
 #: lib/vutuv_web/live/organization_live/index.ex:32
@@ -12539,47 +12541,47 @@ msgstr "%{views} Aufrufe · %{clicks} Bewerbungsklicks"
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr "Eine gefälschte, irreführende oder diskriminierende Stellenanzeige."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:652
+#: lib/vutuv_web/live/job_posting_live/form.ex:678
 #, elixir-autogen, elixir-format
 msgid "A pay range is required to publish (except volunteer postings)."
 msgstr "Zum Veröffentlichen ist eine Gehaltsspanne erforderlich (außer bei Ehrenämtern)."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:749
+#: lib/vutuv_web/live/job_posting_live/form.ex:795
 #, elixir-autogen, elixir-format
 msgid "A vutuv message to me"
 msgstr "Eine vutuv-Nachricht an mich"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:747
+#: lib/vutuv_web/live/job_posting_live/form.ex:793
 #, elixir-autogen, elixir-format
 msgid "A website"
 msgstr "Eine Website"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:748
+#: lib/vutuv_web/live/job_posting_live/form.ex:794
 #, elixir-autogen, elixir-format
 msgid "An e-mail address"
 msgstr "Eine E-Mail-Adresse"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:563
+#: lib/vutuv_web/live/job_posting_live/form.ex:589
 #, elixir-autogen, elixir-format
 msgid "Applicants must be located in"
 msgstr "Bewerber:innen müssen ansässig sein in"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:753
+#: lib/vutuv_web/live/job_posting_live/form.ex:799
 #, elixir-autogen, elixir-format
 msgid "Application URL"
 msgstr "Bewerbungs-URL"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:759
+#: lib/vutuv_web/live/job_posting_live/form.ex:805
 #, elixir-autogen, elixir-format
 msgid "Application e-mail"
 msgstr "Bewerbungs-E-Mail"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:109
+#: lib/vutuv_web/controllers/job_posting_controller.ex:127
 #, elixir-autogen, elixir-format
 msgid "Application: %{title}"
 msgstr "Bewerbung: %{title}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:745
+#: lib/vutuv_web/live/job_posting_live/form.ex:791
 #, elixir-autogen, elixir-format
 msgid "Applications go to"
 msgstr "Bewerbungen gehen an"
@@ -12611,7 +12613,7 @@ msgstr "Geschlossen"
 msgid "Contract"
 msgstr "Freie Mitarbeit"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:692
+#: lib/vutuv_web/live/job_posting_live/form.ex:718
 #, elixir-autogen, elixir-format
 msgid "Describe the role. Markdown is supported."
 msgstr "Beschreiben Sie die Stelle. Markdown wird unterstützt."
@@ -12621,15 +12623,15 @@ msgstr "Beschreiben Sie die Stelle. Markdown wird unterstützt."
 msgid "Drafts"
 msgstr "Entwürfe"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:114
+#: lib/vutuv_web/live/job_posting_live/form.ex:120
 #, elixir-autogen, elixir-format
 msgid "Edit posting"
 msgstr "Anzeige bearbeiten"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:282
-#: lib/vutuv_web/agent_docs/markdown.ex:490
+#: lib/vutuv_web/agent_docs/markdown.ex:492
 #: lib/vutuv_web/agent_docs/text.ex:266
-#: lib/vutuv_web/agent_docs/text.ex:509
+#: lib/vutuv_web/agent_docs/text.ex:511
 #: lib/vutuv_web/live/admin/job_live.ex:340
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
 #: lib/vutuv_web/views/account_event_text.ex:225
@@ -12637,27 +12639,27 @@ msgstr "Anzeige bearbeiten"
 msgid "Employer"
 msgstr "Arbeitgeber"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:459
+#: lib/vutuv_web/live/job_posting_live/form.ex:485
 #, elixir-autogen, elixir-format
 msgid "Employer name (optional)"
 msgstr "Name des Arbeitgebers (optional)"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:283
-#: lib/vutuv_web/agent_docs/markdown.ex:491
+#: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/text.ex:267
-#: lib/vutuv_web/agent_docs/text.ex:510
-#: lib/vutuv_web/live/job_board_live.ex:363
-#: lib/vutuv_web/live/job_posting_live/form.ex:474
+#: lib/vutuv_web/agent_docs/text.ex:512
+#: lib/vutuv_web/live/job_board_live.ex:525
+#: lib/vutuv_web/live/job_posting_live/form.ex:500
 #, elixir-autogen, elixir-format
 msgid "Employment type"
 msgstr "Anstellungsart"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:771
+#: lib/vutuv_web/live/job_posting_live/form.ex:817
 #, elixir-autogen, elixir-format
 msgid "Everyone (public)"
 msgstr "Alle (öffentlich)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:656
+#: lib/vutuv_web/live/job_posting_live/form.ex:682
 #: lib/vutuv_web/live/tag_live/timeline.ex:346
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
@@ -12675,7 +12677,7 @@ msgstr "Vollzeit"
 msgid "Highlighted tags match your profile."
 msgstr "Hervorgehobene Tags passen zu Ihrem Profil."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:743
+#: lib/vutuv_web/live/job_posting_live/form.ex:789
 #, elixir-autogen, elixir-format
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
@@ -12686,25 +12688,25 @@ msgstr "So bewerben Sie sich"
 msgid "Hybrid"
 msgstr "Hybrid"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:128
+#: lib/vutuv_web/controllers/job_posting_controller.ex:146
 #, elixir-autogen, elixir-format
 msgid "I'm interested in your posting: %{url}"
 msgstr "Ich interessiere mich für Ihre Anzeige: %{url}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:691
+#: lib/vutuv_web/live/job_posting_live/form.ex:717
 #, elixir-autogen, elixir-format
 msgid "Job description"
 msgstr "Stellenbeschreibung"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:426
+#: lib/vutuv_web/live/job_posting_live/form.ex:452
 #, elixir-autogen, elixir-format
 msgid "Job title"
 msgstr "Stellenbezeichnung"
 
-#: lib/vutuv_web/agent_docs/job_board_doc.ex:19
+#: lib/vutuv_web/agent_docs/job_board_doc.ex:31
 #: lib/vutuv_web/components/saved_search_components.ex:56
-#: lib/vutuv_web/live/job_board_live.ex:45
-#: lib/vutuv_web/live/job_board_live.ex:211
+#: lib/vutuv_web/live/job_board_live.ex:49
+#: lib/vutuv_web/live/job_board_live.ex:259
 #: lib/vutuv_web/live/post_live/saved.ex:529
 #: lib/vutuv_web/live/shell_live.ex:1178
 #: lib/vutuv_web/templates/layout/app.html.heex:80
@@ -12712,18 +12714,18 @@ msgstr "Stellenbezeichnung"
 msgid "Jobs"
 msgstr "Jobs"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:781
+#: lib/vutuv_web/live/job_posting_live/form.ex:827
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this posting."
 msgstr "Suchmaschinen dürfen diese Anzeige indexieren."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:465
-#: lib/vutuv_web/agent_docs/markdown.ex:468
+#: lib/vutuv_web/agent_docs/markdown.ex:467
 #: lib/vutuv_web/agent_docs/markdown.ex:470
-#: lib/vutuv_web/agent_docs/text.ex:484
-#: lib/vutuv_web/agent_docs/text.ex:487
+#: lib/vutuv_web/agent_docs/markdown.ex:472
+#: lib/vutuv_web/agent_docs/text.ex:486
 #: lib/vutuv_web/agent_docs/text.ex:489
-#: lib/vutuv_web/live/job_posting_live/form.ex:524
+#: lib/vutuv_web/agent_docs/text.ex:491
+#: lib/vutuv_web/live/job_posting_live/form.ex:550
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr "Standort"
@@ -12760,20 +12762,20 @@ msgstr "Irreführende Stellenanzeige"
 msgid "My postings"
 msgstr "Meine Anzeigen"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:396
+#: lib/vutuv_web/live/job_posting_live/form.ex:422
 #, elixir-autogen, elixir-format
 msgid "New accounts can publish after a few days."
 msgstr "Neue Konten können nach einigen Tagen veröffentlichen."
 
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:102
-#: lib/vutuv_web/live/job_posting_live/form.ex:114
+#: lib/vutuv_web/live/job_posting_live/form.ex:120
 #, elixir-autogen, elixir-format
 msgid "New posting"
 msgstr "Neue Anzeige"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:294
 #: lib/vutuv_web/agent_docs/text.ex:277
-#: lib/vutuv_web/live/job_posting_live/form.ex:731
+#: lib/vutuv_web/live/job_posting_live/form.ex:757
 #: lib/vutuv_web/live/job_posting_live/show.ex:177
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
@@ -12794,7 +12796,7 @@ msgstr "Hier ist noch nichts. Jobs mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Jobs you like show up here."
 msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:787
+#: lib/vutuv_web/live/job_posting_live/form.ex:833
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
@@ -12815,27 +12817,27 @@ msgstr "Nur Sie sehen diese Anzeige, während eine Meldung dazu bearbeitet wird.
 msgid "Part-time"
 msgstr "Teilzeit"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:650
+#: lib/vutuv_web/live/job_posting_live/form.ex:676
 #, elixir-autogen, elixir-format
 msgid "Pay"
 msgstr "Bezahlung"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:395
+#: lib/vutuv_web/live/job_posting_live/form.ex:421
 #, elixir-autogen, elixir-format
 msgid "Please confirm your e-mail address first."
 msgstr "Bitte bestätigen Sie zuerst Ihre E-Mail-Adresse."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:71
+#: lib/vutuv_web/live/job_posting_live/form.ex:72
 #, elixir-autogen, elixir-format
 msgid "Please confirm your email address before posting a job."
 msgstr "Bitte bestätigen Sie Ihre E-Mail-Adresse, bevor Sie eine Stelle ausschreiben."
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:120
+#: lib/vutuv_web/controllers/job_posting_controller.ex:138
 #, elixir-autogen, elixir-format
 msgid "Please log in to message the poster."
 msgstr "Bitte melden Sie sich an, um die Anbieter:in anzuschreiben."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:77
+#: lib/vutuv_web/live/job_posting_live/form.ex:78
 #, elixir-autogen, elixir-format
 msgid "Please log in to post a job."
 msgstr "Bitte melden Sie sich an, um eine Stelle auszuschreiben."
@@ -12845,38 +12847,38 @@ msgstr "Bitte melden Sie sich an, um eine Stelle auszuschreiben."
 msgid "Please log in to see your postings."
 msgstr "Bitte melden Sie sich an, um Ihre Anzeigen zu sehen."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:447
+#: lib/vutuv_web/live/job_posting_live/form.ex:473
 #, elixir-autogen, elixir-format
 msgid "Post as"
 msgstr "Veröffentlichen als"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:536
+#: lib/vutuv_web/live/job_posting_live/form.ex:562
 #: lib/vutuv_web/templates/welcome/show.html.heex:67
 #, elixir-autogen, elixir-format
 msgid "Postal code"
 msgstr "Postleitzahl"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:287
-#: lib/vutuv_web/agent_docs/markdown.ex:495
+#: lib/vutuv_web/agent_docs/markdown.ex:497
 #: lib/vutuv_web/agent_docs/text.ex:271
-#: lib/vutuv_web/agent_docs/text.ex:514
+#: lib/vutuv_web/agent_docs/text.ex:516
 #: lib/vutuv_web/live/job_posting_live/show.ex:156
 #, elixir-autogen, elixir-format
 msgid "Posted"
 msgstr "Veröffentlicht"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:505
+#: lib/vutuv_web/live/job_posting_live/form.ex:531
 #, elixir-autogen, elixir-format
 msgid "Posting language"
 msgstr "Sprache der Anzeige"
 
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:50
-#: lib/vutuv_web/live/job_posting_live/form.ex:104
+#: lib/vutuv_web/live/job_posting_live/form.ex:110
 #, elixir-autogen, elixir-format
 msgid "Posting not found."
 msgstr "Anzeige nicht gefunden."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:802
+#: lib/vutuv_web/live/job_posting_live/form.ex:848
 #, elixir-autogen, elixir-format
 msgid "Publish"
 msgstr "Veröffentlichen"
@@ -12884,10 +12886,10 @@ msgstr "Veröffentlichen"
 #: lib/vutuv/accounts/user.ex:1238
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
-#: lib/vutuv_web/agent_docs/markdown.ex:468
 #: lib/vutuv_web/agent_docs/markdown.ex:470
-#: lib/vutuv_web/agent_docs/text.ex:487
+#: lib/vutuv_web/agent_docs/markdown.ex:472
 #: lib/vutuv_web/agent_docs/text.ex:489
+#: lib/vutuv_web/agent_docs/text.ex:491
 #: lib/vutuv_web/components/job_components.ex:140
 #: lib/vutuv_web/components/job_components.ex:141
 #, elixir-autogen, elixir-format
@@ -12901,16 +12903,16 @@ msgstr "Diese Anzeige melden"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:293
 #: lib/vutuv_web/agent_docs/text.ex:276
-#: lib/vutuv_web/live/job_posting_live/form.ex:721
+#: lib/vutuv_web/live/job_posting_live/form.ex:747
 #: lib/vutuv_web/live/job_posting_live/show.ex:172
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr "Erforderlich"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:286
-#: lib/vutuv_web/agent_docs/markdown.ex:494
+#: lib/vutuv_web/agent_docs/markdown.ex:496
 #: lib/vutuv_web/agent_docs/text.ex:270
-#: lib/vutuv_web/agent_docs/text.ex:513
+#: lib/vutuv_web/agent_docs/text.ex:515
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr "Gehalt"
@@ -12921,27 +12923,27 @@ msgid "Salary on request"
 msgstr "Gehalt auf Anfrage"
 
 #: lib/vutuv_web/controllers/settings_controller.ex:395
-#: lib/vutuv_web/live/job_posting_live/form.ex:354
+#: lib/vutuv_web/live/job_posting_live/form.ex:380
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr "Gespeichert."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:468
+#: lib/vutuv_web/live/job_posting_live/form.ex:494
 #, elixir-autogen, elixir-format
 msgid "Shown as an unverified employer name."
 msgstr "Wird als nicht verifizierter Arbeitgebername angezeigt."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:384
+#: lib/vutuv_web/live/job_posting_live/form.ex:410
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:529
+#: lib/vutuv_web/live/job_posting_live/form.ex:555
 #, elixir-autogen, elixir-format
 msgid "Street (optional)"
 msgstr "Straße (optional)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:718
+#: lib/vutuv_web/live/job_posting_live/form.ex:744
 #, elixir-autogen, elixir-format
 msgid "Tags match your posting to members. Separate them with commas; a tag may be several words long, like Ruby on Rails."
 msgstr "Tags bringen Ihre Anzeige mit Mitgliedern zusammen. Mit Kommas trennen; ein Tag darf aus mehreren Wörtern bestehen, zum Beispiel Ruby on Rails."
@@ -12951,17 +12953,17 @@ msgstr "Tags bringen Ihre Anzeige mit Mitgliedern zusammen. Mit Kommas trennen; 
 msgid "Temporary"
 msgstr "Befristet"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:276
+#: lib/vutuv_web/live/job_posting_live/form.ex:302
 #, elixir-autogen, elixir-format
 msgid "That image could not be uploaded."
 msgstr "Dieses Bild konnte nicht hochgeladen werden."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:422
+#: lib/vutuv_web/live/job_posting_live/form.ex:448
 #, elixir-autogen, elixir-format
 msgid "The role"
 msgstr "Die Stelle"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:402
+#: lib/vutuv_web/live/job_posting_live/form.ex:428
 #, elixir-autogen, elixir-format
 msgid "This organization has reached its published-postings limit."
 msgstr "Diese Organisation hat ihr Limit an veröffentlichten Anzeigen erreicht."
@@ -12971,7 +12973,7 @@ msgstr "Diese Organisation hat ihr Limit an veröffentlichten Anzeigen erreicht.
 msgid "This position is no longer available."
 msgstr "Diese Stelle ist nicht mehr verfügbar."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:441
+#: lib/vutuv_web/live/job_posting_live/form.ex:467
 #, elixir-autogen, elixir-format
 msgid "Tip: adding a gender marker like (m/w/d) helps your posting comply with the AGG. This is a suggestion, not legal advice."
 msgstr "Tipp: Ein Geschlechtszusatz wie (m/w/d) hilft Ihrer Anzeige, dem AGG zu entsprechen. Das ist ein Hinweis, keine Rechtsberatung."
@@ -12993,7 +12995,7 @@ msgstr "Ehrenamtlich"
 msgid "Volunteer"
 msgstr "Ehrenamt"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:769
+#: lib/vutuv_web/live/job_posting_live/form.ex:815
 #: lib/vutuv_web/templates/email/form_content.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Who can see it"
@@ -13005,15 +13007,15 @@ msgid "Working student"
 msgstr "Werkstudent:in"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:284
-#: lib/vutuv_web/agent_docs/markdown.ex:492
+#: lib/vutuv_web/agent_docs/markdown.ex:494
 #: lib/vutuv_web/agent_docs/text.ex:268
-#: lib/vutuv_web/agent_docs/text.ex:511
-#: lib/vutuv_web/live/job_posting_live/form.ex:489
+#: lib/vutuv_web/agent_docs/text.ex:513
+#: lib/vutuv_web/live/job_posting_live/form.ex:515
 #, elixir-autogen, elixir-format
 msgid "Workplace"
 msgstr "Arbeitsort"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:399
+#: lib/vutuv_web/live/job_posting_live/form.ex:425
 #, elixir-autogen, elixir-format
 msgid "You already have the maximum number of published postings."
 msgstr "Sie haben bereits die maximale Anzahl veröffentlichter Anzeigen."
@@ -13058,18 +13060,18 @@ msgstr "Ihre Organisationsseite auf vutuv ist nicht mehr öffentlich"
 msgid "Your posting"
 msgstr "Ihre Anzeige"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:334
-#: lib/vutuv_web/live/job_posting_live/form.ex:377
+#: lib/vutuv_web/live/job_posting_live/form.ex:360
+#: lib/vutuv_web/live/job_posting_live/form.ex:403
 #, elixir-autogen, elixir-format
 msgid "Your posting is live."
 msgstr "Ihre Anzeige ist online."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:450
+#: lib/vutuv_web/live/job_posting_live/form.ex:476
 #, elixir-autogen, elixir-format
 msgid "Yourself (personal posting)"
 msgstr "Sie selbst (persönliche Anzeige)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:662
+#: lib/vutuv_web/live/job_posting_live/form.ex:688
 #, elixir-autogen, elixir-format
 msgid "up to"
 msgstr "bis"
@@ -13197,120 +13199,120 @@ msgid_plural "%{count} weeks ago"
 msgstr[0] "vor %{count} Woche"
 msgstr[1] "vor %{count} Wochen"
 
-#: lib/vutuv_web/live/job_board_live.ex:471
+#: lib/vutuv_web/live/job_board_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "%{km} km"
 msgstr "%{km} km"
 
-#: lib/vutuv_web/live/job_board_live.ex:357
+#: lib/vutuv_web/live/job_board_live.ex:519
 #, elixir-autogen, elixir-format
 msgid "All countries"
 msgstr "Alle Länder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:513
+#: lib/vutuv_web/agent_docs/markdown.ex:515
 #: lib/vutuv_web/templates/tag/show.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr "Alle Stellen mit diesem Tag"
 
-#: lib/vutuv_web/agent_docs/text.ex:531
+#: lib/vutuv_web/agent_docs/text.ex:533
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr "Alle Stellen mit diesem Tag: %{url}"
 
-#: lib/vutuv_web/live/job_board_live.ex:364
+#: lib/vutuv_web/live/job_board_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Any employment type"
 msgstr "Alle Anstellungsarten"
 
-#: lib/vutuv_web/live/job_board_live.ex:346
+#: lib/vutuv_web/live/job_board_live.ex:508
 #, elixir-autogen, elixir-format
 msgid "City or zip code"
 msgstr "Stadt oder Postleitzahl"
 
-#: lib/vutuv_web/live/job_board_live.ex:471
+#: lib/vutuv_web/live/job_board_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "Exact"
 msgstr "Genau"
 
-#: lib/vutuv_web/live/job_board_live.ex:245
+#: lib/vutuv_web/live/job_board_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "From my salary expectation"
 msgstr "Ab meiner Gehaltsvorstellung"
 
-#: lib/vutuv_web/live/job_board_live.ex:237
+#: lib/vutuv_web/live/job_board_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "Matches my tags"
 msgstr "Passend zu meinen Tags"
 
-#: lib/vutuv_web/live/job_board_live.ex:452
+#: lib/vutuv_web/live/job_board_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Min. salary/year (%{currency})"
 msgstr "Mindestgehalt/Jahr (%{currency})"
 
-#: lib/vutuv_web/live/job_board_live.ex:406
+#: lib/vutuv_web/live/job_board_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "Minimum yearly salary"
 msgstr "Mindestgehalt pro Jahr"
 
-#: lib/vutuv_web/live/job_board_live.ex:320
+#: lib/vutuv_web/live/job_board_live.ex:383
 #: lib/vutuv_web/live/organization_live/show.ex:834
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr "Weitere Stellen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:306
+#: lib/vutuv_web/agent_docs/markdown.ex:308
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr "Nächste Seite"
 
-#: lib/vutuv_web/agent_docs/text.ex:289
+#: lib/vutuv_web/agent_docs/text.ex:291
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr "Nächste Seite: %{url}"
 
-#: lib/vutuv_web/live/job_board_live.ex:479
+#: lib/vutuv_web/live/job_board_live.ex:641
 #, elixir-autogen, elixir-format
 msgid "No job postings yet."
 msgstr "Noch keine Stellenanzeigen."
 
-#: lib/vutuv_web/live/job_board_live.ex:477
+#: lib/vutuv_web/live/job_board_live.ex:639
 #, elixir-autogen, elixir-format
 msgid "No matching positions. Try adjusting the filters."
 msgstr "Keine passenden Stellen. Passen Sie die Filter an."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:511
-#: lib/vutuv_web/agent_docs/markdown.ex:523
-#: lib/vutuv_web/agent_docs/text.ex:529
-#: lib/vutuv_web/agent_docs/text.ex:541
+#: lib/vutuv_web/agent_docs/markdown.ex:513
+#: lib/vutuv_web/agent_docs/markdown.ex:525
+#: lib/vutuv_web/agent_docs/text.ex:531
+#: lib/vutuv_web/agent_docs/text.ex:543
 #: lib/vutuv_web/live/organization_live/show.ex:826
 #: lib/vutuv_web/templates/tag/show.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Open positions"
 msgstr "Offene Stellen"
 
-#: lib/vutuv_web/agent_docs/job_board_doc.ex:20
-#: lib/vutuv_web/live/job_board_live.ex:213
+#: lib/vutuv_web/agent_docs/job_board_doc.ex:40
+#: lib/vutuv_web/live/job_board_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Open positions on vutuv, newest first."
 msgstr "Offene Stellen auf vutuv, neueste zuerst."
 
-#: lib/vutuv_web/live/job_board_live.ex:217
+#: lib/vutuv_web/live/job_board_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Post a job"
 msgstr "Stelle ausschreiben"
 
-#: lib/vutuv_web/live/job_board_live.ex:305
+#: lib/vutuv_web/live/job_board_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "Post the first one"
 msgstr "Veröffentlichen Sie die erste"
 
-#: lib/vutuv_web/live/job_board_live.ex:350
+#: lib/vutuv_web/live/job_board_live.ex:512
 #, elixir-autogen, elixir-format
 msgid "Radius"
 msgstr "Umkreis"
 
-#: lib/vutuv_web/live/job_board_live.ex:338
+#: lib/vutuv_web/live/job_board_live.ex:500
 #, elixir-autogen, elixir-format
 msgid "Search jobs"
 msgstr "Jobs durchsuchen"
@@ -13743,7 +13745,7 @@ msgstr "Wird eine Organisation ausgeschlossen, ist die Anzeige auch für ihre be
 msgid "Hide from specific viewers"
 msgstr "Vor bestimmten Personen verbergen"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:793
+#: lib/vutuv_web/live/job_posting_live/form.ex:839
 #, elixir-autogen, elixir-format
 msgid "Hide from specific viewers (competitors, your own staff, a person) →"
 msgstr "Vor bestimmten Personen verbergen (Wettbewerber, eigene Belegschaft, Einzelpersonen) →"
@@ -13764,7 +13766,7 @@ msgstr "Ausschlussliste"
 msgid "Job exclusions – %{name}"
 msgstr "Ausschlussliste – %{name}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:796
+#: lib/vutuv_web/live/job_posting_live/form.ex:842
 #, elixir-autogen, elixir-format
 msgid "Keep this posting on the board for everyone except a chosen few."
 msgstr "Halten Sie diese Anzeige für alle im Stellenmarkt sichtbar, außer für wenige Ausgewählte."
@@ -14069,34 +14071,34 @@ msgstr ""
 msgid "Tags you follow"
 msgstr "Tags, denen Sie folgen"
 
-#: lib/vutuv_web/live/job_board_live.ex:419
+#: lib/vutuv_web/live/job_board_live.ex:581
 #, elixir-autogen, elixir-format
 msgid "Looking for a role that goes by several titles? Separate them with a comma and we show postings that match any of them."
 msgstr ""
 "Ein Beruf mit mehreren möglichen Titeln? Trennen Sie sie mit Komma, dann "
 "zeigen wir Anzeigen, die zu einem davon passen."
 
-#: lib/vutuv_web/live/job_board_live.ex:415
+#: lib/vutuv_web/live/job_board_live.ex:577
 #, elixir-autogen, elixir-format
 msgid "Search tips"
 msgstr "Suchtipps"
 
-#: lib/vutuv_web/live/job_board_live.ex:462
+#: lib/vutuv_web/live/job_board_live.ex:624
 #, elixir-autogen, elixir-format
 msgid "any of these titles"
 msgstr "einer dieser Titel"
 
-#: lib/vutuv_web/live/job_board_live.ex:464
+#: lib/vutuv_web/live/job_board_live.ex:626
 #, elixir-autogen, elixir-format
 msgid "exact wording"
 msgstr "genaue Wortfolge"
 
-#: lib/vutuv_web/live/job_board_live.ex:465
+#: lib/vutuv_web/live/job_board_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "without internships"
 msgstr "ohne Praktika"
 
-#: lib/vutuv_web/live/job_board_live.ex:463
+#: lib/vutuv_web/live/job_board_live.ex:625
 #, elixir-autogen, elixir-format
 msgid "word start: also finds Entwickler, Entwicklung"
 msgstr "Wortanfang: findet auch Entwickler, Entwicklung"
@@ -14227,7 +14229,7 @@ msgstr "hat %{count} neue Einträge im Lebenslauf:"
 msgid "Audiobook"
 msgstr "Hörbuch"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1249
+#: lib/vutuv_web/agent_docs/markdown.ex:1274
 #: lib/vutuv_web/components/post_components.ex:5501
 #, elixir-autogen, elixir-format
 msgid "Book review"
@@ -14248,7 +14250,7 @@ msgstr "DVD/Blu-ray"
 msgid "E-book"
 msgstr "E-Book"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1249
+#: lib/vutuv_web/agent_docs/markdown.ex:1274
 #: lib/vutuv_web/components/post_components.ex:5500
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -14338,7 +14340,7 @@ msgstr "Qualifikation"
 msgid "With qualification:"
 msgstr "Mit Qualifikation:"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:788
+#: lib/vutuv_web/agent_docs/markdown.ex:790
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
@@ -14427,19 +14429,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] "Für %{formatted} Job genutzt"
 msgstr[1] "Für %{formatted} Jobs genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:937
+#: lib/vutuv_web/agent_docs/markdown.ex:939
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr "aktuell genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:936
+#: lib/vutuv_web/agent_docs/markdown.ex:938
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] "für %{count} Job genutzt"
 msgstr[1] "für %{count} Jobs genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:942
+#: lib/vutuv_web/agent_docs/markdown.ex:944
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -14519,8 +14521,8 @@ msgstr "Hochgeladener Nachweis für %{name}"
 msgid "View the uploaded proof (%{label})"
 msgstr "Hochgeladenen Nachweis ansehen (%{label})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:874
-#: lib/vutuv_web/agent_docs/text.ex:713
+#: lib/vutuv_web/agent_docs/markdown.ex:876
+#: lib/vutuv_web/agent_docs/text.ex:715
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr "Nachweis"
@@ -14615,8 +14617,8 @@ msgstr "Speichern und weiter"
 msgid "Skip for now"
 msgstr "Erstmal überspringen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:568
-#: lib/vutuv_web/agent_docs/text.ex:560
+#: lib/vutuv_web/agent_docs/markdown.ex:570
+#: lib/vutuv_web/agent_docs/text.ex:562
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr "Bevorzugte Arbeitsform"
@@ -14952,7 +14954,7 @@ msgstr "Alle Empfehlenden"
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr "Filter hinzugefügt. Passende Beiträge sind jetzt in Ihrem Feed ausgeblendet."
 
-#: lib/vutuv_web/live/job_board_live.ex:385
+#: lib/vutuv_web/live/job_board_live.ex:547
 #, elixir-autogen, elixir-format
 msgid "Filter by a tag"
 msgstr "Nach einem Tag filtern"
@@ -15217,7 +15219,7 @@ msgstr "%{blocked} Server blockiert, am aktivsten eingehend: %{host}."
 msgid "none yet"
 msgstr "noch keiner"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1196
+#: lib/vutuv_web/agent_docs/markdown.ex:1221
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr "Reaktionen aus anderen Netzwerken"
@@ -15601,8 +15603,8 @@ msgstr "%{server} hat nicht geantwortet. Kopieren Sie stattdessen die Adresse ob
 msgid "Your server"
 msgstr "Ihr Server"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:625
-#: lib/vutuv_web/agent_docs/text.ex:589
+#: lib/vutuv_web/agent_docs/markdown.ex:627
+#: lib/vutuv_web/agent_docs/text.ex:591
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr "umgezogen nach %{address}"
@@ -15997,7 +15999,7 @@ msgid_plural "%{formatted} reposts"
 msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1198
+#: lib/vutuv_web/agent_docs/markdown.ex:1223
 #: lib/vutuv_web/components/post_components.ex:5942
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
@@ -16008,8 +16010,8 @@ msgstr "Bereits in den Zahlen oben enthalten."
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem Beitrag, gekennzeichnet als aus einem anderen Netzwerk. Wir speichern eine Kopie für bis zu sechs Monate und prüfen ab und zu, ob sie dort noch veröffentlicht ist; löscht sie die Autorin oder der Autor, verschwindet auch unsere. Sie können jede einzelne Antwort entfernen, und wenn Sie das hier ausschalten, werden alle gelöscht."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1396
-#: lib/vutuv_web/agent_docs/text.ex:854
+#: lib/vutuv_web/agent_docs/markdown.ex:1421
+#: lib/vutuv_web/agent_docs/text.ex:876
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr "Inhaltswarnung"
@@ -16033,7 +16035,7 @@ msgstr "Vom Mitglied entfernt"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:135
 #: lib/vutuv_web/agent_docs/markdown.ex:167
-#: lib/vutuv_web/agent_docs/markdown.ex:1197
+#: lib/vutuv_web/agent_docs/markdown.ex:1222
 #: lib/vutuv_web/agent_docs/text.ex:124
 #: lib/vutuv_web/agent_docs/text.ex:153
 #, elixir-autogen, elixir-format
@@ -16091,7 +16093,7 @@ msgstr "Danke. Die Antwort wurde sofort gelöscht."
 msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1398
+#: lib/vutuv_web/agent_docs/markdown.ex:1423
 #: lib/vutuv_web/components/post_components.ex:1427
 #: lib/vutuv_web/components/post_components.ex:1627
 #: lib/vutuv_web/components/post_components.ex:3004
@@ -16798,13 +16800,13 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr "Nicht mehr angeheftet. Der Beitrag ist wieder ein normaler Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1078
+#: lib/vutuv_web/agent_docs/markdown.ex:1080
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr "angehefteter Beitrag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:562
-#: lib/vutuv_web/agent_docs/text.ex:551
+#: lib/vutuv_web/agent_docs/markdown.ex:564
+#: lib/vutuv_web/agent_docs/text.ex:553
 #: lib/vutuv_web/templates/user/edit.html.heex:219
 #: lib/vutuv_web/templates/user/show.html.heex:262
 #: lib/vutuv_web/views/account_event_text.ex:213
@@ -16856,8 +16858,8 @@ msgstr "CC BY-SA 4.0 (Namensnennung, gleiche Bedingungen)"
 msgid "CC0 1.0 (no rights reserved)"
 msgstr "CC0 1.0 (keine Rechte vorbehalten)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1315
-#: lib/vutuv_web/agent_docs/text.ex:808
+#: lib/vutuv_web/agent_docs/markdown.ex:1340
+#: lib/vutuv_web/agent_docs/text.ex:830
 #: lib/vutuv_web/live/post_live/composer.ex:2645
 #, elixir-autogen, elixir-format
 msgid "Cover"
@@ -16868,8 +16870,8 @@ msgstr "Titelbild"
 msgid "Describe the photo for people who can't see it"
 msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1326
-#: lib/vutuv_web/agent_docs/text.ex:821
+#: lib/vutuv_web/agent_docs/markdown.ex:1351
+#: lib/vutuv_web/agent_docs/text.ex:843
 #: lib/vutuv_web/components/ui.ex:3126
 #, elixir-autogen, elixir-format
 msgid "Download the original"
@@ -16926,8 +16928,8 @@ msgstr "Foto wird geprüft"
 msgid "Photo options"
 msgstr "Foto-Einstellungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1359
-#: lib/vutuv_web/agent_docs/text.ex:796
+#: lib/vutuv_web/agent_docs/markdown.ex:1384
+#: lib/vutuv_web/agent_docs/text.ex:818
 #: lib/vutuv_web/components/post_components.ex:4744
 #, elixir-autogen, elixir-format
 msgid "Photos:"
@@ -17088,13 +17090,13 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exakte Datei gibt ihn weiter."
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1216
+#: lib/vutuv_web/agent_docs/markdown.ex:1241
 #: lib/vutuv_web/components/post_components.ex:5980
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1214
+#: lib/vutuv_web/agent_docs/markdown.ex:1239
 #: lib/vutuv_web/components/post_components.ex:5977
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
@@ -17721,7 +17723,7 @@ msgstr "Variante"
 msgid "What is being measured"
 msgstr "Was gemessen wird"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1055
+#: lib/vutuv_web/agent_docs/markdown.ex:1057
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
@@ -17885,8 +17887,8 @@ msgstr "Profil verifizieren"
 msgid "We could not reach the network just now. Please try again in a moment."
 msgstr "Wir konnten das Netzwerk gerade nicht erreichen. Bitte versuchen Sie es gleich noch einmal."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:982
-#: lib/vutuv_web/agent_docs/text.ex:635
+#: lib/vutuv_web/agent_docs/markdown.ex:984
+#: lib/vutuv_web/agent_docs/text.ex:637
 #, elixir-autogen, elixir-format
 msgid "verified profile"
 msgstr "verifiziertes Profil"
@@ -18741,7 +18743,7 @@ msgstr "Höchstens %{max} Tags. Entfernen Sie eines, um ein anderes hinzuzufüge
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder, denen er gefällt. Hier legen Sie fest, ob Sie zu diesen Gesichtern gehören."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1184
+#: lib/vutuv_web/agent_docs/markdown.ex:1209
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
@@ -18783,12 +18785,12 @@ msgstr "Wenn aus, sehen andere Mitglieder Sie nicht mehr bei den Likes eines Bei
 msgid "Your likes follow the site default again."
 msgstr "Ihre Likes folgen wieder dem Standardwert der Website."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1239
+#: lib/vutuv_web/agent_docs/markdown.ex:1264
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr "%{address} (nur diese Seite)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1236
+#: lib/vutuv_web/agent_docs/markdown.ex:1261
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr "%{address} (ganze Website)"
@@ -18798,7 +18800,7 @@ msgstr "%{address} (ganze Website)"
 msgid "Verified webpage of the author (%{address})"
 msgstr "Verifizierte Webseite der Autorin oder des Autors (%{address})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1228
+#: lib/vutuv_web/agent_docs/markdown.ex:1253
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
@@ -18932,7 +18934,7 @@ msgstr "Ausstellungsdatum"
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3408
+#: lib/vutuv_web/live/post_live/feed.ex:3450
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -19134,7 +19136,7 @@ msgstr "Weder den Prompt noch das Modell haben wir geschrieben."
 msgid "Employment references of %{name}"
 msgstr "Arbeitszeugnisse von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:856
+#: lib/vutuv_web/agent_docs/markdown.ex:858
 #, elixir-autogen, elixir-format
 msgid "document"
 msgstr "Dokument"
@@ -21510,6 +21512,7 @@ msgstr "Empfohlen: %{width} × %{height} Pixel (%{ratio})."
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Empfohlen: quadratisch, mindestens %{width} × %{height} Pixel."
 
+#: lib/vutuv_web/live/job_board_live.ex:430
 #: lib/vutuv_web/live/post_live/feed.ex:999
 #: lib/vutuv_web/views/user_html.ex:342
 #, elixir-autogen, elixir-format
@@ -21947,7 +21950,7 @@ msgstr "Weiter zu %{server}"
 msgid "E-mail to %{address}"
 msgstr "E-Mail an %{address}"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:102
+#: lib/vutuv_web/controllers/job_posting_controller.ex:120
 #, elixir-autogen, elixir-format
 msgid "The employer takes applications on their own website."
 msgstr "Das Unternehmen nimmt Bewerbungen auf der eigenen Webseite entgegen."
@@ -21957,7 +21960,7 @@ msgstr "Das Unternehmen nimmt Bewerbungen auf der eigenen Webseite entgegen."
 msgid "Write e-mail"
 msgstr "E-Mail schreiben"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:114
+#: lib/vutuv_web/controllers/job_posting_controller.ex:132
 #, elixir-autogen, elixir-format
 msgid "Your e-mail program opens with the subject filled in."
 msgstr "Ihr E-Mail-Programm öffnet sich mit ausgefülltem Betreff."
@@ -21968,34 +21971,34 @@ msgctxt "qualification detail"
 msgid "Jobs"
 msgstr "Jobs"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:829
+#: lib/vutuv_web/live/job_posting_live/form.ex:875
 #, elixir-autogen, elixir-format
 msgid "%{formatted} country chosen."
 msgid_plural "%{formatted} countries chosen."
 msgstr[0] "%{formatted} Land ausgewählt."
 msgstr[1] "%{formatted} Länder ausgewählt."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:619
+#: lib/vutuv_web/live/job_posting_live/form.ex:645
 #, elixir-autogen, elixir-format
 msgid "No country chosen yet."
 msgstr "Noch kein Land ausgewählt."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:611
+#: lib/vutuv_web/live/job_posting_live/form.ex:637
 #, elixir-autogen, elixir-format
 msgid "No country left to add for that."
 msgstr "Dazu ist kein weiteres Land offen."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:630
+#: lib/vutuv_web/live/job_posting_live/form.ex:656
 #, elixir-autogen, elixir-format
 msgid "Remove %{country}"
 msgstr "%{country} entfernen"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:641
+#: lib/vutuv_web/live/job_posting_live/form.ex:667
 #, elixir-autogen, elixir-format
 msgid "Remove all"
 msgstr "Alle entfernen"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:590
+#: lib/vutuv_web/live/job_posting_live/form.ex:616
 #, elixir-autogen, elixir-format
 msgid "Search for a country"
 msgstr "Land suchen"
@@ -22131,7 +22134,7 @@ msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public po
 msgstr ""
 "Folgen Sie #%{tag} von Mastodon oder einer anderen Fediverse-App aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3569
+#: lib/vutuv_web/live/post_live/feed.ex:3611
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Andere Mitglieder begrüßen"
@@ -22725,7 +22728,7 @@ msgstr "Beiträge mit einem dieser Tags werden genauso zugeklappt."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Beiträge mit einem dieser Wörter werden auf eine Zeile zugeklappt — nicht gelöscht, und mit einem Weg, sie doch zu lesen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3595
+#: lib/vutuv_web/live/post_live/feed.ex:3637
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Weggelegt:"
@@ -22802,10 +22805,10 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "und 1 weiterer"
 msgstr[1] "und %{formatted} weitere"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3182
-#: lib/vutuv_web/live/post_live/feed.ex:3209
-#: lib/vutuv_web/live/post_live/feed.ex:3643
-#: lib/vutuv_web/live/post_live/feed.ex:3648
+#: lib/vutuv_web/live/post_live/feed.ex:3224
+#: lib/vutuv_web/live/post_live/feed.ex:3251
+#: lib/vutuv_web/live/post_live/feed.ex:3685
+#: lib/vutuv_web/live/post_live/feed.ex:3690
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -22874,7 +22877,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} Beitrag am %{day}"
 msgstr[1] "%{count} Beiträge am %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3365
+#: lib/vutuv_web/live/post_live/feed.ex:3407
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Zurück zu jetzt"
@@ -22884,7 +22887,7 @@ msgstr "Zurück zu jetzt"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Voller Monat: die Färbung zählt mindestens so viel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3411
+#: lib/vutuv_web/live/post_live/feed.ex:3453
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22906,7 +22909,7 @@ msgstr "Nächster Monat"
 msgid "Next year"
 msgstr "Nächstes Jahr"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3361
+#: lib/vutuv_web/live/post_live/feed.ex:3403
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Am %{day} ist nichts in Ihrem Feed angekommen."
@@ -22993,7 +22996,7 @@ msgstr "Neue Version bereit."
 msgid "Page management"
 msgstr "Verwaltung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2304
+#: lib/vutuv_web/live/post_live/feed.ex:2312
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
@@ -23005,12 +23008,12 @@ msgstr[1] "Neu (%{formatted}):"
 msgid "Quoted post"
 msgstr "Zitierter Beitrag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1071
+#: lib/vutuv_web/agent_docs/markdown.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Quotes %{name}: %{url}"
 msgstr "Zitiert %{name}: %{url}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1068
+#: lib/vutuv_web/agent_docs/markdown.ex:1070
 #, elixir-autogen, elixir-format
 msgid "Quotes %{url}"
 msgstr "Zitiert %{url}"
@@ -23025,7 +23028,7 @@ msgstr "Ein Konto erwähnen"
 msgid "{used} of {max} mentions"
 msgstr "{used} von {max} Erwähnungen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2453
+#: lib/vutuv_web/live/post_live/feed.ex:2461
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr "Bis hier neu"
@@ -23503,10 +23506,10 @@ msgstr "Dieser Beitrag wartet noch auf Sie"
 msgid "This video could not be converted."
 msgstr "Dieses Video konnte nicht umgewandelt werden."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1311
-#: lib/vutuv_web/agent_docs/markdown.ex:1314
-#: lib/vutuv_web/agent_docs/text.ex:805
-#: lib/vutuv_web/agent_docs/text.ex:806
+#: lib/vutuv_web/agent_docs/markdown.ex:1336
+#: lib/vutuv_web/agent_docs/markdown.ex:1339
+#: lib/vutuv_web/agent_docs/text.ex:827
+#: lib/vutuv_web/agent_docs/text.ex:828
 #: lib/vutuv_web/components/post_components.ex:2506
 #: lib/vutuv_web/components/video_components.ex:126
 #: lib/vutuv_web/live/post_live/composer.ex:2442
@@ -23620,3 +23623,42 @@ msgstr "Standardqualität. Dieses Bild in HD laden."
 #, elixir-autogen, elixir-format
 msgid "Standard quality. Play this video in HD."
 msgstr "Standardqualität. Dieses Video in HD abspielen."
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:773
+#, elixir-autogen, elixir-format
+msgid "Members carrying these tags:"
+msgstr "Mitglieder mit diesen Tags:"
+
+#: lib/vutuv_web/agent_docs/job_board_doc.ex:44
+#: lib/vutuv_web/live/job_board_live.ex:262
+#, elixir-autogen, elixir-format
+msgid "No posting yet. Yours would be the first, and it would stand at the top on its own."
+msgstr "Noch keine Anzeige. Ihre wäre die erste und stünde allein oben."
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1116
+#: lib/vutuv_web/agent_docs/text.ex:758
+#: lib/vutuv_web/live/job_board_live.ex:415
+#, elixir-autogen, elixir-format
+msgid "One member has said they are available."
+msgid_plural "%{formatted} members have said they are available."
+msgstr[0] "Ein Mitglied ist offen für Angebote oder auf Jobsuche."
+msgstr[1] "%{formatted} Mitglieder sind offen für Angebote oder auf Jobsuche."
+
+#: lib/vutuv_web/live/job_board_live.ex:475
+#, elixir-autogen, elixir-format
+msgid "The fields the most members carry, and how many of them do."
+msgstr "Die Fachgebiete mit den meisten Mitgliedern, und wie viele es jeweils sind."
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1123
+#: lib/vutuv_web/agent_docs/text.ex:765
+#: lib/vutuv_web/live/job_board_live.ex:473
+#, elixir-autogen, elixir-format
+msgid "What members here work on"
+msgstr "Woran die Mitglieder hier arbeiten"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1115
+#: lib/vutuv_web/agent_docs/text.ex:757
+#: lib/vutuv_web/live/job_board_live.ex:410
+#, elixir-autogen, elixir-format
+msgid "Who you would reach"
+msgstr "Wen Sie hier erreichen"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -102,10 +102,10 @@ msgstr ""
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:612
-#: lib/vutuv_web/agent_docs/markdown.ex:613
-#: lib/vutuv_web/agent_docs/text.ex:576
-#: lib/vutuv_web/agent_docs/text.ex:577
+#: lib/vutuv_web/agent_docs/markdown.ex:614
+#: lib/vutuv_web/agent_docs/markdown.ex:615
+#: lib/vutuv_web/agent_docs/text.ex:578
+#: lib/vutuv_web/agent_docs/text.ex:579
 #: lib/vutuv_web/templates/user/show.html.heex:1116
 #, elixir-autogen
 msgid "Birthday"
@@ -117,7 +117,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
 #: lib/vutuv_web/live/admin/user_delete_live.ex:202
-#: lib/vutuv_web/live/job_posting_live/form.ex:806
+#: lib/vutuv_web/live/job_posting_live/form.ex:852
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
 #: lib/vutuv_web/live/post_live/composer.ex:1901
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:685
+#: lib/vutuv_web/live/job_posting_live/form.ex:711
 #: lib/vutuv_web/live/organization_live/edit.ex:305
 #: lib/vutuv_web/live/organization_live/edit.ex:318
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
@@ -306,14 +306,14 @@ msgstr ""
 msgid "Fax"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:598
+#: lib/vutuv_web/agent_docs/markdown.ex:600
 #: lib/vutuv_web/templates/user/edit.html.heex:164
 #, elixir-autogen
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:633
-#: lib/vutuv_web/agent_docs/text.ex:597
+#: lib/vutuv_web/agent_docs/markdown.ex:635
+#: lib/vutuv_web/agent_docs/text.ex:599
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
@@ -323,8 +323,8 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:634
-#: lib/vutuv_web/agent_docs/text.ex:598
+#: lib/vutuv_web/agent_docs/markdown.ex:636
+#: lib/vutuv_web/agent_docs/text.ex:600
 #: lib/vutuv_web/components/fediverse_components.ex:468
 #: lib/vutuv_web/components/ui.ex:2964
 #: lib/vutuv_web/components/ui.ex:2999
@@ -380,7 +380,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:600
+#: lib/vutuv_web/agent_docs/markdown.ex:602
 #: lib/vutuv_web/templates/user/edit.html.heex:169
 #, elixir-autogen
 msgid "Last Name"
@@ -447,7 +447,7 @@ msgstr ""
 msgid "Log in"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:599
+#: lib/vutuv_web/agent_docs/markdown.ex:601
 #: lib/vutuv_web/templates/user/edit.html.heex:174
 #, elixir-autogen
 msgid "Middle Name"
@@ -484,7 +484,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:602
+#: lib/vutuv_web/agent_docs/markdown.ex:604
 #: lib/vutuv_web/templates/user/edit.html.heex:179
 #, elixir-autogen
 msgid "Nickname"
@@ -565,7 +565,7 @@ msgstr ""
 msgid "Phone number updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:597
+#: lib/vutuv_web/agent_docs/markdown.ex:599
 #: lib/vutuv_web/templates/user/edit.html.heex:184
 #, elixir-autogen
 msgid "Prefix"
@@ -641,7 +641,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:219
 #: lib/vutuv_web/live/directory_search_live.ex:181
-#: lib/vutuv_web/live/job_board_live.ex:410
+#: lib/vutuv_web/live/job_board_live.ex:572
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Submit a bugreport or a feature request."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:601
+#: lib/vutuv_web/agent_docs/markdown.ex:603
 #: lib/vutuv_web/templates/user/edit.html.heex:189
 #, elixir-autogen
 msgid "Suffix"
@@ -856,7 +856,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5097
 #: lib/vutuv_web/controllers/settings_controller.ex:171
-#: lib/vutuv_web/live/job_posting_live/form.ex:767
+#: lib/vutuv_web/live/job_posting_live/form.ex:813
 #: lib/vutuv_web/live/organization_live/edit.ex:339
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
@@ -1348,11 +1348,11 @@ msgid "Tag urls"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
-#: lib/vutuv_web/agent_docs/markdown.ex:505
-#: lib/vutuv_web/agent_docs/markdown.ex:1123
+#: lib/vutuv_web/agent_docs/markdown.ex:507
+#: lib/vutuv_web/agent_docs/markdown.ex:1148
 #: lib/vutuv_web/agent_docs/text.ex:31
-#: lib/vutuv_web/agent_docs/text.ex:524
-#: lib/vutuv_web/agent_docs/text.ex:770
+#: lib/vutuv_web/agent_docs/text.ex:526
+#: lib/vutuv_web/agent_docs/text.ex:792
 #: lib/vutuv_web/components/ui.ex:4982
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
@@ -1363,8 +1363,8 @@ msgstr ""
 #: lib/vutuv_web/cv/odt.ex:148
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:444
 #: lib/vutuv_web/live/cv_live.ex:323
-#: lib/vutuv_web/live/job_board_live.ex:276
-#: lib/vutuv_web/live/job_posting_live/form.ex:716
+#: lib/vutuv_web/live/job_board_live.ex:339
+#: lib/vutuv_web/live/job_posting_live/form.ex:742
 #: lib/vutuv_web/live/search_live.ex:347
 #: lib/vutuv_web/live/search_live.ex:818
 #: lib/vutuv_web/live/tag_new_live.ex:35
@@ -1539,8 +1539,8 @@ msgid "You'll receive an email with a login link."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:771
-#: lib/vutuv_web/live/job_board_live.ex:356
-#: lib/vutuv_web/live/job_posting_live/form.ex:548
+#: lib/vutuv_web/live/job_board_live.ex:518
+#: lib/vutuv_web/live/job_posting_live/form.ex:574
 #: lib/vutuv_web/live/organization_live/edit.ex:335
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
@@ -2062,7 +2062,7 @@ msgstr ""
 msgid "Markdown is supported: bold, italics, links and lists."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:709
+#: lib/vutuv_web/live/job_posting_live/form.ex:735
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr ""
@@ -2105,7 +2105,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:162
 #: lib/vutuv_web/live/post_live/feed.ex:336
-#: lib/vutuv_web/live/post_live/feed.ex:3069
+#: lib/vutuv_web/live/post_live/feed.ex:3111
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1156
 #: lib/vutuv_web/live/shell_live.ex:1460
@@ -2151,7 +2151,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3385
+#: lib/vutuv_web/live/post_live/feed.ex:3427
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2242,7 +2242,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2310
+#: lib/vutuv_web/live/post_live/feed.ex:2318
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2371,7 +2371,7 @@ msgstr ""
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1161
+#: lib/vutuv_web/agent_docs/markdown.ex:1186
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
 #: lib/vutuv_web/live/shell_live.ex:1296
@@ -2391,7 +2391,7 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1160
+#: lib/vutuv_web/agent_docs/markdown.ex:1185
 #: lib/vutuv_web/components/post_components.ex:6038
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
@@ -2755,7 +2755,7 @@ msgid "Manage"
 msgstr ""
 
 #: lib/vutuv_web/controllers/page_controller.ex:216
-#: lib/vutuv_web/live/post_live/feed.ex:2350
+#: lib/vutuv_web/live/post_live/feed.ex:2358
 #: lib/vutuv_web/templates/user/show.html.heex:507
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2776,6 +2776,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] ""
 msgstr[1] ""
 
+#: lib/vutuv_web/live/job_board_live.ex:457
 #: lib/vutuv_web/live/post_live/feed.ex:1053
 #: lib/vutuv_web/templates/user/card_list.html.heex:51
 #, elixir-autogen, elixir-format
@@ -2784,8 +2785,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:635
-#: lib/vutuv_web/agent_docs/text.ex:599
+#: lib/vutuv_web/agent_docs/markdown.ex:637
+#: lib/vutuv_web/agent_docs/text.ex:601
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2937,8 +2938,8 @@ msgstr ""
 msgid "Bullying or harassment"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:345
-#: lib/vutuv_web/agent_docs/text.ex:326
+#: lib/vutuv_web/agent_docs/markdown.ex:347
+#: lib/vutuv_web/agent_docs/text.ex:328
 #: lib/vutuv_web/controllers/page_controller.ex:81
 #: lib/vutuv_web/templates/layout/app.html.heex:119
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3820,12 +3821,12 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:742
+#: lib/vutuv_web/agent_docs/markdown.ex:744
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1282
+#: lib/vutuv_web/agent_docs/markdown.ex:1307
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3839,11 +3840,11 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:91
 #: lib/vutuv_web/agent_docs/markdown.ex:204
 #: lib/vutuv_web/agent_docs/markdown.ex:218
-#: lib/vutuv_web/agent_docs/markdown.ex:1123
+#: lib/vutuv_web/agent_docs/markdown.ex:1148
 #: lib/vutuv_web/agent_docs/text.ex:86
 #: lib/vutuv_web/agent_docs/text.ex:187
 #: lib/vutuv_web/agent_docs/text.ex:201
-#: lib/vutuv_web/agent_docs/text.ex:770
+#: lib/vutuv_web/agent_docs/text.ex:792
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3857,33 +3858,33 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:158
 #: lib/vutuv_web/agent_docs/text.ex:112
 #: lib/vutuv_web/agent_docs/text.ex:144
-#: lib/vutuv_web/live/job_posting_live/form.ex:699
+#: lib/vutuv_web/live/job_posting_live/form.ex:725
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1141
-#: lib/vutuv_web/agent_docs/text.ex:781
+#: lib/vutuv_web/agent_docs/markdown.ex:1166
+#: lib/vutuv_web/agent_docs/text.ex:803
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1138
-#: lib/vutuv_web/agent_docs/text.ex:778
+#: lib/vutuv_web/agent_docs/markdown.ex:1163
+#: lib/vutuv_web/agent_docs/text.ex:800
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1145
-#: lib/vutuv_web/agent_docs/markdown.ex:1375
-#: lib/vutuv_web/agent_docs/text.ex:784
-#: lib/vutuv_web/agent_docs/text.ex:840
+#: lib/vutuv_web/agent_docs/markdown.ex:1170
+#: lib/vutuv_web/agent_docs/markdown.ex:1400
+#: lib/vutuv_web/agent_docs/text.ex:806
+#: lib/vutuv_web/agent_docs/text.ex:862
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:570
-#: lib/vutuv_web/agent_docs/text.ex:562
+#: lib/vutuv_web/agent_docs/markdown.ex:572
+#: lib/vutuv_web/agent_docs/text.ex:564
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
@@ -3922,23 +3923,23 @@ msgstr ""
 msgid "Posts (%{count} total)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:564
-#: lib/vutuv_web/agent_docs/text.ex:556
+#: lib/vutuv_web/agent_docs/markdown.ex:566
+#: lib/vutuv_web/agent_docs/text.ex:558
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1092
+#: lib/vutuv_web/agent_docs/markdown.ex:1094
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:954
+#: lib/vutuv_web/agent_docs/markdown.ex:956
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:955
+#: lib/vutuv_web/agent_docs/markdown.ex:957
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -4014,8 +4015,8 @@ msgstr ""
 msgid "Billing name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:359
-#: lib/vutuv_web/agent_docs/text.ex:334
+#: lib/vutuv_web/agent_docs/markdown.ex:361
+#: lib/vutuv_web/agent_docs/text.ex:336
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr ""
@@ -4039,7 +4040,7 @@ msgid "Booking requires a vutuv login."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
-#: lib/vutuv_web/live/job_posting_live/form.ex:542
+#: lib/vutuv_web/live/job_posting_live/form.ex:568
 #: lib/vutuv_web/live/organization_live/edit.ex:331
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
@@ -4068,8 +4069,8 @@ msgstr ""
 msgid "Markdown is supported. At most %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:349
-#: lib/vutuv_web/agent_docs/text.ex:330
+#: lib/vutuv_web/agent_docs/markdown.ex:351
+#: lib/vutuv_web/agent_docs/text.ex:332
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4085,8 +4086,8 @@ msgstr ""
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:346
-#: lib/vutuv_web/agent_docs/text.ex:327
+#: lib/vutuv_web/agent_docs/markdown.ex:348
+#: lib/vutuv_web/agent_docs/text.ex:329
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4300,14 +4301,14 @@ msgstr ""
 msgid "deleted account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:351
-#: lib/vutuv_web/agent_docs/text.ex:332
+#: lib/vutuv_web/agent_docs/markdown.ex:353
+#: lib/vutuv_web/agent_docs/text.ex:334
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:347
-#: lib/vutuv_web/agent_docs/text.ex:328
+#: lib/vutuv_web/agent_docs/markdown.ex:349
+#: lib/vutuv_web/agent_docs/text.ex:330
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr ""
@@ -4531,7 +4532,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3390
+#: lib/vutuv_web/live/post_live/feed.ex:3432
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4585,8 +4586,8 @@ msgstr ""
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:446
-#: lib/vutuv_web/agent_docs/text.ex:465
+#: lib/vutuv_web/agent_docs/markdown.ex:448
+#: lib/vutuv_web/agent_docs/text.ex:467
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/notification_live/index.ex:657
 #: lib/vutuv_web/live/notification_live/index.ex:1350
@@ -4660,7 +4661,7 @@ msgstr ""
 msgid "searches first names only (last: for last names)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:384
+#: lib/vutuv_web/live/job_board_live.ex:546
 #: lib/vutuv_web/live/tag_new_live.ex:47
 #: lib/vutuv_web/live/user_profile_live.ex:1358
 #: lib/vutuv_web/templates/user/show.html.heex:610
@@ -6128,8 +6129,8 @@ msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:614
-#: lib/vutuv_web/agent_docs/text.ex:578
+#: lib/vutuv_web/agent_docs/markdown.ex:616
+#: lib/vutuv_web/agent_docs/text.ex:580
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6201,7 +6202,7 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1160
+#: lib/vutuv_web/agent_docs/markdown.ex:1185
 #: lib/vutuv_web/components/post_components.ex:421
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
@@ -6311,7 +6312,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1136
+#: lib/vutuv_web/agent_docs/markdown.ex:1161
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6785,7 +6786,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:36
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:103
-#: lib/vutuv_web/live/job_posting_live/form.ex:318
+#: lib/vutuv_web/live/job_posting_live/form.ex:344
 #, elixir-autogen, elixir-format
 msgid "Draft saved."
 msgstr ""
@@ -7008,7 +7009,7 @@ msgstr ""
 msgid "Save audience"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:804
+#: lib/vutuv_web/live/job_posting_live/form.ex:850
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:16
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:11
 #, elixir-autogen, elixir-format
@@ -7417,7 +7418,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3656
+#: lib/vutuv_web/live/post_live/feed.ex:3698
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #, elixir-autogen
 msgid "Done"
@@ -7492,17 +7493,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1287
+#: lib/vutuv_web/agent_docs/markdown.ex:1312
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1290
+#: lib/vutuv_web/agent_docs/markdown.ex:1315
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1297
+#: lib/vutuv_web/agent_docs/markdown.ex:1322
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -7858,6 +7859,7 @@ msgid "Admins"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
+#: lib/vutuv_web/live/job_board_live.ex:467
 #: lib/vutuv_web/live/post_live/feed.ex:1062
 #, elixir-autogen, elixir-format
 msgid "All members"
@@ -7877,7 +7879,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:189
 #: lib/vutuv_web/live/admin/activity_live.ex:231
 #: lib/vutuv_web/live/admin/user_live.ex:184
-#: lib/vutuv_web/live/job_board_live.ex:256
+#: lib/vutuv_web/live/job_board_live.ex:319
 #: lib/vutuv_web/live/tag_live/timeline.ex:365
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
@@ -8593,10 +8595,10 @@ msgstr ""
 msgid "Write it under Admin › Legal pages"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:624
-#: lib/vutuv_web/agent_docs/markdown.ex:628
-#: lib/vutuv_web/agent_docs/text.ex:588
-#: lib/vutuv_web/agent_docs/text.ex:592
+#: lib/vutuv_web/agent_docs/markdown.ex:626
+#: lib/vutuv_web/agent_docs/markdown.ex:630
+#: lib/vutuv_web/agent_docs/text.ex:590
+#: lib/vutuv_web/agent_docs/text.ex:594
 #: lib/vutuv_web/components/organization_components.ex:276
 #: lib/vutuv_web/components/ui.ex:1695
 #: lib/vutuv_web/components/ui.ex:5113
@@ -8722,13 +8724,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:832
+#: lib/vutuv_web/agent_docs/markdown.ex:834
 #: lib/vutuv_web/views/education_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:831
+#: lib/vutuv_web/agent_docs/markdown.ex:833
 #: lib/vutuv_web/views/education_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8761,7 +8763,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1095
+#: lib/vutuv_web/agent_docs/markdown.ex:1097
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8986,8 +8988,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:644
-#: lib/vutuv_web/agent_docs/text.ex:606
+#: lib/vutuv_web/agent_docs/markdown.ex:646
+#: lib/vutuv_web/agent_docs/text.ex:608
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9411,8 +9413,8 @@ msgstr ""
 msgid "Yoruba"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:566
-#: lib/vutuv_web/agent_docs/text.ex:558
+#: lib/vutuv_web/agent_docs/markdown.ex:568
+#: lib/vutuv_web/agent_docs/text.ex:560
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr ""
@@ -9515,7 +9517,7 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:948
+#: lib/vutuv_web/agent_docs/markdown.ex:950
 #: lib/vutuv_web/views/qualification_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9595,7 +9597,7 @@ msgstr ""
 msgid "Expired"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:923
+#: lib/vutuv_web/agent_docs/markdown.ex:925
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9612,7 +9614,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:947
+#: lib/vutuv_web/agent_docs/markdown.ex:949
 #: lib/vutuv_web/views/qualification_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9639,7 +9641,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:921
+#: lib/vutuv_web/agent_docs/markdown.ex:923
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9654,7 +9656,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:922
+#: lib/vutuv_web/agent_docs/markdown.ex:924
 #: lib/vutuv_web/views/qualification_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "valid until %{date}"
@@ -9670,7 +9672,7 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:759
+#: lib/vutuv_web/agent_docs/markdown.ex:761
 #: lib/vutuv_web/live/section_reorder_live.ex:287
 #: lib/vutuv_web/views/language_html.ex:114
 #, elixir-autogen, elixir-format
@@ -10125,21 +10127,21 @@ msgstr ""
 msgid "Sign in with a one-time code (OTP) from an authenticator app or from a printed code list, typed into the normal PIN field. Your emailed PIN always keeps working."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:719
+#: lib/vutuv_web/agent_docs/markdown.ex:721
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:717
+#: lib/vutuv_web/agent_docs/markdown.ex:719
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:715
+#: lib/vutuv_web/agent_docs/markdown.ex:717
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10196,12 +10198,12 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:733
+#: lib/vutuv_web/agent_docs/markdown.ex:735
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:720
+#: lib/vutuv_web/agent_docs/markdown.ex:722
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -10760,7 +10762,7 @@ msgstr ""
 
 #: lib/vutuv/accounts/user.ex:1266
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
-#: lib/vutuv_web/live/job_posting_live/form.ex:772
+#: lib/vutuv_web/live/job_posting_live/form.ex:818
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr ""
@@ -10777,7 +10779,7 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:668
+#: lib/vutuv_web/live/job_posting_live/form.ex:694
 #: lib/vutuv_web/templates/user/edit.html.heex:321
 #: lib/vutuv_web/templates/welcome/show.html.heex:131
 #, elixir-autogen, elixir-format
@@ -10800,7 +10802,7 @@ msgstr ""
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:675
+#: lib/vutuv_web/live/job_posting_live/form.ex:701
 #: lib/vutuv_web/templates/user/edit.html.heex:317
 #: lib/vutuv_web/templates/welcome/show.html.heex:127
 #, elixir-autogen, elixir-format
@@ -11158,8 +11160,8 @@ msgstr ""
 msgid "Alias removed."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:438
-#: lib/vutuv_web/agent_docs/text.ex:458
+#: lib/vutuv_web/agent_docs/markdown.ex:440
+#: lib/vutuv_web/agent_docs/text.ex:460
 #: lib/vutuv_web/live/organization_live/edit.ex:384
 #: lib/vutuv_web/live/organization_live/show.ex:923
 #: lib/vutuv_web/templates/tag/single_card.html.heex:14
@@ -11380,8 +11382,8 @@ msgstr ""
 msgid "primary"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:459
-#: lib/vutuv_web/agent_docs/text.ex:478
+#: lib/vutuv_web/agent_docs/markdown.ex:461
+#: lib/vutuv_web/agent_docs/text.ex:480
 #: lib/vutuv_web/live/admin/organization_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -11504,8 +11506,8 @@ msgstr ""
 msgid "Verify via file"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:968
-#: lib/vutuv_web/agent_docs/text.ex:734
+#: lib/vutuv_web/agent_docs/markdown.ex:970
+#: lib/vutuv_web/agent_docs/text.ex:736
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -11541,8 +11543,8 @@ msgstr ""
 msgid "Remove link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:450
-#: lib/vutuv_web/agent_docs/text.ex:469
+#: lib/vutuv_web/agent_docs/markdown.ex:452
+#: lib/vutuv_web/agent_docs/text.ex:471
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr ""
@@ -11730,9 +11732,9 @@ msgstr ""
 msgid "Organization unfrozen."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:429
+#: lib/vutuv_web/agent_docs/markdown.ex:431
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
-#: lib/vutuv_web/agent_docs/text.ex:402
+#: lib/vutuv_web/agent_docs/text.ex:404
 #: lib/vutuv_web/components/ui.ex:5140
 #: lib/vutuv_web/controllers/settings_controller.ex:213
 #: lib/vutuv_web/live/organization_live/index.ex:32
@@ -11901,47 +11903,47 @@ msgstr ""
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:652
+#: lib/vutuv_web/live/job_posting_live/form.ex:678
 #, elixir-autogen, elixir-format
 msgid "A pay range is required to publish (except volunteer postings)."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:749
+#: lib/vutuv_web/live/job_posting_live/form.ex:795
 #, elixir-autogen, elixir-format
 msgid "A vutuv message to me"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:747
+#: lib/vutuv_web/live/job_posting_live/form.ex:793
 #, elixir-autogen, elixir-format
 msgid "A website"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:748
+#: lib/vutuv_web/live/job_posting_live/form.ex:794
 #, elixir-autogen, elixir-format
 msgid "An e-mail address"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:563
+#: lib/vutuv_web/live/job_posting_live/form.ex:589
 #, elixir-autogen, elixir-format
 msgid "Applicants must be located in"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:753
+#: lib/vutuv_web/live/job_posting_live/form.ex:799
 #, elixir-autogen, elixir-format
 msgid "Application URL"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:759
+#: lib/vutuv_web/live/job_posting_live/form.ex:805
 #, elixir-autogen, elixir-format
 msgid "Application e-mail"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:109
+#: lib/vutuv_web/controllers/job_posting_controller.ex:127
 #, elixir-autogen, elixir-format
 msgid "Application: %{title}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:745
+#: lib/vutuv_web/live/job_posting_live/form.ex:791
 #, elixir-autogen, elixir-format
 msgid "Applications go to"
 msgstr ""
@@ -11973,7 +11975,7 @@ msgstr ""
 msgid "Contract"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:692
+#: lib/vutuv_web/live/job_posting_live/form.ex:718
 #, elixir-autogen, elixir-format
 msgid "Describe the role. Markdown is supported."
 msgstr ""
@@ -11983,15 +11985,15 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:114
+#: lib/vutuv_web/live/job_posting_live/form.ex:120
 #, elixir-autogen, elixir-format
 msgid "Edit posting"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:282
-#: lib/vutuv_web/agent_docs/markdown.ex:490
+#: lib/vutuv_web/agent_docs/markdown.ex:492
 #: lib/vutuv_web/agent_docs/text.ex:266
-#: lib/vutuv_web/agent_docs/text.ex:509
+#: lib/vutuv_web/agent_docs/text.ex:511
 #: lib/vutuv_web/live/admin/job_live.ex:340
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
 #: lib/vutuv_web/views/account_event_text.ex:225
@@ -11999,27 +12001,27 @@ msgstr ""
 msgid "Employer"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:459
+#: lib/vutuv_web/live/job_posting_live/form.ex:485
 #, elixir-autogen, elixir-format
 msgid "Employer name (optional)"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:283
-#: lib/vutuv_web/agent_docs/markdown.ex:491
+#: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/text.ex:267
-#: lib/vutuv_web/agent_docs/text.ex:510
-#: lib/vutuv_web/live/job_board_live.ex:363
-#: lib/vutuv_web/live/job_posting_live/form.ex:474
+#: lib/vutuv_web/agent_docs/text.ex:512
+#: lib/vutuv_web/live/job_board_live.ex:525
+#: lib/vutuv_web/live/job_posting_live/form.ex:500
 #, elixir-autogen, elixir-format
 msgid "Employment type"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:771
+#: lib/vutuv_web/live/job_posting_live/form.ex:817
 #, elixir-autogen, elixir-format
 msgid "Everyone (public)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:656
+#: lib/vutuv_web/live/job_posting_live/form.ex:682
 #: lib/vutuv_web/live/tag_live/timeline.ex:346
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
@@ -12037,7 +12039,7 @@ msgstr ""
 msgid "Highlighted tags match your profile."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:743
+#: lib/vutuv_web/live/job_posting_live/form.ex:789
 #, elixir-autogen, elixir-format
 msgid "How to apply"
 msgstr ""
@@ -12048,25 +12050,25 @@ msgstr ""
 msgid "Hybrid"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:128
+#: lib/vutuv_web/controllers/job_posting_controller.ex:146
 #, elixir-autogen, elixir-format
 msgid "I'm interested in your posting: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:691
+#: lib/vutuv_web/live/job_posting_live/form.ex:717
 #, elixir-autogen, elixir-format
 msgid "Job description"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:426
+#: lib/vutuv_web/live/job_posting_live/form.ex:452
 #, elixir-autogen, elixir-format
 msgid "Job title"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/job_board_doc.ex:19
+#: lib/vutuv_web/agent_docs/job_board_doc.ex:31
 #: lib/vutuv_web/components/saved_search_components.ex:56
-#: lib/vutuv_web/live/job_board_live.ex:45
-#: lib/vutuv_web/live/job_board_live.ex:211
+#: lib/vutuv_web/live/job_board_live.ex:49
+#: lib/vutuv_web/live/job_board_live.ex:259
 #: lib/vutuv_web/live/post_live/saved.ex:529
 #: lib/vutuv_web/live/shell_live.ex:1178
 #: lib/vutuv_web/templates/layout/app.html.heex:80
@@ -12074,18 +12076,18 @@ msgstr ""
 msgid "Jobs"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:781
+#: lib/vutuv_web/live/job_posting_live/form.ex:827
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this posting."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:465
-#: lib/vutuv_web/agent_docs/markdown.ex:468
+#: lib/vutuv_web/agent_docs/markdown.ex:467
 #: lib/vutuv_web/agent_docs/markdown.ex:470
-#: lib/vutuv_web/agent_docs/text.ex:484
-#: lib/vutuv_web/agent_docs/text.ex:487
+#: lib/vutuv_web/agent_docs/markdown.ex:472
+#: lib/vutuv_web/agent_docs/text.ex:486
 #: lib/vutuv_web/agent_docs/text.ex:489
-#: lib/vutuv_web/live/job_posting_live/form.ex:524
+#: lib/vutuv_web/agent_docs/text.ex:491
+#: lib/vutuv_web/live/job_posting_live/form.ex:550
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr ""
@@ -12122,20 +12124,20 @@ msgstr ""
 msgid "My postings"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:396
+#: lib/vutuv_web/live/job_posting_live/form.ex:422
 #, elixir-autogen, elixir-format
 msgid "New accounts can publish after a few days."
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:102
-#: lib/vutuv_web/live/job_posting_live/form.ex:114
+#: lib/vutuv_web/live/job_posting_live/form.ex:120
 #, elixir-autogen, elixir-format
 msgid "New posting"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:294
 #: lib/vutuv_web/agent_docs/text.ex:277
-#: lib/vutuv_web/live/job_posting_live/form.ex:731
+#: lib/vutuv_web/live/job_posting_live/form.ex:757
 #: lib/vutuv_web/live/job_posting_live/show.ex:177
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
@@ -12156,7 +12158,7 @@ msgstr ""
 msgid "Nothing here yet. Jobs you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:787
+#: lib/vutuv_web/live/job_posting_live/form.ex:833
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
@@ -12177,27 +12179,27 @@ msgstr ""
 msgid "Part-time"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:650
+#: lib/vutuv_web/live/job_posting_live/form.ex:676
 #, elixir-autogen, elixir-format
 msgid "Pay"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:395
+#: lib/vutuv_web/live/job_posting_live/form.ex:421
 #, elixir-autogen, elixir-format
 msgid "Please confirm your e-mail address first."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:71
+#: lib/vutuv_web/live/job_posting_live/form.ex:72
 #, elixir-autogen, elixir-format
 msgid "Please confirm your email address before posting a job."
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:120
+#: lib/vutuv_web/controllers/job_posting_controller.ex:138
 #, elixir-autogen, elixir-format
 msgid "Please log in to message the poster."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:77
+#: lib/vutuv_web/live/job_posting_live/form.ex:78
 #, elixir-autogen, elixir-format
 msgid "Please log in to post a job."
 msgstr ""
@@ -12207,38 +12209,38 @@ msgstr ""
 msgid "Please log in to see your postings."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:447
+#: lib/vutuv_web/live/job_posting_live/form.ex:473
 #, elixir-autogen, elixir-format
 msgid "Post as"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:536
+#: lib/vutuv_web/live/job_posting_live/form.ex:562
 #: lib/vutuv_web/templates/welcome/show.html.heex:67
 #, elixir-autogen, elixir-format
 msgid "Postal code"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:287
-#: lib/vutuv_web/agent_docs/markdown.ex:495
+#: lib/vutuv_web/agent_docs/markdown.ex:497
 #: lib/vutuv_web/agent_docs/text.ex:271
-#: lib/vutuv_web/agent_docs/text.ex:514
+#: lib/vutuv_web/agent_docs/text.ex:516
 #: lib/vutuv_web/live/job_posting_live/show.ex:156
 #, elixir-autogen, elixir-format
 msgid "Posted"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:505
+#: lib/vutuv_web/live/job_posting_live/form.ex:531
 #, elixir-autogen, elixir-format
 msgid "Posting language"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:50
-#: lib/vutuv_web/live/job_posting_live/form.ex:104
+#: lib/vutuv_web/live/job_posting_live/form.ex:110
 #, elixir-autogen, elixir-format
 msgid "Posting not found."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:802
+#: lib/vutuv_web/live/job_posting_live/form.ex:848
 #, elixir-autogen, elixir-format
 msgid "Publish"
 msgstr ""
@@ -12246,10 +12248,10 @@ msgstr ""
 #: lib/vutuv/accounts/user.ex:1238
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
-#: lib/vutuv_web/agent_docs/markdown.ex:468
 #: lib/vutuv_web/agent_docs/markdown.ex:470
-#: lib/vutuv_web/agent_docs/text.ex:487
+#: lib/vutuv_web/agent_docs/markdown.ex:472
 #: lib/vutuv_web/agent_docs/text.ex:489
+#: lib/vutuv_web/agent_docs/text.ex:491
 #: lib/vutuv_web/components/job_components.ex:140
 #: lib/vutuv_web/components/job_components.ex:141
 #, elixir-autogen, elixir-format
@@ -12263,16 +12265,16 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:293
 #: lib/vutuv_web/agent_docs/text.ex:276
-#: lib/vutuv_web/live/job_posting_live/form.ex:721
+#: lib/vutuv_web/live/job_posting_live/form.ex:747
 #: lib/vutuv_web/live/job_posting_live/show.ex:172
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:286
-#: lib/vutuv_web/agent_docs/markdown.ex:494
+#: lib/vutuv_web/agent_docs/markdown.ex:496
 #: lib/vutuv_web/agent_docs/text.ex:270
-#: lib/vutuv_web/agent_docs/text.ex:513
+#: lib/vutuv_web/agent_docs/text.ex:515
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr ""
@@ -12283,27 +12285,27 @@ msgid "Salary on request"
 msgstr ""
 
 #: lib/vutuv_web/controllers/settings_controller.ex:395
-#: lib/vutuv_web/live/job_posting_live/form.ex:354
+#: lib/vutuv_web/live/job_posting_live/form.ex:380
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:468
+#: lib/vutuv_web/live/job_posting_live/form.ex:494
 #, elixir-autogen, elixir-format
 msgid "Shown as an unverified employer name."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:384
+#: lib/vutuv_web/live/job_posting_live/form.ex:410
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:529
+#: lib/vutuv_web/live/job_posting_live/form.ex:555
 #, elixir-autogen, elixir-format
 msgid "Street (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:718
+#: lib/vutuv_web/live/job_posting_live/form.ex:744
 #, elixir-autogen, elixir-format
 msgid "Tags match your posting to members. Separate them with commas; a tag may be several words long, like Ruby on Rails."
 msgstr ""
@@ -12313,17 +12315,17 @@ msgstr ""
 msgid "Temporary"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:276
+#: lib/vutuv_web/live/job_posting_live/form.ex:302
 #, elixir-autogen, elixir-format
 msgid "That image could not be uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:422
+#: lib/vutuv_web/live/job_posting_live/form.ex:448
 #, elixir-autogen, elixir-format
 msgid "The role"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:402
+#: lib/vutuv_web/live/job_posting_live/form.ex:428
 #, elixir-autogen, elixir-format
 msgid "This organization has reached its published-postings limit."
 msgstr ""
@@ -12333,7 +12335,7 @@ msgstr ""
 msgid "This position is no longer available."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:441
+#: lib/vutuv_web/live/job_posting_live/form.ex:467
 #, elixir-autogen, elixir-format
 msgid "Tip: adding a gender marker like (m/w/d) helps your posting comply with the AGG. This is a suggestion, not legal advice."
 msgstr ""
@@ -12355,7 +12357,7 @@ msgstr ""
 msgid "Volunteer"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:769
+#: lib/vutuv_web/live/job_posting_live/form.ex:815
 #: lib/vutuv_web/templates/email/form_content.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Who can see it"
@@ -12367,15 +12369,15 @@ msgid "Working student"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:284
-#: lib/vutuv_web/agent_docs/markdown.ex:492
+#: lib/vutuv_web/agent_docs/markdown.ex:494
 #: lib/vutuv_web/agent_docs/text.ex:268
-#: lib/vutuv_web/agent_docs/text.ex:511
-#: lib/vutuv_web/live/job_posting_live/form.ex:489
+#: lib/vutuv_web/agent_docs/text.ex:513
+#: lib/vutuv_web/live/job_posting_live/form.ex:515
 #, elixir-autogen, elixir-format
 msgid "Workplace"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:399
+#: lib/vutuv_web/live/job_posting_live/form.ex:425
 #, elixir-autogen, elixir-format
 msgid "You already have the maximum number of published postings."
 msgstr ""
@@ -12420,18 +12422,18 @@ msgstr ""
 msgid "Your posting"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:334
-#: lib/vutuv_web/live/job_posting_live/form.ex:377
+#: lib/vutuv_web/live/job_posting_live/form.ex:360
+#: lib/vutuv_web/live/job_posting_live/form.ex:403
 #, elixir-autogen, elixir-format
 msgid "Your posting is live."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:450
+#: lib/vutuv_web/live/job_posting_live/form.ex:476
 #, elixir-autogen, elixir-format
 msgid "Yourself (personal posting)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:662
+#: lib/vutuv_web/live/job_posting_live/form.ex:688
 #, elixir-autogen, elixir-format
 msgid "up to"
 msgstr ""
@@ -12559,120 +12561,120 @@ msgid_plural "%{count} weeks ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/job_board_live.ex:471
+#: lib/vutuv_web/live/job_board_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "%{km} km"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:357
+#: lib/vutuv_web/live/job_board_live.ex:519
 #, elixir-autogen, elixir-format
 msgid "All countries"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:513
+#: lib/vutuv_web/agent_docs/markdown.ex:515
 #: lib/vutuv_web/templates/tag/show.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:531
+#: lib/vutuv_web/agent_docs/text.ex:533
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:364
+#: lib/vutuv_web/live/job_board_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Any employment type"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:346
+#: lib/vutuv_web/live/job_board_live.ex:508
 #, elixir-autogen, elixir-format
 msgid "City or zip code"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:471
+#: lib/vutuv_web/live/job_board_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "Exact"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:245
+#: lib/vutuv_web/live/job_board_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "From my salary expectation"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:237
+#: lib/vutuv_web/live/job_board_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "Matches my tags"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:452
+#: lib/vutuv_web/live/job_board_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Min. salary/year (%{currency})"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:406
+#: lib/vutuv_web/live/job_board_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "Minimum yearly salary"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:320
+#: lib/vutuv_web/live/job_board_live.ex:383
 #: lib/vutuv_web/live/organization_live/show.ex:834
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:306
+#: lib/vutuv_web/agent_docs/markdown.ex:308
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:289
+#: lib/vutuv_web/agent_docs/text.ex:291
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:479
+#: lib/vutuv_web/live/job_board_live.ex:641
 #, elixir-autogen, elixir-format
 msgid "No job postings yet."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:477
+#: lib/vutuv_web/live/job_board_live.ex:639
 #, elixir-autogen, elixir-format
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:511
-#: lib/vutuv_web/agent_docs/markdown.ex:523
-#: lib/vutuv_web/agent_docs/text.ex:529
-#: lib/vutuv_web/agent_docs/text.ex:541
+#: lib/vutuv_web/agent_docs/markdown.ex:513
+#: lib/vutuv_web/agent_docs/markdown.ex:525
+#: lib/vutuv_web/agent_docs/text.ex:531
+#: lib/vutuv_web/agent_docs/text.ex:543
 #: lib/vutuv_web/live/organization_live/show.ex:826
 #: lib/vutuv_web/templates/tag/show.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Open positions"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/job_board_doc.ex:20
-#: lib/vutuv_web/live/job_board_live.ex:213
+#: lib/vutuv_web/agent_docs/job_board_doc.ex:40
+#: lib/vutuv_web/live/job_board_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Open positions on vutuv, newest first."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:217
+#: lib/vutuv_web/live/job_board_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Post a job"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:305
+#: lib/vutuv_web/live/job_board_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "Post the first one"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:350
+#: lib/vutuv_web/live/job_board_live.ex:512
 #, elixir-autogen, elixir-format
 msgid "Radius"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:338
+#: lib/vutuv_web/live/job_board_live.ex:500
 #, elixir-autogen, elixir-format
 msgid "Search jobs"
 msgstr ""
@@ -13093,7 +13095,7 @@ msgstr ""
 msgid "Hide from specific viewers"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:793
+#: lib/vutuv_web/live/job_posting_live/form.ex:839
 #, elixir-autogen, elixir-format
 msgid "Hide from specific viewers (competitors, your own staff, a person) →"
 msgstr ""
@@ -13114,7 +13116,7 @@ msgstr ""
 msgid "Job exclusions – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:796
+#: lib/vutuv_web/live/job_posting_live/form.ex:842
 #, elixir-autogen, elixir-format
 msgid "Keep this posting on the board for everyone except a chosen few."
 msgstr ""
@@ -13412,32 +13414,32 @@ msgstr ""
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:419
+#: lib/vutuv_web/live/job_board_live.ex:581
 #, elixir-autogen, elixir-format
 msgid "Looking for a role that goes by several titles? Separate them with a comma and we show postings that match any of them."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:415
+#: lib/vutuv_web/live/job_board_live.ex:577
 #, elixir-autogen, elixir-format
 msgid "Search tips"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:462
+#: lib/vutuv_web/live/job_board_live.ex:624
 #, elixir-autogen, elixir-format
 msgid "any of these titles"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:464
+#: lib/vutuv_web/live/job_board_live.ex:626
 #, elixir-autogen, elixir-format
 msgid "exact wording"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:465
+#: lib/vutuv_web/live/job_board_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "without internships"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:463
+#: lib/vutuv_web/live/job_board_live.ex:625
 #, elixir-autogen, elixir-format
 msgid "word start: also finds Entwickler, Entwicklung"
 msgstr ""
@@ -13568,7 +13570,7 @@ msgstr ""
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1249
+#: lib/vutuv_web/agent_docs/markdown.ex:1274
 #: lib/vutuv_web/components/post_components.ex:5501
 #, elixir-autogen, elixir-format
 msgid "Book review"
@@ -13589,7 +13591,7 @@ msgstr ""
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1249
+#: lib/vutuv_web/agent_docs/markdown.ex:1274
 #: lib/vutuv_web/components/post_components.ex:5500
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -13679,7 +13681,7 @@ msgstr ""
 msgid "With qualification:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:788
+#: lib/vutuv_web/agent_docs/markdown.ex:790
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr ""
@@ -13768,19 +13770,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:937
+#: lib/vutuv_web/agent_docs/markdown.ex:939
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:936
+#: lib/vutuv_web/agent_docs/markdown.ex:938
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:942
+#: lib/vutuv_web/agent_docs/markdown.ex:944
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -13860,8 +13862,8 @@ msgstr ""
 msgid "View the uploaded proof (%{label})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:874
-#: lib/vutuv_web/agent_docs/text.ex:713
+#: lib/vutuv_web/agent_docs/markdown.ex:876
+#: lib/vutuv_web/agent_docs/text.ex:715
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
@@ -13944,8 +13946,8 @@ msgstr ""
 msgid "Skip for now"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:568
-#: lib/vutuv_web/agent_docs/text.ex:560
+#: lib/vutuv_web/agent_docs/markdown.ex:570
+#: lib/vutuv_web/agent_docs/text.ex:562
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr ""
@@ -14271,7 +14273,7 @@ msgstr ""
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:385
+#: lib/vutuv_web/live/job_board_live.ex:547
 #, elixir-autogen, elixir-format
 msgid "Filter by a tag"
 msgstr ""
@@ -14534,7 +14536,7 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1196
+#: lib/vutuv_web/agent_docs/markdown.ex:1221
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr ""
@@ -14918,8 +14920,8 @@ msgstr ""
 msgid "Your server"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:625
-#: lib/vutuv_web/agent_docs/text.ex:589
+#: lib/vutuv_web/agent_docs/markdown.ex:627
+#: lib/vutuv_web/agent_docs/text.ex:591
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr ""
@@ -15300,7 +15302,7 @@ msgid_plural "%{formatted} reposts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1198
+#: lib/vutuv_web/agent_docs/markdown.ex:1223
 #: lib/vutuv_web/components/post_components.ex:5942
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
@@ -15311,8 +15313,8 @@ msgstr ""
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1396
-#: lib/vutuv_web/agent_docs/text.ex:854
+#: lib/vutuv_web/agent_docs/markdown.ex:1421
+#: lib/vutuv_web/agent_docs/text.ex:876
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr ""
@@ -15336,7 +15338,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:135
 #: lib/vutuv_web/agent_docs/markdown.ex:167
-#: lib/vutuv_web/agent_docs/markdown.ex:1197
+#: lib/vutuv_web/agent_docs/markdown.ex:1222
 #: lib/vutuv_web/agent_docs/text.ex:124
 #: lib/vutuv_web/agent_docs/text.ex:153
 #, elixir-autogen, elixir-format
@@ -15394,7 +15396,7 @@ msgstr ""
 msgid "That reply is not yours to remove."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1398
+#: lib/vutuv_web/agent_docs/markdown.ex:1423
 #: lib/vutuv_web/components/post_components.ex:1427
 #: lib/vutuv_web/components/post_components.ex:1627
 #: lib/vutuv_web/components/post_components.ex:3004
@@ -16095,13 +16097,13 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1078
+#: lib/vutuv_web/agent_docs/markdown.ex:1080
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:562
-#: lib/vutuv_web/agent_docs/text.ex:551
+#: lib/vutuv_web/agent_docs/markdown.ex:564
+#: lib/vutuv_web/agent_docs/text.ex:553
 #: lib/vutuv_web/templates/user/edit.html.heex:219
 #: lib/vutuv_web/templates/user/show.html.heex:262
 #: lib/vutuv_web/views/account_event_text.ex:213
@@ -16149,8 +16151,8 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1315
-#: lib/vutuv_web/agent_docs/text.ex:808
+#: lib/vutuv_web/agent_docs/markdown.ex:1340
+#: lib/vutuv_web/agent_docs/text.ex:830
 #: lib/vutuv_web/live/post_live/composer.ex:2645
 #, elixir-autogen, elixir-format
 msgid "Cover"
@@ -16161,8 +16163,8 @@ msgstr ""
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1326
-#: lib/vutuv_web/agent_docs/text.ex:821
+#: lib/vutuv_web/agent_docs/markdown.ex:1351
+#: lib/vutuv_web/agent_docs/text.ex:843
 #: lib/vutuv_web/components/ui.ex:3126
 #, elixir-autogen, elixir-format
 msgid "Download the original"
@@ -16219,8 +16221,8 @@ msgstr ""
 msgid "Photo options"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1359
-#: lib/vutuv_web/agent_docs/text.ex:796
+#: lib/vutuv_web/agent_docs/markdown.ex:1384
+#: lib/vutuv_web/agent_docs/text.ex:818
 #: lib/vutuv_web/components/post_components.ex:4744
 #, elixir-autogen, elixir-format
 msgid "Photos:"
@@ -16381,13 +16383,13 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1216
+#: lib/vutuv_web/agent_docs/markdown.ex:1241
 #: lib/vutuv_web/components/post_components.ex:5980
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1214
+#: lib/vutuv_web/agent_docs/markdown.ex:1239
 #: lib/vutuv_web/components/post_components.ex:5977
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
@@ -17005,7 +17007,7 @@ msgstr ""
 msgid "What is being measured"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1055
+#: lib/vutuv_web/agent_docs/markdown.ex:1057
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
@@ -17156,8 +17158,8 @@ msgstr ""
 msgid "We could not reach the network just now. Please try again in a moment."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:982
-#: lib/vutuv_web/agent_docs/text.ex:635
+#: lib/vutuv_web/agent_docs/markdown.ex:984
+#: lib/vutuv_web/agent_docs/text.ex:637
 #, elixir-autogen, elixir-format
 msgid "verified profile"
 msgstr ""
@@ -18009,7 +18011,7 @@ msgstr ""
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1184
+#: lib/vutuv_web/agent_docs/markdown.ex:1209
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr ""
@@ -18051,12 +18053,12 @@ msgstr ""
 msgid "Your likes follow the site default again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1239
+#: lib/vutuv_web/agent_docs/markdown.ex:1264
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1236
+#: lib/vutuv_web/agent_docs/markdown.ex:1261
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr ""
@@ -18066,7 +18068,7 @@ msgstr ""
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1228
+#: lib/vutuv_web/agent_docs/markdown.ex:1253
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
@@ -18198,7 +18200,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3408
+#: lib/vutuv_web/live/post_live/feed.ex:3450
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -18400,7 +18402,7 @@ msgstr ""
 msgid "Employment references of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:856
+#: lib/vutuv_web/agent_docs/markdown.ex:858
 #, elixir-autogen, elixir-format
 msgid "document"
 msgstr ""
@@ -20739,6 +20741,7 @@ msgstr ""
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
+#: lib/vutuv_web/live/job_board_live.ex:430
 #: lib/vutuv_web/live/post_live/feed.ex:999
 #: lib/vutuv_web/views/user_html.ex:342
 #, elixir-autogen, elixir-format
@@ -21176,7 +21179,7 @@ msgstr ""
 msgid "E-mail to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:102
+#: lib/vutuv_web/controllers/job_posting_controller.ex:120
 #, elixir-autogen, elixir-format
 msgid "The employer takes applications on their own website."
 msgstr ""
@@ -21186,7 +21189,7 @@ msgstr ""
 msgid "Write e-mail"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:114
+#: lib/vutuv_web/controllers/job_posting_controller.ex:132
 #, elixir-autogen, elixir-format
 msgid "Your e-mail program opens with the subject filled in."
 msgstr ""
@@ -21197,34 +21200,34 @@ msgctxt "qualification detail"
 msgid "Jobs"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:829
+#: lib/vutuv_web/live/job_posting_live/form.ex:875
 #, elixir-autogen, elixir-format
 msgid "%{formatted} country chosen."
 msgid_plural "%{formatted} countries chosen."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:619
+#: lib/vutuv_web/live/job_posting_live/form.ex:645
 #, elixir-autogen, elixir-format
 msgid "No country chosen yet."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:611
+#: lib/vutuv_web/live/job_posting_live/form.ex:637
 #, elixir-autogen, elixir-format
 msgid "No country left to add for that."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:630
+#: lib/vutuv_web/live/job_posting_live/form.ex:656
 #, elixir-autogen, elixir-format
 msgid "Remove %{country}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:641
+#: lib/vutuv_web/live/job_posting_live/form.ex:667
 #, elixir-autogen, elixir-format
 msgid "Remove all"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:590
+#: lib/vutuv_web/live/job_posting_live/form.ex:616
 #, elixir-autogen, elixir-format
 msgid "Search for a country"
 msgstr ""
@@ -21359,7 +21362,7 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3569
+#: lib/vutuv_web/live/post_live/feed.ex:3611
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
@@ -21928,7 +21931,7 @@ msgstr ""
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3595
+#: lib/vutuv_web/live/post_live/feed.ex:3637
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
@@ -22005,10 +22008,10 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3182
-#: lib/vutuv_web/live/post_live/feed.ex:3209
-#: lib/vutuv_web/live/post_live/feed.ex:3643
-#: lib/vutuv_web/live/post_live/feed.ex:3648
+#: lib/vutuv_web/live/post_live/feed.ex:3224
+#: lib/vutuv_web/live/post_live/feed.ex:3251
+#: lib/vutuv_web/live/post_live/feed.ex:3685
+#: lib/vutuv_web/live/post_live/feed.ex:3690
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -22073,7 +22076,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3365
+#: lib/vutuv_web/live/post_live/feed.ex:3407
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr ""
@@ -22083,7 +22086,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3411
+#: lib/vutuv_web/live/post_live/feed.ex:3453
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22105,7 +22108,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3361
+#: lib/vutuv_web/live/post_live/feed.ex:3403
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -22192,7 +22195,7 @@ msgstr ""
 msgid "Page management"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2304
+#: lib/vutuv_web/live/post_live/feed.ex:2312
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
@@ -22204,12 +22207,12 @@ msgstr[1] ""
 msgid "Quoted post"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1071
+#: lib/vutuv_web/agent_docs/markdown.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Quotes %{name}: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1068
+#: lib/vutuv_web/agent_docs/markdown.ex:1070
 #, elixir-autogen, elixir-format
 msgid "Quotes %{url}"
 msgstr ""
@@ -22224,7 +22227,7 @@ msgstr ""
 msgid "{used} of {max} mentions"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2453
+#: lib/vutuv_web/live/post_live/feed.ex:2461
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""
@@ -22702,10 +22705,10 @@ msgstr ""
 msgid "This video could not be converted."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1311
-#: lib/vutuv_web/agent_docs/markdown.ex:1314
-#: lib/vutuv_web/agent_docs/text.ex:805
-#: lib/vutuv_web/agent_docs/text.ex:806
+#: lib/vutuv_web/agent_docs/markdown.ex:1336
+#: lib/vutuv_web/agent_docs/markdown.ex:1339
+#: lib/vutuv_web/agent_docs/text.ex:827
+#: lib/vutuv_web/agent_docs/text.ex:828
 #: lib/vutuv_web/components/post_components.ex:2506
 #: lib/vutuv_web/components/video_components.ex:126
 #: lib/vutuv_web/live/post_live/composer.ex:2442
@@ -22818,4 +22821,43 @@ msgstr ""
 #: lib/vutuv_web/components/video_components.ex:117
 #, elixir-autogen, elixir-format
 msgid "Standard quality. Play this video in HD."
+msgstr ""
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:773
+#, elixir-autogen, elixir-format
+msgid "Members carrying these tags:"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/job_board_doc.ex:44
+#: lib/vutuv_web/live/job_board_live.ex:262
+#, elixir-autogen, elixir-format
+msgid "No posting yet. Yours would be the first, and it would stand at the top on its own."
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1116
+#: lib/vutuv_web/agent_docs/text.ex:758
+#: lib/vutuv_web/live/job_board_live.ex:415
+#, elixir-autogen, elixir-format
+msgid "One member has said they are available."
+msgid_plural "%{formatted} members have said they are available."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/job_board_live.ex:475
+#, elixir-autogen, elixir-format
+msgid "The fields the most members carry, and how many of them do."
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1123
+#: lib/vutuv_web/agent_docs/text.ex:765
+#: lib/vutuv_web/live/job_board_live.ex:473
+#, elixir-autogen, elixir-format
+msgid "What members here work on"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1115
+#: lib/vutuv_web/agent_docs/text.ex:757
+#: lib/vutuv_web/live/job_board_live.ex:410
+#, elixir-autogen, elixir-format
+msgid "Who you would reach"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -100,10 +100,10 @@ msgstr ""
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:612
-#: lib/vutuv_web/agent_docs/markdown.ex:613
-#: lib/vutuv_web/agent_docs/text.ex:576
-#: lib/vutuv_web/agent_docs/text.ex:577
+#: lib/vutuv_web/agent_docs/markdown.ex:614
+#: lib/vutuv_web/agent_docs/markdown.ex:615
+#: lib/vutuv_web/agent_docs/text.ex:578
+#: lib/vutuv_web/agent_docs/text.ex:579
 #: lib/vutuv_web/templates/user/show.html.heex:1116
 #, elixir-autogen
 msgid "Birthday"
@@ -115,7 +115,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
 #: lib/vutuv_web/live/admin/user_delete_live.ex:202
-#: lib/vutuv_web/live/job_posting_live/form.ex:806
+#: lib/vutuv_web/live/job_posting_live/form.ex:852
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
 #: lib/vutuv_web/live/post_live/composer.ex:1901
@@ -176,7 +176,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:685
+#: lib/vutuv_web/live/job_posting_live/form.ex:711
 #: lib/vutuv_web/live/organization_live/edit.ex:305
 #: lib/vutuv_web/live/organization_live/edit.ex:318
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
@@ -304,14 +304,14 @@ msgstr ""
 msgid "Fax"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:598
+#: lib/vutuv_web/agent_docs/markdown.ex:600
 #: lib/vutuv_web/templates/user/edit.html.heex:164
 #, elixir-autogen
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:633
-#: lib/vutuv_web/agent_docs/text.ex:597
+#: lib/vutuv_web/agent_docs/markdown.ex:635
+#: lib/vutuv_web/agent_docs/text.ex:599
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
@@ -321,8 +321,8 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:634
-#: lib/vutuv_web/agent_docs/text.ex:598
+#: lib/vutuv_web/agent_docs/markdown.ex:636
+#: lib/vutuv_web/agent_docs/text.ex:600
 #: lib/vutuv_web/components/fediverse_components.ex:468
 #: lib/vutuv_web/components/ui.ex:2964
 #: lib/vutuv_web/components/ui.ex:2999
@@ -378,7 +378,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:600
+#: lib/vutuv_web/agent_docs/markdown.ex:602
 #: lib/vutuv_web/templates/user/edit.html.heex:169
 #, elixir-autogen
 msgid "Last Name"
@@ -445,7 +445,7 @@ msgstr ""
 msgid "Log in"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:599
+#: lib/vutuv_web/agent_docs/markdown.ex:601
 #: lib/vutuv_web/templates/user/edit.html.heex:174
 #, elixir-autogen
 msgid "Middle Name"
@@ -482,7 +482,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:602
+#: lib/vutuv_web/agent_docs/markdown.ex:604
 #: lib/vutuv_web/templates/user/edit.html.heex:179
 #, elixir-autogen
 msgid "Nickname"
@@ -563,7 +563,7 @@ msgstr ""
 msgid "Phone number updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:597
+#: lib/vutuv_web/agent_docs/markdown.ex:599
 #: lib/vutuv_web/templates/user/edit.html.heex:184
 #, elixir-autogen
 msgid "Prefix"
@@ -639,7 +639,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:219
 #: lib/vutuv_web/live/directory_search_live.ex:181
-#: lib/vutuv_web/live/job_board_live.ex:410
+#: lib/vutuv_web/live/job_board_live.ex:572
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
@@ -742,7 +742,7 @@ msgstr ""
 msgid "Submit a bugreport or a feature request."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:601
+#: lib/vutuv_web/agent_docs/markdown.ex:603
 #: lib/vutuv_web/templates/user/edit.html.heex:189
 #, elixir-autogen
 msgid "Suffix"
@@ -854,7 +854,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5097
 #: lib/vutuv_web/controllers/settings_controller.ex:171
-#: lib/vutuv_web/live/job_posting_live/form.ex:767
+#: lib/vutuv_web/live/job_posting_live/form.ex:813
 #: lib/vutuv_web/live/organization_live/edit.ex:339
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
@@ -1346,11 +1346,11 @@ msgid "Tag urls"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
-#: lib/vutuv_web/agent_docs/markdown.ex:505
-#: lib/vutuv_web/agent_docs/markdown.ex:1123
+#: lib/vutuv_web/agent_docs/markdown.ex:507
+#: lib/vutuv_web/agent_docs/markdown.ex:1148
 #: lib/vutuv_web/agent_docs/text.ex:31
-#: lib/vutuv_web/agent_docs/text.ex:524
-#: lib/vutuv_web/agent_docs/text.ex:770
+#: lib/vutuv_web/agent_docs/text.ex:526
+#: lib/vutuv_web/agent_docs/text.ex:792
 #: lib/vutuv_web/components/ui.ex:4982
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
@@ -1361,8 +1361,8 @@ msgstr ""
 #: lib/vutuv_web/cv/odt.ex:148
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:444
 #: lib/vutuv_web/live/cv_live.ex:323
-#: lib/vutuv_web/live/job_board_live.ex:276
-#: lib/vutuv_web/live/job_posting_live/form.ex:716
+#: lib/vutuv_web/live/job_board_live.ex:339
+#: lib/vutuv_web/live/job_posting_live/form.ex:742
 #: lib/vutuv_web/live/search_live.ex:347
 #: lib/vutuv_web/live/search_live.ex:818
 #: lib/vutuv_web/live/tag_new_live.ex:35
@@ -1537,8 +1537,8 @@ msgid "You'll receive an email with a login link."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:771
-#: lib/vutuv_web/live/job_board_live.ex:356
-#: lib/vutuv_web/live/job_posting_live/form.ex:548
+#: lib/vutuv_web/live/job_board_live.ex:518
+#: lib/vutuv_web/live/job_posting_live/form.ex:574
 #: lib/vutuv_web/live/organization_live/edit.ex:335
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
@@ -2060,7 +2060,7 @@ msgstr ""
 msgid "Markdown is supported: bold, italics, links and lists."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:709
+#: lib/vutuv_web/live/job_posting_live/form.ex:735
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr ""
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:162
 #: lib/vutuv_web/live/post_live/feed.ex:336
-#: lib/vutuv_web/live/post_live/feed.ex:3069
+#: lib/vutuv_web/live/post_live/feed.ex:3111
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1156
 #: lib/vutuv_web/live/shell_live.ex:1460
@@ -2149,7 +2149,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3385
+#: lib/vutuv_web/live/post_live/feed.ex:3427
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2240,7 +2240,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2310
+#: lib/vutuv_web/live/post_live/feed.ex:2318
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2369,7 +2369,7 @@ msgstr ""
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1161
+#: lib/vutuv_web/agent_docs/markdown.ex:1186
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
 #: lib/vutuv_web/live/shell_live.ex:1296
@@ -2389,7 +2389,7 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1160
+#: lib/vutuv_web/agent_docs/markdown.ex:1185
 #: lib/vutuv_web/components/post_components.ex:6038
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
@@ -2753,7 +2753,7 @@ msgid "Manage"
 msgstr ""
 
 #: lib/vutuv_web/controllers/page_controller.ex:216
-#: lib/vutuv_web/live/post_live/feed.ex:2350
+#: lib/vutuv_web/live/post_live/feed.ex:2358
 #: lib/vutuv_web/templates/user/show.html.heex:507
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2774,6 +2774,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] ""
 msgstr[1] ""
 
+#: lib/vutuv_web/live/job_board_live.ex:457
 #: lib/vutuv_web/live/post_live/feed.ex:1053
 #: lib/vutuv_web/templates/user/card_list.html.heex:51
 #, elixir-autogen, elixir-format
@@ -2782,8 +2783,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:635
-#: lib/vutuv_web/agent_docs/text.ex:599
+#: lib/vutuv_web/agent_docs/markdown.ex:637
+#: lib/vutuv_web/agent_docs/text.ex:601
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2935,8 +2936,8 @@ msgstr ""
 msgid "Bullying or harassment"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:345
-#: lib/vutuv_web/agent_docs/text.ex:326
+#: lib/vutuv_web/agent_docs/markdown.ex:347
+#: lib/vutuv_web/agent_docs/text.ex:328
 #: lib/vutuv_web/controllers/page_controller.ex:81
 #: lib/vutuv_web/templates/layout/app.html.heex:119
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3818,12 +3819,12 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:742
+#: lib/vutuv_web/agent_docs/markdown.ex:744
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1282
+#: lib/vutuv_web/agent_docs/markdown.ex:1307
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3837,11 +3838,11 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:91
 #: lib/vutuv_web/agent_docs/markdown.ex:204
 #: lib/vutuv_web/agent_docs/markdown.ex:218
-#: lib/vutuv_web/agent_docs/markdown.ex:1123
+#: lib/vutuv_web/agent_docs/markdown.ex:1148
 #: lib/vutuv_web/agent_docs/text.ex:86
 #: lib/vutuv_web/agent_docs/text.ex:187
 #: lib/vutuv_web/agent_docs/text.ex:201
-#: lib/vutuv_web/agent_docs/text.ex:770
+#: lib/vutuv_web/agent_docs/text.ex:792
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3855,33 +3856,33 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:158
 #: lib/vutuv_web/agent_docs/text.ex:112
 #: lib/vutuv_web/agent_docs/text.ex:144
-#: lib/vutuv_web/live/job_posting_live/form.ex:699
+#: lib/vutuv_web/live/job_posting_live/form.ex:725
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1141
-#: lib/vutuv_web/agent_docs/text.ex:781
+#: lib/vutuv_web/agent_docs/markdown.ex:1166
+#: lib/vutuv_web/agent_docs/text.ex:803
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1138
-#: lib/vutuv_web/agent_docs/text.ex:778
+#: lib/vutuv_web/agent_docs/markdown.ex:1163
+#: lib/vutuv_web/agent_docs/text.ex:800
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1145
-#: lib/vutuv_web/agent_docs/markdown.ex:1375
-#: lib/vutuv_web/agent_docs/text.ex:784
-#: lib/vutuv_web/agent_docs/text.ex:840
+#: lib/vutuv_web/agent_docs/markdown.ex:1170
+#: lib/vutuv_web/agent_docs/markdown.ex:1400
+#: lib/vutuv_web/agent_docs/text.ex:806
+#: lib/vutuv_web/agent_docs/text.ex:862
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:570
-#: lib/vutuv_web/agent_docs/text.ex:562
+#: lib/vutuv_web/agent_docs/markdown.ex:572
+#: lib/vutuv_web/agent_docs/text.ex:564
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
@@ -3920,23 +3921,23 @@ msgstr ""
 msgid "Posts (%{count} total)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:564
-#: lib/vutuv_web/agent_docs/text.ex:556
+#: lib/vutuv_web/agent_docs/markdown.ex:566
+#: lib/vutuv_web/agent_docs/text.ex:558
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1092
+#: lib/vutuv_web/agent_docs/markdown.ex:1094
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:954
+#: lib/vutuv_web/agent_docs/markdown.ex:956
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:955
+#: lib/vutuv_web/agent_docs/markdown.ex:957
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -4012,8 +4013,8 @@ msgstr ""
 msgid "Billing name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:359
-#: lib/vutuv_web/agent_docs/text.ex:334
+#: lib/vutuv_web/agent_docs/markdown.ex:361
+#: lib/vutuv_web/agent_docs/text.ex:336
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr ""
@@ -4037,7 +4038,7 @@ msgid "Booking requires a vutuv login."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
-#: lib/vutuv_web/live/job_posting_live/form.ex:542
+#: lib/vutuv_web/live/job_posting_live/form.ex:568
 #: lib/vutuv_web/live/organization_live/edit.ex:331
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
@@ -4066,8 +4067,8 @@ msgstr ""
 msgid "Markdown is supported. At most %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:349
-#: lib/vutuv_web/agent_docs/text.ex:330
+#: lib/vutuv_web/agent_docs/markdown.ex:351
+#: lib/vutuv_web/agent_docs/text.ex:332
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4083,8 +4084,8 @@ msgstr ""
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:346
-#: lib/vutuv_web/agent_docs/text.ex:327
+#: lib/vutuv_web/agent_docs/markdown.ex:348
+#: lib/vutuv_web/agent_docs/text.ex:329
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4298,14 +4299,14 @@ msgstr ""
 msgid "deleted account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:351
-#: lib/vutuv_web/agent_docs/text.ex:332
+#: lib/vutuv_web/agent_docs/markdown.ex:353
+#: lib/vutuv_web/agent_docs/text.ex:334
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:347
-#: lib/vutuv_web/agent_docs/text.ex:328
+#: lib/vutuv_web/agent_docs/markdown.ex:349
+#: lib/vutuv_web/agent_docs/text.ex:330
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr ""
@@ -4529,7 +4530,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3390
+#: lib/vutuv_web/live/post_live/feed.ex:3432
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4583,8 +4584,8 @@ msgstr ""
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:446
-#: lib/vutuv_web/agent_docs/text.ex:465
+#: lib/vutuv_web/agent_docs/markdown.ex:448
+#: lib/vutuv_web/agent_docs/text.ex:467
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/notification_live/index.ex:657
 #: lib/vutuv_web/live/notification_live/index.ex:1350
@@ -4658,7 +4659,7 @@ msgstr ""
 msgid "searches first names only (last: for last names)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:384
+#: lib/vutuv_web/live/job_board_live.ex:546
 #: lib/vutuv_web/live/tag_new_live.ex:47
 #: lib/vutuv_web/live/user_profile_live.ex:1358
 #: lib/vutuv_web/templates/user/show.html.heex:610
@@ -6126,8 +6127,8 @@ msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:614
-#: lib/vutuv_web/agent_docs/text.ex:578
+#: lib/vutuv_web/agent_docs/markdown.ex:616
+#: lib/vutuv_web/agent_docs/text.ex:580
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6199,7 +6200,7 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1160
+#: lib/vutuv_web/agent_docs/markdown.ex:1185
 #: lib/vutuv_web/components/post_components.ex:421
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
@@ -6309,7 +6310,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1136
+#: lib/vutuv_web/agent_docs/markdown.ex:1161
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6783,7 +6784,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:36
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:103
-#: lib/vutuv_web/live/job_posting_live/form.ex:318
+#: lib/vutuv_web/live/job_posting_live/form.ex:344
 #, elixir-autogen, elixir-format
 msgid "Draft saved."
 msgstr ""
@@ -7006,7 +7007,7 @@ msgstr ""
 msgid "Save audience"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:804
+#: lib/vutuv_web/live/job_posting_live/form.ex:850
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:16
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:11
 #, elixir-autogen, elixir-format
@@ -7415,7 +7416,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3656
+#: lib/vutuv_web/live/post_live/feed.ex:3698
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #, elixir-autogen
 msgid "Done"
@@ -7490,17 +7491,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1287
+#: lib/vutuv_web/agent_docs/markdown.ex:1312
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1290
+#: lib/vutuv_web/agent_docs/markdown.ex:1315
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1297
+#: lib/vutuv_web/agent_docs/markdown.ex:1322
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -7856,6 +7857,7 @@ msgid "Admins"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
+#: lib/vutuv_web/live/job_board_live.ex:467
 #: lib/vutuv_web/live/post_live/feed.ex:1062
 #, elixir-autogen, elixir-format
 msgid "All members"
@@ -7875,7 +7877,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:189
 #: lib/vutuv_web/live/admin/activity_live.ex:231
 #: lib/vutuv_web/live/admin/user_live.ex:184
-#: lib/vutuv_web/live/job_board_live.ex:256
+#: lib/vutuv_web/live/job_board_live.ex:319
 #: lib/vutuv_web/live/tag_live/timeline.ex:365
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
@@ -8591,10 +8593,10 @@ msgstr ""
 msgid "Write it under Admin › Legal pages"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:624
-#: lib/vutuv_web/agent_docs/markdown.ex:628
-#: lib/vutuv_web/agent_docs/text.ex:588
-#: lib/vutuv_web/agent_docs/text.ex:592
+#: lib/vutuv_web/agent_docs/markdown.ex:626
+#: lib/vutuv_web/agent_docs/markdown.ex:630
+#: lib/vutuv_web/agent_docs/text.ex:590
+#: lib/vutuv_web/agent_docs/text.ex:594
 #: lib/vutuv_web/components/organization_components.ex:276
 #: lib/vutuv_web/components/ui.ex:1695
 #: lib/vutuv_web/components/ui.ex:5113
@@ -8720,13 +8722,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:832
+#: lib/vutuv_web/agent_docs/markdown.ex:834
 #: lib/vutuv_web/views/education_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:831
+#: lib/vutuv_web/agent_docs/markdown.ex:833
 #: lib/vutuv_web/views/education_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8759,7 +8761,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1095
+#: lib/vutuv_web/agent_docs/markdown.ex:1097
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8984,8 +8986,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:644
-#: lib/vutuv_web/agent_docs/text.ex:606
+#: lib/vutuv_web/agent_docs/markdown.ex:646
+#: lib/vutuv_web/agent_docs/text.ex:608
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9409,8 +9411,8 @@ msgstr ""
 msgid "Yoruba"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:566
-#: lib/vutuv_web/agent_docs/text.ex:558
+#: lib/vutuv_web/agent_docs/markdown.ex:568
+#: lib/vutuv_web/agent_docs/text.ex:560
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr ""
@@ -9513,7 +9515,7 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:948
+#: lib/vutuv_web/agent_docs/markdown.ex:950
 #: lib/vutuv_web/views/qualification_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9593,7 +9595,7 @@ msgstr ""
 msgid "Expired"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:923
+#: lib/vutuv_web/agent_docs/markdown.ex:925
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9610,7 +9612,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:947
+#: lib/vutuv_web/agent_docs/markdown.ex:949
 #: lib/vutuv_web/views/qualification_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9637,7 +9639,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:921
+#: lib/vutuv_web/agent_docs/markdown.ex:923
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9652,7 +9654,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:922
+#: lib/vutuv_web/agent_docs/markdown.ex:924
 #: lib/vutuv_web/views/qualification_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "valid until %{date}"
@@ -9668,7 +9670,7 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:759
+#: lib/vutuv_web/agent_docs/markdown.ex:761
 #: lib/vutuv_web/live/section_reorder_live.ex:287
 #: lib/vutuv_web/views/language_html.ex:114
 #, elixir-autogen, elixir-format
@@ -10123,21 +10125,21 @@ msgstr ""
 msgid "Sign in with a one-time code (OTP) from an authenticator app or from a printed code list, typed into the normal PIN field. Your emailed PIN always keeps working."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:719
+#: lib/vutuv_web/agent_docs/markdown.ex:721
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:717
+#: lib/vutuv_web/agent_docs/markdown.ex:719
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:715
+#: lib/vutuv_web/agent_docs/markdown.ex:717
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10194,12 +10196,12 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:733
+#: lib/vutuv_web/agent_docs/markdown.ex:735
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:720
+#: lib/vutuv_web/agent_docs/markdown.ex:722
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -10758,7 +10760,7 @@ msgstr ""
 
 #: lib/vutuv/accounts/user.ex:1266
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
-#: lib/vutuv_web/live/job_posting_live/form.ex:772
+#: lib/vutuv_web/live/job_posting_live/form.ex:818
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr ""
@@ -10775,7 +10777,7 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:668
+#: lib/vutuv_web/live/job_posting_live/form.ex:694
 #: lib/vutuv_web/templates/user/edit.html.heex:321
 #: lib/vutuv_web/templates/welcome/show.html.heex:131
 #, elixir-autogen, elixir-format
@@ -10798,7 +10800,7 @@ msgstr ""
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:675
+#: lib/vutuv_web/live/job_posting_live/form.ex:701
 #: lib/vutuv_web/templates/user/edit.html.heex:317
 #: lib/vutuv_web/templates/welcome/show.html.heex:127
 #, elixir-autogen, elixir-format
@@ -11156,8 +11158,8 @@ msgstr ""
 msgid "Alias removed."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:438
-#: lib/vutuv_web/agent_docs/text.ex:458
+#: lib/vutuv_web/agent_docs/markdown.ex:440
+#: lib/vutuv_web/agent_docs/text.ex:460
 #: lib/vutuv_web/live/organization_live/edit.ex:384
 #: lib/vutuv_web/live/organization_live/show.ex:923
 #: lib/vutuv_web/templates/tag/single_card.html.heex:14
@@ -11378,8 +11380,8 @@ msgstr ""
 msgid "primary"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:459
-#: lib/vutuv_web/agent_docs/text.ex:478
+#: lib/vutuv_web/agent_docs/markdown.ex:461
+#: lib/vutuv_web/agent_docs/text.ex:480
 #: lib/vutuv_web/live/admin/organization_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -11502,8 +11504,8 @@ msgstr ""
 msgid "Verify via file"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:968
-#: lib/vutuv_web/agent_docs/text.ex:734
+#: lib/vutuv_web/agent_docs/markdown.ex:970
+#: lib/vutuv_web/agent_docs/text.ex:736
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -11539,8 +11541,8 @@ msgstr ""
 msgid "Remove link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:450
-#: lib/vutuv_web/agent_docs/text.ex:469
+#: lib/vutuv_web/agent_docs/markdown.ex:452
+#: lib/vutuv_web/agent_docs/text.ex:471
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr ""
@@ -11728,9 +11730,9 @@ msgstr ""
 msgid "Organization unfrozen."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:429
+#: lib/vutuv_web/agent_docs/markdown.ex:431
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
-#: lib/vutuv_web/agent_docs/text.ex:402
+#: lib/vutuv_web/agent_docs/text.ex:404
 #: lib/vutuv_web/components/ui.ex:5140
 #: lib/vutuv_web/controllers/settings_controller.ex:213
 #: lib/vutuv_web/live/organization_live/index.ex:32
@@ -11899,47 +11901,47 @@ msgstr ""
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:652
+#: lib/vutuv_web/live/job_posting_live/form.ex:678
 #, elixir-autogen, elixir-format
 msgid "A pay range is required to publish (except volunteer postings)."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:749
+#: lib/vutuv_web/live/job_posting_live/form.ex:795
 #, elixir-autogen, elixir-format
 msgid "A vutuv message to me"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:747
+#: lib/vutuv_web/live/job_posting_live/form.ex:793
 #, elixir-autogen, elixir-format
 msgid "A website"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:748
+#: lib/vutuv_web/live/job_posting_live/form.ex:794
 #, elixir-autogen, elixir-format
 msgid "An e-mail address"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:563
+#: lib/vutuv_web/live/job_posting_live/form.ex:589
 #, elixir-autogen, elixir-format
 msgid "Applicants must be located in"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:753
+#: lib/vutuv_web/live/job_posting_live/form.ex:799
 #, elixir-autogen, elixir-format
 msgid "Application URL"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:759
+#: lib/vutuv_web/live/job_posting_live/form.ex:805
 #, elixir-autogen, elixir-format
 msgid "Application e-mail"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:109
+#: lib/vutuv_web/controllers/job_posting_controller.ex:127
 #, elixir-autogen, elixir-format
 msgid "Application: %{title}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:745
+#: lib/vutuv_web/live/job_posting_live/form.ex:791
 #, elixir-autogen, elixir-format
 msgid "Applications go to"
 msgstr ""
@@ -11971,7 +11973,7 @@ msgstr ""
 msgid "Contract"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:692
+#: lib/vutuv_web/live/job_posting_live/form.ex:718
 #, elixir-autogen, elixir-format
 msgid "Describe the role. Markdown is supported."
 msgstr ""
@@ -11981,15 +11983,15 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:114
+#: lib/vutuv_web/live/job_posting_live/form.ex:120
 #, elixir-autogen, elixir-format
 msgid "Edit posting"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:282
-#: lib/vutuv_web/agent_docs/markdown.ex:490
+#: lib/vutuv_web/agent_docs/markdown.ex:492
 #: lib/vutuv_web/agent_docs/text.ex:266
-#: lib/vutuv_web/agent_docs/text.ex:509
+#: lib/vutuv_web/agent_docs/text.ex:511
 #: lib/vutuv_web/live/admin/job_live.ex:340
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
 #: lib/vutuv_web/views/account_event_text.ex:225
@@ -11997,27 +11999,27 @@ msgstr ""
 msgid "Employer"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:459
+#: lib/vutuv_web/live/job_posting_live/form.ex:485
 #, elixir-autogen, elixir-format
 msgid "Employer name (optional)"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:283
-#: lib/vutuv_web/agent_docs/markdown.ex:491
+#: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/text.ex:267
-#: lib/vutuv_web/agent_docs/text.ex:510
-#: lib/vutuv_web/live/job_board_live.ex:363
-#: lib/vutuv_web/live/job_posting_live/form.ex:474
+#: lib/vutuv_web/agent_docs/text.ex:512
+#: lib/vutuv_web/live/job_board_live.ex:525
+#: lib/vutuv_web/live/job_posting_live/form.ex:500
 #, elixir-autogen, elixir-format
 msgid "Employment type"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:771
+#: lib/vutuv_web/live/job_posting_live/form.ex:817
 #, elixir-autogen, elixir-format
 msgid "Everyone (public)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:656
+#: lib/vutuv_web/live/job_posting_live/form.ex:682
 #: lib/vutuv_web/live/tag_live/timeline.ex:346
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
@@ -12035,7 +12037,7 @@ msgstr ""
 msgid "Highlighted tags match your profile."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:743
+#: lib/vutuv_web/live/job_posting_live/form.ex:789
 #, elixir-autogen, elixir-format
 msgid "How to apply"
 msgstr ""
@@ -12046,25 +12048,25 @@ msgstr ""
 msgid "Hybrid"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:128
+#: lib/vutuv_web/controllers/job_posting_controller.ex:146
 #, elixir-autogen, elixir-format
 msgid "I'm interested in your posting: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:691
+#: lib/vutuv_web/live/job_posting_live/form.ex:717
 #, elixir-autogen, elixir-format
 msgid "Job description"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:426
+#: lib/vutuv_web/live/job_posting_live/form.ex:452
 #, elixir-autogen, elixir-format
 msgid "Job title"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/job_board_doc.ex:19
+#: lib/vutuv_web/agent_docs/job_board_doc.ex:31
 #: lib/vutuv_web/components/saved_search_components.ex:56
-#: lib/vutuv_web/live/job_board_live.ex:45
-#: lib/vutuv_web/live/job_board_live.ex:211
+#: lib/vutuv_web/live/job_board_live.ex:49
+#: lib/vutuv_web/live/job_board_live.ex:259
 #: lib/vutuv_web/live/post_live/saved.ex:529
 #: lib/vutuv_web/live/shell_live.ex:1178
 #: lib/vutuv_web/templates/layout/app.html.heex:80
@@ -12072,18 +12074,18 @@ msgstr ""
 msgid "Jobs"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:781
+#: lib/vutuv_web/live/job_posting_live/form.ex:827
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this posting."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:465
-#: lib/vutuv_web/agent_docs/markdown.ex:468
+#: lib/vutuv_web/agent_docs/markdown.ex:467
 #: lib/vutuv_web/agent_docs/markdown.ex:470
-#: lib/vutuv_web/agent_docs/text.ex:484
-#: lib/vutuv_web/agent_docs/text.ex:487
+#: lib/vutuv_web/agent_docs/markdown.ex:472
+#: lib/vutuv_web/agent_docs/text.ex:486
 #: lib/vutuv_web/agent_docs/text.ex:489
-#: lib/vutuv_web/live/job_posting_live/form.ex:524
+#: lib/vutuv_web/agent_docs/text.ex:491
+#: lib/vutuv_web/live/job_posting_live/form.ex:550
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr ""
@@ -12120,20 +12122,20 @@ msgstr ""
 msgid "My postings"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:396
+#: lib/vutuv_web/live/job_posting_live/form.ex:422
 #, elixir-autogen, elixir-format
 msgid "New accounts can publish after a few days."
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:102
-#: lib/vutuv_web/live/job_posting_live/form.ex:114
+#: lib/vutuv_web/live/job_posting_live/form.ex:120
 #, elixir-autogen, elixir-format
 msgid "New posting"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:294
 #: lib/vutuv_web/agent_docs/text.ex:277
-#: lib/vutuv_web/live/job_posting_live/form.ex:731
+#: lib/vutuv_web/live/job_posting_live/form.ex:757
 #: lib/vutuv_web/live/job_posting_live/show.ex:177
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
@@ -12154,7 +12156,7 @@ msgstr ""
 msgid "Nothing here yet. Jobs you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:787
+#: lib/vutuv_web/live/job_posting_live/form.ex:833
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
@@ -12175,27 +12177,27 @@ msgstr ""
 msgid "Part-time"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:650
+#: lib/vutuv_web/live/job_posting_live/form.ex:676
 #, elixir-autogen, elixir-format
 msgid "Pay"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:395
+#: lib/vutuv_web/live/job_posting_live/form.ex:421
 #, elixir-autogen, elixir-format
 msgid "Please confirm your e-mail address first."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:71
+#: lib/vutuv_web/live/job_posting_live/form.ex:72
 #, elixir-autogen, elixir-format
 msgid "Please confirm your email address before posting a job."
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:120
+#: lib/vutuv_web/controllers/job_posting_controller.ex:138
 #, elixir-autogen, elixir-format
 msgid "Please log in to message the poster."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:77
+#: lib/vutuv_web/live/job_posting_live/form.ex:78
 #, elixir-autogen, elixir-format
 msgid "Please log in to post a job."
 msgstr ""
@@ -12205,38 +12207,38 @@ msgstr ""
 msgid "Please log in to see your postings."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:447
+#: lib/vutuv_web/live/job_posting_live/form.ex:473
 #, elixir-autogen, elixir-format
 msgid "Post as"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:536
+#: lib/vutuv_web/live/job_posting_live/form.ex:562
 #: lib/vutuv_web/templates/welcome/show.html.heex:67
 #, elixir-autogen, elixir-format
 msgid "Postal code"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:287
-#: lib/vutuv_web/agent_docs/markdown.ex:495
+#: lib/vutuv_web/agent_docs/markdown.ex:497
 #: lib/vutuv_web/agent_docs/text.ex:271
-#: lib/vutuv_web/agent_docs/text.ex:514
+#: lib/vutuv_web/agent_docs/text.ex:516
 #: lib/vutuv_web/live/job_posting_live/show.ex:156
 #, elixir-autogen, elixir-format
 msgid "Posted"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:505
+#: lib/vutuv_web/live/job_posting_live/form.ex:531
 #, elixir-autogen, elixir-format
 msgid "Posting language"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:50
-#: lib/vutuv_web/live/job_posting_live/form.ex:104
+#: lib/vutuv_web/live/job_posting_live/form.ex:110
 #, elixir-autogen, elixir-format
 msgid "Posting not found."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:802
+#: lib/vutuv_web/live/job_posting_live/form.ex:848
 #, elixir-autogen, elixir-format
 msgid "Publish"
 msgstr ""
@@ -12244,10 +12246,10 @@ msgstr ""
 #: lib/vutuv/accounts/user.ex:1238
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
-#: lib/vutuv_web/agent_docs/markdown.ex:468
 #: lib/vutuv_web/agent_docs/markdown.ex:470
-#: lib/vutuv_web/agent_docs/text.ex:487
+#: lib/vutuv_web/agent_docs/markdown.ex:472
 #: lib/vutuv_web/agent_docs/text.ex:489
+#: lib/vutuv_web/agent_docs/text.ex:491
 #: lib/vutuv_web/components/job_components.ex:140
 #: lib/vutuv_web/components/job_components.ex:141
 #, elixir-autogen, elixir-format
@@ -12261,16 +12263,16 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:293
 #: lib/vutuv_web/agent_docs/text.ex:276
-#: lib/vutuv_web/live/job_posting_live/form.ex:721
+#: lib/vutuv_web/live/job_posting_live/form.ex:747
 #: lib/vutuv_web/live/job_posting_live/show.ex:172
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:286
-#: lib/vutuv_web/agent_docs/markdown.ex:494
+#: lib/vutuv_web/agent_docs/markdown.ex:496
 #: lib/vutuv_web/agent_docs/text.ex:270
-#: lib/vutuv_web/agent_docs/text.ex:513
+#: lib/vutuv_web/agent_docs/text.ex:515
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr ""
@@ -12281,27 +12283,27 @@ msgid "Salary on request"
 msgstr ""
 
 #: lib/vutuv_web/controllers/settings_controller.ex:395
-#: lib/vutuv_web/live/job_posting_live/form.ex:354
+#: lib/vutuv_web/live/job_posting_live/form.ex:380
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:468
+#: lib/vutuv_web/live/job_posting_live/form.ex:494
 #, elixir-autogen, elixir-format
 msgid "Shown as an unverified employer name."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:384
+#: lib/vutuv_web/live/job_posting_live/form.ex:410
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:529
+#: lib/vutuv_web/live/job_posting_live/form.ex:555
 #, elixir-autogen, elixir-format
 msgid "Street (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:718
+#: lib/vutuv_web/live/job_posting_live/form.ex:744
 #, elixir-autogen, elixir-format
 msgid "Tags match your posting to members. Separate them with commas; a tag may be several words long, like Ruby on Rails."
 msgstr ""
@@ -12311,17 +12313,17 @@ msgstr ""
 msgid "Temporary"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:276
+#: lib/vutuv_web/live/job_posting_live/form.ex:302
 #, elixir-autogen, elixir-format
 msgid "That image could not be uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:422
+#: lib/vutuv_web/live/job_posting_live/form.ex:448
 #, elixir-autogen, elixir-format
 msgid "The role"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:402
+#: lib/vutuv_web/live/job_posting_live/form.ex:428
 #, elixir-autogen, elixir-format
 msgid "This organization has reached its published-postings limit."
 msgstr ""
@@ -12331,7 +12333,7 @@ msgstr ""
 msgid "This position is no longer available."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:441
+#: lib/vutuv_web/live/job_posting_live/form.ex:467
 #, elixir-autogen, elixir-format
 msgid "Tip: adding a gender marker like (m/w/d) helps your posting comply with the AGG. This is a suggestion, not legal advice."
 msgstr ""
@@ -12353,7 +12355,7 @@ msgstr ""
 msgid "Volunteer"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:769
+#: lib/vutuv_web/live/job_posting_live/form.ex:815
 #: lib/vutuv_web/templates/email/form_content.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Who can see it"
@@ -12365,15 +12367,15 @@ msgid "Working student"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:284
-#: lib/vutuv_web/agent_docs/markdown.ex:492
+#: lib/vutuv_web/agent_docs/markdown.ex:494
 #: lib/vutuv_web/agent_docs/text.ex:268
-#: lib/vutuv_web/agent_docs/text.ex:511
-#: lib/vutuv_web/live/job_posting_live/form.ex:489
+#: lib/vutuv_web/agent_docs/text.ex:513
+#: lib/vutuv_web/live/job_posting_live/form.ex:515
 #, elixir-autogen, elixir-format
 msgid "Workplace"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:399
+#: lib/vutuv_web/live/job_posting_live/form.ex:425
 #, elixir-autogen, elixir-format
 msgid "You already have the maximum number of published postings."
 msgstr ""
@@ -12418,18 +12420,18 @@ msgstr ""
 msgid "Your posting"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:334
-#: lib/vutuv_web/live/job_posting_live/form.ex:377
+#: lib/vutuv_web/live/job_posting_live/form.ex:360
+#: lib/vutuv_web/live/job_posting_live/form.ex:403
 #, elixir-autogen, elixir-format
 msgid "Your posting is live."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:450
+#: lib/vutuv_web/live/job_posting_live/form.ex:476
 #, elixir-autogen, elixir-format
 msgid "Yourself (personal posting)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:662
+#: lib/vutuv_web/live/job_posting_live/form.ex:688
 #, elixir-autogen, elixir-format
 msgid "up to"
 msgstr ""
@@ -12557,120 +12559,120 @@ msgid_plural "%{count} weeks ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/job_board_live.ex:471
+#: lib/vutuv_web/live/job_board_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "%{km} km"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:357
+#: lib/vutuv_web/live/job_board_live.ex:519
 #, elixir-autogen, elixir-format
 msgid "All countries"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:513
+#: lib/vutuv_web/agent_docs/markdown.ex:515
 #: lib/vutuv_web/templates/tag/show.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:531
+#: lib/vutuv_web/agent_docs/text.ex:533
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:364
+#: lib/vutuv_web/live/job_board_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Any employment type"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:346
+#: lib/vutuv_web/live/job_board_live.ex:508
 #, elixir-autogen, elixir-format
 msgid "City or zip code"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:471
+#: lib/vutuv_web/live/job_board_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "Exact"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:245
+#: lib/vutuv_web/live/job_board_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "From my salary expectation"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:237
+#: lib/vutuv_web/live/job_board_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "Matches my tags"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:452
+#: lib/vutuv_web/live/job_board_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Min. salary/year (%{currency})"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:406
+#: lib/vutuv_web/live/job_board_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "Minimum yearly salary"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:320
+#: lib/vutuv_web/live/job_board_live.ex:383
 #: lib/vutuv_web/live/organization_live/show.ex:834
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:306
+#: lib/vutuv_web/agent_docs/markdown.ex:308
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:289
+#: lib/vutuv_web/agent_docs/text.ex:291
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:479
+#: lib/vutuv_web/live/job_board_live.ex:641
 #, elixir-autogen, elixir-format
 msgid "No job postings yet."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:477
+#: lib/vutuv_web/live/job_board_live.ex:639
 #, elixir-autogen, elixir-format
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:511
-#: lib/vutuv_web/agent_docs/markdown.ex:523
-#: lib/vutuv_web/agent_docs/text.ex:529
-#: lib/vutuv_web/agent_docs/text.ex:541
+#: lib/vutuv_web/agent_docs/markdown.ex:513
+#: lib/vutuv_web/agent_docs/markdown.ex:525
+#: lib/vutuv_web/agent_docs/text.ex:531
+#: lib/vutuv_web/agent_docs/text.ex:543
 #: lib/vutuv_web/live/organization_live/show.ex:826
 #: lib/vutuv_web/templates/tag/show.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Open positions"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/job_board_doc.ex:20
-#: lib/vutuv_web/live/job_board_live.ex:213
+#: lib/vutuv_web/agent_docs/job_board_doc.ex:40
+#: lib/vutuv_web/live/job_board_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Open positions on vutuv, newest first."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:217
+#: lib/vutuv_web/live/job_board_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Post a job"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:305
+#: lib/vutuv_web/live/job_board_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "Post the first one"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:350
+#: lib/vutuv_web/live/job_board_live.ex:512
 #, elixir-autogen, elixir-format
 msgid "Radius"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:338
+#: lib/vutuv_web/live/job_board_live.ex:500
 #, elixir-autogen, elixir-format
 msgid "Search jobs"
 msgstr ""
@@ -13091,7 +13093,7 @@ msgstr ""
 msgid "Hide from specific viewers"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:793
+#: lib/vutuv_web/live/job_posting_live/form.ex:839
 #, elixir-autogen, elixir-format
 msgid "Hide from specific viewers (competitors, your own staff, a person) →"
 msgstr ""
@@ -13112,7 +13114,7 @@ msgstr ""
 msgid "Job exclusions – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:796
+#: lib/vutuv_web/live/job_posting_live/form.ex:842
 #, elixir-autogen, elixir-format
 msgid "Keep this posting on the board for everyone except a chosen few."
 msgstr ""
@@ -13410,32 +13412,32 @@ msgstr ""
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:419
+#: lib/vutuv_web/live/job_board_live.ex:581
 #, elixir-autogen, elixir-format
 msgid "Looking for a role that goes by several titles? Separate them with a comma and we show postings that match any of them."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:415
+#: lib/vutuv_web/live/job_board_live.ex:577
 #, elixir-autogen, elixir-format
 msgid "Search tips"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:462
+#: lib/vutuv_web/live/job_board_live.ex:624
 #, elixir-autogen, elixir-format
 msgid "any of these titles"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:464
+#: lib/vutuv_web/live/job_board_live.ex:626
 #, elixir-autogen, elixir-format
 msgid "exact wording"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:465
+#: lib/vutuv_web/live/job_board_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "without internships"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:463
+#: lib/vutuv_web/live/job_board_live.ex:625
 #, elixir-autogen, elixir-format
 msgid "word start: also finds Entwickler, Entwicklung"
 msgstr ""
@@ -13566,7 +13568,7 @@ msgstr ""
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1249
+#: lib/vutuv_web/agent_docs/markdown.ex:1274
 #: lib/vutuv_web/components/post_components.ex:5501
 #, elixir-autogen, elixir-format
 msgid "Book review"
@@ -13587,7 +13589,7 @@ msgstr ""
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1249
+#: lib/vutuv_web/agent_docs/markdown.ex:1274
 #: lib/vutuv_web/components/post_components.ex:5500
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -13677,7 +13679,7 @@ msgstr ""
 msgid "With qualification:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:788
+#: lib/vutuv_web/agent_docs/markdown.ex:790
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr ""
@@ -13766,19 +13768,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:937
+#: lib/vutuv_web/agent_docs/markdown.ex:939
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:936
+#: lib/vutuv_web/agent_docs/markdown.ex:938
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:942
+#: lib/vutuv_web/agent_docs/markdown.ex:944
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -13858,8 +13860,8 @@ msgstr ""
 msgid "View the uploaded proof (%{label})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:874
-#: lib/vutuv_web/agent_docs/text.ex:713
+#: lib/vutuv_web/agent_docs/markdown.ex:876
+#: lib/vutuv_web/agent_docs/text.ex:715
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
@@ -13942,8 +13944,8 @@ msgstr ""
 msgid "Skip for now"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:568
-#: lib/vutuv_web/agent_docs/text.ex:560
+#: lib/vutuv_web/agent_docs/markdown.ex:570
+#: lib/vutuv_web/agent_docs/text.ex:562
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr ""
@@ -14269,7 +14271,7 @@ msgstr ""
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:385
+#: lib/vutuv_web/live/job_board_live.ex:547
 #, elixir-autogen, elixir-format
 msgid "Filter by a tag"
 msgstr ""
@@ -14532,7 +14534,7 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1196
+#: lib/vutuv_web/agent_docs/markdown.ex:1221
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr ""
@@ -14916,8 +14918,8 @@ msgstr ""
 msgid "Your server"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:625
-#: lib/vutuv_web/agent_docs/text.ex:589
+#: lib/vutuv_web/agent_docs/markdown.ex:627
+#: lib/vutuv_web/agent_docs/text.ex:591
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr ""
@@ -15298,7 +15300,7 @@ msgid_plural "%{formatted} reposts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1198
+#: lib/vutuv_web/agent_docs/markdown.ex:1223
 #: lib/vutuv_web/components/post_components.ex:5942
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
@@ -15309,8 +15311,8 @@ msgstr ""
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1396
-#: lib/vutuv_web/agent_docs/text.ex:854
+#: lib/vutuv_web/agent_docs/markdown.ex:1421
+#: lib/vutuv_web/agent_docs/text.ex:876
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Content warning"
 msgstr ""
@@ -15334,7 +15336,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:135
 #: lib/vutuv_web/agent_docs/markdown.ex:167
-#: lib/vutuv_web/agent_docs/markdown.ex:1197
+#: lib/vutuv_web/agent_docs/markdown.ex:1222
 #: lib/vutuv_web/agent_docs/text.ex:124
 #: lib/vutuv_web/agent_docs/text.ex:153
 #, elixir-autogen, elixir-format
@@ -15392,7 +15394,7 @@ msgstr ""
 msgid "That reply is not yours to remove."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1398
+#: lib/vutuv_web/agent_docs/markdown.ex:1423
 #: lib/vutuv_web/components/post_components.ex:1427
 #: lib/vutuv_web/components/post_components.ex:1627
 #: lib/vutuv_web/components/post_components.ex:3004
@@ -16093,13 +16095,13 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1078
+#: lib/vutuv_web/agent_docs/markdown.ex:1080
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:562
-#: lib/vutuv_web/agent_docs/text.ex:551
+#: lib/vutuv_web/agent_docs/markdown.ex:564
+#: lib/vutuv_web/agent_docs/text.ex:553
 #: lib/vutuv_web/templates/user/edit.html.heex:219
 #: lib/vutuv_web/templates/user/show.html.heex:262
 #: lib/vutuv_web/views/account_event_text.ex:213
@@ -16147,8 +16149,8 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1315
-#: lib/vutuv_web/agent_docs/text.ex:808
+#: lib/vutuv_web/agent_docs/markdown.ex:1340
+#: lib/vutuv_web/agent_docs/text.ex:830
 #: lib/vutuv_web/live/post_live/composer.ex:2645
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
@@ -16159,8 +16161,8 @@ msgstr ""
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1326
-#: lib/vutuv_web/agent_docs/text.ex:821
+#: lib/vutuv_web/agent_docs/markdown.ex:1351
+#: lib/vutuv_web/agent_docs/text.ex:843
 #: lib/vutuv_web/components/ui.ex:3126
 #, elixir-autogen, elixir-format
 msgid "Download the original"
@@ -16217,8 +16219,8 @@ msgstr ""
 msgid "Photo options"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1359
-#: lib/vutuv_web/agent_docs/text.ex:796
+#: lib/vutuv_web/agent_docs/markdown.ex:1384
+#: lib/vutuv_web/agent_docs/text.ex:818
 #: lib/vutuv_web/components/post_components.ex:4744
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
@@ -16379,13 +16381,13 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1216
+#: lib/vutuv_web/agent_docs/markdown.ex:1241
 #: lib/vutuv_web/components/post_components.ex:5980
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1214
+#: lib/vutuv_web/agent_docs/markdown.ex:1239
 #: lib/vutuv_web/components/post_components.ex:5977
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
@@ -17003,7 +17005,7 @@ msgstr ""
 msgid "What is being measured"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1055
+#: lib/vutuv_web/agent_docs/markdown.ex:1057
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
@@ -17154,8 +17156,8 @@ msgstr ""
 msgid "We could not reach the network just now. Please try again in a moment."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:982
-#: lib/vutuv_web/agent_docs/text.ex:635
+#: lib/vutuv_web/agent_docs/markdown.ex:984
+#: lib/vutuv_web/agent_docs/text.ex:637
 #, elixir-autogen, elixir-format, fuzzy
 msgid "verified profile"
 msgstr ""
@@ -18007,7 +18009,7 @@ msgstr ""
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1184
+#: lib/vutuv_web/agent_docs/markdown.ex:1209
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr ""
@@ -18049,12 +18051,12 @@ msgstr ""
 msgid "Your likes follow the site default again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1239
+#: lib/vutuv_web/agent_docs/markdown.ex:1264
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1236
+#: lib/vutuv_web/agent_docs/markdown.ex:1261
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr ""
@@ -18064,7 +18066,7 @@ msgstr ""
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1228
+#: lib/vutuv_web/agent_docs/markdown.ex:1253
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
@@ -18196,7 +18198,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3408
+#: lib/vutuv_web/live/post_live/feed.ex:3450
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Loading…"
@@ -18398,7 +18400,7 @@ msgstr ""
 msgid "Employment references of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:856
+#: lib/vutuv_web/agent_docs/markdown.ex:858
 #, elixir-autogen, elixir-format, fuzzy
 msgid "document"
 msgstr ""
@@ -20737,6 +20739,7 @@ msgstr ""
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
+#: lib/vutuv_web/live/job_board_live.ex:430
 #: lib/vutuv_web/live/post_live/feed.ex:999
 #: lib/vutuv_web/views/user_html.ex:342
 #, elixir-autogen, elixir-format
@@ -21174,7 +21177,7 @@ msgstr ""
 msgid "E-mail to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:102
+#: lib/vutuv_web/controllers/job_posting_controller.ex:120
 #, elixir-autogen, elixir-format
 msgid "The employer takes applications on their own website."
 msgstr ""
@@ -21184,7 +21187,7 @@ msgstr ""
 msgid "Write e-mail"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:114
+#: lib/vutuv_web/controllers/job_posting_controller.ex:132
 #, elixir-autogen, elixir-format
 msgid "Your e-mail program opens with the subject filled in."
 msgstr ""
@@ -21195,34 +21198,34 @@ msgctxt "qualification detail"
 msgid "Jobs"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:829
+#: lib/vutuv_web/live/job_posting_live/form.ex:875
 #, elixir-autogen, elixir-format
 msgid "%{formatted} country chosen."
 msgid_plural "%{formatted} countries chosen."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:619
+#: lib/vutuv_web/live/job_posting_live/form.ex:645
 #, elixir-autogen, elixir-format
 msgid "No country chosen yet."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:611
+#: lib/vutuv_web/live/job_posting_live/form.ex:637
 #, elixir-autogen, elixir-format
 msgid "No country left to add for that."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:630
+#: lib/vutuv_web/live/job_posting_live/form.ex:656
 #, elixir-autogen, elixir-format
 msgid "Remove %{country}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:641
+#: lib/vutuv_web/live/job_posting_live/form.ex:667
 #, elixir-autogen, elixir-format
 msgid "Remove all"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:590
+#: lib/vutuv_web/live/job_posting_live/form.ex:616
 #, elixir-autogen, elixir-format
 msgid "Search for a country"
 msgstr ""
@@ -21357,7 +21360,7 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3569
+#: lib/vutuv_web/live/post_live/feed.ex:3611
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
@@ -21926,7 +21929,7 @@ msgstr "Posts carrying one of these tags are folded the same way."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3595
+#: lib/vutuv_web/live/post_live/feed.ex:3637
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
@@ -22003,10 +22006,10 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3182
-#: lib/vutuv_web/live/post_live/feed.ex:3209
-#: lib/vutuv_web/live/post_live/feed.ex:3643
-#: lib/vutuv_web/live/post_live/feed.ex:3648
+#: lib/vutuv_web/live/post_live/feed.ex:3224
+#: lib/vutuv_web/live/post_live/feed.ex:3251
+#: lib/vutuv_web/live/post_live/feed.ex:3685
+#: lib/vutuv_web/live/post_live/feed.ex:3690
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -22071,7 +22074,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3365
+#: lib/vutuv_web/live/post_live/feed.ex:3407
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to now"
 msgstr ""
@@ -22081,7 +22084,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3411
+#: lib/vutuv_web/live/post_live/feed.ex:3453
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22103,7 +22106,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3361
+#: lib/vutuv_web/live/post_live/feed.ex:3403
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -22190,7 +22193,7 @@ msgstr ""
 msgid "Page management"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2304
+#: lib/vutuv_web/live/post_live/feed.ex:2312
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
@@ -22202,12 +22205,12 @@ msgstr[1] ""
 msgid "Quoted post"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1071
+#: lib/vutuv_web/agent_docs/markdown.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Quotes %{name}: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1068
+#: lib/vutuv_web/agent_docs/markdown.ex:1070
 #, elixir-autogen, elixir-format
 msgid "Quotes %{url}"
 msgstr ""
@@ -22222,7 +22225,7 @@ msgstr ""
 msgid "{used} of {max} mentions"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2453
+#: lib/vutuv_web/live/post_live/feed.ex:2461
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""
@@ -22700,10 +22703,10 @@ msgstr ""
 msgid "This video could not be converted."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1311
-#: lib/vutuv_web/agent_docs/markdown.ex:1314
-#: lib/vutuv_web/agent_docs/text.ex:805
-#: lib/vutuv_web/agent_docs/text.ex:806
+#: lib/vutuv_web/agent_docs/markdown.ex:1336
+#: lib/vutuv_web/agent_docs/markdown.ex:1339
+#: lib/vutuv_web/agent_docs/text.ex:827
+#: lib/vutuv_web/agent_docs/text.ex:828
 #: lib/vutuv_web/components/post_components.ex:2506
 #: lib/vutuv_web/components/video_components.ex:126
 #: lib/vutuv_web/live/post_live/composer.ex:2442
@@ -22816,4 +22819,43 @@ msgstr ""
 #: lib/vutuv_web/components/video_components.ex:117
 #, elixir-autogen, elixir-format
 msgid "Standard quality. Play this video in HD."
+msgstr ""
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:773
+#, elixir-autogen, elixir-format
+msgid "Members carrying these tags:"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/job_board_doc.ex:44
+#: lib/vutuv_web/live/job_board_live.ex:262
+#, elixir-autogen, elixir-format
+msgid "No posting yet. Yours would be the first, and it would stand at the top on its own."
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1116
+#: lib/vutuv_web/agent_docs/text.ex:758
+#: lib/vutuv_web/live/job_board_live.ex:415
+#, elixir-autogen, elixir-format
+msgid "One member has said they are available."
+msgid_plural "%{formatted} members have said they are available."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/job_board_live.ex:475
+#, elixir-autogen, elixir-format
+msgid "The fields the most members carry, and how many of them do."
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1123
+#: lib/vutuv_web/agent_docs/text.ex:765
+#: lib/vutuv_web/live/job_board_live.ex:473
+#, elixir-autogen, elixir-format
+msgid "What members here work on"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1115
+#: lib/vutuv_web/agent_docs/text.ex:757
+#: lib/vutuv_web/live/job_board_live.ex:410
+#, elixir-autogen, elixir-format
+msgid "Who you would reach"
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -102,10 +102,10 @@ msgstr "Immagine del profilo"
 msgid "Birthdate"
 msgstr "Data di nascita"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:612
-#: lib/vutuv_web/agent_docs/markdown.ex:613
-#: lib/vutuv_web/agent_docs/text.ex:576
-#: lib/vutuv_web/agent_docs/text.ex:577
+#: lib/vutuv_web/agent_docs/markdown.ex:614
+#: lib/vutuv_web/agent_docs/markdown.ex:615
+#: lib/vutuv_web/agent_docs/text.ex:578
+#: lib/vutuv_web/agent_docs/text.ex:579
 #: lib/vutuv_web/templates/user/show.html.heex:1116
 #, elixir-autogen
 msgid "Birthday"
@@ -117,7 +117,7 @@ msgstr "Compleanno"
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
 #: lib/vutuv_web/live/admin/user_delete_live.ex:202
-#: lib/vutuv_web/live/job_posting_live/form.ex:806
+#: lib/vutuv_web/live/job_posting_live/form.ex:852
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
 #: lib/vutuv_web/live/post_live/composer.ex:1901
@@ -178,7 +178,7 @@ msgstr "Non è stato possibile ricambiare il follow a %{name}."
 msgid "Delete"
 msgstr "Elimina"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:685
+#: lib/vutuv_web/live/job_posting_live/form.ex:711
 #: lib/vutuv_web/live/organization_live/edit.ex:305
 #: lib/vutuv_web/live/organization_live/edit.ex:318
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
@@ -306,14 +306,14 @@ msgstr "Esperienza"
 msgid "Fax"
 msgstr "Fax"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:598
+#: lib/vutuv_web/agent_docs/markdown.ex:600
 #: lib/vutuv_web/templates/user/edit.html.heex:164
 #, elixir-autogen
 msgid "First Name"
 msgstr "Nome"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:633
-#: lib/vutuv_web/agent_docs/text.ex:597
+#: lib/vutuv_web/agent_docs/markdown.ex:635
+#: lib/vutuv_web/agent_docs/text.ex:599
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
@@ -323,8 +323,8 @@ msgstr "Nome"
 msgid "Followers"
 msgstr "Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:634
-#: lib/vutuv_web/agent_docs/text.ex:598
+#: lib/vutuv_web/agent_docs/markdown.ex:636
+#: lib/vutuv_web/agent_docs/text.ex:600
 #: lib/vutuv_web/components/fediverse_components.ex:468
 #: lib/vutuv_web/components/ui.ex:2964
 #: lib/vutuv_web/components/ui.ex:2999
@@ -382,7 +382,7 @@ msgstr "Qualifica"
 msgid "Language"
 msgstr "Lingua"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:600
+#: lib/vutuv_web/agent_docs/markdown.ex:602
 #: lib/vutuv_web/templates/user/edit.html.heex:169
 #, elixir-autogen
 msgid "Last Name"
@@ -449,7 +449,7 @@ msgstr "Esci"
 msgid "Log in"
 msgstr "Accedi"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:599
+#: lib/vutuv_web/agent_docs/markdown.ex:601
 #: lib/vutuv_web/templates/user/edit.html.heex:174
 #, elixir-autogen
 msgid "Middle Name"
@@ -486,7 +486,7 @@ msgstr "Nome"
 msgid "New"
 msgstr "Nuovo"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:602
+#: lib/vutuv_web/agent_docs/markdown.ex:604
 #: lib/vutuv_web/templates/user/edit.html.heex:179
 #, elixir-autogen
 msgid "Nickname"
@@ -567,7 +567,7 @@ msgstr "Numero di telefono eliminato."
 msgid "Phone number updated successfully."
 msgstr "Numero di telefono aggiornato."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:597
+#: lib/vutuv_web/agent_docs/markdown.ex:599
 #: lib/vutuv_web/templates/user/edit.html.heex:184
 #, elixir-autogen
 msgid "Prefix"
@@ -643,7 +643,7 @@ msgstr "Salva"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:219
 #: lib/vutuv_web/live/directory_search_live.ex:181
-#: lib/vutuv_web/live/job_board_live.ex:410
+#: lib/vutuv_web/live/job_board_live.ex:572
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
@@ -746,7 +746,7 @@ msgstr "Qualcosa è andato storto"
 msgid "Submit a bugreport or a feature request."
 msgstr "Segnali un problema o proponga una funzione."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:601
+#: lib/vutuv_web/agent_docs/markdown.ex:603
 #: lib/vutuv_web/templates/user/edit.html.heex:189
 #, elixir-autogen
 msgid "Suffix"
@@ -858,7 +858,7 @@ msgstr "Mostra tutti"
 
 #: lib/vutuv_web/components/ui.ex:5097
 #: lib/vutuv_web/controllers/settings_controller.ex:171
-#: lib/vutuv_web/live/job_posting_live/form.ex:767
+#: lib/vutuv_web/live/job_posting_live/form.ex:813
 #: lib/vutuv_web/live/organization_live/edit.ex:339
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
@@ -1371,11 +1371,11 @@ msgid "Tag urls"
 msgstr "URL dei tag"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
-#: lib/vutuv_web/agent_docs/markdown.ex:505
-#: lib/vutuv_web/agent_docs/markdown.ex:1123
+#: lib/vutuv_web/agent_docs/markdown.ex:507
+#: lib/vutuv_web/agent_docs/markdown.ex:1148
 #: lib/vutuv_web/agent_docs/text.ex:31
-#: lib/vutuv_web/agent_docs/text.ex:524
-#: lib/vutuv_web/agent_docs/text.ex:770
+#: lib/vutuv_web/agent_docs/text.ex:526
+#: lib/vutuv_web/agent_docs/text.ex:792
 #: lib/vutuv_web/components/ui.ex:4982
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
@@ -1386,8 +1386,8 @@ msgstr "URL dei tag"
 #: lib/vutuv_web/cv/odt.ex:148
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:444
 #: lib/vutuv_web/live/cv_live.ex:323
-#: lib/vutuv_web/live/job_board_live.ex:276
-#: lib/vutuv_web/live/job_posting_live/form.ex:716
+#: lib/vutuv_web/live/job_board_live.ex:339
+#: lib/vutuv_web/live/job_posting_live/form.ex:742
 #: lib/vutuv_web/live/search_live.ex:347
 #: lib/vutuv_web/live/search_live.ex:818
 #: lib/vutuv_web/live/tag_new_live.ex:35
@@ -1567,8 +1567,8 @@ msgid "You'll receive an email with a login link."
 msgstr "Riceverà un'e-mail con un link di accesso."
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:771
-#: lib/vutuv_web/live/job_board_live.ex:356
-#: lib/vutuv_web/live/job_posting_live/form.ex:548
+#: lib/vutuv_web/live/job_board_live.ex:518
+#: lib/vutuv_web/live/job_posting_live/form.ex:574
 #: lib/vutuv_web/live/organization_live/edit.ex:335
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
@@ -2100,7 +2100,7 @@ msgstr "Settembre"
 msgid "Markdown is supported: bold, italics, links and lists."
 msgstr "Markdown è supportato: grassetto, corsivo, link ed elenchi."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:709
+#: lib/vutuv_web/live/job_posting_live/form.ex:735
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr "Aggiungi immagini"
@@ -2145,7 +2145,7 @@ msgstr "Modifica il post"
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:162
 #: lib/vutuv_web/live/post_live/feed.ex:336
-#: lib/vutuv_web/live/post_live/feed.ex:3069
+#: lib/vutuv_web/live/post_live/feed.ex:3111
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1156
 #: lib/vutuv_web/live/shell_live.ex:1460
@@ -2191,7 +2191,7 @@ msgstr "Visitatori non connessi"
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3385
+#: lib/vutuv_web/live/post_live/feed.ex:3427
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2286,7 +2286,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Salvataggio…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2310
+#: lib/vutuv_web/live/post_live/feed.ex:2318
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2415,7 +2415,7 @@ msgstr "Tutti i post"
 msgid "Bookmark"
 msgstr "Salva"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1161
+#: lib/vutuv_web/agent_docs/markdown.ex:1186
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
 #: lib/vutuv_web/live/shell_live.ex:1296
@@ -2435,7 +2435,7 @@ msgstr "Salvati"
 msgid "Like"
 msgstr "Mi piace"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1160
+#: lib/vutuv_web/agent_docs/markdown.ex:1185
 #: lib/vutuv_web/components/post_components.ex:6038
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
@@ -2806,7 +2806,7 @@ msgid "Manage"
 msgstr "Gestisci"
 
 #: lib/vutuv_web/controllers/page_controller.ex:216
-#: lib/vutuv_web/live/post_live/feed.ex:2350
+#: lib/vutuv_web/live/post_live/feed.ex:2358
 #: lib/vutuv_web/templates/user/show.html.heex:507
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2827,6 +2827,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] "1 collegamento"
 msgstr[1] "%{formatted} collegamenti"
 
+#: lib/vutuv_web/live/job_board_live.ex:457
 #: lib/vutuv_web/live/post_live/feed.ex:1053
 #: lib/vutuv_web/templates/user/card_list.html.heex:51
 #, elixir-autogen, elixir-format
@@ -2835,8 +2836,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] "+1 altro tag"
 msgstr[1] "+%{formatted} altri tag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:635
-#: lib/vutuv_web/agent_docs/text.ex:599
+#: lib/vutuv_web/agent_docs/markdown.ex:637
+#: lib/vutuv_web/agent_docs/text.ex:601
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2994,8 +2995,8 @@ msgstr "Qualcosa che i nostri amministratori dovrebbero sapere? (facoltativo)"
 msgid "Bullying or harassment"
 msgstr "Bullismo o molestie"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:345
-#: lib/vutuv_web/agent_docs/text.ex:326
+#: lib/vutuv_web/agent_docs/markdown.ex:347
+#: lib/vutuv_web/agent_docs/text.ex:328
 #: lib/vutuv_web/controllers/page_controller.ex:81
 #: lib/vutuv_web/templates/layout/app.html.heex:119
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3951,12 +3952,12 @@ msgstr "messaggio segnalato"
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Scorra dentro il riquadro, o prema per aprire l'immagine intera."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:742
+#: lib/vutuv_web/agent_docs/markdown.ex:744
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr "%{count} conferme"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1282
+#: lib/vutuv_web/agent_docs/markdown.ex:1307
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} in questa pagina, usi ?page=N"
@@ -3970,11 +3971,11 @@ msgstr "%{count} post di %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:91
 #: lib/vutuv_web/agent_docs/markdown.ex:204
 #: lib/vutuv_web/agent_docs/markdown.ex:218
-#: lib/vutuv_web/agent_docs/markdown.ex:1123
+#: lib/vutuv_web/agent_docs/markdown.ex:1148
 #: lib/vutuv_web/agent_docs/text.ex:86
 #: lib/vutuv_web/agent_docs/text.ex:187
 #: lib/vutuv_web/agent_docs/text.ex:201
-#: lib/vutuv_web/agent_docs/text.ex:770
+#: lib/vutuv_web/agent_docs/text.ex:792
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr "%{count} in totale"
@@ -3988,33 +3989,33 @@ msgstr "Follower di %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:158
 #: lib/vutuv_web/agent_docs/text.ex:112
 #: lib/vutuv_web/agent_docs/text.ex:144
-#: lib/vutuv_web/live/job_posting_live/form.ex:699
+#: lib/vutuv_web/live/job_posting_live/form.ex:725
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr "Immagini"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1141
-#: lib/vutuv_web/agent_docs/text.ex:781
+#: lib/vutuv_web/agent_docs/markdown.ex:1166
+#: lib/vutuv_web/agent_docs/text.ex:803
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr "In risposta a un post eliminato di %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1138
-#: lib/vutuv_web/agent_docs/text.ex:778
+#: lib/vutuv_web/agent_docs/markdown.ex:1163
+#: lib/vutuv_web/agent_docs/text.ex:800
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr "In risposta a un post eliminato."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1145
-#: lib/vutuv_web/agent_docs/markdown.ex:1375
-#: lib/vutuv_web/agent_docs/text.ex:784
-#: lib/vutuv_web/agent_docs/text.ex:840
+#: lib/vutuv_web/agent_docs/markdown.ex:1170
+#: lib/vutuv_web/agent_docs/markdown.ex:1400
+#: lib/vutuv_web/agent_docs/text.ex:806
+#: lib/vutuv_web/agent_docs/text.ex:862
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr "In risposta a un post di %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:570
-#: lib/vutuv_web/agent_docs/text.ex:562
+#: lib/vutuv_web/agent_docs/markdown.ex:572
+#: lib/vutuv_web/agent_docs/text.ex:564
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr "Membro da"
@@ -4053,23 +4054,23 @@ msgstr "Post di %{name}"
 msgid "Posts (%{count} total)"
 msgstr "Post (%{count} in totale)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:564
-#: lib/vutuv_web/agent_docs/text.ex:556
+#: lib/vutuv_web/agent_docs/markdown.ex:566
+#: lib/vutuv_web/agent_docs/text.ex:558
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr "Profilo verificato: sì"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1092
+#: lib/vutuv_web/agent_docs/markdown.ex:1094
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr "ripubblicato da %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:954
+#: lib/vutuv_web/agent_docs/markdown.ex:956
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr "oggi"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:955
+#: lib/vutuv_web/agent_docs/markdown.ex:957
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr "fino al %{date}"
@@ -4147,8 +4148,8 @@ msgstr ""
 msgid "Billing name"
 msgstr "Intestazione della fattura"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:359
-#: lib/vutuv_web/agent_docs/text.ex:334
+#: lib/vutuv_web/agent_docs/markdown.ex:361
+#: lib/vutuv_web/agent_docs/text.ex:336
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr "Prenoti online (serve l'accesso): %{url}"
@@ -4172,7 +4173,7 @@ msgid "Booking requires a vutuv login."
 msgstr "Per prenotare serve un accesso a vutuv."
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
-#: lib/vutuv_web/live/job_posting_live/form.ex:542
+#: lib/vutuv_web/live/job_posting_live/form.ex:568
 #: lib/vutuv_web/live/organization_live/edit.ex:331
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
@@ -4201,8 +4202,8 @@ msgstr "Giorno"
 msgid "Markdown is supported. At most %{max} characters."
 msgstr "Markdown è supportato. Al massimo %{max} caratteri."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:349
-#: lib/vutuv_web/agent_docs/text.ex:330
+#: lib/vutuv_web/agent_docs/markdown.ex:351
+#: lib/vutuv_web/agent_docs/text.ex:332
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4219,8 +4220,8 @@ msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr ""
 "Una sola pubblicità di solo testo al giorno, vista da tutti i visitatori."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:346
-#: lib/vutuv_web/agent_docs/text.ex:327
+#: lib/vutuv_web/agent_docs/markdown.ex:348
+#: lib/vutuv_web/agent_docs/text.ex:329
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4455,14 +4456,14 @@ msgstr "prenotata il"
 msgid "deleted account"
 msgstr "account eliminato"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:351
-#: lib/vutuv_web/agent_docs/text.ex:332
+#: lib/vutuv_web/agent_docs/markdown.ex:353
+#: lib/vutuv_web/agent_docs/text.ex:334
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr "Già prenotato"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:347
-#: lib/vutuv_web/agent_docs/text.ex:328
+#: lib/vutuv_web/agent_docs/markdown.ex:349
+#: lib/vutuv_web/agent_docs/text.ex:330
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr "Periodo di prenotazione"
@@ -4706,7 +4707,7 @@ msgstr "Non ha bloccato nessuno."
 msgid "You unblocked @%{slug}."
 msgstr "Ha sbloccato @%{slug}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3390
+#: lib/vutuv_web/live/post_live/feed.ex:3432
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Scopra persone da seguire"
@@ -4760,8 +4761,8 @@ msgstr "Nessun risultato per \"%{query}\""
 msgid "Not an exact match, but sounds like your search."
 msgstr "Non è una corrispondenza esatta, ma somiglia alla Sua ricerca."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:446
-#: lib/vutuv_web/agent_docs/text.ex:465
+#: lib/vutuv_web/agent_docs/markdown.ex:448
+#: lib/vutuv_web/agent_docs/text.ex:467
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/notification_live/index.ex:657
 #: lib/vutuv_web/live/notification_live/index.ex:1350
@@ -4835,7 +4836,7 @@ msgstr "rossi"
 msgid "searches first names only (last: for last names)"
 msgstr "cerca solo nel nome (cognome: per il cognome)"
 
-#: lib/vutuv_web/live/job_board_live.ex:384
+#: lib/vutuv_web/live/job_board_live.ex:546
 #: lib/vutuv_web/live/tag_new_live.ex:47
 #: lib/vutuv_web/live/user_profile_live.ex:1358
 #: lib/vutuv_web/templates/user/show.html.heex:610
@@ -6357,8 +6358,8 @@ msgid_plural "%{count} years old"
 msgstr[0] "%{count} anno"
 msgstr[1] "%{count} anni"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:614
-#: lib/vutuv_web/agent_docs/text.ex:578
+#: lib/vutuv_web/agent_docs/markdown.ex:616
+#: lib/vutuv_web/agent_docs/text.ex:580
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr "Età"
@@ -6432,7 +6433,7 @@ msgstr "Apri il rapporto giornaliero"
 msgid "Previous day"
 msgstr "Giorno precedente"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1160
+#: lib/vutuv_web/agent_docs/markdown.ex:1185
 #: lib/vutuv_web/components/post_components.ex:421
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
@@ -6548,7 +6549,7 @@ msgstr "Ancora nessuna conferma."
 msgid "and %{count} more"
 msgstr "e altri %{count}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1136
+#: lib/vutuv_web/agent_docs/markdown.ex:1161
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr "confermato il %{date}"
@@ -7056,7 +7057,7 @@ msgstr "Bozza"
 
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:36
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:103
-#: lib/vutuv_web/live/job_posting_live/form.ex:318
+#: lib/vutuv_web/live/job_posting_live/form.ex:344
 #, elixir-autogen, elixir-format
 msgid "Draft saved."
 msgstr "Bozza salvata."
@@ -7284,7 +7285,7 @@ msgstr "Azzera"
 msgid "Save audience"
 msgstr "Salva il gruppo destinatari"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:804
+#: lib/vutuv_web/live/job_posting_live/form.ex:850
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:16
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:11
 #, elixir-autogen, elixir-format
@@ -7710,7 +7711,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr "Si aggiorna da sola. Può lasciare questa pagina: l'invio prosegue."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3656
+#: lib/vutuv_web/live/post_live/feed.ex:3698
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #, elixir-autogen
 msgid "Done"
@@ -7791,17 +7792,17 @@ msgstr "Feed di %{name}"
 msgid "The vutuv newsfeed of %{name}"
 msgstr "Il feed di notizie vutuv di %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1287
+#: lib/vutuv_web/agent_docs/markdown.ex:1312
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr "Il Suo feed è vuoto."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1290
+#: lib/vutuv_web/agent_docs/markdown.ex:1315
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr "%{count} post in questa pagina"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1297
+#: lib/vutuv_web/agent_docs/markdown.ex:1322
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "altri post disponibili, aggiunga ?cursor=%{cursor}"
@@ -8188,6 +8189,7 @@ msgid "Admins"
 msgstr "Amministratori"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
+#: lib/vutuv_web/live/job_board_live.ex:467
 #: lib/vutuv_web/live/post_live/feed.ex:1062
 #, elixir-autogen, elixir-format
 msgid "All members"
@@ -8207,7 +8209,7 @@ msgstr "In attesa di verifica"
 #: lib/vutuv_web/live/account_activity_live.ex:189
 #: lib/vutuv_web/live/admin/activity_live.ex:231
 #: lib/vutuv_web/live/admin/user_live.ex:184
-#: lib/vutuv_web/live/job_board_live.ex:256
+#: lib/vutuv_web/live/job_board_live.ex:319
 #: lib/vutuv_web/live/tag_live/timeline.ex:365
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
@@ -8981,10 +8983,10 @@ msgstr "La pagina è stata pubblicata."
 msgid "Write it under Admin › Legal pages"
 msgstr "La scriva in Amministrazione › Pagine legali"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:624
-#: lib/vutuv_web/agent_docs/markdown.ex:628
-#: lib/vutuv_web/agent_docs/text.ex:588
-#: lib/vutuv_web/agent_docs/text.ex:592
+#: lib/vutuv_web/agent_docs/markdown.ex:626
+#: lib/vutuv_web/agent_docs/markdown.ex:630
+#: lib/vutuv_web/agent_docs/text.ex:590
+#: lib/vutuv_web/agent_docs/text.ex:594
 #: lib/vutuv_web/components/organization_components.ex:276
 #: lib/vutuv_web/components/ui.ex:1695
 #: lib/vutuv_web/components/ui.ex:5113
@@ -9117,13 +9119,13 @@ msgstr "Il Suo profilo come CV"
 msgid "Higher Education"
 msgstr "Istruzione universitaria"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:832
+#: lib/vutuv_web/agent_docs/markdown.ex:834
 #: lib/vutuv_web/views/education_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr "Istruzione scolastica"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:831
+#: lib/vutuv_web/agent_docs/markdown.ex:833
 #: lib/vutuv_web/views/education_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -9158,7 +9160,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] "Ripubblicato da %{name} e da %{formatted} altro"
 msgstr[1] "Ripubblicato da %{name} e da altri %{formatted}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1095
+#: lib/vutuv_web/agent_docs/markdown.ex:1097
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr "ripubblicato da %{name} e da altri %{count}"
@@ -9407,8 +9409,8 @@ msgstr "Tag d'onore"
 msgid "Honor tag (only site admins can assign it)"
 msgstr "Tag d'onore (può assegnarlo solo un amministratore del sito)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:644
-#: lib/vutuv_web/agent_docs/text.ex:606
+#: lib/vutuv_web/agent_docs/markdown.ex:646
+#: lib/vutuv_web/agent_docs/text.ex:608
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr "tag d'onore"
@@ -9832,8 +9834,8 @@ msgstr "Gallese"
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:566
-#: lib/vutuv_web/agent_docs/text.ex:558
+#: lib/vutuv_web/agent_docs/markdown.ex:568
+#: lib/vutuv_web/agent_docs/text.ex:560
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr "Situazione lavorativa"
@@ -9946,7 +9948,7 @@ msgstr[1] "%{count} certificati o abilitazioni"
 msgid "Add a certificate or license"
 msgstr "Aggiungi un certificato o un'abilitazione"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:948
+#: lib/vutuv_web/agent_docs/markdown.ex:950
 #: lib/vutuv_web/views/qualification_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -10026,7 +10028,7 @@ msgstr "Non scade"
 msgid "Expired"
 msgstr "Scaduto"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:923
+#: lib/vutuv_web/agent_docs/markdown.ex:925
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr "ID: %{id}"
@@ -10043,7 +10045,7 @@ msgstr "Rilasciato"
 msgid "Issuer"
 msgstr "Ente rilasciante"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:947
+#: lib/vutuv_web/agent_docs/markdown.ex:949
 #: lib/vutuv_web/views/qualification_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -10073,7 +10075,7 @@ msgstr "Documento di prova"
 msgid "Verification link"
 msgstr "Link di verifica"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:921
+#: lib/vutuv_web/agent_docs/markdown.ex:923
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr "conseguito il %{date}"
@@ -10088,7 +10090,7 @@ msgstr "ad esempio AWS Solutions Architect – Associate"
 msgid "e.g. Amazon Web Services"
 msgstr "ad esempio Amazon Web Services"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:922
+#: lib/vutuv_web/agent_docs/markdown.ex:924
 #: lib/vutuv_web/views/qualification_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "valid until %{date}"
@@ -10106,7 +10108,7 @@ msgstr ""
 msgid "Preferred"
 msgstr "Preferita"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:759
+#: lib/vutuv_web/agent_docs/markdown.ex:761
 #: lib/vutuv_web/live/section_reorder_live.ex:287
 #: lib/vutuv_web/views/language_html.ex:114
 #, elixir-autogen, elixir-format
@@ -10602,21 +10604,21 @@ msgstr ""
 "elenco stampato, digitandolo nel normale campo del PIN. Il Suo PIN via "
 "e-mail continua sempre a funzionare."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:719
+#: lib/vutuv_web/agent_docs/markdown.ex:721
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] "%{count} follower"
 msgstr[1] "%{count} follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:717
+#: lib/vutuv_web/agent_docs/markdown.ex:719
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] "%{count} repository"
 msgstr[1] "%{count} repository"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:715
+#: lib/vutuv_web/agent_docs/markdown.ex:717
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10678,12 +10680,12 @@ msgstr ""
 "Se disattivo, la scheda Social media elenca i Suoi account come semplici "
 "link."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:733
+#: lib/vutuv_web/agent_docs/markdown.ex:735
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr "ultima attività il %{date}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:720
+#: lib/vutuv_web/agent_docs/markdown.ex:722
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr "dal %{date}"
@@ -11298,7 +11300,7 @@ msgstr "Nessuno"
 
 #: lib/vutuv/accounts/user.ex:1266
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
-#: lib/vutuv_web/live/job_posting_live/form.ex:772
+#: lib/vutuv_web/live/job_posting_live/form.ex:818
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr "Solo i membri connessi"
@@ -11315,7 +11317,7 @@ msgstr "Chi può vedere la Sua disponibilità?"
 msgid "Amount"
 msgstr "Importo"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:668
+#: lib/vutuv_web/live/job_posting_live/form.ex:694
 #: lib/vutuv_web/templates/user/edit.html.heex:321
 #: lib/vutuv_web/templates/welcome/show.html.heex:131
 #, elixir-autogen, elixir-format
@@ -11344,7 +11346,7 @@ msgstr ""
 "avvisi, escludendo gli annunci al di sotto. Lasci vuoto l'importo per "
 "rimuoverla."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:675
+#: lib/vutuv_web/live/job_posting_live/form.ex:701
 #: lib/vutuv_web/templates/user/edit.html.heex:317
 #: lib/vutuv_web/templates/welcome/show.html.heex:127
 #, elixir-autogen, elixir-format
@@ -11718,8 +11720,8 @@ msgstr "Alias aggiunto."
 msgid "Alias removed."
 msgstr "Alias rimosso."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:438
-#: lib/vutuv_web/agent_docs/text.ex:458
+#: lib/vutuv_web/agent_docs/markdown.ex:440
+#: lib/vutuv_web/agent_docs/text.ex:460
 #: lib/vutuv_web/live/organization_live/edit.ex:384
 #: lib/vutuv_web/live/organization_live/show.ex:923
 #: lib/vutuv_web/templates/tag/single_card.html.heex:14
@@ -11944,8 +11946,8 @@ msgstr "in attesa"
 msgid "primary"
 msgstr "principale"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:459
-#: lib/vutuv_web/agent_docs/text.ex:478
+#: lib/vutuv_web/agent_docs/markdown.ex:461
+#: lib/vutuv_web/agent_docs/text.ex:480
 #: lib/vutuv_web/live/admin/organization_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -12074,8 +12076,8 @@ msgstr "Verifica tramite link di ritorno"
 msgid "Verify via file"
 msgstr "Verifica tramite file"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:968
-#: lib/vutuv_web/agent_docs/text.ex:734
+#: lib/vutuv_web/agent_docs/markdown.ex:970
+#: lib/vutuv_web/agent_docs/text.ex:736
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr "pagina web verificata"
@@ -12112,8 +12114,8 @@ msgstr "Collegata a {name}"
 msgid "Remove link"
 msgstr "Rimuovi il collegamento"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:450
-#: lib/vutuv_web/agent_docs/text.ex:469
+#: lib/vutuv_web/agent_docs/markdown.ex:452
+#: lib/vutuv_web/agent_docs/text.ex:471
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr "precedente"
@@ -12339,9 +12341,9 @@ msgstr "Ruolo nell'organizzazione"
 msgid "Organization unfrozen."
 msgstr "Organizzazione sbloccata."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:429
+#: lib/vutuv_web/agent_docs/markdown.ex:431
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
-#: lib/vutuv_web/agent_docs/text.ex:402
+#: lib/vutuv_web/agent_docs/text.ex:404
 #: lib/vutuv_web/components/ui.ex:5140
 #: lib/vutuv_web/controllers/settings_controller.ex:213
 #: lib/vutuv_web/live/organization_live/index.ex:32
@@ -12524,49 +12526,49 @@ msgstr "%{views} visualizzazioni · %{clicks} clic per candidarsi"
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr "Un annuncio di lavoro falso, ingannevole o discriminatorio."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:652
+#: lib/vutuv_web/live/job_posting_live/form.ex:678
 #, elixir-autogen, elixir-format
 msgid "A pay range is required to publish (except volunteer postings)."
 msgstr ""
 "Per pubblicare serve una fascia retributiva (tranne che per gli annunci di "
 "volontariato)."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:749
+#: lib/vutuv_web/live/job_posting_live/form.ex:795
 #, elixir-autogen, elixir-format
 msgid "A vutuv message to me"
 msgstr "Un messaggio vutuv a me"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:747
+#: lib/vutuv_web/live/job_posting_live/form.ex:793
 #, elixir-autogen, elixir-format
 msgid "A website"
 msgstr "Un sito web"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:748
+#: lib/vutuv_web/live/job_posting_live/form.ex:794
 #, elixir-autogen, elixir-format
 msgid "An e-mail address"
 msgstr "Un indirizzo e-mail"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:563
+#: lib/vutuv_web/live/job_posting_live/form.ex:589
 #, elixir-autogen, elixir-format
 msgid "Applicants must be located in"
 msgstr "I candidati devono trovarsi in"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:753
+#: lib/vutuv_web/live/job_posting_live/form.ex:799
 #, elixir-autogen, elixir-format
 msgid "Application URL"
 msgstr "URL per la candidatura"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:759
+#: lib/vutuv_web/live/job_posting_live/form.ex:805
 #, elixir-autogen, elixir-format
 msgid "Application e-mail"
 msgstr "Indirizzo e-mail per la candidatura"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:109
+#: lib/vutuv_web/controllers/job_posting_controller.ex:127
 #, elixir-autogen, elixir-format
 msgid "Application: %{title}"
 msgstr "Candidatura: %{title}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:745
+#: lib/vutuv_web/live/job_posting_live/form.ex:791
 #, elixir-autogen, elixir-format
 msgid "Applications go to"
 msgstr "Le candidature arrivano a"
@@ -12598,7 +12600,7 @@ msgstr "Chiuso"
 msgid "Contract"
 msgstr "Collaborazione"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:692
+#: lib/vutuv_web/live/job_posting_live/form.ex:718
 #, elixir-autogen, elixir-format
 msgid "Describe the role. Markdown is supported."
 msgstr "Descriva il ruolo. Markdown è supportato."
@@ -12608,15 +12610,15 @@ msgstr "Descriva il ruolo. Markdown è supportato."
 msgid "Drafts"
 msgstr "Bozze"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:114
+#: lib/vutuv_web/live/job_posting_live/form.ex:120
 #, elixir-autogen, elixir-format
 msgid "Edit posting"
 msgstr "Modifica l'annuncio"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:282
-#: lib/vutuv_web/agent_docs/markdown.ex:490
+#: lib/vutuv_web/agent_docs/markdown.ex:492
 #: lib/vutuv_web/agent_docs/text.ex:266
-#: lib/vutuv_web/agent_docs/text.ex:509
+#: lib/vutuv_web/agent_docs/text.ex:511
 #: lib/vutuv_web/live/admin/job_live.ex:340
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
 #: lib/vutuv_web/views/account_event_text.ex:225
@@ -12624,27 +12626,27 @@ msgstr "Modifica l'annuncio"
 msgid "Employer"
 msgstr "Datore di lavoro"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:459
+#: lib/vutuv_web/live/job_posting_live/form.ex:485
 #, elixir-autogen, elixir-format
 msgid "Employer name (optional)"
 msgstr "Nome del datore di lavoro (facoltativo)"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:283
-#: lib/vutuv_web/agent_docs/markdown.ex:491
+#: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/text.ex:267
-#: lib/vutuv_web/agent_docs/text.ex:510
-#: lib/vutuv_web/live/job_board_live.ex:363
-#: lib/vutuv_web/live/job_posting_live/form.ex:474
+#: lib/vutuv_web/agent_docs/text.ex:512
+#: lib/vutuv_web/live/job_board_live.ex:525
+#: lib/vutuv_web/live/job_posting_live/form.ex:500
 #, elixir-autogen, elixir-format
 msgid "Employment type"
 msgstr "Tipo di contratto"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:771
+#: lib/vutuv_web/live/job_posting_live/form.ex:817
 #, elixir-autogen, elixir-format
 msgid "Everyone (public)"
 msgstr "Tutti (pubblico)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:656
+#: lib/vutuv_web/live/job_posting_live/form.ex:682
 #: lib/vutuv_web/live/tag_live/timeline.ex:346
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
@@ -12662,7 +12664,7 @@ msgstr "Tempo pieno"
 msgid "Highlighted tags match your profile."
 msgstr "I tag evidenziati corrispondono al Suo profilo."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:743
+#: lib/vutuv_web/live/job_posting_live/form.ex:789
 #, elixir-autogen, elixir-format
 msgid "How to apply"
 msgstr "Come candidarsi"
@@ -12673,25 +12675,25 @@ msgstr "Come candidarsi"
 msgid "Hybrid"
 msgstr "Ibrido"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:128
+#: lib/vutuv_web/controllers/job_posting_controller.ex:146
 #, elixir-autogen, elixir-format
 msgid "I'm interested in your posting: %{url}"
 msgstr "Mi interessa il Suo annuncio: %{url}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:691
+#: lib/vutuv_web/live/job_posting_live/form.ex:717
 #, elixir-autogen, elixir-format
 msgid "Job description"
 msgstr "Descrizione della posizione"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:426
+#: lib/vutuv_web/live/job_posting_live/form.ex:452
 #, elixir-autogen, elixir-format
 msgid "Job title"
 msgstr "Titolo della posizione"
 
-#: lib/vutuv_web/agent_docs/job_board_doc.ex:19
+#: lib/vutuv_web/agent_docs/job_board_doc.ex:31
 #: lib/vutuv_web/components/saved_search_components.ex:56
-#: lib/vutuv_web/live/job_board_live.ex:45
-#: lib/vutuv_web/live/job_board_live.ex:211
+#: lib/vutuv_web/live/job_board_live.ex:49
+#: lib/vutuv_web/live/job_board_live.ex:259
 #: lib/vutuv_web/live/post_live/saved.ex:529
 #: lib/vutuv_web/live/shell_live.ex:1178
 #: lib/vutuv_web/templates/layout/app.html.heex:80
@@ -12699,18 +12701,18 @@ msgstr "Titolo della posizione"
 msgid "Jobs"
 msgstr "Lavoro"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:781
+#: lib/vutuv_web/live/job_posting_live/form.ex:827
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this posting."
 msgstr "Consenti ai motori di ricerca di indicizzare questo annuncio."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:465
-#: lib/vutuv_web/agent_docs/markdown.ex:468
+#: lib/vutuv_web/agent_docs/markdown.ex:467
 #: lib/vutuv_web/agent_docs/markdown.ex:470
-#: lib/vutuv_web/agent_docs/text.ex:484
-#: lib/vutuv_web/agent_docs/text.ex:487
+#: lib/vutuv_web/agent_docs/markdown.ex:472
+#: lib/vutuv_web/agent_docs/text.ex:486
 #: lib/vutuv_web/agent_docs/text.ex:489
-#: lib/vutuv_web/live/job_posting_live/form.ex:524
+#: lib/vutuv_web/agent_docs/text.ex:491
+#: lib/vutuv_web/live/job_posting_live/form.ex:550
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr "Luogo"
@@ -12747,20 +12749,20 @@ msgstr "Annuncio di lavoro ingannevole"
 msgid "My postings"
 msgstr "I miei annunci"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:396
+#: lib/vutuv_web/live/job_posting_live/form.ex:422
 #, elixir-autogen, elixir-format
 msgid "New accounts can publish after a few days."
 msgstr "I nuovi account possono pubblicare dopo qualche giorno."
 
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:102
-#: lib/vutuv_web/live/job_posting_live/form.ex:114
+#: lib/vutuv_web/live/job_posting_live/form.ex:120
 #, elixir-autogen, elixir-format
 msgid "New posting"
 msgstr "Nuovo annuncio"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:294
 #: lib/vutuv_web/agent_docs/text.ex:277
-#: lib/vutuv_web/live/job_posting_live/form.ex:731
+#: lib/vutuv_web/live/job_posting_live/form.ex:757
 #: lib/vutuv_web/live/job_posting_live/show.ex:177
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
@@ -12782,7 +12784,7 @@ msgid "Nothing here yet. Jobs you like show up here."
 msgstr ""
 "Qui non c'è ancora nulla. Gli annunci a cui mette Mi piace compaiono qui."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:787
+#: lib/vutuv_web/live/job_posting_live/form.ex:833
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
@@ -12806,28 +12808,28 @@ msgstr ""
 msgid "Part-time"
 msgstr "Tempo parziale"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:650
+#: lib/vutuv_web/live/job_posting_live/form.ex:676
 #, elixir-autogen, elixir-format
 msgid "Pay"
 msgstr "Retribuzione"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:395
+#: lib/vutuv_web/live/job_posting_live/form.ex:421
 #, elixir-autogen, elixir-format
 msgid "Please confirm your e-mail address first."
 msgstr "Prima confermi il Suo indirizzo e-mail."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:71
+#: lib/vutuv_web/live/job_posting_live/form.ex:72
 #, elixir-autogen, elixir-format
 msgid "Please confirm your email address before posting a job."
 msgstr ""
 "Confermi il Suo indirizzo e-mail prima di pubblicare un annuncio di lavoro."
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:120
+#: lib/vutuv_web/controllers/job_posting_controller.ex:138
 #, elixir-autogen, elixir-format
 msgid "Please log in to message the poster."
 msgstr "Acceda per scrivere a chi ha pubblicato."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:77
+#: lib/vutuv_web/live/job_posting_live/form.ex:78
 #, elixir-autogen, elixir-format
 msgid "Please log in to post a job."
 msgstr "Acceda per pubblicare un annuncio di lavoro."
@@ -12837,38 +12839,38 @@ msgstr "Acceda per pubblicare un annuncio di lavoro."
 msgid "Please log in to see your postings."
 msgstr "Acceda per vedere i Suoi annunci."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:447
+#: lib/vutuv_web/live/job_posting_live/form.ex:473
 #, elixir-autogen, elixir-format
 msgid "Post as"
 msgstr "Pubblica come"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:536
+#: lib/vutuv_web/live/job_posting_live/form.ex:562
 #: lib/vutuv_web/templates/welcome/show.html.heex:67
 #, elixir-autogen, elixir-format
 msgid "Postal code"
 msgstr "CAP"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:287
-#: lib/vutuv_web/agent_docs/markdown.ex:495
+#: lib/vutuv_web/agent_docs/markdown.ex:497
 #: lib/vutuv_web/agent_docs/text.ex:271
-#: lib/vutuv_web/agent_docs/text.ex:514
+#: lib/vutuv_web/agent_docs/text.ex:516
 #: lib/vutuv_web/live/job_posting_live/show.ex:156
 #, elixir-autogen, elixir-format
 msgid "Posted"
 msgstr "Pubblicato"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:505
+#: lib/vutuv_web/live/job_posting_live/form.ex:531
 #, elixir-autogen, elixir-format
 msgid "Posting language"
 msgstr "Lingua dell'annuncio"
 
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:50
-#: lib/vutuv_web/live/job_posting_live/form.ex:104
+#: lib/vutuv_web/live/job_posting_live/form.ex:110
 #, elixir-autogen, elixir-format
 msgid "Posting not found."
 msgstr "Annuncio non trovato."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:802
+#: lib/vutuv_web/live/job_posting_live/form.ex:848
 #, elixir-autogen, elixir-format
 msgid "Publish"
 msgstr "Pubblica"
@@ -12876,10 +12878,10 @@ msgstr "Pubblica"
 #: lib/vutuv/accounts/user.ex:1238
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
-#: lib/vutuv_web/agent_docs/markdown.ex:468
 #: lib/vutuv_web/agent_docs/markdown.ex:470
-#: lib/vutuv_web/agent_docs/text.ex:487
+#: lib/vutuv_web/agent_docs/markdown.ex:472
 #: lib/vutuv_web/agent_docs/text.ex:489
+#: lib/vutuv_web/agent_docs/text.ex:491
 #: lib/vutuv_web/components/job_components.ex:140
 #: lib/vutuv_web/components/job_components.ex:141
 #, elixir-autogen, elixir-format
@@ -12893,16 +12895,16 @@ msgstr "Segnala questo annuncio"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:293
 #: lib/vutuv_web/agent_docs/text.ex:276
-#: lib/vutuv_web/live/job_posting_live/form.ex:721
+#: lib/vutuv_web/live/job_posting_live/form.ex:747
 #: lib/vutuv_web/live/job_posting_live/show.ex:172
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr "Richiesto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:286
-#: lib/vutuv_web/agent_docs/markdown.ex:494
+#: lib/vutuv_web/agent_docs/markdown.ex:496
 #: lib/vutuv_web/agent_docs/text.ex:270
-#: lib/vutuv_web/agent_docs/text.ex:513
+#: lib/vutuv_web/agent_docs/text.ex:515
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr "Retribuzione"
@@ -12913,27 +12915,27 @@ msgid "Salary on request"
 msgstr "Retribuzione su richiesta"
 
 #: lib/vutuv_web/controllers/settings_controller.ex:395
-#: lib/vutuv_web/live/job_posting_live/form.ex:354
+#: lib/vutuv_web/live/job_posting_live/form.ex:380
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr "Salvato."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:468
+#: lib/vutuv_web/live/job_posting_live/form.ex:494
 #, elixir-autogen, elixir-format
 msgid "Shown as an unverified employer name."
 msgstr "Mostrato come nome di datore di lavoro non verificato."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:384
+#: lib/vutuv_web/live/job_posting_live/form.ex:410
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr "Qualcosa è andato storto. Riprovi."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:529
+#: lib/vutuv_web/live/job_posting_live/form.ex:555
 #, elixir-autogen, elixir-format
 msgid "Street (optional)"
 msgstr "Via (facoltativo)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:718
+#: lib/vutuv_web/live/job_posting_live/form.ex:744
 #, elixir-autogen, elixir-format
 msgid "Tags match your posting to members. Separate them with commas; a tag may be several words long, like Ruby on Rails."
 msgstr ""
@@ -12945,17 +12947,17 @@ msgstr ""
 msgid "Temporary"
 msgstr "A tempo determinato"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:276
+#: lib/vutuv_web/live/job_posting_live/form.ex:302
 #, elixir-autogen, elixir-format
 msgid "That image could not be uploaded."
 msgstr "Non è stato possibile caricare questa immagine."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:422
+#: lib/vutuv_web/live/job_posting_live/form.ex:448
 #, elixir-autogen, elixir-format
 msgid "The role"
 msgstr "Il ruolo"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:402
+#: lib/vutuv_web/live/job_posting_live/form.ex:428
 #, elixir-autogen, elixir-format
 msgid "This organization has reached its published-postings limit."
 msgstr "Questa organizzazione ha raggiunto il limite di annunci pubblicati."
@@ -12965,7 +12967,7 @@ msgstr "Questa organizzazione ha raggiunto il limite di annunci pubblicati."
 msgid "This position is no longer available."
 msgstr "Questa posizione non è più disponibile."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:441
+#: lib/vutuv_web/live/job_posting_live/form.ex:467
 #, elixir-autogen, elixir-format
 msgid "Tip: adding a gender marker like (m/w/d) helps your posting comply with the AGG. This is a suggestion, not legal advice."
 msgstr ""
@@ -12990,7 +12992,7 @@ msgstr "Volontariato"
 msgid "Volunteer"
 msgstr "Volontario"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:769
+#: lib/vutuv_web/live/job_posting_live/form.ex:815
 #: lib/vutuv_web/templates/email/form_content.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Who can see it"
@@ -13002,15 +13004,15 @@ msgid "Working student"
 msgstr "Studente lavoratore"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:284
-#: lib/vutuv_web/agent_docs/markdown.ex:492
+#: lib/vutuv_web/agent_docs/markdown.ex:494
 #: lib/vutuv_web/agent_docs/text.ex:268
-#: lib/vutuv_web/agent_docs/text.ex:511
-#: lib/vutuv_web/live/job_posting_live/form.ex:489
+#: lib/vutuv_web/agent_docs/text.ex:513
+#: lib/vutuv_web/live/job_posting_live/form.ex:515
 #, elixir-autogen, elixir-format
 msgid "Workplace"
 msgstr "Modalità di lavoro"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:399
+#: lib/vutuv_web/live/job_posting_live/form.ex:425
 #, elixir-autogen, elixir-format
 msgid "You already have the maximum number of published postings."
 msgstr "Ha già raggiunto il numero massimo di annunci pubblicati."
@@ -13060,18 +13062,18 @@ msgstr "La Sua pagina di organizzazione su vutuv non è più pubblica"
 msgid "Your posting"
 msgstr "Il Suo annuncio"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:334
-#: lib/vutuv_web/live/job_posting_live/form.ex:377
+#: lib/vutuv_web/live/job_posting_live/form.ex:360
+#: lib/vutuv_web/live/job_posting_live/form.ex:403
 #, elixir-autogen, elixir-format
 msgid "Your posting is live."
 msgstr "Il Suo annuncio è online."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:450
+#: lib/vutuv_web/live/job_posting_live/form.ex:476
 #, elixir-autogen, elixir-format
 msgid "Yourself (personal posting)"
 msgstr "Se stesso (annuncio personale)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:662
+#: lib/vutuv_web/live/job_posting_live/form.ex:688
 #, elixir-autogen, elixir-format
 msgid "up to"
 msgstr "fino a"
@@ -13222,120 +13224,120 @@ msgid_plural "%{count} weeks ago"
 msgstr[0] "%{count} settimana fa"
 msgstr[1] "%{count} settimane fa"
 
-#: lib/vutuv_web/live/job_board_live.ex:471
+#: lib/vutuv_web/live/job_board_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "%{km} km"
 msgstr "%{km} km"
 
-#: lib/vutuv_web/live/job_board_live.ex:357
+#: lib/vutuv_web/live/job_board_live.ex:519
 #, elixir-autogen, elixir-format
 msgid "All countries"
 msgstr "Tutti i paesi"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:513
+#: lib/vutuv_web/agent_docs/markdown.ex:515
 #: lib/vutuv_web/templates/tag/show.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr "Tutti gli annunci con questo tag"
 
-#: lib/vutuv_web/agent_docs/text.ex:531
+#: lib/vutuv_web/agent_docs/text.ex:533
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr "Tutti gli annunci con questo tag: %{url}"
 
-#: lib/vutuv_web/live/job_board_live.ex:364
+#: lib/vutuv_web/live/job_board_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Any employment type"
 msgstr "Qualsiasi tipo di contratto"
 
-#: lib/vutuv_web/live/job_board_live.ex:346
+#: lib/vutuv_web/live/job_board_live.ex:508
 #, elixir-autogen, elixir-format
 msgid "City or zip code"
 msgstr "Città o CAP"
 
-#: lib/vutuv_web/live/job_board_live.ex:471
+#: lib/vutuv_web/live/job_board_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "Exact"
 msgstr "Esatto"
 
-#: lib/vutuv_web/live/job_board_live.ex:245
+#: lib/vutuv_web/live/job_board_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "From my salary expectation"
 msgstr "Dalla mia retribuzione desiderata"
 
-#: lib/vutuv_web/live/job_board_live.ex:237
+#: lib/vutuv_web/live/job_board_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "Matches my tags"
 msgstr "Corrisponde ai miei tag"
 
-#: lib/vutuv_web/live/job_board_live.ex:452
+#: lib/vutuv_web/live/job_board_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Min. salary/year (%{currency})"
 msgstr "Retribuzione min./anno (%{currency})"
 
-#: lib/vutuv_web/live/job_board_live.ex:406
+#: lib/vutuv_web/live/job_board_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "Minimum yearly salary"
 msgstr "Retribuzione annua minima"
 
-#: lib/vutuv_web/live/job_board_live.ex:320
+#: lib/vutuv_web/live/job_board_live.ex:383
 #: lib/vutuv_web/live/organization_live/show.ex:834
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr "Altri annunci"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:306
+#: lib/vutuv_web/agent_docs/markdown.ex:308
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr "Pagina successiva"
 
-#: lib/vutuv_web/agent_docs/text.ex:289
+#: lib/vutuv_web/agent_docs/text.ex:291
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr "Pagina successiva: %{url}"
 
-#: lib/vutuv_web/live/job_board_live.ex:479
+#: lib/vutuv_web/live/job_board_live.ex:641
 #, elixir-autogen, elixir-format
 msgid "No job postings yet."
 msgstr "Ancora nessun annuncio di lavoro."
 
-#: lib/vutuv_web/live/job_board_live.ex:477
+#: lib/vutuv_web/live/job_board_live.ex:639
 #, elixir-autogen, elixir-format
 msgid "No matching positions. Try adjusting the filters."
 msgstr "Nessuna posizione corrispondente. Provi a modificare i filtri."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:511
-#: lib/vutuv_web/agent_docs/markdown.ex:523
-#: lib/vutuv_web/agent_docs/text.ex:529
-#: lib/vutuv_web/agent_docs/text.ex:541
+#: lib/vutuv_web/agent_docs/markdown.ex:513
+#: lib/vutuv_web/agent_docs/markdown.ex:525
+#: lib/vutuv_web/agent_docs/text.ex:531
+#: lib/vutuv_web/agent_docs/text.ex:543
 #: lib/vutuv_web/live/organization_live/show.ex:826
 #: lib/vutuv_web/templates/tag/show.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Open positions"
 msgstr "Posizioni aperte"
 
-#: lib/vutuv_web/agent_docs/job_board_doc.ex:20
-#: lib/vutuv_web/live/job_board_live.ex:213
+#: lib/vutuv_web/agent_docs/job_board_doc.ex:40
+#: lib/vutuv_web/live/job_board_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Open positions on vutuv, newest first."
 msgstr "Posizioni aperte su vutuv, dalla più recente."
 
-#: lib/vutuv_web/live/job_board_live.ex:217
+#: lib/vutuv_web/live/job_board_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Post a job"
 msgstr "Pubblichi un annuncio di lavoro"
 
-#: lib/vutuv_web/live/job_board_live.ex:305
+#: lib/vutuv_web/live/job_board_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "Post the first one"
 msgstr "Pubblichi il primo"
 
-#: lib/vutuv_web/live/job_board_live.ex:350
+#: lib/vutuv_web/live/job_board_live.ex:512
 #, elixir-autogen, elixir-format
 msgid "Radius"
 msgstr "Raggio"
 
-#: lib/vutuv_web/live/job_board_live.ex:338
+#: lib/vutuv_web/live/job_board_live.ex:500
 #, elixir-autogen, elixir-format
 msgid "Search jobs"
 msgstr "Cerchi annunci di lavoro"
@@ -13787,7 +13789,7 @@ msgstr ""
 msgid "Hide from specific viewers"
 msgstr "Nascondi a lettori specifici"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:793
+#: lib/vutuv_web/live/job_posting_live/form.ex:839
 #, elixir-autogen, elixir-format
 msgid "Hide from specific viewers (competitors, your own staff, a person) →"
 msgstr ""
@@ -13809,7 +13811,7 @@ msgstr "Esclusioni sugli annunci"
 msgid "Job exclusions – %{name}"
 msgstr "Esclusioni sugli annunci – %{name}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:796
+#: lib/vutuv_web/live/job_posting_live/form.ex:842
 #, elixir-autogen, elixir-format
 msgid "Keep this posting on the board for everyone except a chosen few."
 msgstr ""
@@ -14146,34 +14148,34 @@ msgstr ""
 msgid "Tags you follow"
 msgstr "Tag che segue"
 
-#: lib/vutuv_web/live/job_board_live.ex:419
+#: lib/vutuv_web/live/job_board_live.ex:581
 #, elixir-autogen, elixir-format
 msgid "Looking for a role that goes by several titles? Separate them with a comma and we show postings that match any of them."
 msgstr ""
 "Cerca un ruolo che ha più titoli diversi? Li separi con una virgola e "
 "mostreremo gli annunci che corrispondono a uno qualsiasi di essi."
 
-#: lib/vutuv_web/live/job_board_live.ex:415
+#: lib/vutuv_web/live/job_board_live.ex:577
 #, elixir-autogen, elixir-format
 msgid "Search tips"
 msgstr "Consigli per la ricerca"
 
-#: lib/vutuv_web/live/job_board_live.ex:462
+#: lib/vutuv_web/live/job_board_live.ex:624
 #, elixir-autogen, elixir-format
 msgid "any of these titles"
 msgstr "uno qualsiasi di questi titoli"
 
-#: lib/vutuv_web/live/job_board_live.ex:464
+#: lib/vutuv_web/live/job_board_live.ex:626
 #, elixir-autogen, elixir-format
 msgid "exact wording"
 msgstr "dicitura esatta"
 
-#: lib/vutuv_web/live/job_board_live.ex:465
+#: lib/vutuv_web/live/job_board_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "without internships"
 msgstr "senza tirocini"
 
-#: lib/vutuv_web/live/job_board_live.ex:463
+#: lib/vutuv_web/live/job_board_live.ex:625
 #, elixir-autogen, elixir-format
 msgid "word start: also finds Entwickler, Entwicklung"
 msgstr "inizio di parola: trova anche Sviluppatore, Sviluppo"
@@ -14312,7 +14314,7 @@ msgstr "ha aggiunto %{count} nuove voci al proprio CV:"
 msgid "Audiobook"
 msgstr "Audiolibro"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1249
+#: lib/vutuv_web/agent_docs/markdown.ex:1274
 #: lib/vutuv_web/components/post_components.ex:5501
 #, elixir-autogen, elixir-format
 msgid "Book review"
@@ -14333,7 +14335,7 @@ msgstr "DVD/Blu-ray"
 msgid "E-book"
 msgstr "E-book"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1249
+#: lib/vutuv_web/agent_docs/markdown.ex:1274
 #: lib/vutuv_web/components/post_components.ex:5500
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -14425,7 +14427,7 @@ msgstr "Certificazione"
 msgid "With qualification:"
 msgstr "Con certificazione:"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:788
+#: lib/vutuv_web/agent_docs/markdown.ex:790
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr "Con certificazione: %{name}"
@@ -14514,19 +14516,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] "Usato per %{formatted} impiego"
 msgstr[1] "Usato per %{formatted} impieghi"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:937
+#: lib/vutuv_web/agent_docs/markdown.ex:939
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr "attualmente in uso"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:936
+#: lib/vutuv_web/agent_docs/markdown.ex:938
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] "usato per %{count} impiego"
 msgstr[1] "usato per %{count} impieghi"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:942
+#: lib/vutuv_web/agent_docs/markdown.ex:944
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -14610,8 +14612,8 @@ msgstr "Prova caricata per %{name}"
 msgid "View the uploaded proof (%{label})"
 msgstr "Vedi la prova caricata (%{label})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:874
-#: lib/vutuv_web/agent_docs/text.ex:713
+#: lib/vutuv_web/agent_docs/markdown.ex:876
+#: lib/vutuv_web/agent_docs/text.ex:715
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr "documento di prova"
@@ -14704,8 +14706,8 @@ msgstr "Salva e continua"
 msgid "Skip for now"
 msgstr "Salta per ora"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:568
-#: lib/vutuv_web/agent_docs/text.ex:560
+#: lib/vutuv_web/agent_docs/markdown.ex:570
+#: lib/vutuv_web/agent_docs/text.ex:562
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr "Modalità di lavoro preferita"
@@ -15071,7 +15073,7 @@ msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
 "Filtro aggiunto. I post corrispondenti sono ora nascosti nel Suo feed."
 
-#: lib/vutuv_web/live/job_board_live.ex:385
+#: lib/vutuv_web/live/job_board_live.ex:547
 #, elixir-autogen, elixir-format
 msgid "Filter by a tag"
 msgstr "Filtra per tag"
@@ -15366,7 +15368,7 @@ msgstr "%{blocked} server bloccati, il più attivo in entrata: %{host}."
 msgid "none yet"
 msgstr "ancora nessuno"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1196
+#: lib/vutuv_web/agent_docs/markdown.ex:1221
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr "Reazioni da altre reti"
@@ -15793,8 +15795,8 @@ msgstr ""
 msgid "Your server"
 msgstr "Il Suo server"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:625
-#: lib/vutuv_web/agent_docs/text.ex:589
+#: lib/vutuv_web/agent_docs/markdown.ex:627
+#: lib/vutuv_web/agent_docs/text.ex:591
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr "spostato a %{address}"
@@ -16204,7 +16206,7 @@ msgid_plural "%{formatted} reposts"
 msgstr[0] "%{formatted} ripubblicazione"
 msgstr[1] "%{formatted} ripubblicazioni"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1198
+#: lib/vutuv_web/agent_docs/markdown.ex:1223
 #: lib/vutuv_web/components/post_components.ex:5942
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
@@ -16220,8 +16222,8 @@ msgstr ""
 " se l'autore la elimina, sparisce anche la nostra. Può rimuovere qualsiasi "
 "singola risposta, e disattivando questa opzione vengono eliminate tutte."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1396
-#: lib/vutuv_web/agent_docs/text.ex:854
+#: lib/vutuv_web/agent_docs/markdown.ex:1421
+#: lib/vutuv_web/agent_docs/text.ex:876
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr "Avviso sul contenuto"
@@ -16245,7 +16247,7 @@ msgstr "Rimossa dal membro"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:135
 #: lib/vutuv_web/agent_docs/markdown.ex:167
-#: lib/vutuv_web/agent_docs/markdown.ex:1197
+#: lib/vutuv_web/agent_docs/markdown.ex:1222
 #: lib/vutuv_web/agent_docs/text.ex:124
 #: lib/vutuv_web/agent_docs/text.ex:153
 #, elixir-autogen, elixir-format
@@ -16304,7 +16306,7 @@ msgstr "Grazie. La risposta è stata eliminata subito."
 msgid "That reply is not yours to remove."
 msgstr "Questa risposta non spetta a Lei rimuoverla."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1398
+#: lib/vutuv_web/agent_docs/markdown.ex:1423
 #: lib/vutuv_web/components/post_components.ex:1427
 #: lib/vutuv_web/components/post_components.ex:1627
 #: lib/vutuv_web/components/post_components.ex:3004
@@ -17040,13 +17042,13 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr "Non più fissato. Il post torna a essere un post normale."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1078
+#: lib/vutuv_web/agent_docs/markdown.ex:1080
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr "post fissato"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:562
-#: lib/vutuv_web/agent_docs/text.ex:551
+#: lib/vutuv_web/agent_docs/markdown.ex:564
+#: lib/vutuv_web/agent_docs/text.ex:553
 #: lib/vutuv_web/templates/user/edit.html.heex:219
 #: lib/vutuv_web/templates/user/show.html.heex:262
 #: lib/vutuv_web/views/account_event_text.ex:213
@@ -17098,8 +17100,8 @@ msgstr "CC BY-SA 4.0 (attribuzione, stessa licenza)"
 msgid "CC0 1.0 (no rights reserved)"
 msgstr "CC0 1.0 (nessun diritto riservato)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1315
-#: lib/vutuv_web/agent_docs/text.ex:808
+#: lib/vutuv_web/agent_docs/markdown.ex:1340
+#: lib/vutuv_web/agent_docs/text.ex:830
 #: lib/vutuv_web/live/post_live/composer.ex:2645
 #, elixir-autogen, elixir-format
 msgid "Cover"
@@ -17110,8 +17112,8 @@ msgstr "Copertina"
 msgid "Describe the photo for people who can't see it"
 msgstr "Descriva la foto per chi non può vederla"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1326
-#: lib/vutuv_web/agent_docs/text.ex:821
+#: lib/vutuv_web/agent_docs/markdown.ex:1351
+#: lib/vutuv_web/agent_docs/text.ex:843
 #: lib/vutuv_web/components/ui.ex:3126
 #, elixir-autogen, elixir-format
 msgid "Download the original"
@@ -17170,8 +17172,8 @@ msgstr "La foto è in fase di controllo"
 msgid "Photo options"
 msgstr "Opzioni della foto"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1359
-#: lib/vutuv_web/agent_docs/text.ex:796
+#: lib/vutuv_web/agent_docs/markdown.ex:1384
+#: lib/vutuv_web/agent_docs/text.ex:818
 #: lib/vutuv_web/components/post_components.ex:4744
 #, elixir-autogen, elixir-format
 msgid "Photos:"
@@ -17358,13 +17360,13 @@ msgstr[1] ""
 "Alcune di queste foto portano con sé il luogo in cui sono state scattate, e "
 "il file esatto lo rivela."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1216
+#: lib/vutuv_web/agent_docs/markdown.ex:1241
 #: lib/vutuv_web/components/post_components.ex:5980
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "A %{handle} è piaciuto"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1214
+#: lib/vutuv_web/agent_docs/markdown.ex:1239
 #: lib/vutuv_web/components/post_components.ex:5977
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
@@ -18074,7 +18076,7 @@ msgstr "Variante"
 msgid "What is being measured"
 msgstr "Cosa viene misurato"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1055
+#: lib/vutuv_web/agent_docs/markdown.ex:1057
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
@@ -18241,8 +18243,8 @@ msgid "We could not reach the network just now. Please try again in a moment."
 msgstr ""
 "Al momento non siamo riusciti a raggiungere la rete. Riprovi tra poco."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:982
-#: lib/vutuv_web/agent_docs/text.ex:635
+#: lib/vutuv_web/agent_docs/markdown.ex:984
+#: lib/vutuv_web/agent_docs/text.ex:637
 #, elixir-autogen, elixir-format
 msgid "verified profile"
 msgstr "profilo verificato"
@@ -19225,7 +19227,7 @@ msgstr ""
 "La pagina di un post mostra i membri a cui è piaciuto, subito sotto il "
 "contatore. Questa impostazione decide se Lei è tra quei volti."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1184
+#: lib/vutuv_web/agent_docs/markdown.ex:1209
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr "Piace a"
@@ -19273,12 +19275,12 @@ msgstr ""
 msgid "Your likes follow the site default again."
 msgstr "I Suoi Mi piace tornano a seguire il valore predefinito del sito."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1239
+#: lib/vutuv_web/agent_docs/markdown.ex:1264
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr "%{address} (solo questa pagina)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1236
+#: lib/vutuv_web/agent_docs/markdown.ex:1261
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr "%{address} (intero sito web)"
@@ -19288,7 +19290,7 @@ msgstr "%{address} (intero sito web)"
 msgid "Verified webpage of the author (%{address})"
 msgstr "Pagina web verificata dell'autore (%{address})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1228
+#: lib/vutuv_web/agent_docs/markdown.ex:1253
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr "Pagine web verificate dell'autore collegate qui: %{addresses}"
@@ -19423,7 +19425,7 @@ msgstr "Rilasciato il"
 msgid "Label"
 msgstr "Etichetta"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3408
+#: lib/vutuv_web/live/post_live/feed.ex:3450
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -19642,7 +19644,7 @@ msgstr "Non abbiamo scritto né il prompt né il modello."
 msgid "Employment references of %{name}"
 msgstr "Attestati di lavoro di %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:856
+#: lib/vutuv_web/agent_docs/markdown.ex:858
 #, elixir-autogen, elixir-format
 msgid "document"
 msgstr "documento"
@@ -22247,6 +22249,7 @@ msgstr "Consigliato: %{width} × %{height} pixel (%{ratio})."
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Consigliato: quadrata, almeno %{width} × %{height} pixel."
 
+#: lib/vutuv_web/live/job_board_live.ex:430
 #: lib/vutuv_web/live/post_live/feed.ex:999
 #: lib/vutuv_web/views/user_html.ex:342
 #, elixir-autogen, elixir-format
@@ -22740,7 +22743,7 @@ msgstr "Prosegui verso %{server}"
 msgid "E-mail to %{address}"
 msgstr "E-mail a %{address}"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:102
+#: lib/vutuv_web/controllers/job_posting_controller.ex:120
 #, elixir-autogen, elixir-format
 msgid "The employer takes applications on their own website."
 msgstr "Il datore di lavoro raccoglie le candidature sul proprio sito web."
@@ -22750,7 +22753,7 @@ msgstr "Il datore di lavoro raccoglie le candidature sul proprio sito web."
 msgid "Write e-mail"
 msgstr "Scrivi un'e-mail"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:114
+#: lib/vutuv_web/controllers/job_posting_controller.ex:132
 #, elixir-autogen, elixir-format
 msgid "Your e-mail program opens with the subject filled in."
 msgstr "Il Suo programma di posta si apre con l'oggetto già compilato."
@@ -22761,34 +22764,34 @@ msgctxt "qualification detail"
 msgid "Jobs"
 msgstr "Impieghi"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:829
+#: lib/vutuv_web/live/job_posting_live/form.ex:875
 #, elixir-autogen, elixir-format
 msgid "%{formatted} country chosen."
 msgid_plural "%{formatted} countries chosen."
 msgstr[0] "%{formatted} paese scelto."
 msgstr[1] "%{formatted} paesi scelti."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:619
+#: lib/vutuv_web/live/job_posting_live/form.ex:645
 #, elixir-autogen, elixir-format
 msgid "No country chosen yet."
 msgstr "Ancora nessun paese scelto."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:611
+#: lib/vutuv_web/live/job_posting_live/form.ex:637
 #, elixir-autogen, elixir-format
 msgid "No country left to add for that."
 msgstr "Non resta alcun paese da aggiungere per questo."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:630
+#: lib/vutuv_web/live/job_posting_live/form.ex:656
 #, elixir-autogen, elixir-format
 msgid "Remove %{country}"
 msgstr "Rimuovi %{country}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:641
+#: lib/vutuv_web/live/job_posting_live/form.ex:667
 #, elixir-autogen, elixir-format
 msgid "Remove all"
 msgstr "Rimuovi tutti"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:590
+#: lib/vutuv_web/live/job_posting_live/form.ex:616
 #, elixir-autogen, elixir-format
 msgid "Search for a country"
 msgstr "Cerchi un paese"
@@ -22943,7 +22946,7 @@ msgstr ""
 "Segua #%{tag} da Mastodon o da qualsiasi altra app del Fediverso e i suoi "
 "post pubblici arriveranno nella Sua cronologia. Non serve un account vutuv."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3569
+#: lib/vutuv_web/live/post_live/feed.ex:3611
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Saluti gli altri membri"
@@ -23525,7 +23528,7 @@ msgstr "I post con uno di questi tag vengono ridotti allo stesso modo."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "I post che contengono una di queste parole vengono ridotti a una riga — non eliminati, e con un modo per aprirli comunque."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3595
+#: lib/vutuv_web/live/post_live/feed.ex:3637
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Messe da parte:"
@@ -23602,10 +23605,10 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "e 1 altro"
 msgstr[1] "e altri %{formatted}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3182
-#: lib/vutuv_web/live/post_live/feed.ex:3209
-#: lib/vutuv_web/live/post_live/feed.ex:3643
-#: lib/vutuv_web/live/post_live/feed.ex:3648
+#: lib/vutuv_web/live/post_live/feed.ex:3224
+#: lib/vutuv_web/live/post_live/feed.ex:3251
+#: lib/vutuv_web/live/post_live/feed.ex:3685
+#: lib/vutuv_web/live/post_live/feed.ex:3690
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -23674,7 +23677,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} post il %{day}"
 msgstr[1] "%{count} post il %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3365
+#: lib/vutuv_web/live/post_live/feed.ex:3407
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Torna al presente"
@@ -23684,7 +23687,7 @@ msgstr "Torna al presente"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Mese intenso: la tonalità indica almeno questo valore."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3411
+#: lib/vutuv_web/live/post_live/feed.ex:3453
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -23706,7 +23709,7 @@ msgstr "Mese successivo"
 msgid "Next year"
 msgstr "Anno successivo"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3361
+#: lib/vutuv_web/live/post_live/feed.ex:3403
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Il %{day} non è arrivato nulla nel Suo feed."
@@ -23793,7 +23796,7 @@ msgstr "È pronta una nuova versione."
 msgid "Page management"
 msgstr "Gestione"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2304
+#: lib/vutuv_web/live/post_live/feed.ex:2312
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
@@ -23805,12 +23808,12 @@ msgstr[1] "Nuovi (%{formatted}):"
 msgid "Quoted post"
 msgstr "Post citato"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1071
+#: lib/vutuv_web/agent_docs/markdown.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Quotes %{name}: %{url}"
 msgstr "Cita %{name}: %{url}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1068
+#: lib/vutuv_web/agent_docs/markdown.ex:1070
 #, elixir-autogen, elixir-format
 msgid "Quotes %{url}"
 msgstr "Cita %{url}"
@@ -23825,7 +23828,7 @@ msgstr "Menziona un account"
 msgid "{used} of {max} mentions"
 msgstr "{used} di {max} menzioni"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2453
+#: lib/vutuv_web/live/post_live/feed.ex:2461
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""
@@ -24303,10 +24306,10 @@ msgstr "Questo post La sta ancora aspettando"
 msgid "This video could not be converted."
 msgstr "Questo video non può essere convertito."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1311
-#: lib/vutuv_web/agent_docs/markdown.ex:1314
-#: lib/vutuv_web/agent_docs/text.ex:805
-#: lib/vutuv_web/agent_docs/text.ex:806
+#: lib/vutuv_web/agent_docs/markdown.ex:1336
+#: lib/vutuv_web/agent_docs/markdown.ex:1339
+#: lib/vutuv_web/agent_docs/text.ex:827
+#: lib/vutuv_web/agent_docs/text.ex:828
 #: lib/vutuv_web/components/post_components.ex:2506
 #: lib/vutuv_web/components/video_components.ex:126
 #: lib/vutuv_web/live/post_live/composer.ex:2442
@@ -24420,3 +24423,42 @@ msgstr "Qualità standard. Carica questa immagine in HD."
 #, elixir-autogen, elixir-format
 msgid "Standard quality. Play this video in HD."
 msgstr "Qualità standard. Riproduci questo video in HD."
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:773
+#, elixir-autogen, elixir-format
+msgid "Members carrying these tags:"
+msgstr "Membri con questi tag:"
+
+#: lib/vutuv_web/agent_docs/job_board_doc.ex:44
+#: lib/vutuv_web/live/job_board_live.ex:262
+#, elixir-autogen, elixir-format
+msgid "No posting yet. Yours would be the first, and it would stand at the top on its own."
+msgstr "Ancora nessun annuncio. Il Suo sarebbe il primo e resterebbe da solo in cima."
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1116
+#: lib/vutuv_web/agent_docs/text.ex:758
+#: lib/vutuv_web/live/job_board_live.ex:415
+#, elixir-autogen, elixir-format
+msgid "One member has said they are available."
+msgid_plural "%{formatted} members have said they are available."
+msgstr[0] "Un membro è aperto a proposte o in cerca di lavoro."
+msgstr[1] "%{formatted} membri sono aperti a proposte o in cerca di lavoro."
+
+#: lib/vutuv_web/live/job_board_live.ex:475
+#, elixir-autogen, elixir-format
+msgid "The fields the most members carry, and how many of them do."
+msgstr "Gli ambiti con più membri, e quanti sono per ciascuno."
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1123
+#: lib/vutuv_web/agent_docs/text.ex:765
+#: lib/vutuv_web/live/job_board_live.ex:473
+#, elixir-autogen, elixir-format
+msgid "What members here work on"
+msgstr "Di cosa si occupano i membri qui"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1115
+#: lib/vutuv_web/agent_docs/text.ex:757
+#: lib/vutuv_web/live/job_board_live.ex:410
+#, elixir-autogen, elixir-format
+msgid "Who you would reach"
+msgstr "Chi raggiungerebbe"

--- a/test/vutuv/accounts/open_to_offers_test.exs
+++ b/test/vutuv/accounts/open_to_offers_test.exs
@@ -1,0 +1,121 @@
+defmodule Vutuv.Accounts.OpenToOffersTest do
+  @moduledoc """
+  `Accounts.open_to_offers/2`: the members who said they are available, as a
+  listing rather than one profile at a time.
+
+  It is the same availability signal the profile badge shows (issue #928), so
+  it obeys the same three-way visibility and the same job-search exclusion list
+  (#938). A listing multiplies the cost of getting that wrong: a profile leaks
+  one member's status to one visitor, a list hands a crawler everybody's.
+  """
+  use Vutuv.DataCase, async: true
+
+  alias Vutuv.Accounts
+  alias Vutuv.Accounts.User
+  alias Vutuv.Repo
+
+  defp seeker(attrs) do
+    insert(:activated_user, Keyword.merge([employment_status: "open"], attrs))
+  end
+
+  test "lists only members who set a status" do
+    available = seeker(employment_status_visibility: "everyone")
+    _quiet = insert(:activated_user, employment_status: nil)
+
+    assert ids(Accounts.open_to_offers(nil)) == [available.id]
+  end
+
+  test "a logged-out visitor sees only the members open to everyone" do
+    public = seeker(employment_status_visibility: "everyone")
+    _members_only = seeker(employment_status_visibility: "members")
+    _hidden = seeker(employment_status_visibility: "hidden")
+
+    assert ids(Accounts.open_to_offers(nil)) == [public.id]
+    assert Accounts.open_to_offers(nil).total == 1
+  end
+
+  test "a signed-in member also sees the members-only ones, never the hidden" do
+    public = seeker(employment_status_visibility: "everyone")
+    members_only = seeker(employment_status_visibility: "members")
+    _hidden = seeker(employment_status_visibility: "hidden")
+    viewer = insert(:activated_user)
+
+    listed = ids(Accounts.open_to_offers(viewer))
+
+    assert Enum.sort(listed) == Enum.sort([public.id, members_only.id])
+    assert Accounts.open_to_offers(viewer).total == 2
+  end
+
+  test "a viewer on the seeker's exclusion list never sees them (issue #938)" do
+    seeker = seeker(employment_status_visibility: "members")
+    viewer = insert(:activated_user)
+    insert(:viewer_exclusion, user: seeker, excluded_user: viewer, domain: nil)
+
+    # The count is the same answer as the list, so an excluded viewer is not
+    # told "one member is looking" by a number they can never resolve to a row.
+    assert Accounts.open_to_offers(viewer) == %{people: [], total: 0}
+  end
+
+  test "an unconfirmed or moderation-hidden member is not listed" do
+    _unconfirmed =
+      insert(:user, employment_status: "looking", employment_status_visibility: "everyone")
+
+    seeker(employment_status_visibility: "everyone", frozen_at: NaiveDateTime.utc_now(:second))
+
+    assert Accounts.open_to_offers(nil) == %{people: [], total: 0}
+  end
+
+  test "the freshest signal comes first, and the limit is honoured" do
+    older = seeker(employment_status_visibility: "everyone")
+    newer = seeker(employment_status_visibility: "everyone")
+
+    stamp(older, ~N[2026-01-01 10:00:00])
+    stamp(newer, ~N[2026-09-01 10:00:00])
+
+    assert ids(Accounts.open_to_offers(nil)) == [newer.id, older.id]
+
+    # The limit shortens the list and not the count: the page says "showing 1
+    # of 2", never "there is 1".
+    assert Accounts.open_to_offers(nil, limit: 1) |> ids() == [newer.id]
+    assert Accounts.open_to_offers(nil, limit: 1).total == 2
+  end
+
+  # The listing gate is SQL and `User.employment_status_visible?/2` is pattern
+  # matching over a loaded struct — two spellings of the one #928 rule, which is
+  # exactly the shape that drifts. This pins them to each other: every
+  # visibility value, seen by nobody and by a signed-in member.
+  test "the SQL gate answers what the struct predicate answers" do
+    viewer = insert(:activated_user)
+
+    for visibility <- ["everyone", "members", "hidden", nil],
+        {label, looker} <- [{"anonymous", nil}, {"signed in", viewer}] do
+      member = seeker(employment_status_visibility: visibility)
+      listed? = member.id in ids(Accounts.open_to_offers(looker))
+      predicate? = User.employment_status_visible?(member, looker)
+
+      assert listed? == predicate?,
+             "#{label} viewer, visibility #{inspect(visibility)}: listing says #{listed?}, " <>
+               "employment_status_visible?/2 says #{predicate?}"
+
+      Repo.delete!(member)
+    end
+  end
+
+  test "the rows carry what a listing card draws, without a second query" do
+    seeker(employment_status_visibility: "everyone", desired_workplace_types: ["remote"])
+
+    %{people: [row]} = Accounts.open_to_offers(nil)
+
+    assert row.employment_status == "open"
+    assert row.desired_workplace_types == ["remote"]
+    assert is_binary(row.username)
+  end
+
+  defp ids(%{people: people}), do: Enum.map(people, & &1.id)
+
+  defp stamp(user, at) do
+    user
+    |> Ecto.Changeset.change(employment_status_set_at: at)
+    |> Repo.update!()
+  end
+end

--- a/test/vutuv_web/agent_docs/job_board_reach_doc_test.exs
+++ b/test/vutuv_web/agent_docs/job_board_reach_doc_test.exs
@@ -1,0 +1,66 @@
+defmodule VutuvWeb.AgentDocs.JobBoardReachDocTest do
+  @moduledoc """
+  The `/jobs` agent siblings when the board is empty.
+
+  With no posting, the HTML board stops being a board and shows the other side
+  of the market — the members who said they are available, and the fields they
+  carry. An agent reading `/jobs.json` must get the same two facts, or the
+  document answers "nobody is hiring" where the page answers "nobody is hiring
+  yet, and here is who is here" (the drift rule in `CLAUDE.md`).
+
+  The document is the **anonymous** view, so a `members`-only availability
+  belongs in neither.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  import Vutuv.JobsHelpers
+
+  test "the empty board's document carries the available members and the fields" do
+    tag = insert(:tag, name: "Reach Doc Elixir", slug: "reach_doc_elixir")
+
+    seeker =
+      insert(:activated_user,
+        employment_status: "open",
+        employment_status_visibility: "everyone",
+        desired_workplace_types: ["remote"]
+      )
+
+    insert(:user_tag, user: seeker, tag: tag)
+
+    doc = build_conn() |> get(~p"/jobs.json") |> json_response(200)
+
+    assert doc["count"] == 0
+    assert doc["open_to_offers"]["total"] == 1
+    assert [person] = doc["open_to_offers"]["people"]
+    assert person["employment_status"] == "open"
+    assert person["desired_workplace_types"] == ["remote"]
+    assert Enum.any?(doc["fields"], &(&1["name"] == "Reach Doc Elixir" and &1["members"] == 1))
+
+    # And the Markdown sibling says it in words rather than dropping the block.
+    md = build_conn() |> get(~p"/jobs.md") |> response(200)
+    assert md =~ "Who you would reach"
+    assert md =~ "Reach Doc Elixir"
+  end
+
+  test "a members-only availability stays out of the anonymous document" do
+    insert(:activated_user,
+      employment_status: "looking",
+      employment_status_visibility: "members"
+    )
+
+    doc = build_conn() |> get(~p"/jobs.json") |> json_response(200)
+
+    assert doc["open_to_offers"]["total"] == 0
+    assert doc["open_to_offers"]["people"] == []
+  end
+
+  test "a board with a posting carries neither key" do
+    publish_job!()
+
+    doc = build_conn() |> get(~p"/jobs.json") |> json_response(200)
+
+    assert doc["count"] == 1
+    refute Map.has_key?(doc, "open_to_offers")
+    refute Map.has_key?(doc, "fields")
+  end
+end

--- a/test/vutuv_web/job_posting_test.exs
+++ b/test/vutuv_web/job_posting_test.exs
@@ -54,6 +54,31 @@ defmodule VutuvWeb.JobPostingTest do
       assert html =~ "Publish"
     end
 
+    test "the tag fields say how many members carry what was typed", %{conn: conn} do
+      tag = insert(:tag, name: "Reach Elixir", slug: "reach_elixir")
+      for _ <- 1..2, do: insert(:user_tag, user: insert(:activated_user), tag: tag)
+
+      {conn, _user} = create_and_login_user(conn)
+      {:ok, view, html} = live(conn, ~p"/jobs/new")
+
+      # Nothing typed yet, so there is nothing to say.
+      refute html =~ "job-tag-reach"
+
+      html =
+        view
+        |> form("#job-posting-form",
+          job_posting: form_params(%{"required_tags" => "Reach Elixir"})
+        )
+        |> render_change()
+
+      assert html =~ "Members carrying these tags:"
+      assert html =~ ~s(data-tag-reach="Reach Elixir")
+      assert has_element?(view, "[data-tag-reach='Reach Elixir']", "2")
+      # A tag nobody here carries says 0 rather than going quiet: that is the
+      # half the poster can act on, by spelling the field the way members do.
+      assert has_element?(view, "[data-tag-reach='Kubernetes']", "0")
+    end
+
     test "publishing without a salary range is rejected inline", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       age_account(user)

--- a/test/vutuv_web/live/job_board_live_test.exs
+++ b/test/vutuv_web/live/job_board_live_test.exs
@@ -55,18 +55,104 @@ defmodule VutuvWeb.JobBoardLiveTest do
   end
 
   test "the search-tips help is on the board", %{conn: conn} do
+    publish_job!()
     {:ok, view, _html} = live(conn, ~p"/jobs")
 
     assert has_element?(view, "details summary", "Search tips")
     assert render(view) =~ "Webentwickler, PHP-Entwickler"
   end
 
-  test "shows an empty state with no postings", %{conn: conn} do
-    {:ok, _view, html} = live(conn, ~p"/jobs")
-    assert html =~ "No job postings yet"
+  test "with no postings at all the board is not a board", %{conn: conn} do
+    {:ok, view, html} = live(conn, ~p"/jobs")
+
+    # A search box over an empty corpus promises a stock and disproves it in
+    # the same view, so neither it nor the filter chips render.
+    refute has_element?(view, "form[action='/jobs'] input[name='q']")
+    refute has_element?(view, "#job-filter-chips")
+    assert html =~ "Yours would be the first"
+    # The way in stays, logged out included: whoever has a job to fill is who
+    # this page exists for.
+    assert has_element?(view, "a[href='/jobs/new']")
+  end
+
+  test "the empty board offers the members who said they are available", %{conn: conn} do
+    seeker =
+      insert(:activated_user,
+        employment_status: "open",
+        employment_status_visibility: "everyone",
+        desired_workplace_types: ["remote"]
+      )
+
+    {:ok, view, html} = live(conn, ~p"/jobs")
+
+    assert has_element?(view, "#seeker-#{seeker.id}")
+    assert html =~ "Open to offers"
+    assert html =~ "Who you would reach"
+  end
+
+  test "the empty board keeps a members-only availability from a logged-out visitor", %{
+    conn: conn
+  } do
+    quiet =
+      insert(:activated_user,
+        employment_status: "looking",
+        employment_status_visibility: "members"
+      )
+
+    {:ok, view, _html} = live(conn, ~p"/jobs")
+
+    refute has_element?(view, "#seeker-#{quiet.id}")
+  end
+
+  test "the empty board names the fields members carry", %{conn: conn} do
+    tag = insert(:tag, name: "Elixir", slug: "elixir")
+    user = insert(:activated_user)
+    insert(:user_tag, user: user, tag: tag)
+
+    {:ok, view, html} = live(conn, ~p"/jobs")
+
+    assert html =~ "What members here work on"
+    assert has_element?(view, "a[href='/tags/elixir']", "Elixir")
+  end
+
+  test "the empty board speaks German to a German browser", %{conn: conn} do
+    # Every string on this page is new, and `mix gettext.extract --merge`
+    # fuzzy-fills a new msgid with the translation of whatever it resembles —
+    # so the German render is asserted by name rather than trusted.
+    insert(:activated_user, employment_status: "open", employment_status_visibility: "everyone")
+
+    {:ok, _view, html} =
+      conn
+      |> put_req_header("accept-language", "de-DE,de;q=0.9")
+      |> live(~p"/jobs")
+
+    assert html =~ "Wen Sie hier erreichen"
+    assert html =~ "stünde allein oben"
+    assert html =~ "Offen für Angebote"
+  end
+
+  test "a filter that matches nothing keeps the board, it does not read as empty", %{conn: conn} do
+    # The reach page is for somebody who arrived at the plain board. A visitor
+    # who searched asked a question, and the answer is "nothing matched" plus a
+    # way to clear it — even on a corpus that happens to be empty.
+    {:ok, view, html} = live(conn, ~p"/jobs?#{[q: "elixir"]}")
+
+    assert has_element?(view, "#job-filter-chips")
+    refute html =~ "Yours would be the first"
+    assert html =~ "No matching positions"
+  end
+
+  test "one published posting brings the board back", %{conn: conn} do
+    publish_job!()
+
+    {:ok, view, _html} = live(conn, ~p"/jobs")
+
+    assert has_element?(view, "#job-filter-chips")
+    refute has_element?(view, "[id^='seeker-']")
   end
 
   test "a signed-in member sees the tag- and salary-match chips", %{conn: conn} do
+    publish_job!()
     {conn, user} = create_and_login_user(conn)
     # A stored minimum-salary expectation (#928) offers the "from my expectation"
     # prefill chip; every signed-in member gets the "Matches my tags" chip.
@@ -169,6 +255,7 @@ defmodule VutuvWeb.JobBoardLiveTest do
 
   describe "salary field (#953)" do
     test "everyone gets a minimum-salary input, even logged out", %{conn: conn} do
+      publish_job!()
       {:ok, view, _html} = live(conn, ~p"/jobs")
       assert has_element?(view, "input#job-salary-min[name='salary_min']")
     end
@@ -197,6 +284,7 @@ defmodule VutuvWeb.JobBoardLiveTest do
     end
 
     test "the 'from my expectation' chip never renders the private figure", %{conn: conn} do
+      publish_job!()
       {conn, user} = create_and_login_user(conn)
 
       user
@@ -220,6 +308,7 @@ defmodule VutuvWeb.JobBoardLiveTest do
     end
 
     test "a member saves the current board filters as an alert", %{conn: conn} do
+      publish_job!()
       {conn, user} = create_and_login_user(conn)
       {:ok, view, _html} = live(conn, ~p"/jobs?#{[q: "elixir"]}")
 


### PR DESCRIPTION
The board at `/jobs` has no postings, and said so: a four-field search form, a
row of filter chips, and a card reading "No job postings yet." A box over an
empty corpus promises a stock and disproves it in the same view, and a
logged-out visitor with a job to fill got one sentence and no way in.

With no posting at all, `VutuvWeb.JobBoardLive` now shows the side of the
market this installation has instead: the members who set a #928 availability
(same visibility and #938 exclusion list as the profile badge, both in SQL) and
the fields the most members carry. "Post a job" renders logged out too.
`Jobs.board_reach/1` owns that answer, so the page and its `/jobs.md|.json|…`
siblings cannot drift. The posting form now names the member count beside each
typed tag.

Hot deploy. On an active board nothing changes; with a filter set, the ordinary
"no matching positions" card still answers.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01GmvDFKimQ4gGpSV97ckumc