### PR TITLE
Show the unread count on the installed app's icon while it is closed

### DIFF
--- a/assets/js/sw.js
+++ b/assets/js/sw.js
@@ -120,6 +120,28 @@ function line(kind, locale) {
   return strings[locale] || strings[CONFIG.fallbackLocale] || "vutuv"
 }
 
+// The number on the app icon while vutuv is closed (issue #1732). The page's
+// own hook writes it from an open tab, and a push is precisely the moment there
+// is no open tab — so the count comes with the payload (`Vutuv.WebPush.
+// Dispatcher.badge_count/1`) and this is the only thing that can put it there.
+// The API is write-only, so a worker could not count for itself even if it had
+// a session.
+//
+// On iOS the icon shows it only once notifications are allowed — which this
+// push already required — and elsewhere the platform ignores the write outside
+// an installed app. So it is guarded and never falls back, exactly like the
+// page's own copy in app.js.
+function setBadge(count) {
+  if (!self.navigator || !("setAppBadge" in self.navigator)) return
+
+  try {
+    const written = count > 0 ? self.navigator.setAppBadge(count) : self.navigator.clearAppBadge()
+    written?.catch(() => {})
+  } catch (_e) {
+    // A context that declares the API and refuses to use it.
+  }
+}
+
 self.addEventListener("push", (event) => {
   let payload = {}
   try {
@@ -142,6 +164,11 @@ self.addEventListener("push", (event) => {
       // this worker is for. Where both do fire, the shared tag collapses them
       // into one popup rather than stacking two.
       if (clients.some((client) => client.visibilityState === "visible")) return
+
+      // Under the same gate as the notification, and for the same reason: a
+      // visible page owns the badge through `TabBadge`, whose number is the one
+      // being looked at, while this one was counted before the push was sent.
+      if (typeof payload.unread === "number") setBadge(payload.unread)
 
       return self.registration.showNotification(line(kind, payload.locale), {
         tag: kind === "message" ? "vutuv-messages" : "vutuv-activity",

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -52,6 +52,27 @@ front of the title cannot disagree. The call is guarded and never falls back:
 most browsers do not carry the API, and where they do the platform ignores the
 write outside an installed app.
 
+An open page is not the only moment that number moves, though, and on a phone it
+is the rarer one. **The service worker writes the badge too**, from the count
+`Vutuv.WebPush.Dispatcher.badge_count/1` puts in every push payload — otherwise a
+message arriving overnight raises a lock-screen line and leaves the icon at last
+night's number, since nothing is open to write it. It is read once per member per
+push, and only where a device is actually subscribed. Two properties of that
+count are load-bearing: it is the same two sources `push_badge/1` adds up (the
+feed's own badge is not among them), and it is **never zero** — `notify/2` often
+runs inside the transaction that produced the notification while the push task
+reads from another process, so the row behind this very push may not be visible
+yet, and a zero would take the badge off at the moment something arrived. Being
+one short until the app is opened is the cheaper mistake.
+
+**On iOS the badge appears only once notifications are allowed** (WebKit shows a
+badge on a Home Screen web app from 16.4, gated on that permission), and only for
+the copy on the Home Screen — the same site open in Safari has no icon to write
+to. So a member who never turned on "Also notify me on this device when vutuv is
+closed" under `/settings/notifications`, *inside the installed app*, sees no
+number however correct the count is. That switch is also what a push needs to
+exist at all, which is why the two questions have one answer.
+
 `#tab-badge` is therefore the one element in the shell **not** gated on the
 member: the logged-out shell renders it too and is pushed a zero, which is what
 takes a signed-out member's count off the Home Screen icon. `push_badge/1`
@@ -75,13 +96,8 @@ The rest is **install-dialog metadata**: `description`
 (`VutuvWeb.OpenGraph.default_description/0`, the same sentence the page carries
 as its `<meta name="description">`), `lang`, `dir`, `categories` and
 `display_override`. Still open on #1732: `share_target` (vutuv in Android's share
-sheet), `screenshots` (which earns a real install dialog instead of a thin
-strip), and the badge while the app is **closed** — `TabBadge` writes it only
-from an open page, so a message arriving overnight raises a lock-screen line and
-leaves the icon at last night's number. The service worker below is the half that
-knows, since it already branches on "no visible client"; a bare
-`self.navigator.setAppBadge()` there would earn the platform dot for free, an
-exact count needs `unread` in the push payload.
+sheet) and `screenshots` (which earns a real install dialog instead of a thin
+strip).
 
 ### The service worker and Web Push (issue #1729)
 

--- a/lib/vutuv/web_push/dispatcher.ex
+++ b/lib/vutuv/web_push/dispatcher.ex
@@ -16,15 +16,18 @@ defmodule Vutuv.WebPush.Dispatcher do
   a subscription belongs to a browser, so "also when vutuv is closed" is a
   question each phone answers for itself.
 
-  The payload carries **no content** — the kind of thing that happened and
-  where it leads, never a word of what was written. The service worker draws a
-  generic line per kind in the member's own language, because what a push turns
-  into here is text on a lock screen, and the bell is one tap away.
+  The payload carries **no content** — the kind of thing that happened, where it
+  leads, and the member's own unread total for the icon. Never a word of what
+  was written: the service worker draws a generic line per kind in the member's
+  own language, because what a push turns into here is text on a lock screen,
+  and the bell is one tap away.
   """
 
   import Ecto.Query, only: [from: 2]
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Activity
+  alias Vutuv.Chat
   alias Vutuv.Languages
   alias Vutuv.Repo
   alias Vutuv.WebPush
@@ -81,11 +84,39 @@ defmodule Vutuv.WebPush.Dispatcher do
   # rewritten author), so this runs N times for one reply and the difference is
   # not academic.
   defp fan_out(user_id, notification) do
-    user_id
-    |> devices()
-    |> Enum.each(fn {subscription, locale, param} ->
-      deliver(subscription, notification, locale, param)
-    end)
+    case devices(user_id) do
+      [] ->
+        :ok
+
+      devices ->
+        # Read once for the member, not once per device, and only where a device
+        # is really waiting — which is what keeps `badge_count/1`'s reads off
+        # every notification of every member who never installed the app.
+        unread = badge_count(user_id)
+
+        Enum.each(devices, fn {subscription, locale, param} ->
+          deliver(subscription, notification, locale, param, unread)
+        end)
+    end
+  end
+
+  @doc """
+  The number the installed app's icon carries, for a member whose app is shut.
+
+  The same two counts `VutuvWeb.ShellLive.push_badge/1` sends an open page (the
+  feed's own badge is deliberately not among them), read from the database here
+  because the page that holds them is precisely what a push exists in the
+  absence of.
+
+  **Never zero.** `Vutuv.Activity.notify/2` often runs inside the transaction
+  that produced the notification while this reads from another process, so the
+  row that caused this very push may not be visible yet — and a zero would take
+  the badge *off* at the moment something arrived, which is the one answer that
+  is certainly wrong. Being one short for a few seconds is not: the open app
+  recomputes the whole number the instant the member taps the icon.
+  """
+  def badge_count(user_id) do
+    max(Chat.unread_conversations_count(user_id) + Activity.unread_notification_count(user_id), 1)
   end
 
   # The member's own language, not a hardcoded "de", and their handle for the
@@ -104,10 +135,15 @@ defmodule Vutuv.WebPush.Dispatcher do
     end)
   end
 
-  defp deliver(subscription, notification, locale, param) do
+  defp deliver(subscription, notification, locale, param, unread) do
     payload = %{
       kind: notification[:kind],
       locale: locale,
+      # What goes on the Home Screen icon (issue #1732). It rides in the payload
+      # rather than being counted in the worker, because a service worker has no
+      # session and no database — and the Badging API can only be written, never
+      # read, so it cannot count for itself either.
+      unread: unread,
       # Where the row under the bell would take them — the post, the case, the
       # profile. A push is raised precisely when the member is NOT looking at
       # vutuv, so the notifications list is the one place that makes them hunt

--- a/test/support/web_push_helpers.ex
+++ b/test/support/web_push_helpers.ex
@@ -26,6 +26,70 @@ defmodule Vutuv.WebPushHelpers do
     %{"endpoint" => endpoint, "p256dh" => @p256dh, "auth" => @auth}
   end
 
+  @curve :prime256v1
+
+  @doc """
+  A subscriber whose payloads a test can actually READ, as
+  `%{attrs:, public:, private:, auth:}`.
+
+  `p256dh/0` above is the RFC 8291 vector and its private half is not part of
+  it, so nothing sent to that subscription can ever be opened again — which is
+  why the payload test that used it could only assert that some word is absent
+  from a ciphertext, a thing that is true of every ciphertext. This mints a
+  fresh pair, and `decrypt_push/2` then reads the same bytes the browser hands
+  the service worker.
+  """
+  def subscriber(endpoint) do
+    {public, private} = :crypto.generate_key(:ecdh, @curve)
+    auth = :crypto.strong_rand_bytes(16)
+
+    %{
+      public: public,
+      private: private,
+      auth: auth,
+      attrs: %{
+        "endpoint" => endpoint,
+        "p256dh" => Base.url_encode64(public, padding: false),
+        "auth" => Base.url_encode64(auth, padding: false)
+      }
+    }
+  end
+
+  @doc """
+  The decoded payload of one `aes128gcm` push body (RFC 8291 §3.4) — the exact
+  mirror of `Vutuv.WebPush.encrypt/5`, kept here rather than in the app because
+  only a subscriber ever decrypts, and this installation never is one.
+  """
+  def decrypt_push(body, %{public: ua_public, private: ua_private, auth: auth}) do
+    <<salt::binary-16, _rs::unsigned-big-32, key_len::unsigned-8, rest::binary>> = body
+    <<as_public::binary-size(^key_len), sealed::binary>> = rest
+
+    shared = :crypto.compute_key(:ecdh, as_public, ua_private, @curve)
+    key_info = "WebPush: info" <> <<0>> <> ua_public <> as_public
+    ikm = hkdf(auth, shared, key_info, 32)
+    cek = hkdf(salt, ikm, "Content-Encoding: aes128gcm" <> <<0>>, 16)
+    nonce = hkdf(salt, ikm, "Content-Encoding: nonce" <> <<0>>, 12)
+
+    body_len = byte_size(sealed) - 16
+    <<ciphertext::binary-size(^body_len), tag::binary-16>> = sealed
+
+    padded = :crypto.crypto_one_time_aead(:aes_128_gcm, cek, nonce, ciphertext, <<>>, tag, false)
+
+    # 0x02 is the record delimiter of the last record, which is the only one.
+    plaintext_len = byte_size(padded) - 1
+    <<plaintext::binary-size(^plaintext_len), 2>> = padded
+
+    Jason.decode!(plaintext)
+  end
+
+  # RFC 5869 with the one-block expand every Web Push step needs; the same
+  # function `Vutuv.WebPush` keeps private.
+  defp hkdf(salt, ikm, info, length) do
+    prk = :crypto.mac(:hmac, :sha256, salt, ikm)
+    <<key::binary-size(^length), _rest::binary>> = :crypto.mac(:hmac, :sha256, prk, info <> <<1>>)
+    key
+  end
+
   @doc """
   Sets an application env for the test and restores it afterwards.
 

--- a/test/vutuv/web_push/dispatcher_test.exs
+++ b/test/vutuv/web_push/dispatcher_test.exs
@@ -99,9 +99,13 @@ defmodule Vutuv.WebPush.DispatcherTest do
   end
 
   # The payload is what a lock screen is drawn from, so this is where "a push
-  # carries no content" is enforced. It names the kind and where the tap lands —
-  # never the actor, never a word of what was written.
-  test "the payload names the kind and the destination and nothing else" do
+  # carries no content" is enforced. It names the kind, where the tap lands and
+  # the count for the icon — never the actor, never a word of what was written.
+  #
+  # It reads the real plaintext (`decrypt_push/2`) rather than searching the
+  # ciphertext for a word: a body this test cannot open refutes every string it
+  # is handed, including the ones that are in there.
+  test "the payload names the kind, the destination and the count, and nothing else" do
     test = self()
 
     put_config(:web_push_req_options,
@@ -116,21 +120,66 @@ defmodule Vutuv.WebPush.DispatcherTest do
       if family == :inet, do: {:ok, [{93, 184, 216, 34}]}, else: {:error, :nxdomain}
     end)
 
-    user = member()
+    user = insert(:user, browser_notifications?: true)
+    subscriber = subscriber("https://push.example.com/#{user.id}")
+    {:ok, _} = Subscriptions.subscribe(user.id, subscriber.attrs, "Safari on iPhone")
 
     Dispatcher.dispatch(user.id, %{
       kind: "like",
       id: "like:1",
       actor_name: "Anna Müller",
-      text: "liked your post."
+      text: "liked your post.",
+      source_id: Vutuv.UUIDv7.generate()
     })
 
     assert_receive {:body, body}, @wait
-    # The body is aes128gcm, so nothing is legible in it either way; what this
-    # asserts is that the plaintext never carried the words in the first
-    # place — the encryption is not what is being relied on.
-    refute body =~ "Anna"
-    refute body =~ "liked your post"
+    payload = decrypt_push(body, subscriber)
+
+    assert %{"kind" => "like", "locale" => _, "url" => _, "unread" => 1} = payload
+    assert payload |> Map.keys() |> Enum.sort() == ["kind", "locale", "unread", "url"]
+    refute inspect(payload) =~ "Anna"
+    refute inspect(payload) =~ "liked your post"
+  end
+
+  # The number the Home Screen icon carries while vutuv is closed (issue #1732).
+  # The page's own hook can only write it from an open tab, which is exactly the
+  # tab a push exists because there is none of - so the count rides along in the
+  # payload and the service worker puts it on the icon.
+  describe "the count the icon shows" do
+    test "adds unread conversations to unread notifications" do
+      me = insert(:user)
+      other = insert(:user)
+
+      conversation = insert_conversation_between(other, me)
+      insert(:message, conversation: conversation, sender: other)
+      follow!(other, me)
+
+      assert Dispatcher.badge_count(me.id) == 2
+    end
+
+    # A second message in a conversation that is already unread does not move
+    # it: the badge counts conversations, the way the shell's own does.
+    test "counts a conversation once, however many messages are waiting" do
+      me = insert(:user)
+      other = insert(:user)
+
+      conversation = insert_conversation_between(other, me)
+      insert(:message, conversation: conversation, sender: other)
+      insert(:message, conversation: conversation, sender: other)
+
+      assert Dispatcher.badge_count(me.id) == 1
+    end
+
+    # `Activity.notify/2` often runs inside the transaction that produced the
+    # notification, and this count is read from another process - so the row
+    # that caused this very push may not be visible yet. Zero would then TAKE
+    # the badge off at the moment something arrived, which is the one answer
+    # that is certainly wrong; the open app corrects the number either way.
+    test "is never zero, even when the row behind it is not committed yet" do
+      me = insert(:user)
+
+      assert Dispatcher.badge_count(me.id) == 1
+    end
   end
 
   describe "a direct message" do

--- a/test/vutuv_web/controllers/service_worker_test.exs
+++ b/test/vutuv_web/controllers/service_worker_test.exs
@@ -37,6 +37,18 @@ defmodule VutuvWeb.ServiceWorkerTest do
       assert length(String.split(body, "cache.put")) == 2
     end
 
+    # The half of the Home Screen badge the page cannot reach (issue #1732):
+    # `TabBadge` writes the number from an open tab, and a push is what happens
+    # when there is none — so the worker has to put the count that came with it
+    # on the icon, or a message arriving overnight leaves last night's number
+    # standing.
+    test "puts the unread count that came with a push on the app icon", %{conn: conn} do
+      body = conn |> get("/sw.js") |> response(200)
+
+      assert body =~ "setAppBadge"
+      assert body =~ "payload.unread"
+    end
+
     # `no-cache` means "ask every time", not "do not store" — so without a
     # validator every one of those asks is a fresh 200 carrying the whole
     # commented file, and Chrome asks on navigation.


### PR DESCRIPTION
On an iPhone the Home Screen icon kept last night's number. `TabBadge` writes the count only from an open page, and a push is exactly the moment there is none — so a message arriving overnight raised a lock-screen line and left the icon untouched. `docs/architecture/realtime.md` had this as the open half of #1732.

`Vutuv.WebPush.Dispatcher.badge_count/1` now puts the unread total into every push payload and `assets/js/sw.js` writes it onto the icon. It reads the same two sources as `ShellLive.push_badge/1`, once per member and only where a device is subscribed, and it is never zero: `notify/2` often runs inside the transaction that produced the notification while the push task reads from another process, and a zero would take the badge off at the moment something arrived.

Also fixed: the payload test could not fail. It searched the *encrypted* body for words, which refutes every string. It now decrypts (RFC 8291) and asserts the payload keys.

Note for iOS: the icon shows a badge only once notifications are allowed for the installed app — that part is the platform, not the code.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01L8rjkrKGaANGc9yMMBhguf