### PR TITLE
The mention card shows four posts and never the one you have open

### DIFF
--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -338,27 +338,59 @@ LiveView can sit on either style.
   **who is this** (a `.actor-card__chip` carrying the globe and the host, then
   name, address and a two-line self-description), **is it worth it**
   (`.actor-card__stats` — how many of their posts we hold for *this* reader and
-  how recently, through `delimited_count/1` and `relative_time/1`; plus
-  `.actor-card__latest`, the newest one quoted in two lines, left out when its
-  author marked it sensitive or the reader's own filters hide it), and **what
+  how recently, through `compact_count/1` and `relative_time/1`; plus
+  `.actor-card__posts`, a stack of the newest four: the first quoted in two
+  lines under a "Latest here" label, the rest one line each with their age at
+  the end (`.actor-card__older-row`), folded away behind
+  `.actor-card__posts-toggle` and already in the fragment, so opening the drawer
+  asks the server for nothing. One post is a poor sample of an account when the
+  reader is standing in front of a Follow button, and three stacked labels
+  reading "2 days ago" are a list that says nothing — hence the split between a
+  quote and a row. Which posts survive is `Fediverse.account_card_summary/2`
+  (audience, the count, the clock, and `@card_quotes` + a buffer beside the
+  account page's own cap) and then the controller's reader gates, which are
+  `PostTeaser.record_line/4` — the reader's rewrite rules, then their filters
+  over what those left, then the line, never reordered — plus the two the card
+  owns: the author's content warning, and **the post the reader has open behind
+  the card**. That last one is the card's whole reason for a `context` param:
+  opened from a post's author line it otherwise quotes that very post back as
+  the freshest thing the account wrote, spending its best line on what is
+  already on the screen (`mention_card.js` reads it off the enclosing
+  `article[data-remote-post]` and sends it with every request, acts included,
+  alongside `expanded` — every act replaces the whole fragment, so a drawer the
+  reader opened folds itself away without it). The count and the clock stay the
+  account's whatever the stack drops, or a post behind a content warning would
+  make an account that wrote a minute ago read as silent; and the quote that
+  moves up when the context drop takes the newest one says **when** instead of
+  "Latest here", because that label is a claim and not a position), and **what
   now** (one `.actor-card__state-btn` that reads as the follow state and becomes
   the refusal in red on hover — never a status pill beside a loud Unfollow,
   which said the same thing twice and made the one unwanted act the loudest
-  control — a `.actor-card__more` ⋯ holding both mutes and the address, and
-  `.actor-card__links`, both ways onward in one weight — the one that leaves
-  this site **names where it goes** ("View the original on
-  chaos.social/@feed", `RemoteActorCardHTML.origin_address/1`, which borrows
-  both halves: `RemoteHtml.display_form/1` drops the scheme, the `www.` and a
+  control; its three modifiers are spelled by `state_btn_modifier/1` as
+  `--#{Follow.display_state(follow)}`, so `--accepted` / `--requested` /
+  `--moved` are the only names that can style it, and CSS calling the first one
+  `--following` left the commonest state of all unstyled from the day the card
+  shipped — an interpolated class name is invisible to grep, so
+  `actor_card_state_css_test.exs` reads the atoms off `display_state/1` and
+  fails the build when one of them has no colour in either theme — a
+  `.actor-card__more` ⋯ holding both mutes and the address, and
+  `.actor-card__links`, both ways onward in one weight, as **rows on every
+  screen**: two links sharing a line is a shape a 20rem card has no room for.
+  The one that leaves this site **names where it goes** ("View the original"
+  with `ard.social/users/tagesschau` under it in the muted weight of a browser's
+  status bar, `.actor-card__link-address`; `RemoteActorCardHTML.origin_address/1`
+  is `RemoteHtml.display_form/1`, which drops the scheme, the `www.` and a
   trailing slash — case-insensitively, since the string is a remote server's and
-  may well say `HTTPS://` — and `SocialFeed.Post.truncate/2` cuts it at 40, a
-  measurement of *this* card, so the host at the front can never be the part
-  that goes. An actor URI need not be spelled like the `@user@host` above it, so
-  the destination is not guessable from the card, and `overflow-wrap: anywhere`
-  is what lets an address with no spaces in it wrap rather than overflow).
+  may well say `HTTPS://`. Nothing cuts it in Elixir any more: a character count
+  measured against one card is wrong on the next screen, so `text-overflow:
+  ellipsis` ends it where the card ends, always from the END, since the host
+  leads the string and is the fact the line is carrying. An actor URI need not
+  be spelled like the `@user@host` above it, so the destination is not guessable
+  from the card).
   **One fragment serves
   both shapes**: `.actor-card--sheet` restyles it for the phone (grab bar,
   stacked full-width targets, the ⋯ menu in the flow rather than floating, the
-  links as full-width rows), and the only thing that cannot be CSS travels as an
+  two link rows given a thumb's worth of height), and the only thing that cannot be CSS travels as an
   attribute — a touch screen has no hover, so the follow button's first press
   asks with the server-written `data-actor-confirm` and the second one acts. The markup arrives from the server
   on every act (`VutuvWeb.RemoteActorCardController` +

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -3892,12 +3892,17 @@ html[data-feed-pull="busy"] .feed-pull__glyph {
   font-variant-numeric: tabular-nums;
 }
 
-/* The last thing they wrote: two lines, quoted, and a link to our copy of it.
+/* The last few things they wrote: a stack of quotes, each a link to our copy.
    The rule on the left is the quotation mark this does not spend a character
-   on. */
+   on, and the stack reads as one block because every entry wears it. */
+.actor-card__posts {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-top: 0.7rem;
+}
 .actor-card__latest {
   display: block;
-  margin-top: 0.7rem;
   padding: 0.45rem 0.6rem 0.5rem;
   border-left: 2px solid var(--color-brand-300);
   border-radius: 0.5rem;
@@ -3905,6 +3910,41 @@ html[data-feed-pull="busy"] .feed-pull__glyph {
   text-decoration: none;
 }
 .actor-card__latest:hover { background: #f1f5f9; }
+/* The older ones are the sample, not the headline: one line each, the age at
+   the end of it, and a paler rule, so the stack cannot compete with the post
+   above it. The age was a label on its own line for one afternoon, which put
+   three identical "2 days ago" under one another and doubled the drawer's
+   height for it. */
+.actor-card__older-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.3rem 0.6rem 0.35rem;
+  border-left: 2px solid #e2e8f0;
+  border-radius: 0.5rem;
+  background: #f8fafc;
+  text-decoration: none;
+}
+.actor-card__older-row:hover { background: #f1f5f9; }
+/* One line, cut where the card ends. `min-width: 0` is what lets a flex item
+   shrink below its content at all — without it the row grows and the age is
+   pushed off the card instead. */
+.actor-card__older-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  color: #334155;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.actor-card__older-when {
+  flex: 0 0 auto;
+  color: #94a3b8;
+  font-size: 0.6875rem;
+  white-space: nowrap;
+}
 .actor-card__latest-label {
   display: block;
   color: #64748b;
@@ -3914,8 +3954,11 @@ html[data-feed-pull="busy"] .feed-pull__glyph {
   text-transform: uppercase;
 }
 /* The two-line clamp is `line-clamp-2` at the call site, like the
-   self-description two elements above it — one spelling of "cut this at two
-   lines" on this card, and the utility already carries the four properties. */
+   self-description above it — one spelling of "cut this at two lines" on this
+   card, and the utility already carries the four properties. The older rows
+   below cut differently (one line, ellipsis, an age beside them), which is why
+   they hand-roll it rather than reach for `line-clamp-1`: that utility makes
+   the span a `-webkit-box` and the flex row holding the age comes apart. */
 .actor-card__latest-text {
   display: block;
   margin-top: 0.1rem;
@@ -3924,6 +3967,37 @@ html[data-feed-pull="busy"] .feed-pull__glyph {
   line-height: 1.45;
   overflow-wrap: anywhere;
 }
+
+/* The expander under the stack: a quiet text control, because what it reveals
+   is context and not the card's business end. Two labels, one shown — the same
+   arrangement as the follow button, so the JS adds a class and writes no
+   words. */
+.actor-card__posts-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  align-self: flex-start;
+  padding: 0.3rem 0.2rem;
+  border: 0;
+  background: transparent;
+  color: #64748b;
+  font-size: 0.78125rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.actor-card__posts-toggle:hover { color: #0f172a; }
+.actor-card__posts-toggle [data-actor-posts-open] { display: none; }
+.actor-card__posts-toggle.is-open [data-actor-posts-closed] { display: none; }
+.actor-card__posts-toggle.is-open [data-actor-posts-open] { display: inline; }
+.actor-card__posts-chevron {
+  line-height: 1;
+  transition: transform 120ms ease;
+}
+.actor-card__posts-toggle.is-open .actor-card__posts-chevron { transform: rotate(180deg); }
+/* `contents` so the rows are items of the stack above and share its gap; the
+   `hidden` attribute still hides them, because preflight's
+   `[hidden] { display: none !important }` outranks any normal declaration. */
+.actor-card__older { display: contents; }
 
 .actor-card__actions {
   display: flex;
@@ -3976,7 +4050,15 @@ html[data-feed-pull="busy"] .feed-pull__glyph {
   .actor-card__state-btn:focus-visible [data-actor-state-off] { display: inline; }
 }
 
-.actor-card__state-btn--following {
+/* The three modifiers are spelled by `RemoteActorCardHTML.state_btn_modifier/1`
+   as `--#{Follow.display_state(follow)}`, so their names are that function's
+   three atoms and nothing else. `--following` sat here instead of `--accepted`
+   from the day the card shipped, which left the commonest state of all — the
+   member already follows this account — as an unstyled button carrying the
+   card's own text colour, exactly where the reader looks to find out where they
+   stand. A modifier whose name is derived cannot be renamed on this side
+   alone. */
+.actor-card__state-btn--accepted {
   background: #ecfdf5;
   box-shadow: inset 0 0 0 1px #a7f3d0;
   color: #065f46;
@@ -4059,29 +4141,56 @@ html[data-feed-pull="busy"] .feed-pull__glyph {
 .actor-card__menu-icon { flex: 0 0 auto; width: 1rem; text-align: center; opacity: 0.7; }
 
 /* Both ways onward in one weight and one colour. They were blue and grey, which
-   reads as a main way and a lesser one; they are neither. */
+   reads as a main way and a lesser one; they are neither.
+
+   Rows on every screen, not only in the sheet: two links sharing a line is a
+   shape a 20rem card has no room for — the second of them names an address, and
+   an address that wraps turns the quietest half of the card into its tallest
+   block. As rows, the label leads and the chevron closes each line, which is
+   also what a thumb wants. */
 .actor-card__links {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.3rem 0.9rem;
+  flex-direction: column;
   margin-top: 0.75rem;
-  padding-top: 0.65rem;
+  padding-top: 0.35rem;
   border-top: 1px solid #f1f5f9;
   font-size: 0.84375rem;
 }
 .actor-card__links a {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.5rem 0.1rem;
   color: var(--color-brand-600);
   font-weight: 600;
   text-decoration: none;
-  /* The way out names its destination, and an address has no spaces to break
-     at. `anywhere` and not `break-word`: only the former lowers the box's
-     min-content width, which is what a flex item (the sheet form's rows) sizes
-     against — with `break-word` the row simply overflows instead. */
-  overflow-wrap: anywhere;
 }
+.actor-card__links a + a { border-top: 1px solid #f1f5f9; }
 .actor-card__links a:hover { text-decoration: underline; }
-.actor-card__go { opacity: 0.6; }
+.actor-card__go { flex: 0 0 auto; opacity: 0.6; }
+
+/* The way out, in two parts: what it does, and where it goes. The address sits
+   under the label in the muted weight of a browser's status bar — a reader
+   checks it before leaving, which is a glance and not a heading. */
+/* `min-width: 0` is the one declaration here that does work: it is what lets a
+   flex item shrink below its content, and without it the address pushes the row
+   wider instead of ending in an ellipsis. */
+.actor-card__out { min-width: 0; }
+/* One line, cut by the browser at whatever the card really is. Cut from the
+   END: the host leads the string and is the fact the line is carrying, so the
+   part naming which server can never be the part that goes. */
+.actor-card__link-address {
+  display: block;
+  overflow: hidden;
+  margin-top: 0.05rem;
+  color: #64748b;
+  font-size: 0.75rem;
+  font-weight: 400;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.actor-card__links a:hover .actor-card__link-address { text-decoration: none; }
 
 /* The grab bar: only the sheet has one, and it says "swipe this away". */
 .actor-card__grab { display: none; }
@@ -4127,21 +4236,12 @@ html[data-feed-pull="busy"] .feed-pull__glyph {
   box-shadow: none;
 }
 .actor-card--sheet .actor-card__menu button { min-height: 2.75rem; }
-/* Full-width list rows with a chevron, rather than two text links sharing a
-   line: same two destinations, a thumb's worth of target each. */
-.actor-card--sheet .actor-card__links {
-  display: block;
-  padding-top: 0.25rem;
-}
+/* The two ways onward are rows on every screen now; the sheet only makes them
+   a thumb's worth of target. */
 .actor-card--sheet .actor-card__links a {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.75rem 0.1rem;
-  border-bottom: 1px solid #f1f5f9;
+  padding: 0.7rem 0.1rem;
   font-size: 0.875rem;
 }
-.actor-card--sheet .actor-card__links a:last-child { border-bottom: 0; }
 
 @media (prefers-color-scheme: dark) {
   .actor-card {
@@ -4163,10 +4263,16 @@ html[data-feed-pull="busy"] .feed-pull__glyph {
 
   .actor-card__latest { border-left-color: var(--color-brand-600); background: #16233b; }
   .actor-card__latest:hover { background: #1e293b; }
+  .actor-card__older-row { border-left-color: #334155; background: #16233b; }
+  .actor-card__older-row:hover { background: #1e293b; }
+  .actor-card__older-text { color: #cbd5e1; }
+  .actor-card__older-when { color: #64748b; }
   .actor-card__latest-label { color: #94a3b8; }
   .actor-card__latest-text { color: #cbd5e1; }
+  .actor-card__posts-toggle { color: #94a3b8; }
+  .actor-card__posts-toggle:hover { color: #e2e8f0; }
 
-  .actor-card__state-btn--following {
+  .actor-card__state-btn--accepted {
     background: rgb(6 78 59 / 0.35);
     box-shadow: inset 0 0 0 1px #065f46;
     color: #a7f3d0;
@@ -4202,7 +4308,8 @@ html[data-feed-pull="busy"] .feed-pull__glyph {
 
   .actor-card__links { border-top-color: #1e293b; }
   .actor-card__links a { color: var(--color-brand-300); }
-  .actor-card--sheet .actor-card__links a { border-bottom-color: #1e293b; }
+  .actor-card__links a + a { border-top-color: #1e293b; }
+  .actor-card__link-address { color: #94a3b8; }
   .actor-card--sheet .actor-card__grab { background: #334155; }
 }
 

--- a/assets/js/mention_card.js
+++ b/assets/js/mention_card.js
@@ -158,10 +158,36 @@ async function fetchCard(url, method, extra = "") {
   const resp = await request(url, {
     method,
     headers: { "content-type": "application/x-www-form-urlencoded" },
-    body: `address=${encodeURIComponent(anchor.dataset.remoteActor)}${extra}`,
+    body: `address=${encodeURIComponent(anchor.dataset.remoteActor)}${state()}${extra}`,
   })
   if (!resp.ok) throw new Error(`actor card ${resp.status}`)
   return resp.text()
+}
+
+// What the reader has in front of them, sent with every request: which post is
+// open behind the card, and whether they have opened its drawer of older posts.
+//
+// `context` is the post the handle they pressed sits inside
+// (`article[data-remote-post]`, written by the remote post card). The card
+// quotes the account's newest posts, and opened from a post's author line that
+// newest post is the one on the screen underneath it — so the server is told
+// which one to skip.
+//
+// `expanded` is read back out of the card's own DOM. Every act replaces the
+// whole fragment, so anything this side does not send back is lost on the next
+// press: without it, opening the drawer and then pressing Follow folds it away
+// again — the same "the card contradicts itself over one click" the context
+// param exists to prevent. Both are read fresh on every request rather than
+// remembered, which costs one `closest` and one `querySelector` and cannot go
+// stale.
+function state() {
+  const post = anchor.closest("[data-remote-post]")
+  const older = panel.querySelector("[data-actor-more-posts]")
+
+  return (
+    (post ? `&context=${encodeURIComponent(post.dataset.remotePost)}` : "") +
+    (older && !older.hidden ? "&expanded=1" : "")
+  )
 }
 
 // What each control on the card sends. The card is the only thing that knows
@@ -302,6 +328,24 @@ function toggleMenu(button) {
   place()
 }
 
+// The older posts, folded away under the newest one. They are already in the
+// fragment — four short strings the server had in hand — so this opens a drawer
+// rather than asking for anything, and `place()` re-runs because the card just
+// grew and may no longer fit below the word it belongs to.
+//
+// Which label the button wears is CSS's business, like the follow button's
+// three: this adds a class and writes no words.
+function togglePosts(button) {
+  const older = panel.querySelector("[data-actor-more-posts]")
+  if (!older) return
+
+  const opening = older.hidden
+  older.hidden = !opening
+  button.classList.toggle("is-open", opening)
+  button.setAttribute("aria-expanded", String(opening))
+  place()
+}
+
 // The address, for pasting into another client. Purely local: nothing here is a
 // question for the server. The confirmation is the button's own label for a
 // moment — a toast for something this small would outweigh it — and the word is
@@ -352,6 +396,12 @@ document.addEventListener("click", (e) => {
       if (copy) {
         e.preventDefault()
         return copyAddress(copy)
+      }
+
+      const posts = e.target.closest("[data-actor-posts-toggle]")
+      if (posts) {
+        e.preventDefault()
+        return togglePosts(posts)
       }
 
       const button = e.target.closest("[data-actor-act]")

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -4025,15 +4025,41 @@ defmodule Vutuv.Fediverse do
     |> then(fn {posts, rest} -> {posts, rest != []} end)
   end
 
+  # How many of an account's newest posts the mention card quotes, and how many
+  # it fetches to fill them. Here rather than in the controller because the
+  # account page's own cap is here (`@account_page_posts`), so no caller has to
+  # know either number.
+  #
+  # The buffer is for what the card drops of its own accord: the post the reader
+  # already has open (one), and then a post its author marked sensitive, one the
+  # reader's filters hide, or one with no words to quote. Measured on the dev
+  # copy of production, 6,390 cached posts: 4 carry a content warning (0.14 %)
+  # and 32 no text at all (0.5 %), so three spare beyond the context drop is
+  # generous — an earlier 12 fetched eight rows (~6 KB) nothing could read.
+  @card_quotes 4
+  @card_candidates @card_quotes + 4
+
+  @doc "How many posts the mention card quotes, for the gates that fill them."
+  def card_quotes, do: @card_quotes
+
   @doc """
   What the mention card says about an account beyond its own words: how many of
-  its posts this installation holds **for this reader**, and the newest of them,
-  as `%{count: n, latest: post_or_nil}`.
+  its posts this installation holds **for this reader**, when the newest of them
+  arrived, and its newest few, as
+  `%{count: n, last_at: datetime_or_nil, posts: [post]}`.
 
   A self-description settles nothing — every account claims to be worth reading
   — so the card that opens from a `@user@host` in a sentence carries the
   reader's actual evidence instead: how much of this account is already here,
-  and the last thing it wrote.
+  and the last few things it wrote.
+
+  `count` and `last_at` describe the **account**, `posts` is the card's raw
+  material — and the two must not be derived from one another. The card drops
+  posts of its own accord (a content warning, the reader's filters, the very
+  post they have open behind the card), so an account that wrote a minute ago
+  would otherwise read as silent the moment its newest post is one the card may
+  not quote. `@card_candidates` above is more than the card shows, for the same
+  reason.
 
   Audience-scoped through the same `visible_account_posts/2` the account page's
   list uses. That sharing is the point rather than tidiness: this number is read
@@ -4041,25 +4067,29 @@ defmodule Vutuv.Fediverse do
   is a leak that looks like a feature, and one of the two widening its audience
   without the other is exactly how that happens.
 
-  One query, not two. `count(*) OVER ()` rides along with the row the card is
-  fetching anyway, which is both simpler and measurably cheaper than a separate
-  `Repo.aggregate/2`: on a table seeded to 50,000 posts across 200 accounts the
-  pair took 112–128 µs and this takes 80–84 µs, because it scans once instead of
-  scanning and then seeking. (An earlier version of this comment claimed the
-  separate count kept an index-only plan. It never had one —
-  `(remote_account_id, published_at)` does not carry `audience`, so the audience
-  test is a heap filter either way.)
+  One query, not two. `count(*) OVER ()` rides along with the rows the card is
+  fetching anyway — a window function is computed before `LIMIT`, so the count
+  stays the account's however few rows come back — which is both simpler and
+  measurably cheaper than a separate `Repo.aggregate/2`: on a table seeded to
+  50,000 posts across 200 accounts the pair took 112–128 µs and this takes 80–84
+  µs, because it scans once instead of scanning and then seeking. (An earlier
+  version of this comment claimed the separate count kept an index-only plan. It
+  never had one — `(remote_account_id, published_at)` does not carry `audience`,
+  so the audience test is a heap filter either way.)
   """
   def account_card_summary(%RemoteAccount{} = account, party) do
     from(p in visible_account_posts(account, party),
       order_by: [desc: p.published_at, desc: p.id],
-      limit: 1,
+      limit: @card_candidates,
       select: {p, fragment("count(*) OVER ()")}
     )
-    |> Repo.one()
+    |> Repo.all()
     |> case do
-      nil -> %{count: 0, latest: nil}
-      {latest, count} -> %{count: count, latest: latest}
+      [] ->
+        %{count: 0, last_at: nil, posts: []}
+
+      [{newest, count} | _] = rows ->
+        %{count: count, last_at: newest.published_at, posts: Enum.map(rows, &elem(&1, 0))}
     end
   end
 

--- a/lib/vutuv_web/controllers/remote_actor_card_controller.ex
+++ b/lib/vutuv_web/controllers/remote_actor_card_controller.ex
@@ -45,6 +45,13 @@ defmodule VutuvWeb.RemoteActorCardController do
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.PostRewrites
+  alias VutuvWeb.PostTeaser
+
+  # How much of a quote the card ever shows: two clamped lines on the newest and
+  # one truncated line on each of the others, at 20rem. The default 200 shipped
+  # about twice this and CSS hid the rest.
+  @quote_length 120
 
   @doc """
   Who is `address`, and where do I stand with them.
@@ -159,11 +166,23 @@ defmodule VutuvWeb.RemoteActorCardController do
   # The one render. The follow is re-read from the database rather than taken
   # from whatever the act returned, so what the card draws is what is true — a
   # second tab that changed it is then not contradicted by this one.
+  #
+  # `context` and `expanded` come off `conn.params` rather than travelling
+  # through the four actions: both say what the reader has in front of them —
+  # which post is open *behind* the card, and whether they have opened its
+  # drawer — which is a fact about the request and not about the act. Every act
+  # re-renders the whole card, so anything the client does not send back is lost
+  # on the next press: a quote that appears only once Follow is pressed, or a
+  # drawer that folds itself away, is the card contradicting itself over one
+  # click.
   defp card(conn, address, account, error \\ nil) do
     viewer = conn.assigns[:current_user]
 
     summary =
-      (account && Fediverse.account_card_summary(account, viewer)) || %{count: 0, latest: nil}
+      (account && Fediverse.account_card_summary(account, viewer)) ||
+        %{count: 0, last_at: nil, posts: []}
+
+    quotes = quotes(summary.posts, account, viewer, conn.params["context"])
 
     render(conn, :card,
       address: address,
@@ -172,33 +191,74 @@ defmodule VutuvWeb.RemoteActorCardController do
       blocked_reason: Fediverse.follow_refusal(viewer),
       error: error,
       post_count: summary.count,
-      latest: preview(summary.latest, account, viewer),
+      last_at: summary.last_at,
+      # Split here rather than in the template: which quote is the headline and
+      # which are the sample is the same decision as which posts may be quoted
+      # at all, and that one is stated to be the controller's.
+      newest: List.first(quotes),
+      older: Enum.drop(quotes, 1),
+      expanded?: conn.params["expanded"] == "1",
       host_muted?: account && account.host in Fediverse.muted_hosts(viewer)
     )
   end
 
-  # Which post, if any, the card may quote. Three gates, and each one is a
-  # reader's decision this line would otherwise walk straight past.
+  # Which of the account's posts the card may quote, newest first, each with the
+  # one line it is shown as and whether it really is the account's latest.
   #
-  # A content warning is the author asking for a click before their words are
-  # read, so a preview that ignores it puts them on screen unasked —
-  # `RemotePost.warned?/1` and not a bare `sensitive` test, because the two
-  # arrive independently and a server that sets only `summary` still asked. A
-  # word the member muted is the same promise from the other side; the count
-  # line deliberately stays either way, because we do hold the post, they just
-  # do not want to read it here.
-  defp preview(nil, _account, _viewer), do: nil
+  # **The post the reader has open** is this card's own gate, and the only one
+  # that is not about permission: a card opened from the author line of a post
+  # quotes that post back at the reader as the freshest thing the account wrote,
+  # which spends its most valuable line saying what is on the screen behind it.
+  # Drop it and the next one moves up — the count and the clock stay the
+  # account's, because they are facts about the account and not about this card,
+  # and `latest?` is how the quote that moved up stops calling itself the latest.
+  #
+  # It comes first so that a card with nothing else to quote never asks the
+  # database for a filter set nobody then consults.
+  defp quotes(posts, account, viewer, context) do
+    posts
+    |> Enum.reject(&(&1.id == context))
+    |> quotable(account, viewer, List.first(posts))
+  end
 
-  defp preview(%RemotePost{} = post, account, viewer) do
-    # The author, put back where the filter looks for it: a rule scoped to an
+  defp quotable([], _account, _viewer, _newest), do: []
+
+  # The rest of the gates belong to the reader, and `PostTeaser.record_line/4`
+  # owns them — their search-and-replace rules first, then their content
+  # filters over what those left, then the one line. That order is not this
+  # module's to restate (reversed, a filter judges a line the reader was never
+  # going to see), and the card is the fourth surface over these same rows.
+  #
+  # A **content warning** stays here, because it is the author's decision rather
+  # than the reader's: it is the author asking for a click before their words
+  # are read, so a quote that ignores it puts them on screen unasked.
+  # `RemotePost.warned?/1` and not a bare `sensitive` test, because the two
+  # arrive independently and a server that sets only `summary` still asked. The
+  # count line deliberately stays whatever these drop, because we do hold the
+  # posts, the reader just may not be shown them here.
+  defp quotable(posts, account, viewer, newest) do
+    filters = ContentFilters.compile_for(viewer)
+    # One account, so one set of rules for every post on the card — the card is
+    # about that account, which is exactly what `author_rules/2` answers.
+    rewrites = PostRewrites.author_rules(viewer, account)
+
+    posts
+    # The author, put back where both passes look for it: a rule scoped to an
     # account asks `Posts.account_names/1` who wrote this, which loads the row
     # from the database when the association is not there. It is in hand — by
-    # construction this post is that account's.
-    post = %{post | remote_account: account}
+    # construction these posts are that account's.
+    |> Stream.map(fn %RemotePost{} = post -> %{post | remote_account: account} end)
+    |> Stream.reject(&RemotePost.warned?/1)
+    |> Stream.map(&quote_entry(&1, rewrites, filters, newest))
+    |> Stream.reject(&is_nil(&1.line))
+    |> Enum.take(Fediverse.card_quotes())
+  end
 
-    if RemotePost.warned?(post) or
-         ContentFilters.filtered(post, ContentFilters.compile_for(viewer)),
-       do: nil,
-       else: post
+  defp quote_entry(post, rewrites, filters, newest) do
+    %{
+      post: post,
+      line: PostTeaser.record_line(post, rewrites, filters, length: @quote_length),
+      latest?: newest != nil and post.id == newest.id
+    }
   end
 end

--- a/lib/vutuv_web/post_teaser.ex
+++ b/lib/vutuv_web/post_teaser.ex
@@ -196,6 +196,35 @@ defmodule VutuvWeb.PostTeaser do
   end
 
   @doc """
+  The same for a bare record rather than a feed entry: the one line `record`
+  is quoted as, as **this** reader would read it, or nil where they have muted
+  it or it has no words at all.
+
+  Same two passes in the same order as `quote_for/4` — the reader's
+  search-and-replace rules first, their content filters over what those left —
+  because reversed, a filter would judge a line the reader was never going to
+  see, and skipped, the quote carries the footer a mirror puts under every post
+  while every other surface deletes it. The mention card asks with the rules of
+  the one account it is about (`PostRewrites.author_rules/2`); a surface holding
+  records from several authors compiles once and passes the same map.
+
+  **nil for a wordless post**, which `line/2` answers as `""` — a photograph
+  with no caption has no line to be, and a caller that tests the line rather
+  than the post is the one that gets that right. It is a real state: 32 of the
+  6,390 cached posts on the dev copy carry no text.
+  """
+  def record_line(record, rewrites, filters, opts \\ []) do
+    record = PostRewrites.rewrite_with(record, rewrites)
+
+    with nil <- ContentFilters.filtered(record, filters),
+         line when line != "" <- plain_line(record, opts) do
+      line
+    else
+      _muted_or_wordless -> nil
+    end
+  end
+
+  @doc """
   The record a feed entry is about: a remote reply, a cached remote post, or the
   vutuv post itself.
 

--- a/lib/vutuv_web/templates/remote_actor_card/card.html.heex
+++ b/lib/vutuv_web/templates/remote_actor_card/card.html.heex
@@ -89,14 +89,18 @@ renders the same element. --%>
 
       `%{formatted}` and not `%{count}`: `ngettext/3` binds `%{count}` to the
       raw integer and a `count:` binding does not override it, so a formatted
-      number needs a placeholder of its own. --%>
+      number needs a placeholder of its own.
+
+      `@last_at` and not the newest quote's stamp: the clock is a fact about the
+      account, and the gates below drop quotes for reasons that have nothing to
+      do with when the account last wrote. An account that posted a minute ago
+      behind a content warning must not read as silent. It needs no `:if` of its
+      own — `published_at` is NOT NULL, so a count above zero is a stamp. --%>
       <p :if={@post_count > 0} class="actor-card__stats">
         {ngettext("%{formatted} post here", "%{formatted} posts here", @post_count,
           formatted: compact_count(@post_count)
         )}
-        <span :if={@latest}>
-          · {relative_time(@latest.published_at)}
-        </span>
+        · {relative_time(@last_at)}
       </p>
     </div>
   </div>
@@ -112,26 +116,83 @@ renders the same element. --%>
     {@account.summary}
   </p>
 
-  <%!-- The last thing they wrote, which is what actually answers "is this worth
-  following". Gated in the controller: a post its author marked sensitive and a
-  post the reader's own filters hide are both left out, and the count line above
-  stays either way. --%>
-  <%!-- `PostTeaser.plain_line/2` and not the raw body: it is the app's one owner
-  of a post in one line, so this quote skips what every other teaser skips (a
-  bare `RE: <url>` quote line, a hashtags-only post), shortens our own handles
-  and arrives already cut to length instead of shipping 10,000 characters for
-  CSS to hide. It answers nil for a post with no words at all — a photo without
-  a caption — which is why the box is gated on the line and not on the post. --%>
-  <% line = @latest && VutuvWeb.PostTeaser.plain_line(@latest) %>
-  <.link
-    :if={line}
-    href={remote_post_permalink(@latest, @current_user)}
-    data-actor-card-latest
-    class="actor-card__latest"
-  >
-    <span class="actor-card__latest-label">{gettext("Latest here")}</span>
-    <span class="actor-card__latest-text line-clamp-2">{line}</span>
-  </.link>
+  <%!-- The last few things they wrote, which is what actually answers "is this
+  worth following" — one post is a poor sample of an account, and the reader is
+  standing in front of a Follow button. The newest is quoted in two lines and
+  the rest wait behind an expander, so the card stays the size of a card until
+  somebody asks for more.
+
+  Which posts these are, and which of them is the headline, is the controller's
+  decision and not this template's: it drops the one the reader has open behind
+  the card, the ones their author marked sensitive and the ones the reader's own
+  filters hide, and hands over each survivor with the single line it is shown
+  as. The count line above stays whatever it drops.
+
+  **"Latest here" is a claim, so it is `latest?` and not the top of the list.**
+  Drop the account's newest post because the reader is looking at it, and the
+  one that moves up is not the latest — the stats line above still dates the one
+  that went. It then says when it was written, like every row below it. --%>
+  <div :if={@newest} class="actor-card__posts">
+    <.link
+      href={remote_post_permalink(@newest.post, @current_user)}
+      data-actor-card-latest
+      class="actor-card__latest"
+    >
+      <span class="actor-card__latest-label">
+        {if @newest.latest?,
+          do: gettext("Latest here"),
+          else: relative_time(@newest.post.published_at)}
+      </span>
+      <span class="actor-card__latest-text line-clamp-2">{@newest.line}</span>
+    </.link>
+
+    <%!-- The rest, rendered but folded away: they are three short strings the
+    card already has in hand, so a second request to read them would cost a
+    round trip to save nothing. `hidden` rather than a class, so a card whose
+    JavaScript never arrives still shows the newest and no dead control — and
+    `@expanded?`, so the drawer the reader opened is still open on the card that
+    comes back from pressing Follow. --%>
+    <div
+      :if={@older != []}
+      class="actor-card__older"
+      data-actor-more-posts
+      hidden={not @expanded?}
+    >
+      <%!-- One line each, with the age at the end rather than on a line of its
+      own: three stacked labels reading "2 days ago" under one another is the
+      shape of a list that says nothing, and it made the drawer twice the height
+      of the card it opens under. The newest post above keeps the two-line quote
+      — it is the headline, these are the sample. --%>
+      <.link
+        :for={entry <- @older}
+        href={remote_post_permalink(entry.post, @current_user)}
+        class="actor-card__older-row"
+      >
+        <span class="actor-card__older-text">{entry.line}</span>
+        <span class="actor-card__older-when">{relative_time(entry.post.published_at)}</span>
+      </.link>
+    </div>
+
+    <%!-- Two labels and one chevron, and CSS decides which label shows — the
+    same arrangement the follow button below uses, in the same `data-actor-`
+    namespace, and for the same reason: `mention_card.js` writes no sentences,
+    it adds a class. --%>
+    <button
+      :if={@older != []}
+      type="button"
+      data-actor-posts-toggle
+      aria-expanded={to_string(@expanded?)}
+      class={["actor-card__posts-toggle", @expanded? && "is-open"]}
+    >
+      <span data-actor-posts-closed>
+        {ngettext("%{formatted} older post", "%{formatted} older posts", length(@older),
+          formatted: compact_count(length(@older))
+        )}
+      </span>
+      <span data-actor-posts-open>{gettext("Show less")}</span>
+      <span class="actor-card__posts-chevron" aria-hidden="true">⌄</span>
+    </button>
+  </div>
 
   <%!-- Why nothing can be followed from here, in the vocabulary every other
   follow surface speaks: the standing refusal (this member has no Fediverse
@@ -230,29 +291,37 @@ renders the same element. --%>
     </button>
   </div>
 
-  <%!-- Both ways onward in one weight and one colour. They were blue and grey
-  before, which reads as a main way and a lesser one; they are neither. In the
-  sheet the same two become full-width list rows, where a thumb can hit them. --%>
+  <%!-- Both ways onward, as two rows of one weight and one colour. They were
+  blue and grey before, which reads as a main way and a lesser one; they are
+  neither. Rows on every screen, not only in the sheet: two links sharing a line
+  is a shape a 20rem card has no room for, and the one that leaves this site
+  carries an address that wrapped it onto a third line. --%>
   <div class="actor-card__links">
     <%!-- The page here first: it is the one that holds this account's cached
     posts, the mute switch and the whole self-description. --%>
     <.link :if={@account} href={~p"/system/fediverse/account/#{@account}"}>
-      {gettext("Their account page here")}
+      <span>{gettext("Their page here")}</span>
       <span class="actor-card__go" aria-hidden="true">›</span>
     </.link>
-    <%!-- And out to their server, named. "View the original" said only that
-    there was one; a reader about to leave this site for somebody else's reads
-    the address first, the way they would read a browser's status bar. It is not
-    guessable from the card either — an actor URI need not be spelled like the
-    `@user@host` above it (`/users/them`, `/u/them`, `/profile/them`). The name
-    is only a label: the `href` stays the whole URL.
+    <%!-- And out to their server, named — but named on a line of its own,
+    below the label and in the muted weight of a browser's status bar. Reading
+    the destination before leaving is what the address is for, and it was doing
+    that job in bold brand blue at the same size as the label, where its three
+    wrapped lines were the loudest thing on the card. It is not guessable from
+    the card either — an actor URI need not be spelled like the `@user@host`
+    above it (`/users/them`, `/u/them`, `/profile/them`) — so it stays; the
+    `href` is the whole URL either way, and CSS cuts what does not fit rather
+    than a character count guessing at the width.
 
     `:if={origin}` rather than a second wording for a card with no address at
     all: this used to render the sentence on an anchor carrying no `href`, which
     is a way out that goes nowhere. There is nothing to link to in that state —
     the account page above is gated on the same missing row. --%>
     <a :if={origin} href={origin} target="_blank" rel="nofollow noopener noreferrer">
-      {gettext("View the original on %{url}", url: origin_address(origin))}
+      <span class="actor-card__out">
+        <span>{gettext("View the original")}</span>
+        <span class="actor-card__link-address">{origin_address(origin)}</span>
+      </span>
       <span class="actor-card__go" aria-hidden="true">↗</span>
     </a>
   </div>

--- a/lib/vutuv_web/views/remote_actor_card_html.ex
+++ b/lib/vutuv_web/views/remote_actor_card_html.ex
@@ -10,7 +10,6 @@ defmodule VutuvWeb.RemoteActorCardHTML do
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemoteFollow
   alias Vutuv.RemoteHtml
-  alias Vutuv.SocialFeed.Post
 
   embed_templates("../templates/remote_actor_card/*")
 
@@ -64,41 +63,18 @@ defmodule VutuvWeb.RemoteActorCardHTML do
     end
   end
 
-  # How much of the address the way out may carry. Measured in the browser on
-  # the 20rem popover, where the whole sentence wraps to two lines at any real
-  # length and to three past ~45 characters: 40 is what leaves the account name
-  # whole for every ordinary actor URI while keeping the two lines. It was 32
-  # for one afternoon, which is one character short of
-  # `social.heise.de/users/heiseonline` and cut the account's name two letters
-  # from its end — the worst place for the cut to land, since the name is what
-  # the reader is checking. The number lives here and not beside the other
-  # display-URL caps because it is a measurement of *this* card.
-  @origin_address_max 40
-
   @doc """
-  The destination, written the way a reader checks a link before following it:
-  the address as a server shows it, cut at the end when it is longer than the
-  card is wide.
+  The destination, written the way a reader checks a link before following it —
+  scheme, `www.` and trailing slash dropped, and nothing cut, because the card
+  gives it a line of its own and CSS ends it where the card ends.
 
-  Worth spelling out because the destination is **not** guessable from the card:
-  an actor URI need not be spelled like the `@user@host` above it
-  (`/users/them`, `/u/them`, `/profile/them` are all in use), and this is the one
-  control that takes the reader off this site.
-
-  Both halves are borrowed. `Vutuv.RemoteHtml.display_form/1` drops the scheme,
-  the `www.` and a trailing slash — and drops the scheme case-insensitively,
-  which matters here because the input is a *remote* server's actor URI and one
-  writing `HTTPS://` would otherwise spend eight of these characters saying that
-  a link is a link. `Vutuv.SocialFeed.Post.truncate/2` does the cut; its
-  word-boundary half never fires on a URL, which has no whitespace to find, so
-  what is left is the blunt cut this wants.
-
-  Only ever cut, never elided in the middle: the host leads the string and is
-  the fact this is carrying, so the part naming which server can never be the
-  part that goes.
+  A pass-through to `Vutuv.RemoteHtml.display_form/1` since the 40-character cap
+  went, and kept for its name: this is the one control that takes a reader off
+  the site, and the next thing anybody wants to do to that address (grey out the
+  path, say) belongs here rather than in the template. Why the address is on the
+  card at all is in the template comment beside it.
   """
-  def origin_address(url) when is_binary(url),
-    do: url |> RemoteHtml.display_form() |> Post.truncate(@origin_address_max)
+  def origin_address(url) when is_binary(url), do: RemoteHtml.display_form(url)
 
   @doc """
   The colours the one state-carrying follow button wears, as a modifier rather

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -38,7 +38,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1485
+#: lib/vutuv_web/templates/user/show.html.heex:1501
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -104,7 +104,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/agent_docs/markdown.ex:615
 #: lib/vutuv_web/agent_docs/text.ex:578
 #: lib/vutuv_web/agent_docs/text.ex:579
-#: lib/vutuv_web/templates/user/show.html.heex:1116
+#: lib/vutuv_web/templates/user/show.html.heex:1132
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Geburtstag"
@@ -118,7 +118,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/live/job_posting_live/form.ex:857
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
-#: lib/vutuv_web/live/post_live/composer.ex:1901
+#: lib/vutuv_web/live/post_live/composer.ex:1917
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -154,7 +154,7 @@ msgstr "Wählen Sie einen Typ aus"
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1154
+#: lib/vutuv_web/templates/user/show.html.heex:1170
 #, elixir-autogen
 msgid "Contact"
 msgstr "Kontakt"
@@ -163,7 +163,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:3706
+#: lib/vutuv_web/components/post_components.ex:3678
 #: lib/vutuv_web/components/ui.ex:4593
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -204,14 +204,14 @@ msgid "Disable"
 msgstr "Inaktivieren"
 
 #: lib/vutuv_web/live/cv_live.ex:446
-#: lib/vutuv_web/live/post_live/composer.ex:2946
+#: lib/vutuv_web/live/post_live/composer.ex:2962
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:3671
+#: lib/vutuv_web/components/post_components.ex:3643
 #: lib/vutuv_web/components/ui.ex:4584
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
@@ -225,7 +225,7 @@ msgstr "Download"
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1139
+#: lib/vutuv_web/templates/user/show.html.heex:1155
 #, elixir-autogen
 msgid "Edit"
 msgstr "Ändern"
@@ -290,7 +290,7 @@ msgstr "E-Mail-Adresse eingeben"
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:643
+#: lib/vutuv_web/templates/user/show.html.heex:656
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -333,8 +333,8 @@ msgstr "Follower"
 #: lib/vutuv_web/live/organization_live/show.ex:611
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:987
-#: lib/vutuv_web/views/user_html.ex:617
+#: lib/vutuv_web/templates/user/show.html.heex:1000
+#: lib/vutuv_web/views/user_html.ex:622
 #, elixir-autogen
 msgid "Following"
 msgstr "Folge ich"
@@ -439,8 +439,8 @@ msgstr "Einloggen"
 msgid "Log Out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/live/shell_live.ex:1527
-#: lib/vutuv_web/live/shell_live.ex:1603
+#: lib/vutuv_web/live/shell_live.ex:1561
+#: lib/vutuv_web/live/shell_live.ex:1637
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -454,8 +454,8 @@ msgid "Middle Name"
 msgstr "Zweiter Vorname"
 
 #: lib/vutuv_web/live/notification_live/index.ex:1351
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:193
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:201
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:234
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:242
 #, elixir-autogen
 msgid "More"
 msgstr "Mehr"
@@ -602,7 +602,7 @@ msgstr "Profile von "
 msgid "Provider"
 msgstr "Provider"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2170
+#: lib/vutuv_web/live/post_live/composer.ex:2186
 #: lib/vutuv_web/live/section_reorder_live.ex:270
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -614,7 +614,7 @@ msgstr "Öffentlich"
 
 #: lib/vutuv_web/components/ui.ex:4485
 #: lib/vutuv_web/live/organization_live/edit.ex:376
-#: lib/vutuv_web/live/post_live/composer.ex:2185
+#: lib/vutuv_web/live/post_live/composer.ex:2201
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -645,8 +645,8 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
-#: lib/vutuv_web/live/shell_live.ex:1396
-#: lib/vutuv_web/live/shell_live.ex:1583
+#: lib/vutuv_web/live/shell_live.ex:1430
+#: lib/vutuv_web/live/shell_live.ex:1617
 #: lib/vutuv_web/live/tag_live/timeline.ex:319
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
@@ -656,7 +656,7 @@ msgstr "Speichern"
 msgid "Search"
 msgstr "Suche"
 
-#: lib/vutuv_web/components/post_components.ex:1759
+#: lib/vutuv_web/components/post_components.ex:1731
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -690,13 +690,13 @@ msgstr "Slug"
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1268
+#: lib/vutuv_web/templates/user/show.html.heex:1284
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1270
+#: lib/vutuv_web/templates/user/show.html.heex:1286
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr "Profil hinzufügen"
@@ -721,12 +721,12 @@ msgstr "Profil wurde geändert."
 msgid "Profile deleted successfully."
 msgstr "Profil wurde gelöscht."
 
-#: lib/vutuv_web/views/user_html.ex:1025
+#: lib/vutuv_web/views/user_html.ex:1030
 #, elixir-autogen, elixir-format
 msgid "Social networks"
 msgstr "Soziale Netzwerke"
 
-#: lib/vutuv_web/views/user_html.ex:1032
+#: lib/vutuv_web/views/user_html.ex:1037
 #, elixir-autogen, elixir-format
 msgid "Code & repositories"
 msgstr "Code & Repositorys"
@@ -735,7 +735,7 @@ msgstr "Code & Repositorys"
 #: lib/vutuv_web/controllers/follow_controller.ex:24
 #: lib/vutuv_web/controllers/remote_follow_controller.ex:174
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
-#: lib/vutuv_web/live/user_profile_live.ex:160
+#: lib/vutuv_web/live/user_profile_live.ex:177
 #, elixir-autogen
 msgid "Something went wrong"
 msgstr "Etwas ist schiefgelaufen"
@@ -842,16 +842,16 @@ msgid "Users"
 msgstr "Benutzer"
 
 #: lib/vutuv_web/components/ui.ex:1485
-#: lib/vutuv_web/views/user_html.ex:562
-#: lib/vutuv_web/views/user_html.ex:563
-#: lib/vutuv_web/views/user_html.ex:577
+#: lib/vutuv_web/views/user_html.ex:567
+#: lib/vutuv_web/views/user_html.ex:568
+#: lib/vutuv_web/views/user_html.ex:582
 #, elixir-autogen
 msgid "vCard"
 msgstr "vCard"
 
 #: lib/vutuv_web/components/ui.ex:4654
-#: lib/vutuv_web/templates/user/show.html.heex:981
-#: lib/vutuv_web/templates/user/show.html.heex:1004
+#: lib/vutuv_web/templates/user/show.html.heex:994
+#: lib/vutuv_web/templates/user/show.html.heex:1017
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
@@ -932,7 +932,7 @@ msgid "You follow back %{name}."
 msgstr "Sie folgen %{name} jetzt zurück."
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:190
+#: lib/vutuv_web/live/post_live/feed.ex:191
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1058,7 +1058,7 @@ msgstr "Diese Seite ist für Sie gesperrt."
 msgid "An error occurred"
 msgstr "Es gab einen Fehler."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1105
+#: lib/vutuv_web/templates/user/show.html.heex:1121
 #, elixir-autogen
 msgid "General Info"
 msgstr "Allgemeines"
@@ -1159,7 +1159,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:63
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1503
+#: lib/vutuv_web/live/shell_live.ex:1537
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1200,10 +1200,10 @@ msgstr "Alle Tag-Synonyme"
 msgid "All tag urls"
 msgstr "Alle Tag-URLs"
 
-#: lib/vutuv_web/components/post_components.ex:4261
+#: lib/vutuv_web/components/post_components.ex:4233
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:637
+#: lib/vutuv_web/templates/user/show.html.heex:650
 #, elixir-autogen
 msgid "All tags"
 msgstr "Alle Tags"
@@ -1402,7 +1402,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:28
 #: lib/vutuv_web/templates/tag/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:607
+#: lib/vutuv_web/templates/user/show.html.heex:620
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1602,7 +1602,7 @@ msgstr "Adressen von %{name}"
 msgid "Admin control panel"
 msgstr "Admin-Bereich"
 
-#: lib/vutuv_web/live/shell_live.ex:1601
+#: lib/vutuv_web/live/shell_live.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Mitteilungen"
@@ -1627,11 +1627,11 @@ msgstr "Schauen Sie in Ihr Postfach"
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:477
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1757
-#: lib/vutuv_web/live/post_live/composer.ex:1859
-#: lib/vutuv_web/live/post_live/composer.ex:1860
-#: lib/vutuv_web/live/post_live/composer.ex:2823
-#: lib/vutuv_web/live/post_live/composer.ex:3089
+#: lib/vutuv_web/live/post_live/composer.ex:1773
+#: lib/vutuv_web/live/post_live/composer.ex:1875
+#: lib/vutuv_web/live/post_live/composer.ex:1876
+#: lib/vutuv_web/live/post_live/composer.ex:2839
+#: lib/vutuv_web/live/post_live/composer.ex:3105
 #: lib/vutuv_web/templates/layout/app.html.heex:188
 #: lib/vutuv_web/templates/layout/app.html.heex:194
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
@@ -1701,10 +1701,10 @@ msgstr "Empfehlen"
 #: lib/vutuv_web/live/organization_live/following.ex:421
 #: lib/vutuv_web/live/organization_live/show.ex:572
 #: lib/vutuv_web/live/organization_live/show.ex:609
-#: lib/vutuv_web/live/post_live/feed.ex:942
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:180
-#: lib/vutuv_web/templates/user/show.html.heex:1309
-#: lib/vutuv_web/views/user_html.ex:628
+#: lib/vutuv_web/live/post_live/feed.ex:943
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:221
+#: lib/vutuv_web/templates/user/show.html.heex:1325
+#: lib/vutuv_web/views/user_html.ex:633
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr "Folgen"
@@ -1722,7 +1722,7 @@ msgstr ""
 " von jemandem, den Sie kennen oder interessant finden, und klicken Sie auf "
 "Folgen!"
 
-#: lib/vutuv_web/live/shell_live.ex:1522
+#: lib/vutuv_web/live/shell_live.ex:1556
 #: lib/vutuv_web/views/settings_html.ex:299
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1744,9 +1744,9 @@ msgid "Member"
 msgstr "Mitglied"
 
 #: lib/vutuv_web/live/organization_live/show.ex:631
-#: lib/vutuv_web/views/user_html.ex:655
-#: lib/vutuv_web/views/user_html.ex:656
-#: lib/vutuv_web/views/user_html.ex:666
+#: lib/vutuv_web/views/user_html.ex:660
+#: lib/vutuv_web/views/user_html.ex:661
+#: lib/vutuv_web/views/user_html.ex:671
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr "Nachricht"
@@ -1754,8 +1754,8 @@ msgstr "Nachricht"
 #: lib/vutuv_web/controllers/page_controller.ex:218
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1414
-#: lib/vutuv_web/live/shell_live.ex:1600
+#: lib/vutuv_web/live/shell_live.ex:1448
+#: lib/vutuv_web/live/shell_live.ex:1634
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1787,7 +1787,7 @@ msgstr "Noch nichts Neues."
 #: lib/vutuv_web/controllers/page_controller.ex:219
 #: lib/vutuv_web/live/notification_live/index.ex:152
 #: lib/vutuv_web/live/notification_live/index.ex:457
-#: lib/vutuv_web/live/shell_live.ex:1426
+#: lib/vutuv_web/live/shell_live.ex:1460
 #: lib/vutuv_web/templates/layout/app.html.heex:153
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -1861,7 +1861,7 @@ msgstr "Zu viele Versuche. Bitte versuchen Sie es später erneut."
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
 #: lib/vutuv_web/templates/user/show.html.heex:217
-#: lib/vutuv_web/views/user_html.ex:1077
+#: lib/vutuv_web/views/user_html.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
 msgstr "Verifiziertes Profil"
@@ -1887,7 +1887,7 @@ msgstr ""
 "Wir haben eine PIN an Ihre neue E-Mail-Adresse geschickt. Geben Sie sie "
 "unten ein, um die Adresse zu bestätigen."
 
-#: lib/vutuv_web/views/user_html.ex:230
+#: lib/vutuv_web/views/user_html.ex:235
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr "Vorgeschlagene Profile"
@@ -1906,14 +1906,14 @@ msgstr "Ihre Anmeldung ist abgelaufen. Bitte versuchen Sie es erneut."
 
 #: lib/vutuv_web/open_graph.ex:344
 #: lib/vutuv_web/templates/tag/show.html.heex:32
-#: lib/vutuv_web/views/user_html.ex:499
+#: lib/vutuv_web/views/user_html.ex:504
 #, elixir-autogen, elixir-format
 msgid "follower"
 msgid_plural "followers"
 msgstr[0] "Follower"
 msgstr[1] "Follower"
 
-#: lib/vutuv_web/views/user_html.ex:503
+#: lib/vutuv_web/views/user_html.ex:508
 #, elixir-autogen, elixir-format
 msgid "following"
 msgstr "folgt"
@@ -2070,12 +2070,12 @@ msgstr "März"
 msgid "May"
 msgstr "Mai"
 
-#: lib/vutuv_web/views/user_html.ex:282
+#: lib/vutuv_web/views/user_html.ex:287
 #, elixir-autogen, elixir-format
 msgid "Member since %{month} %{year}"
 msgstr "Mitglied seit %{month} %{year}"
 
-#: lib/vutuv_web/views/user_html.ex:287
+#: lib/vutuv_web/views/user_html.ex:292
 #, elixir-autogen, elixir-format
 msgid "Member since %{year}"
 msgstr "Mitglied seit %{year}"
@@ -2107,7 +2107,7 @@ msgstr "Markdown wird unterstützt: Fett, Kursiv, Links und Listen."
 msgid "Add images"
 msgstr "Bilder hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2299
+#: lib/vutuv_web/live/post_live/composer.ex:2315
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und Suchmaschinen den Beitrag nicht mehr."
@@ -2118,8 +2118,8 @@ msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und
 msgid "Back to the post"
 msgstr "Zurück zum Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1999
-#: lib/vutuv_web/live/post_live/composer.ex:2022
+#: lib/vutuv_web/live/post_live/composer.ex:2015
+#: lib/vutuv_web/live/post_live/composer.ex:2038
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Upload abbrechen"
@@ -2129,7 +2129,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:3703
+#: lib/vutuv_web/components/post_components.ex:3675
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2144,11 +2144,11 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/components/organization_components.ex:265
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:162
-#: lib/vutuv_web/live/post_live/feed.ex:341
-#: lib/vutuv_web/live/post_live/feed.ex:3157
+#: lib/vutuv_web/live/post_live/feed.ex:345
+#: lib/vutuv_web/live/post_live/feed.ex:3088
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1254
-#: lib/vutuv_web/live/shell_live.ex:1573
+#: lib/vutuv_web/live/shell_live.ex:1282
+#: lib/vutuv_web/live/shell_live.ex:1607
 #: lib/vutuv_web/templates/layout/app.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2164,57 +2164,57 @@ msgstr "Folgen Sie %{name}, um ihn zu lesen."
 msgid "Hidden from:"
 msgstr "Verborgen vor:"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2275
+#: lib/vutuv_web/live/post_live/composer.ex:2291
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr "Vor einer bestimmten Person verbergen…"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2203
+#: lib/vutuv_web/live/post_live/composer.ex:2219
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:3657
-#: lib/vutuv_web/components/post_components.ex:3659
+#: lib/vutuv_web/components/post_components.ex:3629
+#: lib/vutuv_web/components/post_components.ex:3631
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2245
+#: lib/vutuv_web/live/post_live/composer.ex:2261
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr "Nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1443
-#: lib/vutuv_web/live/post_live/composer.ex:1546
+#: lib/vutuv_web/live/post_live/composer.ex:1459
+#: lib/vutuv_web/live/post_live/composer.ex:1562
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3473
+#: lib/vutuv_web/live/post_live/feed.ex:3408
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 "Hier ist noch nichts. Folgen Sie anderen, um Ihren Feed zu füllen, oder "
 "schreiben Sie Ihren ersten Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1406
+#: lib/vutuv_web/live/post_live/composer.ex:1422
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr "Eines der Bilder konnte nicht angehängt werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2235
+#: lib/vutuv_web/live/post_live/composer.ex:2251
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr "Personen, denen ich nicht folge"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2225
+#: lib/vutuv_web/live/post_live/composer.ex:2241
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr "Personen, die mir nicht folgen"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:416
-#: lib/vutuv_web/live/post_live/composer.ex:2187
+#: lib/vutuv_web/live/post_live/composer.ex:2203
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2242,28 +2242,29 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:4134
-#: lib/vutuv_web/components/post_components.ex:4138
+#: lib/vutuv_web/components/post_components.ex:4106
+#: lib/vutuv_web/components/post_components.ex:4110
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:4135
+#: lib/vutuv_web/components/post_components.ex:4107
 #: lib/vutuv_web/live/fediverse_account_live.ex:360
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr "Weniger anzeigen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:497
 #: lib/vutuv_web/components/job_exclusion_components.ex:189
-#: lib/vutuv_web/components/post_components.ex:1368
+#: lib/vutuv_web/components/post_components.ex:1340
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:229
 #: lib/vutuv_web/live/organization_live/domains.ex:265
 #: lib/vutuv_web/live/organization_live/edit.ex:404
 #: lib/vutuv_web/live/organization_live/roles.ex:257
-#: lib/vutuv_web/live/post_live/composer.ex:2261
+#: lib/vutuv_web/live/post_live/composer.ex:2277
 #: lib/vutuv_web/live/post_live/filter_band.ex:456
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
@@ -2281,12 +2282,12 @@ msgstr ""
 "Eingeschränkte Beiträge sind auch für nicht eingeloggte Besucher und "
 "Suchmaschinen unsichtbar."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2177
+#: lib/vutuv_web/live/post_live/composer.ex:2193
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2364
+#: lib/vutuv_web/live/post_live/feed.ex:2332
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2298,13 +2299,13 @@ msgstr[1] "%{formatted} neue Beiträge anzeigen"
 msgid "Sorry, that page could not be found."
 msgstr "Diese Seite konnte leider nicht gefunden werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1504
-#: lib/vutuv_web/live/post_live/composer.ex:1572
+#: lib/vutuv_web/live/post_live/composer.ex:1520
+#: lib/vutuv_web/live/post_live/composer.ex:1588
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Diese Datei konnte nicht verarbeitet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1388
+#: lib/vutuv_web/live/post_live/composer.ex:1404
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr "Die Sichtbarkeitsauswahl ist ungültig."
@@ -2314,18 +2315,18 @@ msgstr "Die Sichtbarkeitsauswahl ist ungültig."
 msgid "This post is for followers of %{name}"
 msgstr "Dieser Beitrag ist für Follower von %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3250
+#: lib/vutuv_web/live/post_live/composer.ex:3266
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3251
+#: lib/vutuv_web/live/post_live/composer.ex:3267
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
 #: lib/vutuv_web/components/ui.ex:5363
-#: lib/vutuv_web/live/shell_live.ex:1469
+#: lib/vutuv_web/live/shell_live.ex:1503
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:246
@@ -2333,37 +2334,37 @@ msgstr "Upload fehlgeschlagen."
 msgid "View profile"
 msgstr "Profil ansehen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2393
+#: lib/vutuv_web/live/post_live/composer.ex:2409
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr "Was gibt's Neues?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2394
+#: lib/vutuv_web/live/post_live/composer.ex:2410
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:3654
+#: lib/vutuv_web/components/post_components.ex:3626
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:5694
+#: lib/vutuv_web/components/post_components.ex:5666
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:5698
+#: lib/vutuv_web/components/post_components.ex:5670
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:5696
+#: lib/vutuv_web/components/post_components.ex:5668
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:5697
+#: lib/vutuv_web/components/post_components.ex:5669
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2374,20 +2375,20 @@ msgstr "Personen, denen Sie nicht folgen"
 msgid "unknown"
 msgstr "unbekannt"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2060
+#: lib/vutuv_web/live/post_live/composer.ex:2076
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr "Tags, durch Komma getrennt (max. %{max})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1501
-#: lib/vutuv_web/live/post_live/composer.ex:3231
-#: lib/vutuv_web/live/post_live/composer.ex:3235
+#: lib/vutuv_web/live/post_live/composer.ex:1517
+#: lib/vutuv_web/live/post_live/composer.ex:3247
+#: lib/vutuv_web/live/post_live/composer.ex:3251
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr "Die Datei ist größer als %{mb} MB."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3239
-#: lib/vutuv_web/live/post_live/composer.ex:3245
+#: lib/vutuv_web/live/post_live/composer.ex:3255
+#: lib/vutuv_web/live/post_live/composer.ex:3261
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
@@ -2397,7 +2398,7 @@ msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
 msgid "Posts by %{name}"
 msgstr "Beiträge von %{name}"
 
-#: lib/vutuv_web/templates/user/show.html.heex:597
+#: lib/vutuv_web/templates/user/show.html.heex:610
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr "Alle %{count} Beiträge ansehen"
@@ -2407,10 +2408,10 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:2040
-#: lib/vutuv_web/components/post_components.ex:5790
+#: lib/vutuv_web/components/post_components.ex:2012
+#: lib/vutuv_web/components/post_components.ex:5762
 #: lib/vutuv_web/components/ui.ex:4053
-#: lib/vutuv_web/views/user_html.ex:461
+#: lib/vutuv_web/views/user_html.ex:466
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
@@ -2418,28 +2419,28 @@ msgstr "Lesezeichen setzen"
 #: lib/vutuv_web/agent_docs/markdown.ex:1186
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:1406
-#: lib/vutuv_web/live/shell_live.ex:1474
+#: lib/vutuv_web/live/shell_live.ex:1440
+#: lib/vutuv_web/live/shell_live.ex:1508
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:1993
-#: lib/vutuv_web/components/post_components.ex:6028
+#: lib/vutuv_web/components/post_components.ex:1965
+#: lib/vutuv_web/components/post_components.ex:6000
 #: lib/vutuv_web/components/ui.ex:4039
 #: lib/vutuv_web/live/notification_live/index.ex:1512
-#: lib/vutuv_web/views/user_html.ex:471
+#: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1185
-#: lib/vutuv_web/components/post_components.ex:6038
+#: lib/vutuv_web/components/post_components.ex:6010
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:1477
+#: lib/vutuv_web/live/shell_live.ex:1511
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2457,58 +2458,58 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:5778
+#: lib/vutuv_web/components/post_components.ex:5750
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:2039
-#: lib/vutuv_web/components/post_components.ex:5789
+#: lib/vutuv_web/components/post_components.ex:2011
+#: lib/vutuv_web/components/post_components.ex:5761
 #: lib/vutuv_web/live/post_live/saved.ex:806
-#: lib/vutuv_web/views/user_html.ex:461
+#: lib/vutuv_web/views/user_html.ex:466
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:2021
-#: lib/vutuv_web/components/post_components.ex:5775
+#: lib/vutuv_web/components/post_components.ex:1993
+#: lib/vutuv_web/components/post_components.ex:5747
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:2299
-#: lib/vutuv_web/components/post_components.ex:4865
+#: lib/vutuv_web/components/post_components.ex:2271
+#: lib/vutuv_web/components/post_components.ex:4837
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:2020
-#: lib/vutuv_web/components/post_components.ex:5774
+#: lib/vutuv_web/components/post_components.ex:1992
+#: lib/vutuv_web/components/post_components.ex:5746
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:1992
-#: lib/vutuv_web/components/post_components.ex:6027
+#: lib/vutuv_web/components/post_components.ex:1964
+#: lib/vutuv_web/components/post_components.ex:5999
 #: lib/vutuv_web/live/post_live/saved.ex:805
-#: lib/vutuv_web/views/user_html.ex:471
+#: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr "Gefällt mir entfernen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:498
-#: lib/vutuv_web/components/post_components.ex:2734
+#: lib/vutuv_web/components/post_components.ex:2706
 #: lib/vutuv_web/components/ui.ex:2924
 #: lib/vutuv_web/components/ui.ex:2924
 #: lib/vutuv_web/components/ui.ex:3000
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
 #: lib/vutuv_web/live/organization_live/show.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:929
+#: lib/vutuv_web/live/post_live/feed.ex:930
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
-#: lib/vutuv_web/views/user_html.ex:618
+#: lib/vutuv_web/views/user_html.ex:623
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr "Entfolgen"
@@ -2518,7 +2519,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:6082
+#: lib/vutuv_web/components/post_components.ex:6054
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2529,9 +2530,9 @@ msgstr "Nur öffentliche Beiträge können beantwortet werden."
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2006
-#: lib/vutuv_web/components/post_components.ex:6065
-#: lib/vutuv_web/components/post_components.ex:6066
+#: lib/vutuv_web/components/post_components.ex:1978
+#: lib/vutuv_web/components/post_components.ex:6037
+#: lib/vutuv_web/components/post_components.ex:6038
 #: lib/vutuv_web/live/notification_live/index.ex:1010
 #: lib/vutuv_web/live/notification_live/index.ex:1509
 #: lib/vutuv_web/live/post_live/reply.ex:49
@@ -2539,18 +2540,18 @@ msgstr "Antworten"
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:3621
+#: lib/vutuv_web/components/post_components.ex:3593
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1391
-#: lib/vutuv_web/live/post_live/composer.ex:2165
+#: lib/vutuv_web/live/post_live/composer.ex:1407
+#: lib/vutuv_web/live/post_live/composer.ex:2181
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr "Solange es geteilte Beiträge oder Antworten gibt, lässt sich der Empfängerkreis nicht einschränken."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2306
+#: lib/vutuv_web/live/post_live/composer.ex:2322
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beiträge oder Antworten gibt, bleibt er öffentlich; löschen können Sie ihn weiterhin."
@@ -2560,7 +2561,7 @@ msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beitr
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/components/post_components.ex:3155
+#: lib/vutuv_web/components/post_components.ex:3127
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2568,14 +2569,14 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:3593
+#: lib/vutuv_web/components/post_components.ex:3565
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:3584
-#: lib/vutuv_web/components/post_components.ex:3613
-#: lib/vutuv_web/components/post_components.ex:3616
+#: lib/vutuv_web/components/post_components.ex:3556
+#: lib/vutuv_web/components/post_components.ex:3585
+#: lib/vutuv_web/components/post_components.ex:3588
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2743,38 +2744,38 @@ msgstr "Andere E-Mail-Adresse verwenden"
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:917
+#: lib/vutuv_web/templates/user/show.html.heex:930
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr "Link hinzufügen"
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1228
+#: lib/vutuv_web/templates/user/show.html.heex:1244
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Telefonnummer hinzufügen"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1487
+#: lib/vutuv_web/templates/user/show.html.heex:1503
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Adresse hinzufügen"
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1156
+#: lib/vutuv_web/templates/user/show.html.heex:1172
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "E-Mail-Adresse hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1107
+#: lib/vutuv_web/templates/user/show.html.heex:1123
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Persönliche Angaben hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:646
+#: lib/vutuv_web/templates/user/show.html.heex:659
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2795,14 +2796,13 @@ msgstr "Ersten Beitrag schreiben"
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
-#: lib/vutuv_web/templates/user/show.html.heex:637
+#: lib/vutuv_web/templates/user/show.html.heex:650
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr "Verwalten"
 
+#: lib/vutuv_web/components/post_components.ex:802
 #: lib/vutuv_web/controllers/page_controller.ex:216
-#: lib/vutuv_web/live/post_live/feed.ex:2404
-#: lib/vutuv_web/templates/user/show.html.heex:507
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr "Beitrag schreiben"
@@ -2823,7 +2823,7 @@ msgstr[0] "1 Vernetzung"
 msgstr[1] "%{formatted} Vernetzungen"
 
 #: lib/vutuv_web/live/job_board_live.ex:458
-#: lib/vutuv_web/live/post_live/feed.ex:1058
+#: lib/vutuv_web/live/post_live/feed.ex:1059
 #: lib/vutuv_web/templates/user/card_list.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -2854,7 +2854,7 @@ msgstr "Noch keine Vernetzungen."
 msgid "Other formats"
 msgstr "Andere Formate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2215
+#: lib/vutuv_web/live/post_live/composer.ex:2231
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr "Personen, mit denen ich nicht vernetzt bin"
@@ -2870,14 +2870,14 @@ msgid "This post is for the connections of %{name}"
 msgstr "Dieser Beitrag ist für die Vernetzungen von %{name}"
 
 #: lib/vutuv_web/views/admin/moderation_html.ex:81
-#: lib/vutuv_web/views/user_html.ex:513
+#: lib/vutuv_web/views/user_html.ex:518
 #, elixir-autogen, elixir-format
 msgid "connection"
 msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:5695
+#: lib/vutuv_web/components/post_components.ex:5667
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -2905,7 +2905,7 @@ msgid "Endorsement"
 msgstr "Empfehlung"
 
 #: lib/vutuv_web/live/notification_live/index.ex:1507
-#: lib/vutuv_web/templates/user/show.html.heex:965
+#: lib/vutuv_web/templates/user/show.html.heex:978
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3152,13 +3152,13 @@ msgstr "Nichts zu sehen, keiner Ihrer Inhalte ist derzeit gemeldet."
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1196
-#: lib/vutuv_web/templates/user/show.html.heex:1197
+#: lib/vutuv_web/templates/user/show.html.heex:1212
+#: lib/vutuv_web/templates/user/show.html.heex:1213
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:3560
+#: lib/vutuv_web/components/post_components.ex:3532
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3212,7 +3212,7 @@ msgid "Private message"
 msgstr "Private Nachricht"
 
 #: lib/vutuv_web/components/ui.ex:4973
-#: lib/vutuv_web/live/shell_live.ex:1280
+#: lib/vutuv_web/live/shell_live.ex:1314
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3236,9 +3236,9 @@ msgstr "Abgelehnt"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
-#: lib/vutuv_web/components/post_components.ex:1381
-#: lib/vutuv_web/components/post_components.ex:2754
-#: lib/vutuv_web/components/post_components.ex:3732
+#: lib/vutuv_web/components/post_components.ex:1353
+#: lib/vutuv_web/components/post_components.ex:2726
+#: lib/vutuv_web/components/post_components.ex:3704
 #: lib/vutuv_web/live/organization_live/show.ex:654
 #: lib/vutuv_web/templates/user/show.html.heex:237
 #, elixir-autogen, elixir-format
@@ -4693,12 +4693,12 @@ msgid "You have not blocked anyone."
 msgstr "Sie haben niemanden blockiert."
 
 #: lib/vutuv_web/controllers/block_controller.ex:89
-#: lib/vutuv_web/live/user_profile_live.ex:327
+#: lib/vutuv_web/live/user_profile_live.ex:337
 #, elixir-autogen, elixir-format
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3478
+#: lib/vutuv_web/live/post_live/feed.ex:3413
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -4712,7 +4712,7 @@ msgstr "Mitglieder finden"
 #: lib/vutuv_web/live/organization_live/following.ex:313
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:987
+#: lib/vutuv_web/templates/user/show.html.heex:1000
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folgt"
@@ -4833,8 +4833,8 @@ msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 
 #: lib/vutuv_web/live/job_board_live.ex:547
 #: lib/vutuv_web/live/tag_new_live.ex:47
-#: lib/vutuv_web/live/user_profile_live.ex:1358
-#: lib/vutuv_web/templates/user/show.html.heex:610
+#: lib/vutuv_web/live/user_profile_live.ex:1419
+#: lib/vutuv_web/templates/user/show.html.heex:623
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr "Tags hinzufügen"
@@ -5513,7 +5513,7 @@ msgstr ""
 "dauerhaft. Wir senden Ihnen zur Bestätigung eine PIN per E-Mail. Es kann "
 "nicht rückgängig gemacht werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1412
+#: lib/vutuv_web/live/post_live/composer.ex:1428
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
@@ -5523,7 +5523,7 @@ msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
 msgid "Content under review"
 msgstr "Inhalte in Prüfung"
 
-#: lib/vutuv_web/live/shell_live.ex:1456
+#: lib/vutuv_web/live/shell_live.ex:1490
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Kontomenü"
@@ -5545,7 +5545,7 @@ msgstr "Menüs und Dialoge schließen"
 msgid "General"
 msgstr "Allgemeines"
 
-#: lib/vutuv_web/live/shell_live.ex:1513
+#: lib/vutuv_web/live/shell_live.ex:1547
 #: lib/vutuv_web/templates/layout/app.html.heex:183
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5564,7 +5564,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:276
-#: lib/vutuv_web/live/shell_live.ex:1493
+#: lib/vutuv_web/live/shell_live.ex:1527
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5604,7 +5604,7 @@ msgstr "Profil vervollständigen"
 msgid "A few quick steps so people can find and recognize you."
 msgstr "Ein paar schnelle Schritte, damit andere Sie finden und erkennen."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1364
+#: lib/vutuv_web/live/user_profile_live.ex:1425
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr "Profilfoto hinzufügen"
@@ -5619,8 +5619,8 @@ msgstr "Nächster Beitrag im Feed"
 msgid "Previous post in the feed"
 msgstr "Vorheriger Beitrag im Feed"
 
-#: lib/vutuv_web/live/shell_live.ex:1242
-#: lib/vutuv_web/live/shell_live.ex:1554
+#: lib/vutuv_web/live/shell_live.ex:1270
+#: lib/vutuv_web/live/shell_live.ex:1588
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Hauptnavigation"
@@ -5630,11 +5630,11 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:3798
-#: lib/vutuv_web/components/post_components.ex:3853
-#: lib/vutuv_web/components/post_components.ex:4382
+#: lib/vutuv_web/components/post_components.ex:3770
+#: lib/vutuv_web/components/post_components.ex:3825
+#: lib/vutuv_web/components/post_components.ex:4354
 #: lib/vutuv_web/live/notification_live/index.ex:1086
-#: lib/vutuv_web/views/user_html.ex:126
+#: lib/vutuv_web/views/user_html.ex:131
 #, elixir-autogen, elixir-format
 msgid "View post"
 msgstr "Beitrag ansehen"
@@ -5658,7 +5658,7 @@ msgstr "Andere"
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:1202
+#: lib/vutuv_web/views/user_html.ex:1207
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr "Privat"
@@ -5729,7 +5729,7 @@ msgstr "Personen, die nicht mit Ihnen interagieren können."
 msgid "Personal tokens for the vutuv API."
 msgstr "Persönliche Tokens für die vutuv-API."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2559
+#: lib/vutuv_web/live/post_live/composer.ex:2575
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
@@ -6280,7 +6280,7 @@ msgstr "z. B. MacBook"
 msgid "or"
 msgstr "oder"
 
-#: lib/vutuv_web/live/user_profile_live.ex:1369
+#: lib/vutuv_web/live/user_profile_live.ex:1430
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr "Kurzbeschreibung hinzufügen"
@@ -6295,14 +6295,14 @@ msgstr "Kurzbeschreibung"
 #: lib/vutuv_web/components/ui.ex:480
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:915
+#: lib/vutuv_web/templates/user/show.html.heex:928
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] "Link"
 msgstr[1] "Links"
 
-#: lib/vutuv_web/templates/user/show.html.heex:482
+#: lib/vutuv_web/templates/user/show.html.heex:483
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6316,7 +6316,7 @@ msgstr[1] "Beiträge"
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1537
+#: lib/vutuv_web/templates/user/show.html.heex:1553
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Auch auf"
@@ -6355,15 +6355,15 @@ msgstr "Foto positionieren"
 msgid "Use photo"
 msgstr "Foto verwenden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1903
+#: lib/vutuv_web/live/post_live/composer.ex:1919
 #: lib/vutuv_web/templates/user/edit.html.heex:54
 #: lib/vutuv_web/templates/user/edit.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr "Zoom"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1122
-#: lib/vutuv_web/templates/user/show.html.heex:1132
+#: lib/vutuv_web/templates/user/show.html.heex:1138
+#: lib/vutuv_web/templates/user/show.html.heex:1148
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6405,12 +6405,12 @@ msgstr "Tagesbericht für %{day}"
 msgid "Jump to a day"
 msgstr "Zu einem Tag springen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1244
+#: lib/vutuv_web/templates/user/show.html.heex:1260
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr "E-Mails verwalten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1255
+#: lib/vutuv_web/templates/user/show.html.heex:1271
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr "Telefon verwalten"
@@ -6453,7 +6453,7 @@ msgstr "Vorheriger Tag"
 msgid "Reposts"
 msgstr "Reposts"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1253
+#: lib/vutuv_web/templates/user/show.html.heex:1269
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr "Alle Telefonnummern anzeigen"
@@ -6514,9 +6514,9 @@ msgstr "Anzuzeigende Kartendienste"
 msgid "Maps"
 msgstr "Karten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1527
-#: lib/vutuv_web/templates/user/show.html.heex:1531
 #: lib/vutuv_web/templates/user/show.html.heex:1543
+#: lib/vutuv_web/templates/user/show.html.heex:1547
+#: lib/vutuv_web/templates/user/show.html.heex:1559
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
@@ -6872,13 +6872,13 @@ msgstr ""
 "Schalten Sie einen Schalter aus, geht der passende Opt-out auf den Seiten "
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
-#: lib/vutuv_web/components/post_components.ex:2714
-#: lib/vutuv_web/components/post_components.ex:3723
+#: lib/vutuv_web/components/post_components.ex:2686
+#: lib/vutuv_web/components/post_components.ex:3695
 #: lib/vutuv_web/components/ui.ex:3072
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:215
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:256
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:230
 #, elixir-autogen, elixir-format
@@ -6886,7 +6886,7 @@ msgid "Mute"
 msgstr "Stummschalten"
 
 #: lib/vutuv_web/controllers/follow_controller.ex:49
-#: lib/vutuv_web/live/user_profile_live.ex:268
+#: lib/vutuv_web/live/user_profile_live.ex:278
 #, elixir-autogen, elixir-format
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr "Stummgeschaltet. Die Beiträge erscheinen nicht mehr in Ihrem Feed."
@@ -6901,12 +6901,12 @@ msgstr "Neue Nachrichten und neue Vernetzungen"
 msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
-#: lib/vutuv_web/components/post_components.ex:3723
+#: lib/vutuv_web/components/post_components.ex:3695
 #: lib/vutuv_web/components/ui.ex:3071
 #: lib/vutuv_web/live/fediverse_account_live.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:215
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:256
 #: lib/vutuv_web/templates/settings/filters.html.heex:111
 #: lib/vutuv_web/templates/user/show.html.heex:230
 #, elixir-autogen, elixir-format
@@ -6914,7 +6914,7 @@ msgid "Unmute"
 msgstr "Stummschaltung aufheben"
 
 #: lib/vutuv_web/controllers/follow_controller.ex:51
-#: lib/vutuv_web/live/user_profile_live.ex:270
+#: lib/vutuv_web/live/user_profile_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr ""
@@ -6930,12 +6930,12 @@ msgstr "Folgen Sie einander, um mit %{name} vernetzt zu sein und ihn zu lesen."
 msgid "Go to profile to follow"
 msgstr "Zum Profil, um zu folgen"
 
-#: lib/vutuv_web/views/user_html.ex:1201
+#: lib/vutuv_web/views/user_html.ex:1206
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr "Beruflich"
 
-#: lib/vutuv_web/views/user_html.ex:754
+#: lib/vutuv_web/views/user_html.ex:759
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr "Folgt Ihnen"
@@ -7471,7 +7471,7 @@ msgid "open the dev email inbox"
 msgstr "Dev-Postfach öffnen"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
-#: lib/vutuv_web/views/user_html.ex:753
+#: lib/vutuv_web/views/user_html.ex:758
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr "Vernetzt"
@@ -7568,7 +7568,7 @@ msgid "Removed:"
 msgstr "Entfernt:"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:974
-#: lib/vutuv_web/live/post_live/composer.ex:1751
+#: lib/vutuv_web/live/post_live/composer.ex:1767
 #: lib/vutuv_web/live/post_live/filter_band.ex:533
 #, elixir-autogen, elixir-format
 msgid "Undo"
@@ -7615,7 +7615,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5938
+#: lib/vutuv_web/components/post_components.ex:5910
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7726,7 +7726,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3744
+#: lib/vutuv_web/live/post_live/feed.ex:3679
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #, elixir-autogen
 msgid "Done"
@@ -8204,7 +8204,7 @@ msgstr "Administratoren"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
 #: lib/vutuv_web/live/job_board_live.ex:468
-#: lib/vutuv_web/live/post_live/feed.ex:1067
+#: lib/vutuv_web/live/post_live/feed.ex:1068
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Alle Mitglieder"
@@ -8464,7 +8464,7 @@ msgstr[1] "%{count} Berufserfahrungen"
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:703
+#: lib/vutuv_web/templates/user/show.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr "Ausbildung hinzufügen"
@@ -8488,7 +8488,7 @@ msgstr "Abschluss"
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
-#: lib/vutuv_web/templates/user/show.html.heex:700
+#: lib/vutuv_web/templates/user/show.html.heex:713
 #: lib/vutuv_web/views/import_html.ex:70
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
@@ -8670,13 +8670,13 @@ msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 msgid "Please check the fields marked in red."
 msgstr "Bitte prüfen Sie die rot markierten Felder."
 
-#: lib/vutuv_web/views/user_html.ex:1086
+#: lib/vutuv_web/views/user_html.ex:1091
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
 msgstr "Beiträge werden geladen"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1391
+#: lib/vutuv_web/templates/user/show.html.heex:1407
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Social-Media-Beiträge"
@@ -9028,7 +9028,7 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1296
+#: lib/vutuv_web/templates/user/show.html.heex:1312
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr "Fediverse"
@@ -9182,7 +9182,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:4868
+#: lib/vutuv_web/components/post_components.ex:4840
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9460,7 +9460,7 @@ msgstr "A2 (Grundkenntnisse)"
 #: lib/vutuv_web/live/feed_languages_live.ex:317
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:765
+#: lib/vutuv_web/templates/user/show.html.heex:778
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr "Sprache hinzufügen"
@@ -9685,7 +9685,7 @@ msgstr "Sprache erfolgreich aktualisiert."
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:762
+#: lib/vutuv_web/templates/user/show.html.heex:775
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Sprachen"
@@ -9976,7 +9976,7 @@ msgstr[0] "%{count} Zertifikat oder Lizenz"
 msgstr[1] "%{count} Zertifikate oder Lizenzen"
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:869
+#: lib/vutuv_web/templates/user/show.html.heex:882
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
@@ -10024,7 +10024,7 @@ msgstr "Zertifikate"
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:866
+#: lib/vutuv_web/templates/user/show.html.heex:879
 #: lib/vutuv_web/views/import_html.ex:71
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
@@ -10148,8 +10148,8 @@ msgstr "Bevorzugt"
 msgid "Preferred contact language"
 msgstr "Bevorzugte Kontaktsprache"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1218
-#: lib/vutuv_web/templates/user/show.html.heex:1219
+#: lib/vutuv_web/templates/user/show.html.heex:1234
+#: lib/vutuv_web/templates/user/show.html.heex:1235
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr "+%{code} ist die Ländervorwahl von %{region}"
@@ -10662,15 +10662,15 @@ msgstr[1] "%{count} Sterne"
 
 #: lib/vutuv_web/live/notification_live/index.ex:1433
 #: lib/vutuv_web/live/organization_live/show.ex:641
-#: lib/vutuv_web/views/user_html.ex:950
-#: lib/vutuv_web/views/user_html.ex:1126
+#: lib/vutuv_web/views/user_html.ex:955
+#: lib/vutuv_web/views/user_html.ex:1131
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
 msgstr[0] "%{formatted} Follower"
 msgstr[1] "%{formatted} Follower"
 
-#: lib/vutuv_web/views/user_html.ex:943
+#: lib/vutuv_web/views/user_html.ex:948
 #, elixir-autogen, elixir-format
 msgid "%{formatted} star"
 msgid_plural "%{formatted} stars"
@@ -10679,7 +10679,7 @@ msgstr[1] "%{formatted} Sterne"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:71
 #: lib/vutuv_web/agent_docs/text.ex:66
-#: lib/vutuv_web/templates/user/show.html.heex:1365
+#: lib/vutuv_web/templates/user/show.html.heex:1381
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Code"
@@ -10698,7 +10698,7 @@ msgstr ""
 "dessen öffentliche Statistiken zeigen: Sterne, Repositories, Follower, "
 "Sprachen und letzte Aktivität."
 
-#: lib/vutuv_web/views/user_html.ex:957
+#: lib/vutuv_web/views/user_html.ex:962
 #, elixir-autogen, elixir-format
 msgid "Last active %{date}"
 msgstr "Zuletzt aktiv %{date}"
@@ -10725,7 +10725,7 @@ msgstr "zuletzt aktiv %{date}"
 msgid "since %{date}"
 msgstr "seit %{date}"
 
-#: lib/vutuv_web/views/user_html.ex:873
+#: lib/vutuv_web/views/user_html.ex:878
 #, elixir-autogen, elixir-format
 msgid "since %{year}"
 msgstr "seit %{year}"
@@ -11212,8 +11212,8 @@ msgid "Failed"
 msgstr "Fehlgeschlagen"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
-#: lib/vutuv_web/live/post_live/composer.ex:1982
-#: lib/vutuv_web/live/post_live/composer.ex:2817
+#: lib/vutuv_web/live/post_live/composer.ex:1998
+#: lib/vutuv_web/live/post_live/composer.ex:2833
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr "Galerie"
@@ -12368,7 +12368,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1484
+#: lib/vutuv_web/live/shell_live.ex:1518
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:79
@@ -12711,7 +12711,7 @@ msgstr "Stellenbezeichnung"
 #: lib/vutuv_web/live/job_board_live.ex:47
 #: lib/vutuv_web/live/job_board_live.ex:265
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1288
+#: lib/vutuv_web/live/shell_live.ex:1322
 #: lib/vutuv_web/templates/layout/app.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -13613,7 +13613,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/components/post_components.ex:3114
+#: lib/vutuv_web/components/post_components.ex:3086
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:715
 #: lib/vutuv_web/controllers/settings_controller.ex:733
@@ -14003,7 +14003,7 @@ msgstr "Volle Breite"
 msgid "Insert image"
 msgstr "Bild einfügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3208
+#: lib/vutuv_web/live/post_live/composer.ex:3224
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr "In den Text einfügen"
@@ -14067,7 +14067,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5067
 #: lib/vutuv_web/controllers/settings_controller.ex:634
-#: lib/vutuv_web/live/post_live/feed.ex:750
+#: lib/vutuv_web/live/post_live/feed.ex:751
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14113,7 +14113,7 @@ msgstr "Signal und WhatsApp akzeptieren eine Telefonnummer oder einen Benutzerna
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1331
+#: lib/vutuv_web/templates/user/show.html.heex:1347
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr "Messenger hinzufügen"
@@ -14150,7 +14150,7 @@ msgstr "Messenger wurde geändert."
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1329
+#: lib/vutuv_web/templates/user/show.html.heex:1345
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr "Messenger"
@@ -14227,34 +14227,34 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:5544
+#: lib/vutuv_web/components/post_components.ex:5516
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1274
-#: lib/vutuv_web/components/post_components.ex:5501
+#: lib/vutuv_web/components/post_components.ex:5473
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:5545
+#: lib/vutuv_web/components/post_components.ex:5517
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:5547
+#: lib/vutuv_web/components/post_components.ex:5519
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:5543
+#: lib/vutuv_web/components/post_components.ex:5515
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1274
-#: lib/vutuv_web/components/post_components.ex:5500
+#: lib/vutuv_web/components/post_components.ex:5472
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14265,12 +14265,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:5542
+#: lib/vutuv_web/components/post_components.ex:5514
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:5546
+#: lib/vutuv_web/components/post_components.ex:5518
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14290,7 +14290,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:5583
+#: lib/vutuv_web/components/post_components.ex:5555
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14298,27 +14298,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:5613
+#: lib/vutuv_web/components/post_components.ex:5585
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:5614
+#: lib/vutuv_web/components/post_components.ex:5586
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:5612
+#: lib/vutuv_web/components/post_components.ex:5584
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:5572
+#: lib/vutuv_web/components/post_components.ex:5544
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:5619
+#: lib/vutuv_web/components/post_components.ex:5591
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14348,7 +14348,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5386
+#: lib/vutuv_web/components/post_components.ex:5358
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14391,7 +14391,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:5377
+#: lib/vutuv_web/components/post_components.ex:5349
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -14408,7 +14408,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] "Empfohlen von %{name} und %{formatted} weiteren"
 msgstr[1] "Empfohlen von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/live/shell_live.ex:671
+#: lib/vutuv_web/live/shell_live.ex:699
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -14652,13 +14652,13 @@ msgstr "Erwähnung"
 msgid "mentioned you in a post."
 msgstr "hat Sie in einem Beitrag erwähnt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1396
+#: lib/vutuv_web/live/post_live/composer.ex:1412
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr "Dieser Beitrag lässt sich nicht mehr bearbeiten: jemand hat ihn geliked, geteilt oder beantwortet."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1399
+#: lib/vutuv_web/live/post_live/composer.ex:1415
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14754,14 +14754,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:3387
+#: lib/vutuv_web/components/post_components.ex:3359
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:3410
+#: lib/vutuv_web/components/post_components.ex:3382
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14788,7 +14788,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:6037
+#: lib/vutuv_web/components/post_components.ex:6009
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -14966,7 +14966,7 @@ msgstr ""
 "Wählen Sie unten einen Abschluss oder eine Schule, um ihn statt eines "
 "Jobtitels oben in Ihrem Profil anzuzeigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1127
+#: lib/vutuv_web/live/post_live/feed.ex:1128
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Trotzdem anzeigen"
@@ -15525,7 +15525,7 @@ msgstr "Anwendung bearbeiten"
 msgid "Book an ad"
 msgstr "Anzeige buchen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1038
+#: lib/vutuv_web/templates/user/show.html.heex:1054
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr "%{name} hat dieses Fediverse-Konto umgezogen. Folgen Sie stattdessen der neuen Adresse:"
@@ -15948,7 +15948,7 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:5983
+#: lib/vutuv_web/components/post_components.ex:5955
 #: lib/vutuv_web/live/notification_live/index.ex:1690
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -15956,7 +15956,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:5987
+#: lib/vutuv_web/components/post_components.ex:5959
 #: lib/vutuv_web/live/notification_live/index.ex:1684
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15964,7 +15964,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:5991
+#: lib/vutuv_web/components/post_components.ex:5963
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15972,7 +15972,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1223
-#: lib/vutuv_web/components/post_components.ex:5942
+#: lib/vutuv_web/components/post_components.ex:5914
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -15988,14 +15988,14 @@ msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem 
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
-#: lib/vutuv_web/components/post_components.ex:1496
-#: lib/vutuv_web/components/post_components.ex:2228
+#: lib/vutuv_web/components/post_components.ex:1468
+#: lib/vutuv_web/components/post_components.ex:2200
 #: lib/vutuv_web/live/fediverse_account_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:1366
+#: lib/vutuv_web/components/post_components.ex:1338
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Diese Antwort aus Ihrem Beitrag entfernen?"
@@ -16024,7 +16024,7 @@ msgstr "Antwort aus einem anderen Netzwerk"
 msgid "Reply removed."
 msgstr "Antwort entfernt."
 
-#: lib/vutuv_web/components/post_components.ex:1378
+#: lib/vutuv_web/components/post_components.ex:1350
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
@@ -16034,7 +16034,7 @@ msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
 msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
-#: lib/vutuv_web/components/post_components.ex:1392
+#: lib/vutuv_web/components/post_components.ex:1364
 #: lib/vutuv_web/live/notification_live/index.ex:1134
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -16066,9 +16066,10 @@ msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1423
-#: lib/vutuv_web/components/post_components.ex:1427
-#: lib/vutuv_web/components/post_components.ex:1627
-#: lib/vutuv_web/components/post_components.ex:3004
+#: lib/vutuv_web/components/post_components.ex:1399
+#: lib/vutuv_web/components/post_components.ex:1599
+#: lib/vutuv_web/components/post_components.ex:2976
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:302
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Original ansehen"
@@ -16735,22 +16736,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:3572
+#: lib/vutuv_web/components/post_components.ex:3544
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:3690
+#: lib/vutuv_web/components/post_components.ex:3662
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:3698
+#: lib/vutuv_web/components/post_components.ex:3670
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:3684
+#: lib/vutuv_web/components/post_components.ex:3656
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -16800,7 +16801,7 @@ msgstr ""
 "in eckigen Klammern, wie eine Lautschrift geschrieben wird; die Klammern "
 "ergänzen wir für Sie. Bleibt das Feld leer, wird nichts angezeigt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3221
+#: lib/vutuv_web/live/post_live/composer.ex:3237
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr "Diese Einstellungen für alle Fotos übernehmen"
@@ -16832,12 +16833,12 @@ msgstr "CC0 1.0 (keine Rechte vorbehalten)"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1340
 #: lib/vutuv_web/agent_docs/text.ex:830
-#: lib/vutuv_web/live/post_live/composer.ex:2645
+#: lib/vutuv_web/live/post_live/composer.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Titelbild"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3059
+#: lib/vutuv_web/live/post_live/composer.ex:3075
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
@@ -16849,22 +16850,22 @@ msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 msgid "Download the original"
 msgstr "Original herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3158
+#: lib/vutuv_web/live/post_live/composer.ex:3174
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr "Alle Metadaten bleiben erhalten, auch alles, was Ihre Kamera hineingeschrieben hat."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3114
+#: lib/vutuv_web/live/post_live/composer.ex:3130
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr "Alle dürfen dieses Foto herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3116
+#: lib/vutuv_web/live/post_live/composer.ex:3132
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr "Volle Auflösung, direkt aus dem Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3135
+#: lib/vutuv_web/live/post_live/composer.ex:3151
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr "Nur das Bild"
@@ -16874,35 +16875,35 @@ msgstr "Nur das Bild"
 msgid "Next photo"
 msgstr "Nächstes Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2664
+#: lib/vutuv_web/live/post_live/composer.ex:2680
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:3167
+#: lib/vutuv_web/components/post_components.ex:3139
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:4513
+#: lib/vutuv_web/components/post_components.ex:4485
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:4662
+#: lib/vutuv_web/components/post_components.ex:4634
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2617
-#: lib/vutuv_web/live/post_live/composer.ex:2618
+#: lib/vutuv_web/live/post_live/composer.ex:2633
+#: lib/vutuv_web/live/post_live/composer.ex:2634
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1384
 #: lib/vutuv_web/agent_docs/text.ex:818
-#: lib/vutuv_web/components/post_components.ex:4744
+#: lib/vutuv_web/components/post_components.ex:4716
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
@@ -16912,43 +16913,43 @@ msgstr "Fotos:"
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2677
-#: lib/vutuv_web/live/post_live/composer.ex:2678
+#: lib/vutuv_web/live/post_live/composer.ex:2693
+#: lib/vutuv_web/live/post_live/composer.ex:2694
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr "Foto entfernen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3137
+#: lib/vutuv_web/live/post_live/composer.ex:3153
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qualität unverändert."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3078
+#: lib/vutuv_web/live/post_live/composer.ex:3094
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:3220
+#: lib/vutuv_web/components/post_components.ex:3192
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3156
+#: lib/vutuv_web/live/post_live/composer.ex:3172
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr "Die Datei genau so, wie ich sie hochgeladen habe"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3192
+#: lib/vutuv_web/live/post_live/composer.ex:3208
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen Sie das Foto, wenn Sie das nicht möchten."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3184
+#: lib/vutuv_web/live/post_live/composer.ex:3200
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/components/post_components.ex:3211
+#: lib/vutuv_web/components/post_components.ex:3183
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
@@ -16958,37 +16959,37 @@ msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht �
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/components/post_components.ex:3229
+#: lib/vutuv_web/components/post_components.ex:3201
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Diese Seite nimmt nicht am Fediverse teil."
 
-#: lib/vutuv_web/components/post_components.ex:3163
+#: lib/vutuv_web/components/post_components.ex:3135
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2935
+#: lib/vutuv_web/live/post_live/composer.ex:2951
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr "Wer diese Fotos weiterverwenden darf"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1426
+#: lib/vutuv_web/live/post_live/composer.ex:1442
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:3224
+#: lib/vutuv_web/components/post_components.ex:3196
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1440
+#: lib/vutuv_web/live/post_live/composer.ex:1456
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
 
-#: lib/vutuv_web/components/post_components.ex:3177
+#: lib/vutuv_web/components/post_components.ex:3149
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fediverse-Follower. Auf vutuv ist sie ebenfalls ein öffentlicher Beitrag."
@@ -16998,64 +16999,64 @@ msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fedive
 msgid "© All rights reserved"
 msgstr "© Alle Rechte vorbehalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2560
+#: lib/vutuv_web/live/post_live/composer.ex:2576
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr "Fotos hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2930
+#: lib/vutuv_web/live/post_live/composer.ex:2946
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3049
+#: lib/vutuv_web/live/post_live/composer.ex:3065
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr "Bildunterschrift (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1726
-#: lib/vutuv_web/live/post_live/composer.ex:1789
-#: lib/vutuv_web/live/post_live/composer.ex:1847
+#: lib/vutuv_web/live/post_live/composer.ex:1742
+#: lib/vutuv_web/live/post_live/composer.ex:1805
+#: lib/vutuv_web/live/post_live/composer.ex:1863
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr "Entwurf verwerfen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1719
+#: lib/vutuv_web/live/post_live/composer.ex:1735
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr "Weiter, wo Sie aufgehört haben."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2983
+#: lib/vutuv_web/live/post_live/composer.ex:2999
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr "Eine Datei, deren Format sich nicht säubern lässt, wird exakt so weitergegeben, wie sie hochgeladen wurde."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2372
+#: lib/vutuv_web/live/post_live/composer.ex:2388
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr "Pro Foto verschieden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2371
+#: lib/vutuv_web/live/post_live/composer.ex:2387
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr "Original, exakt wie hochgeladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2370
+#: lib/vutuv_web/live/post_live/composer.ex:2386
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr "Original, ohne Metadaten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2375
+#: lib/vutuv_web/live/post_live/composer.ex:2391
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr "Nur Web-Versionen (%{format})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2953
+#: lib/vutuv_web/live/post_live/composer.ex:2969
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr "Was Besucher speichern können"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2972
+#: lib/vutuv_web/live/post_live/composer.ex:2988
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -17063,13 +17064,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1241
-#: lib/vutuv_web/components/post_components.ex:5980
+#: lib/vutuv_web/components/post_components.ex:5952
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1239
-#: lib/vutuv_web/components/post_components.ex:5977
+#: lib/vutuv_web/components/post_components.ex:5949
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17079,7 +17080,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:5867
+#: lib/vutuv_web/components/post_components.ex:5839
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17175,8 +17176,8 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr "Rücknahme"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1983
-#: lib/vutuv_web/live/post_live/composer.ex:2817
+#: lib/vutuv_web/live/post_live/composer.ex:1999
+#: lib/vutuv_web/live/post_live/composer.ex:2833
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr "Fotodetails"
@@ -17429,7 +17430,7 @@ msgstr "Von hier aus wird %{follows} Konten in anderen Netzwerken gefolgt, davon
 msgid "Cached posts"
 msgstr "Zwischengespeicherte Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:2763
+#: lib/vutuv_web/components/post_components.ex:2735
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Nur für die Follower dieses Kontos"
@@ -17439,7 +17440,7 @@ msgstr "Nur für die Follower dieses Kontos"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:3003
+#: lib/vutuv_web/components/post_components.ex:2975
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -17459,12 +17460,12 @@ msgstr "Zwischengespeicherter Beitrag gemeldet, hier für alle entfernt"
 msgid "Content from other networks taken down by members"
 msgstr "Von Mitgliedern entfernte Inhalte aus anderen Netzwerken"
 
-#: lib/vutuv_web/components/post_components.ex:1762
+#: lib/vutuv_web/components/post_components.ex:1734
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Verbergen"
 
-#: lib/vutuv_web/components/post_components.ex:2944
+#: lib/vutuv_web/components/post_components.ex:2916
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Von der verfassenden Person als sensibel markiert"
@@ -17480,7 +17481,7 @@ msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwin
 msgid "Nobody has removed or reported anything yet."
 msgstr "Bisher hat niemand etwas entfernt oder gemeldet."
 
-#: lib/vutuv_web/components/post_components.ex:2749
+#: lib/vutuv_web/components/post_components.ex:2721
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr "Diesen Beitrag als unangemessen melden? Unsere Kopie wird sofort für alle auf diesem vutuv gelöscht."
@@ -17702,27 +17703,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(ein Bild)"
 msgstr[1] "(%{count} Bilder)"
 
-#: lib/vutuv_web/components/post_components.ex:2400
+#: lib/vutuv_web/components/post_components.ex:2372
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr "Bild wird geprüft"
 
-#: lib/vutuv_web/components/post_components.ex:2433
+#: lib/vutuv_web/components/post_components.ex:2405
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Wieder verdecken"
 
-#: lib/vutuv_web/components/post_components.ex:2428
+#: lib/vutuv_web/components/post_components.ex:2400
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Heikles Motiv. Bild anzeigen."
 
-#: lib/vutuv_web/components/post_components.ex:3070
+#: lib/vutuv_web/components/post_components.ex:3042
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:3076
+#: lib/vutuv_web/components/post_components.ex:3048
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
@@ -17732,7 +17733,7 @@ msgstr "Diesen Beitrag gibt es hier nicht mehr."
 msgid "Back to the feed"
 msgstr "Zurück zum Feed"
 
-#: lib/vutuv_web/components/post_components.ex:3215
+#: lib/vutuv_web/components/post_components.ex:3187
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17783,14 +17784,14 @@ msgstr ""
 "Dieser Link zeigt auf einen einzelnen Beitrag. Von hier aus können Sie dem "
 "Konto dahinter folgen: %{account}."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1403
+#: lib/vutuv_web/live/user_profile_live.ex:1464
 #, elixir-autogen, elixir-format
 msgid "You already follow one member."
 msgid_plural "You already follow %{count} members."
 msgstr[0] "Sie folgen bereits einem Mitglied."
 msgstr[1] "Sie folgen bereits %{count} Mitgliedern."
 
-#: lib/vutuv_web/views/user_html.ex:232
+#: lib/vutuv_web/views/user_html.ex:237
 #, elixir-autogen, elixir-format
 msgid "Your feed shows the posts of members you follow. Follow a few to fill it."
 msgstr ""
@@ -18002,7 +18003,6 @@ msgid "That is a link on this vutuv, not on another network."
 msgstr "Das ist ein Link auf dieses vutuv, nicht auf ein anderes Netzwerk."
 
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:317
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:240
 #, elixir-autogen, elixir-format
 msgid "Their account page here"
 msgstr "Die Seite dieses Kontos hier"
@@ -18057,104 +18057,104 @@ msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, desh
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr "Einen nachgeschlagenen Beitrag bewahrt vutuv genauso sechs Monate lang auf wie jeden anderen Beitrag aus einem anderen Netzwerk. Der Server der verfassenden Person wird sonst nichts gefragt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1900
+#: lib/vutuv_web/live/post_live/composer.ex:1916
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr "Zuschnitt übernehmen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2723
+#: lib/vutuv_web/live/post_live/composer.ex:2739
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr "Großes Foto links"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2724
+#: lib/vutuv_web/live/post_live/composer.ex:2740
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr "Großes Foto rechts"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2729
+#: lib/vutuv_web/live/post_live/composer.ex:2745
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr "Spalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2726
+#: lib/vutuv_web/live/post_live/composer.ex:2742
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr "Titelbild links"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2727
+#: lib/vutuv_web/live/post_live/composer.ex:2743
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr "Titelbild oben"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2728
+#: lib/vutuv_web/live/post_live/composer.ex:2744
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr "Titelbild rechts"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1896
-#: lib/vutuv_web/live/post_live/composer.ex:2694
-#: lib/vutuv_web/live/post_live/composer.ex:2695
+#: lib/vutuv_web/live/post_live/composer.ex:1912
+#: lib/vutuv_web/live/post_live/composer.ex:2710
+#: lib/vutuv_web/live/post_live/composer.ex:2711
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr "Foto zuschneiden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2653
+#: lib/vutuv_web/live/post_live/composer.ex:2669
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr "Zugeschnitten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1818
+#: lib/vutuv_web/live/post_live/composer.ex:1834
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr "Fotos hier ablegen, um sie hinzuzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2730
+#: lib/vutuv_web/live/post_live/composer.ex:2746
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr "Raster"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2731
+#: lib/vutuv_web/live/post_live/composer.ex:2747
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr "Mosaik"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1898
+#: lib/vutuv_web/live/post_live/composer.ex:1914
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr "Wählen Sie ein Format, dann verschieben und zoomen Sie. Der gerahmte Ausschnitt ist das, was der Beitrag zeigt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2722
+#: lib/vutuv_web/live/post_live/composer.ex:2738
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr "Nebeneinander"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2725
+#: lib/vutuv_web/live/post_live/composer.ex:2741
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr "Übereinander"
 
-#: lib/vutuv_web/live/post_live/composer.ex:562
+#: lib/vutuv_web/live/post_live/composer.ex:572
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr "Das Foto konnte nicht zugeschnitten werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3171
+#: lib/vutuv_web/live/post_live/composer.ex:3187
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr "Dieses Foto ist zugeschnitten: Downloads geben das zugeschnittene Bild heraus, die unveränderte Originaldatei bleibt privat."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1902
+#: lib/vutuv_web/live/post_live/composer.ex:1918
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr "Ganzes Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2920
+#: lib/vutuv_web/live/post_live/composer.ex:2936
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr "Kacheln füllen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2904
+#: lib/vutuv_web/live/post_live/composer.ex:2920
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr "Ganze Fotos"
@@ -18417,7 +18417,7 @@ msgstr "Auf vutuv gibt es zu diesem Tag noch keine Beiträge."
 msgid "word in a post"
 msgstr "Wort in einem Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:3073
+#: lib/vutuv_web/components/post_components.ex:3045
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Diese Antwort gibt es hier nicht mehr."
@@ -18720,19 +18720,19 @@ msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:5038
+#: lib/vutuv_web/components/post_components.ex:5010
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5040
+#: lib/vutuv_web/components/post_components.ex:5012
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:5051
+#: lib/vutuv_web/components/post_components.ex:5023
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
@@ -18794,7 +18794,7 @@ msgstr "Für dieses Zeugnis läuft bereits eine Prüfung."
 #: lib/vutuv_web/controllers/job_reference_controller.ex:144
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:18
 #: lib/vutuv_web/templates/job_reference/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:803
+#: lib/vutuv_web/templates/user/show.html.heex:816
 #, elixir-autogen, elixir-format
 msgid "Add an employment reference"
 msgstr "Arbeitszeugnis hinzufügen"
@@ -18871,7 +18871,7 @@ msgstr "Arbeitszeugnis aktualisiert."
 #: lib/vutuv_web/templates/job_reference/new.html.heex:4
 #: lib/vutuv_web/templates/job_reference/show.html.heex:12
 #: lib/vutuv_web/templates/job_reference/view.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:800
+#: lib/vutuv_web/templates/user/show.html.heex:813
 #, elixir-autogen, elixir-format
 msgid "Employment references"
 msgstr "Arbeitszeugnisse"
@@ -18906,7 +18906,7 @@ msgstr "Ausstellungsdatum"
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3496
+#: lib/vutuv_web/live/post_live/feed.ex:3431
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -19508,7 +19508,7 @@ msgstr "Ihr vutuv-Benutzername steht fest."
 msgid "by the lawyer Tom Braegelmann"
 msgstr "von Rechtsanwalt Tom Braegelmann"
 
-#: lib/vutuv_web/templates/user/show.html.heex:844
+#: lib/vutuv_web/templates/user/show.html.heex:857
 #, elixir-autogen, elixir-format
 msgid "Documents:"
 msgstr "Belegt:"
@@ -19689,7 +19689,7 @@ msgstr ""
 "ändern, und unter {import_url} importieren Sie ein bestehendes "
 "LinkedIn-Profil."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1389
+#: lib/vutuv_web/live/user_profile_live.ex:1450
 #, elixir-autogen, elixir-format
 msgid "Follow other members"
 msgstr "Anderen Mitgliedern folgen"
@@ -20399,7 +20399,7 @@ msgstr "Suchen Sie so oft Sie möchten und nehmen Sie dazu, was gehört. Abkürz
 msgid "Start over"
 msgstr "Von vorn beginnen"
 
-#: lib/vutuv_web/components/post_components.ex:3103
+#: lib/vutuv_web/components/post_components.ex:3075
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr "Ein Herz oder ein Repost geht zurück in das Netzwerk, aus dem dieser Beitrag stammt. Ihr Konto nimmt derzeit nicht am Fediverse teil. Einschalten können Sie das in den {settings}."
@@ -20459,22 +20459,22 @@ msgstr "Der Besitzer vergibt die Rollen der anderen Mitglieder auf der Seite und
 msgid "Nothing published yet."
 msgstr "Noch nichts veröffentlicht."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2186
+#: lib/vutuv_web/live/post_live/composer.ex:2202
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr "Als %{name} veröffentlichen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1419
+#: lib/vutuv_web/live/post_live/composer.ex:1435
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2163
+#: lib/vutuv_web/live/post_live/composer.ex:2179
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr "Ein Beitrag im Namen einer Organisation ist immer öffentlich."
 
-#: lib/vutuv_web/live/shell_live.ex:1200
+#: lib/vutuv_web/live/shell_live.ex:1228
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr "Seite öffnen"
@@ -20494,7 +20494,7 @@ msgstr "Beendet, im Namen einer Organisation zu schreiben"
 msgid "Write as %{name} for now"
 msgstr "Vorerst als %{name} schreiben"
 
-#: lib/vutuv_web/live/shell_live.ex:1210
+#: lib/vutuv_web/live/shell_live.ex:1238
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr "Wieder als ich selbst schreiben"
@@ -20504,7 +20504,7 @@ msgstr "Wieder als ich selbst schreiben"
 msgid "You are writing as %{name} now."
 msgstr "Sie schreiben jetzt als %{name}."
 
-#: lib/vutuv_web/live/shell_live.ex:1186
+#: lib/vutuv_web/live/shell_live.ex:1214
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr "Sie schreiben als %{name}."
@@ -20868,21 +20868,21 @@ msgstr "Sie folgen #%{tag} hier bereits."
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr "Sie sind selbst auf diesem vutuv. Sie folgen #%{tag} jetzt direkt hier."
 
-#: lib/vutuv_web/live/shell_live.ex:715
+#: lib/vutuv_web/live/shell_live.ex:743
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] "%{formatted} Person"
 msgstr[1] "%{formatted} Personen"
 
-#: lib/vutuv_web/live/shell_live.ex:702
+#: lib/vutuv_web/live/shell_live.ex:730
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] "Person"
 msgstr[1] "Personen"
 
-#: lib/vutuv_web/live/shell_live.ex:737
+#: lib/vutuv_web/live/shell_live.ex:765
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -21269,44 +21269,44 @@ msgstr "Sie haben %{used} von %{max} Tags."
 msgid "{n} of {max} free slots selected."
 msgstr "{n} von {max} freien Plätzen ausgewählt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2145
+#: lib/vutuv_web/live/post_live/composer.ex:2161
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr "Weitere Sprachen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2136
+#: lib/vutuv_web/live/post_live/composer.ex:2152
 #, elixir-autogen, elixir-format
 msgctxt "post composer"
 msgid "Language"
 msgstr "Sprache"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2132
-#: lib/vutuv_web/live/post_live/composer.ex:2133
+#: lib/vutuv_web/live/post_live/composer.ex:2148
+#: lib/vutuv_web/live/post_live/composer.ex:2149
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr "Die Sprache, in der dieser Beitrag geschrieben ist"
 
-#: lib/vutuv_web/components/post_components.ex:4932
+#: lib/vutuv_web/components/post_components.ex:4904
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Original anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:4968
+#: lib/vutuv_web/components/post_components.ex:4940
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Übersetzen"
 
-#: lib/vutuv_web/components/post_components.ex:4977
+#: lib/vutuv_web/components/post_components.ex:4949
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Übersetzt"
 
-#: lib/vutuv_web/components/post_components.ex:4980
+#: lib/vutuv_web/components/post_components.ex:4952
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Übersetzt aus %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:4957
+#: lib/vutuv_web/components/post_components.ex:4929
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Wird übersetzt …"
@@ -21316,7 +21316,7 @@ msgstr "Wird übersetzt …"
 msgid "Feed language settings reset to the site defaults."
 msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
 
-#: lib/vutuv_web/components/post_components.ex:4947
+#: lib/vutuv_web/components/post_components.ex:4919
 #: lib/vutuv_web/components/ui.ex:5060
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -21445,20 +21445,20 @@ msgstr "Wir haben den Link in Ihrem Profil noch nicht gefunden. Bitte versuchen 
 msgid "Your username, or paste the address of your profile page."
 msgstr "Ihr Benutzername – oder fügen Sie die Adresse Ihrer Profilseite ein."
 
-#: lib/vutuv_web/components/post_components.ex:4710
+#: lib/vutuv_web/components/post_components.ex:4682
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] "Unsere KI prüft es gerade. Sobald die Prüfung durch ist, erscheint das Foto von selbst."
 msgstr[1] "Unsere KI prüft sie gerade, %{done} von %{total} sind durch. Sobald die letzte durch ist, erscheinen die Fotos von selbst."
 
-#: lib/vutuv_web/components/post_components.ex:4707
+#: lib/vutuv_web/components/post_components.ex:4679
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Ihr Beitrag ist veröffentlicht, das Foto noch nicht."
 
-#: lib/vutuv_web/components/post_components.ex:2454
-#: lib/vutuv_web/components/post_components.ex:3918
+#: lib/vutuv_web/components/post_components.ex:2426
+#: lib/vutuv_web/components/post_components.ex:3890
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -21476,13 +21476,13 @@ msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Empfohlen: quadratisch, mindestens %{width} × %{height} Pixel."
 
 #: lib/vutuv_web/live/job_board_live.ex:431
-#: lib/vutuv_web/live/post_live/feed.ex:1004
-#: lib/vutuv_web/views/user_html.ex:342
+#: lib/vutuv_web/live/post_live/feed.ex:1005
+#: lib/vutuv_web/views/user_html.ex:347
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
 msgstr "Profilbild von %{name}"
 
-#: lib/vutuv_web/views/user_html.ex:345
+#: lib/vutuv_web/views/user_html.ex:350
 #, elixir-autogen, elixir-format
 msgid "Show the profile picture larger"
 msgstr "Profilbild größer anzeigen"
@@ -21600,7 +21600,7 @@ msgid "Find my contacts"
 msgstr "Kontakte finden"
 
 #: lib/vutuv_web/templates/user/show.html.heex:460
-#: lib/vutuv_web/views/user_html.ex:254
+#: lib/vutuv_web/views/user_html.ex:259
 #, elixir-autogen, elixir-format
 msgid "Find people you know from LinkedIn"
 msgstr "Bekannte aus LinkedIn finden"
@@ -21972,7 +21972,7 @@ msgstr "Land suchen"
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr "Diese Seite folgt bereits so vielen Konten, wie hier erlaubt sind (%{max})."
 
-#: lib/vutuv_web/components/post_components.ex:2729
+#: lib/vutuv_web/components/post_components.ex:2701
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr "%{handle} nicht mehr folgen? Die Beiträge verschwinden aus Ihrem Feed."
@@ -21982,7 +21982,7 @@ msgstr "%{handle} nicht mehr folgen? Die Beiträge verschwinden aus Ihrem Feed."
 msgid "Unfollowed. Their posts leave your feed."
 msgstr "Nicht mehr gefolgt. Die Beiträge verschwinden aus Ihrem Feed."
 
-#: lib/vutuv_web/live/shell_live.ex:1160
+#: lib/vutuv_web/live/shell_live.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr "Erlauben"
@@ -21997,12 +21997,12 @@ msgstr "Jetzt fragen"
 msgid "Browser notifications"
 msgstr "Browser-Benachrichtigungen"
 
-#: lib/vutuv_web/live/shell_live.ex:1018
+#: lib/vutuv_web/live/shell_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr "Neue Nachricht"
 
-#: lib/vutuv_web/live/shell_live.ex:1163
+#: lib/vutuv_web/live/shell_live.ex:1191
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Jetzt nicht"
@@ -22042,7 +22042,7 @@ msgstr "Dieser Browser zeigt sie an."
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr "Wenn etwas eintrifft, während vutuv in einem Tab offen ist, den Sie gerade nicht ansehen, kann Ihr Browser es als Benachrichtigung anzeigen. Aus, solange Sie es nicht einschalten."
 
-#: lib/vutuv_web/live/shell_live.ex:1157
+#: lib/vutuv_web/live/shell_live.ex:1185
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr "Sie haben Browser-Benachrichtigungen eingeschaltet. Dieser Browser wurde noch nicht um Erlaubnis gebeten."
@@ -22082,12 +22082,12 @@ msgstr "Test-Benachrichtigung senden"
 msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
 msgstr "Gesendet. Wenn nichts erschienen ist, hält Ihr System sie zurück. Prüfen Sie „Nicht stören“ und Ihre Benachrichtigungseinstellungen."
 
-#: lib/vutuv_web/live/shell_live.ex:810
+#: lib/vutuv_web/live/shell_live.ex:838
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr "Test-Benachrichtigung"
 
-#: lib/vutuv_web/live/shell_live.ex:811
+#: lib/vutuv_web/live/shell_live.ex:839
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr "So sieht es aus, wenn auf vutuv etwas für Sie eintrifft."
@@ -22098,12 +22098,12 @@ msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public po
 msgstr ""
 "Folgen Sie #%{tag} von Mastodon oder einer anderen Fediverse-App aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3657
+#: lib/vutuv_web/live/post_live/feed.ex:3592
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Andere Mitglieder begrüßen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:751
+#: lib/vutuv_web/live/post_live/feed.ex:752
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr "Neu dabei"
@@ -22149,7 +22149,7 @@ msgstr "Der beste Weg: Folgen Sie %{name} hier. Neue Beiträge landen in Ihrem F
 msgid "With a vutuv account"
 msgstr "Mit einem vutuv-Konto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:996
+#: lib/vutuv_web/live/post_live/feed.ex:997
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
@@ -22327,7 +22327,7 @@ msgstr "In %{language} übersetzen"
 msgid "Translated into %{language}."
 msgstr "Wird in %{language} übersetzt."
 
-#: lib/vutuv_web/live/shell_live.ex:951
+#: lib/vutuv_web/live/shell_live.ex:979
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -22453,7 +22453,7 @@ msgstr "Neue Nachricht auf vutuv"
 msgid "No connection"
 msgstr "Keine Verbindung"
 
-#: lib/vutuv_web/live/shell_live.ex:1090
+#: lib/vutuv_web/live/shell_live.ex:1118
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr "Neu laden"
@@ -22546,7 +22546,7 @@ msgstr "Alle vutuv Mitglieder, alphabetisch nach Nachname sortiert."
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr "Alle vutuv Mitglieder, gruppiert nach dem Anfangsbuchstaben des Nachnamens."
 
-#: lib/vutuv_web/live/post_live/feed.ex:876
+#: lib/vutuv_web/live/post_live/feed.ex:877
 #: lib/vutuv_web/live/post_live/filter_band.ex:350
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -22562,7 +22562,7 @@ msgstr "Auch in längeren Wörtern: %{word} trifft auch %{example}."
 msgid "A–Z"
 msgstr "A–Z"
 
-#: lib/vutuv_web/live/post_live/feed.ex:959
+#: lib/vutuv_web/live/post_live/feed.ex:960
 #, elixir-autogen, elixir-format
 msgid "Browse the tags"
 msgstr "Alle Tags ansehen"
@@ -22577,7 +22577,7 @@ msgstr "Aktivste zuerst"
 msgid "Clear all"
 msgstr "Alle löschen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:788
+#: lib/vutuv_web/live/post_live/feed.ex:789
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr "Ziehen, oder die Pfeiltasten benutzen"
@@ -22592,13 +22592,13 @@ msgstr "Auf- und zuklappen"
 msgid "Find an account or a server …"
 msgstr "Konto oder Server suchen …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:812
+#: lib/vutuv_web/live/post_live/feed.ex:813
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr "%{card} einklappen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:940
 #: lib/vutuv_web/live/post_live/feed.ex:941
+#: lib/vutuv_web/live/post_live/feed.ex:942
 #, elixir-autogen, elixir-format
 msgid "Follow a tag …"
 msgstr "Einem Tag folgen …"
@@ -22615,17 +22615,17 @@ msgstr "Tag ausblenden …"
 msgid "Hide a word or a whole phrase …"
 msgstr "Wort oder ganzen Satz ausblenden …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:749
+#: lib/vutuv_web/live/post_live/feed.ex:750
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Tags ausblenden"
 
-#: lib/vutuv_web/live/post_live/feed.ex:748
+#: lib/vutuv_web/live/post_live/feed.ex:749
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Wörter ausblenden"
 
-#: lib/vutuv_web/live/post_live/feed.ex:965
+#: lib/vutuv_web/live/post_live/feed.ex:966
 #: lib/vutuv_web/live/post_live/filter_band.ex:394
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -22641,7 +22641,7 @@ msgstr "Trifft gerade nichts in Ihrem Feed — für alles Neue gilt die Regel tr
 msgid "More of your %{formatted} accounts"
 msgstr "Mehr Ihrer %{formatted} Konten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:787
+#: lib/vutuv_web/live/post_live/feed.ex:788
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr "%{card} verschieben"
@@ -22652,12 +22652,12 @@ msgstr "%{card} verschieben"
 msgid "No account found."
 msgstr "Kein Konto gefunden."
 
-#: lib/vutuv_web/live/post_live/feed.ex:954
+#: lib/vutuv_web/live/post_live/feed.ex:955
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr "Noch kein Tag namens %{name}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:741
+#: lib/vutuv_web/live/post_live/feed.ex:742
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr "Noch nicht gelesen"
@@ -22687,13 +22687,13 @@ msgstr "Beiträge mit einem dieser Tags werden genauso zugeklappt."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Beiträge mit einem dieser Wörter werden auf eine Zeile zugeklappt — nicht gelöscht, und mit einem Weg, sie doch zu lesen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3683
+#: lib/vutuv_web/live/post_live/feed.ex:3618
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Weggelegt:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:833
 #: lib/vutuv_web/live/post_live/feed.ex:834
+#: lib/vutuv_web/live/post_live/feed.ex:835
 #, elixir-autogen, elixir-format
 msgid "Remove %{card}"
 msgstr "%{card} entfernen"
@@ -22725,7 +22725,7 @@ msgstr "Nur %{source} anzeigen"
 msgid "Show posts by %{name}"
 msgstr "Beiträge von %{name} anzeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:747
+#: lib/vutuv_web/live/post_live/feed.ex:748
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr "Quellen"
@@ -22735,12 +22735,12 @@ msgstr "Quellen"
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr "Ausschalten heißt stumm schalten, nicht entfolgen. Sie folgen weiter, die Beiträge bleiben nur aus Ihrem Feed: dauerhaft und auf allen Geräten, bis Sie hier wieder einschalten."
 
-#: lib/vutuv_web/live/post_live/feed.ex:811
+#: lib/vutuv_web/live/post_live/feed.ex:812
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr "%{card} ausklappen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:930
+#: lib/vutuv_web/live/post_live/feed.ex:931
 #, elixir-autogen, elixir-format
 msgid "Unfollow the tag %{tag}"
 msgstr "Dem Tag %{tag} nicht mehr folgen"
@@ -22764,29 +22764,29 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "und 1 weiterer"
 msgstr[1] "und %{formatted} weitere"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3270
-#: lib/vutuv_web/live/post_live/feed.ex:3297
-#: lib/vutuv_web/live/post_live/feed.ex:3731
-#: lib/vutuv_web/live/post_live/feed.ex:3736
+#: lib/vutuv_web/live/post_live/feed.ex:3205
+#: lib/vutuv_web/live/post_live/feed.ex:3232
+#: lib/vutuv_web/live/post_live/feed.ex:3666
+#: lib/vutuv_web/live/post_live/feed.ex:3671
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr "Filter"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1135
+#: lib/vutuv_web/live/post_live/feed.ex:1136
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr "Ausgeblendet:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:886
+#: lib/vutuv_web/live/post_live/feed.ex:887
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
 msgstr[0] "%{formatted} Beitrag im Feed anzeigen"
 msgstr[1] "%{formatted} Beiträge im Feed anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2371
+#: lib/vutuv_web/components/post_components.ex:2343
 #, elixir-autogen, elixir-format
 msgid "Picture unavailable"
 msgstr "Bild nicht verfügbar"
@@ -22836,7 +22836,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} Beitrag am %{day}"
 msgstr[1] "%{count} Beiträge am %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3453
+#: lib/vutuv_web/live/post_live/feed.ex:3388
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Zurück zu jetzt"
@@ -22846,7 +22846,7 @@ msgstr "Zurück zu jetzt"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Voller Monat: die Färbung zählt mindestens so viel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3499
+#: lib/vutuv_web/live/post_live/feed.ex:3434
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22868,7 +22868,7 @@ msgstr "Nächster Monat"
 msgid "Next year"
 msgstr "Nächstes Jahr"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3449
+#: lib/vutuv_web/live/post_live/feed.ex:3384
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Am %{day} ist nichts in Ihrem Feed angekommen."
@@ -22945,7 +22945,7 @@ msgstr "Passwortmanager wie Bitwarden übernehmen daraus den ganzen Eintrag: Nam
 msgid "Scan it with the device that has the app"
 msgstr "Mit dem Gerät scannen, auf dem die App läuft"
 
-#: lib/vutuv_web/live/shell_live.ex:1072
+#: lib/vutuv_web/live/shell_live.ex:1100
 #, elixir-autogen, elixir-format
 msgid "A new version is ready."
 msgstr "Neue Version bereit."
@@ -22955,14 +22955,14 @@ msgstr "Neue Version bereit."
 msgid "Page management"
 msgstr "Verwaltung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2358
+#: lib/vutuv_web/live/post_live/feed.ex:2326
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
 msgstr[0] "Neu:"
 msgstr[1] "Neu (%{formatted}):"
 
-#: lib/vutuv_web/components/post_components.ex:2871
+#: lib/vutuv_web/components/post_components.ex:2843
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr "Zitierter Beitrag"
@@ -22987,7 +22987,7 @@ msgstr "Ein Konto erwähnen"
 msgid "{used} of {max} mentions"
 msgstr "{used} von {max} Erwähnungen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2507
+#: lib/vutuv_web/live/post_live/feed.ex:2438
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr "Bis hier neu"
@@ -23078,30 +23078,30 @@ msgstr "Block einfügen"
 msgid "Nothing matches."
 msgstr "Nichts gefunden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1982
-#: lib/vutuv_web/live/post_live/composer.ex:2850
+#: lib/vutuv_web/live/post_live/composer.ex:1998
+#: lib/vutuv_web/live/post_live/composer.ex:2866
 #, elixir-autogen, elixir-format
 msgid "Automatic"
 msgstr "Automatisch"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1987
+#: lib/vutuv_web/live/post_live/composer.ex:2003
 #, elixir-autogen, elixir-format
 msgid "Drag one photo onto another to swap them."
 msgstr "Ein Foto auf ein anderes ziehen, um sie zu tauschen."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1934
+#: lib/vutuv_web/live/post_live/composer.ex:1950
 #, elixir-autogen, elixir-format
 msgid "Not shown in the gallery — drag one into it to swap."
 msgstr "Nicht in der Galerie zu sehen — eines hineinziehen, um zu tauschen."
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:94
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post here"
 msgid_plural "%{formatted} posts here"
 msgstr[0] "%{formatted} Beitrag hier"
 msgstr[1] "%{formatted} Beiträge hier"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:226
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:267
 #, elixir-autogen, elixir-format
 msgid "Address copied"
 msgstr "Adresse kopiert"
@@ -23111,52 +23111,52 @@ msgstr "Adresse kopiert"
 msgid "Another network"
 msgstr "Anderes Netzwerk"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:229
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:270
 #, elixir-autogen, elixir-format
 msgid "Copy address"
 msgstr "Adresse kopieren"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:132
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "Latest here"
 msgstr "Zuletzt hier"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:221
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:262
 #, elixir-autogen, elixir-format
 msgid "Mute %{host}"
 msgstr "%{host} stummschalten"
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:132
+#: lib/vutuv_web/views/remote_actor_card_html.ex:118
 #, elixir-autogen, elixir-format
 msgid "Really remove?"
 msgstr "Wirklich entfernen?"
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:133
+#: lib/vutuv_web/views/remote_actor_card_html.ex:119
 #, elixir-autogen, elixir-format
 msgid "Really unfollow?"
 msgstr "Wirklich entfolgen?"
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:134
+#: lib/vutuv_web/views/remote_actor_card_html.ex:120
 #, elixir-autogen, elixir-format
 msgid "Really withdraw?"
 msgstr "Anfrage wirklich zurückziehen?"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:220
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "Unmute %{host}"
 msgstr "%{host} wieder einschalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1742
+#: lib/vutuv_web/live/post_live/composer.ex:1758
 #, elixir-autogen, elixir-format
 msgid "Draft discarded."
 msgstr "Entwurf gelöscht."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1781
+#: lib/vutuv_web/live/post_live/composer.ex:1797
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr "Behalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1772
+#: lib/vutuv_web/live/post_live/composer.ex:1788
 #, elixir-autogen, elixir-format
 msgid "Keep this draft for later?"
 msgstr "Diesen Entwurf für später behalten?"
@@ -23193,12 +23193,7 @@ msgstr "Wenn Ihre Verbindung langsam ist oder Ihr Datenvolumen begrenzt, kann vu
 msgid "Low-bandwidth mode"
 msgstr "Datensparmodus"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:255
-#, elixir-autogen, elixir-format
-msgid "View the original on %{url}"
-msgstr "Original auf %{url} ansehen"
-
-#: lib/vutuv_web/live/shell_live.ex:1595
+#: lib/vutuv_web/live/shell_live.ex:1629
 #, elixir-autogen, elixir-format
 msgctxt "phone tab bar"
 msgid "Write"
@@ -23271,9 +23266,9 @@ msgstr "Regeln für %{account}"
 msgid "Rules that rewrite the text of one account's posts before you read them: a footer under every post, a signature, a wall of hashtags. Only you see the difference. Open the ⋯ menu on any post to write rules for its author."
 msgstr "Regeln, die den Text der Beiträge eines Kontos umschreiben, bevor Sie ihn lesen: eine Fußzeile unter jedem Beitrag, eine Signatur, eine Wand aus Hashtags. Nur Sie sehen den Unterschied. Öffnen Sie das ⋯-Menü an einem Beitrag, um Regeln für dessen Autor zu schreiben."
 
-#: lib/vutuv_web/components/post_components.ex:1371
-#: lib/vutuv_web/components/post_components.ex:2742
-#: lib/vutuv_web/components/post_components.ex:3729
+#: lib/vutuv_web/components/post_components.ex:1343
+#: lib/vutuv_web/components/post_components.ex:2714
+#: lib/vutuv_web/components/post_components.ex:3701
 #: lib/vutuv_web/components/ui.ex:5052
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -23355,7 +23350,7 @@ msgstr "bandbreite langsam internet mobil daten sparen datensparmodus volumen sc
 msgid "Appearance"
 msgstr "Darstellung"
 
-#: lib/vutuv_web/live/shell_live.ex:1621
+#: lib/vutuv_web/live/shell_live.ex:1655
 #, elixir-autogen, elixir-format
 msgid "%{count} video in progress"
 msgid_plural "%{count} videos in progress"
@@ -23367,7 +23362,7 @@ msgstr[1] "%{count} Videos in Arbeit"
 msgid "About %{minutes} min of video"
 msgstr "Etwa %{minutes} Min. Video"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2443
+#: lib/vutuv_web/live/post_live/composer.ex:2459
 #, elixir-autogen, elixir-format
 msgid "Add video"
 msgstr "Video hinzufügen"
@@ -23409,32 +23404,32 @@ msgstr "Ohne das Video veröffentlichen"
 msgid "Reading the frames"
 msgstr "Standbilder werden gelesen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2479
+#: lib/vutuv_web/live/post_live/composer.ex:2495
 #, elixir-autogen, elixir-format
 msgid "Remove it to post the text without it, or pick another file."
 msgstr "Entfernen Sie es, um den Text ohne Video zu veröffentlichen, oder wählen Sie eine andere Datei."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1135
+#: lib/vutuv_web/live/post_live/composer.ex:1145
 #, elixir-autogen, elixir-format
 msgid "Remove the refused video to post the text without it."
 msgstr "Entfernen Sie das abgelehnte Video, um den Text ohne Video zu veröffentlichen."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2508
+#: lib/vutuv_web/live/post_live/composer.ex:2524
 #, elixir-autogen, elixir-format
 msgid "Remove video"
 msgstr "Video entfernen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2518
+#: lib/vutuv_web/live/post_live/composer.ex:2534
 #, elixir-autogen, elixir-format
 msgid "Tap a frame to make it the cover."
 msgstr "Tippen Sie auf ein Bild, um es zum Titelbild zu machen."
 
-#: lib/vutuv_web/live/post_live/composer.ex:998
+#: lib/vutuv_web/live/post_live/composer.ex:1008
 #, elixir-autogen, elixir-format
 msgid "That frame could not be used."
 msgstr "Dieses Bild konnte nicht verwendet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1409
+#: lib/vutuv_web/live/post_live/composer.ex:1425
 #, elixir-autogen, elixir-format
 msgid "The video could not be attached."
 msgstr "Das Video konnte nicht angehängt werden."
@@ -23444,7 +23439,7 @@ msgstr "Das Video konnte nicht angehängt werden."
 msgid "The video is gone."
 msgstr "Das Video ist nicht mehr da."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1496
+#: lib/vutuv_web/live/post_live/composer.ex:1512
 #, elixir-autogen, elixir-format
 msgid "The video is longer than %{seconds} seconds."
 msgstr "Das Video ist länger als %{seconds} Sekunden."
@@ -23463,19 +23458,19 @@ msgstr "Dieses Video konnte nicht umgewandelt werden."
 #: lib/vutuv_web/agent_docs/markdown.ex:1339
 #: lib/vutuv_web/agent_docs/text.ex:827
 #: lib/vutuv_web/agent_docs/text.ex:828
-#: lib/vutuv_web/components/post_components.ex:2506
+#: lib/vutuv_web/components/post_components.ex:2478
 #: lib/vutuv_web/components/video_components.ex:126
-#: lib/vutuv_web/live/post_live/composer.ex:2442
+#: lib/vutuv_web/live/post_live/composer.ex:2458
 #, elixir-autogen, elixir-format
 msgid "Video"
 msgstr "Video"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2486
+#: lib/vutuv_web/live/post_live/composer.ex:2502
 #, elixir-autogen, elixir-format
 msgid "Video description"
 msgstr "Videobeschreibung"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1503
+#: lib/vutuv_web/live/post_live/composer.ex:1519
 #, elixir-autogen, elixir-format
 msgid "Videos cannot be uploaded here."
 msgstr "Hier können keine Videos hochgeladen werden."
@@ -23485,12 +23480,12 @@ msgstr "Hier können keine Videos hochgeladen werden."
 msgid "Waiting in line"
 msgstr "Wartet in der Warteschlange"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2493
+#: lib/vutuv_web/live/post_live/composer.ex:2509
 #, elixir-autogen, elixir-format
 msgid "What is in the video, for people who cannot watch it"
 msgstr "Was im Video zu sehen ist, für Menschen, die es nicht ansehen können"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2482
+#: lib/vutuv_web/live/post_live/composer.ex:2498
 #, elixir-autogen, elixir-format
 msgid "You can post now — the post appears as soon as the video is ready."
 msgstr "Sie können jetzt veröffentlichen: Der Beitrag erscheint, sobald das Video fertig ist."
@@ -23526,7 +23521,7 @@ msgstr[1] "%{formatted} neue Follower"
 msgid "Last 30 days: %{parts}"
 msgstr "Letzte 30 Tage: %{parts}"
 
-#: lib/vutuv_web/components/post_components.ex:4270
+#: lib/vutuv_web/components/post_components.ex:4242
 #: lib/vutuv_web/live/notification_live/index.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -23610,7 +23605,7 @@ msgid_plural "%{formatted} random vutuv accounts that are open to offers."
 msgstr[0] "Ein zufälliger vutuv Account, der offen für Angebote ist."
 msgstr[1] "%{formatted} zufällige vutuv Accounts, die offen für Angebote sind."
 
-#: lib/vutuv_web/live/shell_live.ex:685
+#: lib/vutuv_web/live/shell_live.ex:713
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post in your feed"
 msgid_plural "%{formatted} new posts in your feed"
@@ -23646,3 +23641,15 @@ msgstr "Ihr Feed zeigt, was die Konten schreiben, denen Sie folgen. Hier sind ei
 #, elixir-autogen, elixir-format
 msgid "Your public posts then also appear on {mastodon}, for example."
 msgstr "Ihre öffentlichen Beiträge erscheinen dann auch z.B. auf {mastodon}."
+
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:168
+#, elixir-autogen, elixir-format
+msgid "%{formatted} older post"
+msgid_plural "%{formatted} older posts"
+msgstr[0] "%{formatted} älterer Beitrag"
+msgstr[1] "%{formatted} ältere Beiträge"
+
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:283
+#, elixir-autogen, elixir-format
+msgid "Their page here"
+msgstr "Kontoseite hier"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -40,7 +40,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1485
+#: lib/vutuv_web/templates/user/show.html.heex:1501
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -106,7 +106,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:615
 #: lib/vutuv_web/agent_docs/text.ex:578
 #: lib/vutuv_web/agent_docs/text.ex:579
-#: lib/vutuv_web/templates/user/show.html.heex:1116
+#: lib/vutuv_web/templates/user/show.html.heex:1132
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -120,7 +120,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_posting_live/form.ex:857
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
-#: lib/vutuv_web/live/post_live/composer.ex:1901
+#: lib/vutuv_web/live/post_live/composer.ex:1917
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -154,7 +154,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1154
+#: lib/vutuv_web/templates/user/show.html.heex:1170
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -163,7 +163,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3706
+#: lib/vutuv_web/components/post_components.ex:3678
 #: lib/vutuv_web/components/ui.ex:4593
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -204,14 +204,14 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:446
-#: lib/vutuv_web/live/post_live/composer.ex:2946
+#: lib/vutuv_web/live/post_live/composer.ex:2962
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3671
+#: lib/vutuv_web/components/post_components.ex:3643
 #: lib/vutuv_web/components/ui.ex:4584
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
@@ -225,7 +225,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1139
+#: lib/vutuv_web/templates/user/show.html.heex:1155
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -290,7 +290,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:643
+#: lib/vutuv_web/templates/user/show.html.heex:656
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -333,8 +333,8 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/show.ex:611
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:987
-#: lib/vutuv_web/views/user_html.ex:617
+#: lib/vutuv_web/templates/user/show.html.heex:1000
+#: lib/vutuv_web/views/user_html.ex:622
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -439,8 +439,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1527
-#: lib/vutuv_web/live/shell_live.ex:1603
+#: lib/vutuv_web/live/shell_live.ex:1561
+#: lib/vutuv_web/live/shell_live.ex:1637
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -454,8 +454,8 @@ msgid "Middle Name"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:1351
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:193
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:201
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:234
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:242
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2170
+#: lib/vutuv_web/live/post_live/composer.ex:2186
 #: lib/vutuv_web/live/section_reorder_live.ex:270
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -614,7 +614,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4485
 #: lib/vutuv_web/live/organization_live/edit.ex:376
-#: lib/vutuv_web/live/post_live/composer.ex:2185
+#: lib/vutuv_web/live/post_live/composer.ex:2201
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -645,8 +645,8 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
-#: lib/vutuv_web/live/shell_live.ex:1396
-#: lib/vutuv_web/live/shell_live.ex:1583
+#: lib/vutuv_web/live/shell_live.ex:1430
+#: lib/vutuv_web/live/shell_live.ex:1617
 #: lib/vutuv_web/live/tag_live/timeline.ex:319
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
@@ -656,7 +656,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1759
+#: lib/vutuv_web/components/post_components.ex:1731
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -690,13 +690,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1268
+#: lib/vutuv_web/templates/user/show.html.heex:1284
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1270
+#: lib/vutuv_web/templates/user/show.html.heex:1286
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -721,12 +721,12 @@ msgstr ""
 msgid "Profile deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1025
+#: lib/vutuv_web/views/user_html.ex:1030
 #, elixir-autogen, elixir-format
 msgid "Social networks"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1032
+#: lib/vutuv_web/views/user_html.ex:1037
 #, elixir-autogen, elixir-format
 msgid "Code & repositories"
 msgstr ""
@@ -735,7 +735,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/follow_controller.ex:24
 #: lib/vutuv_web/controllers/remote_follow_controller.ex:174
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
-#: lib/vutuv_web/live/user_profile_live.ex:160
+#: lib/vutuv_web/live/user_profile_live.ex:177
 #, elixir-autogen
 msgid "Something went wrong"
 msgstr ""
@@ -840,16 +840,16 @@ msgid "Users"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1485
-#: lib/vutuv_web/views/user_html.ex:562
-#: lib/vutuv_web/views/user_html.ex:563
-#: lib/vutuv_web/views/user_html.ex:577
+#: lib/vutuv_web/views/user_html.ex:567
+#: lib/vutuv_web/views/user_html.ex:568
+#: lib/vutuv_web/views/user_html.ex:582
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4654
-#: lib/vutuv_web/templates/user/show.html.heex:981
-#: lib/vutuv_web/templates/user/show.html.heex:1004
+#: lib/vutuv_web/templates/user/show.html.heex:994
+#: lib/vutuv_web/templates/user/show.html.heex:1017
 #, elixir-autogen
 msgid "View All"
 msgstr ""
@@ -924,7 +924,7 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:190
+#: lib/vutuv_web/live/post_live/feed.ex:191
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1039,7 +1039,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1105
+#: lib/vutuv_web/templates/user/show.html.heex:1121
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1140,7 +1140,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:63
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1503
+#: lib/vutuv_web/live/shell_live.ex:1537
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1181,10 +1181,10 @@ msgstr ""
 msgid "All tag urls"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4261
+#: lib/vutuv_web/components/post_components.ex:4233
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:637
+#: lib/vutuv_web/templates/user/show.html.heex:650
 #, elixir-autogen
 msgid "All tags"
 msgstr ""
@@ -1380,7 +1380,7 @@ msgstr ""
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:28
 #: lib/vutuv_web/templates/tag/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:607
+#: lib/vutuv_web/templates/user/show.html.heex:620
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1575,7 +1575,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1601
+#: lib/vutuv_web/live/shell_live.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1600,11 +1600,11 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:477
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1757
-#: lib/vutuv_web/live/post_live/composer.ex:1859
-#: lib/vutuv_web/live/post_live/composer.ex:1860
-#: lib/vutuv_web/live/post_live/composer.ex:2823
-#: lib/vutuv_web/live/post_live/composer.ex:3089
+#: lib/vutuv_web/live/post_live/composer.ex:1773
+#: lib/vutuv_web/live/post_live/composer.ex:1875
+#: lib/vutuv_web/live/post_live/composer.ex:1876
+#: lib/vutuv_web/live/post_live/composer.ex:2839
+#: lib/vutuv_web/live/post_live/composer.ex:3105
 #: lib/vutuv_web/templates/layout/app.html.heex:188
 #: lib/vutuv_web/templates/layout/app.html.heex:194
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
@@ -1674,10 +1674,10 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:421
 #: lib/vutuv_web/live/organization_live/show.ex:572
 #: lib/vutuv_web/live/organization_live/show.ex:609
-#: lib/vutuv_web/live/post_live/feed.ex:942
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:180
-#: lib/vutuv_web/templates/user/show.html.heex:1309
-#: lib/vutuv_web/views/user_html.ex:628
+#: lib/vutuv_web/live/post_live/feed.ex:943
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:221
+#: lib/vutuv_web/templates/user/show.html.heex:1325
+#: lib/vutuv_web/views/user_html.ex:633
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1692,7 +1692,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1522
+#: lib/vutuv_web/live/shell_live.ex:1556
 #: lib/vutuv_web/views/settings_html.ex:299
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1714,9 +1714,9 @@ msgid "Member"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/show.ex:631
-#: lib/vutuv_web/views/user_html.ex:655
-#: lib/vutuv_web/views/user_html.ex:656
-#: lib/vutuv_web/views/user_html.ex:666
+#: lib/vutuv_web/views/user_html.ex:660
+#: lib/vutuv_web/views/user_html.ex:661
+#: lib/vutuv_web/views/user_html.ex:671
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lib/vutuv_web/controllers/page_controller.ex:218
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1414
-#: lib/vutuv_web/live/shell_live.ex:1600
+#: lib/vutuv_web/live/shell_live.ex:1448
+#: lib/vutuv_web/live/shell_live.ex:1634
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1757,7 +1757,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/page_controller.ex:219
 #: lib/vutuv_web/live/notification_live/index.ex:152
 #: lib/vutuv_web/live/notification_live/index.ex:457
-#: lib/vutuv_web/live/shell_live.ex:1426
+#: lib/vutuv_web/live/shell_live.ex:1460
 #: lib/vutuv_web/templates/layout/app.html.heex:153
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -1831,7 +1831,7 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
 #: lib/vutuv_web/templates/user/show.html.heex:217
-#: lib/vutuv_web/views/user_html.ex:1077
+#: lib/vutuv_web/views/user_html.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
 msgstr ""
@@ -1851,7 +1851,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:230
+#: lib/vutuv_web/views/user_html.ex:235
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -1870,14 +1870,14 @@ msgstr ""
 
 #: lib/vutuv_web/open_graph.ex:344
 #: lib/vutuv_web/templates/tag/show.html.heex:32
-#: lib/vutuv_web/views/user_html.ex:499
+#: lib/vutuv_web/views/user_html.ex:504
 #, elixir-autogen, elixir-format
 msgid "follower"
 msgid_plural "followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:503
+#: lib/vutuv_web/views/user_html.ex:508
 #, elixir-autogen, elixir-format
 msgid "following"
 msgstr ""
@@ -2032,12 +2032,12 @@ msgstr ""
 msgid "May"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:282
+#: lib/vutuv_web/views/user_html.ex:287
 #, elixir-autogen, elixir-format
 msgid "Member since %{month} %{year}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:287
+#: lib/vutuv_web/views/user_html.ex:292
 #, elixir-autogen, elixir-format
 msgid "Member since %{year}"
 msgstr ""
@@ -2069,7 +2069,7 @@ msgstr ""
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2299
+#: lib/vutuv_web/live/post_live/composer.ex:2315
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2080,8 +2080,8 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1999
-#: lib/vutuv_web/live/post_live/composer.ex:2022
+#: lib/vutuv_web/live/post_live/composer.ex:2015
+#: lib/vutuv_web/live/post_live/composer.ex:2038
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2091,7 +2091,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3703
+#: lib/vutuv_web/components/post_components.ex:3675
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2106,11 +2106,11 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:265
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:162
-#: lib/vutuv_web/live/post_live/feed.ex:341
-#: lib/vutuv_web/live/post_live/feed.ex:3157
+#: lib/vutuv_web/live/post_live/feed.ex:345
+#: lib/vutuv_web/live/post_live/feed.ex:3088
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1254
-#: lib/vutuv_web/live/shell_live.ex:1573
+#: lib/vutuv_web/live/shell_live.ex:1282
+#: lib/vutuv_web/live/shell_live.ex:1607
 #: lib/vutuv_web/templates/layout/app.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2126,55 +2126,55 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2275
+#: lib/vutuv_web/live/post_live/composer.ex:2291
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2203
+#: lib/vutuv_web/live/post_live/composer.ex:2219
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3657
-#: lib/vutuv_web/components/post_components.ex:3659
+#: lib/vutuv_web/components/post_components.ex:3629
+#: lib/vutuv_web/components/post_components.ex:3631
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2245
+#: lib/vutuv_web/live/post_live/composer.ex:2261
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1443
-#: lib/vutuv_web/live/post_live/composer.ex:1546
+#: lib/vutuv_web/live/post_live/composer.ex:1459
+#: lib/vutuv_web/live/post_live/composer.ex:1562
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3473
+#: lib/vutuv_web/live/post_live/feed.ex:3408
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1406
+#: lib/vutuv_web/live/post_live/composer.ex:1422
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2235
+#: lib/vutuv_web/live/post_live/composer.ex:2251
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2225
+#: lib/vutuv_web/live/post_live/composer.ex:2241
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:416
-#: lib/vutuv_web/live/post_live/composer.ex:2187
+#: lib/vutuv_web/live/post_live/composer.ex:2203
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2202,28 +2202,29 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4134
-#: lib/vutuv_web/components/post_components.ex:4138
+#: lib/vutuv_web/components/post_components.ex:4106
+#: lib/vutuv_web/components/post_components.ex:4110
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4135
+#: lib/vutuv_web/components/post_components.ex:4107
 #: lib/vutuv_web/live/fediverse_account_live.ex:360
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:497
 #: lib/vutuv_web/components/job_exclusion_components.ex:189
-#: lib/vutuv_web/components/post_components.ex:1368
+#: lib/vutuv_web/components/post_components.ex:1340
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:229
 #: lib/vutuv_web/live/organization_live/domains.ex:265
 #: lib/vutuv_web/live/organization_live/edit.ex:404
 #: lib/vutuv_web/live/organization_live/roles.ex:257
-#: lib/vutuv_web/live/post_live/composer.ex:2261
+#: lib/vutuv_web/live/post_live/composer.ex:2277
 #: lib/vutuv_web/live/post_live/filter_band.ex:456
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
@@ -2239,12 +2240,12 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2177
+#: lib/vutuv_web/live/post_live/composer.ex:2193
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2364
+#: lib/vutuv_web/live/post_live/feed.ex:2332
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2256,13 +2257,13 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1504
-#: lib/vutuv_web/live/post_live/composer.ex:1572
+#: lib/vutuv_web/live/post_live/composer.ex:1520
+#: lib/vutuv_web/live/post_live/composer.ex:1588
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1388
+#: lib/vutuv_web/live/post_live/composer.ex:1404
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2272,18 +2273,18 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3250
+#: lib/vutuv_web/live/post_live/composer.ex:3266
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3251
+#: lib/vutuv_web/live/post_live/composer.ex:3267
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5363
-#: lib/vutuv_web/live/shell_live.ex:1469
+#: lib/vutuv_web/live/shell_live.ex:1503
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:246
@@ -2291,37 +2292,37 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2393
+#: lib/vutuv_web/live/post_live/composer.ex:2409
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2394
+#: lib/vutuv_web/live/post_live/composer.ex:2410
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3654
+#: lib/vutuv_web/components/post_components.ex:3626
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5694
+#: lib/vutuv_web/components/post_components.ex:5666
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5698
+#: lib/vutuv_web/components/post_components.ex:5670
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5696
+#: lib/vutuv_web/components/post_components.ex:5668
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5697
+#: lib/vutuv_web/components/post_components.ex:5669
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2332,20 +2333,20 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2060
+#: lib/vutuv_web/live/post_live/composer.ex:2076
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1501
-#: lib/vutuv_web/live/post_live/composer.ex:3231
-#: lib/vutuv_web/live/post_live/composer.ex:3235
+#: lib/vutuv_web/live/post_live/composer.ex:1517
+#: lib/vutuv_web/live/post_live/composer.ex:3247
+#: lib/vutuv_web/live/post_live/composer.ex:3251
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3239
-#: lib/vutuv_web/live/post_live/composer.ex:3245
+#: lib/vutuv_web/live/post_live/composer.ex:3255
+#: lib/vutuv_web/live/post_live/composer.ex:3261
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2355,7 +2356,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:597
+#: lib/vutuv_web/templates/user/show.html.heex:610
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2365,10 +2366,10 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2040
-#: lib/vutuv_web/components/post_components.ex:5790
+#: lib/vutuv_web/components/post_components.ex:2012
+#: lib/vutuv_web/components/post_components.ex:5762
 #: lib/vutuv_web/components/ui.ex:4053
-#: lib/vutuv_web/views/user_html.ex:461
+#: lib/vutuv_web/views/user_html.ex:466
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
@@ -2376,28 +2377,28 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1186
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:1406
-#: lib/vutuv_web/live/shell_live.ex:1474
+#: lib/vutuv_web/live/shell_live.ex:1440
+#: lib/vutuv_web/live/shell_live.ex:1508
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1993
-#: lib/vutuv_web/components/post_components.ex:6028
+#: lib/vutuv_web/components/post_components.ex:1965
+#: lib/vutuv_web/components/post_components.ex:6000
 #: lib/vutuv_web/components/ui.ex:4039
 #: lib/vutuv_web/live/notification_live/index.ex:1512
-#: lib/vutuv_web/views/user_html.ex:471
+#: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1185
-#: lib/vutuv_web/components/post_components.ex:6038
+#: lib/vutuv_web/components/post_components.ex:6010
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:1477
+#: lib/vutuv_web/live/shell_live.ex:1511
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2415,58 +2416,58 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5778
+#: lib/vutuv_web/components/post_components.ex:5750
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2039
-#: lib/vutuv_web/components/post_components.ex:5789
+#: lib/vutuv_web/components/post_components.ex:2011
+#: lib/vutuv_web/components/post_components.ex:5761
 #: lib/vutuv_web/live/post_live/saved.ex:806
-#: lib/vutuv_web/views/user_html.ex:461
+#: lib/vutuv_web/views/user_html.ex:466
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2021
-#: lib/vutuv_web/components/post_components.ex:5775
+#: lib/vutuv_web/components/post_components.ex:1993
+#: lib/vutuv_web/components/post_components.ex:5747
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2299
-#: lib/vutuv_web/components/post_components.ex:4865
+#: lib/vutuv_web/components/post_components.ex:2271
+#: lib/vutuv_web/components/post_components.ex:4837
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2020
-#: lib/vutuv_web/components/post_components.ex:5774
+#: lib/vutuv_web/components/post_components.ex:1992
+#: lib/vutuv_web/components/post_components.ex:5746
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1992
-#: lib/vutuv_web/components/post_components.ex:6027
+#: lib/vutuv_web/components/post_components.ex:1964
+#: lib/vutuv_web/components/post_components.ex:5999
 #: lib/vutuv_web/live/post_live/saved.ex:805
-#: lib/vutuv_web/views/user_html.ex:471
+#: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:498
-#: lib/vutuv_web/components/post_components.ex:2734
+#: lib/vutuv_web/components/post_components.ex:2706
 #: lib/vutuv_web/components/ui.ex:2924
 #: lib/vutuv_web/components/ui.ex:2924
 #: lib/vutuv_web/components/ui.ex:3000
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
 #: lib/vutuv_web/live/organization_live/show.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:929
+#: lib/vutuv_web/live/post_live/feed.ex:930
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
-#: lib/vutuv_web/views/user_html.ex:618
+#: lib/vutuv_web/views/user_html.ex:623
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr ""
@@ -2476,7 +2477,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6082
+#: lib/vutuv_web/components/post_components.ex:6054
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2487,9 +2488,9 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2006
-#: lib/vutuv_web/components/post_components.ex:6065
-#: lib/vutuv_web/components/post_components.ex:6066
+#: lib/vutuv_web/components/post_components.ex:1978
+#: lib/vutuv_web/components/post_components.ex:6037
+#: lib/vutuv_web/components/post_components.ex:6038
 #: lib/vutuv_web/live/notification_live/index.ex:1010
 #: lib/vutuv_web/live/notification_live/index.ex:1509
 #: lib/vutuv_web/live/post_live/reply.ex:49
@@ -2497,18 +2498,18 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3621
+#: lib/vutuv_web/components/post_components.ex:3593
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1391
-#: lib/vutuv_web/live/post_live/composer.ex:2165
+#: lib/vutuv_web/live/post_live/composer.ex:1407
+#: lib/vutuv_web/live/post_live/composer.ex:2181
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2306
+#: lib/vutuv_web/live/post_live/composer.ex:2322
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2518,7 +2519,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3155
+#: lib/vutuv_web/components/post_components.ex:3127
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2526,14 +2527,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3593
+#: lib/vutuv_web/components/post_components.ex:3565
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3584
-#: lib/vutuv_web/components/post_components.ex:3613
-#: lib/vutuv_web/components/post_components.ex:3616
+#: lib/vutuv_web/components/post_components.ex:3556
+#: lib/vutuv_web/components/post_components.ex:3585
+#: lib/vutuv_web/components/post_components.ex:3588
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2699,38 +2700,38 @@ msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:917
+#: lib/vutuv_web/templates/user/show.html.heex:930
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1228
+#: lib/vutuv_web/templates/user/show.html.heex:1244
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1487
+#: lib/vutuv_web/templates/user/show.html.heex:1503
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1156
+#: lib/vutuv_web/templates/user/show.html.heex:1172
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1107
+#: lib/vutuv_web/templates/user/show.html.heex:1123
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:646
+#: lib/vutuv_web/templates/user/show.html.heex:659
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2751,14 +2752,13 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
-#: lib/vutuv_web/templates/user/show.html.heex:637
+#: lib/vutuv_web/templates/user/show.html.heex:650
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
 
+#: lib/vutuv_web/components/post_components.ex:802
 #: lib/vutuv_web/controllers/page_controller.ex:216
-#: lib/vutuv_web/live/post_live/feed.ex:2404
-#: lib/vutuv_web/templates/user/show.html.heex:507
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr ""
@@ -2779,7 +2779,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/job_board_live.ex:458
-#: lib/vutuv_web/live/post_live/feed.ex:1058
+#: lib/vutuv_web/live/post_live/feed.ex:1059
 #: lib/vutuv_web/templates/user/card_list.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2215
+#: lib/vutuv_web/live/post_live/composer.ex:2231
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -2826,14 +2826,14 @@ msgid "This post is for the connections of %{name}"
 msgstr ""
 
 #: lib/vutuv_web/views/admin/moderation_html.ex:81
-#: lib/vutuv_web/views/user_html.ex:513
+#: lib/vutuv_web/views/user_html.ex:518
 #, elixir-autogen, elixir-format
 msgid "connection"
 msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5695
+#: lib/vutuv_web/components/post_components.ex:5667
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2861,7 +2861,7 @@ msgid "Endorsement"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:1507
-#: lib/vutuv_web/templates/user/show.html.heex:965
+#: lib/vutuv_web/templates/user/show.html.heex:978
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3090,13 +3090,13 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1196
-#: lib/vutuv_web/templates/user/show.html.heex:1197
+#: lib/vutuv_web/templates/user/show.html.heex:1212
+#: lib/vutuv_web/templates/user/show.html.heex:1213
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3560
+#: lib/vutuv_web/components/post_components.ex:3532
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3146,7 +3146,7 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4973
-#: lib/vutuv_web/live/shell_live.ex:1280
+#: lib/vutuv_web/live/shell_live.ex:1314
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3170,9 +3170,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1381
-#: lib/vutuv_web/components/post_components.ex:2754
-#: lib/vutuv_web/components/post_components.ex:3732
+#: lib/vutuv_web/components/post_components.ex:1353
+#: lib/vutuv_web/components/post_components.ex:2726
+#: lib/vutuv_web/components/post_components.ex:3704
 #: lib/vutuv_web/live/organization_live/show.ex:654
 #: lib/vutuv_web/templates/user/show.html.heex:237
 #, elixir-autogen, elixir-format
@@ -4529,12 +4529,12 @@ msgid "You have not blocked anyone."
 msgstr ""
 
 #: lib/vutuv_web/controllers/block_controller.ex:89
-#: lib/vutuv_web/live/user_profile_live.ex:327
+#: lib/vutuv_web/live/user_profile_live.ex:337
 #, elixir-autogen, elixir-format
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3478
+#: lib/vutuv_web/live/post_live/feed.ex:3413
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4548,7 +4548,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:313
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:987
+#: lib/vutuv_web/templates/user/show.html.heex:1000
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4665,8 +4665,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:547
 #: lib/vutuv_web/live/tag_new_live.ex:47
-#: lib/vutuv_web/live/user_profile_live.ex:1358
-#: lib/vutuv_web/templates/user/show.html.heex:610
+#: lib/vutuv_web/live/user_profile_live.ex:1419
+#: lib/vutuv_web/templates/user/show.html.heex:623
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
@@ -5295,7 +5295,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1412
+#: lib/vutuv_web/live/post_live/composer.ex:1428
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5305,7 +5305,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1456
+#: lib/vutuv_web/live/shell_live.ex:1490
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5327,7 +5327,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1513
+#: lib/vutuv_web/live/shell_live.ex:1547
 #: lib/vutuv_web/templates/layout/app.html.heex:183
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5346,7 +5346,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:276
-#: lib/vutuv_web/live/shell_live.ex:1493
+#: lib/vutuv_web/live/shell_live.ex:1527
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5386,7 +5386,7 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1364
+#: lib/vutuv_web/live/user_profile_live.ex:1425
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5401,8 +5401,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1242
-#: lib/vutuv_web/live/shell_live.ex:1554
+#: lib/vutuv_web/live/shell_live.ex:1270
+#: lib/vutuv_web/live/shell_live.ex:1588
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5412,11 +5412,11 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3798
-#: lib/vutuv_web/components/post_components.ex:3853
-#: lib/vutuv_web/components/post_components.ex:4382
+#: lib/vutuv_web/components/post_components.ex:3770
+#: lib/vutuv_web/components/post_components.ex:3825
+#: lib/vutuv_web/components/post_components.ex:4354
 #: lib/vutuv_web/live/notification_live/index.ex:1086
-#: lib/vutuv_web/views/user_html.ex:126
+#: lib/vutuv_web/views/user_html.ex:131
 #, elixir-autogen, elixir-format
 msgid "View post"
 msgstr ""
@@ -5440,7 +5440,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:1202
+#: lib/vutuv_web/views/user_html.ex:1207
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr ""
@@ -5510,7 +5510,7 @@ msgstr ""
 msgid "Personal tokens for the vutuv API."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2559
+#: lib/vutuv_web/live/post_live/composer.ex:2575
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
@@ -6043,7 +6043,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1369
+#: lib/vutuv_web/live/user_profile_live.ex:1430
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6058,14 +6058,14 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:480
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:915
+#: lib/vutuv_web/templates/user/show.html.heex:928
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:482
+#: lib/vutuv_web/templates/user/show.html.heex:483
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6079,7 +6079,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1537
+#: lib/vutuv_web/templates/user/show.html.heex:1553
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6116,15 +6116,15 @@ msgstr ""
 msgid "Use photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1903
+#: lib/vutuv_web/live/post_live/composer.ex:1919
 #: lib/vutuv_web/templates/user/edit.html.heex:54
 #: lib/vutuv_web/templates/user/edit.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1122
-#: lib/vutuv_web/templates/user/show.html.heex:1132
+#: lib/vutuv_web/templates/user/show.html.heex:1138
+#: lib/vutuv_web/templates/user/show.html.heex:1148
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6164,12 +6164,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1244
+#: lib/vutuv_web/templates/user/show.html.heex:1260
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1255
+#: lib/vutuv_web/templates/user/show.html.heex:1271
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6212,7 +6212,7 @@ msgstr ""
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1253
+#: lib/vutuv_web/templates/user/show.html.heex:1269
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6271,9 +6271,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1527
-#: lib/vutuv_web/templates/user/show.html.heex:1531
 #: lib/vutuv_web/templates/user/show.html.heex:1543
+#: lib/vutuv_web/templates/user/show.html.heex:1547
+#: lib/vutuv_web/templates/user/show.html.heex:1559
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6600,13 +6600,13 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2714
-#: lib/vutuv_web/components/post_components.ex:3723
+#: lib/vutuv_web/components/post_components.ex:2686
+#: lib/vutuv_web/components/post_components.ex:3695
 #: lib/vutuv_web/components/ui.ex:3072
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:215
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:256
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:230
 #, elixir-autogen, elixir-format
@@ -6614,7 +6614,7 @@ msgid "Mute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:49
-#: lib/vutuv_web/live/user_profile_live.ex:268
+#: lib/vutuv_web/live/user_profile_live.ex:278
 #, elixir-autogen, elixir-format
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr ""
@@ -6629,12 +6629,12 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3723
+#: lib/vutuv_web/components/post_components.ex:3695
 #: lib/vutuv_web/components/ui.ex:3071
 #: lib/vutuv_web/live/fediverse_account_live.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:215
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:256
 #: lib/vutuv_web/templates/settings/filters.html.heex:111
 #: lib/vutuv_web/templates/user/show.html.heex:230
 #, elixir-autogen, elixir-format
@@ -6642,7 +6642,7 @@ msgid "Unmute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:51
-#: lib/vutuv_web/live/user_profile_live.ex:270
+#: lib/vutuv_web/live/user_profile_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr ""
@@ -6657,12 +6657,12 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1201
+#: lib/vutuv_web/views/user_html.ex:1206
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:754
+#: lib/vutuv_web/views/user_html.ex:759
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr ""
@@ -7180,7 +7180,7 @@ msgid "open the dev email inbox"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
-#: lib/vutuv_web/views/user_html.ex:753
+#: lib/vutuv_web/views/user_html.ex:758
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr ""
@@ -7271,7 +7271,7 @@ msgid "Removed:"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:974
-#: lib/vutuv_web/live/post_live/composer.ex:1751
+#: lib/vutuv_web/live/post_live/composer.ex:1767
 #: lib/vutuv_web/live/post_live/filter_band.ex:533
 #, elixir-autogen, elixir-format
 msgid "Undo"
@@ -7318,7 +7318,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5938
+#: lib/vutuv_web/components/post_components.ex:5910
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7421,7 +7421,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3744
+#: lib/vutuv_web/live/post_live/feed.ex:3679
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #, elixir-autogen
 msgid "Done"
@@ -7863,7 +7863,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
 #: lib/vutuv_web/live/job_board_live.ex:468
-#: lib/vutuv_web/live/post_live/feed.ex:1067
+#: lib/vutuv_web/live/post_live/feed.ex:1068
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -8105,7 +8105,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:703
+#: lib/vutuv_web/templates/user/show.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8129,7 +8129,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
-#: lib/vutuv_web/templates/user/show.html.heex:700
+#: lib/vutuv_web/templates/user/show.html.heex:713
 #: lib/vutuv_web/views/import_html.ex:70
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
@@ -8303,13 +8303,13 @@ msgstr ""
 msgid "Please check the fields marked in red."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1086
+#: lib/vutuv_web/views/user_html.ex:1091
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1391
+#: lib/vutuv_web/templates/user/show.html.heex:1407
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8617,7 +8617,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1296
+#: lib/vutuv_web/templates/user/show.html.heex:1312
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8759,7 +8759,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4868
+#: lib/vutuv_web/components/post_components.ex:4840
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9010,7 +9010,7 @@ msgstr ""
 #: lib/vutuv_web/live/feed_languages_live.ex:317
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:765
+#: lib/vutuv_web/templates/user/show.html.heex:778
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9235,7 +9235,7 @@ msgstr ""
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:762
+#: lib/vutuv_web/templates/user/show.html.heex:775
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -9515,7 +9515,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:869
+#: lib/vutuv_web/templates/user/show.html.heex:882
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
@@ -9563,7 +9563,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:866
+#: lib/vutuv_web/templates/user/show.html.heex:879
 #: lib/vutuv_web/views/import_html.ex:71
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
@@ -9682,8 +9682,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1218
-#: lib/vutuv_web/templates/user/show.html.heex:1219
+#: lib/vutuv_web/templates/user/show.html.heex:1234
+#: lib/vutuv_web/templates/user/show.html.heex:1235
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -10153,15 +10153,15 @@ msgstr[1] ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:1433
 #: lib/vutuv_web/live/organization_live/show.ex:641
-#: lib/vutuv_web/views/user_html.ex:950
-#: lib/vutuv_web/views/user_html.ex:1126
+#: lib/vutuv_web/views/user_html.ex:955
+#: lib/vutuv_web/views/user_html.ex:1131
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:943
+#: lib/vutuv_web/views/user_html.ex:948
 #, elixir-autogen, elixir-format
 msgid "%{formatted} star"
 msgid_plural "%{formatted} stars"
@@ -10170,7 +10170,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:71
 #: lib/vutuv_web/agent_docs/text.ex:66
-#: lib/vutuv_web/templates/user/show.html.heex:1365
+#: lib/vutuv_web/templates/user/show.html.heex:1381
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10186,7 +10186,7 @@ msgstr ""
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:957
+#: lib/vutuv_web/views/user_html.ex:962
 #, elixir-autogen, elixir-format
 msgid "Last active %{date}"
 msgstr ""
@@ -10211,7 +10211,7 @@ msgstr ""
 msgid "since %{date}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:873
+#: lib/vutuv_web/views/user_html.ex:878
 #, elixir-autogen, elixir-format
 msgid "since %{year}"
 msgstr ""
@@ -10649,8 +10649,8 @@ msgid "Failed"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
-#: lib/vutuv_web/live/post_live/composer.ex:1982
-#: lib/vutuv_web/live/post_live/composer.ex:2817
+#: lib/vutuv_web/live/post_live/composer.ex:1998
+#: lib/vutuv_web/live/post_live/composer.ex:2833
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr ""
@@ -11743,7 +11743,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1484
+#: lib/vutuv_web/live/shell_live.ex:1518
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:79
@@ -12073,7 +12073,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:47
 #: lib/vutuv_web/live/job_board_live.ex:265
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1288
+#: lib/vutuv_web/live/shell_live.ex:1322
 #: lib/vutuv_web/templates/layout/app.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -12969,7 +12969,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3114
+#: lib/vutuv_web/components/post_components.ex:3086
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:715
 #: lib/vutuv_web/controllers/settings_controller.ex:733
@@ -13351,7 +13351,7 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3208
+#: lib/vutuv_web/live/post_live/composer.ex:3224
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -13410,7 +13410,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5067
 #: lib/vutuv_web/controllers/settings_controller.ex:634
-#: lib/vutuv_web/live/post_live/feed.ex:750
+#: lib/vutuv_web/live/post_live/feed.ex:751
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13454,7 +13454,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1331
+#: lib/vutuv_web/templates/user/show.html.heex:1347
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13491,7 +13491,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1329
+#: lib/vutuv_web/templates/user/show.html.heex:1345
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13568,34 +13568,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5544
+#: lib/vutuv_web/components/post_components.ex:5516
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1274
-#: lib/vutuv_web/components/post_components.ex:5501
+#: lib/vutuv_web/components/post_components.ex:5473
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5545
+#: lib/vutuv_web/components/post_components.ex:5517
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5547
+#: lib/vutuv_web/components/post_components.ex:5519
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5543
+#: lib/vutuv_web/components/post_components.ex:5515
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1274
-#: lib/vutuv_web/components/post_components.ex:5500
+#: lib/vutuv_web/components/post_components.ex:5472
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13606,12 +13606,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5542
+#: lib/vutuv_web/components/post_components.ex:5514
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5546
+#: lib/vutuv_web/components/post_components.ex:5518
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13631,7 +13631,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5583
+#: lib/vutuv_web/components/post_components.ex:5555
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13639,27 +13639,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5613
+#: lib/vutuv_web/components/post_components.ex:5585
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5614
+#: lib/vutuv_web/components/post_components.ex:5586
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5612
+#: lib/vutuv_web/components/post_components.ex:5584
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5572
+#: lib/vutuv_web/components/post_components.ex:5544
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5619
+#: lib/vutuv_web/components/post_components.ex:5591
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13689,7 +13689,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5386
+#: lib/vutuv_web/components/post_components.ex:5358
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13732,7 +13732,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5377
+#: lib/vutuv_web/components/post_components.ex:5349
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -13749,7 +13749,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:671
+#: lib/vutuv_web/live/shell_live.ex:699
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -13984,13 +13984,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1396
+#: lib/vutuv_web/live/post_live/composer.ex:1412
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1399
+#: lib/vutuv_web/live/post_live/composer.ex:1415
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14079,14 +14079,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3387
+#: lib/vutuv_web/components/post_components.ex:3359
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3410
+#: lib/vutuv_web/components/post_components.ex:3382
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14113,7 +14113,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6037
+#: lib/vutuv_web/components/post_components.ex:6009
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14289,7 +14289,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1127
+#: lib/vutuv_web/live/post_live/feed.ex:1128
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -14848,7 +14848,7 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1038
+#: lib/vutuv_web/templates/user/show.html.heex:1054
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
@@ -15257,7 +15257,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5983
+#: lib/vutuv_web/components/post_components.ex:5955
 #: lib/vutuv_web/live/notification_live/index.ex:1690
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -15265,7 +15265,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5987
+#: lib/vutuv_web/components/post_components.ex:5959
 #: lib/vutuv_web/live/notification_live/index.ex:1684
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15273,7 +15273,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5991
+#: lib/vutuv_web/components/post_components.ex:5963
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15281,7 +15281,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1223
-#: lib/vutuv_web/components/post_components.ex:5942
+#: lib/vutuv_web/components/post_components.ex:5914
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15297,14 +15297,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1496
-#: lib/vutuv_web/components/post_components.ex:2228
+#: lib/vutuv_web/components/post_components.ex:1468
+#: lib/vutuv_web/components/post_components.ex:2200
 #: lib/vutuv_web/live/fediverse_account_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1366
+#: lib/vutuv_web/components/post_components.ex:1338
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15333,7 +15333,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1378
+#: lib/vutuv_web/components/post_components.ex:1350
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15343,7 +15343,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1392
+#: lib/vutuv_web/components/post_components.ex:1364
 #: lib/vutuv_web/live/notification_live/index.ex:1134
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15375,9 +15375,10 @@ msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1423
-#: lib/vutuv_web/components/post_components.ex:1427
-#: lib/vutuv_web/components/post_components.ex:1627
-#: lib/vutuv_web/components/post_components.ex:3004
+#: lib/vutuv_web/components/post_components.ex:1399
+#: lib/vutuv_web/components/post_components.ex:1599
+#: lib/vutuv_web/components/post_components.ex:2976
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:302
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -16040,22 +16041,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3572
+#: lib/vutuv_web/components/post_components.ex:3544
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3690
+#: lib/vutuv_web/components/post_components.ex:3662
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3698
+#: lib/vutuv_web/components/post_components.ex:3670
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3684
+#: lib/vutuv_web/components/post_components.ex:3656
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16099,7 +16100,7 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3221
+#: lib/vutuv_web/live/post_live/composer.ex:3237
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16131,12 +16132,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1340
 #: lib/vutuv_web/agent_docs/text.ex:830
-#: lib/vutuv_web/live/post_live/composer.ex:2645
+#: lib/vutuv_web/live/post_live/composer.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3059
+#: lib/vutuv_web/live/post_live/composer.ex:3075
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
@@ -16148,22 +16149,22 @@ msgstr ""
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3158
+#: lib/vutuv_web/live/post_live/composer.ex:3174
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3114
+#: lib/vutuv_web/live/post_live/composer.ex:3130
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3116
+#: lib/vutuv_web/live/post_live/composer.ex:3132
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3135
+#: lib/vutuv_web/live/post_live/composer.ex:3151
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
@@ -16173,35 +16174,35 @@ msgstr ""
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2664
+#: lib/vutuv_web/live/post_live/composer.ex:2680
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3167
+#: lib/vutuv_web/components/post_components.ex:3139
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4513
+#: lib/vutuv_web/components/post_components.ex:4485
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4662
+#: lib/vutuv_web/components/post_components.ex:4634
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2617
-#: lib/vutuv_web/live/post_live/composer.ex:2618
+#: lib/vutuv_web/live/post_live/composer.ex:2633
+#: lib/vutuv_web/live/post_live/composer.ex:2634
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1384
 #: lib/vutuv_web/agent_docs/text.ex:818
-#: lib/vutuv_web/components/post_components.ex:4744
+#: lib/vutuv_web/components/post_components.ex:4716
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
@@ -16211,43 +16212,43 @@ msgstr ""
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2677
-#: lib/vutuv_web/live/post_live/composer.ex:2678
+#: lib/vutuv_web/live/post_live/composer.ex:2693
+#: lib/vutuv_web/live/post_live/composer.ex:2694
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3137
+#: lib/vutuv_web/live/post_live/composer.ex:3153
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3078
+#: lib/vutuv_web/live/post_live/composer.ex:3094
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3220
+#: lib/vutuv_web/components/post_components.ex:3192
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3156
+#: lib/vutuv_web/live/post_live/composer.ex:3172
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3192
+#: lib/vutuv_web/live/post_live/composer.ex:3208
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3184
+#: lib/vutuv_web/live/post_live/composer.ex:3200
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3211
+#: lib/vutuv_web/components/post_components.ex:3183
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16257,37 +16258,37 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3229
+#: lib/vutuv_web/components/post_components.ex:3201
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3163
+#: lib/vutuv_web/components/post_components.ex:3135
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2935
+#: lib/vutuv_web/live/post_live/composer.ex:2951
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1426
+#: lib/vutuv_web/live/post_live/composer.ex:1442
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3224
+#: lib/vutuv_web/components/post_components.ex:3196
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1440
+#: lib/vutuv_web/live/post_live/composer.ex:1456
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3177
+#: lib/vutuv_web/components/post_components.ex:3149
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16297,64 +16298,64 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2560
+#: lib/vutuv_web/live/post_live/composer.ex:2576
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2930
+#: lib/vutuv_web/live/post_live/composer.ex:2946
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3049
+#: lib/vutuv_web/live/post_live/composer.ex:3065
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1726
-#: lib/vutuv_web/live/post_live/composer.ex:1789
-#: lib/vutuv_web/live/post_live/composer.ex:1847
+#: lib/vutuv_web/live/post_live/composer.ex:1742
+#: lib/vutuv_web/live/post_live/composer.ex:1805
+#: lib/vutuv_web/live/post_live/composer.ex:1863
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1719
+#: lib/vutuv_web/live/post_live/composer.ex:1735
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2983
+#: lib/vutuv_web/live/post_live/composer.ex:2999
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2372
+#: lib/vutuv_web/live/post_live/composer.ex:2388
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2371
+#: lib/vutuv_web/live/post_live/composer.ex:2387
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2370
+#: lib/vutuv_web/live/post_live/composer.ex:2386
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2375
+#: lib/vutuv_web/live/post_live/composer.ex:2391
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2953
+#: lib/vutuv_web/live/post_live/composer.ex:2969
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2972
+#: lib/vutuv_web/live/post_live/composer.ex:2988
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -16362,13 +16363,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1241
-#: lib/vutuv_web/components/post_components.ex:5980
+#: lib/vutuv_web/components/post_components.ex:5952
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1239
-#: lib/vutuv_web/components/post_components.ex:5977
+#: lib/vutuv_web/components/post_components.ex:5949
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16378,7 +16379,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5867
+#: lib/vutuv_web/components/post_components.ex:5839
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -16465,8 +16466,8 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1983
-#: lib/vutuv_web/live/post_live/composer.ex:2817
+#: lib/vutuv_web/live/post_live/composer.ex:1999
+#: lib/vutuv_web/live/post_live/composer.ex:2833
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr ""
@@ -16719,7 +16720,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2763
+#: lib/vutuv_web/components/post_components.ex:2735
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16729,7 +16730,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3003
+#: lib/vutuv_web/components/post_components.ex:2975
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16749,12 +16750,12 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1762
+#: lib/vutuv_web/components/post_components.ex:1734
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2944
+#: lib/vutuv_web/components/post_components.ex:2916
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr ""
@@ -16770,7 +16771,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2749
+#: lib/vutuv_web/components/post_components.ex:2721
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -16992,27 +16993,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2400
+#: lib/vutuv_web/components/post_components.ex:2372
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2433
+#: lib/vutuv_web/components/post_components.ex:2405
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2428
+#: lib/vutuv_web/components/post_components.ex:2400
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3070
+#: lib/vutuv_web/components/post_components.ex:3042
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3076
+#: lib/vutuv_web/components/post_components.ex:3048
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr ""
@@ -17022,7 +17023,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3215
+#: lib/vutuv_web/components/post_components.ex:3187
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17062,14 +17063,14 @@ msgstr ""
 msgid "That link points at a single post. You can follow its author, %{account}, from here."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1403
+#: lib/vutuv_web/live/user_profile_live.ex:1464
 #, elixir-autogen, elixir-format
 msgid "You already follow one member."
 msgid_plural "You already follow %{count} members."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:232
+#: lib/vutuv_web/views/user_html.ex:237
 #, elixir-autogen, elixir-format
 msgid "Your feed shows the posts of members you follow. Follow a few to fill it."
 msgstr ""
@@ -17279,7 +17280,6 @@ msgid "That is a link on this vutuv, not on another network."
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:317
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:240
 #, elixir-autogen, elixir-format
 msgid "Their account page here"
 msgstr ""
@@ -17334,104 +17334,104 @@ msgstr ""
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1900
+#: lib/vutuv_web/live/post_live/composer.ex:1916
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2723
+#: lib/vutuv_web/live/post_live/composer.ex:2739
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2724
+#: lib/vutuv_web/live/post_live/composer.ex:2740
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2729
+#: lib/vutuv_web/live/post_live/composer.ex:2745
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2726
+#: lib/vutuv_web/live/post_live/composer.ex:2742
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2727
+#: lib/vutuv_web/live/post_live/composer.ex:2743
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2728
+#: lib/vutuv_web/live/post_live/composer.ex:2744
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1896
-#: lib/vutuv_web/live/post_live/composer.ex:2694
-#: lib/vutuv_web/live/post_live/composer.ex:2695
+#: lib/vutuv_web/live/post_live/composer.ex:1912
+#: lib/vutuv_web/live/post_live/composer.ex:2710
+#: lib/vutuv_web/live/post_live/composer.ex:2711
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2653
+#: lib/vutuv_web/live/post_live/composer.ex:2669
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1818
+#: lib/vutuv_web/live/post_live/composer.ex:1834
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2730
+#: lib/vutuv_web/live/post_live/composer.ex:2746
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2731
+#: lib/vutuv_web/live/post_live/composer.ex:2747
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1898
+#: lib/vutuv_web/live/post_live/composer.ex:1914
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2722
+#: lib/vutuv_web/live/post_live/composer.ex:2738
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2725
+#: lib/vutuv_web/live/post_live/composer.ex:2741
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:562
+#: lib/vutuv_web/live/post_live/composer.ex:572
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3171
+#: lib/vutuv_web/live/post_live/composer.ex:3187
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1902
+#: lib/vutuv_web/live/post_live/composer.ex:1918
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2920
+#: lib/vutuv_web/live/post_live/composer.ex:2936
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2904
+#: lib/vutuv_web/live/post_live/composer.ex:2920
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr ""
@@ -17691,7 +17691,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3073
+#: lib/vutuv_web/components/post_components.ex:3045
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -17994,19 +17994,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5038
+#: lib/vutuv_web/components/post_components.ex:5010
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5040
+#: lib/vutuv_web/components/post_components.ex:5012
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5051
+#: lib/vutuv_web/components/post_components.ex:5023
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18066,7 +18066,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/job_reference_controller.ex:144
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:18
 #: lib/vutuv_web/templates/job_reference/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:803
+#: lib/vutuv_web/templates/user/show.html.heex:816
 #, elixir-autogen, elixir-format
 msgid "Add an employment reference"
 msgstr ""
@@ -18143,7 +18143,7 @@ msgstr ""
 #: lib/vutuv_web/templates/job_reference/new.html.heex:4
 #: lib/vutuv_web/templates/job_reference/show.html.heex:12
 #: lib/vutuv_web/templates/job_reference/view.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:800
+#: lib/vutuv_web/templates/user/show.html.heex:813
 #, elixir-autogen, elixir-format
 msgid "Employment references"
 msgstr ""
@@ -18178,7 +18178,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3496
+#: lib/vutuv_web/live/post_live/feed.ex:3431
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -18780,7 +18780,7 @@ msgstr ""
 msgid "by the lawyer Tom Braegelmann"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:844
+#: lib/vutuv_web/templates/user/show.html.heex:857
 #, elixir-autogen, elixir-format
 msgid "Documents:"
 msgstr ""
@@ -18951,7 +18951,7 @@ msgstr ""
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1389
+#: lib/vutuv_web/live/user_profile_live.ex:1450
 #, elixir-autogen, elixir-format
 msgid "Follow other members"
 msgstr ""
@@ -19657,7 +19657,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3103
+#: lib/vutuv_web/components/post_components.ex:3075
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -19717,22 +19717,22 @@ msgstr ""
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2186
+#: lib/vutuv_web/live/post_live/composer.ex:2202
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1419
+#: lib/vutuv_web/live/post_live/composer.ex:1435
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2163
+#: lib/vutuv_web/live/post_live/composer.ex:2179
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1200
+#: lib/vutuv_web/live/shell_live.ex:1228
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr ""
@@ -19752,7 +19752,7 @@ msgstr ""
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1210
+#: lib/vutuv_web/live/shell_live.ex:1238
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -19762,7 +19762,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1186
+#: lib/vutuv_web/live/shell_live.ex:1214
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -20126,21 +20126,21 @@ msgstr ""
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:715
+#: lib/vutuv_web/live/shell_live.ex:743
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:702
+#: lib/vutuv_web/live/shell_live.ex:730
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:737
+#: lib/vutuv_web/live/shell_live.ex:765
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -20508,44 +20508,44 @@ msgstr ""
 msgid "{n} of {max} free slots selected."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2145
+#: lib/vutuv_web/live/post_live/composer.ex:2161
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2136
+#: lib/vutuv_web/live/post_live/composer.ex:2152
 #, elixir-autogen, elixir-format
 msgctxt "post composer"
 msgid "Language"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2132
-#: lib/vutuv_web/live/post_live/composer.ex:2133
+#: lib/vutuv_web/live/post_live/composer.ex:2148
+#: lib/vutuv_web/live/post_live/composer.ex:2149
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4932
+#: lib/vutuv_web/components/post_components.ex:4904
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4968
+#: lib/vutuv_web/components/post_components.ex:4940
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4977
+#: lib/vutuv_web/components/post_components.ex:4949
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4980
+#: lib/vutuv_web/components/post_components.ex:4952
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4957
+#: lib/vutuv_web/components/post_components.ex:4929
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20555,7 +20555,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4947
+#: lib/vutuv_web/components/post_components.ex:4919
 #: lib/vutuv_web/components/ui.ex:5060
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20684,20 +20684,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4710
+#: lib/vutuv_web/components/post_components.ex:4682
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4707
+#: lib/vutuv_web/components/post_components.ex:4679
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2454
-#: lib/vutuv_web/components/post_components.ex:3918
+#: lib/vutuv_web/components/post_components.ex:2426
+#: lib/vutuv_web/components/post_components.ex:3890
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20715,13 +20715,13 @@ msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:431
-#: lib/vutuv_web/live/post_live/feed.ex:1004
-#: lib/vutuv_web/views/user_html.ex:342
+#: lib/vutuv_web/live/post_live/feed.ex:1005
+#: lib/vutuv_web/views/user_html.ex:347
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:345
+#: lib/vutuv_web/views/user_html.ex:350
 #, elixir-autogen, elixir-format
 msgid "Show the profile picture larger"
 msgstr ""
@@ -20839,7 +20839,7 @@ msgid "Find my contacts"
 msgstr ""
 
 #: lib/vutuv_web/templates/user/show.html.heex:460
-#: lib/vutuv_web/views/user_html.ex:254
+#: lib/vutuv_web/views/user_html.ex:259
 #, elixir-autogen, elixir-format
 msgid "Find people you know from LinkedIn"
 msgstr ""
@@ -21211,7 +21211,7 @@ msgstr ""
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2729
+#: lib/vutuv_web/components/post_components.ex:2701
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
@@ -21221,7 +21221,7 @@ msgstr ""
 msgid "Unfollowed. Their posts leave your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1160
+#: lib/vutuv_web/live/shell_live.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr ""
@@ -21236,12 +21236,12 @@ msgstr ""
 msgid "Browser notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1018
+#: lib/vutuv_web/live/shell_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1163
+#: lib/vutuv_web/live/shell_live.ex:1191
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
@@ -21281,7 +21281,7 @@ msgstr ""
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1157
+#: lib/vutuv_web/live/shell_live.ex:1185
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -21321,12 +21321,12 @@ msgstr ""
 msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:810
+#: lib/vutuv_web/live/shell_live.ex:838
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:811
+#: lib/vutuv_web/live/shell_live.ex:839
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr ""
@@ -21336,12 +21336,12 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3657
+#: lib/vutuv_web/live/post_live/feed.ex:3592
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:751
+#: lib/vutuv_web/live/post_live/feed.ex:752
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr ""
@@ -21387,7 +21387,7 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:996
+#: lib/vutuv_web/live/post_live/feed.ex:997
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
@@ -21547,7 +21547,7 @@ msgstr ""
 msgid "Translated into %{language}."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:951
+#: lib/vutuv_web/live/shell_live.ex:979
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -21666,7 +21666,7 @@ msgstr ""
 msgid "No connection"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1090
+#: lib/vutuv_web/live/shell_live.ex:1118
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr ""
@@ -21759,7 +21759,7 @@ msgstr ""
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:876
+#: lib/vutuv_web/live/post_live/feed.ex:877
 #: lib/vutuv_web/live/post_live/filter_band.ex:350
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -21775,7 +21775,7 @@ msgstr ""
 msgid "A–Z"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:959
+#: lib/vutuv_web/live/post_live/feed.ex:960
 #, elixir-autogen, elixir-format
 msgid "Browse the tags"
 msgstr ""
@@ -21790,7 +21790,7 @@ msgstr ""
 msgid "Clear all"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:788
+#: lib/vutuv_web/live/post_live/feed.ex:789
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr ""
@@ -21805,13 +21805,13 @@ msgstr ""
 msgid "Find an account or a server …"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:812
+#: lib/vutuv_web/live/post_live/feed.ex:813
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:940
 #: lib/vutuv_web/live/post_live/feed.ex:941
+#: lib/vutuv_web/live/post_live/feed.ex:942
 #, elixir-autogen, elixir-format
 msgid "Follow a tag …"
 msgstr ""
@@ -21828,17 +21828,17 @@ msgstr ""
 msgid "Hide a word or a whole phrase …"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:749
+#: lib/vutuv_web/live/post_live/feed.ex:750
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:748
+#: lib/vutuv_web/live/post_live/feed.ex:749
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:965
+#: lib/vutuv_web/live/post_live/feed.ex:966
 #: lib/vutuv_web/live/post_live/filter_band.ex:394
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -21854,7 +21854,7 @@ msgstr ""
 msgid "More of your %{formatted} accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:787
+#: lib/vutuv_web/live/post_live/feed.ex:788
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr ""
@@ -21865,12 +21865,12 @@ msgstr ""
 msgid "No account found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:954
+#: lib/vutuv_web/live/post_live/feed.ex:955
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:741
+#: lib/vutuv_web/live/post_live/feed.ex:742
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr ""
@@ -21900,13 +21900,13 @@ msgstr ""
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3683
+#: lib/vutuv_web/live/post_live/feed.ex:3618
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:833
 #: lib/vutuv_web/live/post_live/feed.ex:834
+#: lib/vutuv_web/live/post_live/feed.ex:835
 #, elixir-autogen, elixir-format
 msgid "Remove %{card}"
 msgstr ""
@@ -21938,7 +21938,7 @@ msgstr ""
 msgid "Show posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:747
+#: lib/vutuv_web/live/post_live/feed.ex:748
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr ""
@@ -21948,12 +21948,12 @@ msgstr ""
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:811
+#: lib/vutuv_web/live/post_live/feed.ex:812
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:930
+#: lib/vutuv_web/live/post_live/feed.ex:931
 #, elixir-autogen, elixir-format
 msgid "Unfollow the tag %{tag}"
 msgstr ""
@@ -21977,29 +21977,29 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3270
-#: lib/vutuv_web/live/post_live/feed.ex:3297
-#: lib/vutuv_web/live/post_live/feed.ex:3731
-#: lib/vutuv_web/live/post_live/feed.ex:3736
+#: lib/vutuv_web/live/post_live/feed.ex:3205
+#: lib/vutuv_web/live/post_live/feed.ex:3232
+#: lib/vutuv_web/live/post_live/feed.ex:3666
+#: lib/vutuv_web/live/post_live/feed.ex:3671
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1135
+#: lib/vutuv_web/live/post_live/feed.ex:1136
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:886
+#: lib/vutuv_web/live/post_live/feed.ex:887
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2371
+#: lib/vutuv_web/components/post_components.ex:2343
 #, elixir-autogen, elixir-format
 msgid "Picture unavailable"
 msgstr ""
@@ -22045,7 +22045,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3453
+#: lib/vutuv_web/live/post_live/feed.ex:3388
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr ""
@@ -22055,7 +22055,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3499
+#: lib/vutuv_web/live/post_live/feed.ex:3434
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22077,7 +22077,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3449
+#: lib/vutuv_web/live/post_live/feed.ex:3384
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -22154,7 +22154,7 @@ msgstr ""
 msgid "Scan it with the device that has the app"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1072
+#: lib/vutuv_web/live/shell_live.ex:1100
 #, elixir-autogen, elixir-format
 msgid "A new version is ready."
 msgstr ""
@@ -22164,14 +22164,14 @@ msgstr ""
 msgid "Page management"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2358
+#: lib/vutuv_web/live/post_live/feed.ex:2326
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2871
+#: lib/vutuv_web/components/post_components.ex:2843
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr ""
@@ -22196,7 +22196,7 @@ msgstr ""
 msgid "{used} of {max} mentions"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2507
+#: lib/vutuv_web/live/post_live/feed.ex:2438
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""
@@ -22287,30 +22287,30 @@ msgstr ""
 msgid "Nothing matches."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1982
-#: lib/vutuv_web/live/post_live/composer.ex:2850
+#: lib/vutuv_web/live/post_live/composer.ex:1998
+#: lib/vutuv_web/live/post_live/composer.ex:2866
 #, elixir-autogen, elixir-format
 msgid "Automatic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1987
+#: lib/vutuv_web/live/post_live/composer.ex:2003
 #, elixir-autogen, elixir-format
 msgid "Drag one photo onto another to swap them."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1934
+#: lib/vutuv_web/live/post_live/composer.ex:1950
 #, elixir-autogen, elixir-format
 msgid "Not shown in the gallery — drag one into it to swap."
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:94
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post here"
 msgid_plural "%{formatted} posts here"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:226
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:267
 #, elixir-autogen, elixir-format
 msgid "Address copied"
 msgstr ""
@@ -22320,52 +22320,52 @@ msgstr ""
 msgid "Another network"
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:229
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:270
 #, elixir-autogen, elixir-format
 msgid "Copy address"
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:132
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "Latest here"
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:221
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:262
 #, elixir-autogen, elixir-format
 msgid "Mute %{host}"
 msgstr ""
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:132
+#: lib/vutuv_web/views/remote_actor_card_html.ex:118
 #, elixir-autogen, elixir-format
 msgid "Really remove?"
 msgstr ""
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:133
+#: lib/vutuv_web/views/remote_actor_card_html.ex:119
 #, elixir-autogen, elixir-format
 msgid "Really unfollow?"
 msgstr ""
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:134
+#: lib/vutuv_web/views/remote_actor_card_html.ex:120
 #, elixir-autogen, elixir-format
 msgid "Really withdraw?"
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:220
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "Unmute %{host}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1742
+#: lib/vutuv_web/live/post_live/composer.ex:1758
 #, elixir-autogen, elixir-format
 msgid "Draft discarded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1781
+#: lib/vutuv_web/live/post_live/composer.ex:1797
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1772
+#: lib/vutuv_web/live/post_live/composer.ex:1788
 #, elixir-autogen, elixir-format
 msgid "Keep this draft for later?"
 msgstr ""
@@ -22402,12 +22402,7 @@ msgstr ""
 msgid "Low-bandwidth mode"
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:255
-#, elixir-autogen, elixir-format
-msgid "View the original on %{url}"
-msgstr ""
-
-#: lib/vutuv_web/live/shell_live.ex:1595
+#: lib/vutuv_web/live/shell_live.ex:1629
 #, elixir-autogen, elixir-format
 msgctxt "phone tab bar"
 msgid "Write"
@@ -22480,9 +22475,9 @@ msgstr ""
 msgid "Rules that rewrite the text of one account's posts before you read them: a footer under every post, a signature, a wall of hashtags. Only you see the difference. Open the ⋯ menu on any post to write rules for its author."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1371
-#: lib/vutuv_web/components/post_components.ex:2742
-#: lib/vutuv_web/components/post_components.ex:3729
+#: lib/vutuv_web/components/post_components.ex:1343
+#: lib/vutuv_web/components/post_components.ex:2714
+#: lib/vutuv_web/components/post_components.ex:3701
 #: lib/vutuv_web/components/ui.ex:5052
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -22564,7 +22559,7 @@ msgstr ""
 msgid "Appearance"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1621
+#: lib/vutuv_web/live/shell_live.ex:1655
 #, elixir-autogen, elixir-format
 msgid "%{count} video in progress"
 msgid_plural "%{count} videos in progress"
@@ -22576,7 +22571,7 @@ msgstr[1] ""
 msgid "About %{minutes} min of video"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2443
+#: lib/vutuv_web/live/post_live/composer.ex:2459
 #, elixir-autogen, elixir-format
 msgid "Add video"
 msgstr ""
@@ -22618,32 +22613,32 @@ msgstr ""
 msgid "Reading the frames"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2479
+#: lib/vutuv_web/live/post_live/composer.ex:2495
 #, elixir-autogen, elixir-format
 msgid "Remove it to post the text without it, or pick another file."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1135
+#: lib/vutuv_web/live/post_live/composer.ex:1145
 #, elixir-autogen, elixir-format
 msgid "Remove the refused video to post the text without it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2508
+#: lib/vutuv_web/live/post_live/composer.ex:2524
 #, elixir-autogen, elixir-format
 msgid "Remove video"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2518
+#: lib/vutuv_web/live/post_live/composer.ex:2534
 #, elixir-autogen, elixir-format
 msgid "Tap a frame to make it the cover."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:998
+#: lib/vutuv_web/live/post_live/composer.ex:1008
 #, elixir-autogen, elixir-format
 msgid "That frame could not be used."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1409
+#: lib/vutuv_web/live/post_live/composer.ex:1425
 #, elixir-autogen, elixir-format
 msgid "The video could not be attached."
 msgstr ""
@@ -22653,7 +22648,7 @@ msgstr ""
 msgid "The video is gone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1496
+#: lib/vutuv_web/live/post_live/composer.ex:1512
 #, elixir-autogen, elixir-format
 msgid "The video is longer than %{seconds} seconds."
 msgstr ""
@@ -22672,19 +22667,19 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1339
 #: lib/vutuv_web/agent_docs/text.ex:827
 #: lib/vutuv_web/agent_docs/text.ex:828
-#: lib/vutuv_web/components/post_components.ex:2506
+#: lib/vutuv_web/components/post_components.ex:2478
 #: lib/vutuv_web/components/video_components.ex:126
-#: lib/vutuv_web/live/post_live/composer.ex:2442
+#: lib/vutuv_web/live/post_live/composer.ex:2458
 #, elixir-autogen, elixir-format
 msgid "Video"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2486
+#: lib/vutuv_web/live/post_live/composer.ex:2502
 #, elixir-autogen, elixir-format
 msgid "Video description"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1503
+#: lib/vutuv_web/live/post_live/composer.ex:1519
 #, elixir-autogen, elixir-format
 msgid "Videos cannot be uploaded here."
 msgstr ""
@@ -22694,12 +22689,12 @@ msgstr ""
 msgid "Waiting in line"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2493
+#: lib/vutuv_web/live/post_live/composer.ex:2509
 #, elixir-autogen, elixir-format
 msgid "What is in the video, for people who cannot watch it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2482
+#: lib/vutuv_web/live/post_live/composer.ex:2498
 #, elixir-autogen, elixir-format
 msgid "You can post now — the post appears as soon as the video is ready."
 msgstr ""
@@ -22735,7 +22730,7 @@ msgstr[1] ""
 msgid "Last 30 days: %{parts}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4270
+#: lib/vutuv_web/components/post_components.ex:4242
 #: lib/vutuv_web/live/notification_live/index.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -22819,7 +22814,7 @@ msgid_plural "%{formatted} random vutuv accounts that are open to offers."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:685
+#: lib/vutuv_web/live/shell_live.ex:713
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post in your feed"
 msgid_plural "%{formatted} new posts in your feed"
@@ -22854,4 +22849,16 @@ msgstr ""
 #: lib/vutuv_web/templates/page/index.html.heex:265
 #, elixir-autogen, elixir-format
 msgid "Your public posts then also appear on {mastodon}, for example."
+msgstr ""
+
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:168
+#, elixir-autogen, elixir-format
+msgid "%{formatted} older post"
+msgid_plural "%{formatted} older posts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:283
+#, elixir-autogen, elixir-format
+msgid "Their page here"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -38,7 +38,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1485
+#: lib/vutuv_web/templates/user/show.html.heex:1501
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -104,7 +104,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:615
 #: lib/vutuv_web/agent_docs/text.ex:578
 #: lib/vutuv_web/agent_docs/text.ex:579
-#: lib/vutuv_web/templates/user/show.html.heex:1116
+#: lib/vutuv_web/templates/user/show.html.heex:1132
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -118,7 +118,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_posting_live/form.ex:857
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
-#: lib/vutuv_web/live/post_live/composer.ex:1901
+#: lib/vutuv_web/live/post_live/composer.ex:1917
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -152,7 +152,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1154
+#: lib/vutuv_web/templates/user/show.html.heex:1170
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -161,7 +161,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3706
+#: lib/vutuv_web/components/post_components.ex:3678
 #: lib/vutuv_web/components/ui.ex:4593
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -202,14 +202,14 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:446
-#: lib/vutuv_web/live/post_live/composer.ex:2946
+#: lib/vutuv_web/live/post_live/composer.ex:2962
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3671
+#: lib/vutuv_web/components/post_components.ex:3643
 #: lib/vutuv_web/components/ui.ex:4584
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
@@ -223,7 +223,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1139
+#: lib/vutuv_web/templates/user/show.html.heex:1155
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -288,7 +288,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:643
+#: lib/vutuv_web/templates/user/show.html.heex:656
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -331,8 +331,8 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/show.ex:611
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:987
-#: lib/vutuv_web/views/user_html.ex:617
+#: lib/vutuv_web/templates/user/show.html.heex:1000
+#: lib/vutuv_web/views/user_html.ex:622
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -437,8 +437,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1527
-#: lib/vutuv_web/live/shell_live.ex:1603
+#: lib/vutuv_web/live/shell_live.ex:1561
+#: lib/vutuv_web/live/shell_live.ex:1637
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -452,8 +452,8 @@ msgid "Middle Name"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:1351
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:193
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:201
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:234
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:242
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -600,7 +600,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2170
+#: lib/vutuv_web/live/post_live/composer.ex:2186
 #: lib/vutuv_web/live/section_reorder_live.ex:270
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -612,7 +612,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4485
 #: lib/vutuv_web/live/organization_live/edit.ex:376
-#: lib/vutuv_web/live/post_live/composer.ex:2185
+#: lib/vutuv_web/live/post_live/composer.ex:2201
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -643,8 +643,8 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
-#: lib/vutuv_web/live/shell_live.ex:1396
-#: lib/vutuv_web/live/shell_live.ex:1583
+#: lib/vutuv_web/live/shell_live.ex:1430
+#: lib/vutuv_web/live/shell_live.ex:1617
 #: lib/vutuv_web/live/tag_live/timeline.ex:319
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
@@ -654,7 +654,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1759
+#: lib/vutuv_web/components/post_components.ex:1731
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -688,13 +688,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1268
+#: lib/vutuv_web/templates/user/show.html.heex:1284
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1270
+#: lib/vutuv_web/templates/user/show.html.heex:1286
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -719,12 +719,12 @@ msgstr ""
 msgid "Profile deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1025
+#: lib/vutuv_web/views/user_html.ex:1030
 #, elixir-autogen, elixir-format
 msgid "Social networks"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1032
+#: lib/vutuv_web/views/user_html.ex:1037
 #, elixir-autogen, elixir-format
 msgid "Code & repositories"
 msgstr ""
@@ -733,7 +733,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/follow_controller.ex:24
 #: lib/vutuv_web/controllers/remote_follow_controller.ex:174
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
-#: lib/vutuv_web/live/user_profile_live.ex:160
+#: lib/vutuv_web/live/user_profile_live.ex:177
 #, elixir-autogen
 msgid "Something went wrong"
 msgstr ""
@@ -838,16 +838,16 @@ msgid "Users"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1485
-#: lib/vutuv_web/views/user_html.ex:562
-#: lib/vutuv_web/views/user_html.ex:563
-#: lib/vutuv_web/views/user_html.ex:577
+#: lib/vutuv_web/views/user_html.ex:567
+#: lib/vutuv_web/views/user_html.ex:568
+#: lib/vutuv_web/views/user_html.ex:582
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4654
-#: lib/vutuv_web/templates/user/show.html.heex:981
-#: lib/vutuv_web/templates/user/show.html.heex:1004
+#: lib/vutuv_web/templates/user/show.html.heex:994
+#: lib/vutuv_web/templates/user/show.html.heex:1017
 #, elixir-autogen
 msgid "View All"
 msgstr ""
@@ -922,7 +922,7 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:190
+#: lib/vutuv_web/live/post_live/feed.ex:191
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1037,7 +1037,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1105
+#: lib/vutuv_web/templates/user/show.html.heex:1121
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1138,7 +1138,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:63
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1503
+#: lib/vutuv_web/live/shell_live.ex:1537
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1179,10 +1179,10 @@ msgstr ""
 msgid "All tag urls"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4261
+#: lib/vutuv_web/components/post_components.ex:4233
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:637
+#: lib/vutuv_web/templates/user/show.html.heex:650
 #, elixir-autogen
 msgid "All tags"
 msgstr ""
@@ -1378,7 +1378,7 @@ msgstr ""
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:28
 #: lib/vutuv_web/templates/tag/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:607
+#: lib/vutuv_web/templates/user/show.html.heex:620
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1573,7 +1573,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1601
+#: lib/vutuv_web/live/shell_live.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1598,11 +1598,11 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:477
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1757
-#: lib/vutuv_web/live/post_live/composer.ex:1859
-#: lib/vutuv_web/live/post_live/composer.ex:1860
-#: lib/vutuv_web/live/post_live/composer.ex:2823
-#: lib/vutuv_web/live/post_live/composer.ex:3089
+#: lib/vutuv_web/live/post_live/composer.ex:1773
+#: lib/vutuv_web/live/post_live/composer.ex:1875
+#: lib/vutuv_web/live/post_live/composer.ex:1876
+#: lib/vutuv_web/live/post_live/composer.ex:2839
+#: lib/vutuv_web/live/post_live/composer.ex:3105
 #: lib/vutuv_web/templates/layout/app.html.heex:188
 #: lib/vutuv_web/templates/layout/app.html.heex:194
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
@@ -1672,10 +1672,10 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:421
 #: lib/vutuv_web/live/organization_live/show.ex:572
 #: lib/vutuv_web/live/organization_live/show.ex:609
-#: lib/vutuv_web/live/post_live/feed.ex:942
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:180
-#: lib/vutuv_web/templates/user/show.html.heex:1309
-#: lib/vutuv_web/views/user_html.ex:628
+#: lib/vutuv_web/live/post_live/feed.ex:943
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:221
+#: lib/vutuv_web/templates/user/show.html.heex:1325
+#: lib/vutuv_web/views/user_html.ex:633
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1690,7 +1690,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1522
+#: lib/vutuv_web/live/shell_live.ex:1556
 #: lib/vutuv_web/views/settings_html.ex:299
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1712,9 +1712,9 @@ msgid "Member"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/show.ex:631
-#: lib/vutuv_web/views/user_html.ex:655
-#: lib/vutuv_web/views/user_html.ex:656
-#: lib/vutuv_web/views/user_html.ex:666
+#: lib/vutuv_web/views/user_html.ex:660
+#: lib/vutuv_web/views/user_html.ex:661
+#: lib/vutuv_web/views/user_html.ex:671
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
@@ -1722,8 +1722,8 @@ msgstr ""
 #: lib/vutuv_web/controllers/page_controller.ex:218
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1414
-#: lib/vutuv_web/live/shell_live.ex:1600
+#: lib/vutuv_web/live/shell_live.ex:1448
+#: lib/vutuv_web/live/shell_live.ex:1634
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1755,7 +1755,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/page_controller.ex:219
 #: lib/vutuv_web/live/notification_live/index.ex:152
 #: lib/vutuv_web/live/notification_live/index.ex:457
-#: lib/vutuv_web/live/shell_live.ex:1426
+#: lib/vutuv_web/live/shell_live.ex:1460
 #: lib/vutuv_web/templates/layout/app.html.heex:153
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -1829,7 +1829,7 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
 #: lib/vutuv_web/templates/user/show.html.heex:217
-#: lib/vutuv_web/views/user_html.ex:1077
+#: lib/vutuv_web/views/user_html.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
 msgstr ""
@@ -1849,7 +1849,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:230
+#: lib/vutuv_web/views/user_html.ex:235
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -1868,14 +1868,14 @@ msgstr ""
 
 #: lib/vutuv_web/open_graph.ex:344
 #: lib/vutuv_web/templates/tag/show.html.heex:32
-#: lib/vutuv_web/views/user_html.ex:499
+#: lib/vutuv_web/views/user_html.ex:504
 #, elixir-autogen, elixir-format
 msgid "follower"
 msgid_plural "followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:503
+#: lib/vutuv_web/views/user_html.ex:508
 #, elixir-autogen, elixir-format
 msgid "following"
 msgstr ""
@@ -2030,12 +2030,12 @@ msgstr ""
 msgid "May"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:282
+#: lib/vutuv_web/views/user_html.ex:287
 #, elixir-autogen, elixir-format
 msgid "Member since %{month} %{year}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:287
+#: lib/vutuv_web/views/user_html.ex:292
 #, elixir-autogen, elixir-format
 msgid "Member since %{year}"
 msgstr ""
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2299
+#: lib/vutuv_web/live/post_live/composer.ex:2315
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2078,8 +2078,8 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1999
-#: lib/vutuv_web/live/post_live/composer.ex:2022
+#: lib/vutuv_web/live/post_live/composer.ex:2015
+#: lib/vutuv_web/live/post_live/composer.ex:2038
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2089,7 +2089,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3703
+#: lib/vutuv_web/components/post_components.ex:3675
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2104,11 +2104,11 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:265
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:162
-#: lib/vutuv_web/live/post_live/feed.ex:341
-#: lib/vutuv_web/live/post_live/feed.ex:3157
+#: lib/vutuv_web/live/post_live/feed.ex:345
+#: lib/vutuv_web/live/post_live/feed.ex:3088
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1254
-#: lib/vutuv_web/live/shell_live.ex:1573
+#: lib/vutuv_web/live/shell_live.ex:1282
+#: lib/vutuv_web/live/shell_live.ex:1607
 #: lib/vutuv_web/templates/layout/app.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2124,55 +2124,55 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2275
+#: lib/vutuv_web/live/post_live/composer.ex:2291
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2203
+#: lib/vutuv_web/live/post_live/composer.ex:2219
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3657
-#: lib/vutuv_web/components/post_components.ex:3659
+#: lib/vutuv_web/components/post_components.ex:3629
+#: lib/vutuv_web/components/post_components.ex:3631
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2245
+#: lib/vutuv_web/live/post_live/composer.ex:2261
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1443
-#: lib/vutuv_web/live/post_live/composer.ex:1546
+#: lib/vutuv_web/live/post_live/composer.ex:1459
+#: lib/vutuv_web/live/post_live/composer.ex:1562
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3473
+#: lib/vutuv_web/live/post_live/feed.ex:3408
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1406
+#: lib/vutuv_web/live/post_live/composer.ex:1422
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2235
+#: lib/vutuv_web/live/post_live/composer.ex:2251
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2225
+#: lib/vutuv_web/live/post_live/composer.ex:2241
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:416
-#: lib/vutuv_web/live/post_live/composer.ex:2187
+#: lib/vutuv_web/live/post_live/composer.ex:2203
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2200,28 +2200,29 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4134
-#: lib/vutuv_web/components/post_components.ex:4138
+#: lib/vutuv_web/components/post_components.ex:4106
+#: lib/vutuv_web/components/post_components.ex:4110
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4135
+#: lib/vutuv_web/components/post_components.ex:4107
 #: lib/vutuv_web/live/fediverse_account_live.ex:360
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:497
 #: lib/vutuv_web/components/job_exclusion_components.ex:189
-#: lib/vutuv_web/components/post_components.ex:1368
+#: lib/vutuv_web/components/post_components.ex:1340
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:229
 #: lib/vutuv_web/live/organization_live/domains.ex:265
 #: lib/vutuv_web/live/organization_live/edit.ex:404
 #: lib/vutuv_web/live/organization_live/roles.ex:257
-#: lib/vutuv_web/live/post_live/composer.ex:2261
+#: lib/vutuv_web/live/post_live/composer.ex:2277
 #: lib/vutuv_web/live/post_live/filter_band.ex:456
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
@@ -2237,12 +2238,12 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2177
+#: lib/vutuv_web/live/post_live/composer.ex:2193
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2364
+#: lib/vutuv_web/live/post_live/feed.ex:2332
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2254,13 +2255,13 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1504
-#: lib/vutuv_web/live/post_live/composer.ex:1572
+#: lib/vutuv_web/live/post_live/composer.ex:1520
+#: lib/vutuv_web/live/post_live/composer.ex:1588
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1388
+#: lib/vutuv_web/live/post_live/composer.ex:1404
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2270,18 +2271,18 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3250
+#: lib/vutuv_web/live/post_live/composer.ex:3266
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3251
+#: lib/vutuv_web/live/post_live/composer.ex:3267
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5363
-#: lib/vutuv_web/live/shell_live.ex:1469
+#: lib/vutuv_web/live/shell_live.ex:1503
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:246
@@ -2289,37 +2290,37 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2393
+#: lib/vutuv_web/live/post_live/composer.ex:2409
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2394
+#: lib/vutuv_web/live/post_live/composer.ex:2410
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3654
+#: lib/vutuv_web/components/post_components.ex:3626
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5694
+#: lib/vutuv_web/components/post_components.ex:5666
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5698
+#: lib/vutuv_web/components/post_components.ex:5670
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5696
+#: lib/vutuv_web/components/post_components.ex:5668
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5697
+#: lib/vutuv_web/components/post_components.ex:5669
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2330,20 +2331,20 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2060
+#: lib/vutuv_web/live/post_live/composer.ex:2076
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1501
-#: lib/vutuv_web/live/post_live/composer.ex:3231
-#: lib/vutuv_web/live/post_live/composer.ex:3235
+#: lib/vutuv_web/live/post_live/composer.ex:1517
+#: lib/vutuv_web/live/post_live/composer.ex:3247
+#: lib/vutuv_web/live/post_live/composer.ex:3251
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3239
-#: lib/vutuv_web/live/post_live/composer.ex:3245
+#: lib/vutuv_web/live/post_live/composer.ex:3255
+#: lib/vutuv_web/live/post_live/composer.ex:3261
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2353,7 +2354,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:597
+#: lib/vutuv_web/templates/user/show.html.heex:610
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2363,10 +2364,10 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2040
-#: lib/vutuv_web/components/post_components.ex:5790
+#: lib/vutuv_web/components/post_components.ex:2012
+#: lib/vutuv_web/components/post_components.ex:5762
 #: lib/vutuv_web/components/ui.ex:4053
-#: lib/vutuv_web/views/user_html.ex:461
+#: lib/vutuv_web/views/user_html.ex:466
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
@@ -2374,28 +2375,28 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1186
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:1406
-#: lib/vutuv_web/live/shell_live.ex:1474
+#: lib/vutuv_web/live/shell_live.ex:1440
+#: lib/vutuv_web/live/shell_live.ex:1508
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1993
-#: lib/vutuv_web/components/post_components.ex:6028
+#: lib/vutuv_web/components/post_components.ex:1965
+#: lib/vutuv_web/components/post_components.ex:6000
 #: lib/vutuv_web/components/ui.ex:4039
 #: lib/vutuv_web/live/notification_live/index.ex:1512
-#: lib/vutuv_web/views/user_html.ex:471
+#: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1185
-#: lib/vutuv_web/components/post_components.ex:6038
+#: lib/vutuv_web/components/post_components.ex:6010
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:1477
+#: lib/vutuv_web/live/shell_live.ex:1511
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2413,58 +2414,58 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5778
+#: lib/vutuv_web/components/post_components.ex:5750
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2039
-#: lib/vutuv_web/components/post_components.ex:5789
+#: lib/vutuv_web/components/post_components.ex:2011
+#: lib/vutuv_web/components/post_components.ex:5761
 #: lib/vutuv_web/live/post_live/saved.ex:806
-#: lib/vutuv_web/views/user_html.ex:461
+#: lib/vutuv_web/views/user_html.ex:466
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2021
-#: lib/vutuv_web/components/post_components.ex:5775
+#: lib/vutuv_web/components/post_components.ex:1993
+#: lib/vutuv_web/components/post_components.ex:5747
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2299
-#: lib/vutuv_web/components/post_components.ex:4865
+#: lib/vutuv_web/components/post_components.ex:2271
+#: lib/vutuv_web/components/post_components.ex:4837
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2020
-#: lib/vutuv_web/components/post_components.ex:5774
+#: lib/vutuv_web/components/post_components.ex:1992
+#: lib/vutuv_web/components/post_components.ex:5746
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1992
-#: lib/vutuv_web/components/post_components.ex:6027
+#: lib/vutuv_web/components/post_components.ex:1964
+#: lib/vutuv_web/components/post_components.ex:5999
 #: lib/vutuv_web/live/post_live/saved.ex:805
-#: lib/vutuv_web/views/user_html.ex:471
+#: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:498
-#: lib/vutuv_web/components/post_components.ex:2734
+#: lib/vutuv_web/components/post_components.ex:2706
 #: lib/vutuv_web/components/ui.ex:2924
 #: lib/vutuv_web/components/ui.ex:2924
 #: lib/vutuv_web/components/ui.ex:3000
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
 #: lib/vutuv_web/live/organization_live/show.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:929
+#: lib/vutuv_web/live/post_live/feed.ex:930
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
-#: lib/vutuv_web/views/user_html.ex:618
+#: lib/vutuv_web/views/user_html.ex:623
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr ""
@@ -2474,7 +2475,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6082
+#: lib/vutuv_web/components/post_components.ex:6054
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2485,9 +2486,9 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2006
-#: lib/vutuv_web/components/post_components.ex:6065
-#: lib/vutuv_web/components/post_components.ex:6066
+#: lib/vutuv_web/components/post_components.ex:1978
+#: lib/vutuv_web/components/post_components.ex:6037
+#: lib/vutuv_web/components/post_components.ex:6038
 #: lib/vutuv_web/live/notification_live/index.ex:1010
 #: lib/vutuv_web/live/notification_live/index.ex:1509
 #: lib/vutuv_web/live/post_live/reply.ex:49
@@ -2495,18 +2496,18 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3621
+#: lib/vutuv_web/components/post_components.ex:3593
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1391
-#: lib/vutuv_web/live/post_live/composer.ex:2165
+#: lib/vutuv_web/live/post_live/composer.ex:1407
+#: lib/vutuv_web/live/post_live/composer.ex:2181
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2306
+#: lib/vutuv_web/live/post_live/composer.ex:2322
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2516,7 +2517,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3155
+#: lib/vutuv_web/components/post_components.ex:3127
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2524,14 +2525,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3593
+#: lib/vutuv_web/components/post_components.ex:3565
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3584
-#: lib/vutuv_web/components/post_components.ex:3613
-#: lib/vutuv_web/components/post_components.ex:3616
+#: lib/vutuv_web/components/post_components.ex:3556
+#: lib/vutuv_web/components/post_components.ex:3585
+#: lib/vutuv_web/components/post_components.ex:3588
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2697,38 +2698,38 @@ msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:917
+#: lib/vutuv_web/templates/user/show.html.heex:930
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1228
+#: lib/vutuv_web/templates/user/show.html.heex:1244
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1487
+#: lib/vutuv_web/templates/user/show.html.heex:1503
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1156
+#: lib/vutuv_web/templates/user/show.html.heex:1172
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1107
+#: lib/vutuv_web/templates/user/show.html.heex:1123
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:646
+#: lib/vutuv_web/templates/user/show.html.heex:659
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2749,14 +2750,13 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
-#: lib/vutuv_web/templates/user/show.html.heex:637
+#: lib/vutuv_web/templates/user/show.html.heex:650
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
 
+#: lib/vutuv_web/components/post_components.ex:802
 #: lib/vutuv_web/controllers/page_controller.ex:216
-#: lib/vutuv_web/live/post_live/feed.ex:2404
-#: lib/vutuv_web/templates/user/show.html.heex:507
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr ""
@@ -2777,7 +2777,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/job_board_live.ex:458
-#: lib/vutuv_web/live/post_live/feed.ex:1058
+#: lib/vutuv_web/live/post_live/feed.ex:1059
 #: lib/vutuv_web/templates/user/card_list.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -2808,7 +2808,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2215
+#: lib/vutuv_web/live/post_live/composer.ex:2231
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -2824,14 +2824,14 @@ msgid "This post is for the connections of %{name}"
 msgstr ""
 
 #: lib/vutuv_web/views/admin/moderation_html.ex:81
-#: lib/vutuv_web/views/user_html.ex:513
+#: lib/vutuv_web/views/user_html.ex:518
 #, elixir-autogen, elixir-format
 msgid "connection"
 msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5695
+#: lib/vutuv_web/components/post_components.ex:5667
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2859,7 +2859,7 @@ msgid "Endorsement"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:1507
-#: lib/vutuv_web/templates/user/show.html.heex:965
+#: lib/vutuv_web/templates/user/show.html.heex:978
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3088,13 +3088,13 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1196
-#: lib/vutuv_web/templates/user/show.html.heex:1197
+#: lib/vutuv_web/templates/user/show.html.heex:1212
+#: lib/vutuv_web/templates/user/show.html.heex:1213
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3560
+#: lib/vutuv_web/components/post_components.ex:3532
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3144,7 +3144,7 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4973
-#: lib/vutuv_web/live/shell_live.ex:1280
+#: lib/vutuv_web/live/shell_live.ex:1314
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3168,9 +3168,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1381
-#: lib/vutuv_web/components/post_components.ex:2754
-#: lib/vutuv_web/components/post_components.ex:3732
+#: lib/vutuv_web/components/post_components.ex:1353
+#: lib/vutuv_web/components/post_components.ex:2726
+#: lib/vutuv_web/components/post_components.ex:3704
 #: lib/vutuv_web/live/organization_live/show.ex:654
 #: lib/vutuv_web/templates/user/show.html.heex:237
 #, elixir-autogen, elixir-format
@@ -4527,12 +4527,12 @@ msgid "You have not blocked anyone."
 msgstr ""
 
 #: lib/vutuv_web/controllers/block_controller.ex:89
-#: lib/vutuv_web/live/user_profile_live.ex:327
+#: lib/vutuv_web/live/user_profile_live.ex:337
 #, elixir-autogen, elixir-format
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3478
+#: lib/vutuv_web/live/post_live/feed.ex:3413
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4546,7 +4546,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:313
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:987
+#: lib/vutuv_web/templates/user/show.html.heex:1000
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4663,8 +4663,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:547
 #: lib/vutuv_web/live/tag_new_live.ex:47
-#: lib/vutuv_web/live/user_profile_live.ex:1358
-#: lib/vutuv_web/templates/user/show.html.heex:610
+#: lib/vutuv_web/live/user_profile_live.ex:1419
+#: lib/vutuv_web/templates/user/show.html.heex:623
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
@@ -5293,7 +5293,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1412
+#: lib/vutuv_web/live/post_live/composer.ex:1428
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5303,7 +5303,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1456
+#: lib/vutuv_web/live/shell_live.ex:1490
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5325,7 +5325,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1513
+#: lib/vutuv_web/live/shell_live.ex:1547
 #: lib/vutuv_web/templates/layout/app.html.heex:183
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5344,7 +5344,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:276
-#: lib/vutuv_web/live/shell_live.ex:1493
+#: lib/vutuv_web/live/shell_live.ex:1527
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5384,7 +5384,7 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1364
+#: lib/vutuv_web/live/user_profile_live.ex:1425
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5399,8 +5399,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1242
-#: lib/vutuv_web/live/shell_live.ex:1554
+#: lib/vutuv_web/live/shell_live.ex:1270
+#: lib/vutuv_web/live/shell_live.ex:1588
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5410,11 +5410,11 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3798
-#: lib/vutuv_web/components/post_components.ex:3853
-#: lib/vutuv_web/components/post_components.ex:4382
+#: lib/vutuv_web/components/post_components.ex:3770
+#: lib/vutuv_web/components/post_components.ex:3825
+#: lib/vutuv_web/components/post_components.ex:4354
 #: lib/vutuv_web/live/notification_live/index.ex:1086
-#: lib/vutuv_web/views/user_html.ex:126
+#: lib/vutuv_web/views/user_html.ex:131
 #, elixir-autogen, elixir-format
 msgid "View post"
 msgstr ""
@@ -5438,7 +5438,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:1202
+#: lib/vutuv_web/views/user_html.ex:1207
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr ""
@@ -5508,7 +5508,7 @@ msgstr ""
 msgid "Personal tokens for the vutuv API."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2559
+#: lib/vutuv_web/live/post_live/composer.ex:2575
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
@@ -6041,7 +6041,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1369
+#: lib/vutuv_web/live/user_profile_live.ex:1430
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6056,14 +6056,14 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:480
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:915
+#: lib/vutuv_web/templates/user/show.html.heex:928
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:482
+#: lib/vutuv_web/templates/user/show.html.heex:483
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6077,7 +6077,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1537
+#: lib/vutuv_web/templates/user/show.html.heex:1553
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6114,15 +6114,15 @@ msgstr ""
 msgid "Use photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1903
+#: lib/vutuv_web/live/post_live/composer.ex:1919
 #: lib/vutuv_web/templates/user/edit.html.heex:54
 #: lib/vutuv_web/templates/user/edit.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1122
-#: lib/vutuv_web/templates/user/show.html.heex:1132
+#: lib/vutuv_web/templates/user/show.html.heex:1138
+#: lib/vutuv_web/templates/user/show.html.heex:1148
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6162,12 +6162,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1244
+#: lib/vutuv_web/templates/user/show.html.heex:1260
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1255
+#: lib/vutuv_web/templates/user/show.html.heex:1271
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6210,7 +6210,7 @@ msgstr ""
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1253
+#: lib/vutuv_web/templates/user/show.html.heex:1269
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6269,9 +6269,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1527
-#: lib/vutuv_web/templates/user/show.html.heex:1531
 #: lib/vutuv_web/templates/user/show.html.heex:1543
+#: lib/vutuv_web/templates/user/show.html.heex:1547
+#: lib/vutuv_web/templates/user/show.html.heex:1559
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6598,13 +6598,13 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2714
-#: lib/vutuv_web/components/post_components.ex:3723
+#: lib/vutuv_web/components/post_components.ex:2686
+#: lib/vutuv_web/components/post_components.ex:3695
 #: lib/vutuv_web/components/ui.ex:3072
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:215
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:256
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:230
 #, elixir-autogen, elixir-format
@@ -6612,7 +6612,7 @@ msgid "Mute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:49
-#: lib/vutuv_web/live/user_profile_live.ex:268
+#: lib/vutuv_web/live/user_profile_live.ex:278
 #, elixir-autogen, elixir-format
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr ""
@@ -6627,12 +6627,12 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3723
+#: lib/vutuv_web/components/post_components.ex:3695
 #: lib/vutuv_web/components/ui.ex:3071
 #: lib/vutuv_web/live/fediverse_account_live.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:215
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:256
 #: lib/vutuv_web/templates/settings/filters.html.heex:111
 #: lib/vutuv_web/templates/user/show.html.heex:230
 #, elixir-autogen, elixir-format
@@ -6640,7 +6640,7 @@ msgid "Unmute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:51
-#: lib/vutuv_web/live/user_profile_live.ex:270
+#: lib/vutuv_web/live/user_profile_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr ""
@@ -6655,12 +6655,12 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1201
+#: lib/vutuv_web/views/user_html.ex:1206
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:754
+#: lib/vutuv_web/views/user_html.ex:759
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr ""
@@ -7178,7 +7178,7 @@ msgid "open the dev email inbox"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
-#: lib/vutuv_web/views/user_html.ex:753
+#: lib/vutuv_web/views/user_html.ex:758
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr ""
@@ -7269,7 +7269,7 @@ msgid "Removed:"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:974
-#: lib/vutuv_web/live/post_live/composer.ex:1751
+#: lib/vutuv_web/live/post_live/composer.ex:1767
 #: lib/vutuv_web/live/post_live/filter_band.ex:533
 #, elixir-autogen, elixir-format
 msgid "Undo"
@@ -7316,7 +7316,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5938
+#: lib/vutuv_web/components/post_components.ex:5910
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7419,7 +7419,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3744
+#: lib/vutuv_web/live/post_live/feed.ex:3679
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #, elixir-autogen
 msgid "Done"
@@ -7861,7 +7861,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
 #: lib/vutuv_web/live/job_board_live.ex:468
-#: lib/vutuv_web/live/post_live/feed.ex:1067
+#: lib/vutuv_web/live/post_live/feed.ex:1068
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -8103,7 +8103,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:703
+#: lib/vutuv_web/templates/user/show.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8127,7 +8127,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
-#: lib/vutuv_web/templates/user/show.html.heex:700
+#: lib/vutuv_web/templates/user/show.html.heex:713
 #: lib/vutuv_web/views/import_html.ex:70
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
@@ -8301,13 +8301,13 @@ msgstr ""
 msgid "Please check the fields marked in red."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:1086
+#: lib/vutuv_web/views/user_html.ex:1091
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1391
+#: lib/vutuv_web/templates/user/show.html.heex:1407
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8615,7 +8615,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1296
+#: lib/vutuv_web/templates/user/show.html.heex:1312
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8757,7 +8757,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4868
+#: lib/vutuv_web/components/post_components.ex:4840
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9008,7 +9008,7 @@ msgstr ""
 #: lib/vutuv_web/live/feed_languages_live.ex:317
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:765
+#: lib/vutuv_web/templates/user/show.html.heex:778
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9233,7 +9233,7 @@ msgstr ""
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:762
+#: lib/vutuv_web/templates/user/show.html.heex:775
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -9513,7 +9513,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:869
+#: lib/vutuv_web/templates/user/show.html.heex:882
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
@@ -9561,7 +9561,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:866
+#: lib/vutuv_web/templates/user/show.html.heex:879
 #: lib/vutuv_web/views/import_html.ex:71
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
@@ -9680,8 +9680,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1218
-#: lib/vutuv_web/templates/user/show.html.heex:1219
+#: lib/vutuv_web/templates/user/show.html.heex:1234
+#: lib/vutuv_web/templates/user/show.html.heex:1235
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -10151,15 +10151,15 @@ msgstr[1] ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:1433
 #: lib/vutuv_web/live/organization_live/show.ex:641
-#: lib/vutuv_web/views/user_html.ex:950
-#: lib/vutuv_web/views/user_html.ex:1126
+#: lib/vutuv_web/views/user_html.ex:955
+#: lib/vutuv_web/views/user_html.ex:1131
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:943
+#: lib/vutuv_web/views/user_html.ex:948
 #, elixir-autogen, elixir-format
 msgid "%{formatted} star"
 msgid_plural "%{formatted} stars"
@@ -10168,7 +10168,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:71
 #: lib/vutuv_web/agent_docs/text.ex:66
-#: lib/vutuv_web/templates/user/show.html.heex:1365
+#: lib/vutuv_web/templates/user/show.html.heex:1381
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10184,7 +10184,7 @@ msgstr ""
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:957
+#: lib/vutuv_web/views/user_html.ex:962
 #, elixir-autogen, elixir-format
 msgid "Last active %{date}"
 msgstr ""
@@ -10209,7 +10209,7 @@ msgstr ""
 msgid "since %{date}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:873
+#: lib/vutuv_web/views/user_html.ex:878
 #, elixir-autogen, elixir-format
 msgid "since %{year}"
 msgstr ""
@@ -10647,8 +10647,8 @@ msgid "Failed"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
-#: lib/vutuv_web/live/post_live/composer.ex:1982
-#: lib/vutuv_web/live/post_live/composer.ex:2817
+#: lib/vutuv_web/live/post_live/composer.ex:1998
+#: lib/vutuv_web/live/post_live/composer.ex:2833
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr ""
@@ -11741,7 +11741,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1484
+#: lib/vutuv_web/live/shell_live.ex:1518
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:79
@@ -12071,7 +12071,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:47
 #: lib/vutuv_web/live/job_board_live.ex:265
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1288
+#: lib/vutuv_web/live/shell_live.ex:1322
 #: lib/vutuv_web/templates/layout/app.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -12967,7 +12967,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3114
+#: lib/vutuv_web/components/post_components.ex:3086
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:715
 #: lib/vutuv_web/controllers/settings_controller.ex:733
@@ -13349,7 +13349,7 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3208
+#: lib/vutuv_web/live/post_live/composer.ex:3224
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -13408,7 +13408,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5067
 #: lib/vutuv_web/controllers/settings_controller.ex:634
-#: lib/vutuv_web/live/post_live/feed.ex:750
+#: lib/vutuv_web/live/post_live/feed.ex:751
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13452,7 +13452,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1331
+#: lib/vutuv_web/templates/user/show.html.heex:1347
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13489,7 +13489,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1329
+#: lib/vutuv_web/templates/user/show.html.heex:1345
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13566,34 +13566,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5544
+#: lib/vutuv_web/components/post_components.ex:5516
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1274
-#: lib/vutuv_web/components/post_components.ex:5501
+#: lib/vutuv_web/components/post_components.ex:5473
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5545
+#: lib/vutuv_web/components/post_components.ex:5517
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5547
+#: lib/vutuv_web/components/post_components.ex:5519
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5543
+#: lib/vutuv_web/components/post_components.ex:5515
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1274
-#: lib/vutuv_web/components/post_components.ex:5500
+#: lib/vutuv_web/components/post_components.ex:5472
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13604,12 +13604,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5542
+#: lib/vutuv_web/components/post_components.ex:5514
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5546
+#: lib/vutuv_web/components/post_components.ex:5518
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13629,7 +13629,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5583
+#: lib/vutuv_web/components/post_components.ex:5555
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13637,27 +13637,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5613
+#: lib/vutuv_web/components/post_components.ex:5585
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5614
+#: lib/vutuv_web/components/post_components.ex:5586
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5612
+#: lib/vutuv_web/components/post_components.ex:5584
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5572
+#: lib/vutuv_web/components/post_components.ex:5544
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5619
+#: lib/vutuv_web/components/post_components.ex:5591
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13687,7 +13687,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5386
+#: lib/vutuv_web/components/post_components.ex:5358
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13730,7 +13730,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5377
+#: lib/vutuv_web/components/post_components.ex:5349
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -13747,7 +13747,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:671
+#: lib/vutuv_web/live/shell_live.ex:699
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -13982,13 +13982,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1396
+#: lib/vutuv_web/live/post_live/composer.ex:1412
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1399
+#: lib/vutuv_web/live/post_live/composer.ex:1415
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14077,14 +14077,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3387
+#: lib/vutuv_web/components/post_components.ex:3359
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3410
+#: lib/vutuv_web/components/post_components.ex:3382
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14111,7 +14111,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6037
+#: lib/vutuv_web/components/post_components.ex:6009
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14287,7 +14287,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1127
+#: lib/vutuv_web/live/post_live/feed.ex:1128
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -14846,7 +14846,7 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1038
+#: lib/vutuv_web/templates/user/show.html.heex:1054
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
@@ -15255,7 +15255,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5983
+#: lib/vutuv_web/components/post_components.ex:5955
 #: lib/vutuv_web/live/notification_live/index.ex:1690
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
@@ -15263,7 +15263,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5987
+#: lib/vutuv_web/components/post_components.ex:5959
 #: lib/vutuv_web/live/notification_live/index.ex:1684
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15271,7 +15271,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5991
+#: lib/vutuv_web/components/post_components.ex:5963
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15279,7 +15279,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1223
-#: lib/vutuv_web/components/post_components.ex:5942
+#: lib/vutuv_web/components/post_components.ex:5914
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15295,14 +15295,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1496
-#: lib/vutuv_web/components/post_components.ex:2228
+#: lib/vutuv_web/components/post_components.ex:1468
+#: lib/vutuv_web/components/post_components.ex:2200
 #: lib/vutuv_web/live/fediverse_account_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1366
+#: lib/vutuv_web/components/post_components.ex:1338
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15331,7 +15331,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1378
+#: lib/vutuv_web/components/post_components.ex:1350
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15341,7 +15341,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1392
+#: lib/vutuv_web/components/post_components.ex:1364
 #: lib/vutuv_web/live/notification_live/index.ex:1134
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15373,9 +15373,10 @@ msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1423
-#: lib/vutuv_web/components/post_components.ex:1427
-#: lib/vutuv_web/components/post_components.ex:1627
-#: lib/vutuv_web/components/post_components.ex:3004
+#: lib/vutuv_web/components/post_components.ex:1399
+#: lib/vutuv_web/components/post_components.ex:1599
+#: lib/vutuv_web/components/post_components.ex:2976
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:302
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -16038,22 +16039,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3572
+#: lib/vutuv_web/components/post_components.ex:3544
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3690
+#: lib/vutuv_web/components/post_components.ex:3662
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3698
+#: lib/vutuv_web/components/post_components.ex:3670
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3684
+#: lib/vutuv_web/components/post_components.ex:3656
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16097,7 +16098,7 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3221
+#: lib/vutuv_web/live/post_live/composer.ex:3237
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16129,12 +16130,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1340
 #: lib/vutuv_web/agent_docs/text.ex:830
-#: lib/vutuv_web/live/post_live/composer.ex:2645
+#: lib/vutuv_web/live/post_live/composer.ex:2661
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3059
+#: lib/vutuv_web/live/post_live/composer.ex:3075
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
@@ -16146,22 +16147,22 @@ msgstr ""
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3158
+#: lib/vutuv_web/live/post_live/composer.ex:3174
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3114
+#: lib/vutuv_web/live/post_live/composer.ex:3130
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3116
+#: lib/vutuv_web/live/post_live/composer.ex:3132
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3135
+#: lib/vutuv_web/live/post_live/composer.ex:3151
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
@@ -16171,35 +16172,35 @@ msgstr ""
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2664
+#: lib/vutuv_web/live/post_live/composer.ex:2680
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3167
+#: lib/vutuv_web/components/post_components.ex:3139
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4513
+#: lib/vutuv_web/components/post_components.ex:4485
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4662
+#: lib/vutuv_web/components/post_components.ex:4634
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2617
-#: lib/vutuv_web/live/post_live/composer.ex:2618
+#: lib/vutuv_web/live/post_live/composer.ex:2633
+#: lib/vutuv_web/live/post_live/composer.ex:2634
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1384
 #: lib/vutuv_web/agent_docs/text.ex:818
-#: lib/vutuv_web/components/post_components.ex:4744
+#: lib/vutuv_web/components/post_components.ex:4716
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
@@ -16209,43 +16210,43 @@ msgstr ""
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2677
-#: lib/vutuv_web/live/post_live/composer.ex:2678
+#: lib/vutuv_web/live/post_live/composer.ex:2693
+#: lib/vutuv_web/live/post_live/composer.ex:2694
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3137
+#: lib/vutuv_web/live/post_live/composer.ex:3153
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3078
+#: lib/vutuv_web/live/post_live/composer.ex:3094
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3220
+#: lib/vutuv_web/components/post_components.ex:3192
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3156
+#: lib/vutuv_web/live/post_live/composer.ex:3172
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3192
+#: lib/vutuv_web/live/post_live/composer.ex:3208
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3184
+#: lib/vutuv_web/live/post_live/composer.ex:3200
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3211
+#: lib/vutuv_web/components/post_components.ex:3183
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16255,37 +16256,37 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3229
+#: lib/vutuv_web/components/post_components.ex:3201
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3163
+#: lib/vutuv_web/components/post_components.ex:3135
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2935
+#: lib/vutuv_web/live/post_live/composer.ex:2951
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1426
+#: lib/vutuv_web/live/post_live/composer.ex:1442
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3224
+#: lib/vutuv_web/components/post_components.ex:3196
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1440
+#: lib/vutuv_web/live/post_live/composer.ex:1456
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3177
+#: lib/vutuv_web/components/post_components.ex:3149
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16295,64 +16296,64 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2560
+#: lib/vutuv_web/live/post_live/composer.ex:2576
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2930
+#: lib/vutuv_web/live/post_live/composer.ex:2946
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3049
+#: lib/vutuv_web/live/post_live/composer.ex:3065
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1726
-#: lib/vutuv_web/live/post_live/composer.ex:1789
-#: lib/vutuv_web/live/post_live/composer.ex:1847
+#: lib/vutuv_web/live/post_live/composer.ex:1742
+#: lib/vutuv_web/live/post_live/composer.ex:1805
+#: lib/vutuv_web/live/post_live/composer.ex:1863
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1719
+#: lib/vutuv_web/live/post_live/composer.ex:1735
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2983
+#: lib/vutuv_web/live/post_live/composer.ex:2999
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2372
+#: lib/vutuv_web/live/post_live/composer.ex:2388
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2371
+#: lib/vutuv_web/live/post_live/composer.ex:2387
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2370
+#: lib/vutuv_web/live/post_live/composer.ex:2386
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2375
+#: lib/vutuv_web/live/post_live/composer.ex:2391
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2953
+#: lib/vutuv_web/live/post_live/composer.ex:2969
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2972
+#: lib/vutuv_web/live/post_live/composer.ex:2988
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -16360,13 +16361,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1241
-#: lib/vutuv_web/components/post_components.ex:5980
+#: lib/vutuv_web/components/post_components.ex:5952
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1239
-#: lib/vutuv_web/components/post_components.ex:5977
+#: lib/vutuv_web/components/post_components.ex:5949
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16376,7 +16377,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5867
+#: lib/vutuv_web/components/post_components.ex:5839
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -16463,8 +16464,8 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1983
-#: lib/vutuv_web/live/post_live/composer.ex:2817
+#: lib/vutuv_web/live/post_live/composer.ex:1999
+#: lib/vutuv_web/live/post_live/composer.ex:2833
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr ""
@@ -16717,7 +16718,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2763
+#: lib/vutuv_web/components/post_components.ex:2735
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16727,7 +16728,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3003
+#: lib/vutuv_web/components/post_components.ex:2975
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16747,12 +16748,12 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1762
+#: lib/vutuv_web/components/post_components.ex:1734
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2944
+#: lib/vutuv_web/components/post_components.ex:2916
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marked as sensitive by its author"
 msgstr ""
@@ -16768,7 +16769,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2749
+#: lib/vutuv_web/components/post_components.ex:2721
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -16990,27 +16991,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2400
+#: lib/vutuv_web/components/post_components.ex:2372
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2433
+#: lib/vutuv_web/components/post_components.ex:2405
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2428
+#: lib/vutuv_web/components/post_components.ex:2400
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3070
+#: lib/vutuv_web/components/post_components.ex:3042
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3076
+#: lib/vutuv_web/components/post_components.ex:3048
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is not here any more."
 msgstr ""
@@ -17020,7 +17021,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3215
+#: lib/vutuv_web/components/post_components.ex:3187
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17060,14 +17061,14 @@ msgstr ""
 msgid "That link points at a single post. You can follow its author, %{account}, from here."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1403
+#: lib/vutuv_web/live/user_profile_live.ex:1464
 #, elixir-autogen, elixir-format
 msgid "You already follow one member."
 msgid_plural "You already follow %{count} members."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:232
+#: lib/vutuv_web/views/user_html.ex:237
 #, elixir-autogen, elixir-format
 msgid "Your feed shows the posts of members you follow. Follow a few to fill it."
 msgstr ""
@@ -17277,7 +17278,6 @@ msgid "That is a link on this vutuv, not on another network."
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:317
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:240
 #, elixir-autogen, elixir-format
 msgid "Their account page here"
 msgstr ""
@@ -17332,104 +17332,104 @@ msgstr ""
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1900
+#: lib/vutuv_web/live/post_live/composer.ex:1916
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2723
+#: lib/vutuv_web/live/post_live/composer.ex:2739
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2724
+#: lib/vutuv_web/live/post_live/composer.ex:2740
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2729
+#: lib/vutuv_web/live/post_live/composer.ex:2745
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2726
+#: lib/vutuv_web/live/post_live/composer.ex:2742
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2727
+#: lib/vutuv_web/live/post_live/composer.ex:2743
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover on top"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2728
+#: lib/vutuv_web/live/post_live/composer.ex:2744
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1896
-#: lib/vutuv_web/live/post_live/composer.ex:2694
-#: lib/vutuv_web/live/post_live/composer.ex:2695
+#: lib/vutuv_web/live/post_live/composer.ex:1912
+#: lib/vutuv_web/live/post_live/composer.ex:2710
+#: lib/vutuv_web/live/post_live/composer.ex:2711
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Crop photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2653
+#: lib/vutuv_web/live/post_live/composer.ex:2669
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cropped"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1818
+#: lib/vutuv_web/live/post_live/composer.ex:1834
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2730
+#: lib/vutuv_web/live/post_live/composer.ex:2746
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2731
+#: lib/vutuv_web/live/post_live/composer.ex:2747
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1898
+#: lib/vutuv_web/live/post_live/composer.ex:1914
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2722
+#: lib/vutuv_web/live/post_live/composer.ex:2738
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2725
+#: lib/vutuv_web/live/post_live/composer.ex:2741
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:562
+#: lib/vutuv_web/live/post_live/composer.ex:572
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:3171
+#: lib/vutuv_web/live/post_live/composer.ex:3187
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1902
+#: lib/vutuv_web/live/post_live/composer.ex:1918
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Whole photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2920
+#: lib/vutuv_web/live/post_live/composer.ex:2936
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2904
+#: lib/vutuv_web/live/post_live/composer.ex:2920
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Whole photos"
 msgstr ""
@@ -17689,7 +17689,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3073
+#: lib/vutuv_web/components/post_components.ex:3045
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -17992,19 +17992,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5038
+#: lib/vutuv_web/components/post_components.ex:5010
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5040
+#: lib/vutuv_web/components/post_components.ex:5012
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5051
+#: lib/vutuv_web/components/post_components.ex:5023
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18064,7 +18064,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/job_reference_controller.ex:144
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:18
 #: lib/vutuv_web/templates/job_reference/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:803
+#: lib/vutuv_web/templates/user/show.html.heex:816
 #, elixir-autogen, elixir-format
 msgid "Add an employment reference"
 msgstr ""
@@ -18141,7 +18141,7 @@ msgstr ""
 #: lib/vutuv_web/templates/job_reference/new.html.heex:4
 #: lib/vutuv_web/templates/job_reference/show.html.heex:12
 #: lib/vutuv_web/templates/job_reference/view.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:800
+#: lib/vutuv_web/templates/user/show.html.heex:813
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employment references"
 msgstr ""
@@ -18176,7 +18176,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3496
+#: lib/vutuv_web/live/post_live/feed.ex:3431
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Loading…"
@@ -18778,7 +18778,7 @@ msgstr ""
 msgid "by the lawyer Tom Braegelmann"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:844
+#: lib/vutuv_web/templates/user/show.html.heex:857
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Documents:"
 msgstr ""
@@ -18949,7 +18949,7 @@ msgstr ""
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1389
+#: lib/vutuv_web/live/user_profile_live.ex:1450
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow other members"
 msgstr ""
@@ -19655,7 +19655,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3103
+#: lib/vutuv_web/components/post_components.ex:3075
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -19715,22 +19715,22 @@ msgstr ""
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2186
+#: lib/vutuv_web/live/post_live/composer.ex:2202
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1419
+#: lib/vutuv_web/live/post_live/composer.ex:1435
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2163
+#: lib/vutuv_web/live/post_live/composer.ex:2179
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1200
+#: lib/vutuv_web/live/shell_live.ex:1228
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Open the page"
 msgstr ""
@@ -19750,7 +19750,7 @@ msgstr ""
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1210
+#: lib/vutuv_web/live/shell_live.ex:1238
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -19760,7 +19760,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1186
+#: lib/vutuv_web/live/shell_live.ex:1214
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -20124,21 +20124,21 @@ msgstr ""
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:715
+#: lib/vutuv_web/live/shell_live.ex:743
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:702
+#: lib/vutuv_web/live/shell_live.ex:730
 #, elixir-autogen, elixir-format, fuzzy
 msgid "person"
 msgid_plural "people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:737
+#: lib/vutuv_web/live/shell_live.ex:765
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -20506,44 +20506,44 @@ msgstr ""
 msgid "{n} of {max} free slots selected."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2145
+#: lib/vutuv_web/live/post_live/composer.ex:2161
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2136
+#: lib/vutuv_web/live/post_live/composer.ex:2152
 #, elixir-autogen, elixir-format
 msgctxt "post composer"
 msgid "Language"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2132
-#: lib/vutuv_web/live/post_live/composer.ex:2133
+#: lib/vutuv_web/live/post_live/composer.ex:2148
+#: lib/vutuv_web/live/post_live/composer.ex:2149
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4932
+#: lib/vutuv_web/components/post_components.ex:4904
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4968
+#: lib/vutuv_web/components/post_components.ex:4940
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4977
+#: lib/vutuv_web/components/post_components.ex:4949
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4980
+#: lib/vutuv_web/components/post_components.ex:4952
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4957
+#: lib/vutuv_web/components/post_components.ex:4929
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20553,7 +20553,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4947
+#: lib/vutuv_web/components/post_components.ex:4919
 #: lib/vutuv_web/components/ui.ex:5060
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20682,20 +20682,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4710
+#: lib/vutuv_web/components/post_components.ex:4682
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4707
+#: lib/vutuv_web/components/post_components.ex:4679
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2454
-#: lib/vutuv_web/components/post_components.ex:3918
+#: lib/vutuv_web/components/post_components.ex:2426
+#: lib/vutuv_web/components/post_components.ex:3890
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20713,13 +20713,13 @@ msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:431
-#: lib/vutuv_web/live/post_live/feed.ex:1004
-#: lib/vutuv_web/views/user_html.ex:342
+#: lib/vutuv_web/live/post_live/feed.ex:1005
+#: lib/vutuv_web/views/user_html.ex:347
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:345
+#: lib/vutuv_web/views/user_html.ex:350
 #, elixir-autogen, elixir-format
 msgid "Show the profile picture larger"
 msgstr ""
@@ -20837,7 +20837,7 @@ msgid "Find my contacts"
 msgstr ""
 
 #: lib/vutuv_web/templates/user/show.html.heex:460
-#: lib/vutuv_web/views/user_html.ex:254
+#: lib/vutuv_web/views/user_html.ex:259
 #, elixir-autogen, elixir-format
 msgid "Find people you know from LinkedIn"
 msgstr ""
@@ -21209,7 +21209,7 @@ msgstr ""
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2729
+#: lib/vutuv_web/components/post_components.ex:2701
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
@@ -21219,7 +21219,7 @@ msgstr ""
 msgid "Unfollowed. Their posts leave your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1160
+#: lib/vutuv_web/live/shell_live.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr ""
@@ -21234,12 +21234,12 @@ msgstr ""
 msgid "Browser notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1018
+#: lib/vutuv_web/live/shell_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1163
+#: lib/vutuv_web/live/shell_live.ex:1191
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
@@ -21279,7 +21279,7 @@ msgstr ""
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1157
+#: lib/vutuv_web/live/shell_live.ex:1185
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -21319,12 +21319,12 @@ msgstr ""
 msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:810
+#: lib/vutuv_web/live/shell_live.ex:838
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:811
+#: lib/vutuv_web/live/shell_live.ex:839
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr ""
@@ -21334,12 +21334,12 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3657
+#: lib/vutuv_web/live/post_live/feed.ex:3592
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:751
+#: lib/vutuv_web/live/post_live/feed.ex:752
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr ""
@@ -21385,7 +21385,7 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:996
+#: lib/vutuv_web/live/post_live/feed.ex:997
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
@@ -21545,7 +21545,7 @@ msgstr ""
 msgid "Translated into %{language}."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:951
+#: lib/vutuv_web/live/shell_live.ex:979
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -21664,7 +21664,7 @@ msgstr ""
 msgid "No connection"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1090
+#: lib/vutuv_web/live/shell_live.ex:1118
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr ""
@@ -21757,7 +21757,7 @@ msgstr ""
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:876
+#: lib/vutuv_web/live/post_live/feed.ex:877
 #: lib/vutuv_web/live/post_live/filter_band.ex:350
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -21773,7 +21773,7 @@ msgstr ""
 msgid "A–Z"
 msgstr "A–Z"
 
-#: lib/vutuv_web/live/post_live/feed.ex:959
+#: lib/vutuv_web/live/post_live/feed.ex:960
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Browse the tags"
 msgstr ""
@@ -21788,7 +21788,7 @@ msgstr "Busiest first"
 msgid "Clear all"
 msgstr "Clear all"
 
-#: lib/vutuv_web/live/post_live/feed.ex:788
+#: lib/vutuv_web/live/post_live/feed.ex:789
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr ""
@@ -21803,13 +21803,13 @@ msgstr "Expand or collapse"
 msgid "Find an account or a server …"
 msgstr "Find an account …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:812
+#: lib/vutuv_web/live/post_live/feed.ex:813
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:940
 #: lib/vutuv_web/live/post_live/feed.ex:941
+#: lib/vutuv_web/live/post_live/feed.ex:942
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow a tag …"
 msgstr ""
@@ -21826,17 +21826,17 @@ msgstr "Hide a tag …"
 msgid "Hide a word or a whole phrase …"
 msgstr "Hide a word or a whole phrase …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:749
+#: lib/vutuv_web/live/post_live/feed.ex:750
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Hide tags"
 
-#: lib/vutuv_web/live/post_live/feed.ex:748
+#: lib/vutuv_web/live/post_live/feed.ex:749
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Hide words"
 
-#: lib/vutuv_web/live/post_live/feed.ex:965
+#: lib/vutuv_web/live/post_live/feed.ex:966
 #: lib/vutuv_web/live/post_live/filter_band.ex:394
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -21852,7 +21852,7 @@ msgstr "Matches nothing in your feed right now — the rule still holds for what
 msgid "More of your %{formatted} accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:787
+#: lib/vutuv_web/live/post_live/feed.ex:788
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr ""
@@ -21863,12 +21863,12 @@ msgstr ""
 msgid "No account found."
 msgstr "No account found."
 
-#: lib/vutuv_web/live/post_live/feed.ex:954
+#: lib/vutuv_web/live/post_live/feed.ex:955
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:741
+#: lib/vutuv_web/live/post_live/feed.ex:742
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr "Not read yet"
@@ -21898,13 +21898,13 @@ msgstr "Posts carrying one of these tags are folded the same way."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3683
+#: lib/vutuv_web/live/post_live/feed.ex:3618
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:833
 #: lib/vutuv_web/live/post_live/feed.ex:834
+#: lib/vutuv_web/live/post_live/feed.ex:835
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove %{card}"
 msgstr ""
@@ -21936,7 +21936,7 @@ msgstr ""
 msgid "Show posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:747
+#: lib/vutuv_web/live/post_live/feed.ex:748
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sources"
 msgstr ""
@@ -21946,12 +21946,12 @@ msgstr ""
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:811
+#: lib/vutuv_web/live/post_live/feed.ex:812
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:930
+#: lib/vutuv_web/live/post_live/feed.ex:931
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unfollow the tag %{tag}"
 msgstr ""
@@ -21975,29 +21975,29 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3270
-#: lib/vutuv_web/live/post_live/feed.ex:3297
-#: lib/vutuv_web/live/post_live/feed.ex:3731
-#: lib/vutuv_web/live/post_live/feed.ex:3736
+#: lib/vutuv_web/live/post_live/feed.ex:3205
+#: lib/vutuv_web/live/post_live/feed.ex:3232
+#: lib/vutuv_web/live/post_live/feed.ex:3666
+#: lib/vutuv_web/live/post_live/feed.ex:3671
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1135
+#: lib/vutuv_web/live/post_live/feed.ex:1136
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:886
+#: lib/vutuv_web/live/post_live/feed.ex:887
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2371
+#: lib/vutuv_web/components/post_components.ex:2343
 #, elixir-autogen, elixir-format
 msgid "Picture unavailable"
 msgstr "Picture unavailable"
@@ -22043,7 +22043,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3453
+#: lib/vutuv_web/live/post_live/feed.ex:3388
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to now"
 msgstr ""
@@ -22053,7 +22053,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3499
+#: lib/vutuv_web/live/post_live/feed.ex:3434
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22075,7 +22075,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3449
+#: lib/vutuv_web/live/post_live/feed.ex:3384
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -22152,7 +22152,7 @@ msgstr ""
 msgid "Scan it with the device that has the app"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1072
+#: lib/vutuv_web/live/shell_live.ex:1100
 #, elixir-autogen, elixir-format, fuzzy
 msgid "A new version is ready."
 msgstr ""
@@ -22162,14 +22162,14 @@ msgstr ""
 msgid "Page management"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2358
+#: lib/vutuv_web/live/post_live/feed.ex:2326
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2871
+#: lib/vutuv_web/components/post_components.ex:2843
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Quoted post"
 msgstr ""
@@ -22194,7 +22194,7 @@ msgstr ""
 msgid "{used} of {max} mentions"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2507
+#: lib/vutuv_web/live/post_live/feed.ex:2438
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""
@@ -22285,30 +22285,30 @@ msgstr ""
 msgid "Nothing matches."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1982
-#: lib/vutuv_web/live/post_live/composer.ex:2850
+#: lib/vutuv_web/live/post_live/composer.ex:1998
+#: lib/vutuv_web/live/post_live/composer.ex:2866
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Automatic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1987
+#: lib/vutuv_web/live/post_live/composer.ex:2003
 #, elixir-autogen, elixir-format
 msgid "Drag one photo onto another to swap them."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1934
+#: lib/vutuv_web/live/post_live/composer.ex:1950
 #, elixir-autogen, elixir-format
 msgid "Not shown in the gallery — drag one into it to swap."
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:94
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post here"
 msgid_plural "%{formatted} posts here"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:226
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:267
 #, elixir-autogen, elixir-format
 msgid "Address copied"
 msgstr ""
@@ -22318,52 +22318,52 @@ msgstr ""
 msgid "Another network"
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:229
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:270
 #, elixir-autogen, elixir-format
 msgid "Copy address"
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:132
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "Latest here"
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:221
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:262
 #, elixir-autogen, elixir-format
 msgid "Mute %{host}"
 msgstr ""
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:132
+#: lib/vutuv_web/views/remote_actor_card_html.ex:118
 #, elixir-autogen, elixir-format
 msgid "Really remove?"
 msgstr ""
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:133
+#: lib/vutuv_web/views/remote_actor_card_html.ex:119
 #, elixir-autogen, elixir-format
 msgid "Really unfollow?"
 msgstr ""
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:134
+#: lib/vutuv_web/views/remote_actor_card_html.ex:120
 #, elixir-autogen, elixir-format
 msgid "Really withdraw?"
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:220
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "Unmute %{host}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1742
+#: lib/vutuv_web/live/post_live/composer.ex:1758
 #, elixir-autogen, elixir-format
 msgid "Draft discarded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1781
+#: lib/vutuv_web/live/post_live/composer.ex:1797
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1772
+#: lib/vutuv_web/live/post_live/composer.ex:1788
 #, elixir-autogen, elixir-format
 msgid "Keep this draft for later?"
 msgstr ""
@@ -22400,12 +22400,7 @@ msgstr ""
 msgid "Low-bandwidth mode"
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:255
-#, elixir-autogen, elixir-format
-msgid "View the original on %{url}"
-msgstr ""
-
-#: lib/vutuv_web/live/shell_live.ex:1595
+#: lib/vutuv_web/live/shell_live.ex:1629
 #, elixir-autogen, elixir-format
 msgctxt "phone tab bar"
 msgid "Write"
@@ -22478,9 +22473,9 @@ msgstr ""
 msgid "Rules that rewrite the text of one account's posts before you read them: a footer under every post, a signature, a wall of hashtags. Only you see the difference. Open the ⋯ menu on any post to write rules for its author."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1371
-#: lib/vutuv_web/components/post_components.ex:2742
-#: lib/vutuv_web/components/post_components.ex:3729
+#: lib/vutuv_web/components/post_components.ex:1343
+#: lib/vutuv_web/components/post_components.ex:2714
+#: lib/vutuv_web/components/post_components.ex:3701
 #: lib/vutuv_web/components/ui.ex:5052
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -22562,7 +22557,7 @@ msgstr ""
 msgid "Appearance"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1621
+#: lib/vutuv_web/live/shell_live.ex:1655
 #, elixir-autogen, elixir-format
 msgid "%{count} video in progress"
 msgid_plural "%{count} videos in progress"
@@ -22574,7 +22569,7 @@ msgstr[1] ""
 msgid "About %{minutes} min of video"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2443
+#: lib/vutuv_web/live/post_live/composer.ex:2459
 #, elixir-autogen, elixir-format
 msgid "Add video"
 msgstr ""
@@ -22616,32 +22611,32 @@ msgstr ""
 msgid "Reading the frames"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2479
+#: lib/vutuv_web/live/post_live/composer.ex:2495
 #, elixir-autogen, elixir-format
 msgid "Remove it to post the text without it, or pick another file."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1135
+#: lib/vutuv_web/live/post_live/composer.ex:1145
 #, elixir-autogen, elixir-format
 msgid "Remove the refused video to post the text without it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2508
+#: lib/vutuv_web/live/post_live/composer.ex:2524
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove video"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2518
+#: lib/vutuv_web/live/post_live/composer.ex:2534
 #, elixir-autogen, elixir-format
 msgid "Tap a frame to make it the cover."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:998
+#: lib/vutuv_web/live/post_live/composer.ex:1008
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That frame could not be used."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1409
+#: lib/vutuv_web/live/post_live/composer.ex:1425
 #, elixir-autogen, elixir-format, fuzzy
 msgid "The video could not be attached."
 msgstr ""
@@ -22651,7 +22646,7 @@ msgstr ""
 msgid "The video is gone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1496
+#: lib/vutuv_web/live/post_live/composer.ex:1512
 #, elixir-autogen, elixir-format
 msgid "The video is longer than %{seconds} seconds."
 msgstr ""
@@ -22670,19 +22665,19 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1339
 #: lib/vutuv_web/agent_docs/text.ex:827
 #: lib/vutuv_web/agent_docs/text.ex:828
-#: lib/vutuv_web/components/post_components.ex:2506
+#: lib/vutuv_web/components/post_components.ex:2478
 #: lib/vutuv_web/components/video_components.ex:126
-#: lib/vutuv_web/live/post_live/composer.ex:2442
+#: lib/vutuv_web/live/post_live/composer.ex:2458
 #, elixir-autogen, elixir-format
 msgid "Video"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2486
+#: lib/vutuv_web/live/post_live/composer.ex:2502
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Video description"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1503
+#: lib/vutuv_web/live/post_live/composer.ex:1519
 #, elixir-autogen, elixir-format
 msgid "Videos cannot be uploaded here."
 msgstr ""
@@ -22692,12 +22687,12 @@ msgstr ""
 msgid "Waiting in line"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2493
+#: lib/vutuv_web/live/post_live/composer.ex:2509
 #, elixir-autogen, elixir-format
 msgid "What is in the video, for people who cannot watch it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2482
+#: lib/vutuv_web/live/post_live/composer.ex:2498
 #, elixir-autogen, elixir-format
 msgid "You can post now — the post appears as soon as the video is ready."
 msgstr ""
@@ -22733,7 +22728,7 @@ msgstr[1] ""
 msgid "Last 30 days: %{parts}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4270
+#: lib/vutuv_web/components/post_components.ex:4242
 #: lib/vutuv_web/live/notification_live/index.ex:1020
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Less"
@@ -22817,7 +22812,7 @@ msgid_plural "%{formatted} random vutuv accounts that are open to offers."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:685
+#: lib/vutuv_web/live/shell_live.ex:713
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post in your feed"
 msgid_plural "%{formatted} new posts in your feed"
@@ -22852,4 +22847,16 @@ msgstr ""
 #: lib/vutuv_web/templates/page/index.html.heex:265
 #, elixir-autogen, elixir-format
 msgid "Your public posts then also appear on {mastodon}, for example."
+msgstr ""
+
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:168
+#, elixir-autogen, elixir-format
+msgid "%{formatted} older post"
+msgid_plural "%{formatted} older posts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:283
+#, elixir-autogen, elixir-format
+msgid "Their page here"
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -40,7 +40,7 @@ msgstr "Aggiungi"
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1485
+#: lib/vutuv_web/templates/user/show.html.heex:1501
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -106,7 +106,7 @@ msgstr "Data di nascita"
 #: lib/vutuv_web/agent_docs/markdown.ex:615
 #: lib/vutuv_web/agent_docs/text.ex:578
 #: lib/vutuv_web/agent_docs/text.ex:579
-#: lib/vutuv_web/templates/user/show.html.heex:1116
+#: lib/vutuv_web/templates/user/show.html.heex:1132
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Compleanno"
@@ -120,7 +120,7 @@ msgstr "Compleanno"
 #: lib/vutuv_web/live/job_posting_live/form.ex:857
 #: lib/vutuv_web/live/organization_live/edit.ex:378
 #: lib/vutuv_web/live/organization_live/new.ex:222
-#: lib/vutuv_web/live/post_live/composer.ex:1901
+#: lib/vutuv_web/live/post_live/composer.ex:1917
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -154,7 +154,7 @@ msgstr "Selezioni una voce"
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1154
+#: lib/vutuv_web/templates/user/show.html.heex:1170
 #, elixir-autogen
 msgid "Contact"
 msgstr "Contatto"
@@ -163,7 +163,7 @@ msgstr "Contatto"
 msgid "Couldn't follow back to %{name}."
 msgstr "Non è stato possibile ricambiare il follow a %{name}."
 
-#: lib/vutuv_web/components/post_components.ex:3706
+#: lib/vutuv_web/components/post_components.ex:3678
 #: lib/vutuv_web/components/ui.ex:4593
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
@@ -204,14 +204,14 @@ msgid "Disable"
 msgstr "Disattiva"
 
 #: lib/vutuv_web/live/cv_live.ex:446
-#: lib/vutuv_web/live/post_live/composer.ex:2946
+#: lib/vutuv_web/live/post_live/composer.ex:2962
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
 msgid "Download"
 msgstr "Scarica"
 
-#: lib/vutuv_web/components/post_components.ex:3671
+#: lib/vutuv_web/components/post_components.ex:3643
 #: lib/vutuv_web/components/ui.ex:4584
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
@@ -225,7 +225,7 @@ msgstr "Scarica"
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1139
+#: lib/vutuv_web/templates/user/show.html.heex:1155
 #, elixir-autogen
 msgid "Edit"
 msgstr "Modifica"
@@ -290,7 +290,7 @@ msgstr "Inserisca il Suo indirizzo e-mail"
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:643
+#: lib/vutuv_web/templates/user/show.html.heex:656
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -333,8 +333,8 @@ msgstr "Follower"
 #: lib/vutuv_web/live/organization_live/show.ex:611
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:987
-#: lib/vutuv_web/views/user_html.ex:617
+#: lib/vutuv_web/templates/user/show.html.heex:1000
+#: lib/vutuv_web/views/user_html.ex:622
 #, elixir-autogen
 msgid "Following"
 msgstr "Seguiti"
@@ -441,8 +441,8 @@ msgstr "Accedi"
 msgid "Log Out"
 msgstr "Esci"
 
-#: lib/vutuv_web/live/shell_live.ex:1527
-#: lib/vutuv_web/live/shell_live.ex:1603
+#: lib/vutuv_web/live/shell_live.ex:1561
+#: lib/vutuv_web/live/shell_live.ex:1637
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -456,8 +456,8 @@ msgid "Middle Name"
 msgstr "Secondo nome"
 
 #: lib/vutuv_web/live/notification_live/index.ex:1351
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:193
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:201
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:234
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:242
 #, elixir-autogen
 msgid "More"
 msgstr "Altro"
@@ -604,7 +604,7 @@ msgstr "Profili di "
 msgid "Provider"
 msgstr "Piattaforma"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2170
+#: lib/vutuv_web/live/post_live/composer.ex:2186
 #: lib/vutuv_web/live/section_reorder_live.ex:270
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -616,7 +616,7 @@ msgstr "Pubblico"
 
 #: lib/vutuv_web/components/ui.ex:4485
 #: lib/vutuv_web/live/organization_live/edit.ex:376
-#: lib/vutuv_web/live/post_live/composer.ex:2185
+#: lib/vutuv_web/live/post_live/composer.ex:2201
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
@@ -647,8 +647,8 @@ msgstr "Salva"
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
-#: lib/vutuv_web/live/shell_live.ex:1396
-#: lib/vutuv_web/live/shell_live.ex:1583
+#: lib/vutuv_web/live/shell_live.ex:1430
+#: lib/vutuv_web/live/shell_live.ex:1617
 #: lib/vutuv_web/live/tag_live/timeline.ex:319
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
@@ -658,7 +658,7 @@ msgstr "Salva"
 msgid "Search"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:1759
+#: lib/vutuv_web/components/post_components.ex:1731
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -692,13 +692,13 @@ msgstr "Slug"
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1268
+#: lib/vutuv_web/templates/user/show.html.heex:1284
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profili"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1270
+#: lib/vutuv_web/templates/user/show.html.heex:1286
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr "Aggiungi un profilo"
@@ -723,12 +723,12 @@ msgstr "Profilo aggiornato."
 msgid "Profile deleted successfully."
 msgstr "Profilo eliminato."
 
-#: lib/vutuv_web/views/user_html.ex:1025
+#: lib/vutuv_web/views/user_html.ex:1030
 #, elixir-autogen, elixir-format
 msgid "Social networks"
 msgstr "Social network"
 
-#: lib/vutuv_web/views/user_html.ex:1032
+#: lib/vutuv_web/views/user_html.ex:1037
 #, elixir-autogen, elixir-format
 msgid "Code & repositories"
 msgstr "Codice e repository"
@@ -737,7 +737,7 @@ msgstr "Codice e repository"
 #: lib/vutuv_web/controllers/follow_controller.ex:24
 #: lib/vutuv_web/controllers/remote_follow_controller.ex:174
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
-#: lib/vutuv_web/live/user_profile_live.ex:160
+#: lib/vutuv_web/live/user_profile_live.ex:177
 #, elixir-autogen
 msgid "Something went wrong"
 msgstr "Qualcosa è andato storto"
@@ -842,16 +842,16 @@ msgid "Users"
 msgstr "Utenti"
 
 #: lib/vutuv_web/components/ui.ex:1485
-#: lib/vutuv_web/views/user_html.ex:562
-#: lib/vutuv_web/views/user_html.ex:563
-#: lib/vutuv_web/views/user_html.ex:577
+#: lib/vutuv_web/views/user_html.ex:567
+#: lib/vutuv_web/views/user_html.ex:568
+#: lib/vutuv_web/views/user_html.ex:582
 #, elixir-autogen
 msgid "vCard"
 msgstr "vCard"
 
 #: lib/vutuv_web/components/ui.ex:4654
-#: lib/vutuv_web/templates/user/show.html.heex:981
-#: lib/vutuv_web/templates/user/show.html.heex:1004
+#: lib/vutuv_web/templates/user/show.html.heex:994
+#: lib/vutuv_web/templates/user/show.html.heex:1017
 #, elixir-autogen
 msgid "View All"
 msgstr "Mostra tutti"
@@ -933,7 +933,7 @@ msgid "You follow back %{name}."
 msgstr "Ora segue anche %{name}."
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:190
+#: lib/vutuv_web/live/post_live/feed.ex:191
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1059,7 +1059,7 @@ msgstr "Non ha i permessi per vedere questa pagina."
 msgid "An error occurred"
 msgstr "Si è verificato un errore"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1105
+#: lib/vutuv_web/templates/user/show.html.heex:1121
 #, elixir-autogen
 msgid "General Info"
 msgstr "Informazioni generali"
@@ -1161,7 +1161,7 @@ msgstr "Aggiungi localizzazione"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:63
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1503
+#: lib/vutuv_web/live/shell_live.ex:1537
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1202,10 +1202,10 @@ msgstr "Tutti i sinonimi dei tag"
 msgid "All tag urls"
 msgstr "Tutti gli URL dei tag"
 
-#: lib/vutuv_web/components/post_components.ex:4261
+#: lib/vutuv_web/components/post_components.ex:4233
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:637
+#: lib/vutuv_web/templates/user/show.html.heex:650
 #, elixir-autogen
 msgid "All tags"
 msgstr "Tutti i tag"
@@ -1403,7 +1403,7 @@ msgstr "URL dei tag"
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:28
 #: lib/vutuv_web/templates/tag/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:607
+#: lib/vutuv_web/templates/user/show.html.heex:620
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1603,7 +1603,7 @@ msgstr "Indirizzi di %{name}"
 msgid "Admin control panel"
 msgstr "Pannello di amministrazione"
 
-#: lib/vutuv_web/live/shell_live.ex:1601
+#: lib/vutuv_web/live/shell_live.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Avvisi"
@@ -1628,11 +1628,11 @@ msgstr "Controlli la Sua casella di posta"
 #: lib/vutuv_web/live/admin/job_live.ex:321
 #: lib/vutuv_web/live/admin/job_live.ex:477
 #: lib/vutuv_web/live/admin/organization_live.ex:296
-#: lib/vutuv_web/live/post_live/composer.ex:1757
-#: lib/vutuv_web/live/post_live/composer.ex:1859
-#: lib/vutuv_web/live/post_live/composer.ex:1860
-#: lib/vutuv_web/live/post_live/composer.ex:2823
-#: lib/vutuv_web/live/post_live/composer.ex:3089
+#: lib/vutuv_web/live/post_live/composer.ex:1773
+#: lib/vutuv_web/live/post_live/composer.ex:1875
+#: lib/vutuv_web/live/post_live/composer.ex:1876
+#: lib/vutuv_web/live/post_live/composer.ex:2839
+#: lib/vutuv_web/live/post_live/composer.ex:3105
 #: lib/vutuv_web/templates/layout/app.html.heex:188
 #: lib/vutuv_web/templates/layout/app.html.heex:194
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
@@ -1702,10 +1702,10 @@ msgstr "Conferma"
 #: lib/vutuv_web/live/organization_live/following.ex:421
 #: lib/vutuv_web/live/organization_live/show.ex:572
 #: lib/vutuv_web/live/organization_live/show.ex:609
-#: lib/vutuv_web/live/post_live/feed.ex:942
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:180
-#: lib/vutuv_web/templates/user/show.html.heex:1309
-#: lib/vutuv_web/views/user_html.ex:628
+#: lib/vutuv_web/live/post_live/feed.ex:943
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:221
+#: lib/vutuv_web/templates/user/show.html.heex:1325
+#: lib/vutuv_web/views/user_html.ex:633
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr "Segui"
@@ -1722,7 +1722,7 @@ msgstr ""
 "Sembra che non segua ancora nessuno. Apra il profilo di una persona che "
 "conosce o che La incuriosisce e prema il pulsante «Segui»."
 
-#: lib/vutuv_web/live/shell_live.ex:1522
+#: lib/vutuv_web/live/shell_live.ex:1556
 #: lib/vutuv_web/views/settings_html.ex:299
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1744,9 +1744,9 @@ msgid "Member"
 msgstr "Membro"
 
 #: lib/vutuv_web/live/organization_live/show.ex:631
-#: lib/vutuv_web/views/user_html.ex:655
-#: lib/vutuv_web/views/user_html.ex:656
-#: lib/vutuv_web/views/user_html.ex:666
+#: lib/vutuv_web/views/user_html.ex:660
+#: lib/vutuv_web/views/user_html.ex:661
+#: lib/vutuv_web/views/user_html.ex:671
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr "Messaggio"
@@ -1754,8 +1754,8 @@ msgstr "Messaggio"
 #: lib/vutuv_web/controllers/page_controller.ex:218
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1414
-#: lib/vutuv_web/live/shell_live.ex:1600
+#: lib/vutuv_web/live/shell_live.ex:1448
+#: lib/vutuv_web/live/shell_live.ex:1634
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1787,7 +1787,7 @@ msgstr "Ancora nessuna novità."
 #: lib/vutuv_web/controllers/page_controller.ex:219
 #: lib/vutuv_web/live/notification_live/index.ex:152
 #: lib/vutuv_web/live/notification_live/index.ex:457
-#: lib/vutuv_web/live/shell_live.ex:1426
+#: lib/vutuv_web/live/shell_live.ex:1460
 #: lib/vutuv_web/templates/layout/app.html.heex:153
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -1861,7 +1861,7 @@ msgstr "Troppi tentativi. Riprovi più tardi."
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
 #: lib/vutuv_web/templates/user/show.html.heex:217
-#: lib/vutuv_web/views/user_html.ex:1077
+#: lib/vutuv_web/views/user_html.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
 msgstr "Profilo verificato"
@@ -1887,7 +1887,7 @@ msgstr ""
 "Abbiamo inviato un PIN al Suo nuovo indirizzo e-mail. Lo inserisca qui sotto"
 " per confermare l'indirizzo."
 
-#: lib/vutuv_web/views/user_html.ex:230
+#: lib/vutuv_web/views/user_html.ex:235
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr "Chi seguire"
@@ -1906,14 +1906,14 @@ msgstr "La Sua sessione di accesso è scaduta. Riprovi."
 
 #: lib/vutuv_web/open_graph.ex:344
 #: lib/vutuv_web/templates/tag/show.html.heex:32
-#: lib/vutuv_web/views/user_html.ex:499
+#: lib/vutuv_web/views/user_html.ex:504
 #, elixir-autogen, elixir-format
 msgid "follower"
 msgid_plural "followers"
 msgstr[0] "follower"
 msgstr[1] "follower"
 
-#: lib/vutuv_web/views/user_html.ex:503
+#: lib/vutuv_web/views/user_html.ex:508
 #, elixir-autogen, elixir-format
 msgid "following"
 msgstr "seguiti"
@@ -2070,12 +2070,12 @@ msgstr "Marzo"
 msgid "May"
 msgstr "Maggio"
 
-#: lib/vutuv_web/views/user_html.ex:282
+#: lib/vutuv_web/views/user_html.ex:287
 #, elixir-autogen, elixir-format
 msgid "Member since %{month} %{year}"
 msgstr "Membro da %{month} %{year}"
 
-#: lib/vutuv_web/views/user_html.ex:287
+#: lib/vutuv_web/views/user_html.ex:292
 #, elixir-autogen, elixir-format
 msgid "Member since %{year}"
 msgstr "Membro dal %{year}"
@@ -2107,7 +2107,7 @@ msgstr "Markdown è supportato: grassetto, corsivo, link ed elenchi."
 msgid "Add images"
 msgstr "Aggiungi immagini"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2299
+#: lib/vutuv_web/live/post_live/composer.ex:2315
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2120,8 +2120,8 @@ msgstr ""
 msgid "Back to the post"
 msgstr "Torna al post"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1999
-#: lib/vutuv_web/live/post_live/composer.ex:2022
+#: lib/vutuv_web/live/post_live/composer.ex:2015
+#: lib/vutuv_web/live/post_live/composer.ex:2038
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Annulla il caricamento"
@@ -2131,7 +2131,7 @@ msgstr "Annulla il caricamento"
 msgid "Delete post"
 msgstr "Elimina il post"
 
-#: lib/vutuv_web/components/post_components.ex:3703
+#: lib/vutuv_web/components/post_components.ex:3675
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2146,11 +2146,11 @@ msgstr "Modifica il post"
 #: lib/vutuv_web/components/organization_components.ex:265
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:162
-#: lib/vutuv_web/live/post_live/feed.ex:341
-#: lib/vutuv_web/live/post_live/feed.ex:3157
+#: lib/vutuv_web/live/post_live/feed.ex:345
+#: lib/vutuv_web/live/post_live/feed.ex:3088
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1254
-#: lib/vutuv_web/live/shell_live.ex:1573
+#: lib/vutuv_web/live/shell_live.ex:1282
+#: lib/vutuv_web/live/shell_live.ex:1607
 #: lib/vutuv_web/templates/layout/app.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2166,57 +2166,57 @@ msgstr "Segua %{name} per leggerlo."
 msgid "Hidden from:"
 msgstr "Nascosto a:"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2275
+#: lib/vutuv_web/live/post_live/composer.ex:2291
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr "Nascondi a una persona specifica…"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2203
+#: lib/vutuv_web/live/post_live/composer.ex:2219
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr "Nascondi questo post a…"
 
-#: lib/vutuv_web/components/post_components.ex:3657
-#: lib/vutuv_web/components/post_components.ex:3659
+#: lib/vutuv_web/components/post_components.ex:3629
+#: lib/vutuv_web/components/post_components.ex:3631
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Pubblico limitato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2245
+#: lib/vutuv_web/live/post_live/composer.ex:2261
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr "Visitatori non connessi"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1443
-#: lib/vutuv_web/live/post_live/composer.ex:1546
+#: lib/vutuv_web/live/post_live/composer.ex:1459
+#: lib/vutuv_web/live/post_live/composer.ex:1562
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3473
+#: lib/vutuv_web/live/post_live/feed.ex:3408
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 "Qui non c'è ancora nulla. Segua altre persone per riempire il Suo feed, "
 "oppure scriva il Suo primo post."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1406
+#: lib/vutuv_web/live/post_live/composer.ex:1422
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr "Non è stato possibile allegare una delle immagini."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2235
+#: lib/vutuv_web/live/post_live/composer.ex:2251
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr "Persone che non seguo"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2225
+#: lib/vutuv_web/live/post_live/composer.ex:2241
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr "Persone che non mi seguono"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:416
-#: lib/vutuv_web/live/post_live/composer.ex:2187
+#: lib/vutuv_web/live/post_live/composer.ex:2203
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2244,28 +2244,29 @@ msgstr "Post eliminato."
 msgid "Posts"
 msgstr "Post"
 
-#: lib/vutuv_web/components/post_components.ex:4134
-#: lib/vutuv_web/components/post_components.ex:4138
+#: lib/vutuv_web/components/post_components.ex:4106
+#: lib/vutuv_web/components/post_components.ex:4110
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Leggi tutto"
 
-#: lib/vutuv_web/components/post_components.ex:4135
+#: lib/vutuv_web/components/post_components.ex:4107
 #: lib/vutuv_web/live/fediverse_account_live.ex:360
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr "Mostra meno"
 
 #: lib/vutuv_web/components/fediverse_components.ex:497
 #: lib/vutuv_web/components/job_exclusion_components.ex:189
-#: lib/vutuv_web/components/post_components.ex:1368
+#: lib/vutuv_web/components/post_components.ex:1340
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:229
 #: lib/vutuv_web/live/organization_live/domains.ex:265
 #: lib/vutuv_web/live/organization_live/edit.ex:404
 #: lib/vutuv_web/live/organization_live/roles.ex:257
-#: lib/vutuv_web/live/post_live/composer.ex:2261
+#: lib/vutuv_web/live/post_live/composer.ex:2277
 #: lib/vutuv_web/live/post_live/filter_band.ex:456
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
@@ -2283,12 +2284,12 @@ msgstr ""
 "I post con pubblico limitato sono nascosti anche ai visitatori non connessi "
 "e ai motori di ricerca."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2177
+#: lib/vutuv_web/live/post_live/composer.ex:2193
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr "Salvataggio…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2364
+#: lib/vutuv_web/live/post_live/feed.ex:2332
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2300,13 +2301,13 @@ msgstr[1] "Mostra %{formatted} nuovi post"
 msgid "Sorry, that page could not be found."
 msgstr "Spiacenti, la pagina non è stata trovata."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1504
-#: lib/vutuv_web/live/post_live/composer.ex:1572
+#: lib/vutuv_web/live/post_live/composer.ex:1520
+#: lib/vutuv_web/live/post_live/composer.ex:1588
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Non è stato possibile elaborare il file."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1388
+#: lib/vutuv_web/live/post_live/composer.ex:1404
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr "La selezione del pubblico non è valida."
@@ -2316,18 +2317,18 @@ msgstr "La selezione del pubblico non è valida."
 msgid "This post is for followers of %{name}"
 msgstr "Questo post è per i follower di %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3250
+#: lib/vutuv_web/live/post_live/composer.ex:3266
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Troppi file."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3251
+#: lib/vutuv_web/live/post_live/composer.ex:3267
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Caricamento non riuscito."
 
 #: lib/vutuv_web/components/ui.ex:5363
-#: lib/vutuv_web/live/shell_live.ex:1469
+#: lib/vutuv_web/live/shell_live.ex:1503
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:246
@@ -2335,37 +2336,37 @@ msgstr "Caricamento non riuscito."
 msgid "View profile"
 msgstr "Vedi il profilo"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2393
+#: lib/vutuv_web/live/post_live/composer.ex:2409
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr "Che c'è di nuovo?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2394
+#: lib/vutuv_web/live/post_live/composer.ex:2410
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr "Che c'è di nuovo? Markdown è supportato."
 
-#: lib/vutuv_web/components/post_components.ex:3654
+#: lib/vutuv_web/components/post_components.ex:3626
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "modificato"
 
-#: lib/vutuv_web/components/post_components.ex:5694
+#: lib/vutuv_web/components/post_components.ex:5666
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "tutti gli altri"
 
-#: lib/vutuv_web/components/post_components.ex:5698
+#: lib/vutuv_web/components/post_components.ex:5670
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "visitatori non connessi"
 
-#: lib/vutuv_web/components/post_components.ex:5696
+#: lib/vutuv_web/components/post_components.ex:5668
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "persone che non La seguono"
 
-#: lib/vutuv_web/components/post_components.ex:5697
+#: lib/vutuv_web/components/post_components.ex:5669
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "persone che non segue"
@@ -2376,20 +2377,20 @@ msgstr "persone che non segue"
 msgid "unknown"
 msgstr "sconosciuto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2060
+#: lib/vutuv_web/live/post_live/composer.ex:2076
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr "Tag separati da virgole (max. %{max})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1501
-#: lib/vutuv_web/live/post_live/composer.ex:3231
-#: lib/vutuv_web/live/post_live/composer.ex:3235
+#: lib/vutuv_web/live/post_live/composer.ex:1517
+#: lib/vutuv_web/live/post_live/composer.ex:3247
+#: lib/vutuv_web/live/post_live/composer.ex:3251
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr "Il file supera %{mb} MB."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3239
-#: lib/vutuv_web/live/post_live/composer.ex:3245
+#: lib/vutuv_web/live/post_live/composer.ex:3255
+#: lib/vutuv_web/live/post_live/composer.ex:3261
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr "Tipo di file non supportato (ammessi: %{types})."
@@ -2399,7 +2400,7 @@ msgstr "Tipo di file non supportato (ammessi: %{types})."
 msgid "Posts by %{name}"
 msgstr "Post di %{name}"
 
-#: lib/vutuv_web/templates/user/show.html.heex:597
+#: lib/vutuv_web/templates/user/show.html.heex:610
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr "Vedi tutti i %{count} post"
@@ -2409,10 +2410,10 @@ msgstr "Vedi tutti i %{count} post"
 msgid "All posts"
 msgstr "Tutti i post"
 
-#: lib/vutuv_web/components/post_components.ex:2040
-#: lib/vutuv_web/components/post_components.ex:5790
+#: lib/vutuv_web/components/post_components.ex:2012
+#: lib/vutuv_web/components/post_components.ex:5762
 #: lib/vutuv_web/components/ui.ex:4053
-#: lib/vutuv_web/views/user_html.ex:461
+#: lib/vutuv_web/views/user_html.ex:466
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr "Salva"
@@ -2420,28 +2421,28 @@ msgstr "Salva"
 #: lib/vutuv_web/agent_docs/markdown.ex:1186
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:1406
-#: lib/vutuv_web/live/shell_live.ex:1474
+#: lib/vutuv_web/live/shell_live.ex:1440
+#: lib/vutuv_web/live/shell_live.ex:1508
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr "Salvati"
 
-#: lib/vutuv_web/components/post_components.ex:1993
-#: lib/vutuv_web/components/post_components.ex:6028
+#: lib/vutuv_web/components/post_components.ex:1965
+#: lib/vutuv_web/components/post_components.ex:6000
 #: lib/vutuv_web/components/ui.ex:4039
 #: lib/vutuv_web/live/notification_live/index.ex:1512
-#: lib/vutuv_web/views/user_html.ex:471
+#: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr "Mi piace"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1185
-#: lib/vutuv_web/components/post_components.ex:6038
+#: lib/vutuv_web/components/post_components.ex:6010
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:1477
+#: lib/vutuv_web/live/shell_live.ex:1511
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2459,58 +2460,58 @@ msgstr "Qui non c'è ancora nulla. I post che salva compaiono qui."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Qui non c'è ancora nulla. I post a cui mette Mi piace compaiono qui."
 
-#: lib/vutuv_web/components/post_components.ex:5778
+#: lib/vutuv_web/components/post_components.ex:5750
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Solo i post pubblici possono essere ripubblicati."
 
-#: lib/vutuv_web/components/post_components.ex:2039
-#: lib/vutuv_web/components/post_components.ex:5789
+#: lib/vutuv_web/components/post_components.ex:2011
+#: lib/vutuv_web/components/post_components.ex:5761
 #: lib/vutuv_web/live/post_live/saved.ex:806
-#: lib/vutuv_web/views/user_html.ex:461
+#: lib/vutuv_web/views/user_html.ex:466
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Rimuovi dai salvati"
 
-#: lib/vutuv_web/components/post_components.ex:2021
-#: lib/vutuv_web/components/post_components.ex:5775
+#: lib/vutuv_web/components/post_components.ex:1993
+#: lib/vutuv_web/components/post_components.ex:5747
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Ripubblica"
 
-#: lib/vutuv_web/components/post_components.ex:2299
-#: lib/vutuv_web/components/post_components.ex:4865
+#: lib/vutuv_web/components/post_components.ex:2271
+#: lib/vutuv_web/components/post_components.ex:4837
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Ripubblicato da %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:2020
-#: lib/vutuv_web/components/post_components.ex:5774
+#: lib/vutuv_web/components/post_components.ex:1992
+#: lib/vutuv_web/components/post_components.ex:5746
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Annulla la ripubblicazione"
 
-#: lib/vutuv_web/components/post_components.ex:1992
-#: lib/vutuv_web/components/post_components.ex:6027
+#: lib/vutuv_web/components/post_components.ex:1964
+#: lib/vutuv_web/components/post_components.ex:5999
 #: lib/vutuv_web/live/post_live/saved.ex:805
-#: lib/vutuv_web/views/user_html.ex:471
+#: lib/vutuv_web/views/user_html.ex:476
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr "Togli Mi piace"
 
 #: lib/vutuv_web/components/fediverse_components.ex:498
-#: lib/vutuv_web/components/post_components.ex:2734
+#: lib/vutuv_web/components/post_components.ex:2706
 #: lib/vutuv_web/components/ui.ex:2924
 #: lib/vutuv_web/components/ui.ex:2924
 #: lib/vutuv_web/components/ui.ex:3000
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
 #: lib/vutuv_web/live/organization_live/show.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:929
+#: lib/vutuv_web/live/post_live/feed.ex:930
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:42
-#: lib/vutuv_web/views/user_html.ex:618
+#: lib/vutuv_web/views/user_html.ex:623
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr "Non seguire più"
@@ -2520,7 +2521,7 @@ msgstr "Non seguire più"
 msgid "Welcome to vutuv!"
 msgstr "Benvenuto su vutuv."
 
-#: lib/vutuv_web/components/post_components.ex:6082
+#: lib/vutuv_web/components/post_components.ex:6054
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Solo ai post pubblici si può rispondere."
@@ -2531,9 +2532,9 @@ msgstr "Solo ai post pubblici si può rispondere."
 msgid "Replies"
 msgstr "Risposte"
 
-#: lib/vutuv_web/components/post_components.ex:2006
-#: lib/vutuv_web/components/post_components.ex:6065
-#: lib/vutuv_web/components/post_components.ex:6066
+#: lib/vutuv_web/components/post_components.ex:1978
+#: lib/vutuv_web/components/post_components.ex:6037
+#: lib/vutuv_web/components/post_components.ex:6038
 #: lib/vutuv_web/live/notification_live/index.ex:1010
 #: lib/vutuv_web/live/notification_live/index.ex:1509
 #: lib/vutuv_web/live/post_live/reply.ex:49
@@ -2541,20 +2542,20 @@ msgstr "Risposte"
 msgid "Reply"
 msgstr "Rispondi"
 
-#: lib/vutuv_web/components/post_components.ex:3621
+#: lib/vutuv_web/components/post_components.ex:3593
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Risposta a un post eliminato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1391
-#: lib/vutuv_web/live/post_live/composer.ex:2165
+#: lib/vutuv_web/live/post_live/composer.ex:1407
+#: lib/vutuv_web/live/post_live/composer.ex:2181
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 "Il pubblico non può essere limitato finché esistono ripubblicazioni o "
 "risposte."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2306
+#: lib/vutuv_web/live/post_live/composer.ex:2322
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2567,7 +2568,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr "ha risposto al Suo post."
 
-#: lib/vutuv_web/components/post_components.ex:3155
+#: lib/vutuv_web/components/post_components.ex:3127
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2575,14 +2576,14 @@ msgstr "ha risposto al Suo post."
 msgid "Reply to %{handle}"
 msgstr "Rispondi a %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:3593
+#: lib/vutuv_web/components/post_components.ex:3565
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Risposta a un post di %{handle} ora eliminato"
 
-#: lib/vutuv_web/components/post_components.ex:3584
-#: lib/vutuv_web/components/post_components.ex:3613
-#: lib/vutuv_web/components/post_components.ex:3616
+#: lib/vutuv_web/components/post_components.ex:3556
+#: lib/vutuv_web/components/post_components.ex:3585
+#: lib/vutuv_web/components/post_components.ex:3588
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "In risposta a %{handle}"
@@ -2750,38 +2751,38 @@ msgstr "Usa un altro indirizzo e-mail"
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:917
+#: lib/vutuv_web/templates/user/show.html.heex:930
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr "Aggiungi un link"
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1228
+#: lib/vutuv_web/templates/user/show.html.heex:1244
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Aggiungi un numero di telefono"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1487
+#: lib/vutuv_web/templates/user/show.html.heex:1503
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Aggiungi un indirizzo"
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1156
+#: lib/vutuv_web/templates/user/show.html.heex:1172
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "Aggiungi un indirizzo e-mail"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1107
+#: lib/vutuv_web/templates/user/show.html.heex:1123
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Aggiungi i dati personali"
 
-#: lib/vutuv_web/templates/user/show.html.heex:646
+#: lib/vutuv_web/templates/user/show.html.heex:659
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2802,14 +2803,13 @@ msgstr "Scriva il Suo primo post"
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
-#: lib/vutuv_web/templates/user/show.html.heex:637
+#: lib/vutuv_web/templates/user/show.html.heex:650
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr "Gestisci"
 
+#: lib/vutuv_web/components/post_components.ex:802
 #: lib/vutuv_web/controllers/page_controller.ex:216
-#: lib/vutuv_web/live/post_live/feed.ex:2404
-#: lib/vutuv_web/templates/user/show.html.heex:507
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr "Scrivi un post"
@@ -2830,7 +2830,7 @@ msgstr[0] "1 collegamento"
 msgstr[1] "%{formatted} collegamenti"
 
 #: lib/vutuv_web/live/job_board_live.ex:458
-#: lib/vutuv_web/live/post_live/feed.ex:1058
+#: lib/vutuv_web/live/post_live/feed.ex:1059
 #: lib/vutuv_web/templates/user/card_list.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -2861,7 +2861,7 @@ msgstr "Ancora nessun collegamento."
 msgid "Other formats"
 msgstr "Altri formati"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2215
+#: lib/vutuv_web/live/post_live/composer.ex:2231
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr "Persone che non sono miei collegamenti"
@@ -2877,14 +2877,14 @@ msgid "This post is for the connections of %{name}"
 msgstr "Questo post è per i collegamenti di %{name}"
 
 #: lib/vutuv_web/views/admin/moderation_html.ex:81
-#: lib/vutuv_web/views/user_html.ex:513
+#: lib/vutuv_web/views/user_html.ex:518
 #, elixir-autogen, elixir-format
 msgid "connection"
 msgid_plural "connections"
 msgstr[0] "collegamento"
 msgstr[1] "collegamenti"
 
-#: lib/vutuv_web/components/post_components.ex:5695
+#: lib/vutuv_web/components/post_components.ex:5667
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "persone che non sono Suoi collegamenti"
@@ -2912,7 +2912,7 @@ msgid "Endorsement"
 msgstr "Conferma"
 
 #: lib/vutuv_web/live/notification_live/index.ex:1507
-#: lib/vutuv_web/templates/user/show.html.heex:965
+#: lib/vutuv_web/templates/user/show.html.heex:978
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3162,13 +3162,13 @@ msgstr "Qui non c'è nulla: al momento nessun Suo contenuto è segnalato."
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nudità, violenza o altri contenuti che non hanno posto su vutuv."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1196
-#: lib/vutuv_web/templates/user/show.html.heex:1197
+#: lib/vutuv_web/templates/user/show.html.heex:1212
+#: lib/vutuv_web/templates/user/show.html.heex:1213
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr "Visibile solo a Lei"
 
-#: lib/vutuv_web/components/post_components.ex:3560
+#: lib/vutuv_web/components/post_components.ex:3532
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solo Lei può vedere questo post finché la segnalazione è in corso."
@@ -3221,7 +3221,7 @@ msgid "Private message"
 msgstr "Messaggio privato"
 
 #: lib/vutuv_web/components/ui.ex:4973
-#: lib/vutuv_web/live/shell_live.ex:1280
+#: lib/vutuv_web/live/shell_live.ex:1314
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3245,9 +3245,9 @@ msgstr "Respinta"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Lo rimuova. La segnalazione si chiude, senza altre domande."
 
-#: lib/vutuv_web/components/post_components.ex:1381
-#: lib/vutuv_web/components/post_components.ex:2754
-#: lib/vutuv_web/components/post_components.ex:3732
+#: lib/vutuv_web/components/post_components.ex:1353
+#: lib/vutuv_web/components/post_components.ex:2726
+#: lib/vutuv_web/components/post_components.ex:3704
 #: lib/vutuv_web/live/organization_live/show.ex:654
 #: lib/vutuv_web/templates/user/show.html.heex:237
 #, elixir-autogen, elixir-format
@@ -4704,12 +4704,12 @@ msgid "You have not blocked anyone."
 msgstr "Non ha bloccato nessuno."
 
 #: lib/vutuv_web/controllers/block_controller.ex:89
-#: lib/vutuv_web/live/user_profile_live.ex:327
+#: lib/vutuv_web/live/user_profile_live.ex:337
 #, elixir-autogen, elixir-format
 msgid "You unblocked @%{slug}."
 msgstr "Ha sbloccato @%{slug}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3478
+#: lib/vutuv_web/live/post_live/feed.ex:3413
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Scopra persone da seguire"
@@ -4723,7 +4723,7 @@ msgstr "Trova membri"
 #: lib/vutuv_web/live/organization_live/following.ex:313
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:987
+#: lib/vutuv_web/templates/user/show.html.heex:1000
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Segue"
@@ -4840,8 +4840,8 @@ msgstr "cerca solo nel nome (cognome: per il cognome)"
 
 #: lib/vutuv_web/live/job_board_live.ex:547
 #: lib/vutuv_web/live/tag_new_live.ex:47
-#: lib/vutuv_web/live/user_profile_live.ex:1358
-#: lib/vutuv_web/templates/user/show.html.heex:610
+#: lib/vutuv_web/live/user_profile_live.ex:1419
+#: lib/vutuv_web/templates/user/show.html.heex:623
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr "Aggiungi un tag"
@@ -5510,7 +5510,7 @@ msgstr ""
 "Questo elimina definitivamente il Suo profilo, i post, i messaggi e tutto il"
 " resto. Le inviamo un PIN per e-mail per confermare. Non si può annullare."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1412
+#: lib/vutuv_web/live/post_live/composer.ex:1428
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr "Non può più rispondere a questo post."
@@ -5520,7 +5520,7 @@ msgstr "Non può più rispondere a questo post."
 msgid "Content under review"
 msgstr "Contenuto in esame"
 
-#: lib/vutuv_web/live/shell_live.ex:1456
+#: lib/vutuv_web/live/shell_live.ex:1490
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Menu dell'account"
@@ -5542,7 +5542,7 @@ msgstr "Chiudi menu e finestre"
 msgid "General"
 msgstr "Generale"
 
-#: lib/vutuv_web/live/shell_live.ex:1513
+#: lib/vutuv_web/live/shell_live.ex:1547
 #: lib/vutuv_web/templates/layout/app.html.heex:183
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5561,7 +5561,7 @@ msgstr "Navigazione"
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:276
-#: lib/vutuv_web/live/shell_live.ex:1493
+#: lib/vutuv_web/live/shell_live.ex:1527
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5601,7 +5601,7 @@ msgstr "Completi il Suo profilo"
 msgid "A few quick steps so people can find and recognize you."
 msgstr "Pochi passaggi veloci perché le persone La trovino e La riconoscano."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1364
+#: lib/vutuv_web/live/user_profile_live.ex:1425
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr "Aggiungi una foto del profilo"
@@ -5616,8 +5616,8 @@ msgstr "Post successivo nel feed"
 msgid "Previous post in the feed"
 msgstr "Post precedente nel feed"
 
-#: lib/vutuv_web/live/shell_live.ex:1242
-#: lib/vutuv_web/live/shell_live.ex:1554
+#: lib/vutuv_web/live/shell_live.ex:1270
+#: lib/vutuv_web/live/shell_live.ex:1588
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Navigazione principale"
@@ -5627,11 +5627,11 @@ msgstr "Navigazione principale"
 msgid "Footer navigation"
 msgstr "Navigazione a piè di pagina"
 
-#: lib/vutuv_web/components/post_components.ex:3798
-#: lib/vutuv_web/components/post_components.ex:3853
-#: lib/vutuv_web/components/post_components.ex:4382
+#: lib/vutuv_web/components/post_components.ex:3770
+#: lib/vutuv_web/components/post_components.ex:3825
+#: lib/vutuv_web/components/post_components.ex:4354
 #: lib/vutuv_web/live/notification_live/index.ex:1086
-#: lib/vutuv_web/views/user_html.ex:126
+#: lib/vutuv_web/views/user_html.ex:131
 #, elixir-autogen, elixir-format
 msgid "View post"
 msgstr "Vedi il post"
@@ -5655,7 +5655,7 @@ msgstr "Altro"
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:1202
+#: lib/vutuv_web/views/user_html.ex:1207
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr "Personale"
@@ -5725,7 +5725,7 @@ msgstr "Persone che non possono interagire con Lei."
 msgid "Personal tokens for the vutuv API."
 msgstr "Token personali per l'API di vutuv."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2559
+#: lib/vutuv_web/live/post_live/composer.ex:2575
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
@@ -6270,7 +6270,7 @@ msgstr "ad esempio MacBook"
 msgid "or"
 msgstr "oppure"
 
-#: lib/vutuv_web/live/user_profile_live.ex:1369
+#: lib/vutuv_web/live/user_profile_live.ex:1430
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr "Aggiungi una descrizione breve"
@@ -6285,14 +6285,14 @@ msgstr "Descrizione breve"
 #: lib/vutuv_web/components/ui.ex:480
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:915
+#: lib/vutuv_web/templates/user/show.html.heex:928
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] "Link"
 msgstr[1] "Link"
 
-#: lib/vutuv_web/templates/user/show.html.heex:482
+#: lib/vutuv_web/templates/user/show.html.heex:483
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6306,7 +6306,7 @@ msgstr[1] "post"
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Dopo aver scelto un file può spostarlo e ingrandirlo."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1537
+#: lib/vutuv_web/templates/user/show.html.heex:1553
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Anche su"
@@ -6345,15 +6345,15 @@ msgstr "Posizioni la Sua foto"
 msgid "Use photo"
 msgstr "Usa questa foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1903
+#: lib/vutuv_web/live/post_live/composer.ex:1919
 #: lib/vutuv_web/templates/user/edit.html.heex:54
 #: lib/vutuv_web/templates/user/edit.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr "Ingrandimento"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1122
-#: lib/vutuv_web/templates/user/show.html.heex:1132
+#: lib/vutuv_web/templates/user/show.html.heex:1138
+#: lib/vutuv_web/templates/user/show.html.heex:1148
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6395,12 +6395,12 @@ msgstr "Rapporto giornaliero del %{day}"
 msgid "Jump to a day"
 msgstr "Vai a un giorno"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1244
+#: lib/vutuv_web/templates/user/show.html.heex:1260
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr "Gestisci gli indirizzi e-mail"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1255
+#: lib/vutuv_web/templates/user/show.html.heex:1271
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr "Gestisci i numeri di telefono"
@@ -6443,7 +6443,7 @@ msgstr "Giorno precedente"
 msgid "Reposts"
 msgstr "Ripubblicazioni"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1253
+#: lib/vutuv_web/templates/user/show.html.heex:1269
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr "Vedi tutti i numeri di telefono"
@@ -6504,9 +6504,9 @@ msgstr "Servizi di mappe da mostrare"
 msgid "Maps"
 msgstr "Mappe"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1527
-#: lib/vutuv_web/templates/user/show.html.heex:1531
 #: lib/vutuv_web/templates/user/show.html.heex:1543
+#: lib/vutuv_web/templates/user/show.html.heex:1547
+#: lib/vutuv_web/templates/user/show.html.heex:1559
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "Apri in %{name}"
@@ -6864,13 +6864,13 @@ msgstr ""
 "Se disattiva un'opzione, la relativa esclusione viaggia con le pagine e le "
 "risposte che La riguardano. Con entrambe disattivate, ad esempio:"
 
-#: lib/vutuv_web/components/post_components.ex:2714
-#: lib/vutuv_web/components/post_components.ex:3723
+#: lib/vutuv_web/components/post_components.ex:2686
+#: lib/vutuv_web/components/post_components.ex:3695
 #: lib/vutuv_web/components/ui.ex:3072
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:215
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:256
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:230
 #, elixir-autogen, elixir-format
@@ -6878,7 +6878,7 @@ msgid "Mute"
 msgstr "Silenzia"
 
 #: lib/vutuv_web/controllers/follow_controller.ex:49
-#: lib/vutuv_web/live/user_profile_live.ex:268
+#: lib/vutuv_web/live/user_profile_live.ex:278
 #, elixir-autogen, elixir-format
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr "Silenziato. I suoi post non compaiono più nel Suo feed."
@@ -6893,12 +6893,12 @@ msgstr "Nuovi messaggi e nuovi collegamenti"
 msgid "Remove this connection? You will stop following them."
 msgstr "Rimuovere questo collegamento? Smetterà di seguire questa persona."
 
-#: lib/vutuv_web/components/post_components.ex:3723
+#: lib/vutuv_web/components/post_components.ex:3695
 #: lib/vutuv_web/components/ui.ex:3071
 #: lib/vutuv_web/live/fediverse_account_live.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:215
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:256
 #: lib/vutuv_web/templates/settings/filters.html.heex:111
 #: lib/vutuv_web/templates/user/show.html.heex:230
 #, elixir-autogen, elixir-format
@@ -6906,7 +6906,7 @@ msgid "Unmute"
 msgstr "Riattiva"
 
 #: lib/vutuv_web/controllers/follow_controller.ex:51
-#: lib/vutuv_web/live/user_profile_live.ex:270
+#: lib/vutuv_web/live/user_profile_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr "Riattivato. I suoi post tornano a comparire nel Suo feed."
@@ -6921,12 +6921,12 @@ msgstr "Seguitevi a vicenda per collegarsi con %{name} e leggerlo."
 msgid "Go to profile to follow"
 msgstr "Vada al profilo per seguire"
 
-#: lib/vutuv_web/views/user_html.ex:1201
+#: lib/vutuv_web/views/user_html.ex:1206
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr "Professionale"
 
-#: lib/vutuv_web/views/user_html.ex:754
+#: lib/vutuv_web/views/user_html.ex:759
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr "La segue"
@@ -7462,7 +7462,7 @@ msgid "open the dev email inbox"
 msgstr "apri la casella e-mail di sviluppo"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
-#: lib/vutuv_web/views/user_html.ex:753
+#: lib/vutuv_web/views/user_html.ex:758
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr "Collegato"
@@ -7559,7 +7559,7 @@ msgid "Removed:"
 msgstr "Rimossi:"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:974
-#: lib/vutuv_web/live/post_live/composer.ex:1751
+#: lib/vutuv_web/live/post_live/composer.ex:1767
 #: lib/vutuv_web/live/post_live/filter_band.ex:533
 #, elixir-autogen, elixir-format
 msgid "Undo"
@@ -7606,7 +7606,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "vale per l'intero elenco, non solo per questa pagina"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5938
+#: lib/vutuv_web/components/post_components.ex:5910
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7714,7 +7714,7 @@ msgstr "Si aggiorna da sola. Può lasciare questa pagina: l'invio prosegue."
 
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3744
+#: lib/vutuv_web/live/post_live/feed.ex:3679
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #, elixir-autogen
 msgid "Done"
@@ -8193,7 +8193,7 @@ msgstr "Amministratori"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
 #: lib/vutuv_web/live/job_board_live.ex:468
-#: lib/vutuv_web/live/post_live/feed.ex:1067
+#: lib/vutuv_web/live/post_live/feed.ex:1068
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Tutti i membri"
@@ -8453,7 +8453,7 @@ msgstr[1] "%{count} esperienze lavorative"
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:703
+#: lib/vutuv_web/templates/user/show.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr "Aggiungi una formazione"
@@ -8477,7 +8477,7 @@ msgstr "Titolo di studio"
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
-#: lib/vutuv_web/templates/user/show.html.heex:700
+#: lib/vutuv_web/templates/user/show.html.heex:713
 #: lib/vutuv_web/views/import_html.ex:70
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
@@ -8657,13 +8657,13 @@ msgstr "Troppe importazioni. Riprovi tra poco."
 msgid "Please check the fields marked in red."
 msgstr "Controlli i campi contrassegnati in rosso."
 
-#: lib/vutuv_web/views/user_html.ex:1086
+#: lib/vutuv_web/views/user_html.ex:1091
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
 msgstr "Caricamento dei post"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1391
+#: lib/vutuv_web/templates/user/show.html.heex:1407
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Post dai social media"
@@ -9005,7 +9005,7 @@ msgstr "La scriva in Amministrazione › Pagine legali"
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1296
+#: lib/vutuv_web/templates/user/show.html.heex:1312
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr "Fediverso"
@@ -9156,7 +9156,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Download del CV"
 
-#: lib/vutuv_web/components/post_components.ex:4868
+#: lib/vutuv_web/components/post_components.ex:4840
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9431,7 +9431,7 @@ msgstr "A2 (Elementare)"
 #: lib/vutuv_web/live/feed_languages_live.ex:317
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:765
+#: lib/vutuv_web/templates/user/show.html.heex:778
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr "Aggiungi una lingua"
@@ -9656,7 +9656,7 @@ msgstr "Lingua aggiornata."
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:762
+#: lib/vutuv_web/templates/user/show.html.heex:775
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Lingue"
@@ -9946,7 +9946,7 @@ msgstr[0] "%{count} certificato o abilitazione"
 msgstr[1] "%{count} certificati o abilitazioni"
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:869
+#: lib/vutuv_web/templates/user/show.html.heex:882
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr "Aggiungi un certificato o un'abilitazione"
@@ -9994,7 +9994,7 @@ msgstr "Certificati"
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:866
+#: lib/vutuv_web/templates/user/show.html.heex:879
 #: lib/vutuv_web/views/import_html.ex:71
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
@@ -10118,8 +10118,8 @@ msgstr "Preferita"
 msgid "Preferred contact language"
 msgstr "Lingua di contatto preferita"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1218
-#: lib/vutuv_web/templates/user/show.html.heex:1219
+#: lib/vutuv_web/templates/user/show.html.heex:1234
+#: lib/vutuv_web/templates/user/show.html.heex:1235
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr "+%{code} è il prefisso telefonico di %{region}"
@@ -10630,15 +10630,15 @@ msgstr[1] "%{count} stelle"
 
 #: lib/vutuv_web/live/notification_live/index.ex:1433
 #: lib/vutuv_web/live/organization_live/show.ex:641
-#: lib/vutuv_web/views/user_html.ex:950
-#: lib/vutuv_web/views/user_html.ex:1126
+#: lib/vutuv_web/views/user_html.ex:955
+#: lib/vutuv_web/views/user_html.ex:1131
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
 msgstr[0] "%{formatted} follower"
 msgstr[1] "%{formatted} follower"
 
-#: lib/vutuv_web/views/user_html.ex:943
+#: lib/vutuv_web/views/user_html.ex:948
 #, elixir-autogen, elixir-format
 msgid "%{formatted} star"
 msgid_plural "%{formatted} stars"
@@ -10647,7 +10647,7 @@ msgstr[1] "%{formatted} stelle"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:71
 #: lib/vutuv_web/agent_docs/text.ex:66
-#: lib/vutuv_web/templates/user/show.html.heex:1365
+#: lib/vutuv_web/templates/user/show.html.heex:1381
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Codice"
@@ -10666,7 +10666,7 @@ msgstr ""
 " le statistiche pubbliche: stelle, repository, follower, linguaggi e "
 "attività recente."
 
-#: lib/vutuv_web/views/user_html.ex:957
+#: lib/vutuv_web/views/user_html.ex:962
 #, elixir-autogen, elixir-format
 msgid "Last active %{date}"
 msgstr "Ultima attività il %{date}"
@@ -10693,7 +10693,7 @@ msgstr "ultima attività il %{date}"
 msgid "since %{date}"
 msgstr "dal %{date}"
 
-#: lib/vutuv_web/views/user_html.ex:873
+#: lib/vutuv_web/views/user_html.ex:878
 #, elixir-autogen, elixir-format
 msgid "since %{year}"
 msgstr "dal %{year}"
@@ -11181,8 +11181,8 @@ msgid "Failed"
 msgstr "Non riuscito"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:198
-#: lib/vutuv_web/live/post_live/composer.ex:1982
-#: lib/vutuv_web/live/post_live/composer.ex:2817
+#: lib/vutuv_web/live/post_live/composer.ex:1998
+#: lib/vutuv_web/live/post_live/composer.ex:2833
 #, elixir-autogen, elixir-format
 msgid "Gallery"
 msgstr "Galleria"
@@ -12352,7 +12352,7 @@ msgstr "Organizzazione sbloccata."
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1484
+#: lib/vutuv_web/live/shell_live.ex:1518
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:79
@@ -12698,7 +12698,7 @@ msgstr "Titolo della posizione"
 #: lib/vutuv_web/live/job_board_live.ex:47
 #: lib/vutuv_web/live/job_board_live.ex:265
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1288
+#: lib/vutuv_web/live/shell_live.ex:1322
 #: lib/vutuv_web/templates/layout/app.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -13647,7 +13647,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "Interrompere gli avvisi via e-mail per la Sua ricerca salvata \"%{label}\"?"
 
-#: lib/vutuv_web/components/post_components.ex:3114
+#: lib/vutuv_web/components/post_components.ex:3086
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:715
 #: lib/vutuv_web/controllers/settings_controller.ex:733
@@ -14080,7 +14080,7 @@ msgstr "A tutta larghezza"
 msgid "Insert image"
 msgstr "Inserisci un'immagine"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3208
+#: lib/vutuv_web/live/post_live/composer.ex:3224
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr "Inserisci nel testo"
@@ -14144,7 +14144,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5067
 #: lib/vutuv_web/controllers/settings_controller.ex:634
-#: lib/vutuv_web/live/post_live/feed.ex:750
+#: lib/vutuv_web/live/post_live/feed.ex:751
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14193,7 +14193,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1331
+#: lib/vutuv_web/templates/user/show.html.heex:1347
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr "Aggiungi un messenger"
@@ -14230,7 +14230,7 @@ msgstr "Messenger aggiornato."
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1329
+#: lib/vutuv_web/templates/user/show.html.heex:1345
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr "Messenger"
@@ -14312,34 +14312,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr "ha aggiunto %{count} nuove voci al proprio CV:"
 
-#: lib/vutuv_web/components/post_components.ex:5544
+#: lib/vutuv_web/components/post_components.ex:5516
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Audiolibro"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1274
-#: lib/vutuv_web/components/post_components.ex:5501
+#: lib/vutuv_web/components/post_components.ex:5473
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Recensione di un libro"
 
-#: lib/vutuv_web/components/post_components.ex:5545
+#: lib/vutuv_web/components/post_components.ex:5517
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Cinema"
 
-#: lib/vutuv_web/components/post_components.ex:5547
+#: lib/vutuv_web/components/post_components.ex:5519
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:5543
+#: lib/vutuv_web/components/post_components.ex:5515
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1274
-#: lib/vutuv_web/components/post_components.ex:5500
+#: lib/vutuv_web/components/post_components.ex:5472
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Recensione di un film"
@@ -14350,12 +14350,12 @@ msgstr "Recensione di un film"
 msgid "Look up"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:5542
+#: lib/vutuv_web/components/post_components.ex:5514
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Libro cartaceo"
 
-#: lib/vutuv_web/components/post_components.ex:5546
+#: lib/vutuv_web/components/post_components.ex:5518
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14375,7 +14375,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Anno"
 
-#: lib/vutuv_web/components/post_components.ex:5583
+#: lib/vutuv_web/components/post_components.ex:5555
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14383,27 +14383,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} pagina"
 msgstr[1] "%{formatted} pagine"
 
-#: lib/vutuv_web/components/post_components.ex:5613
+#: lib/vutuv_web/components/post_components.ex:5585
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} h"
 
-#: lib/vutuv_web/components/post_components.ex:5614
+#: lib/vutuv_web/components/post_components.ex:5586
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} h %{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:5612
+#: lib/vutuv_web/components/post_components.ex:5584
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:5572
+#: lib/vutuv_web/components/post_components.ex:5544
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(edizione cartacea)"
 
-#: lib/vutuv_web/components/post_components.ex:5619
+#: lib/vutuv_web/components/post_components.ex:5591
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "circa %{duration}"
@@ -14435,7 +14435,7 @@ msgstr "Con certificazione:"
 msgid "With qualification: %{name}"
 msgstr "Con certificazione: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5386
+#: lib/vutuv_web/components/post_components.ex:5358
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Editore:"
@@ -14478,7 +14478,7 @@ msgstr "ora La seguono."
 msgid "endorsed you for %{tags}."
 msgstr "L'ha confermata per %{tags}."
 
-#: lib/vutuv_web/components/post_components.ex:5377
+#: lib/vutuv_web/components/post_components.ex:5349
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "di:"
@@ -14495,7 +14495,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] "Confermato da %{name} e da %{formatted} altro"
 msgstr[1] "Confermato da %{name} e da altri %{formatted}"
 
-#: lib/vutuv_web/live/shell_live.ex:671
+#: lib/vutuv_web/live/shell_live.ex:699
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -14742,7 +14742,7 @@ msgstr "Menzione"
 msgid "mentioned you in a post."
 msgstr "L'ha menzionata in un post."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1396
+#: lib/vutuv_web/live/post_live/composer.ex:1412
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
@@ -14750,7 +14750,7 @@ msgstr ""
 "Questo post non può più essere modificato: qualcuno gli ha messo Mi piace, "
 "lo ha ripubblicato o gli ha risposto."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1399
+#: lib/vutuv_web/live/post_live/composer.ex:1415
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14855,14 +14855,14 @@ msgstr "Cerchi un account da bloccare"
 msgid "See all frozen accounts"
 msgstr "Vedi tutti gli account bloccati"
 
-#: lib/vutuv_web/components/post_components.ex:3387
+#: lib/vutuv_web/components/post_components.ex:3359
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "Mostra %{formatted} post precedente"
 msgstr[1] "Mostra %{formatted} post precedenti"
 
-#: lib/vutuv_web/components/post_components.ex:3410
+#: lib/vutuv_web/components/post_components.ex:3382
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14891,7 +14891,7 @@ msgstr ""
 "Digiti un nome, un @handle o un indirizzo e-mail per trovare un account da "
 "bloccare."
 
-#: lib/vutuv_web/components/post_components.ex:6037
+#: lib/vutuv_web/components/post_components.ex:6009
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Non può mettere Mi piace al Suo stesso post."
@@ -15090,7 +15090,7 @@ msgstr ""
 "Scelga qui sotto un titolo di studio o un istituto da mostrare in cima al "
 "Suo profilo al posto di una qualifica."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1127
+#: lib/vutuv_web/live/post_live/feed.ex:1128
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Mostra comunque"
@@ -15707,7 +15707,7 @@ msgstr "Modifica l'applicazione"
 msgid "Book an ad"
 msgstr "Prenoti una pubblicità"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1038
+#: lib/vutuv_web/templates/user/show.html.heex:1054
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
@@ -16156,7 +16156,7 @@ msgstr ""
 " vedere dove va a finire. Modificare o eliminare un post su vutuv è solo una"
 " richiesta rivolta a quei server, e non tutti la rispettano."
 
-#: lib/vutuv_web/components/post_components.ex:5983
+#: lib/vutuv_web/components/post_components.ex:5955
 #: lib/vutuv_web/live/notification_live/index.ex:1690
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -16164,7 +16164,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} risposta"
 msgstr[1] "%{formatted} risposte"
 
-#: lib/vutuv_web/components/post_components.ex:5987
+#: lib/vutuv_web/components/post_components.ex:5959
 #: lib/vutuv_web/live/notification_live/index.ex:1684
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -16172,7 +16172,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Mi piace"
 msgstr[1] "%{formatted} Mi piace"
 
-#: lib/vutuv_web/components/post_components.ex:5991
+#: lib/vutuv_web/components/post_components.ex:5963
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16180,7 +16180,7 @@ msgstr[0] "%{formatted} ripubblicazione"
 msgstr[1] "%{formatted} ripubblicazioni"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1223
-#: lib/vutuv_web/components/post_components.ex:5942
+#: lib/vutuv_web/components/post_components.ex:5914
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Già conteggiate nei numeri qui sopra."
@@ -16201,14 +16201,14 @@ msgstr ""
 msgid "Content warning"
 msgstr "Avviso sul contenuto"
 
-#: lib/vutuv_web/components/post_components.ex:1496
-#: lib/vutuv_web/components/post_components.ex:2228
+#: lib/vutuv_web/components/post_components.ex:1468
+#: lib/vutuv_web/components/post_components.ex:2200
 #: lib/vutuv_web/live/fediverse_account_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Da un'altra rete"
 
-#: lib/vutuv_web/components/post_components.ex:1366
+#: lib/vutuv_web/components/post_components.ex:1338
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Rimuovere questa risposta dal Suo post?"
@@ -16237,7 +16237,7 @@ msgstr "Risposta da un'altra rete"
 msgid "Reply removed."
 msgstr "Risposta rimossa."
 
-#: lib/vutuv_web/components/post_components.ex:1378
+#: lib/vutuv_web/components/post_components.ex:1350
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -16248,7 +16248,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr "Segnalata come non appropriata"
 
-#: lib/vutuv_web/components/post_components.ex:1392
+#: lib/vutuv_web/components/post_components.ex:1364
 #: lib/vutuv_web/live/notification_live/index.ex:1134
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -16280,9 +16280,10 @@ msgid "That reply is not yours to remove."
 msgstr "Questa risposta non spetta a Lei rimuoverla."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1423
-#: lib/vutuv_web/components/post_components.ex:1427
-#: lib/vutuv_web/components/post_components.ex:1627
-#: lib/vutuv_web/components/post_components.ex:3004
+#: lib/vutuv_web/components/post_components.ex:1399
+#: lib/vutuv_web/components/post_components.ex:1599
+#: lib/vutuv_web/components/post_components.ex:2976
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:302
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Vedi l'originale"
@@ -16977,22 +16978,22 @@ msgstr ""
 msgid "device or detail"
 msgstr "dispositivo o dettaglio"
 
-#: lib/vutuv_web/components/post_components.ex:3572
+#: lib/vutuv_web/components/post_components.ex:3544
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Post fissato"
 
-#: lib/vutuv_web/components/post_components.ex:3690
+#: lib/vutuv_web/components/post_components.ex:3662
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "Fissa sul profilo"
 
-#: lib/vutuv_web/components/post_components.ex:3698
+#: lib/vutuv_web/components/post_components.ex:3670
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Togli dal profilo"
 
-#: lib/vutuv_web/components/post_components.ex:3684
+#: lib/vutuv_web/components/post_components.ex:3656
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -17043,7 +17044,7 @@ msgstr ""
 "profilo, come si scrive una trascrizione, e le parentesi le aggiungiamo noi."
 " Se lo lascia vuoto non viene mostrato nulla."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3221
+#: lib/vutuv_web/live/post_live/composer.ex:3237
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr "Applica queste impostazioni a tutte le foto"
@@ -17075,12 +17076,12 @@ msgstr "CC0 1.0 (nessun diritto riservato)"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1340
 #: lib/vutuv_web/agent_docs/text.ex:830
-#: lib/vutuv_web/live/post_live/composer.ex:2645
+#: lib/vutuv_web/live/post_live/composer.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Copertina"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3059
+#: lib/vutuv_web/live/post_live/composer.ex:3075
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr "Descriva la foto per chi non può vederla"
@@ -17092,24 +17093,24 @@ msgstr "Descriva la foto per chi non può vederla"
 msgid "Download the original"
 msgstr "Scarica l'originale"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3158
+#: lib/vutuv_web/live/post_live/composer.ex:3174
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 "Tutti i campi di metadati conservati, compreso ciò che ha scritto la Sua "
 "fotocamera."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3114
+#: lib/vutuv_web/live/post_live/composer.ex:3130
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr "Chiunque può scaricare questa foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3116
+#: lib/vutuv_web/live/post_live/composer.ex:3132
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr "Risoluzione piena, direttamente dal post."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3135
+#: lib/vutuv_web/live/post_live/composer.ex:3151
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr "Solo l'immagine"
@@ -17119,35 +17120,35 @@ msgstr "Solo l'immagine"
 msgid "Next photo"
 msgstr "Foto successiva"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2664
+#: lib/vutuv_web/live/post_live/composer.ex:2680
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr "Ancora nessuna descrizione dell'immagine"
 
-#: lib/vutuv_web/components/post_components.ex:3167
+#: lib/vutuv_web/components/post_components.ex:3139
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Apri le impostazioni del Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:4513
+#: lib/vutuv_web/components/post_components.ex:4485
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} di %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:4662
+#: lib/vutuv_web/components/post_components.ex:4634
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "La foto è in fase di controllo"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2617
-#: lib/vutuv_web/live/post_live/composer.ex:2618
+#: lib/vutuv_web/live/post_live/composer.ex:2633
+#: lib/vutuv_web/live/post_live/composer.ex:2634
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr "Opzioni della foto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1384
 #: lib/vutuv_web/agent_docs/text.ex:818
-#: lib/vutuv_web/components/post_components.ex:4744
+#: lib/vutuv_web/components/post_components.ex:4716
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Foto:"
@@ -17157,51 +17158,51 @@ msgstr "Foto:"
 msgid "Previous photo"
 msgstr "Foto precedente"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2677
-#: lib/vutuv_web/live/post_live/composer.ex:2678
+#: lib/vutuv_web/live/post_live/composer.ex:2693
+#: lib/vutuv_web/live/post_live/composer.ex:2694
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr "Rimuovi la foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3137
+#: lib/vutuv_web/live/post_live/composer.ex:3153
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 "Gli stessi pixel e nient'altro: posizione e numeri di serie rimossi, qualità"
 " intatta."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3078
+#: lib/vutuv_web/live/post_live/composer.ex:3094
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr "Mostra le impostazioni della fotocamera"
 
-#: lib/vutuv_web/components/post_components.ex:3220
+#: lib/vutuv_web/components/post_components.ex:3192
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 "Quel server è bloccato su questo sito, quindi non gli si può inviare alcuna "
 "risposta."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3156
+#: lib/vutuv_web/live/post_live/composer.ex:3172
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr "Il file esattamente come l'ho caricato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3192
+#: lib/vutuv_web/live/post_live/composer.ex:3208
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 "Questo formato di file può essere consegnato solo così com'è. Rimuova la "
 "foto se non è ciò che desidera."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3184
+#: lib/vutuv_web/live/post_live/composer.ex:3200
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 "Questa foto porta con sé il luogo in cui è stata scattata. Chiunque scarichi"
 " il file esatto può leggerlo."
 
-#: lib/vutuv_web/components/post_components.ex:3211
+#: lib/vutuv_web/components/post_components.ex:3183
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -17216,42 +17217,42 @@ msgstr ""
 "inviare le Sue parole a quella rete, cosa che vutuv fa solo per i membri che"
 " hanno attivato la partecipazione al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:3229
+#: lib/vutuv_web/components/post_components.ex:3201
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Questo sito non partecipa al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:3163
+#: lib/vutuv_web/components/post_components.ex:3135
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Attivi la partecipazione al Fediverso per rispondere"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2935
+#: lib/vutuv_web/live/post_live/composer.ex:2951
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr "Chi può riutilizzare queste foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1426
+#: lib/vutuv_web/live/post_live/composer.ex:1442
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 "Nell'ultima ora ha inviato molte risposte ad altre reti. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:3224
+#: lib/vutuv_web/components/post_components.ex:3196
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 "Ha spostato il Suo account del Fediverso su un altro server, quindi da qui "
 "non vengono più inviate risposte."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1440
+#: lib/vutuv_web/live/post_live/composer.ex:1456
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 "Al momento le Sue impostazioni del Fediverso non consentono di inviare una "
 "risposta."
 
-#: lib/vutuv_web/components/post_components.ex:3177
+#: lib/vutuv_web/components/post_components.ex:3149
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -17263,66 +17264,66 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr "© Tutti i diritti riservati"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2560
+#: lib/vutuv_web/live/post_live/composer.ex:2576
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr "Aggiungi foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2930
+#: lib/vutuv_web/live/post_live/composer.ex:2946
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr "Licenza"
 
-#: lib/vutuv_web/live/post_live/composer.ex:3049
+#: lib/vutuv_web/live/post_live/composer.ex:3065
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr "Didascalia (facoltativa)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1726
-#: lib/vutuv_web/live/post_live/composer.ex:1789
-#: lib/vutuv_web/live/post_live/composer.ex:1847
+#: lib/vutuv_web/live/post_live/composer.ex:1742
+#: lib/vutuv_web/live/post_live/composer.ex:1805
+#: lib/vutuv_web/live/post_live/composer.ex:1863
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr "Scarta la bozza"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1719
+#: lib/vutuv_web/live/post_live/composer.ex:1735
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr "Ripreso da dove aveva lasciato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2983
+#: lib/vutuv_web/live/post_live/composer.ex:2999
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 "Un file il cui formato non può essere ripulito viene consegnato esattamente "
 "come caricato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2372
+#: lib/vutuv_web/live/post_live/composer.ex:2388
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr "Diverso per ogni foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2371
+#: lib/vutuv_web/live/post_live/composer.ex:2387
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr "Originale, esattamente come caricato"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2370
+#: lib/vutuv_web/live/post_live/composer.ex:2386
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr "Originale, senza metadati"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2375
+#: lib/vutuv_web/live/post_live/composer.ex:2391
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr "Solo versioni per il web (%{format})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2953
+#: lib/vutuv_web/live/post_live/composer.ex:2969
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr "Cosa può salvare un visitatore"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2972
+#: lib/vutuv_web/live/post_live/composer.ex:2988
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -17334,13 +17335,13 @@ msgstr[1] ""
 "il file esatto lo rivela."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1241
-#: lib/vutuv_web/components/post_components.ex:5980
+#: lib/vutuv_web/components/post_components.ex:5952
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "A %{handle} è piaciuto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1239
-#: lib/vutuv_web/components/post_components.ex:5977
+#: lib/vutuv_web/components/post_components.ex:5949
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} lo ha condiviso"
@@ -17350,7 +17351,7 @@ msgstr "%{handle} lo ha condiviso"
 msgid "Fediverse reactions"
 msgstr "Reazioni dal Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:5867
+#: lib/vutuv_web/components/post_components.ex:5839
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Da altre reti"
@@ -17446,8 +17447,8 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr "Richiesta di ritiro"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1983
-#: lib/vutuv_web/live/post_live/composer.ex:2817
+#: lib/vutuv_web/live/post_live/composer.ex:1999
+#: lib/vutuv_web/live/post_live/composer.ex:2833
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr "Dettagli della foto"
@@ -17737,7 +17738,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr "Post in cache"
 
-#: lib/vutuv_web/components/post_components.ex:2763
+#: lib/vutuv_web/components/post_components.ex:2735
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Solo per i follower di questo account"
@@ -17747,7 +17748,7 @@ msgstr "Solo per i follower di questo account"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Grazie. La nostra copia è stata eliminata subito."
 
-#: lib/vutuv_web/components/post_components.ex:3003
+#: lib/vutuv_web/components/post_components.ex:2975
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Vota sull'originale"
@@ -17773,12 +17774,12 @@ msgstr "Post in cache segnalato, rimosso per tutti qui"
 msgid "Content from other networks taken down by members"
 msgstr "Contenuti da altre reti rimossi dai membri"
 
-#: lib/vutuv_web/components/post_components.ex:1762
+#: lib/vutuv_web/components/post_components.ex:1734
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Nascondi"
 
-#: lib/vutuv_web/components/post_components.ex:2944
+#: lib/vutuv_web/components/post_components.ex:2916
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Contrassegnato come sensibile dal suo autore"
@@ -17794,7 +17795,7 @@ msgstr "Silenziato. Continua a seguirlo; i suoi post spariscono dal Suo feed."
 msgid "Nobody has removed or reported anything yet."
 msgstr "Nessuno ha ancora rimosso o segnalato nulla."
 
-#: lib/vutuv_web/components/post_components.ex:2749
+#: lib/vutuv_web/components/post_components.ex:2721
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -18056,27 +18057,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(un'immagine)"
 msgstr[1] "(%{count} immagini)"
 
-#: lib/vutuv_web/components/post_components.ex:2400
+#: lib/vutuv_web/components/post_components.ex:2372
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr "L'immagine è in fase di controllo"
 
-#: lib/vutuv_web/components/post_components.ex:2433
+#: lib/vutuv_web/components/post_components.ex:2405
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Coprila di nuovo"
 
-#: lib/vutuv_web/components/post_components.ex:2428
+#: lib/vutuv_web/components/post_components.ex:2400
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Contenuto sensibile. Mostra l'immagine."
 
-#: lib/vutuv_web/components/post_components.ex:3070
+#: lib/vutuv_web/components/post_components.ex:3042
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Sono molti Mi piace in un'ora. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:3076
+#: lib/vutuv_web/components/post_components.ex:3048
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Quel post non è più qui."
@@ -18086,7 +18087,7 @@ msgstr "Quel post non è più qui."
 msgid "Back to the feed"
 msgstr "Torna al feed"
 
-#: lib/vutuv_web/components/post_components.ex:3215
+#: lib/vutuv_web/components/post_components.ex:3187
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18135,14 +18136,14 @@ msgstr ""
 "Quel link punta a un singolo post. Da qui può seguire il suo autore, "
 "%{account}."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1403
+#: lib/vutuv_web/live/user_profile_live.ex:1464
 #, elixir-autogen, elixir-format
 msgid "You already follow one member."
 msgid_plural "You already follow %{count} members."
 msgstr[0] "Segue già un membro."
 msgstr[1] "Segue già %{count} membri."
 
-#: lib/vutuv_web/views/user_html.ex:232
+#: lib/vutuv_web/views/user_html.ex:237
 #, elixir-autogen, elixir-format
 msgid "Your feed shows the posts of members you follow. Follow a few to fill it."
 msgstr ""
@@ -18379,7 +18380,6 @@ msgid "That is a link on this vutuv, not on another network."
 msgstr "Questo è un link su questo vutuv, non su un'altra rete."
 
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:317
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:240
 #, elixir-autogen, elixir-format
 msgid "Their account page here"
 msgstr "La sua pagina account qui"
@@ -18441,108 +18441,108 @@ msgstr ""
 "previsti per ogni altro post da un'altra rete, e al server del suo autore "
 "non viene chiesto nient'altro."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1900
+#: lib/vutuv_web/live/post_live/composer.ex:1916
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr "Applica il ritaglio"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2723
+#: lib/vutuv_web/live/post_live/composer.ex:2739
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr "Foto grande a sinistra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2724
+#: lib/vutuv_web/live/post_live/composer.ex:2740
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr "Foto grande a destra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2729
+#: lib/vutuv_web/live/post_live/composer.ex:2745
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr "Colonne"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2726
+#: lib/vutuv_web/live/post_live/composer.ex:2742
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr "Copertina a sinistra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2727
+#: lib/vutuv_web/live/post_live/composer.ex:2743
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr "Copertina in alto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2728
+#: lib/vutuv_web/live/post_live/composer.ex:2744
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr "Copertina a destra"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1896
-#: lib/vutuv_web/live/post_live/composer.ex:2694
-#: lib/vutuv_web/live/post_live/composer.ex:2695
+#: lib/vutuv_web/live/post_live/composer.ex:1912
+#: lib/vutuv_web/live/post_live/composer.ex:2710
+#: lib/vutuv_web/live/post_live/composer.ex:2711
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr "Ritaglia la foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2653
+#: lib/vutuv_web/live/post_live/composer.ex:2669
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr "Ritagliata"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1818
+#: lib/vutuv_web/live/post_live/composer.ex:1834
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr "Trascini qui le foto per aggiungerle"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2730
+#: lib/vutuv_web/live/post_live/composer.ex:2746
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr "Griglia"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2731
+#: lib/vutuv_web/live/post_live/composer.ex:2747
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr "Mosaico"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1898
+#: lib/vutuv_web/live/post_live/composer.ex:1914
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 "Scelga una forma, poi trascini e ingrandisca. La parte nel riquadro è quella"
 " che il post mostra."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2722
+#: lib/vutuv_web/live/post_live/composer.ex:2738
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr "Affiancate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2725
+#: lib/vutuv_web/live/post_live/composer.ex:2741
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr "Impilate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:562
+#: lib/vutuv_web/live/post_live/composer.ex:572
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr "Non è stato possibile ritagliare la foto."
 
-#: lib/vutuv_web/live/post_live/composer.ex:3171
+#: lib/vutuv_web/live/post_live/composer.ex:3187
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 "Questa foto è ritagliata: i download consegnano l'immagine ritagliata, e il "
 "caricamento intatto resta privato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1902
+#: lib/vutuv_web/live/post_live/composer.ex:1918
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr "Foto intera"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2920
+#: lib/vutuv_web/live/post_live/composer.ex:2936
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr "Riempi le caselle"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2904
+#: lib/vutuv_web/live/post_live/composer.ex:2920
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr "Foto intere"
@@ -18826,7 +18826,7 @@ msgstr "Nessun post su vutuv porta ancora questo tag."
 msgid "word in a post"
 msgstr "parola in un post"
 
-#: lib/vutuv_web/components/post_components.ex:3073
+#: lib/vutuv_web/components/post_components.ex:3045
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Quella risposta non è più qui."
@@ -19205,19 +19205,19 @@ msgstr ""
 msgid "Liked by"
 msgstr "Piace a"
 
-#: lib/vutuv_web/components/post_components.ex:5038
+#: lib/vutuv_web/components/post_components.ex:5010
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Piace a %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5040
+#: lib/vutuv_web/components/post_components.ex:5012
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Piace a %{name} e a %{formatted} altro"
 msgstr[1] "Piace a %{name} e ad altri %{formatted}"
 
-#: lib/vutuv_web/components/post_components.ex:5051
+#: lib/vutuv_web/components/post_components.ex:5023
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -19283,7 +19283,7 @@ msgstr "Per questo attestato è già in corso un'analisi."
 #: lib/vutuv_web/controllers/job_reference_controller.ex:144
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:18
 #: lib/vutuv_web/templates/job_reference/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:803
+#: lib/vutuv_web/templates/user/show.html.heex:816
 #, elixir-autogen, elixir-format
 msgid "Add an employment reference"
 msgstr "Aggiungi un attestato di lavoro"
@@ -19363,7 +19363,7 @@ msgstr "Attestato di lavoro aggiornato."
 #: lib/vutuv_web/templates/job_reference/new.html.heex:4
 #: lib/vutuv_web/templates/job_reference/show.html.heex:12
 #: lib/vutuv_web/templates/job_reference/view.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:800
+#: lib/vutuv_web/templates/user/show.html.heex:813
 #, elixir-autogen, elixir-format
 msgid "Employment references"
 msgstr "Attestati di lavoro"
@@ -19398,7 +19398,7 @@ msgstr "Rilasciato il"
 msgid "Label"
 msgstr "Etichetta"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3496
+#: lib/vutuv_web/live/post_live/feed.ex:3431
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -20050,7 +20050,7 @@ msgstr "Il Suo nome utente vutuv è pronto."
 msgid "by the lawyer Tom Braegelmann"
 msgstr "dall'avvocato Tom Braegelmann"
 
-#: lib/vutuv_web/templates/user/show.html.heex:844
+#: lib/vutuv_web/templates/user/show.html.heex:857
 #, elixir-autogen, elixir-format
 msgid "Documents:"
 msgstr "Documenti:"
@@ -20258,7 +20258,7 @@ msgstr ""
 "Benvenuto su vutuv. Può cambiare il Suo nome utente {handle} su {url}, e su "
 "{import_url} può importare un profilo LinkedIn esistente."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1389
+#: lib/vutuv_web/live/user_profile_live.ex:1450
 #, elixir-autogen, elixir-format
 msgid "Follow other members"
 msgstr "Segua altri membri"
@@ -21040,7 +21040,7 @@ msgstr ""
 msgid "Start over"
 msgstr "Ricomincia"
 
-#: lib/vutuv_web/components/post_components.ex:3103
+#: lib/vutuv_web/components/post_components.ex:3075
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -21109,22 +21109,22 @@ msgstr ""
 msgid "Nothing published yet."
 msgstr "Ancora nulla di pubblicato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2186
+#: lib/vutuv_web/live/post_live/composer.ex:2202
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr "Pubblica come %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1419
+#: lib/vutuv_web/live/post_live/composer.ex:1435
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr "Non può più scrivere a nome di questa organizzazione."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2163
+#: lib/vutuv_web/live/post_live/composer.ex:2179
 #, elixir-autogen, elixir-format
 msgid "A post in an organization's name is always public."
 msgstr "Un post a nome di un'organizzazione è sempre pubblico."
 
-#: lib/vutuv_web/live/shell_live.ex:1200
+#: lib/vutuv_web/live/shell_live.ex:1228
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr "Apri la pagina"
@@ -21144,7 +21144,7 @@ msgstr "Ha smesso di scrivere come organizzazione"
 msgid "Write as %{name} for now"
 msgstr "Scrivi come %{name} per ora"
 
-#: lib/vutuv_web/live/shell_live.ex:1210
+#: lib/vutuv_web/live/shell_live.ex:1238
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr "Torna a scrivere come me stesso"
@@ -21154,7 +21154,7 @@ msgstr "Torna a scrivere come me stesso"
 msgid "You are writing as %{name} now."
 msgstr "Ora sta scrivendo come %{name}."
 
-#: lib/vutuv_web/live/shell_live.ex:1186
+#: lib/vutuv_web/live/shell_live.ex:1214
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr "Sta scrivendo come %{name}."
@@ -21565,21 +21565,21 @@ msgstr "Segue già #%{tag} qui."
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr "Anche Lei è su questo vutuv, quindi ora segue #%{tag} proprio qui."
 
-#: lib/vutuv_web/live/shell_live.ex:715
+#: lib/vutuv_web/live/shell_live.ex:743
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] "%{formatted} persona"
 msgstr[1] "%{formatted} persone"
 
-#: lib/vutuv_web/live/shell_live.ex:702
+#: lib/vutuv_web/live/shell_live.ex:730
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] "persona"
 msgstr[1] "persone"
 
-#: lib/vutuv_web/live/shell_live.ex:737
+#: lib/vutuv_web/live/shell_live.ex:765
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -21985,44 +21985,44 @@ msgstr "Ha %{used} tag su %{max}."
 msgid "{n} of {max} free slots selected."
 msgstr "Selezionati {n} posti liberi su {max}."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2145
+#: lib/vutuv_web/live/post_live/composer.ex:2161
 #, elixir-autogen, elixir-format
 msgid "More languages"
 msgstr "Altre lingue"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2136
+#: lib/vutuv_web/live/post_live/composer.ex:2152
 #, elixir-autogen, elixir-format
 msgctxt "post composer"
 msgid "Language"
 msgstr "Lingua"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2132
-#: lib/vutuv_web/live/post_live/composer.ex:2133
+#: lib/vutuv_web/live/post_live/composer.ex:2148
+#: lib/vutuv_web/live/post_live/composer.ex:2149
 #, elixir-autogen, elixir-format
 msgid "The language this post is written in"
 msgstr "La lingua in cui è scritto questo post"
 
-#: lib/vutuv_web/components/post_components.ex:4932
+#: lib/vutuv_web/components/post_components.ex:4904
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Mostra l'originale"
 
-#: lib/vutuv_web/components/post_components.ex:4968
+#: lib/vutuv_web/components/post_components.ex:4940
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Traduci"
 
-#: lib/vutuv_web/components/post_components.ex:4977
+#: lib/vutuv_web/components/post_components.ex:4949
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Tradotto"
 
-#: lib/vutuv_web/components/post_components.ex:4980
+#: lib/vutuv_web/components/post_components.ex:4952
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Tradotto da %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:4957
+#: lib/vutuv_web/components/post_components.ex:4929
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Traduzione in corso…"
@@ -22033,7 +22033,7 @@ msgid "Feed language settings reset to the site defaults."
 msgstr ""
 "Impostazioni delle lingue del feed riportate ai valori predefiniti del sito."
 
-#: lib/vutuv_web/components/post_components.ex:4947
+#: lib/vutuv_web/components/post_components.ex:4919
 #: lib/vutuv_web/components/ui.ex:5060
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -22176,7 +22176,7 @@ msgid "Your username, or paste the address of your profile page."
 msgstr ""
 "Il Suo nome utente, oppure incolli l'indirizzo della Sua pagina di profilo."
 
-#: lib/vutuv_web/components/post_components.ex:4710
+#: lib/vutuv_web/components/post_components.ex:4682
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
@@ -22187,13 +22187,13 @@ msgstr[1] ""
 "La nostra IA le sta ancora controllando, %{done} su %{total} fatte. Appena "
 "avrà finito con l'ultima, le foto compariranno da sé."
 
-#: lib/vutuv_web/components/post_components.ex:4707
+#: lib/vutuv_web/components/post_components.ex:4679
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Il Suo post è pubblicato, la foto non c'è ancora."
 
-#: lib/vutuv_web/components/post_components.ex:2454
-#: lib/vutuv_web/components/post_components.ex:3918
+#: lib/vutuv_web/components/post_components.ex:2426
+#: lib/vutuv_web/components/post_components.ex:3890
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -22213,13 +22213,13 @@ msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Consigliato: quadrata, almeno %{width} × %{height} pixel."
 
 #: lib/vutuv_web/live/job_board_live.ex:431
-#: lib/vutuv_web/live/post_live/feed.ex:1004
-#: lib/vutuv_web/views/user_html.ex:342
+#: lib/vutuv_web/live/post_live/feed.ex:1005
+#: lib/vutuv_web/views/user_html.ex:347
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
 msgstr "Immagine del profilo di %{name}"
 
-#: lib/vutuv_web/views/user_html.ex:345
+#: lib/vutuv_web/views/user_html.ex:350
 #, elixir-autogen, elixir-format
 msgid "Show the profile picture larger"
 msgstr "Mostra l'immagine del profilo più grande"
@@ -22360,7 +22360,7 @@ msgid "Find my contacts"
 msgstr "Trova i miei contatti"
 
 #: lib/vutuv_web/templates/user/show.html.heex:460
-#: lib/vutuv_web/views/user_html.ex:254
+#: lib/vutuv_web/views/user_html.ex:259
 #, elixir-autogen, elixir-format
 msgid "Find people you know from LinkedIn"
 msgstr "Trovi le persone che conosce da LinkedIn"
@@ -22767,7 +22767,7 @@ msgstr ""
 "Questa pagina sta seguendo il numero massimo di account che consentiamo "
 "(%{max})."
 
-#: lib/vutuv_web/components/post_components.ex:2729
+#: lib/vutuv_web/components/post_components.ex:2701
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr "Smettere di seguire %{handle}? I suoi post spariscono dal Suo feed."
@@ -22777,7 +22777,7 @@ msgstr "Smettere di seguire %{handle}? I suoi post spariscono dal Suo feed."
 msgid "Unfollowed. Their posts leave your feed."
 msgstr "Non lo segue più. I suoi post spariscono dal Suo feed."
 
-#: lib/vutuv_web/live/shell_live.ex:1160
+#: lib/vutuv_web/live/shell_live.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr "Consenti"
@@ -22792,12 +22792,12 @@ msgstr "Chiedi ora"
 msgid "Browser notifications"
 msgstr "Notifiche del browser"
 
-#: lib/vutuv_web/live/shell_live.ex:1018
+#: lib/vutuv_web/live/shell_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr "Nuovo messaggio"
 
-#: lib/vutuv_web/live/shell_live.ex:1163
+#: lib/vutuv_web/live/shell_live.ex:1191
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Non ora"
@@ -22847,7 +22847,7 @@ msgstr ""
 "guardando, il Suo browser può mostrarlo come notifica. Disattivate finché "
 "non le attiva."
 
-#: lib/vutuv_web/live/shell_live.ex:1157
+#: lib/vutuv_web/live/shell_live.ex:1185
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -22893,12 +22893,12 @@ msgstr ""
 "Inviata. Se non è comparso nulla, è il Suo sistema a trattenerla. Controlli "
 "la modalità Non disturbare e le impostazioni delle notifiche."
 
-#: lib/vutuv_web/live/shell_live.ex:810
+#: lib/vutuv_web/live/shell_live.ex:838
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr "Notifica di prova"
 
-#: lib/vutuv_web/live/shell_live.ex:811
+#: lib/vutuv_web/live/shell_live.ex:839
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr "Ecco come si presenta vutuv quando arriva qualcosa."
@@ -22910,12 +22910,12 @@ msgstr ""
 "Segua #%{tag} da Mastodon o da qualsiasi altra app del Fediverso e i suoi "
 "post pubblici arriveranno nella Sua cronologia. Non serve un account vutuv."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3657
+#: lib/vutuv_web/live/post_live/feed.ex:3592
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Saluti gli altri membri"
 
-#: lib/vutuv_web/live/post_live/feed.ex:751
+#: lib/vutuv_web/live/post_live/feed.ex:752
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr "Nuovi qui"
@@ -22965,7 +22965,7 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr "Con un account vutuv"
 
-#: lib/vutuv_web/live/post_live/feed.ex:996
+#: lib/vutuv_web/live/post_live/feed.ex:997
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr "Alcuni fra i membri più recenti. Seguirli è un bel benvenuto."
@@ -23128,7 +23128,7 @@ msgstr "Traducili in %{language}"
 msgid "Translated into %{language}."
 msgstr "Vengono tradotti in %{language}."
 
-#: lib/vutuv_web/live/shell_live.ex:951
+#: lib/vutuv_web/live/shell_live.ex:979
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -23253,7 +23253,7 @@ msgstr "Nuovo messaggio su vutuv"
 msgid "No connection"
 msgstr "Nessuna connessione"
 
-#: lib/vutuv_web/live/shell_live.ex:1090
+#: lib/vutuv_web/live/shell_live.ex:1118
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr "Ricarica"
@@ -23346,7 +23346,7 @@ msgstr "Tutti i membri vutuv, in ordine alfabetico per cognome."
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr "Tutti i membri vutuv, raggruppati per la prima lettera del cognome."
 
-#: lib/vutuv_web/live/post_live/feed.ex:876
+#: lib/vutuv_web/live/post_live/feed.ex:877
 #: lib/vutuv_web/live/post_live/filter_band.ex:350
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -23362,7 +23362,7 @@ msgstr "Anche dentro parole più lunghe: %{word} trova anche %{example}."
 msgid "A–Z"
 msgstr "A–Z"
 
-#: lib/vutuv_web/live/post_live/feed.ex:959
+#: lib/vutuv_web/live/post_live/feed.ex:960
 #, elixir-autogen, elixir-format
 msgid "Browse the tags"
 msgstr "Sfoglia i tag"
@@ -23377,7 +23377,7 @@ msgstr "Più attivi per primi"
 msgid "Clear all"
 msgstr "Cancella tutto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:788
+#: lib/vutuv_web/live/post_live/feed.ex:789
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr "Trascina, oppure usa i tasti freccia"
@@ -23392,13 +23392,13 @@ msgstr "Espandi o comprimi"
 msgid "Find an account or a server …"
 msgstr "Cerca un account o un server …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:812
+#: lib/vutuv_web/live/post_live/feed.ex:813
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr "Riduci %{card}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:940
 #: lib/vutuv_web/live/post_live/feed.ex:941
+#: lib/vutuv_web/live/post_live/feed.ex:942
 #, elixir-autogen, elixir-format
 msgid "Follow a tag …"
 msgstr "Segui un tag …"
@@ -23415,17 +23415,17 @@ msgstr "Nascondi un tag …"
 msgid "Hide a word or a whole phrase …"
 msgstr "Nascondi una parola o un'intera frase …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:749
+#: lib/vutuv_web/live/post_live/feed.ex:750
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Nascondi tag"
 
-#: lib/vutuv_web/live/post_live/feed.ex:748
+#: lib/vutuv_web/live/post_live/feed.ex:749
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Nascondi parole"
 
-#: lib/vutuv_web/live/post_live/feed.ex:965
+#: lib/vutuv_web/live/post_live/feed.ex:966
 #: lib/vutuv_web/live/post_live/filter_band.ex:394
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -23441,7 +23441,7 @@ msgstr "Ora non corrisponde a nulla nel suo feed — la regola vale comunque per
 msgid "More of your %{formatted} accounts"
 msgstr "Altri dei tuoi %{formatted} account"
 
-#: lib/vutuv_web/live/post_live/feed.ex:787
+#: lib/vutuv_web/live/post_live/feed.ex:788
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr "Sposta %{card}"
@@ -23452,12 +23452,12 @@ msgstr "Sposta %{card}"
 msgid "No account found."
 msgstr "Nessun account trovato."
 
-#: lib/vutuv_web/live/post_live/feed.ex:954
+#: lib/vutuv_web/live/post_live/feed.ex:955
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr "Nessun tag chiamato %{name} finora."
 
-#: lib/vutuv_web/live/post_live/feed.ex:741
+#: lib/vutuv_web/live/post_live/feed.ex:742
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr "Non ancora letti"
@@ -23487,13 +23487,13 @@ msgstr "I post con uno di questi tag vengono ridotti allo stesso modo."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "I post che contengono una di queste parole vengono ridotti a una riga — non eliminati, e con un modo per aprirli comunque."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3683
+#: lib/vutuv_web/live/post_live/feed.ex:3618
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Messe da parte:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:833
 #: lib/vutuv_web/live/post_live/feed.ex:834
+#: lib/vutuv_web/live/post_live/feed.ex:835
 #, elixir-autogen, elixir-format
 msgid "Remove %{card}"
 msgstr "Rimuovi %{card}"
@@ -23525,7 +23525,7 @@ msgstr "Mostra solo %{source}"
 msgid "Show posts by %{name}"
 msgstr "Mostra i post di %{name}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:747
+#: lib/vutuv_web/live/post_live/feed.ex:748
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr "Fonti"
@@ -23535,12 +23535,12 @@ msgstr "Fonti"
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr "Disattivare significa silenziare, non smettere di seguire. Continui a seguire, ma i post non arrivano più nel tuo feed: in modo permanente e su tutti i dispositivi, finché non li riattivi qui."
 
-#: lib/vutuv_web/live/post_live/feed.ex:811
+#: lib/vutuv_web/live/post_live/feed.ex:812
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr "Espandi %{card}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:930
+#: lib/vutuv_web/live/post_live/feed.ex:931
 #, elixir-autogen, elixir-format
 msgid "Unfollow the tag %{tag}"
 msgstr "Smetti di seguire il tag %{tag}"
@@ -23564,29 +23564,29 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "e 1 altro"
 msgstr[1] "e altri %{formatted}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3270
-#: lib/vutuv_web/live/post_live/feed.ex:3297
-#: lib/vutuv_web/live/post_live/feed.ex:3731
-#: lib/vutuv_web/live/post_live/feed.ex:3736
+#: lib/vutuv_web/live/post_live/feed.ex:3205
+#: lib/vutuv_web/live/post_live/feed.ex:3232
+#: lib/vutuv_web/live/post_live/feed.ex:3666
+#: lib/vutuv_web/live/post_live/feed.ex:3671
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr "Filtri"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1135
+#: lib/vutuv_web/live/post_live/feed.ex:1136
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr "Nascosto:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:886
+#: lib/vutuv_web/live/post_live/feed.ex:887
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
 msgstr[0] "Mostra %{formatted} post nel feed"
 msgstr[1] "Mostra %{formatted} post nel feed"
 
-#: lib/vutuv_web/components/post_components.ex:2371
+#: lib/vutuv_web/components/post_components.ex:2343
 #, elixir-autogen, elixir-format
 msgid "Picture unavailable"
 msgstr "Immagine non disponibile"
@@ -23636,7 +23636,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} post il %{day}"
 msgstr[1] "%{count} post il %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3453
+#: lib/vutuv_web/live/post_live/feed.ex:3388
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Torna al presente"
@@ -23646,7 +23646,7 @@ msgstr "Torna al presente"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Mese intenso: la tonalità indica almeno questo valore."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3499
+#: lib/vutuv_web/live/post_live/feed.ex:3434
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -23668,7 +23668,7 @@ msgstr "Mese successivo"
 msgid "Next year"
 msgstr "Anno successivo"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3449
+#: lib/vutuv_web/live/post_live/feed.ex:3384
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Il %{day} non è arrivato nulla nel Suo feed."
@@ -23745,7 +23745,7 @@ msgstr "I gestori di password come Bitwarden ne ricavano l'intera voce: nome, ac
 msgid "Scan it with the device that has the app"
 msgstr "Da scansionare con il dispositivo su cui è installata l'app"
 
-#: lib/vutuv_web/live/shell_live.ex:1072
+#: lib/vutuv_web/live/shell_live.ex:1100
 #, elixir-autogen, elixir-format
 msgid "A new version is ready."
 msgstr "È pronta una nuova versione."
@@ -23755,14 +23755,14 @@ msgstr "È pronta una nuova versione."
 msgid "Page management"
 msgstr "Gestione"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2358
+#: lib/vutuv_web/live/post_live/feed.ex:2326
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
 msgstr[0] "Nuovo:"
 msgstr[1] "Nuovi (%{formatted}):"
 
-#: lib/vutuv_web/components/post_components.ex:2871
+#: lib/vutuv_web/components/post_components.ex:2843
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr "Post citato"
@@ -23787,7 +23787,7 @@ msgstr "Menziona un account"
 msgid "{used} of {max} mentions"
 msgstr "{used} di {max} menzioni"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2507
+#: lib/vutuv_web/live/post_live/feed.ex:2438
 #, elixir-autogen, elixir-format
 msgid "Up to here is new"
 msgstr ""
@@ -23878,30 +23878,30 @@ msgstr "Inserisci un blocco"
 msgid "Nothing matches."
 msgstr "Nessun risultato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1982
-#: lib/vutuv_web/live/post_live/composer.ex:2850
+#: lib/vutuv_web/live/post_live/composer.ex:1998
+#: lib/vutuv_web/live/post_live/composer.ex:2866
 #, elixir-autogen, elixir-format
 msgid "Automatic"
 msgstr "Automatico"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1987
+#: lib/vutuv_web/live/post_live/composer.ex:2003
 #, elixir-autogen, elixir-format
 msgid "Drag one photo onto another to swap them."
 msgstr "Trascina una foto su un'altra per scambiarle."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1934
+#: lib/vutuv_web/live/post_live/composer.ex:1950
 #, elixir-autogen, elixir-format
 msgid "Not shown in the gallery — drag one into it to swap."
 msgstr "Non nella galleria — trascinane una dentro per scambiarla."
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:94
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post here"
 msgid_plural "%{formatted} posts here"
 msgstr[0] "%{formatted} post qui"
 msgstr[1] "%{formatted} post qui"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:226
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:267
 #, elixir-autogen, elixir-format
 msgid "Address copied"
 msgstr "Indirizzo copiato"
@@ -23911,52 +23911,52 @@ msgstr "Indirizzo copiato"
 msgid "Another network"
 msgstr "Un'altra rete"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:229
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:270
 #, elixir-autogen, elixir-format
 msgid "Copy address"
 msgstr "Copia indirizzo"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:132
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "Latest here"
 msgstr "Ultimo qui"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:221
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:262
 #, elixir-autogen, elixir-format
 msgid "Mute %{host}"
 msgstr "Silenzia %{host}"
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:132
+#: lib/vutuv_web/views/remote_actor_card_html.ex:118
 #, elixir-autogen, elixir-format
 msgid "Really remove?"
 msgstr "Rimuovere davvero?"
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:133
+#: lib/vutuv_web/views/remote_actor_card_html.ex:119
 #, elixir-autogen, elixir-format
 msgid "Really unfollow?"
 msgstr "Smettere davvero di seguire?"
 
-#: lib/vutuv_web/views/remote_actor_card_html.ex:134
+#: lib/vutuv_web/views/remote_actor_card_html.ex:120
 #, elixir-autogen, elixir-format
 msgid "Really withdraw?"
 msgstr "Ritirare davvero la richiesta?"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:220
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "Unmute %{host}"
 msgstr "Riattiva %{host}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1742
+#: lib/vutuv_web/live/post_live/composer.ex:1758
 #, elixir-autogen, elixir-format
 msgid "Draft discarded."
 msgstr "Bozza eliminata."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1781
+#: lib/vutuv_web/live/post_live/composer.ex:1797
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr "Conserva"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1772
+#: lib/vutuv_web/live/post_live/composer.ex:1788
 #, elixir-autogen, elixir-format
 msgid "Keep this draft for later?"
 msgstr "Conservare questa bozza per dopo?"
@@ -23993,12 +23993,7 @@ msgstr "Se la Sua connessione è lenta o a consumo, vutuv può tralasciare le pa
 msgid "Low-bandwidth mode"
 msgstr "Modalità risparmio dati"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:255
-#, elixir-autogen, elixir-format
-msgid "View the original on %{url}"
-msgstr "Vedi l'originale su %{url}"
-
-#: lib/vutuv_web/live/shell_live.ex:1595
+#: lib/vutuv_web/live/shell_live.ex:1629
 #, elixir-autogen, elixir-format
 msgctxt "phone tab bar"
 msgid "Write"
@@ -24071,9 +24066,9 @@ msgstr "Regole per %{account}"
 msgid "Rules that rewrite the text of one account's posts before you read them: a footer under every post, a signature, a wall of hashtags. Only you see the difference. Open the ⋯ menu on any post to write rules for its author."
 msgstr "Regole che riscrivono il testo dei post di un account prima che Lei li legga: un piè di pagina sotto ogni post, una firma, un muro di hashtag. Solo Lei vede la differenza. Apra il menu ⋯ di un post per scrivere regole per il suo autore."
 
-#: lib/vutuv_web/components/post_components.ex:1371
-#: lib/vutuv_web/components/post_components.ex:2742
-#: lib/vutuv_web/components/post_components.ex:3729
+#: lib/vutuv_web/components/post_components.ex:1343
+#: lib/vutuv_web/components/post_components.ex:2714
+#: lib/vutuv_web/components/post_components.ex:3701
 #: lib/vutuv_web/components/ui.ex:5052
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
@@ -24155,7 +24150,7 @@ msgstr "banda lento internet mobile risparmio dati volume compressione immagini 
 msgid "Appearance"
 msgstr "Aspetto"
 
-#: lib/vutuv_web/live/shell_live.ex:1621
+#: lib/vutuv_web/live/shell_live.ex:1655
 #, elixir-autogen, elixir-format
 msgid "%{count} video in progress"
 msgid_plural "%{count} videos in progress"
@@ -24167,7 +24162,7 @@ msgstr[1] "%{count} video in lavorazione"
 msgid "About %{minutes} min of video"
 msgstr "Circa %{minutes} min di video"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2443
+#: lib/vutuv_web/live/post_live/composer.ex:2459
 #, elixir-autogen, elixir-format
 msgid "Add video"
 msgstr "Aggiungi video"
@@ -24209,32 +24204,32 @@ msgstr "Pubblica senza il video"
 msgid "Reading the frames"
 msgstr "Lettura dei fotogrammi"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2479
+#: lib/vutuv_web/live/post_live/composer.ex:2495
 #, elixir-autogen, elixir-format
 msgid "Remove it to post the text without it, or pick another file."
 msgstr "Lo rimuova per pubblicare il testo senza video, oppure scelga un altro file."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1135
+#: lib/vutuv_web/live/post_live/composer.ex:1145
 #, elixir-autogen, elixir-format
 msgid "Remove the refused video to post the text without it."
 msgstr "Rimuova il video rifiutato per pubblicare il testo senza di esso."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2508
+#: lib/vutuv_web/live/post_live/composer.ex:2524
 #, elixir-autogen, elixir-format
 msgid "Remove video"
 msgstr "Rimuovi video"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2518
+#: lib/vutuv_web/live/post_live/composer.ex:2534
 #, elixir-autogen, elixir-format
 msgid "Tap a frame to make it the cover."
 msgstr "Tocchi un fotogramma per usarlo come copertina."
 
-#: lib/vutuv_web/live/post_live/composer.ex:998
+#: lib/vutuv_web/live/post_live/composer.ex:1008
 #, elixir-autogen, elixir-format
 msgid "That frame could not be used."
 msgstr "Questo fotogramma non può essere usato."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1409
+#: lib/vutuv_web/live/post_live/composer.ex:1425
 #, elixir-autogen, elixir-format
 msgid "The video could not be attached."
 msgstr "Il video non può essere allegato."
@@ -24244,7 +24239,7 @@ msgstr "Il video non può essere allegato."
 msgid "The video is gone."
 msgstr "Il video non c'è più."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1496
+#: lib/vutuv_web/live/post_live/composer.ex:1512
 #, elixir-autogen, elixir-format
 msgid "The video is longer than %{seconds} seconds."
 msgstr "Il video dura più di %{seconds} secondi."
@@ -24263,19 +24258,19 @@ msgstr "Questo video non può essere convertito."
 #: lib/vutuv_web/agent_docs/markdown.ex:1339
 #: lib/vutuv_web/agent_docs/text.ex:827
 #: lib/vutuv_web/agent_docs/text.ex:828
-#: lib/vutuv_web/components/post_components.ex:2506
+#: lib/vutuv_web/components/post_components.ex:2478
 #: lib/vutuv_web/components/video_components.ex:126
-#: lib/vutuv_web/live/post_live/composer.ex:2442
+#: lib/vutuv_web/live/post_live/composer.ex:2458
 #, elixir-autogen, elixir-format
 msgid "Video"
 msgstr "Video"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2486
+#: lib/vutuv_web/live/post_live/composer.ex:2502
 #, elixir-autogen, elixir-format
 msgid "Video description"
 msgstr "Descrizione del video"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1503
+#: lib/vutuv_web/live/post_live/composer.ex:1519
 #, elixir-autogen, elixir-format
 msgid "Videos cannot be uploaded here."
 msgstr "Qui non è possibile caricare video."
@@ -24285,12 +24280,12 @@ msgstr "Qui non è possibile caricare video."
 msgid "Waiting in line"
 msgstr "In attesa in coda"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2493
+#: lib/vutuv_web/live/post_live/composer.ex:2509
 #, elixir-autogen, elixir-format
 msgid "What is in the video, for people who cannot watch it"
 msgstr "Cosa mostra il video, per chi non può guardarlo"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2482
+#: lib/vutuv_web/live/post_live/composer.ex:2498
 #, elixir-autogen, elixir-format
 msgid "You can post now — the post appears as soon as the video is ready."
 msgstr "Può pubblicare subito: il post apparirà appena il video sarà pronto."
@@ -24326,7 +24321,7 @@ msgstr[1] "%{formatted} follower"
 msgid "Last 30 days: %{parts}"
 msgstr "Ultimi 30 giorni"
 
-#: lib/vutuv_web/components/post_components.ex:4270
+#: lib/vutuv_web/components/post_components.ex:4242
 #: lib/vutuv_web/live/notification_live/index.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -24410,7 +24405,7 @@ msgid_plural "%{formatted} random vutuv accounts that are open to offers."
 msgstr[0] "Un account vutuv scelto a caso, aperto a proposte."
 msgstr[1] "%{formatted} account vutuv scelti a caso, aperti a proposte."
 
-#: lib/vutuv_web/live/shell_live.ex:685
+#: lib/vutuv_web/live/shell_live.ex:713
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post in your feed"
 msgid_plural "%{formatted} new posts in your feed"
@@ -24446,3 +24441,15 @@ msgstr "Il tuo feed mostra quello che scrivono gli account che segui. Eccone alc
 #, elixir-autogen, elixir-format
 msgid "Your public posts then also appear on {mastodon}, for example."
 msgstr "I tuoi post pubblici compaiono poi anche su {mastodon}, per esempio."
+
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:168
+#, elixir-autogen, elixir-format
+msgid "%{formatted} older post"
+msgid_plural "%{formatted} older posts"
+msgstr[0] "%{formatted} post più vecchio"
+msgstr[1] "%{formatted} post più vecchi"
+
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:283
+#, elixir-autogen, elixir-format
+msgid "Their page here"
+msgstr "Pagina account qui"

--- a/test/vutuv/fediverse_account_card_summary_test.exs
+++ b/test/vutuv/fediverse_account_card_summary_test.exs
@@ -1,8 +1,9 @@
 defmodule Vutuv.FediverseAccountCardSummaryTest do
   @moduledoc """
   What the mention card is allowed to say about an account beyond its own words:
-  how many of its posts this installation holds *for this reader*, and which one
-  is the newest (`Vutuv.Fediverse.account_card_summary/2`).
+  how many of its posts this installation holds *for this reader*, when the
+  newest of them arrived, and the newest few themselves
+  (`Vutuv.Fediverse.account_card_summary/2`).
 
   The interesting half is "for this reader". The count sits on a card that opens
   from a word in a sentence, so it is read as a fact about the account — which
@@ -38,12 +39,46 @@ defmodule Vutuv.FediverseAccountCardSummaryTest do
 
     newest = cached_post(account, content_text: "Der neueste.")
 
-    assert %{count: 2, latest: latest} = Fediverse.account_card_summary(account, user)
+    assert %{count: 2, posts: [latest, older]} = Fediverse.account_card_summary(account, user)
     assert latest.id == newest.id
+    assert older.content_text == "Der ältere."
+  end
+
+  # More than one, newest first, for the card's expander — and never more than
+  # the card can use, however much the account has written.
+  test "it hands back the newest few, newest first, capped" do
+    user = federating_member()
+    account = remote_account()
+    now = DateTime.utc_now(:second)
+
+    for hours <- 1..12 do
+      cached_post(account,
+        content_text: "Nummer #{hours}.",
+        published_at: DateTime.add(now, -hours * 3600)
+      )
+    end
+
+    assert %{count: 12, posts: posts} = Fediverse.account_card_summary(account, user)
+    assert length(posts) < 12
+    assert Enum.map(posts, & &1.content_text) |> Enum.take(2) == ["Nummer 1.", "Nummer 2."]
+  end
+
+  # The clock on the count line is the account's last word here, and not the
+  # last word the card ends up quoting: the gates that drop a quote (a content
+  # warning, the reader's own filters, the post they are already reading) must
+  # not make an account that posted a minute ago look silent.
+  test "the timestamp is the newest post's, quotable or not" do
+    user = federating_member()
+    account = remote_account()
+
+    newest = cached_post(account, content_text: "Nicht für jeden.", sensitive: true)
+
+    assert %{count: 1, last_at: last_at} = Fediverse.account_card_summary(account, user)
+    assert last_at == newest.published_at
   end
 
   test "an account we hold nothing from answers zero and no post" do
-    assert %{count: 0, latest: nil} =
+    assert %{count: 0, last_at: nil, posts: []} =
              Fediverse.account_card_summary(remote_account(), federating_member())
   end
 
@@ -59,12 +94,12 @@ defmodule Vutuv.FediverseAccountCardSummaryTest do
     cached_post(account, content_text: "Für alle.")
     restricted = cached_post(account, content_text: "Nur für Follower.", audience: "followers")
 
-    assert %{count: 1, latest: latest} = Fediverse.account_card_summary(account, stranger)
+    assert %{count: 1, posts: [latest]} = Fediverse.account_card_summary(account, stranger)
     assert latest.content_text == "Für alle."
 
     follow(follower, account, "accepted")
 
-    assert %{count: 2, latest: seen} = Fediverse.account_card_summary(account, follower)
+    assert %{count: 2, posts: [seen | _]} = Fediverse.account_card_summary(account, follower)
     assert seen.id == restricted.id
   end
 
@@ -77,7 +112,7 @@ defmodule Vutuv.FediverseAccountCardSummaryTest do
     follow(user, account, "requested")
     cached_post(account, content_text: "Nur für Follower.", audience: "followers")
 
-    assert %{count: 0, latest: nil} = Fediverse.account_card_summary(account, user)
+    assert %{count: 0, posts: []} = Fediverse.account_card_summary(account, user)
   end
 
   # A nil identity must answer "no accepted follow" rather than raise on a nil
@@ -90,7 +125,7 @@ defmodule Vutuv.FediverseAccountCardSummaryTest do
     cached_post(account, content_text: "Für alle.")
     cached_post(account, content_text: "Nur für Follower.", audience: "followers")
 
-    assert %{count: 1, latest: latest} = Fediverse.account_card_summary(account, nil)
+    assert %{count: 1, posts: [latest]} = Fediverse.account_card_summary(account, nil)
     assert latest.content_text == "Für alle."
   end
 end

--- a/test/vutuv_web/actor_card_state_css_test.exs
+++ b/test/vutuv_web/actor_card_state_css_test.exs
@@ -1,0 +1,65 @@
+defmodule VutuvWeb.ActorCardStateCssTest do
+  use ExUnit.Case, async: true
+
+  # The mention card's follow button wears its state as a colour, and the class
+  # that colours it is **interpolated** from the state:
+  # `RemoteActorCardHTML.state_btn_modifier/1` is
+  # `"actor-card__state-btn--#{Follow.display_state(follow)}"`. So no grep
+  # connects `Vutuv.Fediverse.Follow`'s three atoms to `components.css`, and
+  # nothing fails when they disagree.
+  #
+  # They disagreed from the day the card shipped (PR #1903) until this test:
+  # the stylesheet spelled the accepted state `--following`, so the commonest
+  # state of all — the member already follows this account — rendered as an
+  # unstyled button in the card's own text colour, in the one place the reader
+  # looks to find out where they stand. Every other state was fine, which is
+  # why it survived review.
+  #
+  # A fourth atom in `display_state/1` would ship the same silence, so the
+  # check is over the atoms rather than over a list of three names: add a state
+  # and this goes red until the colour exists, in both themes.
+  #
+  # Static source check in the spirit of `dark_mode_css_test.exs` and
+  # `mobile_tab_bar_css_test.exs`.
+
+  @follow Path.expand("../../lib/vutuv/fediverse/follow.ex", __DIR__)
+  @components_css Path.expand("../../assets/css/components.css", __DIR__)
+
+  # Comments name selectors; strip them so the assertions only see real rules.
+  defp css, do: Regex.replace(~r{/\*.*?\*/}s, File.read!(@components_css), "")
+
+  # The atoms `Follow.display_state/1` can answer, read off its clause heads
+  # rather than listed here — a list here would be the second copy this test
+  # exists to prevent.
+  defp display_states do
+    File.read!(@follow)
+    |> then(&Regex.scan(~r/def display_state\(.*?\), do: :(\w+)/, &1))
+    |> Enum.map(fn [_, state] -> state end)
+    |> tap(fn states ->
+      assert states != [],
+             "No `display_state/1` clauses found in #{@follow}. If it moved, move this test."
+    end)
+  end
+
+  test "every follow state the card can render has a colour" do
+    css = css()
+
+    for state <- display_states() do
+      assert css =~ ".actor-card__state-btn--#{state} {",
+             """
+             `Follow.display_state/1` can answer `:#{state}`, which the card
+             renders as `.actor-card__state-btn--#{state}` — and components.css
+             has no such rule, so that button paints as unstyled text.
+             """
+    end
+  end
+
+  test "and has one in dark mode too" do
+    [_, dark] = String.split(css(), "@media (prefers-color-scheme: dark) {", parts: 2)
+
+    for state <- display_states() do
+      assert dark =~ ".actor-card__state-btn--#{state} {",
+             "`.actor-card__state-btn--#{state}` has no dark variant in components.css."
+    end
+  end
+end

--- a/test/vutuv_web/controllers/remote_actor_card_test.exs
+++ b/test/vutuv_web/controllers/remote_actor_card_test.exs
@@ -151,8 +151,8 @@ defmodule VutuvWeb.RemoteActorCardTest do
 
     assert html =~ "Anderes Netzwerk"
     assert html =~ "Folgen"
-    assert html =~ "Die Seite dieses Kontos hier"
-    assert html =~ "Original auf social.example/users/them ansehen"
+    assert html =~ "Kontoseite hier"
+    assert html =~ "Original ansehen"
   end
 
   # The one way off this site, and it used to say only that it was one. A reader
@@ -160,22 +160,27 @@ defmodule VutuvWeb.RemoteActorCardTest do
   # they would read a browser's status bar — and here that address is not
   # guessable from the card, since an actor URI need not be spelled like the
   # `@user@host` above it (`/users/them`, `/u/them`, `/profile/them`).
+  #
+  # On a line of its own since the address in the sentence wrapped the row onto
+  # three lines and made the quietest half of the card its tallest block.
   test "the way out names where it goes", %{conn: conn} do
     {conn, _user} = federating(conn)
     account()
 
     html = post(conn, ~p"/system/fediverse/actor_card", address: @address) |> html_response(200)
 
-    assert html =~ "View the original on social.example/users/them"
-    # And the label is only ever a label: the href stays the whole URL.
+    assert html =~ "View the original"
+
+    assert html =~
+             ~s(<span class="actor-card__link-address">social.example/users/them</span>)
+
+    # And the address is only ever a label: the href stays the whole URL.
     assert html =~ @actor
   end
 
-  # A scheme and a `www.` are noise every reader already knows, and dropping them
-  # buys the characters the account name needs. The cap was 32 for one afternoon,
-  # which is one character short of `social.heise.de/users/heiseonline` — so the
-  # part the reader is checking, the account's name, lost its last two letters on
-  # a card that had room for them. An ordinary actor URI reaches the whole way.
+  # A scheme and a `www.` are noise every reader already knows, and dropping
+  # them leaves the two parts a reader actually checks: which server, and whose
+  # account on it.
   #
   # `HTTPS://` is not a curiosity here: this string is a remote server's, not
   # ours, and a scheme left standing would spend eight characters saying that a
@@ -188,18 +193,19 @@ defmodule VutuvWeb.RemoteActorCardTest do
              "chaos.social/@feed"
   end
 
-  # Cut from the end and never from the front: the host leads the string and is
-  # the fact it is carrying, so it is the one part that may not be what goes.
-  # `…` says there is more behind the click.
-  test "an address too long for the card is cut, not wrapped across it" do
+  # Nothing cuts the address here any more: it arrives whole and the browser
+  # ends it where the card ends (`text-overflow: ellipsis` on its own line). It
+  # used to be pre-cut at 40 characters, a number measured against the sentence
+  # it was embedded in, and a count guessing at a width is wrong on the next
+  # screen. Cutting is still only ever from the END, which is the property this
+  # pins: the host leads the string and is the fact it is carrying.
+  test "a long address arrives whole, host first, for the browser to cut" do
     address =
       RemoteActorCardHTML.origin_address(
         "https://www.example.social/users/a-very-long-handle-indeed"
       )
 
-    assert String.starts_with?(address, "example.social/users/")
-    assert String.ends_with?(address, "…")
-    assert String.length(address) == 40
+    assert address == "example.social/users/a-very-long-handle-indeed"
   end
 
   test "a member without a Fediverse identity is told why, not shown a dead button", %{conn: conn} do
@@ -267,7 +273,7 @@ defmodule VutuvWeb.RemoteActorCardTest do
   # A self-description is what an account says about itself and settles nothing:
   # every account claims to be worth reading. What it last wrote, and how much
   # of it we hold, is the reader's actual evidence — so the card carries a count
-  # line and one preview, and the description shrinks to make room.
+  # line and the newest few posts, and the description shrinks to make room.
 
   test "it says how much of the account we hold and quotes the newest post", %{conn: conn} do
     {conn, _user} = federating(conn)
@@ -284,7 +290,110 @@ defmodule VutuvWeb.RemoteActorCardTest do
 
     assert html =~ "2 posts here"
     assert html =~ "Ein Zug fährt durch die Nacht."
-    refute html =~ "Der ältere."
+    # The older one comes along, folded away behind the expander: the card is
+    # the reader deciding whether to follow, and one post is a poor sample.
+    assert html =~ "Der ältere."
+    assert html =~ ~s(data-actor-more-posts)
+  end
+
+  # Only one post to show, so there is nothing to expand — a control that opens
+  # an empty drawer is worse than no control.
+  test "a single post grows no expander", %{conn: conn} do
+    {conn, _user} = federating(conn)
+    acc = account()
+
+    cached_post(acc, content_text: "Ein Zug fährt durch die Nacht.")
+
+    html = post(conn, ~p"/system/fediverse/actor_card", address: @address) |> html_response(200)
+
+    assert html =~ "Ein Zug fährt durch die Nacht."
+    refute html =~ ~s(data-actor-more-posts)
+  end
+
+  # The card opens over a post the reader is already looking at, and quoting
+  # that very post back at them under "Latest here" spends the card's most
+  # valuable line saying what is on the screen behind it. The one below moves
+  # up; the count and the clock stay the account's.
+  test "the post the reader has open is not quoted back at them", %{conn: conn} do
+    {conn, _user} = federating(conn)
+    acc = account()
+
+    cached_post(acc,
+      content_text: "Der ältere.",
+      published_at: DateTime.add(DateTime.utc_now(:second), -3600)
+    )
+
+    open = cached_post(acc, content_text: "Ein Zug fährt durch die Nacht.")
+
+    html =
+      post(conn, ~p"/system/fediverse/actor_card", address: @address, context: open.id)
+      |> html_response(200)
+
+    assert html =~ "2 posts here"
+    refute html =~ "Ein Zug fährt durch die Nacht."
+    assert html =~ "Der ältere."
+  end
+
+  # The one post we hold is the one behind the card: nothing left to quote, and
+  # the count line stays, because we do hold it.
+  test "a context that leaves nothing to quote leaves the count standing", %{conn: conn} do
+    {conn, _user} = federating(conn)
+    acc = account()
+
+    open = cached_post(acc, content_text: "Ein Zug fährt durch die Nacht.")
+
+    html =
+      post(conn, ~p"/system/fediverse/actor_card", address: @address, context: open.id)
+      |> html_response(200)
+
+    assert html =~ "1 post here"
+    refute html =~ ~s(data-actor-card-latest)
+  end
+
+  # The drawer is the other thing the reader has in front of them, and every act
+  # replaces the whole fragment — so without the flag travelling back, opening
+  # the older posts and then pressing Follow folds them away again.
+  test "an opened drawer is still open after a follow", %{conn: conn} do
+    {conn, _user} = federating(conn)
+    acc = account()
+    serve_actor()
+
+    cached_post(acc,
+      content_text: "Der ältere.",
+      published_at: DateTime.add(DateTime.utc_now(:second), -3600)
+    )
+
+    cached_post(acc, content_text: "Ein Zug fährt durch die Nacht.")
+
+    html =
+      post(conn, ~p"/system/fediverse/actor_card", address: @address)
+      |> html_response(200)
+
+    assert html =~ ~s(data-actor-more-posts hidden)
+
+    html =
+      post(conn, ~p"/system/fediverse/actor_card/follow", address: @address, expanded: "1")
+      |> html_response(200)
+
+    refute html =~ ~s(data-actor-more-posts hidden)
+    assert html =~ "is-open"
+  end
+
+  # The context rides along with every act, not only with the open: pressing
+  # Follow re-renders the whole card, and a quote that appears on that press is
+  # the card contradicting itself over one click.
+  test "the context survives a follow", %{conn: conn} do
+    {conn, _user} = federating(conn)
+    acc = account()
+    serve_actor()
+
+    open = cached_post(acc, content_text: "Ein Zug fährt durch die Nacht.")
+
+    html =
+      post(conn, ~p"/system/fediverse/actor_card/follow", address: @address, context: open.id)
+      |> html_response(200)
+
+    refute html =~ "Ein Zug fährt durch die Nacht."
   end
 
   # An account we hold nothing from must not grow an empty row saying so: "0
@@ -319,6 +428,55 @@ defmodule VutuvWeb.RemoteActorCardTest do
     assert html =~ "1 post here"
     refute html =~ "Alles über Krypto."
     refute html =~ ~s(data-actor-card-latest)
+  end
+
+  # The reader's second pass over a post, beside their filters: their own
+  # search-and-replace rules for this author (`Vutuv.PostRewrites`). The card is
+  # the fourth surface over these rows and was the only one skipping them, so a
+  # member who deletes a mirror's footer everywhere else read it here — and the
+  # filter below judged the text before the rule had run, which is the order
+  # `PostTeaser.record_line/4` exists to fix.
+  test "a quote is rewritten by the reader's rules for that account", %{conn: conn} do
+    {conn, user} = federating(conn)
+    acc = account()
+
+    {:ok, _rule} =
+      Vutuv.PostRewrites.create_rule(user, "@them@social.example", %{
+        pattern: " -- Gepostet über einen Bot"
+      })
+
+    cached_post(acc, content_text: "Ein Zug fährt durch die Nacht. -- Gepostet über einen Bot")
+
+    html = post(conn, ~p"/system/fediverse/actor_card", address: @address) |> html_response(200)
+
+    assert html =~ "Ein Zug fährt durch die Nacht."
+    refute html =~ "Gepostet über einen Bot"
+  end
+
+  # A post with nothing written on it — a photograph and no caption — has no
+  # line to be, and `PostTeaser.line/2` answers `""` rather than nil for it. A
+  # gate testing for nil lets it through, and it then spends one of the card's
+  # four quote slots on an empty box.
+  test "a post with no words at all is not quoted as an empty line", %{conn: conn} do
+    {conn, _user} = federating(conn)
+    acc = account()
+
+    # `""` and not nil: the helper's `attrs[:content_text] || "Von woanders."`
+    # would fill a nil in, and both spellings reach the gate the same way —
+    # `Posts.text/1` hands `line/2` an empty binary either way.
+    cached_post(acc,
+      content_text: "",
+      published_at: DateTime.add(DateTime.utc_now(:second), -60)
+    )
+
+    cached_post(acc, content_text: "Ein Zug fährt durch die Nacht.")
+
+    html = post(conn, ~p"/system/fediverse/actor_card", address: @address) |> html_response(200)
+
+    assert html =~ "2 posts here"
+    assert html =~ "Ein Zug fährt durch die Nacht."
+    # The wordless one would have been the only thing behind the expander.
+    refute html =~ ~s(data-actor-more-posts)
   end
 
   # A content warning is the author asking for a click before their words are


### PR DESCRIPTION
Opening the card from a post's author line quoted that same post back under "Latest here" — the card's best line spent on what is already on the screen behind it. `mention_card.js` now sends the enclosing `article[data-remote-post]` id with every request, the next post moves up, and it says *when* rather than claiming to be the latest.

One post is a poor sample of an account you are deciding whether to follow, so the card carries four: the newest quoted in two lines, the rest one line each with their age, behind an expander that opens without a round trip and stays open across a follow.

"Following" was blank because the template writes `--accepted` and the stylesheet only had `--following` — an interpolated class name no grep connects. `actor_card_state_css_test.exs` reads the states off `Follow.display_state/1` and fails the build when one has no colour.

Also fixed: these quotes skipped the reader's rewrite rules, the one surface that did.

Where: `VutuvWeb.RemoteActorCardController`, `assets/js/mention_card.js`.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01We1pUXvZi8Q3bPttPjSH34
