### PR TITLE
Two of four fediverse arrivals never reached an open feed

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -3313,9 +3313,10 @@ defmodule Vutuv.Posts do
   pass and showed a line no other surface in the app would have shown.
   """
   def newest_source_entry(%User{} = viewer, source, %NaiveDateTime{} = since)
-      when source in [:vutuv, :fediverse] do
+      when source in [:vutuv, :fediverse, :all] do
     viewer
     |> feed_sources(source)
+    |> Vutuv.FeedPage.fetch_sources(1, nil)
     |> Enum.flat_map(&newest_row(&1, since))
     |> case do
       [] ->
@@ -3333,12 +3334,14 @@ defmodule Vutuv.Posts do
   end
 
   # One source's newest row, kept only if it is at least as new as `since`.
-  defp newest_row(fetch, since) do
-    case fetch.(1, nil) do
-      [entry | _] -> if NaiveDateTime.compare(entry.at, since) != :lt, do: [entry], else: []
-      [] -> []
-    end
+  # The rows arrive already fetched: `:all` asks ten sources for one row each,
+  # once per arrival announcement, and `Vutuv.FeedPage.fetch_sources/3` owns how
+  # many of those may be in flight at a time.
+  defp newest_row([entry | _], since) do
+    if NaiveDateTime.compare(entry.at, since) != :lt, do: [entry], else: []
   end
+
+  defp newest_row([], _since), do: []
 
   # Everything the six sources produce, made ready to render.
   #

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -2148,20 +2148,54 @@ defmodule VutuvWeb.PostLive.Feed do
   # The queue half of `{:remote_feed_arrival, …}` above: ask this reader's own
   # sources what actually arrived and put it behind the pill.
   #
-  # A member who switched the fediverse half off is told nothing, and neither is
-  # one whose page already holds that entry — the announcement carries no id, so
-  # a burst of deliveries would otherwise queue the same newest post several
-  # times over.
-  defp queue_remote_arrival(%{assigns: %{feed_filter: :vutuv}} = socket, _at), do: socket
-
+  # It asks the sources of the band **the reader is standing on**, which is the
+  # same question `feed_page/2` asks, so the door cannot answer differently from
+  # the timeline it feeds. It used to ask a hard-wired `:fediverse` — and the
+  # announcement is sent for four kinds of write, two of which are vutuv-half
+  # entries: a followed account boosting a **member's** post
+  # (`feed_remote_boosts(only: :local)`, whose own comment in `Fediverse` says
+  # so) and a member here passing a cached post or reply on. For those the door
+  # looked in the wrong place, found nothing and said nothing — no pill, no
+  # card, no error, until the next page load — and on the vutuv half it did not
+  # look at all, which is where both of them belong.
+  #
+  # "My posts" is the one narrowing that needs no query: the announcement is
+  # only ever sent for somebody else's write, and that view holds the reader's
+  # own posts alone.
+  #
+  # A reader whose page already holds the entry is told nothing either — the
+  # announcement carries no id, so a burst of deliveries would otherwise queue
+  # the same newest post several times over.
   defp queue_remote_arrival(socket, at) do
-    entry = Posts.newest_source_entry(socket.assigns.current_user, :fediverse, at)
+    case effective_filter(socket) do
+      :own ->
+        socket
 
-    cond do
-      is_nil(entry) -> socket
-      known_entry?(socket, entry) -> socket
-      true -> place_arrival(socket, for_reader(entry, socket))
+      filter ->
+        entry = Posts.newest_source_entry(socket.assigns.current_user, filter, at)
+
+        cond do
+          is_nil(entry) -> socket
+          known_entry?(socket, entry) -> socket
+          true -> place_arrival(socket, decorate_arrival(entry, socket))
+        end
     end
+  end
+
+  # What an arriving entry still needs, which is not the same for the two kinds
+  # this door can now produce. A cached post or reply from another network wants
+  # the reader's own passes and nothing else — it has no author here, no thread
+  # and no engagement of ours. A **member's** post, carried here by a followed
+  # account's boost, draws the local card and therefore needs everything a local
+  # arrival needs: `decorate/2`, the same one `insert_entry/3`'s doors use.
+  #
+  # Not a nicety. The card reads `entry.engagement` with dot access, so the
+  # missing key raises inside the render instead of degrading — which is what
+  # this door did the moment it could reach a boosted member post at all.
+  defp decorate_arrival(entry, socket) do
+    if Posts.remote_feed_entry?(entry),
+      do: for_reader(entry, socket),
+      else: decorate(entry, socket)
   end
 
   # Where the arrival goes, which is the question `insert_entry/3` asks of every

--- a/test/vutuv_web/live/feed_remote_arrival_sources_test.exs
+++ b/test/vutuv_web/live/feed_remote_arrival_sources_test.exs
@@ -1,0 +1,173 @@
+defmodule VutuvWeb.FeedRemoteArrivalSourcesTest do
+  @moduledoc """
+  What an open feed does with the announcement that something from the other
+  network arrived.
+
+  `Vutuv.Fediverse.nudge_feeds/2` deliberately carries no id — only the
+  reader's own sources know whether that write reaches *them* — so the message
+  says "look" and the feed asks. Which sources it asks is the whole subject of
+  this file: it used to ask a hard-wired `:fediverse`, while the nudge is sent
+  for **four** kinds of write, two of which are vutuv-tab entries
+  (`feed_remote_boosts(only: :local)` and the two reshare sources). The feed
+  looked in the wrong place, found nothing, and said nothing — no pill, no
+  card, no error, until the next page load.
+
+  So each test drives one of the four and asks for the pill. The two that were
+  broken are marked; keep all four, because the pair that worked is what stops
+  a future narrowing of the source list from passing.
+
+  Not async: the reshare claims from `Vutuv.RateLimiter`, a shared ETS table
+  the SQL sandbox does not roll back.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.PostBoost
+  alias Vutuv.MastodonHelpers
+  alias Vutuv.Posts
+  alias Vutuv.Social
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    :ok
+  end
+
+  defp reader(conn) do
+    {conn, user} = create_and_login_user(conn)
+    {conn, user}
+  end
+
+  # The reader following an account out there, which is what makes that
+  # account's own posts and its boosts reach them at all.
+  defp follow_remote!(user, account) do
+    Repo.insert!(%Follow{
+      user_id: user.id,
+      remote_account_id: account.id,
+      state: "accepted",
+      follow_activity_id: "https://vutuv.test/#{user.id}/actor#follows/#{account.id}"
+    })
+  end
+
+  # The announcement itself, in the shape `nudge_feeds/2` really broadcasts:
+  # naive UTC, and no id.
+  defp announce(view, %DateTime{} = at), do: announce(view, DateTime.to_naive(at))
+
+  defp announce(view, %NaiveDateTime{} = at) do
+    send(view.pid, {:remote_feed_arrival, %{at: at}})
+    render(view)
+  end
+
+  describe "a followed account's own post" do
+    test "fills the pill", %{conn: conn} do
+      {conn, user} = reader(conn)
+      account = MastodonHelpers.remote_account()
+      follow_remote!(user, account)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      post = MastodonHelpers.cached_post(account, content_text: "Direkt von dort.")
+      announce(view, post.published_at)
+
+      assert has_element?(view, "#show-new-posts")
+    end
+  end
+
+  describe "a followed account boosting a stranger's post" do
+    test "fills the pill", %{conn: conn} do
+      {conn, user} = reader(conn)
+      booster = MastodonHelpers.remote_account()
+      follow_remote!(user, booster)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      post = MastodonHelpers.cached_post(MastodonHelpers.remote_account())
+
+      boost =
+        Repo.insert!(%PostBoost{
+          remote_account_id: booster.id,
+          remote_post_id: post.id,
+          activity_id: "https://social.example/act/#{System.unique_integer([:positive])}",
+          announced_at: DateTime.utc_now(:second)
+        })
+
+      announce(view, boost.announced_at)
+
+      assert has_element?(view, "#show-new-posts")
+    end
+  end
+
+  describe "a followed account boosting a MEMBER's post" do
+    # Broken until this file: the boost of a member's post is
+    # `feed_remote_boosts(only: :local)`, a vutuv-tab source, so a door asking
+    # `:fediverse` never found it. `nudge_boost_feeds/4`'s own comment says this
+    # is a vutuv-tab entry — the door did not know.
+    setup %{conn: conn} do
+      {conn, user} = reader(conn)
+
+      # The author is deliberately **not** followed: the boost is the only
+      # reason this post could reach the reader, which is the whole point of
+      # issue #1167 ("how members get discovered through the outside network").
+      # Following the author instead would put the post on screen before the
+      # boost lands, and then silence is the right answer — that is the
+      # one-card-per-subject rule from #1970, not this gap.
+      author = insert(:activated_user)
+      {:ok, post} = Posts.create_post(author, %{body: "Ein Beitrag von hier."})
+
+      booster = MastodonHelpers.remote_account()
+      follow_remote!(user, booster)
+
+      %{conn: conn, user: user, post: post, booster: booster}
+    end
+
+    test "fills the pill on the All tab", %{conn: conn, post: post, booster: booster} do
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      boost = MastodonHelpers.boost(booster, post)
+      announce(view, boost.announced_at)
+
+      assert has_element?(view, "#show-new-posts")
+    end
+
+    test "and on the vutuv half of the band, which is where it belongs", %{
+      conn: conn,
+      post: post,
+      booster: booster,
+      user: user
+    } do
+      # The band's own state, written the way the band writes it and read back
+      # at mount (`Posts.remembered_feed_filter/1`) — the source switch is a
+      # stored member setting, not a control on this LiveView.
+      :ok = Posts.remember_feed_filter(user, :vutuv, :all)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      boost = MastodonHelpers.boost(booster, post)
+      announce(view, boost.announced_at)
+
+      assert has_element?(view, "#show-new-posts")
+    end
+  end
+
+  describe "a member here resharing a post from the other network" do
+    # Broken until this file, the same way: `feed_remote_reposts` is a vutuv-tab
+    # source. This one drives the real write, so the broadcast is the app's own
+    # rather than a hand-sent message.
+    test "fills the pill", %{conn: conn} do
+      {conn, user} = reader(conn)
+
+      resharer = MastodonHelpers.federating_member()
+      Social.follow(user, resharer.id)
+
+      post = MastodonHelpers.cached_post(MastodonHelpers.remote_account())
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      {:ok, :reposted} = Fediverse.repost_remote_post(resharer, post)
+
+      assert has_element?(view, "#show-new-posts")
+    end
+  end
+end


### PR DESCRIPTION
An open feed is told "something from the other network arrived, look" — deliberately without an id, since only the reader's own sources know whether it reaches them. `VutuvWeb.PostLive.Feed`'s door then asked a hard-wired `:fediverse`, but `Vutuv.Fediverse.nudge_feeds/2` is sent for four kinds of write, and two of them are vutuv-half sources: a followed account boosting a **member's** post, and a member here passing a cached post or reply on. The door looked in the wrong place, found nothing and said nothing — no pill, no card, no error, until the next page load. On the vutuv half it did not look at all, which is where those two belong.

It now asks the sources of the half the reader is standing on, the same question `feed_page/2` asks.

Two things that came out of the new test: a member's post carried in by a boost draws the local card, so it needs `decorate/2` — the card reads `entry.engagement` with dot access and the render raises without it. And `:all` asks ten sources per announcement, so the query goes through `FeedPage.fetch_sources/3`, which owns the concurrency.

Five tests, calibrated: the two paths that already worked were green from the start and hold the source list against a future narrowing.

https://claude.ai/code/session_01KE2NaGdpqUG5idSC7Cf2v1
