### PR TITLE
Link preview tiles update without a reload on profiles and organization pages

### DIFF
--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -506,6 +506,20 @@ about it are deliberate:
   cards re-read again on the verdict. Announcing only the verdict meant nobody
   watching a feed ever saw a preview — the card was drawn a second before the
   download finished and kept its grey tile for the whole scan.
+- **Every surface that draws `<.link_thumb>` hears it** (issue #1928). The
+  component draws the same three states on four surfaces, and at first only a
+  post's card was told about any of them: a **profile's** Links card and an
+  **organization page's** homepage capture (which is absent until there is
+  something to show, so its arrival moves the page above the fold) both waited
+  for the next load. Each owner module owns the routing for its own rows —
+  `Vutuv.PageScreenshot.announce/1` broadcasts `{:link_screenshot_changed, …}`
+  on the link owner's activity topic, `Vutuv.Organizations.Screenshots.announce/1`
+  goes through `Organizations.broadcast_screenshot_changed/1` onto the page's —
+  and `Vutuv.Moderation.ImageSubjects` calls those rather than keeping a second
+  copy of who to tell. One event per kind for all three moments: a capture
+  landing, a release and a refusal are one sentence to a reader, *re-read what
+  you draw*. The `/:slug/links` index is a dead controller page and is
+  deliberately left out.
 
 Where it exists: post photos (`post_images/<token>/pixelated.avif`, served by
 the proxy at `pixelated.avif` — which redirects to the real picture once

--- a/lib/vutuv/moderation/image_subjects.ex
+++ b/lib/vutuv/moderation/image_subjects.ex
@@ -25,6 +25,8 @@ defmodule Vutuv.Moderation.ImageSubjects do
   alias Vutuv.Organizations.Organization
   alias Vutuv.Organizations.OrganizationImage
   alias Vutuv.Organizations.OrganizationScreenshot
+  alias Vutuv.Organizations.Screenshots, as: OrganizationScreenshots
+  alias Vutuv.PageScreenshot
   alias Vutuv.Posts.PostImage
   alias Vutuv.Posts.PostReview
   alias Vutuv.Posts.PostScreenshot
@@ -396,13 +398,17 @@ defmodule Vutuv.Moderation.ImageSubjects do
       from(u in Url,
         where:
           u.id == ^scan.subject_id and u.screenshot == ^scan.fingerprint and
-            u.screenshot_moderation == "pending"
+            u.screenshot_moderation == "pending",
+        # The released row rides back with the write; promoting the file and
+        # telling the tile both need it, and neither needs a second read.
+        select: u
       )
       |> Repo.update_all(set: [screenshot_moderation: "approved"])
 
     case flipped do
-      {1, _} ->
-        Vutuv.Screenshot.promote_from_quarantine(Repo.get!(Url, scan.subject_id))
+      {1, [%Url{} = url]} ->
+        Vutuv.Screenshot.promote_from_quarantine(url)
+        PageScreenshot.announce(url)
         :ok
 
       _ ->
@@ -436,16 +442,16 @@ defmodule Vutuv.Moderation.ImageSubjects do
       from(os in OrganizationScreenshot,
         where:
           os.id == ^scan.subject_id and os.screenshot == ^scan.fingerprint and
-            os.moderation == "pending"
+            os.moderation == "pending",
+        # Rides back with the write (see the Url branch).
+        select: os
       )
       |> Repo.update_all(set: [moderation: "approved"])
 
     case flipped do
-      {1, _} ->
-        Vutuv.Screenshot.promote_from_quarantine(
-          Repo.get!(OrganizationScreenshot, scan.subject_id)
-        )
-
+      {1, [%OrganizationScreenshot{} = capture]} ->
+        Vutuv.Screenshot.promote_from_quarantine(capture)
+        OrganizationScreenshots.announce(capture)
         :ok
 
       _ ->
@@ -592,7 +598,11 @@ defmodule Vutuv.Moderation.ImageSubjects do
 
   def apply_rejected(%ImageScan{kind: "url_screenshot"} = scan) do
     cleared =
-      from(u in Url, where: u.id == ^scan.subject_id and u.screenshot == ^scan.fingerprint)
+      from(u in Url,
+        where: u.id == ^scan.subject_id and u.screenshot == ^scan.fingerprint,
+        # Which tile to tell rides back with the write (see the Url branch above).
+        select: u
+      )
       # "rejected", not nil, the way the post branch below records it: the row
       # is the only memory of the verdict, and `Vutuv.PageScreenshot.due/1`
       # reads it to leave the link alone. Clearing it would put the page back
@@ -601,8 +611,9 @@ defmodule Vutuv.Moderation.ImageSubjects do
       |> Repo.update_all(set: [screenshot: nil, screenshot_moderation: "rejected"])
 
     case cleared do
-      {1, _} ->
+      {1, [%Url{} = cleared_row]} ->
         Vutuv.Screenshot.delete(%Url{id: scan.subject_id})
+        PageScreenshot.announce(cleared_row)
         :ok
 
       _ ->
@@ -649,7 +660,9 @@ defmodule Vutuv.Moderation.ImageSubjects do
   def apply_rejected(%ImageScan{kind: "organization_screenshot"} = scan) do
     cleared =
       from(os in OrganizationScreenshot,
-        where: os.id == ^scan.subject_id and os.screenshot == ^scan.fingerprint
+        where: os.id == ^scan.subject_id and os.screenshot == ^scan.fingerprint,
+        # Which page to tell rides along with the write (see the Url branch).
+        select: os
       )
       |> Repo.update_all(
         set: [
@@ -661,8 +674,9 @@ defmodule Vutuv.Moderation.ImageSubjects do
       )
 
     case cleared do
-      {1, _} ->
+      {1, [%OrganizationScreenshot{} = cleared_row]} ->
         Vutuv.Screenshot.delete(%OrganizationScreenshot{id: scan.subject_id})
+        OrganizationScreenshots.announce(cleared_row)
         :ok
 
       _ ->

--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -1664,17 +1664,31 @@ defmodule Vutuv.Organizations do
   @doc "Subscribes to an organization's live counter topic."
   def subscribe(organization_id), do: Engagement.subscribe(organization_id, @engagement_cfg)
 
+  @doc """
+  Tells an open organization page that its homepage capture moved (issue
+  #1928) — `Vutuv.Organizations.Screenshots.announce/1` decides when, this
+  names the topic, the same split `broadcast_verified/1` follows.
+  """
+  def broadcast_screenshot_changed(organization_id),
+    do: broadcast_to_page(organization_id, {:organization_screenshot_changed, organization_id})
+
   # Tells an open page that the background pass finished its claim, so somebody
   # who published the record and left the tab sitting there watches it go live
   # instead of reloading to find out (issue #1466). Lives here rather than with
   # the pending pass above because `@engagement_cfg` owns the topic name.
-  defp broadcast_verified(%Organization{id: id}) do
-    Phoenix.PubSub.broadcast(
-      Vutuv.PubSub,
-      Engagement.topic(id, @engagement_cfg),
-      {:organization_verified, id}
-    )
-  end
+  defp broadcast_verified(%Organization{id: id}),
+    do: broadcast_to_page(id, {:organization_verified, id})
+
+  # The counter topic is where an open page already listens, so everything this
+  # module tells one goes out on it — named once, beside the `subscribe/1` that
+  # reads it.
+  defp broadcast_to_page(organization_id, message),
+    do:
+      Phoenix.PubSub.broadcast(
+        Vutuv.PubSub,
+        Engagement.topic(organization_id, @engagement_cfg),
+        message
+      )
 
   @doc """
   One page of the member's liked / bookmarked organizations for the `/bookmarks`

--- a/lib/vutuv/organizations/screenshots.ex
+++ b/lib/vutuv/organizations/screenshots.ex
@@ -38,6 +38,7 @@ defmodule Vutuv.Organizations.Screenshots do
   import Ecto.Query
 
   alias Vutuv.Moderation.ImageScans
+  alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
   alias Vutuv.Organizations.OrganizationScreenshot
   alias Vutuv.Organizations.ScreenshotWorker
@@ -308,8 +309,26 @@ defmodule Vutuv.Organizations.Screenshots do
       ImageScans.enqueue("organization_screenshot", ready.id, nil, ready.screenshot)
     end
 
+    # Announced whether or not the gate still holds it (issue #1928). What a
+    # held capture draws is its mosaic preview, and on this page that is the
+    # difference between no tile at all and a tile — a layout change above the
+    # fold, which nobody should have to reload to get.
+    announce(ready)
+
     ready
   end
+
+  @doc """
+  Tells whoever is drawing this page's homepage capture that it moved — the
+  capture landed, the AI gate released it, or a refusal took it away.
+
+  One event for all three: they are one sentence to a reader (re-read what you
+  draw), and the page they reach is the organization's own
+  (`VutuvWeb.OrganizationLive.Show`), which is already listening on that topic
+  for its counters and its verification.
+  """
+  def announce(%OrganizationScreenshot{organization_id: id}),
+    do: Organizations.broadcast_screenshot_changed(id)
 
   defp mark_retry(%OrganizationScreenshot{} = job, reason) do
     attempts = job.attempts + 1

--- a/lib/vutuv/page_screenshot.ex
+++ b/lib/vutuv/page_screenshot.ex
@@ -23,6 +23,7 @@ defmodule Vutuv.PageScreenshot do
 
   import Ecto.Query
 
+  alias Vutuv.Activity
   alias Vutuv.BrowserFrame
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.PageScreenshot.Cdp
@@ -141,11 +142,15 @@ defmodule Vutuv.PageScreenshot do
   @doc """
   Captures the due links one after the other and returns how many it worked
   through — attempts, not successes, since a blocklisted page is neither. What
-  `Vutuv.PageScreenshot.Sweeper` runs; `opts` are `due/1`'s.
+  `Vutuv.PageScreenshot.Sweeper` runs; `opts` are `due/1`'s, plus `capture:`
+  for the per-link capture function (the seam the post and organization queues
+  already have — a test stubs it and everything after the browser runs for
+  real).
   """
   def capture_due(opts \\ []) do
     urls = due(opts)
-    Enum.each(urls, &generate_screenshot/1)
+    capture = Keyword.get(opts, :capture, &capture_and_frame/1)
+    Enum.each(urls, &generate_screenshot(&1, capture))
     length(urls)
   end
 
@@ -173,14 +178,18 @@ defmodule Vutuv.PageScreenshot do
   Safe to run from an unsupervised `Task` — all failures are logged, never
   raised.
   """
-  def generate_screenshot(%Url{id: id}) do
+  def generate_screenshot(%Url{} = url), do: generate_screenshot(url, &capture_and_frame/1)
+
+  # The capture step stays an argument for `capture_due/1`'s seam alone — the
+  # public entry point above keeps its one arity, since nothing else picks it.
+  defp generate_screenshot(%Url{id: id}, capture) do
     case Repo.get(Url, id) do
       nil -> :ok
-      url -> capture_store_and_flag(url)
+      url -> capture_store_and_flag(url, capture)
     end
   end
 
-  defp capture_store_and_flag(url) do
+  defp capture_store_and_flag(url, capture) do
     # Before the capture, not after, and on every outcome: this is `due/1`'s
     # clock, not a claim that anything was captured. A run that dies mid-way —
     # a Chromium crash, a deploy stopping the slot — must still move the link
@@ -188,7 +197,7 @@ defmodule Vutuv.PageScreenshot do
     # sorts oldest-first and spends every batch on itself forever.
     stamp_attempt(url)
 
-    case capture_and_frame(url) do
+    case capture.(url) do
       {:ok, framed_path} ->
         store(url, framed_path)
         File.rm(framed_path)
@@ -444,10 +453,32 @@ defmodule Vutuv.PageScreenshot do
     # not reach the public link card.
     with {:ok, updated} <- result do
       ImageScans.enqueue("url_screenshot", updated.id, updated.user_id, updated.screenshot)
+      # Announced whether or not the gate still holds it (issue #1928): a held
+      # capture draws its mosaic preview (issue #1720), so the capture landing
+      # is itself something to show, and the tile that has been grey since the
+      # member added the link can stop being grey.
+      announce(updated)
     end
 
     result
   end
+
+  @doc """
+  Tells whoever is drawing this link's preview tile that it moved — a capture
+  landed, the AI gate released it, or a refusal took it away.
+
+  One event for all three because they are one sentence to a reader: re-read
+  what you draw. The audience is the member's own topic, which is what a
+  profile page subscribes to (`VutuvWeb.UserProfileLive`), and the owner is
+  the only party a link's picture reaches — unlike a post's capture, which
+  fans out to every follower's feed.
+
+  `urls.user_id` is nullable and a link nobody owns reaches no profile, which
+  needs no clause of its own: `Activity.broadcast/2` is the chokepoint that
+  answers nil with `:ok`.
+  """
+  def announce(%Url{user_id: user_id, id: id}),
+    do: Activity.broadcast(user_id, {:link_screenshot_changed, %{url_id: id}})
 
   defp set_broken(url, value) do
     url

--- a/lib/vutuv_web/live/organization_live/show.ex
+++ b/lib/vutuv_web/live/organization_live/show.ex
@@ -439,6 +439,13 @@ defmodule VutuvWeb.OrganizationLive.Show do
      |> update(:posts_offset, &(&1 + 1))}
   end
 
+  # The homepage capture moved (issue #1928): it landed, the AI gate released
+  # it, or a refusal took it away. The tile sits above the fold and is absent
+  # until there is something to show, so all three change the page's layout
+  # under whoever is reading it — one re-read answers each.
+  def handle_info({:organization_screenshot_changed, _id}, socket),
+    do: {:noreply, assign_screenshot(socket, socket.assigns.organization)}
+
   def handle_info(_message, socket), do: {:noreply, socket}
 
   # `primary_domain` is a %OrganizationDomain{} struct here (the assign holds the row

--- a/lib/vutuv_web/live/user_profile_live.ex
+++ b/lib/vutuv_web/live/user_profile_live.ex
@@ -499,6 +499,19 @@ defmodule VutuvWeb.UserProfileLive do
     {:noreply, reload_posts(socket)}
   end
 
+  # A link's preview tile moved (issue #1928): the capture landed, the AI gate
+  # released it, or a refusal took it away. One event for all three, because
+  # the Links card answers each the same way — re-read the links and let
+  # `<.link_thumb>` pick the tile again.
+  #
+  # Deliberately not narrowed to the links already on screen: the card previews
+  # the top `preview_limit(:links)`, and the member who just added their first
+  # link is looking at a card that does not hold it yet — which is the very
+  # case this issue is about. The sweeper's batch is 5 every 5 minutes, so the
+  # re-read this occasionally spends on an unshown link is not worth the risk.
+  def handle_info({:link_screenshot_changed, _payload}, socket),
+    do: {:noreply, refresh_links(socket)}
+
   # The social feed cache answered a mount-time request (or a concurrent
   # visitor's fetch this page joined — single-flight): drop the account's
   # loading spinner and, on success, fold the feed into the mixed posts card.
@@ -658,6 +671,20 @@ defmodule VutuvWeb.UserProfileLive do
   defp refresh_tags(socket) do
     assign(socket, :user_tags, load_user_tags(socket.assigns.user))
   end
+
+  # The Links card's slice of the assigns. Re-preloaded with `links_query/0`
+  # rather than through `mount_profile/1`, which would re-read the whole profile
+  # and its twenty preloads to change one tile.
+  defp refresh_links(socket) do
+    user = Repo.preload(socket.assigns.user, [urls: links_query()], force: true)
+
+    assign(socket, :user, user)
+  end
+
+  # The Links card's preview, shared by the initial load and the live refresh so
+  # the two cannot drift — `refresh_social/1` is the cautionary tale, where the
+  # re-read's own copy of the follower limit has already fallen behind mount's.
+  defp links_query, do: Url.ordered() |> limit(^preview_limit(:links))
 
   defp load_user_tags(user) do
     user
@@ -1319,7 +1346,7 @@ defmodule VutuvWeb.UserProfileLive do
       # from the same rows, without a query per entry.
       job_references: {JobReference.public_scope(), :links},
       phone_numbers: PhoneNumber.ordered() |> limit(^preview_limit(:phone_numbers)),
-      urls: Url.ordered() |> limit(^preview_limit(:links)),
+      urls: links_query(),
       addresses: Address.ordered() |> limit(^preview_limit(:addresses)),
       inbound_follows: {Follow.latest(preview_limit(:followers), :follower), [:follower]},
       outbound_follows: {Follow.latest(preview_limit(:following), :followee), [:followee]}

--- a/test/vutuv_web/live/link_thumb_arrives_test.exs
+++ b/test/vutuv_web/live/link_thumb_arrives_test.exs
@@ -1,0 +1,217 @@
+defmodule VutuvWeb.LinkThumbArrivesTest do
+  @moduledoc """
+  A link preview tile changes while somebody is looking at it, and the page
+  follows without a reload (issue #1928) — the two surfaces issue #1927 left
+  out.
+
+  `<.link_thumb>` draws the same three states on four surfaces. A post's card
+  learned to hear about all three; a **profile's** Links card and an
+  **organization page's** homepage capture did not, so a member watched a grey
+  tile that had been a real picture for two minutes. Both moments count: the
+  capture landing is when the mosaic preview appears (issue #1720), the verdict
+  is when the picture itself does, and a refusal deletes the very file the
+  mosaic names.
+
+  `async: false` — flips `:moderate_images` and `:uploads_dir_prefix`, which
+  the SQL sandbox does not roll back.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Vutuv.Factory
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Moderation.ImageScan
+  alias Vutuv.Moderation.ImageSubjects
+  alias Vutuv.Organizations.OrganizationScreenshot
+  alias Vutuv.Organizations.Screenshots
+  alias Vutuv.PageScreenshot
+  alias Vutuv.Profiles.Url
+  alias Vutuv.Repo
+  alias Vutuv.Screenshot
+
+  setup do
+    tmp =
+      Path.join(System.tmp_dir!(), "vutuv_link_thumb_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmp)
+
+    put_config(:uploads_dir_prefix, tmp)
+    put_config(:moderate_images, true)
+
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    {:ok, tmp: tmp}
+  end
+
+  defp put_config(key, value) do
+    original = Application.fetch_env(:vutuv, key)
+    Application.put_env(:vutuv, key, value)
+
+    on_exit(fn ->
+      case original do
+        {:ok, was} -> Application.put_env(:vutuv, key, was)
+        :error -> Application.delete_env(:vutuv, key)
+      end
+    end)
+  end
+
+  # A real, decodable image where the browser would have left its framed webp:
+  # the store runs libvips over it and derives the mosaic from those pixels, so
+  # a fake binary would test nothing.
+  defp framed_capture(tmp) do
+    path = Path.join(tmp, "framed-#{System.unique_integer([:positive])}.webp")
+    {:ok, image} = Image.new(400, 264, color: [30, 90, 160])
+    {:ok, _} = Image.write(image, path)
+    path
+  end
+
+  # The profile queue's Chromium seam: only the browser step is stubbed, so the
+  # store, the scan enqueue and the announcement all run for real.
+  defp capture_link(tmp),
+    do: PageScreenshot.capture_due(capture: fn _url -> {:ok, framed_capture(tmp)} end)
+
+  defp scan(kind, subject) do
+    %ImageScan{
+      kind: kind,
+      subject_id: subject.id,
+      fingerprint: subject.screenshot,
+      owner_user_id: Map.get(subject, :user_id)
+    }
+  end
+
+  describe "a profile's Links card" do
+    setup %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      url = insert(:url, user: user, value: "https://blog.example/entry")
+      {:ok, conn: conn, user: user, url: url}
+    end
+
+    test "the capture lands and the tile stops being grey", %{
+      conn: conn,
+      user: user,
+      url: url,
+      tmp: tmp
+    } do
+      {:ok, view, _html} = live(conn, ~p"/#{user}")
+      assert has_element?(view, ~s([data-link-thumb="pending"]))
+
+      capture_link(tmp)
+
+      # The gate still holds the picture, so what arrives is the mosaic — which
+      # is the point: there was nothing to look at before, and now there is.
+      assert has_element?(view, ~s([data-link-thumb="pixelated"]))
+      assert Repo.get!(Url, url.id).screenshot_moderation == "pending"
+    end
+
+    test "the verdict releases it and the picture swaps in", %{
+      conn: conn,
+      user: user,
+      url: url,
+      tmp: tmp
+    } do
+      {:ok, view, _html} = live(conn, ~p"/#{user}")
+      capture_link(tmp)
+      assert has_element?(view, ~s([data-link-thumb="pixelated"]))
+
+      assert :ok = ImageSubjects.apply_approved(scan("url_screenshot", Repo.get!(Url, url.id)))
+
+      assert has_element?(view, ~s([data-link-thumb="shot"]))
+      refute has_element?(view, ~s([data-link-thumb="pixelated"]))
+    end
+
+    test "a refused capture is announced too, so the mosaic goes", %{
+      conn: conn,
+      user: user,
+      url: url,
+      tmp: tmp
+    } do
+      # The rejection deletes the very file the mosaic on an open page names, so
+      # a page nobody tells goes on asking for it and draws a broken image.
+      {:ok, view, _html} = live(conn, ~p"/#{user}")
+      capture_link(tmp)
+      assert has_element?(view, ~s([data-link-thumb="pixelated"]))
+
+      assert :ok = ImageSubjects.apply_rejected(scan("url_screenshot", Repo.get!(Url, url.id)))
+
+      refute has_element?(view, ~s([data-link-thumb="pixelated"]))
+      assert has_element?(view, ~s([data-link-thumb="pending"]))
+    end
+  end
+
+  describe "an organization page's homepage capture" do
+    setup do
+      put_config(:verify_organization_domains, true)
+      on_exit(fn -> Application.delete_env(:vutuv, :organizations_dns_resolver) end)
+
+      {organization, _owner} = active_organization()
+      {:ok, organization: organization}
+    end
+
+    test "the capture lands and the tile appears above the fold", %{
+      conn: conn,
+      organization: organization,
+      tmp: tmp
+    } do
+      {:ok, view, _html} = live(conn, ~p"/organizations/#{organization.slug}")
+      # Nothing is drawn before the capture: a lone grey rectangle reads as a
+      # broken image, so the tile is absent rather than empty.
+      refute has_element?(view, "[data-organization-screenshot]")
+
+      Screenshots.deliver_due(force: true, capture: capture(tmp))
+
+      assert has_element?(view, ~s([data-link-thumb="pixelated"]))
+      assert Repo.one(OrganizationScreenshot).moderation == "pending"
+    end
+
+    test "the verdict releases it and the picture swaps in", %{
+      conn: conn,
+      organization: organization,
+      tmp: tmp
+    } do
+      {:ok, view, _html} = live(conn, ~p"/organizations/#{organization.slug}")
+      Screenshots.deliver_due(force: true, capture: capture(tmp))
+      assert has_element?(view, ~s([data-link-thumb="pixelated"]))
+
+      assert :ok =
+               ImageSubjects.apply_approved(
+                 scan("organization_screenshot", Repo.one(OrganizationScreenshot))
+               )
+
+      assert has_element?(view, ~s([data-link-thumb="shot"]))
+      refute has_element?(view, ~s([data-link-thumb="pixelated"]))
+    end
+
+    test "a refused capture takes the tile away again", %{
+      conn: conn,
+      organization: organization,
+      tmp: tmp
+    } do
+      {:ok, view, _html} = live(conn, ~p"/organizations/#{organization.slug}")
+      Screenshots.deliver_due(force: true, capture: capture(tmp))
+      assert has_element?(view, ~s([data-link-thumb="pixelated"]))
+
+      assert :ok =
+               ImageSubjects.apply_rejected(
+                 scan("organization_screenshot", Repo.one(OrganizationScreenshot))
+               )
+
+      refute has_element?(view, "[data-organization-screenshot]")
+    end
+  end
+
+  # The organization queue's Chromium seam, storing a real picture the way the
+  # browser path stores one — the mosaic is written from those bytes.
+  defp capture(tmp) do
+    fn job ->
+      upload = %Plug.Upload{
+        filename: "framed.webp",
+        path: framed_capture(tmp),
+        content_type: "image/webp"
+      }
+
+      {:ok, stored} = Screenshot.store({upload, job})
+      {:ok, %{screenshot: stored, width: 400, height: 264}}
+    end
+  end
+end


### PR DESCRIPTION
A link's preview tile on a profile (`/:slug`, the Links card) and an organization page's homepage capture (`/organizations/:slug`) only changed on the next page load: the mosaic preview when the capture landed, the picture itself when the AI scan released it, and nothing at all when a refusal deleted the file the mosaic names. `<.link_thumb>` draws the same states on four surfaces and only the post card had been told about any of them (#1927).

Each row-owning module now routes its own announcement — `PageScreenshot.announce/1` onto the link owner's activity topic, `Organizations.Screenshots.announce/1` onto the page's — and `ImageSubjects` calls those instead of keeping a second copy of who to tell. One event per kind covers all three moments.

`capture_due/1` gains the `capture:` seam both sibling queues already have, so a test drives the store, the scan enqueue and the announcement for real.

Six tests, calibrated: all red with the announcements removed. Also driven in a browser on both surfaces, both directions, no reload.

Closes #1928

https://claude.ai/code/session_01QmHH9GfSuxUicMJw4X22Ya
