### PR TITLE
Say what the empty board drew, not how many members exist

### DIFF
--- a/docs/architecture/jobs.md
+++ b/docs/architecture/jobs.md
@@ -216,7 +216,7 @@ and the crawl path — the board is a shared-footer + top-bar nav link). PubSub
   carrying the structured location / salary / tag fields
   (`JobPostingDoc.summary/1`) so agents filter client-side, cursor-paginated with
   a `next` link. On an empty board the document adds `open_to_offers`
-  (`%{total:, people:}`) and `fields` from the same `Jobs.board_reach/1` the
+  (the drawn people) and `fields` from the same `Jobs.board_reach/1` the
   page reads, with the anonymous viewer — the people entries are the shared
   listing shape (`AgentDocs.person_entry/3`, as on the follow lists) plus the
   availability. **No `JobPosting` JSON-LD on the list** (leaf pages only).
@@ -228,15 +228,18 @@ and the crawl path — the board is a shared-footer + top-bar nav link). PubSub
   `Jobs.board_reach(viewer)` returns `%{count:, people:, fields:}` or `nil`
   ("render the ordinary board"), so the page and its agent documents cannot show
   different members or a different number of them. It composes
-  `Accounts.open_to_offers/2` (the members who set a #928 availability, under
-  the same three-way visibility and the same #938 exclusion list — both in SQL,
-  and `count(*) OVER ()` brings the total back with the rows, so one round trip
-  and no way for the headline number to disagree with what is under it; a test
-  pins that SQL gate to `User.employment_status_visible?/2`) and
+  `Accounts.open_to_offers/2` (twelve of the members who set a #928
+  availability, **drawn at random** — a ranking would show the same faces to
+  every visitor until somebody's status changes — under the same three-way
+  visibility and the same #938 exclusion list, both in SQL, with a test pinning
+  that gate to `User.employment_status_visible?/2`) and
   `Tags.popular_member_tags/1` (the fields the most listed members carry). The
   "Post a job" button renders logged out too, because whoever has a job to fill
   is exactly who that page has to keep; `/jobs/new` sends them to the login page
-  with a line saying why. The reach block is for a visitor who arrived at the
+  with a line saying why. The block states **what it drew** ("12 random vutuv
+  accounts that are open to offers"), never how many there are in all: a sample
+  can only vouch for its own rows, and the empty board carries no subline of its
+  own either, since a sentence about the missing stock only repeats the heading. The reach block is for a visitor who arrived at the
   **plain** board: with a filter active the ordinary "no matching positions" card
   answers instead, which also keeps the everyday filtered-to-zero case from
   paying for the corpus check. `JobPostingLive.Form` answers the same question

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -2105,11 +2105,19 @@ defmodule Vutuv.Accounts do
   @available_shown 6
 
   @doc """
-  The members who said they are available — `%{people: [%User{}], total:
-  integer}`, freshest signal first. The same #928 availability the profile
-  badge carries, read as a **listing**.
+  **A random handful** of the members who said they are available. The same
+  #928 availability the profile badge carries, read as a **listing**.
 
-  `viewer` decides what is on it, exactly as on a profile: an anonymous visitor
+  Random rather than ranked or newest-first, and that is the point: a ranking
+  would show the same faces to every visitor for as long as nobody's status
+  changes, so the members further down the list might as well not have answered
+  the question. The draw happens in the query, so the caller decides how long
+  one lasts by deciding when to ask again (the job board draws on mount, not on
+  render, or the list would reshuffle under a reader). Nothing states how many
+  members there are in all: with a random sample the page can only vouch for
+  what it drew, so it says that number and no other.
+
+  `viewer` decides who is on it, exactly as on a profile: an anonymous visitor
   (nil) sees only the members open to `everyone`, a signed-in one also the
   `members` ones, nobody sees `hidden`, and the #938 exclusion list is
   subtracted last. Both gates run in SQL rather than over the loaded rows: a
@@ -2119,12 +2127,6 @@ defmodule Vutuv.Accounts do
   `test/vutuv/accounts/open_to_offers_test.exs`, so the SQL spelling and the
   struct predicate cannot drift into two different answers.
 
-  `total` counts the whole gated set, not the returned page, and comes back
-  from the same query as the rows (`count(*) OVER ()`) — one round trip, and no
-  way for the headline number to disagree with what is under it. A count that
-  ignored the exclusion list would tell an excluded visitor that somebody is
-  looking and then show them nobody.
-
   Opts: `:limit` (default #{@available_shown}). The rows carry the listing
   fields plus the two the availability line reads, so a card needs no second
   query.
@@ -2132,20 +2134,12 @@ defmodule Vutuv.Accounts do
   def open_to_offers(viewer, opts \\ []) do
     fields = User.listing_fields() ++ ~w(employment_status desired_workplace_types)a
 
-    rows =
-      available(viewer)
-      |> order_by([candidate: u], desc_nulls_last: u.employment_status_set_at, desc: u.id)
-      |> limit(^Keyword.get(opts, :limit, @available_shown))
-      |> select([candidate: u], {struct(u, ^fields), fragment("count(*) OVER ()")})
-      |> Repo.all()
-
-    %{people: Enum.map(rows, &elem(&1, 0)), total: gated_total(rows)}
+    available(viewer)
+    |> order_by(fragment("random()"))
+    |> limit(^Keyword.get(opts, :limit, @available_shown))
+    |> select([candidate: u], struct(u, ^fields))
+    |> Repo.all()
   end
-
-  # The window count rides on every row, so an empty page carries none — and an
-  # empty page means an empty set.
-  defp gated_total([]), do: 0
-  defp gated_total([{_person, total} | _rest]), do: total
 
   # The listed, confirmed members carrying a status this viewer may see.
   defp available(viewer) do

--- a/lib/vutuv/jobs.ex
+++ b/lib/vutuv/jobs.ex
@@ -883,13 +883,13 @@ defmodule Vutuv.Jobs do
   # the two call sites, because the HTML board and its agent-format sibling have
   # to show the same two facts (`VutuvWeb.AgentDocs.JobBoardDoc`) and a number
   # written twice is a number that drifts.
-  @reach_people 6
+  @reach_people 12
   @reach_fields 12
 
   @doc """
   What the board shows in place of a listing when `viewer` would find no
-  posting at all: the members who said they are available (with how many there
-  are) and the fields the most members carry — `%{count:, people:, fields:}`.
+  posting at all: a random handful of the members who said they are available
+  and the fields the most members carry — `%{people:, fields:}`.
 
   `nil` on a board that has something to list, which is the caller's signal to
   render the ordinary board. One home for the answer, so the page
@@ -898,11 +898,8 @@ defmodule Vutuv.Jobs do
   """
   def board_reach(viewer) do
     if board_empty?(viewer) do
-      available = Accounts.open_to_offers(viewer, limit: @reach_people)
-
       %{
-        count: available.total,
-        people: available.people,
+        people: Accounts.open_to_offers(viewer, limit: @reach_people),
         fields: Tags.popular_member_tags(@reach_fields)
       }
     end

--- a/lib/vutuv_web/agent_docs/job_board_doc.ex
+++ b/lib/vutuv_web/agent_docs/job_board_doc.ex
@@ -8,10 +8,13 @@ defmodule VutuvWeb.AgentDocs.JobBoardDoc do
   filter client-side; a `next` link walks to the following page.
 
   With no posting at all the HTML board shows the other side of the market
-  instead — the members who said they are available and the fields they carry —
-  so the document carries the same two facts under `open_to_offers` and
-  `fields`. An agent asked "is anybody hiring on vutuv?" then gets the honest
-  answer *and* the reason to look further, exactly like a reader.
+  instead — a random handful of the members who said they are available, and
+  the fields they carry — so the document carries the same two facts under
+  `open_to_offers` and `fields`. An agent asked "is anybody hiring on vutuv?"
+  then gets the honest answer *and* the reason to look further, exactly like a
+  reader. `open_to_offers` is the drawn people and nothing else: with a random
+  sample, how many there are in all is a number neither the page nor this
+  document can back up with rows.
   """
 
   use Gettext, backend: VutuvWeb.Gettext
@@ -25,15 +28,15 @@ defmodule VutuvWeb.AgentDocs.JobBoardDoc do
   @tags_shown 3
 
   @doc """
-  The board document. `reach` is the empty-board companion (`%{count:, people:,
-  fields:}` from `Vutuv.Jobs`/`Vutuv.Accounts`, anonymous view) or nil on a
-  board that has postings.
+  The board document. `reach` is the empty-board companion (`%{people:,
+  fields:}` from `Vutuv.Jobs.board_reach/1`, anonymous view) or nil on a board
+  that has postings.
   """
   def build(postings, next_cursor \\ nil, reach \\ nil) do
     AgentDocs.doc_meta("job_board", "/jobs")
     |> Map.merge(%{
       title: gettext("Jobs"),
-      description: description(reach),
+      description: gettext("Open positions on vutuv, newest first."),
       count: length(postings),
       next: next_url(next_cursor),
       postings: Enum.map(postings, &JobPostingDoc.summary/1)
@@ -41,25 +44,14 @@ defmodule VutuvWeb.AgentDocs.JobBoardDoc do
     |> put_reach(reach)
   end
 
-  defp description(nil), do: gettext("Open positions on vutuv, newest first.")
-
-  defp description(_reach),
-    do:
-      gettext(
-        "No posting yet. Yours would be the first, and it would stand at the top on its own."
-      )
-
   defp put_reach(doc, nil), do: doc
 
-  defp put_reach(doc, %{count: count, people: people, fields: fields}) do
+  defp put_reach(doc, %{people: people, fields: fields}) do
     work_info = UserHelpers.work_information_map(people, 45)
     tags = UserHelpers.tag_summary_map(people, @tags_shown)
 
     Map.merge(doc, %{
-      open_to_offers: %{
-        total: count,
-        people: Enum.map(people, &person_entry(&1, work_info, tags))
-      },
+      open_to_offers: Enum.map(people, &person_entry(&1, work_info, tags)),
       fields:
         Enum.map(fields, fn {tag, members} ->
           %{name: tag.name, url: AgentDocs.abs_url("/tags/" <> tag.slug), members: members}

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -1114,12 +1114,12 @@ defmodule VutuvWeb.AgentDocs.Markdown do
     [
       "## #{gettext("Who you would reach")}",
       ngettext(
-        "One member has said they are available.",
-        "%{formatted} members have said they are available.",
-        available.total,
-        formatted: to_string(available.total)
+        "One random vutuv account that is open to offers.",
+        "%{formatted} random vutuv accounts that are open to offers.",
+        length(available),
+        formatted: to_string(length(available))
       ),
-      Enum.map_join(available.people, "\n", &person_line/1),
+      Enum.map_join(available, "\n", &person_line/1),
       "## #{gettext("What members here work on")}",
       Enum.map_join(fields, "\n", fn field ->
         "- #{md_link(field.name, field.url)} (#{field.members})"

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -756,12 +756,12 @@ defmodule VutuvWeb.AgentDocs.Text do
     [
       heading(gettext("Who you would reach")),
       ngettext(
-        "One member has said they are available.",
-        "%{formatted} members have said they are available.",
-        available.total,
-        formatted: to_string(available.total)
+        "One random vutuv account that is open to offers.",
+        "%{formatted} random vutuv accounts that are open to offers.",
+        length(available),
+        formatted: to_string(length(available))
       ),
-      Enum.map(available.people, &person_line/1),
+      Enum.map(available, &person_line/1),
       heading(gettext("What members here work on")),
       Enum.map(fields, fn field -> "* #{field.name} (#{field.members})\n  #{field.url}" end)
     ]

--- a/lib/vutuv_web/live/job_board_live.ex
+++ b/lib/vutuv_web/live/job_board_live.ex
@@ -263,12 +263,11 @@ defmodule VutuvWeb.JobBoardLive do
       <div class="mb-4 flex flex-wrap items-end justify-between gap-3">
         <div>
           <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">{gettext("Jobs")}</h1>
-          <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
-            <%= if @reach do %>
-              {gettext("No posting yet. Yours would be the first, and it would stand at the top on its own.")}
-            <% else %>
-              {gettext("Open positions on vutuv, newest first.")}
-            <% end %>
+          <%!-- No subline on an empty board: what there is to say is in the
+          card below, and a sentence about the missing stock only says the
+          heading again. --%>
+          <p :if={!@reach} class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+            {gettext("Open positions on vutuv, newest first.")}
           </p>
         </div>
         <%!-- Shown logged out too, and deliberately: a visitor with a job to
@@ -399,7 +398,7 @@ defmodule VutuvWeb.JobBoardLive do
   # Both blocks render only when they have something, so a brand-new
   # installation shows the heading and the button and nothing that reads as a
   # gap.
-  attr(:reach, :map, required: true, doc: "`Vutuv.Jobs.board_reach/1`: count + fields")
+  attr(:reach, :map, required: true, doc: "`Vutuv.Jobs.board_reach/1`: the fields")
   attr(:seekers, :list, required: true, doc: "its members, decorated by `seeker_rows/1`")
 
   defp reach(assigns) do
@@ -409,14 +408,16 @@ defmodule VutuvWeb.JobBoardLive do
         <div>
           <.section_title>{gettext("Who you would reach")}</.section_title>
           <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
-            <%!-- `%{formatted}` rather than `%{count}`: ngettext binds the raw
-            integer to `count` and a `count:` binding does not override it, so
-            the grouped number needs a placeholder of its own. --%>
+            <%!-- The number is what is DRAWN, not how many exist: the draw is
+            random, so a total nobody can page to would be a number the page
+            cannot back up. `%{formatted}` rather than `%{count}`, because
+            ngettext binds the raw integer to `count` and a `count:` binding
+            does not override it. --%>
             {ngettext(
-              "One member has said they are available.",
-              "%{formatted} members have said they are available.",
-              @reach.count,
-              formatted: delimited_count(@reach.count)
+              "One random vutuv account that is open to offers.",
+              "%{formatted} random vutuv accounts that are open to offers.",
+              length(@seekers),
+              formatted: delimited_count(length(@seekers))
             )}
           </p>
         </div>

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -115,7 +115,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
 #: lib/vutuv_web/live/admin/user_delete_live.ex:202
-#: lib/vutuv_web/live/job_posting_live/form.ex:852
+#: lib/vutuv_web/live/job_posting_live/form.ex:857
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
 #: lib/vutuv_web/live/post_live/composer.ex:1901
@@ -178,7 +178,7 @@ msgstr "%{name} konnte nicht zurückgefolgt werden."
 msgid "Delete"
 msgstr "Löschen"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:711
+#: lib/vutuv_web/live/job_posting_live/form.ex:710
 #: lib/vutuv_web/live/organization_live/edit.ex:305
 #: lib/vutuv_web/live/organization_live/edit.ex:318
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
@@ -641,7 +641,7 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:219
 #: lib/vutuv_web/live/directory_search_live.ex:181
-#: lib/vutuv_web/live/job_board_live.ex:572
+#: lib/vutuv_web/live/job_board_live.ex:573
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
@@ -858,7 +858,7 @@ msgstr "Alle anzeigen"
 
 #: lib/vutuv_web/components/ui.ex:5097
 #: lib/vutuv_web/controllers/settings_controller.ex:171
-#: lib/vutuv_web/live/job_posting_live/form.ex:813
+#: lib/vutuv_web/live/job_posting_live/form.ex:818
 #: lib/vutuv_web/live/organization_live/edit.ex:339
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
@@ -1386,7 +1386,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:444
 #: lib/vutuv_web/live/cv_live.ex:323
 #: lib/vutuv_web/live/job_board_live.ex:339
-#: lib/vutuv_web/live/job_posting_live/form.ex:742
+#: lib/vutuv_web/live/job_posting_live/form.ex:741
 #: lib/vutuv_web/live/search_live.ex:347
 #: lib/vutuv_web/live/search_live.ex:818
 #: lib/vutuv_web/live/tag_new_live.ex:35
@@ -1566,8 +1566,8 @@ msgstr ""
 "Login-Link."
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:771
-#: lib/vutuv_web/live/job_board_live.ex:518
-#: lib/vutuv_web/live/job_posting_live/form.ex:574
+#: lib/vutuv_web/live/job_board_live.ex:519
+#: lib/vutuv_web/live/job_posting_live/form.ex:573
 #: lib/vutuv_web/live/organization_live/edit.ex:335
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
@@ -2100,7 +2100,7 @@ msgstr "September"
 msgid "Markdown is supported: bold, italics, links and lists."
 msgstr "Markdown wird unterstützt: Fett, Kursiv, Links und Listen."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:735
+#: lib/vutuv_web/live/job_posting_live/form.ex:734
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr "Bilder hinzufügen"
@@ -2820,7 +2820,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] "1 Vernetzung"
 msgstr[1] "%{formatted} Vernetzungen"
 
-#: lib/vutuv_web/live/job_board_live.ex:457
+#: lib/vutuv_web/live/job_board_live.ex:458
 #: lib/vutuv_web/live/post_live/feed.ex:1053
 #: lib/vutuv_web/templates/user/card_list.html.heex:51
 #, elixir-autogen, elixir-format
@@ -3979,7 +3979,7 @@ msgstr "Follower von %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:158
 #: lib/vutuv_web/agent_docs/text.ex:112
 #: lib/vutuv_web/agent_docs/text.ex:144
-#: lib/vutuv_web/live/job_posting_live/form.ex:725
+#: lib/vutuv_web/live/job_posting_live/form.ex:724
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr "Bilder"
@@ -4065,7 +4065,7 @@ msgstr "heute"
 msgid "until %{date}"
 msgstr "bis %{date}"
 
-#: lib/vutuv_web/agent_docs/agent_docs.ex:371
+#: lib/vutuv_web/agent_docs/agent_docs.ex:413
 #, elixir-autogen, elixir-format
 msgid "This page in %{language}: %{url}"
 msgstr "Diese Seite auf %{language}: %{url}"
@@ -4163,7 +4163,7 @@ msgid "Booking requires a vutuv login."
 msgstr "Für die Buchung ist ein vutuv-Login erforderlich."
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
-#: lib/vutuv_web/live/job_posting_live/form.ex:568
+#: lib/vutuv_web/live/job_posting_live/form.ex:567
 #: lib/vutuv_web/live/organization_live/edit.ex:331
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
@@ -4829,7 +4829,7 @@ msgstr "müller"
 msgid "searches first names only (last: for last names)"
 msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 
-#: lib/vutuv_web/live/job_board_live.ex:546
+#: lib/vutuv_web/live/job_board_live.ex:547
 #: lib/vutuv_web/live/tag_new_live.ex:47
 #: lib/vutuv_web/live/user_profile_live.ex:1358
 #: lib/vutuv_web/templates/user/show.html.heex:610
@@ -7067,7 +7067,7 @@ msgstr "Entwurf"
 
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:36
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:103
-#: lib/vutuv_web/live/job_posting_live/form.ex:344
+#: lib/vutuv_web/live/job_posting_live/form.ex:343
 #, elixir-autogen, elixir-format
 msgid "Draft saved."
 msgstr "Entwurf gespeichert."
@@ -7294,7 +7294,7 @@ msgstr "Zurücksetzen"
 msgid "Save audience"
 msgstr "Zielgruppe speichern"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:850
+#: lib/vutuv_web/live/job_posting_live/form.ex:855
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:16
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:11
 #, elixir-autogen, elixir-format
@@ -8200,7 +8200,7 @@ msgid "Admins"
 msgstr "Administratoren"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/job_board_live.ex:467
+#: lib/vutuv_web/live/job_board_live.ex:468
 #: lib/vutuv_web/live/post_live/feed.ex:1062
 #, elixir-autogen, elixir-format
 msgid "All members"
@@ -11332,7 +11332,7 @@ msgstr "Niemand"
 
 #: lib/vutuv/accounts/user.ex:1266
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
-#: lib/vutuv_web/live/job_posting_live/form.ex:818
+#: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr "Nur angemeldete Mitglieder"
@@ -11349,7 +11349,7 @@ msgstr "Wer kann Ihre Verfügbarkeit sehen?"
 msgid "Amount"
 msgstr "Betrag"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:694
+#: lib/vutuv_web/live/job_posting_live/form.ex:693
 #: lib/vutuv_web/templates/user/edit.html.heex:321
 #: lib/vutuv_web/templates/welcome/show.html.heex:131
 #, elixir-autogen, elixir-format
@@ -11378,7 +11378,7 @@ msgstr ""
 "Benachrichtigungen, indem Stellen darunter herausgefiltert werden. Lassen "
 "Sie den Betrag leer, um die Angabe zu entfernen."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:701
+#: lib/vutuv_web/live/job_posting_live/form.ex:700
 #: lib/vutuv_web/templates/user/edit.html.heex:317
 #: lib/vutuv_web/templates/welcome/show.html.heex:127
 #, elixir-autogen, elixir-format
@@ -12541,47 +12541,47 @@ msgstr "%{views} Aufrufe · %{clicks} Bewerbungsklicks"
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr "Eine gefälschte, irreführende oder diskriminierende Stellenanzeige."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:678
+#: lib/vutuv_web/live/job_posting_live/form.ex:677
 #, elixir-autogen, elixir-format
 msgid "A pay range is required to publish (except volunteer postings)."
 msgstr "Zum Veröffentlichen ist eine Gehaltsspanne erforderlich (außer bei Ehrenämtern)."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:795
+#: lib/vutuv_web/live/job_posting_live/form.ex:800
 #, elixir-autogen, elixir-format
 msgid "A vutuv message to me"
 msgstr "Eine vutuv-Nachricht an mich"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:793
+#: lib/vutuv_web/live/job_posting_live/form.ex:798
 #, elixir-autogen, elixir-format
 msgid "A website"
 msgstr "Eine Website"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:794
+#: lib/vutuv_web/live/job_posting_live/form.ex:799
 #, elixir-autogen, elixir-format
 msgid "An e-mail address"
 msgstr "Eine E-Mail-Adresse"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:589
+#: lib/vutuv_web/live/job_posting_live/form.ex:588
 #, elixir-autogen, elixir-format
 msgid "Applicants must be located in"
 msgstr "Bewerber:innen müssen ansässig sein in"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:799
+#: lib/vutuv_web/live/job_posting_live/form.ex:804
 #, elixir-autogen, elixir-format
 msgid "Application URL"
 msgstr "Bewerbungs-URL"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:805
+#: lib/vutuv_web/live/job_posting_live/form.ex:810
 #, elixir-autogen, elixir-format
 msgid "Application e-mail"
 msgstr "Bewerbungs-E-Mail"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:127
+#: lib/vutuv_web/controllers/job_posting_controller.ex:116
 #, elixir-autogen, elixir-format
 msgid "Application: %{title}"
 msgstr "Bewerbung: %{title}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:791
+#: lib/vutuv_web/live/job_posting_live/form.ex:796
 #, elixir-autogen, elixir-format
 msgid "Applications go to"
 msgstr "Bewerbungen gehen an"
@@ -12613,7 +12613,7 @@ msgstr "Geschlossen"
 msgid "Contract"
 msgstr "Freie Mitarbeit"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:718
+#: lib/vutuv_web/live/job_posting_live/form.ex:717
 #, elixir-autogen, elixir-format
 msgid "Describe the role. Markdown is supported."
 msgstr "Beschreiben Sie die Stelle. Markdown wird unterstützt."
@@ -12639,7 +12639,7 @@ msgstr "Anzeige bearbeiten"
 msgid "Employer"
 msgstr "Arbeitgeber"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:485
+#: lib/vutuv_web/live/job_posting_live/form.ex:484
 #, elixir-autogen, elixir-format
 msgid "Employer name (optional)"
 msgstr "Name des Arbeitgebers (optional)"
@@ -12648,18 +12648,18 @@ msgstr "Name des Arbeitgebers (optional)"
 #: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/text.ex:267
 #: lib/vutuv_web/agent_docs/text.ex:512
-#: lib/vutuv_web/live/job_board_live.ex:525
-#: lib/vutuv_web/live/job_posting_live/form.ex:500
+#: lib/vutuv_web/live/job_board_live.ex:526
+#: lib/vutuv_web/live/job_posting_live/form.ex:499
 #, elixir-autogen, elixir-format
 msgid "Employment type"
 msgstr "Anstellungsart"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:817
+#: lib/vutuv_web/live/job_posting_live/form.ex:822
 #, elixir-autogen, elixir-format
 msgid "Everyone (public)"
 msgstr "Alle (öffentlich)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:682
+#: lib/vutuv_web/live/job_posting_live/form.ex:681
 #: lib/vutuv_web/live/tag_live/timeline.ex:346
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
@@ -12677,7 +12677,7 @@ msgstr "Vollzeit"
 msgid "Highlighted tags match your profile."
 msgstr "Hervorgehobene Tags passen zu Ihrem Profil."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:789
+#: lib/vutuv_web/live/job_posting_live/form.ex:794
 #, elixir-autogen, elixir-format
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
@@ -12688,25 +12688,25 @@ msgstr "So bewerben Sie sich"
 msgid "Hybrid"
 msgstr "Hybrid"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:146
+#: lib/vutuv_web/controllers/job_posting_controller.ex:135
 #, elixir-autogen, elixir-format
 msgid "I'm interested in your posting: %{url}"
 msgstr "Ich interessiere mich für Ihre Anzeige: %{url}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:717
+#: lib/vutuv_web/live/job_posting_live/form.ex:716
 #, elixir-autogen, elixir-format
 msgid "Job description"
 msgstr "Stellenbeschreibung"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:452
+#: lib/vutuv_web/live/job_posting_live/form.ex:451
 #, elixir-autogen, elixir-format
 msgid "Job title"
 msgstr "Stellenbezeichnung"
 
-#: lib/vutuv_web/agent_docs/job_board_doc.ex:31
+#: lib/vutuv_web/agent_docs/job_board_doc.ex:38
 #: lib/vutuv_web/components/saved_search_components.ex:56
-#: lib/vutuv_web/live/job_board_live.ex:49
-#: lib/vutuv_web/live/job_board_live.ex:259
+#: lib/vutuv_web/live/job_board_live.ex:47
+#: lib/vutuv_web/live/job_board_live.ex:265
 #: lib/vutuv_web/live/post_live/saved.ex:529
 #: lib/vutuv_web/live/shell_live.ex:1178
 #: lib/vutuv_web/templates/layout/app.html.heex:80
@@ -12714,7 +12714,7 @@ msgstr "Stellenbezeichnung"
 msgid "Jobs"
 msgstr "Jobs"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:827
+#: lib/vutuv_web/live/job_posting_live/form.ex:832
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this posting."
 msgstr "Suchmaschinen dürfen diese Anzeige indexieren."
@@ -12725,7 +12725,7 @@ msgstr "Suchmaschinen dürfen diese Anzeige indexieren."
 #: lib/vutuv_web/agent_docs/text.ex:486
 #: lib/vutuv_web/agent_docs/text.ex:489
 #: lib/vutuv_web/agent_docs/text.ex:491
-#: lib/vutuv_web/live/job_posting_live/form.ex:550
+#: lib/vutuv_web/live/job_posting_live/form.ex:549
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr "Standort"
@@ -12762,7 +12762,7 @@ msgstr "Irreführende Stellenanzeige"
 msgid "My postings"
 msgstr "Meine Anzeigen"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:422
+#: lib/vutuv_web/live/job_posting_live/form.ex:421
 #, elixir-autogen, elixir-format
 msgid "New accounts can publish after a few days."
 msgstr "Neue Konten können nach einigen Tagen veröffentlichen."
@@ -12775,7 +12775,7 @@ msgstr "Neue Anzeige"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:294
 #: lib/vutuv_web/agent_docs/text.ex:277
-#: lib/vutuv_web/live/job_posting_live/form.ex:757
+#: lib/vutuv_web/live/job_posting_live/form.ex:756
 #: lib/vutuv_web/live/job_posting_live/show.ex:177
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
@@ -12796,7 +12796,7 @@ msgstr "Hier ist noch nichts. Jobs mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Jobs you like show up here."
 msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:833
+#: lib/vutuv_web/live/job_posting_live/form.ex:838
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
@@ -12817,12 +12817,12 @@ msgstr "Nur Sie sehen diese Anzeige, während eine Meldung dazu bearbeitet wird.
 msgid "Part-time"
 msgstr "Teilzeit"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:676
+#: lib/vutuv_web/live/job_posting_live/form.ex:675
 #, elixir-autogen, elixir-format
 msgid "Pay"
 msgstr "Bezahlung"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:421
+#: lib/vutuv_web/live/job_posting_live/form.ex:420
 #, elixir-autogen, elixir-format
 msgid "Please confirm your e-mail address first."
 msgstr "Bitte bestätigen Sie zuerst Ihre E-Mail-Adresse."
@@ -12832,7 +12832,7 @@ msgstr "Bitte bestätigen Sie zuerst Ihre E-Mail-Adresse."
 msgid "Please confirm your email address before posting a job."
 msgstr "Bitte bestätigen Sie Ihre E-Mail-Adresse, bevor Sie eine Stelle ausschreiben."
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:138
+#: lib/vutuv_web/controllers/job_posting_controller.ex:127
 #, elixir-autogen, elixir-format
 msgid "Please log in to message the poster."
 msgstr "Bitte melden Sie sich an, um die Anbieter:in anzuschreiben."
@@ -12847,12 +12847,12 @@ msgstr "Bitte melden Sie sich an, um eine Stelle auszuschreiben."
 msgid "Please log in to see your postings."
 msgstr "Bitte melden Sie sich an, um Ihre Anzeigen zu sehen."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:473
+#: lib/vutuv_web/live/job_posting_live/form.ex:472
 #, elixir-autogen, elixir-format
 msgid "Post as"
 msgstr "Veröffentlichen als"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:562
+#: lib/vutuv_web/live/job_posting_live/form.ex:561
 #: lib/vutuv_web/templates/welcome/show.html.heex:67
 #, elixir-autogen, elixir-format
 msgid "Postal code"
@@ -12867,7 +12867,7 @@ msgstr "Postleitzahl"
 msgid "Posted"
 msgstr "Veröffentlicht"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:531
+#: lib/vutuv_web/live/job_posting_live/form.ex:530
 #, elixir-autogen, elixir-format
 msgid "Posting language"
 msgstr "Sprache der Anzeige"
@@ -12878,7 +12878,7 @@ msgstr "Sprache der Anzeige"
 msgid "Posting not found."
 msgstr "Anzeige nicht gefunden."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:848
+#: lib/vutuv_web/live/job_posting_live/form.ex:853
 #, elixir-autogen, elixir-format
 msgid "Publish"
 msgstr "Veröffentlichen"
@@ -12903,7 +12903,7 @@ msgstr "Diese Anzeige melden"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:293
 #: lib/vutuv_web/agent_docs/text.ex:276
-#: lib/vutuv_web/live/job_posting_live/form.ex:747
+#: lib/vutuv_web/live/job_posting_live/form.ex:746
 #: lib/vutuv_web/live/job_posting_live/show.ex:172
 #, elixir-autogen, elixir-format
 msgid "Required"
@@ -12923,27 +12923,27 @@ msgid "Salary on request"
 msgstr "Gehalt auf Anfrage"
 
 #: lib/vutuv_web/controllers/settings_controller.ex:395
-#: lib/vutuv_web/live/job_posting_live/form.ex:380
+#: lib/vutuv_web/live/job_posting_live/form.ex:379
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr "Gespeichert."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:494
+#: lib/vutuv_web/live/job_posting_live/form.ex:493
 #, elixir-autogen, elixir-format
 msgid "Shown as an unverified employer name."
 msgstr "Wird als nicht verifizierter Arbeitgebername angezeigt."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:410
+#: lib/vutuv_web/live/job_posting_live/form.ex:409
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:555
+#: lib/vutuv_web/live/job_posting_live/form.ex:554
 #, elixir-autogen, elixir-format
 msgid "Street (optional)"
 msgstr "Straße (optional)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:744
+#: lib/vutuv_web/live/job_posting_live/form.ex:743
 #, elixir-autogen, elixir-format
 msgid "Tags match your posting to members. Separate them with commas; a tag may be several words long, like Ruby on Rails."
 msgstr "Tags bringen Ihre Anzeige mit Mitgliedern zusammen. Mit Kommas trennen; ein Tag darf aus mehreren Wörtern bestehen, zum Beispiel Ruby on Rails."
@@ -12953,17 +12953,17 @@ msgstr "Tags bringen Ihre Anzeige mit Mitgliedern zusammen. Mit Kommas trennen; 
 msgid "Temporary"
 msgstr "Befristet"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:302
+#: lib/vutuv_web/live/job_posting_live/form.ex:301
 #, elixir-autogen, elixir-format
 msgid "That image could not be uploaded."
 msgstr "Dieses Bild konnte nicht hochgeladen werden."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:448
+#: lib/vutuv_web/live/job_posting_live/form.ex:447
 #, elixir-autogen, elixir-format
 msgid "The role"
 msgstr "Die Stelle"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:428
+#: lib/vutuv_web/live/job_posting_live/form.ex:427
 #, elixir-autogen, elixir-format
 msgid "This organization has reached its published-postings limit."
 msgstr "Diese Organisation hat ihr Limit an veröffentlichten Anzeigen erreicht."
@@ -12973,7 +12973,7 @@ msgstr "Diese Organisation hat ihr Limit an veröffentlichten Anzeigen erreicht.
 msgid "This position is no longer available."
 msgstr "Diese Stelle ist nicht mehr verfügbar."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:467
+#: lib/vutuv_web/live/job_posting_live/form.ex:466
 #, elixir-autogen, elixir-format
 msgid "Tip: adding a gender marker like (m/w/d) helps your posting comply with the AGG. This is a suggestion, not legal advice."
 msgstr "Tipp: Ein Geschlechtszusatz wie (m/w/d) hilft Ihrer Anzeige, dem AGG zu entsprechen. Das ist ein Hinweis, keine Rechtsberatung."
@@ -12995,7 +12995,7 @@ msgstr "Ehrenamtlich"
 msgid "Volunteer"
 msgstr "Ehrenamt"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:815
+#: lib/vutuv_web/live/job_posting_live/form.ex:820
 #: lib/vutuv_web/templates/email/form_content.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Who can see it"
@@ -13010,12 +13010,12 @@ msgstr "Werkstudent:in"
 #: lib/vutuv_web/agent_docs/markdown.ex:494
 #: lib/vutuv_web/agent_docs/text.ex:268
 #: lib/vutuv_web/agent_docs/text.ex:513
-#: lib/vutuv_web/live/job_posting_live/form.ex:515
+#: lib/vutuv_web/live/job_posting_live/form.ex:514
 #, elixir-autogen, elixir-format
 msgid "Workplace"
 msgstr "Arbeitsort"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:425
+#: lib/vutuv_web/live/job_posting_live/form.ex:424
 #, elixir-autogen, elixir-format
 msgid "You already have the maximum number of published postings."
 msgstr "Sie haben bereits die maximale Anzahl veröffentlichter Anzeigen."
@@ -13060,18 +13060,18 @@ msgstr "Ihre Organisationsseite auf vutuv ist nicht mehr öffentlich"
 msgid "Your posting"
 msgstr "Ihre Anzeige"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:360
-#: lib/vutuv_web/live/job_posting_live/form.ex:403
+#: lib/vutuv_web/live/job_posting_live/form.ex:359
+#: lib/vutuv_web/live/job_posting_live/form.ex:402
 #, elixir-autogen, elixir-format
 msgid "Your posting is live."
 msgstr "Ihre Anzeige ist online."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:476
+#: lib/vutuv_web/live/job_posting_live/form.ex:475
 #, elixir-autogen, elixir-format
 msgid "Yourself (personal posting)"
 msgstr "Sie selbst (persönliche Anzeige)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:688
+#: lib/vutuv_web/live/job_posting_live/form.ex:687
 #, elixir-autogen, elixir-format
 msgid "up to"
 msgstr "bis"
@@ -13199,12 +13199,12 @@ msgid_plural "%{count} weeks ago"
 msgstr[0] "vor %{count} Woche"
 msgstr[1] "vor %{count} Wochen"
 
-#: lib/vutuv_web/live/job_board_live.ex:633
+#: lib/vutuv_web/live/job_board_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "%{km} km"
 msgstr "%{km} km"
 
-#: lib/vutuv_web/live/job_board_live.ex:519
+#: lib/vutuv_web/live/job_board_live.ex:520
 #, elixir-autogen, elixir-format
 msgid "All countries"
 msgstr "Alle Länder"
@@ -13220,17 +13220,17 @@ msgstr "Alle Stellen mit diesem Tag"
 msgid "All jobs with this tag: %{url}"
 msgstr "Alle Stellen mit diesem Tag: %{url}"
 
-#: lib/vutuv_web/live/job_board_live.ex:526
+#: lib/vutuv_web/live/job_board_live.ex:527
 #, elixir-autogen, elixir-format
 msgid "Any employment type"
 msgstr "Alle Anstellungsarten"
 
-#: lib/vutuv_web/live/job_board_live.ex:508
+#: lib/vutuv_web/live/job_board_live.ex:509
 #, elixir-autogen, elixir-format
 msgid "City or zip code"
 msgstr "Stadt oder Postleitzahl"
 
-#: lib/vutuv_web/live/job_board_live.ex:633
+#: lib/vutuv_web/live/job_board_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "Exact"
 msgstr "Genau"
@@ -13245,12 +13245,12 @@ msgstr "Ab meiner Gehaltsvorstellung"
 msgid "Matches my tags"
 msgstr "Passend zu meinen Tags"
 
-#: lib/vutuv_web/live/job_board_live.ex:614
+#: lib/vutuv_web/live/job_board_live.ex:615
 #, elixir-autogen, elixir-format
 msgid "Min. salary/year (%{currency})"
 msgstr "Mindestgehalt/Jahr (%{currency})"
 
-#: lib/vutuv_web/live/job_board_live.ex:568
+#: lib/vutuv_web/live/job_board_live.ex:569
 #, elixir-autogen, elixir-format
 msgid "Minimum yearly salary"
 msgstr "Mindestgehalt pro Jahr"
@@ -13271,12 +13271,12 @@ msgstr "Nächste Seite"
 msgid "Next page: %{url}"
 msgstr "Nächste Seite: %{url}"
 
-#: lib/vutuv_web/live/job_board_live.ex:641
+#: lib/vutuv_web/live/job_board_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "No job postings yet."
 msgstr "Noch keine Stellenanzeigen."
 
-#: lib/vutuv_web/live/job_board_live.ex:639
+#: lib/vutuv_web/live/job_board_live.ex:640
 #, elixir-autogen, elixir-format
 msgid "No matching positions. Try adjusting the filters."
 msgstr "Keine passenden Stellen. Passen Sie die Filter an."
@@ -13291,13 +13291,13 @@ msgstr "Keine passenden Stellen. Passen Sie die Filter an."
 msgid "Open positions"
 msgstr "Offene Stellen"
 
-#: lib/vutuv_web/agent_docs/job_board_doc.ex:40
-#: lib/vutuv_web/live/job_board_live.ex:264
+#: lib/vutuv_web/agent_docs/job_board_doc.ex:39
+#: lib/vutuv_web/live/job_board_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Open positions on vutuv, newest first."
 msgstr "Offene Stellen auf vutuv, neueste zuerst."
 
-#: lib/vutuv_web/live/job_board_live.ex:272
+#: lib/vutuv_web/live/job_board_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "Post a job"
 msgstr "Stelle ausschreiben"
@@ -13307,12 +13307,12 @@ msgstr "Stelle ausschreiben"
 msgid "Post the first one"
 msgstr "Veröffentlichen Sie die erste"
 
-#: lib/vutuv_web/live/job_board_live.ex:512
+#: lib/vutuv_web/live/job_board_live.ex:513
 #, elixir-autogen, elixir-format
 msgid "Radius"
 msgstr "Umkreis"
 
-#: lib/vutuv_web/live/job_board_live.ex:500
+#: lib/vutuv_web/live/job_board_live.ex:501
 #, elixir-autogen, elixir-format
 msgid "Search jobs"
 msgstr "Jobs durchsuchen"
@@ -13745,7 +13745,7 @@ msgstr "Wird eine Organisation ausgeschlossen, ist die Anzeige auch für ihre be
 msgid "Hide from specific viewers"
 msgstr "Vor bestimmten Personen verbergen"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:839
+#: lib/vutuv_web/live/job_posting_live/form.ex:844
 #, elixir-autogen, elixir-format
 msgid "Hide from specific viewers (competitors, your own staff, a person) →"
 msgstr "Vor bestimmten Personen verbergen (Wettbewerber, eigene Belegschaft, Einzelpersonen) →"
@@ -13766,7 +13766,7 @@ msgstr "Ausschlussliste"
 msgid "Job exclusions – %{name}"
 msgstr "Ausschlussliste – %{name}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:842
+#: lib/vutuv_web/live/job_posting_live/form.ex:847
 #, elixir-autogen, elixir-format
 msgid "Keep this posting on the board for everyone except a chosen few."
 msgstr "Halten Sie diese Anzeige für alle im Stellenmarkt sichtbar, außer für wenige Ausgewählte."
@@ -14071,34 +14071,34 @@ msgstr ""
 msgid "Tags you follow"
 msgstr "Tags, denen Sie folgen"
 
-#: lib/vutuv_web/live/job_board_live.ex:581
+#: lib/vutuv_web/live/job_board_live.ex:582
 #, elixir-autogen, elixir-format
 msgid "Looking for a role that goes by several titles? Separate them with a comma and we show postings that match any of them."
 msgstr ""
 "Ein Beruf mit mehreren möglichen Titeln? Trennen Sie sie mit Komma, dann "
 "zeigen wir Anzeigen, die zu einem davon passen."
 
-#: lib/vutuv_web/live/job_board_live.ex:577
+#: lib/vutuv_web/live/job_board_live.ex:578
 #, elixir-autogen, elixir-format
 msgid "Search tips"
 msgstr "Suchtipps"
 
-#: lib/vutuv_web/live/job_board_live.ex:624
+#: lib/vutuv_web/live/job_board_live.ex:625
 #, elixir-autogen, elixir-format
 msgid "any of these titles"
 msgstr "einer dieser Titel"
 
-#: lib/vutuv_web/live/job_board_live.ex:626
+#: lib/vutuv_web/live/job_board_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "exact wording"
 msgstr "genaue Wortfolge"
 
-#: lib/vutuv_web/live/job_board_live.ex:627
+#: lib/vutuv_web/live/job_board_live.ex:628
 #, elixir-autogen, elixir-format
 msgid "without internships"
 msgstr "ohne Praktika"
 
-#: lib/vutuv_web/live/job_board_live.ex:625
+#: lib/vutuv_web/live/job_board_live.ex:626
 #, elixir-autogen, elixir-format
 msgid "word start: also finds Entwickler, Entwicklung"
 msgstr "Wortanfang: findet auch Entwickler, Entwicklung"
@@ -14954,7 +14954,7 @@ msgstr "Alle Empfehlenden"
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr "Filter hinzugefügt. Passende Beiträge sind jetzt in Ihrem Feed ausgeblendet."
 
-#: lib/vutuv_web/live/job_board_live.ex:547
+#: lib/vutuv_web/live/job_board_live.ex:548
 #, elixir-autogen, elixir-format
 msgid "Filter by a tag"
 msgstr "Nach einem Tag filtern"
@@ -21512,7 +21512,7 @@ msgstr "Empfohlen: %{width} × %{height} Pixel (%{ratio})."
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Empfohlen: quadratisch, mindestens %{width} × %{height} Pixel."
 
-#: lib/vutuv_web/live/job_board_live.ex:430
+#: lib/vutuv_web/live/job_board_live.ex:431
 #: lib/vutuv_web/live/post_live/feed.ex:999
 #: lib/vutuv_web/views/user_html.ex:342
 #, elixir-autogen, elixir-format
@@ -21950,7 +21950,7 @@ msgstr "Weiter zu %{server}"
 msgid "E-mail to %{address}"
 msgstr "E-Mail an %{address}"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:120
+#: lib/vutuv_web/controllers/job_posting_controller.ex:109
 #, elixir-autogen, elixir-format
 msgid "The employer takes applications on their own website."
 msgstr "Das Unternehmen nimmt Bewerbungen auf der eigenen Webseite entgegen."
@@ -21960,7 +21960,7 @@ msgstr "Das Unternehmen nimmt Bewerbungen auf der eigenen Webseite entgegen."
 msgid "Write e-mail"
 msgstr "E-Mail schreiben"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:132
+#: lib/vutuv_web/controllers/job_posting_controller.ex:121
 #, elixir-autogen, elixir-format
 msgid "Your e-mail program opens with the subject filled in."
 msgstr "Ihr E-Mail-Programm öffnet sich mit ausgefülltem Betreff."
@@ -21971,34 +21971,34 @@ msgctxt "qualification detail"
 msgid "Jobs"
 msgstr "Jobs"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:875
+#: lib/vutuv_web/live/job_posting_live/form.ex:880
 #, elixir-autogen, elixir-format
 msgid "%{formatted} country chosen."
 msgid_plural "%{formatted} countries chosen."
 msgstr[0] "%{formatted} Land ausgewählt."
 msgstr[1] "%{formatted} Länder ausgewählt."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:645
+#: lib/vutuv_web/live/job_posting_live/form.ex:644
 #, elixir-autogen, elixir-format
 msgid "No country chosen yet."
 msgstr "Noch kein Land ausgewählt."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:637
+#: lib/vutuv_web/live/job_posting_live/form.ex:636
 #, elixir-autogen, elixir-format
 msgid "No country left to add for that."
 msgstr "Dazu ist kein weiteres Land offen."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:656
+#: lib/vutuv_web/live/job_posting_live/form.ex:655
 #, elixir-autogen, elixir-format
 msgid "Remove %{country}"
 msgstr "%{country} entfernen"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:667
+#: lib/vutuv_web/live/job_posting_live/form.ex:666
 #, elixir-autogen, elixir-format
 msgid "Remove all"
 msgstr "Alle entfernen"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:616
+#: lib/vutuv_web/live/job_posting_live/form.ex:615
 #, elixir-autogen, elixir-format
 msgid "Search for a country"
 msgstr "Land suchen"
@@ -23624,41 +23624,35 @@ msgstr "Standardqualität. Dieses Bild in HD laden."
 msgid "Standard quality. Play this video in HD."
 msgstr "Standardqualität. Dieses Video in HD abspielen."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:773
+#: lib/vutuv_web/live/job_posting_live/form.ex:772
 #, elixir-autogen, elixir-format
 msgid "Members carrying these tags:"
 msgstr "Mitglieder mit diesen Tags:"
 
-#: lib/vutuv_web/agent_docs/job_board_doc.ex:44
-#: lib/vutuv_web/live/job_board_live.ex:262
-#, elixir-autogen, elixir-format
-msgid "No posting yet. Yours would be the first, and it would stand at the top on its own."
-msgstr "Noch keine Anzeige. Ihre wäre die erste und stünde allein oben."
-
-#: lib/vutuv_web/agent_docs/markdown.ex:1116
-#: lib/vutuv_web/agent_docs/text.ex:758
-#: lib/vutuv_web/live/job_board_live.ex:415
-#, elixir-autogen, elixir-format
-msgid "One member has said they are available."
-msgid_plural "%{formatted} members have said they are available."
-msgstr[0] "Ein Mitglied ist offen für Angebote oder auf Jobsuche."
-msgstr[1] "%{formatted} Mitglieder sind offen für Angebote oder auf Jobsuche."
-
-#: lib/vutuv_web/live/job_board_live.ex:475
+#: lib/vutuv_web/live/job_board_live.ex:476
 #, elixir-autogen, elixir-format
 msgid "The fields the most members carry, and how many of them do."
 msgstr "Die Fachgebiete mit den meisten Mitgliedern, und wie viele es jeweils sind."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1123
 #: lib/vutuv_web/agent_docs/text.ex:765
-#: lib/vutuv_web/live/job_board_live.ex:473
+#: lib/vutuv_web/live/job_board_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "What members here work on"
 msgstr "Woran die Mitglieder hier arbeiten"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1115
 #: lib/vutuv_web/agent_docs/text.ex:757
-#: lib/vutuv_web/live/job_board_live.ex:410
+#: lib/vutuv_web/live/job_board_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "Who you would reach"
 msgstr "Wen Sie hier erreichen"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1116
+#: lib/vutuv_web/agent_docs/text.ex:758
+#: lib/vutuv_web/live/job_board_live.ex:416
+#, elixir-autogen, elixir-format
+msgid "One random vutuv account that is open to offers."
+msgid_plural "%{formatted} random vutuv accounts that are open to offers."
+msgstr[0] "Ein zufälliger vutuv Account, der offen für Angebote ist."
+msgstr[1] "%{formatted} zufällige vutuv Accounts, die offen für Angebote sind."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -117,7 +117,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
 #: lib/vutuv_web/live/admin/user_delete_live.ex:202
-#: lib/vutuv_web/live/job_posting_live/form.ex:852
+#: lib/vutuv_web/live/job_posting_live/form.ex:857
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
 #: lib/vutuv_web/live/post_live/composer.ex:1901
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:711
+#: lib/vutuv_web/live/job_posting_live/form.ex:710
 #: lib/vutuv_web/live/organization_live/edit.ex:305
 #: lib/vutuv_web/live/organization_live/edit.ex:318
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
@@ -641,7 +641,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:219
 #: lib/vutuv_web/live/directory_search_live.ex:181
-#: lib/vutuv_web/live/job_board_live.ex:572
+#: lib/vutuv_web/live/job_board_live.ex:573
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
@@ -856,7 +856,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5097
 #: lib/vutuv_web/controllers/settings_controller.ex:171
-#: lib/vutuv_web/live/job_posting_live/form.ex:813
+#: lib/vutuv_web/live/job_posting_live/form.ex:818
 #: lib/vutuv_web/live/organization_live/edit.ex:339
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
@@ -1364,7 +1364,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:444
 #: lib/vutuv_web/live/cv_live.ex:323
 #: lib/vutuv_web/live/job_board_live.ex:339
-#: lib/vutuv_web/live/job_posting_live/form.ex:742
+#: lib/vutuv_web/live/job_posting_live/form.ex:741
 #: lib/vutuv_web/live/search_live.ex:347
 #: lib/vutuv_web/live/search_live.ex:818
 #: lib/vutuv_web/live/tag_new_live.ex:35
@@ -1539,8 +1539,8 @@ msgid "You'll receive an email with a login link."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:771
-#: lib/vutuv_web/live/job_board_live.ex:518
-#: lib/vutuv_web/live/job_posting_live/form.ex:574
+#: lib/vutuv_web/live/job_board_live.ex:519
+#: lib/vutuv_web/live/job_posting_live/form.ex:573
 #: lib/vutuv_web/live/organization_live/edit.ex:335
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
@@ -2062,7 +2062,7 @@ msgstr ""
 msgid "Markdown is supported: bold, italics, links and lists."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:735
+#: lib/vutuv_web/live/job_posting_live/form.ex:734
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr ""
@@ -2776,7 +2776,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/job_board_live.ex:457
+#: lib/vutuv_web/live/job_board_live.ex:458
 #: lib/vutuv_web/live/post_live/feed.ex:1053
 #: lib/vutuv_web/templates/user/card_list.html.heex:51
 #, elixir-autogen, elixir-format
@@ -3858,7 +3858,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:158
 #: lib/vutuv_web/agent_docs/text.ex:112
 #: lib/vutuv_web/agent_docs/text.ex:144
-#: lib/vutuv_web/live/job_posting_live/form.ex:725
+#: lib/vutuv_web/live/job_posting_live/form.ex:724
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr ""
@@ -3944,7 +3944,7 @@ msgstr ""
 msgid "until %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/agent_docs.ex:371
+#: lib/vutuv_web/agent_docs/agent_docs.ex:413
 #, elixir-autogen, elixir-format
 msgid "This page in %{language}: %{url}"
 msgstr ""
@@ -4040,7 +4040,7 @@ msgid "Booking requires a vutuv login."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
-#: lib/vutuv_web/live/job_posting_live/form.ex:568
+#: lib/vutuv_web/live/job_posting_live/form.ex:567
 #: lib/vutuv_web/live/organization_live/edit.ex:331
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
@@ -4661,7 +4661,7 @@ msgstr ""
 msgid "searches first names only (last: for last names)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:546
+#: lib/vutuv_web/live/job_board_live.ex:547
 #: lib/vutuv_web/live/tag_new_live.ex:47
 #: lib/vutuv_web/live/user_profile_live.ex:1358
 #: lib/vutuv_web/templates/user/show.html.heex:610
@@ -6786,7 +6786,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:36
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:103
-#: lib/vutuv_web/live/job_posting_live/form.ex:344
+#: lib/vutuv_web/live/job_posting_live/form.ex:343
 #, elixir-autogen, elixir-format
 msgid "Draft saved."
 msgstr ""
@@ -7009,7 +7009,7 @@ msgstr ""
 msgid "Save audience"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:850
+#: lib/vutuv_web/live/job_posting_live/form.ex:855
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:16
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:11
 #, elixir-autogen, elixir-format
@@ -7859,7 +7859,7 @@ msgid "Admins"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/job_board_live.ex:467
+#: lib/vutuv_web/live/job_board_live.ex:468
 #: lib/vutuv_web/live/post_live/feed.ex:1062
 #, elixir-autogen, elixir-format
 msgid "All members"
@@ -10762,7 +10762,7 @@ msgstr ""
 
 #: lib/vutuv/accounts/user.ex:1266
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
-#: lib/vutuv_web/live/job_posting_live/form.ex:818
+#: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr ""
@@ -10779,7 +10779,7 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:694
+#: lib/vutuv_web/live/job_posting_live/form.ex:693
 #: lib/vutuv_web/templates/user/edit.html.heex:321
 #: lib/vutuv_web/templates/welcome/show.html.heex:131
 #, elixir-autogen, elixir-format
@@ -10802,7 +10802,7 @@ msgstr ""
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:701
+#: lib/vutuv_web/live/job_posting_live/form.ex:700
 #: lib/vutuv_web/templates/user/edit.html.heex:317
 #: lib/vutuv_web/templates/welcome/show.html.heex:127
 #, elixir-autogen, elixir-format
@@ -11903,47 +11903,47 @@ msgstr ""
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:678
+#: lib/vutuv_web/live/job_posting_live/form.ex:677
 #, elixir-autogen, elixir-format
 msgid "A pay range is required to publish (except volunteer postings)."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:795
+#: lib/vutuv_web/live/job_posting_live/form.ex:800
 #, elixir-autogen, elixir-format
 msgid "A vutuv message to me"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:793
+#: lib/vutuv_web/live/job_posting_live/form.ex:798
 #, elixir-autogen, elixir-format
 msgid "A website"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:794
+#: lib/vutuv_web/live/job_posting_live/form.ex:799
 #, elixir-autogen, elixir-format
 msgid "An e-mail address"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:589
+#: lib/vutuv_web/live/job_posting_live/form.ex:588
 #, elixir-autogen, elixir-format
 msgid "Applicants must be located in"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:799
+#: lib/vutuv_web/live/job_posting_live/form.ex:804
 #, elixir-autogen, elixir-format
 msgid "Application URL"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:805
+#: lib/vutuv_web/live/job_posting_live/form.ex:810
 #, elixir-autogen, elixir-format
 msgid "Application e-mail"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:127
+#: lib/vutuv_web/controllers/job_posting_controller.ex:116
 #, elixir-autogen, elixir-format
 msgid "Application: %{title}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:791
+#: lib/vutuv_web/live/job_posting_live/form.ex:796
 #, elixir-autogen, elixir-format
 msgid "Applications go to"
 msgstr ""
@@ -11975,7 +11975,7 @@ msgstr ""
 msgid "Contract"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:718
+#: lib/vutuv_web/live/job_posting_live/form.ex:717
 #, elixir-autogen, elixir-format
 msgid "Describe the role. Markdown is supported."
 msgstr ""
@@ -12001,7 +12001,7 @@ msgstr ""
 msgid "Employer"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:485
+#: lib/vutuv_web/live/job_posting_live/form.ex:484
 #, elixir-autogen, elixir-format
 msgid "Employer name (optional)"
 msgstr ""
@@ -12010,18 +12010,18 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/text.ex:267
 #: lib/vutuv_web/agent_docs/text.ex:512
-#: lib/vutuv_web/live/job_board_live.ex:525
-#: lib/vutuv_web/live/job_posting_live/form.ex:500
+#: lib/vutuv_web/live/job_board_live.ex:526
+#: lib/vutuv_web/live/job_posting_live/form.ex:499
 #, elixir-autogen, elixir-format
 msgid "Employment type"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:817
+#: lib/vutuv_web/live/job_posting_live/form.ex:822
 #, elixir-autogen, elixir-format
 msgid "Everyone (public)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:682
+#: lib/vutuv_web/live/job_posting_live/form.ex:681
 #: lib/vutuv_web/live/tag_live/timeline.ex:346
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
@@ -12039,7 +12039,7 @@ msgstr ""
 msgid "Highlighted tags match your profile."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:789
+#: lib/vutuv_web/live/job_posting_live/form.ex:794
 #, elixir-autogen, elixir-format
 msgid "How to apply"
 msgstr ""
@@ -12050,25 +12050,25 @@ msgstr ""
 msgid "Hybrid"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:146
+#: lib/vutuv_web/controllers/job_posting_controller.ex:135
 #, elixir-autogen, elixir-format
 msgid "I'm interested in your posting: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:717
+#: lib/vutuv_web/live/job_posting_live/form.ex:716
 #, elixir-autogen, elixir-format
 msgid "Job description"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:452
+#: lib/vutuv_web/live/job_posting_live/form.ex:451
 #, elixir-autogen, elixir-format
 msgid "Job title"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/job_board_doc.ex:31
+#: lib/vutuv_web/agent_docs/job_board_doc.ex:38
 #: lib/vutuv_web/components/saved_search_components.ex:56
-#: lib/vutuv_web/live/job_board_live.ex:49
-#: lib/vutuv_web/live/job_board_live.ex:259
+#: lib/vutuv_web/live/job_board_live.ex:47
+#: lib/vutuv_web/live/job_board_live.ex:265
 #: lib/vutuv_web/live/post_live/saved.ex:529
 #: lib/vutuv_web/live/shell_live.ex:1178
 #: lib/vutuv_web/templates/layout/app.html.heex:80
@@ -12076,7 +12076,7 @@ msgstr ""
 msgid "Jobs"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:827
+#: lib/vutuv_web/live/job_posting_live/form.ex:832
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this posting."
 msgstr ""
@@ -12087,7 +12087,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:486
 #: lib/vutuv_web/agent_docs/text.ex:489
 #: lib/vutuv_web/agent_docs/text.ex:491
-#: lib/vutuv_web/live/job_posting_live/form.ex:550
+#: lib/vutuv_web/live/job_posting_live/form.ex:549
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr ""
@@ -12124,7 +12124,7 @@ msgstr ""
 msgid "My postings"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:422
+#: lib/vutuv_web/live/job_posting_live/form.ex:421
 #, elixir-autogen, elixir-format
 msgid "New accounts can publish after a few days."
 msgstr ""
@@ -12137,7 +12137,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:294
 #: lib/vutuv_web/agent_docs/text.ex:277
-#: lib/vutuv_web/live/job_posting_live/form.ex:757
+#: lib/vutuv_web/live/job_posting_live/form.ex:756
 #: lib/vutuv_web/live/job_posting_live/show.ex:177
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
@@ -12158,7 +12158,7 @@ msgstr ""
 msgid "Nothing here yet. Jobs you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:833
+#: lib/vutuv_web/live/job_posting_live/form.ex:838
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
@@ -12179,12 +12179,12 @@ msgstr ""
 msgid "Part-time"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:676
+#: lib/vutuv_web/live/job_posting_live/form.ex:675
 #, elixir-autogen, elixir-format
 msgid "Pay"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:421
+#: lib/vutuv_web/live/job_posting_live/form.ex:420
 #, elixir-autogen, elixir-format
 msgid "Please confirm your e-mail address first."
 msgstr ""
@@ -12194,7 +12194,7 @@ msgstr ""
 msgid "Please confirm your email address before posting a job."
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:138
+#: lib/vutuv_web/controllers/job_posting_controller.ex:127
 #, elixir-autogen, elixir-format
 msgid "Please log in to message the poster."
 msgstr ""
@@ -12209,12 +12209,12 @@ msgstr ""
 msgid "Please log in to see your postings."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:473
+#: lib/vutuv_web/live/job_posting_live/form.ex:472
 #, elixir-autogen, elixir-format
 msgid "Post as"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:562
+#: lib/vutuv_web/live/job_posting_live/form.ex:561
 #: lib/vutuv_web/templates/welcome/show.html.heex:67
 #, elixir-autogen, elixir-format
 msgid "Postal code"
@@ -12229,7 +12229,7 @@ msgstr ""
 msgid "Posted"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:531
+#: lib/vutuv_web/live/job_posting_live/form.ex:530
 #, elixir-autogen, elixir-format
 msgid "Posting language"
 msgstr ""
@@ -12240,7 +12240,7 @@ msgstr ""
 msgid "Posting not found."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:848
+#: lib/vutuv_web/live/job_posting_live/form.ex:853
 #, elixir-autogen, elixir-format
 msgid "Publish"
 msgstr ""
@@ -12265,7 +12265,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:293
 #: lib/vutuv_web/agent_docs/text.ex:276
-#: lib/vutuv_web/live/job_posting_live/form.ex:747
+#: lib/vutuv_web/live/job_posting_live/form.ex:746
 #: lib/vutuv_web/live/job_posting_live/show.ex:172
 #, elixir-autogen, elixir-format
 msgid "Required"
@@ -12285,27 +12285,27 @@ msgid "Salary on request"
 msgstr ""
 
 #: lib/vutuv_web/controllers/settings_controller.ex:395
-#: lib/vutuv_web/live/job_posting_live/form.ex:380
+#: lib/vutuv_web/live/job_posting_live/form.ex:379
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:494
+#: lib/vutuv_web/live/job_posting_live/form.ex:493
 #, elixir-autogen, elixir-format
 msgid "Shown as an unverified employer name."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:410
+#: lib/vutuv_web/live/job_posting_live/form.ex:409
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:555
+#: lib/vutuv_web/live/job_posting_live/form.ex:554
 #, elixir-autogen, elixir-format
 msgid "Street (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:744
+#: lib/vutuv_web/live/job_posting_live/form.ex:743
 #, elixir-autogen, elixir-format
 msgid "Tags match your posting to members. Separate them with commas; a tag may be several words long, like Ruby on Rails."
 msgstr ""
@@ -12315,17 +12315,17 @@ msgstr ""
 msgid "Temporary"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:302
+#: lib/vutuv_web/live/job_posting_live/form.ex:301
 #, elixir-autogen, elixir-format
 msgid "That image could not be uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:448
+#: lib/vutuv_web/live/job_posting_live/form.ex:447
 #, elixir-autogen, elixir-format
 msgid "The role"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:428
+#: lib/vutuv_web/live/job_posting_live/form.ex:427
 #, elixir-autogen, elixir-format
 msgid "This organization has reached its published-postings limit."
 msgstr ""
@@ -12335,7 +12335,7 @@ msgstr ""
 msgid "This position is no longer available."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:467
+#: lib/vutuv_web/live/job_posting_live/form.ex:466
 #, elixir-autogen, elixir-format
 msgid "Tip: adding a gender marker like (m/w/d) helps your posting comply with the AGG. This is a suggestion, not legal advice."
 msgstr ""
@@ -12357,7 +12357,7 @@ msgstr ""
 msgid "Volunteer"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:815
+#: lib/vutuv_web/live/job_posting_live/form.ex:820
 #: lib/vutuv_web/templates/email/form_content.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Who can see it"
@@ -12372,12 +12372,12 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:494
 #: lib/vutuv_web/agent_docs/text.ex:268
 #: lib/vutuv_web/agent_docs/text.ex:513
-#: lib/vutuv_web/live/job_posting_live/form.ex:515
+#: lib/vutuv_web/live/job_posting_live/form.ex:514
 #, elixir-autogen, elixir-format
 msgid "Workplace"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:425
+#: lib/vutuv_web/live/job_posting_live/form.ex:424
 #, elixir-autogen, elixir-format
 msgid "You already have the maximum number of published postings."
 msgstr ""
@@ -12422,18 +12422,18 @@ msgstr ""
 msgid "Your posting"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:360
-#: lib/vutuv_web/live/job_posting_live/form.ex:403
+#: lib/vutuv_web/live/job_posting_live/form.ex:359
+#: lib/vutuv_web/live/job_posting_live/form.ex:402
 #, elixir-autogen, elixir-format
 msgid "Your posting is live."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:476
+#: lib/vutuv_web/live/job_posting_live/form.ex:475
 #, elixir-autogen, elixir-format
 msgid "Yourself (personal posting)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:688
+#: lib/vutuv_web/live/job_posting_live/form.ex:687
 #, elixir-autogen, elixir-format
 msgid "up to"
 msgstr ""
@@ -12561,12 +12561,12 @@ msgid_plural "%{count} weeks ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/job_board_live.ex:633
+#: lib/vutuv_web/live/job_board_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "%{km} km"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:519
+#: lib/vutuv_web/live/job_board_live.ex:520
 #, elixir-autogen, elixir-format
 msgid "All countries"
 msgstr ""
@@ -12582,17 +12582,17 @@ msgstr ""
 msgid "All jobs with this tag: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:526
+#: lib/vutuv_web/live/job_board_live.ex:527
 #, elixir-autogen, elixir-format
 msgid "Any employment type"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:508
+#: lib/vutuv_web/live/job_board_live.ex:509
 #, elixir-autogen, elixir-format
 msgid "City or zip code"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:633
+#: lib/vutuv_web/live/job_board_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "Exact"
 msgstr ""
@@ -12607,12 +12607,12 @@ msgstr ""
 msgid "Matches my tags"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:614
+#: lib/vutuv_web/live/job_board_live.ex:615
 #, elixir-autogen, elixir-format
 msgid "Min. salary/year (%{currency})"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:568
+#: lib/vutuv_web/live/job_board_live.ex:569
 #, elixir-autogen, elixir-format
 msgid "Minimum yearly salary"
 msgstr ""
@@ -12633,12 +12633,12 @@ msgstr ""
 msgid "Next page: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:641
+#: lib/vutuv_web/live/job_board_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "No job postings yet."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:639
+#: lib/vutuv_web/live/job_board_live.ex:640
 #, elixir-autogen, elixir-format
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
@@ -12653,13 +12653,13 @@ msgstr ""
 msgid "Open positions"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/job_board_doc.ex:40
-#: lib/vutuv_web/live/job_board_live.ex:264
+#: lib/vutuv_web/agent_docs/job_board_doc.ex:39
+#: lib/vutuv_web/live/job_board_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Open positions on vutuv, newest first."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:272
+#: lib/vutuv_web/live/job_board_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "Post a job"
 msgstr ""
@@ -12669,12 +12669,12 @@ msgstr ""
 msgid "Post the first one"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:512
+#: lib/vutuv_web/live/job_board_live.ex:513
 #, elixir-autogen, elixir-format
 msgid "Radius"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:500
+#: lib/vutuv_web/live/job_board_live.ex:501
 #, elixir-autogen, elixir-format
 msgid "Search jobs"
 msgstr ""
@@ -13095,7 +13095,7 @@ msgstr ""
 msgid "Hide from specific viewers"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:839
+#: lib/vutuv_web/live/job_posting_live/form.ex:844
 #, elixir-autogen, elixir-format
 msgid "Hide from specific viewers (competitors, your own staff, a person) →"
 msgstr ""
@@ -13116,7 +13116,7 @@ msgstr ""
 msgid "Job exclusions – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:842
+#: lib/vutuv_web/live/job_posting_live/form.ex:847
 #, elixir-autogen, elixir-format
 msgid "Keep this posting on the board for everyone except a chosen few."
 msgstr ""
@@ -13414,32 +13414,32 @@ msgstr ""
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:581
+#: lib/vutuv_web/live/job_board_live.ex:582
 #, elixir-autogen, elixir-format
 msgid "Looking for a role that goes by several titles? Separate them with a comma and we show postings that match any of them."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:577
+#: lib/vutuv_web/live/job_board_live.ex:578
 #, elixir-autogen, elixir-format
 msgid "Search tips"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:624
+#: lib/vutuv_web/live/job_board_live.ex:625
 #, elixir-autogen, elixir-format
 msgid "any of these titles"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:626
+#: lib/vutuv_web/live/job_board_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "exact wording"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:627
+#: lib/vutuv_web/live/job_board_live.ex:628
 #, elixir-autogen, elixir-format
 msgid "without internships"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:625
+#: lib/vutuv_web/live/job_board_live.ex:626
 #, elixir-autogen, elixir-format
 msgid "word start: also finds Entwickler, Entwicklung"
 msgstr ""
@@ -14273,7 +14273,7 @@ msgstr ""
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:547
+#: lib/vutuv_web/live/job_board_live.ex:548
 #, elixir-autogen, elixir-format
 msgid "Filter by a tag"
 msgstr ""
@@ -20741,7 +20741,7 @@ msgstr ""
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:430
+#: lib/vutuv_web/live/job_board_live.ex:431
 #: lib/vutuv_web/live/post_live/feed.ex:999
 #: lib/vutuv_web/views/user_html.ex:342
 #, elixir-autogen, elixir-format
@@ -21179,7 +21179,7 @@ msgstr ""
 msgid "E-mail to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:120
+#: lib/vutuv_web/controllers/job_posting_controller.ex:109
 #, elixir-autogen, elixir-format
 msgid "The employer takes applications on their own website."
 msgstr ""
@@ -21189,7 +21189,7 @@ msgstr ""
 msgid "Write e-mail"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:132
+#: lib/vutuv_web/controllers/job_posting_controller.ex:121
 #, elixir-autogen, elixir-format
 msgid "Your e-mail program opens with the subject filled in."
 msgstr ""
@@ -21200,34 +21200,34 @@ msgctxt "qualification detail"
 msgid "Jobs"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:875
+#: lib/vutuv_web/live/job_posting_live/form.ex:880
 #, elixir-autogen, elixir-format
 msgid "%{formatted} country chosen."
 msgid_plural "%{formatted} countries chosen."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:645
+#: lib/vutuv_web/live/job_posting_live/form.ex:644
 #, elixir-autogen, elixir-format
 msgid "No country chosen yet."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:637
+#: lib/vutuv_web/live/job_posting_live/form.ex:636
 #, elixir-autogen, elixir-format
 msgid "No country left to add for that."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:656
+#: lib/vutuv_web/live/job_posting_live/form.ex:655
 #, elixir-autogen, elixir-format
 msgid "Remove %{country}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:667
+#: lib/vutuv_web/live/job_posting_live/form.ex:666
 #, elixir-autogen, elixir-format
 msgid "Remove all"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:616
+#: lib/vutuv_web/live/job_posting_live/form.ex:615
 #, elixir-autogen, elixir-format
 msgid "Search for a country"
 msgstr ""
@@ -22823,41 +22823,35 @@ msgstr ""
 msgid "Standard quality. Play this video in HD."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:773
+#: lib/vutuv_web/live/job_posting_live/form.ex:772
 #, elixir-autogen, elixir-format
 msgid "Members carrying these tags:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/job_board_doc.ex:44
-#: lib/vutuv_web/live/job_board_live.ex:262
-#, elixir-autogen, elixir-format
-msgid "No posting yet. Yours would be the first, and it would stand at the top on its own."
-msgstr ""
-
-#: lib/vutuv_web/agent_docs/markdown.ex:1116
-#: lib/vutuv_web/agent_docs/text.ex:758
-#: lib/vutuv_web/live/job_board_live.ex:415
-#, elixir-autogen, elixir-format
-msgid "One member has said they are available."
-msgid_plural "%{formatted} members have said they are available."
-msgstr[0] ""
-msgstr[1] ""
-
-#: lib/vutuv_web/live/job_board_live.ex:475
+#: lib/vutuv_web/live/job_board_live.ex:476
 #, elixir-autogen, elixir-format
 msgid "The fields the most members carry, and how many of them do."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1123
 #: lib/vutuv_web/agent_docs/text.ex:765
-#: lib/vutuv_web/live/job_board_live.ex:473
+#: lib/vutuv_web/live/job_board_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "What members here work on"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1115
 #: lib/vutuv_web/agent_docs/text.ex:757
-#: lib/vutuv_web/live/job_board_live.ex:410
+#: lib/vutuv_web/live/job_board_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "Who you would reach"
 msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1116
+#: lib/vutuv_web/agent_docs/text.ex:758
+#: lib/vutuv_web/live/job_board_live.ex:416
+#, elixir-autogen, elixir-format
+msgid "One random vutuv account that is open to offers."
+msgid_plural "%{formatted} random vutuv accounts that are open to offers."
+msgstr[0] ""
+msgstr[1] ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -115,7 +115,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
 #: lib/vutuv_web/live/admin/user_delete_live.ex:202
-#: lib/vutuv_web/live/job_posting_live/form.ex:852
+#: lib/vutuv_web/live/job_posting_live/form.ex:857
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
 #: lib/vutuv_web/live/post_live/composer.ex:1901
@@ -176,7 +176,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:711
+#: lib/vutuv_web/live/job_posting_live/form.ex:710
 #: lib/vutuv_web/live/organization_live/edit.ex:305
 #: lib/vutuv_web/live/organization_live/edit.ex:318
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
@@ -639,7 +639,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:219
 #: lib/vutuv_web/live/directory_search_live.ex:181
-#: lib/vutuv_web/live/job_board_live.ex:572
+#: lib/vutuv_web/live/job_board_live.ex:573
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
@@ -854,7 +854,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5097
 #: lib/vutuv_web/controllers/settings_controller.ex:171
-#: lib/vutuv_web/live/job_posting_live/form.ex:813
+#: lib/vutuv_web/live/job_posting_live/form.ex:818
 #: lib/vutuv_web/live/organization_live/edit.ex:339
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
@@ -1362,7 +1362,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:444
 #: lib/vutuv_web/live/cv_live.ex:323
 #: lib/vutuv_web/live/job_board_live.ex:339
-#: lib/vutuv_web/live/job_posting_live/form.ex:742
+#: lib/vutuv_web/live/job_posting_live/form.ex:741
 #: lib/vutuv_web/live/search_live.ex:347
 #: lib/vutuv_web/live/search_live.ex:818
 #: lib/vutuv_web/live/tag_new_live.ex:35
@@ -1537,8 +1537,8 @@ msgid "You'll receive an email with a login link."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:771
-#: lib/vutuv_web/live/job_board_live.ex:518
-#: lib/vutuv_web/live/job_posting_live/form.ex:574
+#: lib/vutuv_web/live/job_board_live.ex:519
+#: lib/vutuv_web/live/job_posting_live/form.ex:573
 #: lib/vutuv_web/live/organization_live/edit.ex:335
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
@@ -2060,7 +2060,7 @@ msgstr ""
 msgid "Markdown is supported: bold, italics, links and lists."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:735
+#: lib/vutuv_web/live/job_posting_live/form.ex:734
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr ""
@@ -2774,7 +2774,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/job_board_live.ex:457
+#: lib/vutuv_web/live/job_board_live.ex:458
 #: lib/vutuv_web/live/post_live/feed.ex:1053
 #: lib/vutuv_web/templates/user/card_list.html.heex:51
 #, elixir-autogen, elixir-format
@@ -3856,7 +3856,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:158
 #: lib/vutuv_web/agent_docs/text.ex:112
 #: lib/vutuv_web/agent_docs/text.ex:144
-#: lib/vutuv_web/live/job_posting_live/form.ex:725
+#: lib/vutuv_web/live/job_posting_live/form.ex:724
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr ""
@@ -3942,7 +3942,7 @@ msgstr ""
 msgid "until %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/agent_docs.ex:371
+#: lib/vutuv_web/agent_docs/agent_docs.ex:413
 #, elixir-autogen, elixir-format
 msgid "This page in %{language}: %{url}"
 msgstr ""
@@ -4038,7 +4038,7 @@ msgid "Booking requires a vutuv login."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
-#: lib/vutuv_web/live/job_posting_live/form.ex:568
+#: lib/vutuv_web/live/job_posting_live/form.ex:567
 #: lib/vutuv_web/live/organization_live/edit.ex:331
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
@@ -4659,7 +4659,7 @@ msgstr ""
 msgid "searches first names only (last: for last names)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:546
+#: lib/vutuv_web/live/job_board_live.ex:547
 #: lib/vutuv_web/live/tag_new_live.ex:47
 #: lib/vutuv_web/live/user_profile_live.ex:1358
 #: lib/vutuv_web/templates/user/show.html.heex:610
@@ -6784,7 +6784,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:36
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:103
-#: lib/vutuv_web/live/job_posting_live/form.ex:344
+#: lib/vutuv_web/live/job_posting_live/form.ex:343
 #, elixir-autogen, elixir-format
 msgid "Draft saved."
 msgstr ""
@@ -7007,7 +7007,7 @@ msgstr ""
 msgid "Save audience"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:850
+#: lib/vutuv_web/live/job_posting_live/form.ex:855
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:16
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:11
 #, elixir-autogen, elixir-format
@@ -7857,7 +7857,7 @@ msgid "Admins"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/job_board_live.ex:467
+#: lib/vutuv_web/live/job_board_live.ex:468
 #: lib/vutuv_web/live/post_live/feed.ex:1062
 #, elixir-autogen, elixir-format
 msgid "All members"
@@ -10760,7 +10760,7 @@ msgstr ""
 
 #: lib/vutuv/accounts/user.ex:1266
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
-#: lib/vutuv_web/live/job_posting_live/form.ex:818
+#: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr ""
@@ -10777,7 +10777,7 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:694
+#: lib/vutuv_web/live/job_posting_live/form.ex:693
 #: lib/vutuv_web/templates/user/edit.html.heex:321
 #: lib/vutuv_web/templates/welcome/show.html.heex:131
 #, elixir-autogen, elixir-format
@@ -10800,7 +10800,7 @@ msgstr ""
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:701
+#: lib/vutuv_web/live/job_posting_live/form.ex:700
 #: lib/vutuv_web/templates/user/edit.html.heex:317
 #: lib/vutuv_web/templates/welcome/show.html.heex:127
 #, elixir-autogen, elixir-format
@@ -11901,47 +11901,47 @@ msgstr ""
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:678
+#: lib/vutuv_web/live/job_posting_live/form.ex:677
 #, elixir-autogen, elixir-format
 msgid "A pay range is required to publish (except volunteer postings)."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:795
+#: lib/vutuv_web/live/job_posting_live/form.ex:800
 #, elixir-autogen, elixir-format
 msgid "A vutuv message to me"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:793
+#: lib/vutuv_web/live/job_posting_live/form.ex:798
 #, elixir-autogen, elixir-format
 msgid "A website"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:794
+#: lib/vutuv_web/live/job_posting_live/form.ex:799
 #, elixir-autogen, elixir-format
 msgid "An e-mail address"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:589
+#: lib/vutuv_web/live/job_posting_live/form.ex:588
 #, elixir-autogen, elixir-format
 msgid "Applicants must be located in"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:799
+#: lib/vutuv_web/live/job_posting_live/form.ex:804
 #, elixir-autogen, elixir-format
 msgid "Application URL"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:805
+#: lib/vutuv_web/live/job_posting_live/form.ex:810
 #, elixir-autogen, elixir-format
 msgid "Application e-mail"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:127
+#: lib/vutuv_web/controllers/job_posting_controller.ex:116
 #, elixir-autogen, elixir-format
 msgid "Application: %{title}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:791
+#: lib/vutuv_web/live/job_posting_live/form.ex:796
 #, elixir-autogen, elixir-format
 msgid "Applications go to"
 msgstr ""
@@ -11973,7 +11973,7 @@ msgstr ""
 msgid "Contract"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:718
+#: lib/vutuv_web/live/job_posting_live/form.ex:717
 #, elixir-autogen, elixir-format
 msgid "Describe the role. Markdown is supported."
 msgstr ""
@@ -11999,7 +11999,7 @@ msgstr ""
 msgid "Employer"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:485
+#: lib/vutuv_web/live/job_posting_live/form.ex:484
 #, elixir-autogen, elixir-format
 msgid "Employer name (optional)"
 msgstr ""
@@ -12008,18 +12008,18 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/text.ex:267
 #: lib/vutuv_web/agent_docs/text.ex:512
-#: lib/vutuv_web/live/job_board_live.ex:525
-#: lib/vutuv_web/live/job_posting_live/form.ex:500
+#: lib/vutuv_web/live/job_board_live.ex:526
+#: lib/vutuv_web/live/job_posting_live/form.ex:499
 #, elixir-autogen, elixir-format
 msgid "Employment type"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:817
+#: lib/vutuv_web/live/job_posting_live/form.ex:822
 #, elixir-autogen, elixir-format
 msgid "Everyone (public)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:682
+#: lib/vutuv_web/live/job_posting_live/form.ex:681
 #: lib/vutuv_web/live/tag_live/timeline.ex:346
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
@@ -12037,7 +12037,7 @@ msgstr ""
 msgid "Highlighted tags match your profile."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:789
+#: lib/vutuv_web/live/job_posting_live/form.ex:794
 #, elixir-autogen, elixir-format
 msgid "How to apply"
 msgstr ""
@@ -12048,25 +12048,25 @@ msgstr ""
 msgid "Hybrid"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:146
+#: lib/vutuv_web/controllers/job_posting_controller.ex:135
 #, elixir-autogen, elixir-format
 msgid "I'm interested in your posting: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:717
+#: lib/vutuv_web/live/job_posting_live/form.ex:716
 #, elixir-autogen, elixir-format
 msgid "Job description"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:452
+#: lib/vutuv_web/live/job_posting_live/form.ex:451
 #, elixir-autogen, elixir-format
 msgid "Job title"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/job_board_doc.ex:31
+#: lib/vutuv_web/agent_docs/job_board_doc.ex:38
 #: lib/vutuv_web/components/saved_search_components.ex:56
-#: lib/vutuv_web/live/job_board_live.ex:49
-#: lib/vutuv_web/live/job_board_live.ex:259
+#: lib/vutuv_web/live/job_board_live.ex:47
+#: lib/vutuv_web/live/job_board_live.ex:265
 #: lib/vutuv_web/live/post_live/saved.ex:529
 #: lib/vutuv_web/live/shell_live.ex:1178
 #: lib/vutuv_web/templates/layout/app.html.heex:80
@@ -12074,7 +12074,7 @@ msgstr ""
 msgid "Jobs"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:827
+#: lib/vutuv_web/live/job_posting_live/form.ex:832
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this posting."
 msgstr ""
@@ -12085,7 +12085,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:486
 #: lib/vutuv_web/agent_docs/text.ex:489
 #: lib/vutuv_web/agent_docs/text.ex:491
-#: lib/vutuv_web/live/job_posting_live/form.ex:550
+#: lib/vutuv_web/live/job_posting_live/form.ex:549
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr ""
@@ -12122,7 +12122,7 @@ msgstr ""
 msgid "My postings"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:422
+#: lib/vutuv_web/live/job_posting_live/form.ex:421
 #, elixir-autogen, elixir-format
 msgid "New accounts can publish after a few days."
 msgstr ""
@@ -12135,7 +12135,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:294
 #: lib/vutuv_web/agent_docs/text.ex:277
-#: lib/vutuv_web/live/job_posting_live/form.ex:757
+#: lib/vutuv_web/live/job_posting_live/form.ex:756
 #: lib/vutuv_web/live/job_posting_live/show.ex:177
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
@@ -12156,7 +12156,7 @@ msgstr ""
 msgid "Nothing here yet. Jobs you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:833
+#: lib/vutuv_web/live/job_posting_live/form.ex:838
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
@@ -12177,12 +12177,12 @@ msgstr ""
 msgid "Part-time"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:676
+#: lib/vutuv_web/live/job_posting_live/form.ex:675
 #, elixir-autogen, elixir-format
 msgid "Pay"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:421
+#: lib/vutuv_web/live/job_posting_live/form.ex:420
 #, elixir-autogen, elixir-format
 msgid "Please confirm your e-mail address first."
 msgstr ""
@@ -12192,7 +12192,7 @@ msgstr ""
 msgid "Please confirm your email address before posting a job."
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:138
+#: lib/vutuv_web/controllers/job_posting_controller.ex:127
 #, elixir-autogen, elixir-format
 msgid "Please log in to message the poster."
 msgstr ""
@@ -12207,12 +12207,12 @@ msgstr ""
 msgid "Please log in to see your postings."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:473
+#: lib/vutuv_web/live/job_posting_live/form.ex:472
 #, elixir-autogen, elixir-format
 msgid "Post as"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:562
+#: lib/vutuv_web/live/job_posting_live/form.ex:561
 #: lib/vutuv_web/templates/welcome/show.html.heex:67
 #, elixir-autogen, elixir-format
 msgid "Postal code"
@@ -12227,7 +12227,7 @@ msgstr ""
 msgid "Posted"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:531
+#: lib/vutuv_web/live/job_posting_live/form.ex:530
 #, elixir-autogen, elixir-format
 msgid "Posting language"
 msgstr ""
@@ -12238,7 +12238,7 @@ msgstr ""
 msgid "Posting not found."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:848
+#: lib/vutuv_web/live/job_posting_live/form.ex:853
 #, elixir-autogen, elixir-format
 msgid "Publish"
 msgstr ""
@@ -12263,7 +12263,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:293
 #: lib/vutuv_web/agent_docs/text.ex:276
-#: lib/vutuv_web/live/job_posting_live/form.ex:747
+#: lib/vutuv_web/live/job_posting_live/form.ex:746
 #: lib/vutuv_web/live/job_posting_live/show.ex:172
 #, elixir-autogen, elixir-format
 msgid "Required"
@@ -12283,27 +12283,27 @@ msgid "Salary on request"
 msgstr ""
 
 #: lib/vutuv_web/controllers/settings_controller.ex:395
-#: lib/vutuv_web/live/job_posting_live/form.ex:380
+#: lib/vutuv_web/live/job_posting_live/form.ex:379
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:494
+#: lib/vutuv_web/live/job_posting_live/form.ex:493
 #, elixir-autogen, elixir-format
 msgid "Shown as an unverified employer name."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:410
+#: lib/vutuv_web/live/job_posting_live/form.ex:409
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:555
+#: lib/vutuv_web/live/job_posting_live/form.ex:554
 #, elixir-autogen, elixir-format
 msgid "Street (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:744
+#: lib/vutuv_web/live/job_posting_live/form.ex:743
 #, elixir-autogen, elixir-format
 msgid "Tags match your posting to members. Separate them with commas; a tag may be several words long, like Ruby on Rails."
 msgstr ""
@@ -12313,17 +12313,17 @@ msgstr ""
 msgid "Temporary"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:302
+#: lib/vutuv_web/live/job_posting_live/form.ex:301
 #, elixir-autogen, elixir-format
 msgid "That image could not be uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:448
+#: lib/vutuv_web/live/job_posting_live/form.ex:447
 #, elixir-autogen, elixir-format
 msgid "The role"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:428
+#: lib/vutuv_web/live/job_posting_live/form.ex:427
 #, elixir-autogen, elixir-format
 msgid "This organization has reached its published-postings limit."
 msgstr ""
@@ -12333,7 +12333,7 @@ msgstr ""
 msgid "This position is no longer available."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:467
+#: lib/vutuv_web/live/job_posting_live/form.ex:466
 #, elixir-autogen, elixir-format
 msgid "Tip: adding a gender marker like (m/w/d) helps your posting comply with the AGG. This is a suggestion, not legal advice."
 msgstr ""
@@ -12355,7 +12355,7 @@ msgstr ""
 msgid "Volunteer"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:815
+#: lib/vutuv_web/live/job_posting_live/form.ex:820
 #: lib/vutuv_web/templates/email/form_content.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Who can see it"
@@ -12370,12 +12370,12 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:494
 #: lib/vutuv_web/agent_docs/text.ex:268
 #: lib/vutuv_web/agent_docs/text.ex:513
-#: lib/vutuv_web/live/job_posting_live/form.ex:515
+#: lib/vutuv_web/live/job_posting_live/form.ex:514
 #, elixir-autogen, elixir-format
 msgid "Workplace"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:425
+#: lib/vutuv_web/live/job_posting_live/form.ex:424
 #, elixir-autogen, elixir-format
 msgid "You already have the maximum number of published postings."
 msgstr ""
@@ -12420,18 +12420,18 @@ msgstr ""
 msgid "Your posting"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:360
-#: lib/vutuv_web/live/job_posting_live/form.ex:403
+#: lib/vutuv_web/live/job_posting_live/form.ex:359
+#: lib/vutuv_web/live/job_posting_live/form.ex:402
 #, elixir-autogen, elixir-format
 msgid "Your posting is live."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:476
+#: lib/vutuv_web/live/job_posting_live/form.ex:475
 #, elixir-autogen, elixir-format
 msgid "Yourself (personal posting)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:688
+#: lib/vutuv_web/live/job_posting_live/form.ex:687
 #, elixir-autogen, elixir-format
 msgid "up to"
 msgstr ""
@@ -12559,12 +12559,12 @@ msgid_plural "%{count} weeks ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/job_board_live.ex:633
+#: lib/vutuv_web/live/job_board_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "%{km} km"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:519
+#: lib/vutuv_web/live/job_board_live.ex:520
 #, elixir-autogen, elixir-format
 msgid "All countries"
 msgstr ""
@@ -12580,17 +12580,17 @@ msgstr ""
 msgid "All jobs with this tag: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:526
+#: lib/vutuv_web/live/job_board_live.ex:527
 #, elixir-autogen, elixir-format
 msgid "Any employment type"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:508
+#: lib/vutuv_web/live/job_board_live.ex:509
 #, elixir-autogen, elixir-format
 msgid "City or zip code"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:633
+#: lib/vutuv_web/live/job_board_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "Exact"
 msgstr ""
@@ -12605,12 +12605,12 @@ msgstr ""
 msgid "Matches my tags"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:614
+#: lib/vutuv_web/live/job_board_live.ex:615
 #, elixir-autogen, elixir-format
 msgid "Min. salary/year (%{currency})"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:568
+#: lib/vutuv_web/live/job_board_live.ex:569
 #, elixir-autogen, elixir-format
 msgid "Minimum yearly salary"
 msgstr ""
@@ -12631,12 +12631,12 @@ msgstr ""
 msgid "Next page: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:641
+#: lib/vutuv_web/live/job_board_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "No job postings yet."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:639
+#: lib/vutuv_web/live/job_board_live.ex:640
 #, elixir-autogen, elixir-format
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
@@ -12651,13 +12651,13 @@ msgstr ""
 msgid "Open positions"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/job_board_doc.ex:40
-#: lib/vutuv_web/live/job_board_live.ex:264
+#: lib/vutuv_web/agent_docs/job_board_doc.ex:39
+#: lib/vutuv_web/live/job_board_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Open positions on vutuv, newest first."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:272
+#: lib/vutuv_web/live/job_board_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "Post a job"
 msgstr ""
@@ -12667,12 +12667,12 @@ msgstr ""
 msgid "Post the first one"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:512
+#: lib/vutuv_web/live/job_board_live.ex:513
 #, elixir-autogen, elixir-format
 msgid "Radius"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:500
+#: lib/vutuv_web/live/job_board_live.ex:501
 #, elixir-autogen, elixir-format
 msgid "Search jobs"
 msgstr ""
@@ -13093,7 +13093,7 @@ msgstr ""
 msgid "Hide from specific viewers"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:839
+#: lib/vutuv_web/live/job_posting_live/form.ex:844
 #, elixir-autogen, elixir-format
 msgid "Hide from specific viewers (competitors, your own staff, a person) →"
 msgstr ""
@@ -13114,7 +13114,7 @@ msgstr ""
 msgid "Job exclusions – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:842
+#: lib/vutuv_web/live/job_posting_live/form.ex:847
 #, elixir-autogen, elixir-format
 msgid "Keep this posting on the board for everyone except a chosen few."
 msgstr ""
@@ -13412,32 +13412,32 @@ msgstr ""
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:581
+#: lib/vutuv_web/live/job_board_live.ex:582
 #, elixir-autogen, elixir-format
 msgid "Looking for a role that goes by several titles? Separate them with a comma and we show postings that match any of them."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:577
+#: lib/vutuv_web/live/job_board_live.ex:578
 #, elixir-autogen, elixir-format
 msgid "Search tips"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:624
+#: lib/vutuv_web/live/job_board_live.ex:625
 #, elixir-autogen, elixir-format
 msgid "any of these titles"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:626
+#: lib/vutuv_web/live/job_board_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "exact wording"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:627
+#: lib/vutuv_web/live/job_board_live.ex:628
 #, elixir-autogen, elixir-format
 msgid "without internships"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:625
+#: lib/vutuv_web/live/job_board_live.ex:626
 #, elixir-autogen, elixir-format
 msgid "word start: also finds Entwickler, Entwicklung"
 msgstr ""
@@ -14271,7 +14271,7 @@ msgstr ""
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:547
+#: lib/vutuv_web/live/job_board_live.ex:548
 #, elixir-autogen, elixir-format
 msgid "Filter by a tag"
 msgstr ""
@@ -20739,7 +20739,7 @@ msgstr ""
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:430
+#: lib/vutuv_web/live/job_board_live.ex:431
 #: lib/vutuv_web/live/post_live/feed.ex:999
 #: lib/vutuv_web/views/user_html.ex:342
 #, elixir-autogen, elixir-format
@@ -21177,7 +21177,7 @@ msgstr ""
 msgid "E-mail to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:120
+#: lib/vutuv_web/controllers/job_posting_controller.ex:109
 #, elixir-autogen, elixir-format
 msgid "The employer takes applications on their own website."
 msgstr ""
@@ -21187,7 +21187,7 @@ msgstr ""
 msgid "Write e-mail"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:132
+#: lib/vutuv_web/controllers/job_posting_controller.ex:121
 #, elixir-autogen, elixir-format
 msgid "Your e-mail program opens with the subject filled in."
 msgstr ""
@@ -21198,34 +21198,34 @@ msgctxt "qualification detail"
 msgid "Jobs"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:875
+#: lib/vutuv_web/live/job_posting_live/form.ex:880
 #, elixir-autogen, elixir-format
 msgid "%{formatted} country chosen."
 msgid_plural "%{formatted} countries chosen."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:645
+#: lib/vutuv_web/live/job_posting_live/form.ex:644
 #, elixir-autogen, elixir-format
 msgid "No country chosen yet."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:637
+#: lib/vutuv_web/live/job_posting_live/form.ex:636
 #, elixir-autogen, elixir-format
 msgid "No country left to add for that."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:656
+#: lib/vutuv_web/live/job_posting_live/form.ex:655
 #, elixir-autogen, elixir-format
 msgid "Remove %{country}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:667
+#: lib/vutuv_web/live/job_posting_live/form.ex:666
 #, elixir-autogen, elixir-format
 msgid "Remove all"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:616
+#: lib/vutuv_web/live/job_posting_live/form.ex:615
 #, elixir-autogen, elixir-format
 msgid "Search for a country"
 msgstr ""
@@ -22821,41 +22821,35 @@ msgstr ""
 msgid "Standard quality. Play this video in HD."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:773
+#: lib/vutuv_web/live/job_posting_live/form.ex:772
 #, elixir-autogen, elixir-format
 msgid "Members carrying these tags:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/job_board_doc.ex:44
-#: lib/vutuv_web/live/job_board_live.ex:262
-#, elixir-autogen, elixir-format
-msgid "No posting yet. Yours would be the first, and it would stand at the top on its own."
-msgstr ""
-
-#: lib/vutuv_web/agent_docs/markdown.ex:1116
-#: lib/vutuv_web/agent_docs/text.ex:758
-#: lib/vutuv_web/live/job_board_live.ex:415
-#, elixir-autogen, elixir-format
-msgid "One member has said they are available."
-msgid_plural "%{formatted} members have said they are available."
-msgstr[0] ""
-msgstr[1] ""
-
-#: lib/vutuv_web/live/job_board_live.ex:475
+#: lib/vutuv_web/live/job_board_live.ex:476
 #, elixir-autogen, elixir-format
 msgid "The fields the most members carry, and how many of them do."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1123
 #: lib/vutuv_web/agent_docs/text.ex:765
-#: lib/vutuv_web/live/job_board_live.ex:473
+#: lib/vutuv_web/live/job_board_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "What members here work on"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1115
 #: lib/vutuv_web/agent_docs/text.ex:757
-#: lib/vutuv_web/live/job_board_live.ex:410
+#: lib/vutuv_web/live/job_board_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "Who you would reach"
 msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1116
+#: lib/vutuv_web/agent_docs/text.ex:758
+#: lib/vutuv_web/live/job_board_live.ex:416
+#, elixir-autogen, elixir-format
+msgid "One random vutuv account that is open to offers."
+msgid_plural "%{formatted} random vutuv accounts that are open to offers."
+msgstr[0] ""
+msgstr[1] ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -117,7 +117,7 @@ msgstr "Compleanno"
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
 #: lib/vutuv_web/live/admin/user_delete_live.ex:202
-#: lib/vutuv_web/live/job_posting_live/form.ex:852
+#: lib/vutuv_web/live/job_posting_live/form.ex:857
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
 #: lib/vutuv_web/live/post_live/composer.ex:1901
@@ -178,7 +178,7 @@ msgstr "Non è stato possibile ricambiare il follow a %{name}."
 msgid "Delete"
 msgstr "Elimina"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:711
+#: lib/vutuv_web/live/job_posting_live/form.ex:710
 #: lib/vutuv_web/live/organization_live/edit.ex:305
 #: lib/vutuv_web/live/organization_live/edit.ex:318
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
@@ -643,7 +643,7 @@ msgstr "Salva"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:219
 #: lib/vutuv_web/live/directory_search_live.ex:181
-#: lib/vutuv_web/live/job_board_live.ex:572
+#: lib/vutuv_web/live/job_board_live.ex:573
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
@@ -858,7 +858,7 @@ msgstr "Mostra tutti"
 
 #: lib/vutuv_web/components/ui.ex:5097
 #: lib/vutuv_web/controllers/settings_controller.ex:171
-#: lib/vutuv_web/live/job_posting_live/form.ex:813
+#: lib/vutuv_web/live/job_posting_live/form.ex:818
 #: lib/vutuv_web/live/organization_live/edit.ex:339
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
@@ -1387,7 +1387,7 @@ msgstr "URL dei tag"
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:444
 #: lib/vutuv_web/live/cv_live.ex:323
 #: lib/vutuv_web/live/job_board_live.ex:339
-#: lib/vutuv_web/live/job_posting_live/form.ex:742
+#: lib/vutuv_web/live/job_posting_live/form.ex:741
 #: lib/vutuv_web/live/search_live.ex:347
 #: lib/vutuv_web/live/search_live.ex:818
 #: lib/vutuv_web/live/tag_new_live.ex:35
@@ -1567,8 +1567,8 @@ msgid "You'll receive an email with a login link."
 msgstr "Riceverà un'e-mail con un link di accesso."
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:771
-#: lib/vutuv_web/live/job_board_live.ex:518
-#: lib/vutuv_web/live/job_posting_live/form.ex:574
+#: lib/vutuv_web/live/job_board_live.ex:519
+#: lib/vutuv_web/live/job_posting_live/form.ex:573
 #: lib/vutuv_web/live/organization_live/edit.ex:335
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
@@ -2100,7 +2100,7 @@ msgstr "Settembre"
 msgid "Markdown is supported: bold, italics, links and lists."
 msgstr "Markdown è supportato: grassetto, corsivo, link ed elenchi."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:735
+#: lib/vutuv_web/live/job_posting_live/form.ex:734
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr "Aggiungi immagini"
@@ -2827,7 +2827,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] "1 collegamento"
 msgstr[1] "%{formatted} collegamenti"
 
-#: lib/vutuv_web/live/job_board_live.ex:457
+#: lib/vutuv_web/live/job_board_live.ex:458
 #: lib/vutuv_web/live/post_live/feed.ex:1053
 #: lib/vutuv_web/templates/user/card_list.html.heex:51
 #, elixir-autogen, elixir-format
@@ -3989,7 +3989,7 @@ msgstr "Follower di %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:158
 #: lib/vutuv_web/agent_docs/text.ex:112
 #: lib/vutuv_web/agent_docs/text.ex:144
-#: lib/vutuv_web/live/job_posting_live/form.ex:725
+#: lib/vutuv_web/live/job_posting_live/form.ex:724
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr "Immagini"
@@ -4075,7 +4075,7 @@ msgstr "oggi"
 msgid "until %{date}"
 msgstr "fino al %{date}"
 
-#: lib/vutuv_web/agent_docs/agent_docs.ex:371
+#: lib/vutuv_web/agent_docs/agent_docs.ex:413
 #, elixir-autogen, elixir-format
 msgid "This page in %{language}: %{url}"
 msgstr "Questa pagina in %{language}: %{url}"
@@ -4173,7 +4173,7 @@ msgid "Booking requires a vutuv login."
 msgstr "Per prenotare serve un accesso a vutuv."
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
-#: lib/vutuv_web/live/job_posting_live/form.ex:568
+#: lib/vutuv_web/live/job_posting_live/form.ex:567
 #: lib/vutuv_web/live/organization_live/edit.ex:331
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
@@ -4836,7 +4836,7 @@ msgstr "rossi"
 msgid "searches first names only (last: for last names)"
 msgstr "cerca solo nel nome (cognome: per il cognome)"
 
-#: lib/vutuv_web/live/job_board_live.ex:546
+#: lib/vutuv_web/live/job_board_live.ex:547
 #: lib/vutuv_web/live/tag_new_live.ex:47
 #: lib/vutuv_web/live/user_profile_live.ex:1358
 #: lib/vutuv_web/templates/user/show.html.heex:610
@@ -7057,7 +7057,7 @@ msgstr "Bozza"
 
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:36
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:103
-#: lib/vutuv_web/live/job_posting_live/form.ex:344
+#: lib/vutuv_web/live/job_posting_live/form.ex:343
 #, elixir-autogen, elixir-format
 msgid "Draft saved."
 msgstr "Bozza salvata."
@@ -7285,7 +7285,7 @@ msgstr "Azzera"
 msgid "Save audience"
 msgstr "Salva il gruppo destinatari"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:850
+#: lib/vutuv_web/live/job_posting_live/form.ex:855
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:16
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:11
 #, elixir-autogen, elixir-format
@@ -8189,7 +8189,7 @@ msgid "Admins"
 msgstr "Amministratori"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/job_board_live.ex:467
+#: lib/vutuv_web/live/job_board_live.ex:468
 #: lib/vutuv_web/live/post_live/feed.ex:1062
 #, elixir-autogen, elixir-format
 msgid "All members"
@@ -11300,7 +11300,7 @@ msgstr "Nessuno"
 
 #: lib/vutuv/accounts/user.ex:1266
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
-#: lib/vutuv_web/live/job_posting_live/form.ex:818
+#: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr "Solo i membri connessi"
@@ -11317,7 +11317,7 @@ msgstr "Chi può vedere la Sua disponibilità?"
 msgid "Amount"
 msgstr "Importo"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:694
+#: lib/vutuv_web/live/job_posting_live/form.ex:693
 #: lib/vutuv_web/templates/user/edit.html.heex:321
 #: lib/vutuv_web/templates/welcome/show.html.heex:131
 #, elixir-autogen, elixir-format
@@ -11346,7 +11346,7 @@ msgstr ""
 "avvisi, escludendo gli annunci al di sotto. Lasci vuoto l'importo per "
 "rimuoverla."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:701
+#: lib/vutuv_web/live/job_posting_live/form.ex:700
 #: lib/vutuv_web/templates/user/edit.html.heex:317
 #: lib/vutuv_web/templates/welcome/show.html.heex:127
 #, elixir-autogen, elixir-format
@@ -12526,49 +12526,49 @@ msgstr "%{views} visualizzazioni · %{clicks} clic per candidarsi"
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr "Un annuncio di lavoro falso, ingannevole o discriminatorio."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:678
+#: lib/vutuv_web/live/job_posting_live/form.ex:677
 #, elixir-autogen, elixir-format
 msgid "A pay range is required to publish (except volunteer postings)."
 msgstr ""
 "Per pubblicare serve una fascia retributiva (tranne che per gli annunci di "
 "volontariato)."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:795
+#: lib/vutuv_web/live/job_posting_live/form.ex:800
 #, elixir-autogen, elixir-format
 msgid "A vutuv message to me"
 msgstr "Un messaggio vutuv a me"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:793
+#: lib/vutuv_web/live/job_posting_live/form.ex:798
 #, elixir-autogen, elixir-format
 msgid "A website"
 msgstr "Un sito web"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:794
+#: lib/vutuv_web/live/job_posting_live/form.ex:799
 #, elixir-autogen, elixir-format
 msgid "An e-mail address"
 msgstr "Un indirizzo e-mail"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:589
+#: lib/vutuv_web/live/job_posting_live/form.ex:588
 #, elixir-autogen, elixir-format
 msgid "Applicants must be located in"
 msgstr "I candidati devono trovarsi in"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:799
+#: lib/vutuv_web/live/job_posting_live/form.ex:804
 #, elixir-autogen, elixir-format
 msgid "Application URL"
 msgstr "URL per la candidatura"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:805
+#: lib/vutuv_web/live/job_posting_live/form.ex:810
 #, elixir-autogen, elixir-format
 msgid "Application e-mail"
 msgstr "Indirizzo e-mail per la candidatura"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:127
+#: lib/vutuv_web/controllers/job_posting_controller.ex:116
 #, elixir-autogen, elixir-format
 msgid "Application: %{title}"
 msgstr "Candidatura: %{title}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:791
+#: lib/vutuv_web/live/job_posting_live/form.ex:796
 #, elixir-autogen, elixir-format
 msgid "Applications go to"
 msgstr "Le candidature arrivano a"
@@ -12600,7 +12600,7 @@ msgstr "Chiuso"
 msgid "Contract"
 msgstr "Collaborazione"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:718
+#: lib/vutuv_web/live/job_posting_live/form.ex:717
 #, elixir-autogen, elixir-format
 msgid "Describe the role. Markdown is supported."
 msgstr "Descriva il ruolo. Markdown è supportato."
@@ -12626,7 +12626,7 @@ msgstr "Modifica l'annuncio"
 msgid "Employer"
 msgstr "Datore di lavoro"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:485
+#: lib/vutuv_web/live/job_posting_live/form.ex:484
 #, elixir-autogen, elixir-format
 msgid "Employer name (optional)"
 msgstr "Nome del datore di lavoro (facoltativo)"
@@ -12635,18 +12635,18 @@ msgstr "Nome del datore di lavoro (facoltativo)"
 #: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/text.ex:267
 #: lib/vutuv_web/agent_docs/text.ex:512
-#: lib/vutuv_web/live/job_board_live.ex:525
-#: lib/vutuv_web/live/job_posting_live/form.ex:500
+#: lib/vutuv_web/live/job_board_live.ex:526
+#: lib/vutuv_web/live/job_posting_live/form.ex:499
 #, elixir-autogen, elixir-format
 msgid "Employment type"
 msgstr "Tipo di contratto"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:817
+#: lib/vutuv_web/live/job_posting_live/form.ex:822
 #, elixir-autogen, elixir-format
 msgid "Everyone (public)"
 msgstr "Tutti (pubblico)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:682
+#: lib/vutuv_web/live/job_posting_live/form.ex:681
 #: lib/vutuv_web/live/tag_live/timeline.ex:346
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
@@ -12664,7 +12664,7 @@ msgstr "Tempo pieno"
 msgid "Highlighted tags match your profile."
 msgstr "I tag evidenziati corrispondono al Suo profilo."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:789
+#: lib/vutuv_web/live/job_posting_live/form.ex:794
 #, elixir-autogen, elixir-format
 msgid "How to apply"
 msgstr "Come candidarsi"
@@ -12675,25 +12675,25 @@ msgstr "Come candidarsi"
 msgid "Hybrid"
 msgstr "Ibrido"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:146
+#: lib/vutuv_web/controllers/job_posting_controller.ex:135
 #, elixir-autogen, elixir-format
 msgid "I'm interested in your posting: %{url}"
 msgstr "Mi interessa il Suo annuncio: %{url}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:717
+#: lib/vutuv_web/live/job_posting_live/form.ex:716
 #, elixir-autogen, elixir-format
 msgid "Job description"
 msgstr "Descrizione della posizione"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:452
+#: lib/vutuv_web/live/job_posting_live/form.ex:451
 #, elixir-autogen, elixir-format
 msgid "Job title"
 msgstr "Titolo della posizione"
 
-#: lib/vutuv_web/agent_docs/job_board_doc.ex:31
+#: lib/vutuv_web/agent_docs/job_board_doc.ex:38
 #: lib/vutuv_web/components/saved_search_components.ex:56
-#: lib/vutuv_web/live/job_board_live.ex:49
-#: lib/vutuv_web/live/job_board_live.ex:259
+#: lib/vutuv_web/live/job_board_live.ex:47
+#: lib/vutuv_web/live/job_board_live.ex:265
 #: lib/vutuv_web/live/post_live/saved.ex:529
 #: lib/vutuv_web/live/shell_live.ex:1178
 #: lib/vutuv_web/templates/layout/app.html.heex:80
@@ -12701,7 +12701,7 @@ msgstr "Titolo della posizione"
 msgid "Jobs"
 msgstr "Lavoro"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:827
+#: lib/vutuv_web/live/job_posting_live/form.ex:832
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this posting."
 msgstr "Consenti ai motori di ricerca di indicizzare questo annuncio."
@@ -12712,7 +12712,7 @@ msgstr "Consenti ai motori di ricerca di indicizzare questo annuncio."
 #: lib/vutuv_web/agent_docs/text.ex:486
 #: lib/vutuv_web/agent_docs/text.ex:489
 #: lib/vutuv_web/agent_docs/text.ex:491
-#: lib/vutuv_web/live/job_posting_live/form.ex:550
+#: lib/vutuv_web/live/job_posting_live/form.ex:549
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr "Luogo"
@@ -12749,7 +12749,7 @@ msgstr "Annuncio di lavoro ingannevole"
 msgid "My postings"
 msgstr "I miei annunci"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:422
+#: lib/vutuv_web/live/job_posting_live/form.ex:421
 #, elixir-autogen, elixir-format
 msgid "New accounts can publish after a few days."
 msgstr "I nuovi account possono pubblicare dopo qualche giorno."
@@ -12762,7 +12762,7 @@ msgstr "Nuovo annuncio"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:294
 #: lib/vutuv_web/agent_docs/text.ex:277
-#: lib/vutuv_web/live/job_posting_live/form.ex:757
+#: lib/vutuv_web/live/job_posting_live/form.ex:756
 #: lib/vutuv_web/live/job_posting_live/show.ex:177
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
@@ -12784,7 +12784,7 @@ msgid "Nothing here yet. Jobs you like show up here."
 msgstr ""
 "Qui non c'è ancora nulla. Gli annunci a cui mette Mi piace compaiono qui."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:833
+#: lib/vutuv_web/live/job_posting_live/form.ex:838
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
@@ -12808,12 +12808,12 @@ msgstr ""
 msgid "Part-time"
 msgstr "Tempo parziale"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:676
+#: lib/vutuv_web/live/job_posting_live/form.ex:675
 #, elixir-autogen, elixir-format
 msgid "Pay"
 msgstr "Retribuzione"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:421
+#: lib/vutuv_web/live/job_posting_live/form.ex:420
 #, elixir-autogen, elixir-format
 msgid "Please confirm your e-mail address first."
 msgstr "Prima confermi il Suo indirizzo e-mail."
@@ -12824,7 +12824,7 @@ msgid "Please confirm your email address before posting a job."
 msgstr ""
 "Confermi il Suo indirizzo e-mail prima di pubblicare un annuncio di lavoro."
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:138
+#: lib/vutuv_web/controllers/job_posting_controller.ex:127
 #, elixir-autogen, elixir-format
 msgid "Please log in to message the poster."
 msgstr "Acceda per scrivere a chi ha pubblicato."
@@ -12839,12 +12839,12 @@ msgstr "Acceda per pubblicare un annuncio di lavoro."
 msgid "Please log in to see your postings."
 msgstr "Acceda per vedere i Suoi annunci."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:473
+#: lib/vutuv_web/live/job_posting_live/form.ex:472
 #, elixir-autogen, elixir-format
 msgid "Post as"
 msgstr "Pubblica come"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:562
+#: lib/vutuv_web/live/job_posting_live/form.ex:561
 #: lib/vutuv_web/templates/welcome/show.html.heex:67
 #, elixir-autogen, elixir-format
 msgid "Postal code"
@@ -12859,7 +12859,7 @@ msgstr "CAP"
 msgid "Posted"
 msgstr "Pubblicato"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:531
+#: lib/vutuv_web/live/job_posting_live/form.ex:530
 #, elixir-autogen, elixir-format
 msgid "Posting language"
 msgstr "Lingua dell'annuncio"
@@ -12870,7 +12870,7 @@ msgstr "Lingua dell'annuncio"
 msgid "Posting not found."
 msgstr "Annuncio non trovato."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:848
+#: lib/vutuv_web/live/job_posting_live/form.ex:853
 #, elixir-autogen, elixir-format
 msgid "Publish"
 msgstr "Pubblica"
@@ -12895,7 +12895,7 @@ msgstr "Segnala questo annuncio"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:293
 #: lib/vutuv_web/agent_docs/text.ex:276
-#: lib/vutuv_web/live/job_posting_live/form.ex:747
+#: lib/vutuv_web/live/job_posting_live/form.ex:746
 #: lib/vutuv_web/live/job_posting_live/show.ex:172
 #, elixir-autogen, elixir-format
 msgid "Required"
@@ -12915,27 +12915,27 @@ msgid "Salary on request"
 msgstr "Retribuzione su richiesta"
 
 #: lib/vutuv_web/controllers/settings_controller.ex:395
-#: lib/vutuv_web/live/job_posting_live/form.ex:380
+#: lib/vutuv_web/live/job_posting_live/form.ex:379
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr "Salvato."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:494
+#: lib/vutuv_web/live/job_posting_live/form.ex:493
 #, elixir-autogen, elixir-format
 msgid "Shown as an unverified employer name."
 msgstr "Mostrato come nome di datore di lavoro non verificato."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:410
+#: lib/vutuv_web/live/job_posting_live/form.ex:409
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr "Qualcosa è andato storto. Riprovi."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:555
+#: lib/vutuv_web/live/job_posting_live/form.ex:554
 #, elixir-autogen, elixir-format
 msgid "Street (optional)"
 msgstr "Via (facoltativo)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:744
+#: lib/vutuv_web/live/job_posting_live/form.ex:743
 #, elixir-autogen, elixir-format
 msgid "Tags match your posting to members. Separate them with commas; a tag may be several words long, like Ruby on Rails."
 msgstr ""
@@ -12947,17 +12947,17 @@ msgstr ""
 msgid "Temporary"
 msgstr "A tempo determinato"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:302
+#: lib/vutuv_web/live/job_posting_live/form.ex:301
 #, elixir-autogen, elixir-format
 msgid "That image could not be uploaded."
 msgstr "Non è stato possibile caricare questa immagine."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:448
+#: lib/vutuv_web/live/job_posting_live/form.ex:447
 #, elixir-autogen, elixir-format
 msgid "The role"
 msgstr "Il ruolo"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:428
+#: lib/vutuv_web/live/job_posting_live/form.ex:427
 #, elixir-autogen, elixir-format
 msgid "This organization has reached its published-postings limit."
 msgstr "Questa organizzazione ha raggiunto il limite di annunci pubblicati."
@@ -12967,7 +12967,7 @@ msgstr "Questa organizzazione ha raggiunto il limite di annunci pubblicati."
 msgid "This position is no longer available."
 msgstr "Questa posizione non è più disponibile."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:467
+#: lib/vutuv_web/live/job_posting_live/form.ex:466
 #, elixir-autogen, elixir-format
 msgid "Tip: adding a gender marker like (m/w/d) helps your posting comply with the AGG. This is a suggestion, not legal advice."
 msgstr ""
@@ -12992,7 +12992,7 @@ msgstr "Volontariato"
 msgid "Volunteer"
 msgstr "Volontario"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:815
+#: lib/vutuv_web/live/job_posting_live/form.ex:820
 #: lib/vutuv_web/templates/email/form_content.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Who can see it"
@@ -13007,12 +13007,12 @@ msgstr "Studente lavoratore"
 #: lib/vutuv_web/agent_docs/markdown.ex:494
 #: lib/vutuv_web/agent_docs/text.ex:268
 #: lib/vutuv_web/agent_docs/text.ex:513
-#: lib/vutuv_web/live/job_posting_live/form.ex:515
+#: lib/vutuv_web/live/job_posting_live/form.ex:514
 #, elixir-autogen, elixir-format
 msgid "Workplace"
 msgstr "Modalità di lavoro"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:425
+#: lib/vutuv_web/live/job_posting_live/form.ex:424
 #, elixir-autogen, elixir-format
 msgid "You already have the maximum number of published postings."
 msgstr "Ha già raggiunto il numero massimo di annunci pubblicati."
@@ -13062,18 +13062,18 @@ msgstr "La Sua pagina di organizzazione su vutuv non è più pubblica"
 msgid "Your posting"
 msgstr "Il Suo annuncio"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:360
-#: lib/vutuv_web/live/job_posting_live/form.ex:403
+#: lib/vutuv_web/live/job_posting_live/form.ex:359
+#: lib/vutuv_web/live/job_posting_live/form.ex:402
 #, elixir-autogen, elixir-format
 msgid "Your posting is live."
 msgstr "Il Suo annuncio è online."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:476
+#: lib/vutuv_web/live/job_posting_live/form.ex:475
 #, elixir-autogen, elixir-format
 msgid "Yourself (personal posting)"
 msgstr "Se stesso (annuncio personale)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:688
+#: lib/vutuv_web/live/job_posting_live/form.ex:687
 #, elixir-autogen, elixir-format
 msgid "up to"
 msgstr "fino a"
@@ -13224,12 +13224,12 @@ msgid_plural "%{count} weeks ago"
 msgstr[0] "%{count} settimana fa"
 msgstr[1] "%{count} settimane fa"
 
-#: lib/vutuv_web/live/job_board_live.ex:633
+#: lib/vutuv_web/live/job_board_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "%{km} km"
 msgstr "%{km} km"
 
-#: lib/vutuv_web/live/job_board_live.ex:519
+#: lib/vutuv_web/live/job_board_live.ex:520
 #, elixir-autogen, elixir-format
 msgid "All countries"
 msgstr "Tutti i paesi"
@@ -13245,17 +13245,17 @@ msgstr "Tutti gli annunci con questo tag"
 msgid "All jobs with this tag: %{url}"
 msgstr "Tutti gli annunci con questo tag: %{url}"
 
-#: lib/vutuv_web/live/job_board_live.ex:526
+#: lib/vutuv_web/live/job_board_live.ex:527
 #, elixir-autogen, elixir-format
 msgid "Any employment type"
 msgstr "Qualsiasi tipo di contratto"
 
-#: lib/vutuv_web/live/job_board_live.ex:508
+#: lib/vutuv_web/live/job_board_live.ex:509
 #, elixir-autogen, elixir-format
 msgid "City or zip code"
 msgstr "Città o CAP"
 
-#: lib/vutuv_web/live/job_board_live.ex:633
+#: lib/vutuv_web/live/job_board_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "Exact"
 msgstr "Esatto"
@@ -13270,12 +13270,12 @@ msgstr "Dalla mia retribuzione desiderata"
 msgid "Matches my tags"
 msgstr "Corrisponde ai miei tag"
 
-#: lib/vutuv_web/live/job_board_live.ex:614
+#: lib/vutuv_web/live/job_board_live.ex:615
 #, elixir-autogen, elixir-format
 msgid "Min. salary/year (%{currency})"
 msgstr "Retribuzione min./anno (%{currency})"
 
-#: lib/vutuv_web/live/job_board_live.ex:568
+#: lib/vutuv_web/live/job_board_live.ex:569
 #, elixir-autogen, elixir-format
 msgid "Minimum yearly salary"
 msgstr "Retribuzione annua minima"
@@ -13296,12 +13296,12 @@ msgstr "Pagina successiva"
 msgid "Next page: %{url}"
 msgstr "Pagina successiva: %{url}"
 
-#: lib/vutuv_web/live/job_board_live.ex:641
+#: lib/vutuv_web/live/job_board_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "No job postings yet."
 msgstr "Ancora nessun annuncio di lavoro."
 
-#: lib/vutuv_web/live/job_board_live.ex:639
+#: lib/vutuv_web/live/job_board_live.ex:640
 #, elixir-autogen, elixir-format
 msgid "No matching positions. Try adjusting the filters."
 msgstr "Nessuna posizione corrispondente. Provi a modificare i filtri."
@@ -13316,13 +13316,13 @@ msgstr "Nessuna posizione corrispondente. Provi a modificare i filtri."
 msgid "Open positions"
 msgstr "Posizioni aperte"
 
-#: lib/vutuv_web/agent_docs/job_board_doc.ex:40
-#: lib/vutuv_web/live/job_board_live.ex:264
+#: lib/vutuv_web/agent_docs/job_board_doc.ex:39
+#: lib/vutuv_web/live/job_board_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Open positions on vutuv, newest first."
 msgstr "Posizioni aperte su vutuv, dalla più recente."
 
-#: lib/vutuv_web/live/job_board_live.ex:272
+#: lib/vutuv_web/live/job_board_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "Post a job"
 msgstr "Pubblichi un annuncio di lavoro"
@@ -13332,12 +13332,12 @@ msgstr "Pubblichi un annuncio di lavoro"
 msgid "Post the first one"
 msgstr "Pubblichi il primo"
 
-#: lib/vutuv_web/live/job_board_live.ex:512
+#: lib/vutuv_web/live/job_board_live.ex:513
 #, elixir-autogen, elixir-format
 msgid "Radius"
 msgstr "Raggio"
 
-#: lib/vutuv_web/live/job_board_live.ex:500
+#: lib/vutuv_web/live/job_board_live.ex:501
 #, elixir-autogen, elixir-format
 msgid "Search jobs"
 msgstr "Cerchi annunci di lavoro"
@@ -13789,7 +13789,7 @@ msgstr ""
 msgid "Hide from specific viewers"
 msgstr "Nascondi a lettori specifici"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:839
+#: lib/vutuv_web/live/job_posting_live/form.ex:844
 #, elixir-autogen, elixir-format
 msgid "Hide from specific viewers (competitors, your own staff, a person) →"
 msgstr ""
@@ -13811,7 +13811,7 @@ msgstr "Esclusioni sugli annunci"
 msgid "Job exclusions – %{name}"
 msgstr "Esclusioni sugli annunci – %{name}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:842
+#: lib/vutuv_web/live/job_posting_live/form.ex:847
 #, elixir-autogen, elixir-format
 msgid "Keep this posting on the board for everyone except a chosen few."
 msgstr ""
@@ -14148,34 +14148,34 @@ msgstr ""
 msgid "Tags you follow"
 msgstr "Tag che segue"
 
-#: lib/vutuv_web/live/job_board_live.ex:581
+#: lib/vutuv_web/live/job_board_live.ex:582
 #, elixir-autogen, elixir-format
 msgid "Looking for a role that goes by several titles? Separate them with a comma and we show postings that match any of them."
 msgstr ""
 "Cerca un ruolo che ha più titoli diversi? Li separi con una virgola e "
 "mostreremo gli annunci che corrispondono a uno qualsiasi di essi."
 
-#: lib/vutuv_web/live/job_board_live.ex:577
+#: lib/vutuv_web/live/job_board_live.ex:578
 #, elixir-autogen, elixir-format
 msgid "Search tips"
 msgstr "Consigli per la ricerca"
 
-#: lib/vutuv_web/live/job_board_live.ex:624
+#: lib/vutuv_web/live/job_board_live.ex:625
 #, elixir-autogen, elixir-format
 msgid "any of these titles"
 msgstr "uno qualsiasi di questi titoli"
 
-#: lib/vutuv_web/live/job_board_live.ex:626
+#: lib/vutuv_web/live/job_board_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "exact wording"
 msgstr "dicitura esatta"
 
-#: lib/vutuv_web/live/job_board_live.ex:627
+#: lib/vutuv_web/live/job_board_live.ex:628
 #, elixir-autogen, elixir-format
 msgid "without internships"
 msgstr "senza tirocini"
 
-#: lib/vutuv_web/live/job_board_live.ex:625
+#: lib/vutuv_web/live/job_board_live.ex:626
 #, elixir-autogen, elixir-format
 msgid "word start: also finds Entwickler, Entwicklung"
 msgstr "inizio di parola: trova anche Sviluppatore, Sviluppo"
@@ -15073,7 +15073,7 @@ msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
 "Filtro aggiunto. I post corrispondenti sono ora nascosti nel Suo feed."
 
-#: lib/vutuv_web/live/job_board_live.ex:547
+#: lib/vutuv_web/live/job_board_live.ex:548
 #, elixir-autogen, elixir-format
 msgid "Filter by a tag"
 msgstr "Filtra per tag"
@@ -22249,7 +22249,7 @@ msgstr "Consigliato: %{width} × %{height} pixel (%{ratio})."
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Consigliato: quadrata, almeno %{width} × %{height} pixel."
 
-#: lib/vutuv_web/live/job_board_live.ex:430
+#: lib/vutuv_web/live/job_board_live.ex:431
 #: lib/vutuv_web/live/post_live/feed.ex:999
 #: lib/vutuv_web/views/user_html.ex:342
 #, elixir-autogen, elixir-format
@@ -22743,7 +22743,7 @@ msgstr "Prosegui verso %{server}"
 msgid "E-mail to %{address}"
 msgstr "E-mail a %{address}"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:120
+#: lib/vutuv_web/controllers/job_posting_controller.ex:109
 #, elixir-autogen, elixir-format
 msgid "The employer takes applications on their own website."
 msgstr "Il datore di lavoro raccoglie le candidature sul proprio sito web."
@@ -22753,7 +22753,7 @@ msgstr "Il datore di lavoro raccoglie le candidature sul proprio sito web."
 msgid "Write e-mail"
 msgstr "Scrivi un'e-mail"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:132
+#: lib/vutuv_web/controllers/job_posting_controller.ex:121
 #, elixir-autogen, elixir-format
 msgid "Your e-mail program opens with the subject filled in."
 msgstr "Il Suo programma di posta si apre con l'oggetto già compilato."
@@ -22764,34 +22764,34 @@ msgctxt "qualification detail"
 msgid "Jobs"
 msgstr "Impieghi"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:875
+#: lib/vutuv_web/live/job_posting_live/form.ex:880
 #, elixir-autogen, elixir-format
 msgid "%{formatted} country chosen."
 msgid_plural "%{formatted} countries chosen."
 msgstr[0] "%{formatted} paese scelto."
 msgstr[1] "%{formatted} paesi scelti."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:645
+#: lib/vutuv_web/live/job_posting_live/form.ex:644
 #, elixir-autogen, elixir-format
 msgid "No country chosen yet."
 msgstr "Ancora nessun paese scelto."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:637
+#: lib/vutuv_web/live/job_posting_live/form.ex:636
 #, elixir-autogen, elixir-format
 msgid "No country left to add for that."
 msgstr "Non resta alcun paese da aggiungere per questo."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:656
+#: lib/vutuv_web/live/job_posting_live/form.ex:655
 #, elixir-autogen, elixir-format
 msgid "Remove %{country}"
 msgstr "Rimuovi %{country}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:667
+#: lib/vutuv_web/live/job_posting_live/form.ex:666
 #, elixir-autogen, elixir-format
 msgid "Remove all"
 msgstr "Rimuovi tutti"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:616
+#: lib/vutuv_web/live/job_posting_live/form.ex:615
 #, elixir-autogen, elixir-format
 msgid "Search for a country"
 msgstr "Cerchi un paese"
@@ -24424,41 +24424,35 @@ msgstr "Qualità standard. Carica questa immagine in HD."
 msgid "Standard quality. Play this video in HD."
 msgstr "Qualità standard. Riproduci questo video in HD."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:773
+#: lib/vutuv_web/live/job_posting_live/form.ex:772
 #, elixir-autogen, elixir-format
 msgid "Members carrying these tags:"
 msgstr "Membri con questi tag:"
 
-#: lib/vutuv_web/agent_docs/job_board_doc.ex:44
-#: lib/vutuv_web/live/job_board_live.ex:262
-#, elixir-autogen, elixir-format
-msgid "No posting yet. Yours would be the first, and it would stand at the top on its own."
-msgstr "Ancora nessun annuncio. Il Suo sarebbe il primo e resterebbe da solo in cima."
-
-#: lib/vutuv_web/agent_docs/markdown.ex:1116
-#: lib/vutuv_web/agent_docs/text.ex:758
-#: lib/vutuv_web/live/job_board_live.ex:415
-#, elixir-autogen, elixir-format
-msgid "One member has said they are available."
-msgid_plural "%{formatted} members have said they are available."
-msgstr[0] "Un membro è aperto a proposte o in cerca di lavoro."
-msgstr[1] "%{formatted} membri sono aperti a proposte o in cerca di lavoro."
-
-#: lib/vutuv_web/live/job_board_live.ex:475
+#: lib/vutuv_web/live/job_board_live.ex:476
 #, elixir-autogen, elixir-format
 msgid "The fields the most members carry, and how many of them do."
 msgstr "Gli ambiti con più membri, e quanti sono per ciascuno."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1123
 #: lib/vutuv_web/agent_docs/text.ex:765
-#: lib/vutuv_web/live/job_board_live.ex:473
+#: lib/vutuv_web/live/job_board_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "What members here work on"
 msgstr "Di cosa si occupano i membri qui"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1115
 #: lib/vutuv_web/agent_docs/text.ex:757
-#: lib/vutuv_web/live/job_board_live.ex:410
+#: lib/vutuv_web/live/job_board_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "Who you would reach"
 msgstr "Chi raggiungerebbe"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1116
+#: lib/vutuv_web/agent_docs/text.ex:758
+#: lib/vutuv_web/live/job_board_live.ex:416
+#, elixir-autogen, elixir-format
+msgid "One random vutuv account that is open to offers."
+msgid_plural "%{formatted} random vutuv accounts that are open to offers."
+msgstr[0] "Un account vutuv scelto a caso, aperto a proposte."
+msgstr[1] "%{formatted} account vutuv scelti a caso, aperti a proposte."

--- a/test/vutuv/accounts/open_to_offers_test.exs
+++ b/test/vutuv/accounts/open_to_offers_test.exs
@@ -31,7 +31,6 @@ defmodule Vutuv.Accounts.OpenToOffersTest do
     _hidden = seeker(employment_status_visibility: "hidden")
 
     assert ids(Accounts.open_to_offers(nil)) == [public.id]
-    assert Accounts.open_to_offers(nil).total == 1
   end
 
   test "a signed-in member also sees the members-only ones, never the hidden" do
@@ -43,7 +42,6 @@ defmodule Vutuv.Accounts.OpenToOffersTest do
     listed = ids(Accounts.open_to_offers(viewer))
 
     assert Enum.sort(listed) == Enum.sort([public.id, members_only.id])
-    assert Accounts.open_to_offers(viewer).total == 2
   end
 
   test "a viewer on the seeker's exclusion list never sees them (issue #938)" do
@@ -51,9 +49,7 @@ defmodule Vutuv.Accounts.OpenToOffersTest do
     viewer = insert(:activated_user)
     insert(:viewer_exclusion, user: seeker, excluded_user: viewer, domain: nil)
 
-    # The count is the same answer as the list, so an excluded viewer is not
-    # told "one member is looking" by a number they can never resolve to a row.
-    assert Accounts.open_to_offers(viewer) == %{people: [], total: 0}
+    assert Accounts.open_to_offers(viewer) == []
   end
 
   test "an unconfirmed or moderation-hidden member is not listed" do
@@ -62,22 +58,26 @@ defmodule Vutuv.Accounts.OpenToOffersTest do
 
     seeker(employment_status_visibility: "everyone", frozen_at: NaiveDateTime.utc_now(:second))
 
-    assert Accounts.open_to_offers(nil) == %{people: [], total: 0}
+    assert Accounts.open_to_offers(nil) == []
   end
 
-  test "the freshest signal comes first, and the limit is honoured" do
-    older = seeker(employment_status_visibility: "everyone")
-    newer = seeker(employment_status_visibility: "everyone")
+  test "the limit is honoured and the draw is random, not an order" do
+    first = seeker(employment_status_visibility: "everyone")
+    second = seeker(employment_status_visibility: "everyone")
 
-    stamp(older, ~N[2026-01-01 10:00:00])
-    stamp(newer, ~N[2026-09-01 10:00:00])
+    # Both are eligible, so a page of two holds both whatever the draw.
+    assert Accounts.open_to_offers(nil) |> ids() |> Enum.sort() ==
+             Enum.sort([first.id, second.id])
 
-    assert ids(Accounts.open_to_offers(nil)) == [newer.id, older.id]
+    # Drawing one of two, forty times: a fixed order would name the same member
+    # every time. Missing one of them by chance is a 2^-39 event, so a failure
+    # here is a lost draw, not a flake.
+    drawn =
+      for _ <- 1..40, reduce: MapSet.new() do
+        seen -> MapSet.union(seen, MapSet.new(ids(Accounts.open_to_offers(nil, limit: 1))))
+      end
 
-    # The limit shortens the list and not the count: the page says "showing 1
-    # of 2", never "there is 1".
-    assert Accounts.open_to_offers(nil, limit: 1) |> ids() == [newer.id]
-    assert Accounts.open_to_offers(nil, limit: 1).total == 2
+    assert MapSet.size(drawn) == 2, "the draw always returned the same member"
   end
 
   # The listing gate is SQL and `User.employment_status_visible?/2` is pattern
@@ -104,18 +104,12 @@ defmodule Vutuv.Accounts.OpenToOffersTest do
   test "the rows carry what a listing card draws, without a second query" do
     seeker(employment_status_visibility: "everyone", desired_workplace_types: ["remote"])
 
-    %{people: [row]} = Accounts.open_to_offers(nil)
+    [row] = Accounts.open_to_offers(nil)
 
     assert row.employment_status == "open"
     assert row.desired_workplace_types == ["remote"]
     assert is_binary(row.username)
   end
 
-  defp ids(%{people: people}), do: Enum.map(people, & &1.id)
-
-  defp stamp(user, at) do
-    user
-    |> Ecto.Changeset.change(employment_status_set_at: at)
-    |> Repo.update!()
-  end
+  defp ids(people), do: Enum.map(people, & &1.id)
 end

--- a/test/vutuv_web/agent_docs/job_board_reach_doc_test.exs
+++ b/test/vutuv_web/agent_docs/job_board_reach_doc_test.exs
@@ -30,8 +30,7 @@ defmodule VutuvWeb.AgentDocs.JobBoardReachDocTest do
     doc = build_conn() |> get(~p"/jobs.json") |> json_response(200)
 
     assert doc["count"] == 0
-    assert doc["open_to_offers"]["total"] == 1
-    assert [person] = doc["open_to_offers"]["people"]
+    assert [person] = doc["open_to_offers"]
     assert person["employment_status"] == "open"
     assert person["desired_workplace_types"] == ["remote"]
     assert Enum.any?(doc["fields"], &(&1["name"] == "Reach Doc Elixir" and &1["members"] == 1))
@@ -50,8 +49,7 @@ defmodule VutuvWeb.AgentDocs.JobBoardReachDocTest do
 
     doc = build_conn() |> get(~p"/jobs.json") |> json_response(200)
 
-    assert doc["open_to_offers"]["total"] == 0
-    assert doc["open_to_offers"]["people"] == []
+    assert doc["open_to_offers"] == []
   end
 
   test "a board with a posting carries neither key" do

--- a/test/vutuv_web/live/job_board_live_test.exs
+++ b/test/vutuv_web/live/job_board_live_test.exs
@@ -69,7 +69,7 @@ defmodule VutuvWeb.JobBoardLiveTest do
     # the same view, so neither it nor the filter chips render.
     refute has_element?(view, "form[action='/jobs'] input[name='q']")
     refute has_element?(view, "#job-filter-chips")
-    assert html =~ "Yours would be the first"
+    refute html =~ "Open positions on vutuv"
     # The way in stays, logged out included: whoever has a job to fill is who
     # this page exists for.
     assert has_element?(view, "a[href='/jobs/new']")
@@ -88,6 +88,8 @@ defmodule VutuvWeb.JobBoardLiveTest do
     assert has_element?(view, "#seeker-#{seeker.id}")
     assert html =~ "Open to offers"
     assert html =~ "Who you would reach"
+    # The number says what was drawn, not how many exist.
+    assert html =~ "One random vutuv account that is open to offers."
   end
 
   test "the empty board keeps a members-only availability from a logged-out visitor", %{
@@ -127,7 +129,7 @@ defmodule VutuvWeb.JobBoardLiveTest do
       |> live(~p"/jobs")
 
     assert html =~ "Wen Sie hier erreichen"
-    assert html =~ "stünde allein oben"
+    assert html =~ "zufälliger vutuv Account"
     assert html =~ "Offen für Angebote"
   end
 
@@ -138,7 +140,7 @@ defmodule VutuvWeb.JobBoardLiveTest do
     {:ok, view, html} = live(conn, ~p"/jobs?#{[q: "elixir"]}")
 
     assert has_element?(view, "#job-filter-chips")
-    refute html =~ "Yours would be the first"
+    refute html =~ "random vutuv accounts"
     assert html =~ "No matching positions"
   end
 


### PR DESCRIPTION
Follow-up to #1971, on Stefan's wording. Two things go: the subline over the
page ("Yours would be the first, and it would stand at the top on its own"),
which only repeated the heading, and the total ("N members have said they are
available"). In its place the block says what is actually under it — "12 random
vutuv accounts that are open to offers."

"Random" is the substance, not the phrasing: a ranking shows every visitor the
same faces until somebody changes their status, so `Accounts.open_to_offers/2`
now draws with `random()` (once per mount, not per render) and the window count
behind the old total is gone with it. The agent siblings carry the drawn people
and no total either, for the same reason: a sample can only vouch for its own
rows.

Entry point: `/jobs` with no posting, `VutuvWeb.JobBoardLive`. Hot deploy.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01GmvDFKimQ4gGpSV97ckumc