### PR TITLE
Availability defaults open up, and three sentences go

### DIFF
--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -12,6 +12,18 @@ defmodule Vutuv.Accounts.User do
   alias Vutuv.WebAddress
   @derive {Phoenix.Param, key: :username}
 
+  # How a job-seeking member wants to work. Deliberately the same three values
+  # `Vutuv.Jobs.JobPosting`'s workplace_type uses (kept as literals here rather
+  # than read from that schema, so the Accounts context does not depend on the
+  # Jobs one). The single source of truth for the changeset's subset check and,
+  # via workplace_type_values/0, the form's checkboxes — and the canonical
+  # ORDER a member's choices are stored and rendered in, so two members who
+  # ticked the same boxes read alike.
+  #
+  # Defined up here rather than beside its reader below, because the schema's
+  # own default is this list and an attribute has to exist before it is read.
+  @desired_workplace_types ~w(onsite hybrid remote)
+
   schema "users" do
     field(:first_name, :string)
     field(:last_name, :string)
@@ -65,11 +77,19 @@ defmodule Vutuv.Accounts.User do
     field(:employment_status, :string)
     # Who may see the employment-status badge (issue #928): "everyone" (all
     # visitors, incl. logged-out + crawlers/agent formats), "members" (only a
-    # signed-in member — the safe default) or "hidden" (nobody; the status
-    # stays stored but shows to no one). Resolved for a given viewer through
+    # signed-in member) or "hidden" (nobody; the status stays stored but shows
+    # to no one). Resolved for a given viewer through
     # employment_status_visible?/2, the single seam the profile pill and the
-    # agent docs both read. NOT NULL with a "members" default in the DB.
-    field(:employment_status_visibility, :string, default: "members")
+    # agent docs both read. NOT NULL with an "everyone" default in the DB.
+    #
+    # It defaults to "everyone" because the column only means anything once a
+    # status is set — `employment_status` is nil until the member says
+    # otherwise, and a nil status renders no badge for anybody — so the default
+    # is read as "somebody who just said they are open to offers", and hiding
+    # that from logged-out visitors is the opposite of what saying it is for.
+    # It was "members" until 2026-09-03; rows written before that keep their
+    # stored value, deliberately, since a stored visibility is a member's own.
+    field(:employment_status_visibility, :string, default: "everyone")
     # When the member last changed their availability status or its visibility
     # (issue #935): the freshness signal a saved recruiter "people" search reads,
     # so a member who newly becomes "open"/"looking" (or opens up a hidden
@@ -94,12 +114,19 @@ defmodule Vutuv.Accounts.User do
     # "remote" — the same vocabulary a job posting's workplace_type uses, so a
     # preference maps straight onto the board's workplace chips. A **list**,
     # because the three are not mutually exclusive: plenty of people take
-    # hybrid or remote but not a five-day office. `[]` = no preference (the
-    # default; NOT NULL in the DB, so no call site has to tell nil and [] apart).
+    # hybrid or remote but not a five-day office. `[]` = no preference (NOT NULL
+    # in the DB, so no call site has to tell nil and [] apart).
     # It is part of the availability signal, not a separate secret: it shows
     # beside the status badge under employment_status_visibility and is cleared
     # whenever the status goes back to "not open to work".
-    field(:desired_workplace_types, {:array, :string}, default: [])
+    #
+    # All three are the default (since 2026-09-03; it was `[]`), for the reason
+    # the visibility above defaults to "everyone": the column is only read once
+    # somebody has said they are open to offers, and starting them out excluded
+    # from every posting that is not their one ticked shape is a narrowing
+    # nobody asked for. Ticking none still means "no preference" — the two
+    # answers only differ in which postings the board offers first.
+    field(:desired_workplace_types, {:array, :string}, default: @desired_workplace_types)
     field(:birthdate, :date)
     # How much of the birthday the public profile (and its agent-format
     # siblings + the public CV) reveal: "full" (date + age, the historical
@@ -611,19 +638,10 @@ defmodule Vutuv.Accounts.User do
 
   def max_also_known_as, do: @max_also_known_as
 
-  # How a job-seeking member wants to work. Deliberately the same three values
-  # `Vutuv.Jobs.JobPosting`'s workplace_type uses (kept as literals here rather
-  # than read from that schema, so the Accounts context does not depend on the
-  # Jobs one). The single source of truth for the changeset's subset check and,
-  # via workplace_type_values/0, the form's checkboxes — and the canonical
-  # ORDER a member's choices are stored and rendered in, so two members who
-  # ticked the same boxes read alike.
-  @desired_workplace_types ~w(onsite hybrid remote)
-
   def workplace_type_values, do: @desired_workplace_types
 
   # The shared three-way visibility set (issue #928), used by BOTH
-  # employment_status_visibility (default "members") and
+  # employment_status_visibility (default "everyone") and
   # desired_salary_visibility (default "hidden"): "everyone" (all visitors,
   # incl. logged-out + crawlers/agent formats), "members" (only a signed-in
   # member) or "hidden" (nobody). The single source of truth for the

--- a/lib/vutuv_web/templates/user/edit.html.heex
+++ b/lib/vutuv_web/templates/user/edit.html.heex
@@ -367,11 +367,6 @@ lands here). --%>
                   <span>{wlabel}</span>
                 </label>
               </div>
-              <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
-                {gettext(
-                  "Shown next to your availability, and used to match you with postings."
-                )}
-              </p>
               <%= error_tag f, :desired_workplace_types %>
             </fieldset>
 

--- a/lib/vutuv_web/templates/welcome/show.html.heex
+++ b/lib/vutuv_web/templates/welcome/show.html.heex
@@ -113,11 +113,6 @@ optional; "Skip" is a second submit button that saves nothing. --%>
           <p class="text-sm font-medium text-slate-900 dark:text-white">
             {gettext("Minimum salary expectation")}
           </p>
-          <p class={hint_class}>
-            {gettext(
-              "Optional, and nobody else sees it. It filters postings below it out of your own job search."
-            )}
-          </p>
           <div class="mt-2 grid gap-3 sm:grid-cols-3">
             <div>
               <%= label uf, :desired_salary_min, gettext("Amount"), class: small_label_class %>
@@ -158,9 +153,6 @@ optional; "Skip" is a second submit button that saves nothing. --%>
               <span>{wlabel}</span>
             </label>
           </div>
-          <p class={hint_class}>
-            {gettext("Shown next to your availability, and used to match you with postings.")}
-          </p>
           <%= error_tag uf, :desired_workplace_types %>
         </fieldset>
       </div>

--- a/lib/vutuv_web/views/page_html.ex
+++ b/lib/vutuv_web/views/page_html.ex
@@ -52,12 +52,20 @@ defmodule VutuvWeb.PageHTML do
   @doc """
   The three claims under the founder quote, inside the hero panel.
 
-  Each is a short claim plus the reason it is not filler, and each half is its
-  own `gettext` call: the claim is set in white and the reason in `brand-100`,
-  and a translator gets two whole sentences rather than one sentence cut in
-  half. Two of the three are properties of the software and hold on every
-  installation; the import is a feature of this codebase, so all three survive
-  a third-party install without the operator having to promise anything.
+  Each is a short claim, and each may carry the reason it is not filler. Both
+  halves are their own `gettext` call: the claim is set in white and the reason
+  in `brand-100`, so a translator gets two whole sentences rather than one
+  sentence cut in half. Two of the three are properties of the software and hold
+  on every installation; the import is a feature of this codebase, so all three
+  survive a third-party install without the operator having to promise anything.
+
+  **The reason is optional, and "Fast." is the one that has none.** A reason
+  that only restates its claim ("Fast." — "vutuv is ridiculously fast.") is the
+  filler the other two avoid, and the empty `msgstr` that would seem to remove
+  it is a trap: gettext reads an empty translation as *untranslated* and falls
+  back to the msgid, so blanking it in the catalog would have put the English
+  sentence on the German page. A claim with no reason therefore drops the whole
+  span rather than rendering an empty one.
 
   Deliberately not links. `/import/linkedin` needs an account, so a logged-out
   click would trade the sign-up form beside them for a login screen.
@@ -71,7 +79,7 @@ defmodule VutuvWeb.PageHTML do
         <span aria-hidden="true" class="shrink-0 font-bold text-brand-200">✓</span>
         <span>
           <span class="font-semibold text-white">{claim}</span>
-          <span class="text-brand-100">{reason}</span>
+          <span :if={reason} class="text-brand-100">{reason}</span>
         </span>
       </li>
     </ul>
@@ -81,7 +89,7 @@ defmodule VutuvWeb.PageHTML do
   defp hero_point_list do
     [
       {gettext("Easy profile import."), gettext("Your LinkedIn profile can come along.")},
-      {gettext("Fast."), gettext("vutuv is ridiculously fast.")},
+      {gettext("Fast."), nil},
       {gettext("No paid premium accounts."), gettext("Nobody wants those anyway.")}
     ]
   end

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -2143,7 +2143,7 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:162
 #: lib/vutuv_web/live/post_live/feed.ex:336
-#: lib/vutuv_web/live/post_live/feed.ex:3111
+#: lib/vutuv_web/live/post_live/feed.ex:3145
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1156
 #: lib/vutuv_web/live/shell_live.ex:1460
@@ -2189,7 +2189,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3427
+#: lib/vutuv_web/live/post_live/feed.ex:3461
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2284,7 +2284,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2318
+#: lib/vutuv_web/live/post_live/feed.ex:2352
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2799,7 +2799,7 @@ msgid "Manage"
 msgstr "Verwalten"
 
 #: lib/vutuv_web/controllers/page_controller.ex:216
-#: lib/vutuv_web/live/post_live/feed.ex:2358
+#: lib/vutuv_web/live/post_live/feed.ex:2392
 #: lib/vutuv_web/templates/user/show.html.heex:507
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -4696,7 +4696,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3432
+#: lib/vutuv_web/live/post_live/feed.ex:3466
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -5586,7 +5586,7 @@ msgid "Write a new post"
 msgstr "Beitrag schreiben"
 
 #: lib/vutuv_web/templates/layout/app.html.heex:154
-#: lib/vutuv_web/views/page_html.ex:543
+#: lib/vutuv_web/views/page_html.ex:551
 #, elixir-autogen, elixir-format
 msgid "Your profile"
 msgstr "Ihr Profil"
@@ -7723,7 +7723,7 @@ msgstr ""
 "der Versand läuft weiter."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3698
+#: lib/vutuv_web/live/post_live/feed.ex:3732
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #, elixir-autogen
 msgid "Done"
@@ -18492,7 +18492,7 @@ msgstr "Das ist die Kopie, die vutuv von einem auf %{host} veröffentlichten Bei
 msgid "Subscribe to this feed in your RSS reader"
 msgstr "Diesen Feed in Ihrem RSS-Reader abonnieren"
 
-#: lib/vutuv_web/views/page_html.ex:546
+#: lib/vutuv_web/views/page_html.ex:554
 #, elixir-autogen, elixir-format
 msgid "A CV with positions, education, certificates including proof, spoken languages and tags other members endorse you for."
 msgstr "Ein Lebenslauf mit Stationen, Ausbildung, Zertifikaten samt Nachweis, Sprachen und Tags, für die andere Mitglieder Sie empfehlen."
@@ -18502,17 +18502,17 @@ msgstr "Ein Lebenslauf mit Stationen, Ausbildung, Zertifikaten samt Nachweis, Sp
 msgid "A business network that is free, does not lock your data in, and is yours to run yourself if you want to."
 msgstr "Ein Business-Netzwerk, das kostenlos ist, Ihre Daten nicht einsperrt und das Sie auf Wunsch selbst betreiben können."
 
-#: lib/vutuv_web/views/page_html.ex:561
+#: lib/vutuv_web/views/page_html.ex:569
 #, elixir-autogen, elixir-format
 msgid "A job board with radius search and saved searches that email you when something matches."
 msgstr "Eine Jobbörse mit Umkreissuche und gespeicherten Suchen, die sich per E-Mail melden, sobald etwas passt."
 
-#: lib/vutuv_web/views/page_html.ex:552
+#: lib/vutuv_web/views/page_html.ex:560
 #, elixir-autogen, elixir-format
 msgid "A permanent public address, readable without an account and downloadable as a vCard."
 msgstr "Eine feste öffentliche Adresse, ohne Konto lesbar und als vCard herunterladbar."
 
-#: lib/vutuv_web/views/page_html.ex:549
+#: lib/vutuv_web/views/page_html.ex:557
 #, elixir-autogen, elixir-format
 msgid "CV download as PDF, Word, OpenDocument, LaTeX or JSON Resume, and you pick what goes in before you download it."
 msgstr "Lebenslauf-Download als PDF, Word, OpenDocument, LaTeX oder JSON Resume, und Sie wählen vor dem Download aus, was darin steht."
@@ -18537,22 +18537,22 @@ msgstr "Für Maschinen"
 msgid "Open by default"
 msgstr "Offen von Haus aus"
 
-#: lib/vutuv_web/views/page_html.ex:577
+#: lib/vutuv_web/views/page_html.ex:585
 #, elixir-autogen, elixir-format
 msgid "Open source under the MIT license, and you can run your own installation on the internet or in your own intranet."
 msgstr "Open Source unter der MIT-Lizenz, und Sie können eine eigene Installation betreiben, im Internet oder im eigenen Intranet."
 
-#: lib/vutuv_web/views/page_html.ex:564
+#: lib/vutuv_web/views/page_html.ex:572
 #, elixir-autogen, elixir-format
 msgid "Organization pages that only exist once somebody has proven control of the organization's domain."
 msgstr "Organisationsseiten, die erst entstehen, wenn jemand die Domain der Organisation nachgewiesen hat."
 
-#: lib/vutuv_web/views/page_html.ex:558
+#: lib/vutuv_web/views/page_html.ex:566
 #, elixir-autogen, elixir-format
 msgid "People, posts, jobs"
 msgstr "Menschen, Beiträge, Jobs"
 
-#: lib/vutuv_web/views/page_html.ex:560
+#: lib/vutuv_web/views/page_html.ex:568
 #, elixir-autogen, elixir-format
 msgid "Posts, likes, reposts, replies and 1:1 messages, in real time."
 msgstr "Beiträge, Likes, Reposts, Antworten und 1:1-Nachrichten, in Echtzeit."
@@ -18567,7 +18567,7 @@ msgstr "Lesbar für Menschen, für Maschinen und auf Ihrem eigenen Server"
 msgid "Run it yourself"
 msgstr "Selbst hosten"
 
-#: lib/vutuv_web/views/page_html.ex:574
+#: lib/vutuv_web/views/page_html.ex:582
 #, elixir-autogen, elixir-format
 msgid "Sign in without a password, by emailed PIN, passkey, authenticator app or a printed list of codes."
 msgstr "Einloggen ohne Passwort, per PIN in der E-Mail, Passkey, Authenticator-App oder gedruckter Kennwortliste."
@@ -18593,7 +18593,7 @@ msgstr "Was vutuv kann"
 msgid "What you get"
 msgstr "Was Sie bekommen"
 
-#: lib/vutuv_web/views/page_html.ex:570
+#: lib/vutuv_web/views/page_html.ex:578
 #, elixir-autogen, elixir-format
 msgid "Your independence"
 msgstr "Ihre Unabhängigkeit"
@@ -18608,7 +18608,7 @@ msgstr "vutuv ist Open Source unter der MIT-Lizenz. Betreiben Sie es für ein Un
 msgid "A look inside"
 msgstr "Ein Blick hinein"
 
-#: lib/vutuv_web/views/page_html.ex:223
+#: lib/vutuv_web/views/page_html.ex:231
 #, elixir-autogen, elixir-format
 msgid "A vutuv profile: cover picture, photo, name, tagline and job title, follower counts and the first posts, with contact details and social media profiles in a column on the right."
 msgstr "Ein vutuv-Profil: Titelbild, Foto, Name, Motto und Position, die Follower-Zahlen und die ersten Beiträge, rechts daneben eine Spalte mit Kontaktdaten und Profilen in sozialen Netzwerken."
@@ -18618,17 +18618,17 @@ msgstr "Ein vutuv-Profil: Titelbild, Foto, Name, Motto und Position, die Followe
 msgid "Browse real profiles"
 msgstr "Echte Profile durchstöbern"
 
-#: lib/vutuv_web/views/page_html.ex:245
+#: lib/vutuv_web/views/page_html.ex:253
 #, elixir-autogen, elixir-format
 msgid "The lower part of the profile: spoken languages with levels, web links each shown as a preview image with a verification mark, and a panel offering the CV for download."
 msgstr "Der untere Teil des Profils: gesprochene Sprachen mit Niveau, Weblinks jeweils als Vorschaubild mit Verifizierungshaken, und ein Feld, das den Lebenslauf zum Download anbietet."
 
-#: lib/vutuv_web/views/page_html.ex:235
+#: lib/vutuv_web/views/page_html.ex:243
 #, elixir-autogen, elixir-format
 msgid "The same profile further down: tags, each with the number of members who endorse it, and a CV as a timeline of positions with employer and duration."
 msgstr "Dasselbe Profil weiter unten: Tags mit der Zahl der Mitglieder, die sie jeweils empfehlen, und ein Lebenslauf als Zeitleiste der Stationen mit Arbeitgeber und Dauer."
 
-#: lib/vutuv_web/views/page_html.ex:407
+#: lib/vutuv_web/views/page_html.ex:415
 #, elixir-autogen, elixir-format
 msgid "Try it out:"
 msgstr "Probieren Sie es aus:"
@@ -18648,17 +18648,17 @@ msgstr "Berufserfahrung, Ausbildung, Zertifikate, Sprachen, Links und Tags, für
 msgid "Talking to people"
 msgstr "Miteinander reden"
 
-#: lib/vutuv_web/views/page_html.ex:274
+#: lib/vutuv_web/views/page_html.ex:282
 #, elixir-autogen, elixir-format
 msgid "The settings page for followed Fediverse accounts: a field to enter an address like @name@server, and a table of accounts already followed with their server and an unfollow link."
 msgstr "Die Einstellungsseite für gefolgte Fediverse-Konten: ein Feld für eine Adresse der Form @name@server und eine Tabelle der bereits gefolgten Konten mit ihrem Server und einem Link zum Entfolgen."
 
-#: lib/vutuv_web/views/page_html.ex:264
+#: lib/vutuv_web/views/page_html.ex:272
 #, elixir-autogen, elixir-format
 msgid "The vutuv feed with the Fediverse tab selected: posts by news accounts on ard.social, mastodon.social and bonn.social, each with the server it came from, and heart, reply and repost counts underneath."
 msgstr "Der vutuv-Feed mit ausgewähltem Fediverse-Reiter: Beiträge von Nachrichtenkonten auf ard.social, mastodon.social und bonn.social, jeweils mit dem Server, von dem sie kommen, und darunter die Zahlen für Herz, Antwort und Repost."
 
-#: lib/vutuv_web/views/page_html.ex:515
+#: lib/vutuv_web/views/page_html.ex:523
 #, elixir-autogen, elixir-format
 msgid "The Fediverse: let people follow you from Mastodon, and your public posts show up there. You choose at sign-up, and can change it later."
 msgstr "Das Fediverse: Menschen können Ihnen von Mastodon aus folgen, und Ihre öffentlichen Beiträge erscheinen dort. Sie entscheiden das bei der Anmeldung und können es später ändern."
@@ -18934,7 +18934,7 @@ msgstr "Ausstellungsdatum"
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3450
+#: lib/vutuv_web/live/post_live/feed.ex:3484
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -19605,7 +19605,7 @@ msgstr "Sie haben Ihr Limit von %{limit} Prüfungen erreicht. Bitte versuchen Si
 msgid "Employment reference"
 msgstr "Arbeitszeugnis"
 
-#: lib/vutuv_web/views/page_html.ex:531
+#: lib/vutuv_web/views/page_html.ex:539
 #, elixir-autogen, elixir-format
 msgid "Employment references: upload them, keep them private, and have the wording read and graded on our own servers."
 msgstr "Arbeitszeugnisse hochladen, privat halten und die Formulierungen auf unseren eigenen Servern lesen und benoten lassen."
@@ -19615,12 +19615,12 @@ msgstr "Arbeitszeugnisse hochladen, privat halten und die Formulierungen auf uns
 msgid "Job applications"
 msgstr "Bewerbungsunterlagen"
 
-#: lib/vutuv_web/views/page_html.ex:295
+#: lib/vutuv_web/views/page_html.ex:303
 #, elixir-autogen, elixir-format
 msgid "The CV builder: a checklist of everything that could go into the CV, with name, photo, tagline and contact details, and beside it a panel offering the download as PDF, Word, OpenDocument, LaTeX or JSON Resume."
 msgstr "Der Lebenslauf-Baukasten: eine Liste zum Abhaken mit allem, was in den Lebenslauf kann, darunter Name, Foto, Kurzbeschreibung und Kontaktdaten, daneben ein Feld mit dem Download als PDF, Word, OpenDocument, LaTeX oder JSON Resume."
 
-#: lib/vutuv_web/views/page_html.ex:305
+#: lib/vutuv_web/views/page_html.ex:313
 #, elixir-autogen, elixir-format
 msgid "The finished CV ready to print: name, tagline and contact details at the top, below them the positions held with employer and period, and further down the tags and the spoken languages."
 msgstr "Der fertige Lebenslauf in der Druckansicht: oben Name, Kurzbeschreibung und Kontaktdaten, darunter die Stationen mit Arbeitgeber und Zeitraum, weiter unten die Tags und die Sprachkenntnisse."
@@ -19630,12 +19630,12 @@ msgstr "Der fertige Lebenslauf in der Druckansicht: oben Name, Kurzbeschreibung 
 msgid "The review is a text analysis, not legal advice, and it covers German employment references."
 msgstr "Die Prüfung ist eine Textanalyse, keine Rechtsberatung, und sie deckt deutsche Arbeitszeugnisse ab."
 
-#: lib/vutuv_web/views/page_html.ex:336
+#: lib/vutuv_web/views/page_html.ex:344
 #, elixir-autogen, elixir-format
 msgid "The review of a single employment reference: the overall grade on a red panel, then a report naming the kind of reference, the grade range, a traffic-light tally of its wordings and the main criticism."
 msgstr "Die Prüfung eines einzelnen Arbeitszeugnisses: die Gesamtnote in einem roten Feld, darunter ein Bericht mit Zeugnisart, Notenspanne, einer Ampel-Bilanz der Formulierungen und der Hauptkritik."
 
-#: lib/vutuv_web/views/page_html.ex:326
+#: lib/vutuv_web/views/page_html.ex:334
 #, elixir-autogen, elixir-format
 msgid "The uploaded employment references, each marked private: one graded 1 (very good) on a green panel, one graded 4 to 5 (poor to unsatisfactory) on a red one, each with a link to its full report."
 msgstr "Die hochgeladenen Arbeitszeugnisse, jedes als privat gekennzeichnet: eines mit der Note 1 (sehr gut) in einem grünen Feld, eines mit der Note 4 bis 5 (mangelhaft bis ungenügend) in einem roten, jeweils mit einem Link zum vollständigen Bericht."
@@ -22134,7 +22134,7 @@ msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public po
 msgstr ""
 "Folgen Sie #%{tag} von Mastodon oder einer anderen Fediverse-App aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3611
+#: lib/vutuv_web/live/post_live/feed.ex:3645
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Andere Mitglieder begrüßen"
@@ -22433,32 +22433,27 @@ msgstr ""
 msgid "That alternative name is no longer on record."
 msgstr "Dieser Zweitname ist nicht mehr vermerkt."
 
-#: lib/vutuv_web/views/page_html.ex:83
+#: lib/vutuv_web/views/page_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "Easy profile import."
 msgstr "Einfacher Profilimport."
 
-#: lib/vutuv_web/views/page_html.ex:84
+#: lib/vutuv_web/views/page_html.ex:92
 #, elixir-autogen, elixir-format
 msgid "Fast."
 msgstr "Schnell."
 
-#: lib/vutuv_web/views/page_html.ex:85
+#: lib/vutuv_web/views/page_html.ex:93
 #, elixir-autogen, elixir-format
 msgid "Nobody wants those anyway."
 msgstr "Das will doch eh keiner."
 
-#: lib/vutuv_web/views/page_html.ex:84
-#, elixir-autogen, elixir-format
-msgid "vutuv is ridiculously fast."
-msgstr "vutuv ist einfach rattenschnell."
-
-#: lib/vutuv_web/views/page_html.ex:85
+#: lib/vutuv_web/views/page_html.ex:93
 #, elixir-autogen, elixir-format
 msgid "No paid premium accounts."
 msgstr "Keine bezahlten Premium-Accounts."
 
-#: lib/vutuv_web/views/page_html.ex:83
+#: lib/vutuv_web/views/page_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "Your LinkedIn profile can come along."
 msgstr "Ihr LinkedIn-Profil kann mitkommen."
@@ -22728,7 +22723,7 @@ msgstr "Beiträge mit einem dieser Tags werden genauso zugeklappt."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Beiträge mit einem dieser Wörter werden auf eine Zeile zugeklappt — nicht gelöscht, und mit einem Weg, sie doch zu lesen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3637
+#: lib/vutuv_web/live/post_live/feed.ex:3671
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Weggelegt:"
@@ -22805,10 +22800,10 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "und 1 weiterer"
 msgstr[1] "und %{formatted} weitere"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3224
-#: lib/vutuv_web/live/post_live/feed.ex:3251
-#: lib/vutuv_web/live/post_live/feed.ex:3685
-#: lib/vutuv_web/live/post_live/feed.ex:3690
+#: lib/vutuv_web/live/post_live/feed.ex:3258
+#: lib/vutuv_web/live/post_live/feed.ex:3285
+#: lib/vutuv_web/live/post_live/feed.ex:3719
+#: lib/vutuv_web/live/post_live/feed.ex:3724
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -22877,7 +22872,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} Beitrag am %{day}"
 msgstr[1] "%{count} Beiträge am %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3407
+#: lib/vutuv_web/live/post_live/feed.ex:3441
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Zurück zu jetzt"
@@ -22887,7 +22882,7 @@ msgstr "Zurück zu jetzt"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Voller Monat: die Färbung zählt mindestens so viel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3453
+#: lib/vutuv_web/live/post_live/feed.ex:3487
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22909,7 +22904,7 @@ msgstr "Nächster Monat"
 msgid "Next year"
 msgstr "Nächstes Jahr"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3403
+#: lib/vutuv_web/live/post_live/feed.ex:3437
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Am %{day} ist nichts in Ihrem Feed angekommen."
@@ -22996,7 +22991,7 @@ msgstr "Neue Version bereit."
 msgid "Page management"
 msgstr "Verwaltung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2312
+#: lib/vutuv_web/live/post_live/feed.ex:2346
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
@@ -23028,7 +23023,7 @@ msgstr "Ein Konto erwähnen"
 msgid "{used} of {max} mentions"
 msgstr "{used} von {max} Erwähnungen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2461
+#: lib/vutuv_web/live/post_live/feed.ex:2495
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr "Bis hier neu"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -95,7 +95,7 @@ msgstr "Sind Sie sicher?"
 msgid "Avatar"
 msgstr "Avatar"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:407
+#: lib/vutuv_web/templates/user/edit.html.heex:402
 #, elixir-autogen
 msgid "Birthdate"
 msgstr "Geburtstag"
@@ -130,8 +130,8 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:53
 #: lib/vutuv_web/templates/user/edit.html.heex:133
-#: lib/vutuv_web/templates/user/edit.html.heex:463
-#: lib/vutuv_web/templates/user/edit.html.heex:508
+#: lib/vutuv_web/templates/user/edit.html.heex:458
+#: lib/vutuv_web/templates/user/edit.html.heex:503
 #: lib/vutuv_web/templates/username/confirm.html.heex:220
 #, elixir-autogen
 msgid "Cancel"
@@ -628,7 +628,7 @@ msgstr "Öffentlich"
 #: lib/vutuv_web/templates/settings/preferences.html.heex:362
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:61
-#: lib/vutuv_web/templates/user/edit.html.heex:458
+#: lib/vutuv_web/templates/user/edit.html.heex:453
 #: lib/vutuv_web/views/settings_html.ex:212
 #, elixir-autogen
 msgid "Save"
@@ -8766,7 +8766,7 @@ msgstr "Basisdaten & Fotos"
 msgid "Language & display"
 msgstr "Sprache & Anzeige"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:523
+#: lib/vutuv_web/templates/user/edit.html.heex:518
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
@@ -9869,7 +9869,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
-#: lib/vutuv/accounts/user.ex:1225
+#: lib/vutuv/accounts/user.ex:1243
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9880,7 +9880,7 @@ msgstr "Auf Jobsuche"
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
-#: lib/vutuv/accounts/user.ex:1222
+#: lib/vutuv/accounts/user.ex:1240
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10161,18 +10161,18 @@ msgstr "+%{code} ist die Ländervorwahl von %{region}"
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:436
-#: lib/vutuv_web/templates/user/edit.html.heex:511
+#: lib/vutuv_web/templates/user/edit.html.heex:431
+#: lib/vutuv_web/templates/user/edit.html.heex:506
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr "Geburtsdatum entfernen"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:499
+#: lib/vutuv_web/templates/user/edit.html.heex:494
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr "Geburtsdatum entfernen?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:502
+#: lib/vutuv_web/templates/user/edit.html.heex:497
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -11318,19 +11318,19 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
-#: lib/vutuv/accounts/user.ex:1263
+#: lib/vutuv/accounts/user.ex:1281
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
-#: lib/vutuv/accounts/user.ex:1268
+#: lib/vutuv/accounts/user.ex:1286
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
-#: lib/vutuv/accounts/user.ex:1266
+#: lib/vutuv/accounts/user.ex:1284
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -11344,14 +11344,14 @@ msgid "Who can see your availability?"
 msgstr "Wer kann Ihre Verfügbarkeit sehen?"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:313
-#: lib/vutuv_web/templates/welcome/show.html.heex:123
+#: lib/vutuv_web/templates/welcome/show.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr "Betrag"
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:693
 #: lib/vutuv_web/templates/user/edit.html.heex:321
-#: lib/vutuv_web/templates/welcome/show.html.heex:131
+#: lib/vutuv_web/templates/welcome/show.html.heex:126
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr "Währung"
@@ -11380,7 +11380,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:700
 #: lib/vutuv_web/templates/user/edit.html.heex:317
-#: lib/vutuv_web/templates/welcome/show.html.heex:127
+#: lib/vutuv_web/templates/welcome/show.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Per"
 msgstr "Pro"
@@ -11459,7 +11459,7 @@ msgstr "Ein Mitglied ausschließen"
 msgid "Exclude an email domain"
 msgstr "Eine E-Mail-Domain ausschließen"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:384
+#: lib/vutuv_web/templates/user/edit.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr "Vor bestimmten Personen verbergen"
@@ -11470,7 +11470,7 @@ msgstr "Vor bestimmten Personen verbergen"
 msgid "Job-search exclusion list"
 msgstr "Ausschlussliste für die Jobsuche"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:387
+#: lib/vutuv_web/templates/user/edit.html.heex:382
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
@@ -11479,7 +11479,7 @@ msgstr ""
 "Mitglieder oder E-Mail-Domains aus; sie sehen Ihre Verfügbarkeit und Ihre "
 "Gehaltsvorstellung dann nie, auch nicht bei „Alle“."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:395
+#: lib/vutuv_web/templates/user/edit.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -12682,7 +12682,7 @@ msgstr "Hervorgehobene Tags passen zu Ihrem Profil."
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
 
-#: lib/vutuv/accounts/user.ex:1237
+#: lib/vutuv/accounts/user.ex:1255
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12801,7 +12801,7 @@ msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
 
-#: lib/vutuv/accounts/user.ex:1236
+#: lib/vutuv/accounts/user.ex:1254
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12883,7 +12883,7 @@ msgstr "Anzeige nicht gefunden."
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: lib/vutuv/accounts/user.ex:1238
+#: lib/vutuv/accounts/user.ex:1256
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
 #: lib/vutuv_web/agent_docs/markdown.ex:470
@@ -13912,36 +13912,36 @@ msgstr "Screenshot entfernt."
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
-#: lib/vutuv/accounts/user.ex:1281
+#: lib/vutuv/accounts/user.ex:1299
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
 msgstr "Nur das Alter, ohne das Datum"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:447
+#: lib/vutuv_web/templates/user/edit.html.heex:442
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
-#: lib/vutuv/accounts/user.ex:1284
+#: lib/vutuv/accounts/user.ex:1302
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
-#: lib/vutuv/accounts/user.ex:1287
+#: lib/vutuv/accounts/user.ex:1305
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
-#: lib/vutuv/accounts/user.ex:1278
+#: lib/vutuv/accounts/user.ex:1296
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
 msgstr "Vollständiges Datum und Alter"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:444
+#: lib/vutuv_web/templates/user/edit.html.heex:439
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr "Geburtstag anzeigen als"
@@ -14586,33 +14586,18 @@ msgstr "Art der Adresse"
 msgid "Are you looking for a job?"
 msgstr "Suchen Sie eine Stelle?"
 
-#: lib/vutuv_web/templates/welcome/show.html.heex:117
-#, elixir-autogen, elixir-format
-msgid "Optional, and nobody else sees it. It filters postings below it out of your own job search."
-msgstr ""
-"Optional, und niemand sonst sieht es. Die Angabe filtert Stellen darunter "
-"aus Ihrer eigenen Jobsuche."
-
 #: lib/vutuv_web/templates/user/edit.html.heex:351
-#: lib/vutuv_web/templates/welcome/show.html.heex:143
+#: lib/vutuv_web/templates/welcome/show.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr "Wie möchten Sie arbeiten?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:371
 #: lib/vutuv_web/templates/welcome/show.html.heex:162
-#, elixir-autogen, elixir-format
-msgid "Shown next to your availability, and used to match you with postings."
-msgstr ""
-"Wird neben Ihrer Verfügbarkeit angezeigt und für passende Stellenangebote "
-"genutzt."
-
-#: lib/vutuv_web/templates/welcome/show.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Save and continue"
 msgstr "Speichern und weiter"
 
-#: lib/vutuv_web/templates/welcome/show.html.heex:172
+#: lib/vutuv_web/templates/welcome/show.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "Skip for now"
 msgstr "Erstmal überspringen"
@@ -19738,17 +19723,17 @@ msgstr ""
 "Kommt keine PIN an? Ist die E-Mail-Adresse {email} korrekt? Haben Sie einmal "
 "in Ihren Spam-Ordner geschaut?"
 
-#: lib/vutuv/accounts/user.ex:1384
+#: lib/vutuv/accounts/user.ex:1402
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/vutuv/accounts/user.ex:1382
+#: lib/vutuv/accounts/user.ex:1400
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Weiblich"
 
-#: lib/vutuv/accounts/user.ex:1383
+#: lib/vutuv/accounts/user.ex:1401
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -2105,7 +2105,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:162
 #: lib/vutuv_web/live/post_live/feed.ex:336
-#: lib/vutuv_web/live/post_live/feed.ex:3111
+#: lib/vutuv_web/live/post_live/feed.ex:3145
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1156
 #: lib/vutuv_web/live/shell_live.ex:1460
@@ -2151,7 +2151,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3427
+#: lib/vutuv_web/live/post_live/feed.ex:3461
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2242,7 +2242,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2318
+#: lib/vutuv_web/live/post_live/feed.ex:2352
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2755,7 +2755,7 @@ msgid "Manage"
 msgstr ""
 
 #: lib/vutuv_web/controllers/page_controller.ex:216
-#: lib/vutuv_web/live/post_live/feed.ex:2358
+#: lib/vutuv_web/live/post_live/feed.ex:2392
 #: lib/vutuv_web/templates/user/show.html.heex:507
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -4532,7 +4532,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3432
+#: lib/vutuv_web/live/post_live/feed.ex:3466
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -5368,7 +5368,7 @@ msgid "Write a new post"
 msgstr ""
 
 #: lib/vutuv_web/templates/layout/app.html.heex:154
-#: lib/vutuv_web/views/page_html.ex:543
+#: lib/vutuv_web/views/page_html.ex:551
 #, elixir-autogen, elixir-format
 msgid "Your profile"
 msgstr ""
@@ -7418,7 +7418,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3698
+#: lib/vutuv_web/live/post_live/feed.ex:3732
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #, elixir-autogen
 msgid "Done"
@@ -17760,7 +17760,7 @@ msgstr ""
 msgid "Subscribe to this feed in your RSS reader"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:546
+#: lib/vutuv_web/views/page_html.ex:554
 #, elixir-autogen, elixir-format
 msgid "A CV with positions, education, certificates including proof, spoken languages and tags other members endorse you for."
 msgstr ""
@@ -17770,17 +17770,17 @@ msgstr ""
 msgid "A business network that is free, does not lock your data in, and is yours to run yourself if you want to."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:561
+#: lib/vutuv_web/views/page_html.ex:569
 #, elixir-autogen, elixir-format
 msgid "A job board with radius search and saved searches that email you when something matches."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:552
+#: lib/vutuv_web/views/page_html.ex:560
 #, elixir-autogen, elixir-format
 msgid "A permanent public address, readable without an account and downloadable as a vCard."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:549
+#: lib/vutuv_web/views/page_html.ex:557
 #, elixir-autogen, elixir-format
 msgid "CV download as PDF, Word, OpenDocument, LaTeX or JSON Resume, and you pick what goes in before you download it."
 msgstr ""
@@ -17805,22 +17805,22 @@ msgstr ""
 msgid "Open by default"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:577
+#: lib/vutuv_web/views/page_html.ex:585
 #, elixir-autogen, elixir-format
 msgid "Open source under the MIT license, and you can run your own installation on the internet or in your own intranet."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:564
+#: lib/vutuv_web/views/page_html.ex:572
 #, elixir-autogen, elixir-format
 msgid "Organization pages that only exist once somebody has proven control of the organization's domain."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:558
+#: lib/vutuv_web/views/page_html.ex:566
 #, elixir-autogen, elixir-format
 msgid "People, posts, jobs"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:560
+#: lib/vutuv_web/views/page_html.ex:568
 #, elixir-autogen, elixir-format
 msgid "Posts, likes, reposts, replies and 1:1 messages, in real time."
 msgstr ""
@@ -17835,7 +17835,7 @@ msgstr ""
 msgid "Run it yourself"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:574
+#: lib/vutuv_web/views/page_html.ex:582
 #, elixir-autogen, elixir-format
 msgid "Sign in without a password, by emailed PIN, passkey, authenticator app or a printed list of codes."
 msgstr ""
@@ -17861,7 +17861,7 @@ msgstr ""
 msgid "What you get"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:570
+#: lib/vutuv_web/views/page_html.ex:578
 #, elixir-autogen, elixir-format
 msgid "Your independence"
 msgstr ""
@@ -17876,7 +17876,7 @@ msgstr ""
 msgid "A look inside"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:223
+#: lib/vutuv_web/views/page_html.ex:231
 #, elixir-autogen, elixir-format
 msgid "A vutuv profile: cover picture, photo, name, tagline and job title, follower counts and the first posts, with contact details and social media profiles in a column on the right."
 msgstr ""
@@ -17886,17 +17886,17 @@ msgstr ""
 msgid "Browse real profiles"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:245
+#: lib/vutuv_web/views/page_html.ex:253
 #, elixir-autogen, elixir-format
 msgid "The lower part of the profile: spoken languages with levels, web links each shown as a preview image with a verification mark, and a panel offering the CV for download."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:235
+#: lib/vutuv_web/views/page_html.ex:243
 #, elixir-autogen, elixir-format
 msgid "The same profile further down: tags, each with the number of members who endorse it, and a CV as a timeline of positions with employer and duration."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:407
+#: lib/vutuv_web/views/page_html.ex:415
 #, elixir-autogen, elixir-format
 msgid "Try it out:"
 msgstr ""
@@ -17916,17 +17916,17 @@ msgstr ""
 msgid "Talking to people"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:274
+#: lib/vutuv_web/views/page_html.ex:282
 #, elixir-autogen, elixir-format
 msgid "The settings page for followed Fediverse accounts: a field to enter an address like @name@server, and a table of accounts already followed with their server and an unfollow link."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:264
+#: lib/vutuv_web/views/page_html.ex:272
 #, elixir-autogen, elixir-format
 msgid "The vutuv feed with the Fediverse tab selected: posts by news accounts on ard.social, mastodon.social and bonn.social, each with the server it came from, and heart, reply and repost counts underneath."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:515
+#: lib/vutuv_web/views/page_html.ex:523
 #, elixir-autogen, elixir-format
 msgid "The Fediverse: let people follow you from Mastodon, and your public posts show up there. You choose at sign-up, and can change it later."
 msgstr ""
@@ -18200,7 +18200,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3450
+#: lib/vutuv_web/live/post_live/feed.ex:3484
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -18871,7 +18871,7 @@ msgstr ""
 msgid "Employment reference"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:531
+#: lib/vutuv_web/views/page_html.ex:539
 #, elixir-autogen, elixir-format
 msgid "Employment references: upload them, keep them private, and have the wording read and graded on our own servers."
 msgstr ""
@@ -18881,12 +18881,12 @@ msgstr ""
 msgid "Job applications"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:295
+#: lib/vutuv_web/views/page_html.ex:303
 #, elixir-autogen, elixir-format
 msgid "The CV builder: a checklist of everything that could go into the CV, with name, photo, tagline and contact details, and beside it a panel offering the download as PDF, Word, OpenDocument, LaTeX or JSON Resume."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:305
+#: lib/vutuv_web/views/page_html.ex:313
 #, elixir-autogen, elixir-format
 msgid "The finished CV ready to print: name, tagline and contact details at the top, below them the positions held with employer and period, and further down the tags and the spoken languages."
 msgstr ""
@@ -18896,12 +18896,12 @@ msgstr ""
 msgid "The review is a text analysis, not legal advice, and it covers German employment references."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:336
+#: lib/vutuv_web/views/page_html.ex:344
 #, elixir-autogen, elixir-format
 msgid "The review of a single employment reference: the overall grade on a red panel, then a report naming the kind of reference, the grade range, a traffic-light tally of its wordings and the main criticism."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:326
+#: lib/vutuv_web/views/page_html.ex:334
 #, elixir-autogen, elixir-format
 msgid "The uploaded employment references, each marked private: one graded 1 (very good) on a green panel, one graded 4 to 5 (poor to unsatisfactory) on a red one, each with a link to its full report."
 msgstr ""
@@ -21362,7 +21362,7 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3611
+#: lib/vutuv_web/live/post_live/feed.ex:3645
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
@@ -21636,32 +21636,27 @@ msgstr ""
 msgid "That alternative name is no longer on record."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:83
+#: lib/vutuv_web/views/page_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "Easy profile import."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:84
+#: lib/vutuv_web/views/page_html.ex:92
 #, elixir-autogen, elixir-format
 msgid "Fast."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:85
+#: lib/vutuv_web/views/page_html.ex:93
 #, elixir-autogen, elixir-format
 msgid "Nobody wants those anyway."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:84
-#, elixir-autogen, elixir-format
-msgid "vutuv is ridiculously fast."
-msgstr ""
-
-#: lib/vutuv_web/views/page_html.ex:85
+#: lib/vutuv_web/views/page_html.ex:93
 #, elixir-autogen, elixir-format
 msgid "No paid premium accounts."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:83
+#: lib/vutuv_web/views/page_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "Your LinkedIn profile can come along."
 msgstr ""
@@ -21931,7 +21926,7 @@ msgstr ""
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3637
+#: lib/vutuv_web/live/post_live/feed.ex:3671
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
@@ -22008,10 +22003,10 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3224
-#: lib/vutuv_web/live/post_live/feed.ex:3251
-#: lib/vutuv_web/live/post_live/feed.ex:3685
-#: lib/vutuv_web/live/post_live/feed.ex:3690
+#: lib/vutuv_web/live/post_live/feed.ex:3258
+#: lib/vutuv_web/live/post_live/feed.ex:3285
+#: lib/vutuv_web/live/post_live/feed.ex:3719
+#: lib/vutuv_web/live/post_live/feed.ex:3724
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -22076,7 +22071,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3407
+#: lib/vutuv_web/live/post_live/feed.ex:3441
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr ""
@@ -22086,7 +22081,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3453
+#: lib/vutuv_web/live/post_live/feed.ex:3487
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22108,7 +22103,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3403
+#: lib/vutuv_web/live/post_live/feed.ex:3437
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -22195,7 +22190,7 @@ msgstr ""
 msgid "Page management"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2312
+#: lib/vutuv_web/live/post_live/feed.ex:2346
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
@@ -22227,7 +22222,7 @@ msgstr ""
 msgid "{used} of {max} mentions"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2461
+#: lib/vutuv_web/live/post_live/feed.ex:2495
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Avatar"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:407
+#: lib/vutuv_web/templates/user/edit.html.heex:402
 #, elixir-autogen
 msgid "Birthdate"
 msgstr ""
@@ -132,8 +132,8 @@ msgstr ""
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:53
 #: lib/vutuv_web/templates/user/edit.html.heex:133
-#: lib/vutuv_web/templates/user/edit.html.heex:463
-#: lib/vutuv_web/templates/user/edit.html.heex:508
+#: lib/vutuv_web/templates/user/edit.html.heex:458
+#: lib/vutuv_web/templates/user/edit.html.heex:503
 #: lib/vutuv_web/templates/username/confirm.html.heex:220
 #, elixir-autogen
 msgid "Cancel"
@@ -628,7 +628,7 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/preferences.html.heex:362
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:61
-#: lib/vutuv_web/templates/user/edit.html.heex:458
+#: lib/vutuv_web/templates/user/edit.html.heex:453
 #: lib/vutuv_web/views/settings_html.ex:212
 #, elixir-autogen
 msgid "Save"
@@ -8380,7 +8380,7 @@ msgstr ""
 msgid "Language & display"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:523
+#: lib/vutuv_web/templates/user/edit.html.heex:518
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr ""
@@ -9419,7 +9419,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1225
+#: lib/vutuv/accounts/user.ex:1243
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9430,7 +9430,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1222
+#: lib/vutuv/accounts/user.ex:1240
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9695,18 +9695,18 @@ msgstr ""
 msgid "Date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:436
-#: lib/vutuv_web/templates/user/edit.html.heex:511
+#: lib/vutuv_web/templates/user/edit.html.heex:431
+#: lib/vutuv_web/templates/user/edit.html.heex:506
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:499
+#: lib/vutuv_web/templates/user/edit.html.heex:494
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:502
+#: lib/vutuv_web/templates/user/edit.html.heex:497
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -10748,19 +10748,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1263
+#: lib/vutuv/accounts/user.ex:1281
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1268
+#: lib/vutuv/accounts/user.ex:1286
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1266
+#: lib/vutuv/accounts/user.ex:1284
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -10774,14 +10774,14 @@ msgid "Who can see your availability?"
 msgstr ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:313
-#: lib/vutuv_web/templates/welcome/show.html.heex:123
+#: lib/vutuv_web/templates/welcome/show.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:693
 #: lib/vutuv_web/templates/user/edit.html.heex:321
-#: lib/vutuv_web/templates/welcome/show.html.heex:131
+#: lib/vutuv_web/templates/welcome/show.html.heex:126
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr ""
@@ -10804,7 +10804,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:700
 #: lib/vutuv_web/templates/user/edit.html.heex:317
-#: lib/vutuv_web/templates/welcome/show.html.heex:127
+#: lib/vutuv_web/templates/welcome/show.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Per"
 msgstr ""
@@ -10883,7 +10883,7 @@ msgstr ""
 msgid "Exclude an email domain"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:384
+#: lib/vutuv_web/templates/user/edit.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr ""
@@ -10894,12 +10894,12 @@ msgstr ""
 msgid "Job-search exclusion list"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:387
+#: lib/vutuv_web/templates/user/edit.html.heex:382
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:395
+#: lib/vutuv_web/templates/user/edit.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -12044,7 +12044,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1237
+#: lib/vutuv/accounts/user.ex:1255
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12163,7 +12163,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1236
+#: lib/vutuv/accounts/user.ex:1254
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12245,7 +12245,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1238
+#: lib/vutuv/accounts/user.ex:1256
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
 #: lib/vutuv_web/agent_docs/markdown.ex:470
@@ -13260,36 +13260,36 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1281
+#: lib/vutuv/accounts/user.ex:1299
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:447
+#: lib/vutuv_web/templates/user/edit.html.heex:442
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1284
+#: lib/vutuv/accounts/user.ex:1302
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1287
+#: lib/vutuv/accounts/user.ex:1305
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1278
+#: lib/vutuv/accounts/user.ex:1296
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:444
+#: lib/vutuv_web/templates/user/edit.html.heex:439
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr ""
@@ -13919,29 +13919,18 @@ msgstr ""
 msgid "Are you looking for a job?"
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex:117
-#, elixir-autogen, elixir-format
-msgid "Optional, and nobody else sees it. It filters postings below it out of your own job search."
-msgstr ""
-
 #: lib/vutuv_web/templates/user/edit.html.heex:351
-#: lib/vutuv_web/templates/welcome/show.html.heex:143
+#: lib/vutuv_web/templates/welcome/show.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:371
 #: lib/vutuv_web/templates/welcome/show.html.heex:162
-#, elixir-autogen, elixir-format
-msgid "Shown next to your availability, and used to match you with postings."
-msgstr ""
-
-#: lib/vutuv_web/templates/welcome/show.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Save and continue"
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex:172
+#: lib/vutuv_web/templates/welcome/show.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "Skip for now"
 msgstr ""
@@ -18988,17 +18977,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1384
+#: lib/vutuv/accounts/user.ex:1402
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1382
+#: lib/vutuv/accounts/user.ex:1400
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1383
+#: lib/vutuv/accounts/user.ex:1401
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:162
 #: lib/vutuv_web/live/post_live/feed.ex:336
-#: lib/vutuv_web/live/post_live/feed.ex:3111
+#: lib/vutuv_web/live/post_live/feed.ex:3145
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1156
 #: lib/vutuv_web/live/shell_live.ex:1460
@@ -2149,7 +2149,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3427
+#: lib/vutuv_web/live/post_live/feed.ex:3461
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2240,7 +2240,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2318
+#: lib/vutuv_web/live/post_live/feed.ex:2352
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2753,7 +2753,7 @@ msgid "Manage"
 msgstr ""
 
 #: lib/vutuv_web/controllers/page_controller.ex:216
-#: lib/vutuv_web/live/post_live/feed.ex:2358
+#: lib/vutuv_web/live/post_live/feed.ex:2392
 #: lib/vutuv_web/templates/user/show.html.heex:507
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3432
+#: lib/vutuv_web/live/post_live/feed.ex:3466
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -5366,7 +5366,7 @@ msgid "Write a new post"
 msgstr ""
 
 #: lib/vutuv_web/templates/layout/app.html.heex:154
-#: lib/vutuv_web/views/page_html.ex:543
+#: lib/vutuv_web/views/page_html.ex:551
 #, elixir-autogen, elixir-format
 msgid "Your profile"
 msgstr ""
@@ -7416,7 +7416,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3698
+#: lib/vutuv_web/live/post_live/feed.ex:3732
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #, elixir-autogen
 msgid "Done"
@@ -17758,7 +17758,7 @@ msgstr ""
 msgid "Subscribe to this feed in your RSS reader"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:546
+#: lib/vutuv_web/views/page_html.ex:554
 #, elixir-autogen, elixir-format
 msgid "A CV with positions, education, certificates including proof, spoken languages and tags other members endorse you for."
 msgstr ""
@@ -17768,17 +17768,17 @@ msgstr ""
 msgid "A business network that is free, does not lock your data in, and is yours to run yourself if you want to."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:561
+#: lib/vutuv_web/views/page_html.ex:569
 #, elixir-autogen, elixir-format
 msgid "A job board with radius search and saved searches that email you when something matches."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:552
+#: lib/vutuv_web/views/page_html.ex:560
 #, elixir-autogen, elixir-format
 msgid "A permanent public address, readable without an account and downloadable as a vCard."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:549
+#: lib/vutuv_web/views/page_html.ex:557
 #, elixir-autogen, elixir-format
 msgid "CV download as PDF, Word, OpenDocument, LaTeX or JSON Resume, and you pick what goes in before you download it."
 msgstr ""
@@ -17803,22 +17803,22 @@ msgstr ""
 msgid "Open by default"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:577
+#: lib/vutuv_web/views/page_html.ex:585
 #, elixir-autogen, elixir-format
 msgid "Open source under the MIT license, and you can run your own installation on the internet or in your own intranet."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:564
+#: lib/vutuv_web/views/page_html.ex:572
 #, elixir-autogen, elixir-format
 msgid "Organization pages that only exist once somebody has proven control of the organization's domain."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:558
+#: lib/vutuv_web/views/page_html.ex:566
 #, elixir-autogen, elixir-format
 msgid "People, posts, jobs"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:560
+#: lib/vutuv_web/views/page_html.ex:568
 #, elixir-autogen, elixir-format
 msgid "Posts, likes, reposts, replies and 1:1 messages, in real time."
 msgstr ""
@@ -17833,7 +17833,7 @@ msgstr ""
 msgid "Run it yourself"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:574
+#: lib/vutuv_web/views/page_html.ex:582
 #, elixir-autogen, elixir-format
 msgid "Sign in without a password, by emailed PIN, passkey, authenticator app or a printed list of codes."
 msgstr ""
@@ -17859,7 +17859,7 @@ msgstr ""
 msgid "What you get"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:570
+#: lib/vutuv_web/views/page_html.ex:578
 #, elixir-autogen, elixir-format
 msgid "Your independence"
 msgstr ""
@@ -17874,7 +17874,7 @@ msgstr ""
 msgid "A look inside"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:223
+#: lib/vutuv_web/views/page_html.ex:231
 #, elixir-autogen, elixir-format
 msgid "A vutuv profile: cover picture, photo, name, tagline and job title, follower counts and the first posts, with contact details and social media profiles in a column on the right."
 msgstr ""
@@ -17884,17 +17884,17 @@ msgstr ""
 msgid "Browse real profiles"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:245
+#: lib/vutuv_web/views/page_html.ex:253
 #, elixir-autogen, elixir-format
 msgid "The lower part of the profile: spoken languages with levels, web links each shown as a preview image with a verification mark, and a panel offering the CV for download."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:235
+#: lib/vutuv_web/views/page_html.ex:243
 #, elixir-autogen, elixir-format
 msgid "The same profile further down: tags, each with the number of members who endorse it, and a CV as a timeline of positions with employer and duration."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:407
+#: lib/vutuv_web/views/page_html.ex:415
 #, elixir-autogen, elixir-format
 msgid "Try it out:"
 msgstr ""
@@ -17914,17 +17914,17 @@ msgstr ""
 msgid "Talking to people"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:274
+#: lib/vutuv_web/views/page_html.ex:282
 #, elixir-autogen, elixir-format
 msgid "The settings page for followed Fediverse accounts: a field to enter an address like @name@server, and a table of accounts already followed with their server and an unfollow link."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:264
+#: lib/vutuv_web/views/page_html.ex:272
 #, elixir-autogen, elixir-format
 msgid "The vutuv feed with the Fediverse tab selected: posts by news accounts on ard.social, mastodon.social and bonn.social, each with the server it came from, and heart, reply and repost counts underneath."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:515
+#: lib/vutuv_web/views/page_html.ex:523
 #, elixir-autogen, elixir-format
 msgid "The Fediverse: let people follow you from Mastodon, and your public posts show up there. You choose at sign-up, and can change it later."
 msgstr ""
@@ -18198,7 +18198,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3450
+#: lib/vutuv_web/live/post_live/feed.ex:3484
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Loading…"
@@ -18869,7 +18869,7 @@ msgstr ""
 msgid "Employment reference"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:531
+#: lib/vutuv_web/views/page_html.ex:539
 #, elixir-autogen, elixir-format
 msgid "Employment references: upload them, keep them private, and have the wording read and graded on our own servers."
 msgstr ""
@@ -18879,12 +18879,12 @@ msgstr ""
 msgid "Job applications"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:295
+#: lib/vutuv_web/views/page_html.ex:303
 #, elixir-autogen, elixir-format
 msgid "The CV builder: a checklist of everything that could go into the CV, with name, photo, tagline and contact details, and beside it a panel offering the download as PDF, Word, OpenDocument, LaTeX or JSON Resume."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:305
+#: lib/vutuv_web/views/page_html.ex:313
 #, elixir-autogen, elixir-format
 msgid "The finished CV ready to print: name, tagline and contact details at the top, below them the positions held with employer and period, and further down the tags and the spoken languages."
 msgstr ""
@@ -18894,12 +18894,12 @@ msgstr ""
 msgid "The review is a text analysis, not legal advice, and it covers German employment references."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:336
+#: lib/vutuv_web/views/page_html.ex:344
 #, elixir-autogen, elixir-format
 msgid "The review of a single employment reference: the overall grade on a red panel, then a report naming the kind of reference, the grade range, a traffic-light tally of its wordings and the main criticism."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:326
+#: lib/vutuv_web/views/page_html.ex:334
 #, elixir-autogen, elixir-format
 msgid "The uploaded employment references, each marked private: one graded 1 (very good) on a green panel, one graded 4 to 5 (poor to unsatisfactory) on a red one, each with a link to its full report."
 msgstr ""
@@ -21360,7 +21360,7 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3611
+#: lib/vutuv_web/live/post_live/feed.ex:3645
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
@@ -21634,32 +21634,27 @@ msgstr ""
 msgid "That alternative name is no longer on record."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:83
+#: lib/vutuv_web/views/page_html.ex:91
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Easy profile import."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:84
+#: lib/vutuv_web/views/page_html.ex:92
 #, elixir-autogen, elixir-format
 msgid "Fast."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:85
+#: lib/vutuv_web/views/page_html.ex:93
 #, elixir-autogen, elixir-format
 msgid "Nobody wants those anyway."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:84
-#, elixir-autogen, elixir-format
-msgid "vutuv is ridiculously fast."
-msgstr ""
-
-#: lib/vutuv_web/views/page_html.ex:85
+#: lib/vutuv_web/views/page_html.ex:93
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No paid premium accounts."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:83
+#: lib/vutuv_web/views/page_html.ex:91
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Your LinkedIn profile can come along."
 msgstr ""
@@ -21929,7 +21924,7 @@ msgstr "Posts carrying one of these tags are folded the same way."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3637
+#: lib/vutuv_web/live/post_live/feed.ex:3671
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
@@ -22006,10 +22001,10 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3224
-#: lib/vutuv_web/live/post_live/feed.ex:3251
-#: lib/vutuv_web/live/post_live/feed.ex:3685
-#: lib/vutuv_web/live/post_live/feed.ex:3690
+#: lib/vutuv_web/live/post_live/feed.ex:3258
+#: lib/vutuv_web/live/post_live/feed.ex:3285
+#: lib/vutuv_web/live/post_live/feed.ex:3719
+#: lib/vutuv_web/live/post_live/feed.ex:3724
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -22074,7 +22069,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3407
+#: lib/vutuv_web/live/post_live/feed.ex:3441
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to now"
 msgstr ""
@@ -22084,7 +22079,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3453
+#: lib/vutuv_web/live/post_live/feed.ex:3487
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22106,7 +22101,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3403
+#: lib/vutuv_web/live/post_live/feed.ex:3437
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -22193,7 +22188,7 @@ msgstr ""
 msgid "Page management"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2312
+#: lib/vutuv_web/live/post_live/feed.ex:2346
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
@@ -22225,7 +22220,7 @@ msgstr ""
 msgid "{used} of {max} mentions"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2461
+#: lib/vutuv_web/live/post_live/feed.ex:2495
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -95,7 +95,7 @@ msgstr ""
 msgid "Avatar"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:407
+#: lib/vutuv_web/templates/user/edit.html.heex:402
 #, elixir-autogen
 msgid "Birthdate"
 msgstr ""
@@ -130,8 +130,8 @@ msgstr ""
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:53
 #: lib/vutuv_web/templates/user/edit.html.heex:133
-#: lib/vutuv_web/templates/user/edit.html.heex:463
-#: lib/vutuv_web/templates/user/edit.html.heex:508
+#: lib/vutuv_web/templates/user/edit.html.heex:458
+#: lib/vutuv_web/templates/user/edit.html.heex:503
 #: lib/vutuv_web/templates/username/confirm.html.heex:220
 #, elixir-autogen
 msgid "Cancel"
@@ -626,7 +626,7 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/preferences.html.heex:362
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:61
-#: lib/vutuv_web/templates/user/edit.html.heex:458
+#: lib/vutuv_web/templates/user/edit.html.heex:453
 #: lib/vutuv_web/views/settings_html.ex:212
 #, elixir-autogen
 msgid "Save"
@@ -8378,7 +8378,7 @@ msgstr ""
 msgid "Language & display"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:523
+#: lib/vutuv_web/templates/user/edit.html.heex:518
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr ""
@@ -9417,7 +9417,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1225
+#: lib/vutuv/accounts/user.ex:1243
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9428,7 +9428,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1222
+#: lib/vutuv/accounts/user.ex:1240
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9693,18 +9693,18 @@ msgstr ""
 msgid "Date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:436
-#: lib/vutuv_web/templates/user/edit.html.heex:511
+#: lib/vutuv_web/templates/user/edit.html.heex:431
+#: lib/vutuv_web/templates/user/edit.html.heex:506
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:499
+#: lib/vutuv_web/templates/user/edit.html.heex:494
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:502
+#: lib/vutuv_web/templates/user/edit.html.heex:497
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -10746,19 +10746,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1263
+#: lib/vutuv/accounts/user.ex:1281
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1268
+#: lib/vutuv/accounts/user.ex:1286
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1266
+#: lib/vutuv/accounts/user.ex:1284
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -10772,14 +10772,14 @@ msgid "Who can see your availability?"
 msgstr ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:313
-#: lib/vutuv_web/templates/welcome/show.html.heex:123
+#: lib/vutuv_web/templates/welcome/show.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:693
 #: lib/vutuv_web/templates/user/edit.html.heex:321
-#: lib/vutuv_web/templates/welcome/show.html.heex:131
+#: lib/vutuv_web/templates/welcome/show.html.heex:126
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr ""
@@ -10802,7 +10802,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:700
 #: lib/vutuv_web/templates/user/edit.html.heex:317
-#: lib/vutuv_web/templates/welcome/show.html.heex:127
+#: lib/vutuv_web/templates/welcome/show.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Per"
 msgstr ""
@@ -10881,7 +10881,7 @@ msgstr ""
 msgid "Exclude an email domain"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:384
+#: lib/vutuv_web/templates/user/edit.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr ""
@@ -10892,12 +10892,12 @@ msgstr ""
 msgid "Job-search exclusion list"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:387
+#: lib/vutuv_web/templates/user/edit.html.heex:382
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:395
+#: lib/vutuv_web/templates/user/edit.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -12042,7 +12042,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1237
+#: lib/vutuv/accounts/user.ex:1255
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12161,7 +12161,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1236
+#: lib/vutuv/accounts/user.ex:1254
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12243,7 +12243,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1238
+#: lib/vutuv/accounts/user.ex:1256
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
 #: lib/vutuv_web/agent_docs/markdown.ex:470
@@ -13258,36 +13258,36 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1281
+#: lib/vutuv/accounts/user.ex:1299
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:447
+#: lib/vutuv_web/templates/user/edit.html.heex:442
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1284
+#: lib/vutuv/accounts/user.ex:1302
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1287
+#: lib/vutuv/accounts/user.ex:1305
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1278
+#: lib/vutuv/accounts/user.ex:1296
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:444
+#: lib/vutuv_web/templates/user/edit.html.heex:439
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr ""
@@ -13917,29 +13917,18 @@ msgstr ""
 msgid "Are you looking for a job?"
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex:117
-#, elixir-autogen, elixir-format
-msgid "Optional, and nobody else sees it. It filters postings below it out of your own job search."
-msgstr ""
-
 #: lib/vutuv_web/templates/user/edit.html.heex:351
-#: lib/vutuv_web/templates/welcome/show.html.heex:143
+#: lib/vutuv_web/templates/welcome/show.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:371
 #: lib/vutuv_web/templates/welcome/show.html.heex:162
-#, elixir-autogen, elixir-format
-msgid "Shown next to your availability, and used to match you with postings."
-msgstr ""
-
-#: lib/vutuv_web/templates/welcome/show.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Save and continue"
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex:172
+#: lib/vutuv_web/templates/welcome/show.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "Skip for now"
 msgstr ""
@@ -18986,17 +18975,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1384
+#: lib/vutuv/accounts/user.ex:1402
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1382
+#: lib/vutuv/accounts/user.ex:1400
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1383
+#: lib/vutuv/accounts/user.ex:1401
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -2145,7 +2145,7 @@ msgstr "Modifica il post"
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:162
 #: lib/vutuv_web/live/post_live/feed.ex:336
-#: lib/vutuv_web/live/post_live/feed.ex:3111
+#: lib/vutuv_web/live/post_live/feed.ex:3145
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1156
 #: lib/vutuv_web/live/shell_live.ex:1460
@@ -2191,7 +2191,7 @@ msgstr "Visitatori non connessi"
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3427
+#: lib/vutuv_web/live/post_live/feed.ex:3461
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2286,7 +2286,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Salvataggio…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2318
+#: lib/vutuv_web/live/post_live/feed.ex:2352
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2806,7 +2806,7 @@ msgid "Manage"
 msgstr "Gestisci"
 
 #: lib/vutuv_web/controllers/page_controller.ex:216
-#: lib/vutuv_web/live/post_live/feed.ex:2358
+#: lib/vutuv_web/live/post_live/feed.ex:2392
 #: lib/vutuv_web/templates/user/show.html.heex:507
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -4707,7 +4707,7 @@ msgstr "Non ha bloccato nessuno."
 msgid "You unblocked @%{slug}."
 msgstr "Ha sbloccato @%{slug}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3432
+#: lib/vutuv_web/live/post_live/feed.ex:3466
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Scopra persone da seguire"
@@ -5583,7 +5583,7 @@ msgid "Write a new post"
 msgstr "Scrivi un nuovo post"
 
 #: lib/vutuv_web/templates/layout/app.html.heex:154
-#: lib/vutuv_web/views/page_html.ex:543
+#: lib/vutuv_web/views/page_html.ex:551
 #, elixir-autogen, elixir-format
 msgid "Your profile"
 msgstr "Il Suo profilo"
@@ -7711,7 +7711,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr "Si aggiorna da sola. Può lasciare questa pagina: l'invio prosegue."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3698
+#: lib/vutuv_web/live/post_live/feed.ex:3732
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #, elixir-autogen
 msgid "Done"
@@ -18904,7 +18904,7 @@ msgstr ""
 msgid "Subscribe to this feed in your RSS reader"
 msgstr "Si iscriva a questo feed nel Suo lettore RSS"
 
-#: lib/vutuv_web/views/page_html.ex:546
+#: lib/vutuv_web/views/page_html.ex:554
 #, elixir-autogen, elixir-format
 msgid "A CV with positions, education, certificates including proof, spoken languages and tags other members endorse you for."
 msgstr ""
@@ -18918,21 +18918,21 @@ msgstr ""
 "Una rete professionale gratuita, che non tiene prigionieri i Suoi dati e "
 "che, se vuole, può gestire Lei stesso."
 
-#: lib/vutuv_web/views/page_html.ex:561
+#: lib/vutuv_web/views/page_html.ex:569
 #, elixir-autogen, elixir-format
 msgid "A job board with radius search and saved searches that email you when something matches."
 msgstr ""
 "Una bacheca di annunci con ricerca per raggio e ricerche salvate che Le "
 "scrivono quando qualcosa corrisponde."
 
-#: lib/vutuv_web/views/page_html.ex:552
+#: lib/vutuv_web/views/page_html.ex:560
 #, elixir-autogen, elixir-format
 msgid "A permanent public address, readable without an account and downloadable as a vCard."
 msgstr ""
 "Un indirizzo pubblico permanente, leggibile senza account e scaricabile come"
 " vCard."
 
-#: lib/vutuv_web/views/page_html.ex:549
+#: lib/vutuv_web/views/page_html.ex:557
 #, elixir-autogen, elixir-format
 msgid "CV download as PDF, Word, OpenDocument, LaTeX or JSON Resume, and you pick what goes in before you download it."
 msgstr ""
@@ -18962,26 +18962,26 @@ msgstr "Per le macchine"
 msgid "Open by default"
 msgstr "Aperto per impostazione predefinita"
 
-#: lib/vutuv_web/views/page_html.ex:577
+#: lib/vutuv_web/views/page_html.ex:585
 #, elixir-autogen, elixir-format
 msgid "Open source under the MIT license, and you can run your own installation on the internet or in your own intranet."
 msgstr ""
 "Open source con licenza MIT, e può gestire una Sua installazione su internet"
 " o nella Sua intranet."
 
-#: lib/vutuv_web/views/page_html.ex:564
+#: lib/vutuv_web/views/page_html.ex:572
 #, elixir-autogen, elixir-format
 msgid "Organization pages that only exist once somebody has proven control of the organization's domain."
 msgstr ""
 "Pagine di organizzazione che esistono solo dopo che qualcuno ha dimostrato "
 "di controllare il dominio dell'organizzazione."
 
-#: lib/vutuv_web/views/page_html.ex:558
+#: lib/vutuv_web/views/page_html.ex:566
 #, elixir-autogen, elixir-format
 msgid "People, posts, jobs"
 msgstr "Persone, post, lavoro"
 
-#: lib/vutuv_web/views/page_html.ex:560
+#: lib/vutuv_web/views/page_html.ex:568
 #, elixir-autogen, elixir-format
 msgid "Posts, likes, reposts, replies and 1:1 messages, in real time."
 msgstr ""
@@ -18998,7 +18998,7 @@ msgstr "Leggibile dalle persone, dalle macchine e sul Suo server"
 msgid "Run it yourself"
 msgstr "Lo gestisca Lei"
 
-#: lib/vutuv_web/views/page_html.ex:574
+#: lib/vutuv_web/views/page_html.ex:582
 #, elixir-autogen, elixir-format
 msgid "Sign in without a password, by emailed PIN, passkey, authenticator app or a printed list of codes."
 msgstr ""
@@ -19026,7 +19026,7 @@ msgstr "Cosa sa fare vutuv"
 msgid "What you get"
 msgstr "Cosa ottiene"
 
-#: lib/vutuv_web/views/page_html.ex:570
+#: lib/vutuv_web/views/page_html.ex:578
 #, elixir-autogen, elixir-format
 msgid "Your independence"
 msgstr "La Sua indipendenza"
@@ -19043,7 +19043,7 @@ msgstr ""
 msgid "A look inside"
 msgstr "Uno sguardo dentro"
 
-#: lib/vutuv_web/views/page_html.ex:223
+#: lib/vutuv_web/views/page_html.ex:231
 #, elixir-autogen, elixir-format
 msgid "A vutuv profile: cover picture, photo, name, tagline and job title, follower counts and the first posts, with contact details and social media profiles in a column on the right."
 msgstr ""
@@ -19056,7 +19056,7 @@ msgstr ""
 msgid "Browse real profiles"
 msgstr "Sfogli profili veri"
 
-#: lib/vutuv_web/views/page_html.ex:245
+#: lib/vutuv_web/views/page_html.ex:253
 #, elixir-autogen, elixir-format
 msgid "The lower part of the profile: spoken languages with levels, web links each shown as a preview image with a verification mark, and a panel offering the CV for download."
 msgstr ""
@@ -19064,7 +19064,7 @@ msgstr ""
 "mostrati ciascuno come immagine di anteprima con un contrassegno di "
 "verifica, e un riquadro che offre il CV in download."
 
-#: lib/vutuv_web/views/page_html.ex:235
+#: lib/vutuv_web/views/page_html.ex:243
 #, elixir-autogen, elixir-format
 msgid "The same profile further down: tags, each with the number of members who endorse it, and a CV as a timeline of positions with employer and duration."
 msgstr ""
@@ -19072,7 +19072,7 @@ msgstr ""
 "lo confermano, e un CV come sequenza di posizioni con datore di lavoro e "
 "durata."
 
-#: lib/vutuv_web/views/page_html.ex:407
+#: lib/vutuv_web/views/page_html.ex:415
 #, elixir-autogen, elixir-format
 msgid "Try it out:"
 msgstr "Lo provi:"
@@ -19098,7 +19098,7 @@ msgstr ""
 msgid "Talking to people"
 msgstr "Parlare con le persone"
 
-#: lib/vutuv_web/views/page_html.ex:274
+#: lib/vutuv_web/views/page_html.ex:282
 #, elixir-autogen, elixir-format
 msgid "The settings page for followed Fediverse accounts: a field to enter an address like @name@server, and a table of accounts already followed with their server and an unfollow link."
 msgstr ""
@@ -19106,7 +19106,7 @@ msgstr ""
 " per inserire un indirizzo come @nome@server e una tabella degli account già"
 " seguiti con il loro server e un link per smettere di seguirli."
 
-#: lib/vutuv_web/views/page_html.ex:264
+#: lib/vutuv_web/views/page_html.ex:272
 #, elixir-autogen, elixir-format
 msgid "The vutuv feed with the Fediverse tab selected: posts by news accounts on ard.social, mastodon.social and bonn.social, each with the server it came from, and heart, reply and repost counts underneath."
 msgstr ""
@@ -19114,7 +19114,7 @@ msgstr ""
 "notizie su ard.social, mastodon.social e bonn.social, ciascuno con il server"
 " da cui proviene, e sotto i contatori di cuori, risposte e ripubblicazioni."
 
-#: lib/vutuv_web/views/page_html.ex:515
+#: lib/vutuv_web/views/page_html.ex:523
 #, elixir-autogen, elixir-format
 msgid "The Fediverse: let people follow you from Mastodon, and your public posts show up there. You choose at sign-up, and can change it later."
 msgstr ""
@@ -19425,7 +19425,7 @@ msgstr "Rilasciato il"
 msgid "Label"
 msgstr "Etichetta"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3450
+#: lib/vutuv_web/live/post_live/feed.ex:3484
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -20151,7 +20151,7 @@ msgstr ""
 msgid "Employment reference"
 msgstr "Attestato di lavoro"
 
-#: lib/vutuv_web/views/page_html.ex:531
+#: lib/vutuv_web/views/page_html.ex:539
 #, elixir-autogen, elixir-format
 msgid "Employment references: upload them, keep them private, and have the wording read and graded on our own servers."
 msgstr ""
@@ -20163,7 +20163,7 @@ msgstr ""
 msgid "Job applications"
 msgstr "Candidature"
 
-#: lib/vutuv_web/views/page_html.ex:295
+#: lib/vutuv_web/views/page_html.ex:303
 #, elixir-autogen, elixir-format
 msgid "The CV builder: a checklist of everything that could go into the CV, with name, photo, tagline and contact details, and beside it a panel offering the download as PDF, Word, OpenDocument, LaTeX or JSON Resume."
 msgstr ""
@@ -20171,7 +20171,7 @@ msgstr ""
 "CV, con nome, foto, descrizione breve e recapiti, e accanto un riquadro che "
 "offre il download in PDF, Word, OpenDocument, LaTeX o JSON Resume."
 
-#: lib/vutuv_web/views/page_html.ex:305
+#: lib/vutuv_web/views/page_html.ex:313
 #, elixir-autogen, elixir-format
 msgid "The finished CV ready to print: name, tagline and contact details at the top, below them the positions held with employer and period, and further down the tags and the spoken languages."
 msgstr ""
@@ -20186,7 +20186,7 @@ msgstr ""
 "L'analisi è un esame del testo, non un parere legale, e riguarda gli "
 "attestati di lavoro tedeschi."
 
-#: lib/vutuv_web/views/page_html.ex:336
+#: lib/vutuv_web/views/page_html.ex:344
 #, elixir-autogen, elixir-format
 msgid "The review of a single employment reference: the overall grade on a red panel, then a report naming the kind of reference, the grade range, a traffic-light tally of its wordings and the main criticism."
 msgstr ""
@@ -20194,7 +20194,7 @@ msgstr ""
 "riquadro rosso, poi un rapporto che indica il tipo di attestato, la fascia "
 "di voto, un conteggio a semaforo delle sue formule e la critica principale."
 
-#: lib/vutuv_web/views/page_html.ex:326
+#: lib/vutuv_web/views/page_html.ex:334
 #, elixir-autogen, elixir-format
 msgid "The uploaded employment references, each marked private: one graded 1 (very good) on a green panel, one graded 4 to 5 (poor to unsatisfactory) on a red one, each with a link to its full report."
 msgstr ""
@@ -22946,7 +22946,7 @@ msgstr ""
 "Segua #%{tag} da Mastodon o da qualsiasi altra app del Fediverso e i suoi "
 "post pubblici arriveranno nella Sua cronologia. Non serve un account vutuv."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3611
+#: lib/vutuv_web/live/post_live/feed.ex:3645
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Saluti gli altri membri"
@@ -23233,32 +23233,27 @@ msgstr ""
 msgid "That alternative name is no longer on record."
 msgstr "Quel nome alternativo non risulta più registrato."
 
-#: lib/vutuv_web/views/page_html.ex:83
+#: lib/vutuv_web/views/page_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "Easy profile import."
 msgstr "Importazione del profilo semplice."
 
-#: lib/vutuv_web/views/page_html.ex:84
+#: lib/vutuv_web/views/page_html.ex:92
 #, elixir-autogen, elixir-format
 msgid "Fast."
 msgstr "Veloce."
 
-#: lib/vutuv_web/views/page_html.ex:85
+#: lib/vutuv_web/views/page_html.ex:93
 #, elixir-autogen, elixir-format
 msgid "Nobody wants those anyway."
 msgstr "Tanto non li vuole nessuno."
 
-#: lib/vutuv_web/views/page_html.ex:84
-#, elixir-autogen, elixir-format
-msgid "vutuv is ridiculously fast."
-msgstr "vutuv è semplicemente velocissimo."
-
-#: lib/vutuv_web/views/page_html.ex:85
+#: lib/vutuv_web/views/page_html.ex:93
 #, elixir-autogen, elixir-format
 msgid "No paid premium accounts."
 msgstr "Nessun account premium a pagamento."
 
-#: lib/vutuv_web/views/page_html.ex:83
+#: lib/vutuv_web/views/page_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "Your LinkedIn profile can come along."
 msgstr "Il suo profilo LinkedIn può venire con lei."
@@ -23528,7 +23523,7 @@ msgstr "I post con uno di questi tag vengono ridotti allo stesso modo."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "I post che contengono una di queste parole vengono ridotti a una riga — non eliminati, e con un modo per aprirli comunque."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3637
+#: lib/vutuv_web/live/post_live/feed.ex:3671
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Messe da parte:"
@@ -23605,10 +23600,10 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "e 1 altro"
 msgstr[1] "e altri %{formatted}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3224
-#: lib/vutuv_web/live/post_live/feed.ex:3251
-#: lib/vutuv_web/live/post_live/feed.ex:3685
-#: lib/vutuv_web/live/post_live/feed.ex:3690
+#: lib/vutuv_web/live/post_live/feed.ex:3258
+#: lib/vutuv_web/live/post_live/feed.ex:3285
+#: lib/vutuv_web/live/post_live/feed.ex:3719
+#: lib/vutuv_web/live/post_live/feed.ex:3724
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
@@ -23677,7 +23672,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} post il %{day}"
 msgstr[1] "%{count} post il %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3407
+#: lib/vutuv_web/live/post_live/feed.ex:3441
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Torna al presente"
@@ -23687,7 +23682,7 @@ msgstr "Torna al presente"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Mese intenso: la tonalità indica almeno questo valore."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3453
+#: lib/vutuv_web/live/post_live/feed.ex:3487
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -23709,7 +23704,7 @@ msgstr "Mese successivo"
 msgid "Next year"
 msgstr "Anno successivo"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3403
+#: lib/vutuv_web/live/post_live/feed.ex:3437
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Il %{day} non è arrivato nulla nel Suo feed."
@@ -23796,7 +23791,7 @@ msgstr "È pronta una nuova versione."
 msgid "Page management"
 msgstr "Gestione"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2312
+#: lib/vutuv_web/live/post_live/feed.ex:2346
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
@@ -23828,7 +23823,7 @@ msgstr "Menziona un account"
 msgid "{used} of {max} mentions"
 msgstr "{used} di {max} menzioni"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2461
+#: lib/vutuv_web/live/post_live/feed.ex:2495
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -97,7 +97,7 @@ msgstr "Confermi?"
 msgid "Avatar"
 msgstr "Immagine del profilo"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:407
+#: lib/vutuv_web/templates/user/edit.html.heex:402
 #, elixir-autogen
 msgid "Birthdate"
 msgstr "Data di nascita"
@@ -132,8 +132,8 @@ msgstr "Compleanno"
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:53
 #: lib/vutuv_web/templates/user/edit.html.heex:133
-#: lib/vutuv_web/templates/user/edit.html.heex:463
-#: lib/vutuv_web/templates/user/edit.html.heex:508
+#: lib/vutuv_web/templates/user/edit.html.heex:458
+#: lib/vutuv_web/templates/user/edit.html.heex:503
 #: lib/vutuv_web/templates/username/confirm.html.heex:220
 #, elixir-autogen
 msgid "Cancel"
@@ -630,7 +630,7 @@ msgstr "Pubblico"
 #: lib/vutuv_web/templates/settings/preferences.html.heex:362
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:61
-#: lib/vutuv_web/templates/user/edit.html.heex:458
+#: lib/vutuv_web/templates/user/edit.html.heex:453
 #: lib/vutuv_web/views/settings_html.ex:212
 #, elixir-autogen
 msgid "Save"
@@ -8749,7 +8749,7 @@ msgstr "Dati di base e foto"
 msgid "Language & display"
 msgstr "Lingua e visualizzazione"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:523
+#: lib/vutuv_web/templates/user/edit.html.heex:518
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr "Altre sezioni del profilo"
@@ -9840,7 +9840,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Situazione lavorativa"
 
-#: lib/vutuv/accounts/user.ex:1225
+#: lib/vutuv/accounts/user.ex:1243
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9851,7 +9851,7 @@ msgstr "In cerca di lavoro"
 msgid "Not open to work"
 msgstr "Non in cerca di lavoro"
 
-#: lib/vutuv/accounts/user.ex:1222
+#: lib/vutuv/accounts/user.ex:1240
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10131,18 +10131,18 @@ msgstr "+%{code} è il prefisso telefonico di %{region}"
 msgid "Date of birth"
 msgstr "Data di nascita"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:436
-#: lib/vutuv_web/templates/user/edit.html.heex:511
+#: lib/vutuv_web/templates/user/edit.html.heex:431
+#: lib/vutuv_web/templates/user/edit.html.heex:506
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr "Rimuovi la data di nascita"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:499
+#: lib/vutuv_web/templates/user/edit.html.heex:494
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr "Rimuovere la Sua data di nascita?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:502
+#: lib/vutuv_web/templates/user/edit.html.heex:497
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -11286,19 +11286,19 @@ msgstr ""
 "Sua disponibilità ma non può garantirla, perché chiunque può creare un "
 "account. Scelga \"Nessuno\" per conservare lo stato senza mostrarlo."
 
-#: lib/vutuv/accounts/user.ex:1263
+#: lib/vutuv/accounts/user.ex:1281
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Tutti, compresi i visitatori non connessi"
 
-#: lib/vutuv/accounts/user.ex:1268
+#: lib/vutuv/accounts/user.ex:1286
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Nessuno"
 
-#: lib/vutuv/accounts/user.ex:1266
+#: lib/vutuv/accounts/user.ex:1284
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -11312,14 +11312,14 @@ msgid "Who can see your availability?"
 msgstr "Chi può vedere la Sua disponibilità?"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:313
-#: lib/vutuv_web/templates/welcome/show.html.heex:123
+#: lib/vutuv_web/templates/welcome/show.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr "Importo"
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:693
 #: lib/vutuv_web/templates/user/edit.html.heex:321
-#: lib/vutuv_web/templates/welcome/show.html.heex:131
+#: lib/vutuv_web/templates/welcome/show.html.heex:126
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr "Valuta"
@@ -11348,7 +11348,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:700
 #: lib/vutuv_web/templates/user/edit.html.heex:317
-#: lib/vutuv_web/templates/welcome/show.html.heex:127
+#: lib/vutuv_web/templates/welcome/show.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Per"
 msgstr "Per"
@@ -11428,7 +11428,7 @@ msgstr "Escludi un membro"
 msgid "Exclude an email domain"
 msgstr "Escludi un dominio e-mail"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:384
+#: lib/vutuv_web/templates/user/edit.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr "Nascondi a persone specifiche"
@@ -11439,7 +11439,7 @@ msgstr "Nascondi a persone specifiche"
 msgid "Job-search exclusion list"
 msgstr "Elenco di esclusioni per la ricerca di lavoro"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:387
+#: lib/vutuv_web/templates/user/edit.html.heex:382
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
@@ -11448,7 +11448,7 @@ msgstr ""
 "specifici: non vedranno mai la Sua disponibilità né la Sua retribuzione "
 "desiderata, nemmeno con l'impostazione \"Tutti\"."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:395
+#: lib/vutuv_web/templates/user/edit.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -12669,7 +12669,7 @@ msgstr "I tag evidenziati corrispondono al Suo profilo."
 msgid "How to apply"
 msgstr "Come candidarsi"
 
-#: lib/vutuv/accounts/user.ex:1237
+#: lib/vutuv/accounts/user.ex:1255
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12791,7 +12791,7 @@ msgstr ""
 "Offri i formati leggibili dalle macchine (.md/.txt/.json/.xml) agli agenti "
 "IA."
 
-#: lib/vutuv/accounts/user.ex:1236
+#: lib/vutuv/accounts/user.ex:1254
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12875,7 +12875,7 @@ msgstr "Annuncio non trovato."
 msgid "Publish"
 msgstr "Pubblica"
 
-#: lib/vutuv/accounts/user.ex:1238
+#: lib/vutuv/accounts/user.ex:1256
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
 #: lib/vutuv_web/agent_docs/markdown.ex:470
@@ -13975,13 +13975,13 @@ msgstr ""
 "Se è venuto male (ad esempio con un avviso sui cookie che copre la pagina), "
 "può rimuoverlo."
 
-#: lib/vutuv/accounts/user.ex:1281
+#: lib/vutuv/accounts/user.ex:1299
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
 msgstr "Solo l'età, senza la data"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:447
+#: lib/vutuv_web/templates/user/edit.html.heex:442
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
@@ -13989,25 +13989,25 @@ msgstr ""
 "la data esatta, \"Giorno e mese\" nasconde l'anno (e la Sua età) e \"Non "
 "mostrare\" lo conserva ma lo tiene fuori dal profilo."
 
-#: lib/vutuv/accounts/user.ex:1284
+#: lib/vutuv/accounts/user.ex:1302
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Giorno e mese, senza l'anno"
 
-#: lib/vutuv/accounts/user.ex:1287
+#: lib/vutuv/accounts/user.ex:1305
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Non mostrare il mio compleanno"
 
-#: lib/vutuv/accounts/user.ex:1278
+#: lib/vutuv/accounts/user.ex:1296
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
 msgstr "Data completa ed età"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:444
+#: lib/vutuv_web/templates/user/edit.html.heex:439
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr "Mostra il mio compleanno come"
@@ -14676,32 +14676,18 @@ msgstr "Tipo di indirizzo"
 msgid "Are you looking for a job?"
 msgstr "È in cerca di lavoro?"
 
-#: lib/vutuv_web/templates/welcome/show.html.heex:117
-#, elixir-autogen, elixir-format
-msgid "Optional, and nobody else sees it. It filters postings below it out of your own job search."
-msgstr ""
-"Facoltativo, e nessun altro lo vede. Esclude dalla Sua ricerca di lavoro gli"
-" annunci al di sotto."
-
 #: lib/vutuv_web/templates/user/edit.html.heex:351
-#: lib/vutuv_web/templates/welcome/show.html.heex:143
+#: lib/vutuv_web/templates/welcome/show.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr "Come vuole lavorare?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:371
 #: lib/vutuv_web/templates/welcome/show.html.heex:162
-#, elixir-autogen, elixir-format
-msgid "Shown next to your availability, and used to match you with postings."
-msgstr ""
-"Mostrata accanto alla Sua disponibilità e usata per abbinarla agli annunci."
-
-#: lib/vutuv_web/templates/welcome/show.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Save and continue"
 msgstr "Salva e continua"
 
-#: lib/vutuv_web/templates/welcome/show.html.heex:172
+#: lib/vutuv_web/templates/welcome/show.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "Skip for now"
 msgstr "Salta per ora"
@@ -20307,17 +20293,17 @@ msgstr ""
 "Il PIN non arriva? L'indirizzo e-mail {email} è corretto? Ha controllato la "
 "cartella dello spam?"
 
-#: lib/vutuv/accounts/user.ex:1384
+#: lib/vutuv/accounts/user.ex:1402
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Non binario"
 
-#: lib/vutuv/accounts/user.ex:1382
+#: lib/vutuv/accounts/user.ex:1400
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Femminile"
 
-#: lib/vutuv/accounts/user.ex:1383
+#: lib/vutuv/accounts/user.ex:1401
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Maschile"

--- a/priv/repo/migrations/20260903155453_availability_defaults_open_up.exs
+++ b/priv/repo/migrations/20260903155453_availability_defaults_open_up.exs
@@ -1,0 +1,36 @@
+defmodule Vutuv.Repo.Migrations.AvailabilityDefaultsOpenUp do
+  use Ecto.Migration
+
+  # What a member gets before they touch the availability block, once they have
+  # said they are open to offers: seen by everyone rather than by signed-in
+  # members alone, and matched against every shape of work rather than none.
+  #
+  # Both columns only mean anything once `employment_status` is set — it is nil
+  # until the member says otherwise, and a nil status shows no badge to anybody
+  # — so widening the defaults changes nothing for the members who never
+  # answered, and for the ones who do it stops the answer from being narrowed
+  # by a setting they were never asked about.
+  #
+  # **Defaults only, no backfill.** A stored value is a member's own decision,
+  # including the ones that merely inherited the old default; overwriting a
+  # visibility column would be changing a privacy setting on somebody's behalf.
+  #
+  # N-1 safe: the previous release writes both columns explicitly on every
+  # save, so it neither reads nor depends on the default, and no column type
+  # changes (no cached-plan blip).
+  def up do
+    execute("ALTER TABLE users ALTER COLUMN employment_status_visibility SET DEFAULT 'everyone'")
+
+    execute(
+      "ALTER TABLE users ALTER COLUMN desired_workplace_types SET DEFAULT ARRAY['onsite','hybrid','remote']::varchar[]"
+    )
+  end
+
+  def down do
+    execute("ALTER TABLE users ALTER COLUMN employment_status_visibility SET DEFAULT 'members'")
+
+    execute(
+      "ALTER TABLE users ALTER COLUMN desired_workplace_types SET DEFAULT ARRAY[]::varchar[]"
+    )
+  end
+end

--- a/test/vutuv/accounts/open_to_offers_test.exs
+++ b/test/vutuv/accounts/open_to_offers_test.exs
@@ -84,12 +84,19 @@ defmodule Vutuv.Accounts.OpenToOffersTest do
   # matching over a loaded struct — two spellings of the one #928 rule, which is
   # exactly the shape that drifts. This pins them to each other: every
   # visibility value, seen by nobody and by a signed-in member.
+  #
+  # `nil` is not a value the column can hold (NOT NULL): passing it means "let
+  # the default decide", which is what a member who never opened the block gets
+  # — so the row is read back before the predicate is asked, or the struct
+  # answers about a value the database does not have. That reload is doing real
+  # work here: it is the only reason this case tests the shipped default rather
+  # than whatever the fixture happened to type.
   test "the SQL gate answers what the struct predicate answers" do
     viewer = insert(:activated_user)
 
     for visibility <- ["everyone", "members", "hidden", nil],
         {label, looker} <- [{"anonymous", nil}, {"signed in", viewer}] do
-      member = seeker(employment_status_visibility: visibility)
+      member = Repo.reload!(seeker(employment_status_visibility: visibility))
       listed? = member.id in ids(Accounts.open_to_offers(looker))
       predicate? = User.employment_status_visible?(member, looker)
 

--- a/test/vutuv/accounts/user_test.exs
+++ b/test/vutuv/accounts/user_test.exs
@@ -367,8 +367,11 @@ defmodule Vutuv.Accounts.UserTest do
   end
 
   describe "employment-status visibility (issue #928)" do
-    test "defaults to members" do
-      assert %User{}.employment_status_visibility == "members"
+    # Since 2026-09-03. The column is only read once a status is set, and
+    # somebody who has just said they are open to offers is not helped by
+    # hiding that from everyone who is not signed in.
+    test "defaults to everyone" do
+      assert %User{}.employment_status_visibility == "everyone"
     end
 
     test "accepts the three visibility values" do

--- a/test/vutuv_web/controllers/employment_status_test.exs
+++ b/test/vutuv_web/controllers/employment_status_test.exs
@@ -71,9 +71,15 @@ defmodule VutuvWeb.EmploymentStatusTest do
   end
 
   describe "badge visibility scoping (issue #928)" do
-    test "the default (members) hides the badge from a logged-out visitor", %{conn: conn} do
-      user = insert_activated_user(employment_status: "looking")
-      assert user.employment_status_visibility == "members"
+    test "members hides the badge from a logged-out visitor", %{conn: conn} do
+      # Spelled out rather than left to the default, which stopped being
+      # "members" on 2026-09-03 — the rule this pins is the one the value
+      # names, not whichever value ships as the default.
+      user =
+        insert_activated_user(
+          employment_status: "looking",
+          employment_status_visibility: "members"
+        )
 
       html = conn |> get(~p"/#{user}") |> html_response(200)
 
@@ -81,7 +87,19 @@ defmodule VutuvWeb.EmploymentStatusTest do
       refute html =~ "Looking for a job"
     end
 
-    test "the default (members) shows the badge to a signed-in member", %{conn: conn} do
+    test "the default shows the badge to a logged-out visitor", %{conn: conn} do
+      # The other half of that change, end to end: somebody who only said they
+      # are looking, and touched nothing else, is seen by the visitor who is
+      # not signed in — which is what saying it is for.
+      user = insert_activated_user(employment_status: "looking")
+      assert user.employment_status_visibility == "everyone"
+
+      html = conn |> get(~p"/#{user}") |> html_response(200)
+
+      assert html =~ "Looking for a job"
+    end
+
+    test "the default shows the badge to a signed-in member", %{conn: conn} do
       {conn, _viewer} = create_and_login_user(conn)
       user = insert_activated_user(employment_status: "looking")
 

--- a/test/vutuv_web/controllers/welcome_controller_test.exs
+++ b/test/vutuv_web/controllers/welcome_controller_test.exs
@@ -251,9 +251,10 @@ defmodule VutuvWeb.WelcomeControllerTest do
       assert user.desired_salary_min == 60_000
       # Ticked in any order, stored in the canonical one, blanks dropped.
       assert user.desired_workplace_types == ["hybrid", "remote"]
-      # The shipped visibility defaults are untouched: the status shows to
-      # signed-in members, the salary to nobody.
-      assert user.employment_status_visibility == "members"
+      # The shipped visibility defaults are untouched, and they deliberately
+      # differ: saying you are looking is meant to be seen, so the status opens
+      # to everyone, while what you want to earn is nobody's business.
+      assert user.employment_status_visibility == "everyone"
       assert user.desired_salary_visibility == "hidden"
     end
 

--- a/test/vutuv_web/landing_page_test.exs
+++ b/test/vutuv_web/landing_page_test.exs
@@ -42,21 +42,28 @@ defmodule VutuvWeb.LandingPageTest do
   end
 
   describe "the landing page" do
-    # The three claims beside the quote, both halves of each: whoever agrees that
-    # LinkedIn is annoying wants to know what they have to retype, how it feels,
-    # and what it will cost them later. Asserted as the rendered German literals
-    # for the reason the whole file renders in German — an untranslated or
-    # fuzzy-filled msgstr shows up perfectly in an English render, and the
-    # short ones ("Schnell.") are the likeliest to be fuzzy-matched.
+    # The three claims beside the quote: whoever agrees that LinkedIn is
+    # annoying wants to know what they have to retype, how it feels, and what it
+    # will cost them later. Asserted as the rendered German literals for the
+    # reason the whole file renders in German — an untranslated or fuzzy-filled
+    # msgstr shows up perfectly in an English render, and the short ones
+    # ("Schnell.") are the likeliest to be fuzzy-matched.
+    #
+    # Two of them carry a reason; "Schnell." does not, since its own only
+    # restated it. Both spellings are refused below because the way that
+    # sentence would come back is the English one: an empty `msgstr` reads as
+    # untranslated, and gettext then renders the msgid on the German page.
     test "the hero lists what a LinkedIn refugee gets", %{conn: conn} do
       html = landing_de(conn)
 
       assert html =~ "Einfacher Profilimport."
       assert html =~ "Ihr LinkedIn-Profil kann mitkommen."
       assert html =~ "Schnell."
-      assert html =~ "vutuv ist einfach rattenschnell."
       assert html =~ "Keine bezahlten Premium-Accounts."
       assert html =~ "Das will doch eh keiner."
+
+      refute html =~ "rattenschnell"
+      refute html =~ "ridiculously fast"
 
       # Deliberately statements, not links: /import/linkedin needs an account,
       # so a logged-out click would trade the sign-up form for the login page.


### PR DESCRIPTION
Copy and defaults on the availability block, plus one hero line.

**Availability opens up by default.** `employment_status_visibility` now starts at `everyone` instead of `members`, and `desired_workplace_types` at all three instead of none. Both columns are only read once a status is set — a nil status shows no badge to anybody — so the default is the answer for somebody who has just said they are open to offers, and hiding that from logged-out visitors is the opposite of what saying it is for.

Defaults only, no backfill (Stefan's call): a stored visibility is a member's own decision, including an inherited one. The migration is N-1 safe — the previous release writes both columns explicitly on every save, and no column type changes.

**Three sentences dropped.** The two hints under the availability fields explained nothing the field beside them does not, and the hero's "vutuv is ridiculously fast." only restated its own claim ("Fast."). That one is removed at the source, not by blanking the German: gettext reads an empty `msgstr` as untranslated and falls back to the msgid, which would have put the English sentence on the German page.

Two tests held the old default; a third compared the SQL gate against the struct predicate and passed by coincidence — for `nil` it read a struct that never carried the column against a row holding the database default. It reloads now.

Surfaces: `/settings/profile`, `/system/welcome`, `/`.

https://claude.ai/code/session_01KE2NaGdpqUG5idSC7Cf2v1
