### PR TITLE
Let the account card's self-description use both of its lines

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -3893,8 +3893,18 @@ html[data-feed-pull="busy"] .feed-pull__glyph {
 }
 
 /* The last few things they wrote: a stack of quotes, each a link to our copy.
-   The rule on the left is the quotation mark this does not spend a character
-   on, and the stack reads as one block because every entry wears it. */
+   A tinted tile with a hairline around it, and the stack reads as one block
+   because every entry wears the same one.
+
+   It wore a brand-blue rule down its left edge first — the quotation mark the
+   block does not spend a character on. On a card that already carries a blue
+   handle, a blue Follow button and two blue links, a fourth blue thing pointing
+   sideways read as an accent nobody had put there on purpose (Stefan,
+   2026-09-04). What separates a quote from the self-description above it is the
+   tinted ground and the small label on top of it; neither needs a colour — and
+   for the same reason the headline and the older rows wear the same hairline
+   rather than two shades of one, since what ranks them is the label and the
+   position, not a tone nobody can see. */
 .actor-card__posts {
   display: flex;
   flex-direction: column;
@@ -3904,25 +3914,25 @@ html[data-feed-pull="busy"] .feed-pull__glyph {
 .actor-card__latest {
   display: block;
   padding: 0.45rem 0.6rem 0.5rem;
-  border-left: 2px solid var(--color-brand-300);
   border-radius: 0.5rem;
   background: #f8fafc;
+  box-shadow: inset 0 0 0 1px #e9eef4;
   text-decoration: none;
 }
 .actor-card__latest:hover { background: #f1f5f9; }
 /* The older ones are the sample, not the headline: one line each, the age at
-   the end of it, and a paler rule, so the stack cannot compete with the post
-   above it. The age was a label on its own line for one afternoon, which put
-   three identical "2 days ago" under one another and doubled the drawer's
+   the end of it, and no label above it, so the stack cannot compete with the
+   post above it. The age was a label on its own line for one afternoon, which
+   put three identical "2 days ago" under one another and doubled the drawer's
    height for it. */
 .actor-card__older-row {
   display: flex;
   align-items: baseline;
   gap: 0.5rem;
   padding: 0.3rem 0.6rem 0.35rem;
-  border-left: 2px solid #e2e8f0;
   border-radius: 0.5rem;
   background: #f8fafc;
+  box-shadow: inset 0 0 0 1px #e9eef4;
   text-decoration: none;
 }
 .actor-card__older-row:hover { background: #f1f5f9; }
@@ -4261,9 +4271,9 @@ html[data-feed-pull="busy"] .feed-pull__glyph {
   }
   .actor-card__stats { color: #94a3b8; }
 
-  .actor-card__latest { border-left-color: var(--color-brand-600); background: #16233b; }
+  .actor-card__latest { background: #16233b; box-shadow: inset 0 0 0 1px #1e2f4d; }
   .actor-card__latest:hover { background: #1e293b; }
-  .actor-card__older-row { border-left-color: #334155; background: #16233b; }
+  .actor-card__older-row { background: #16233b; box-shadow: inset 0 0 0 1px #1e2f4d; }
   .actor-card__older-row:hover { background: #1e293b; }
   .actor-card__older-text { color: #cbd5e1; }
   .actor-card__older-when { color: #64748b; }

--- a/lib/vutuv_web/live/fediverse_account_live.ex
+++ b/lib/vutuv_web/live/fediverse_account_live.ex
@@ -360,16 +360,18 @@ defmodule VutuvWeb.FediverseAccountLive do
                 {gettext("Show less")}
               </span>
             </span>
+            <%!-- Both expressions sit against their tags, with no line of
+            their own: `whitespace-pre-line` keeps every newline in the markup,
+            and HEEx hands the text over with the template's own indentation in
+            front of it, so an indented `{@account.summary}` opens the bio with
+            a blank line — and in the clamped half it is one of the few lines
+            the reader gets. --%>
             <p
               data-clamp-body
               class="post-clamp mb-0 whitespace-pre-line break-words text-sm leading-relaxed text-slate-700 group-open:hidden dark:text-slate-300"
-            >
-              {@account.summary}
-            </p>
+            >{@account.summary}</p>
           </summary>
-          <p class="mb-0 whitespace-pre-line break-words text-sm leading-relaxed text-slate-700 dark:text-slate-300">
-            {@account.summary}
-          </p>
+          <p class="mb-0 whitespace-pre-line break-words text-sm leading-relaxed text-slate-700 dark:text-slate-300">{@account.summary}</p>
         </details>
 
         <div class="mt-5">

--- a/lib/vutuv_web/templates/remote_actor_card/card.html.heex
+++ b/lib/vutuv_web/templates/remote_actor_card/card.html.heex
@@ -108,10 +108,19 @@ renders the same element. --%>
   <%!-- A self-description can be 10,000 characters, and this card is 20rem
   wide: two lines now rather than three, because the line below is worth more
   than a third line of somebody introducing themselves. The account page carries
-  the whole of it. --%>
+  the whole of it, line breaks and all.
+
+  **Both of those lines have to carry words, which is why this one is not
+  `whitespace-pre-line`.** With it, every break the author wrote costs one of
+  the two — and the first one always did, because HEEx hands the text over with
+  its own indentation in front of it, so the clamp spent its first line on the
+  newline before "B" and the reader got one line of self-description under a
+  blank one. A bio's own shape is worth something at full length and nothing at
+  two lines, so here it reads as running text and keeps its structure on the
+  account page. --%>
   <p
     :if={@account && @account.summary}
-    class="mb-0 mt-3 line-clamp-2 whitespace-pre-line break-words text-sm leading-relaxed text-slate-700 dark:text-slate-300"
+    class="mb-0 mt-2 line-clamp-2 break-words text-sm leading-relaxed text-slate-700 dark:text-slate-300"
   >
     {@account.summary}
   </p>

--- a/test/vutuv_web/controllers/remote_actor_card_test.exs
+++ b/test/vutuv_web/controllers/remote_actor_card_test.exs
@@ -92,6 +92,27 @@ defmodule VutuvWeb.RemoteActorCardTest do
     assert html =~ @actor
   end
 
+  # Calibrated against the template that shipped first: with
+  # `whitespace-pre-line` on this paragraph the two-line clamp spent its first
+  # line on the newline HEEx writes in front of an indented expression, so every
+  # card showed one line of self-description under one blank one. The bio's own
+  # line breaks are worth something at full length, on the account page, and
+  # nothing at two lines here.
+  test "the self-description is clamped as running text, so both lines carry words",
+       %{conn: conn} do
+    {conn, _user} = federating(conn)
+    account()
+
+    html = post(conn, ~p"/system/fediverse/actor_card", address: @address) |> html_response(200)
+
+    assert [summary] =
+             html |> elements("p") |> Enum.filter(&(LazyHTML.text(&1) =~ "Schreibt über Züge."))
+
+    assert [class] = LazyHTML.attribute(summary, "class")
+    assert class =~ "line-clamp-2"
+    refute class =~ "whitespace-pre-line"
+  end
+
   # The common case, and the reason the card is cheap: most accounts a member
   # meets in a post are already stored, because somebody here follows them or
   # something of theirs arrived. Calibrated by the stub, which fails the test if

--- a/test/vutuv_web/pre_line_indentation_test.exs
+++ b/test/vutuv_web/pre_line_indentation_test.exs
@@ -1,0 +1,52 @@
+defmodule VutuvWeb.PreLineIndentationTest do
+  @moduledoc """
+  An element that keeps the newlines in its markup must not open with the
+  template's own indentation.
+
+  `whitespace-pre-line` (and `pre-wrap`) tell the browser to render every
+  newline inside the element, and HEEx hands the text over exactly as the
+  template is written — so
+
+      <p class="whitespace-pre-line">
+        {@account.summary}
+      </p>
+
+  renders a blank line before the first word. Nothing warns about it: the page
+  compiles, the tests pass, and the reader sees a paragraph that starts one line
+  too low. Where the element is also clamped (`line-clamp-2`, `.post-clamp`,
+  `.notif-clamp`), that blank line is one of the few the reader gets, which is
+  how the account card came to show a single line of self-description under an
+  empty one (2026-09-04).
+
+  The fix is to write the expression against its tags, `>{@account.summary}</p>`,
+  which is how every other such paragraph in the app is written. `mix format`
+  cannot do it for you — `.formatter.exs` binds no `.heex` files.
+  """
+  use ExUnit.Case, async: true
+
+  # The opening tag may run over several lines, so this matches from the tag's
+  # `<` to its `>` and then asks what follows: a newline plus an interpolation is
+  # the defect, anything else (text, a child element, the expression on the same
+  # line) is fine.
+  @offender ~r/<[a-zA-Z][^<>]*whitespace-pre-(?:line|wrap)[^<>]*>[ \t]*\r?\n\s*\{/
+
+  test "no element that keeps its newlines opens on an indented expression" do
+    offenders =
+      for path <- Path.wildcard("lib/**/*.heex") ++ Path.wildcard("lib/**/*.ex"),
+          source = File.read!(path),
+          [{offset, _length} | _] <- Regex.scan(@offender, source, return: :index) do
+        line = source |> binary_part(0, offset) |> String.split("\n") |> length()
+        "#{path}:#{line}"
+      end
+
+    assert offenders == [],
+           """
+           These elements preserve their newlines and open on an indented \
+           expression, so each renders a blank first line:
+
+           #{Enum.join(offenders, "\n")}
+
+           Write the expression against the tags instead: >{@thing}</p>
+           """
+  end
+end


### PR DESCRIPTION
On the card behind a `@user@host` mention, the self-description showed one line under a blank one — the paragraph carried `whitespace-pre-line`, and HEEx hands the text over with the template's own indentation in front of it, so the two-line clamp spent its first line on that newline. It now reads as running text over both lines and sits closer to the count line above it. The bio keeps its own line breaks on `/system/fediverse/account/<id>`, where the same defect opened it with a blank line; there the expression now sits flush against its tags.

The quote block lost the brand-blue rule down its left edge — beside the blue handle, the follow button and the two links below, a fourth blue accent read as an accident. A hairline around the tinted tile takes its place, the same one on the headline and the older rows.

Where: `lib/vutuv_web/templates/remote_actor_card/card.html.heex`, `VutuvWeb.FediverseAccountLive`.

Hot deploy. `pre_line_indentation_test.exs` fails the build on the next element that repeats this.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01K4qF7Av61ya3HPeA2NKxxo