### PR TITLE
Link Bluesky handles in posts and messages to bsky.app

### DIFF
--- a/assets/js/markdown_editor.js
+++ b/assets/js/markdown_editor.js
@@ -440,9 +440,20 @@ const AT_BOUNDARY = String.raw`(?<![\p{L}\p{N}_@/])@`
 // address on OUR host (`@ada@vutuv.de`) is a real mention and the renderer links
 // it, but it goes unchipped here too — the client does not know which host is
 // ours, and a missing chip is the harmless direction.
+//
+// The third alternative is a **Bluesky** handle, `@hilwiller.bsky.social`, which
+// the server reads as one whole address that names nobody here. Without it the
+// run chips the `@hilwiller` in front of the dot, spends one of the five
+// mentions a post may carry and asks the server whether that member exists —
+// about a handle the renderer will not link. Its own trailing guard mirrors the
+// server's: `@a.bsky.socialize` is not a Bluesky handle, so there the chip is
+// right. The `i` flag is what reads a capitalised host (a hostname is
+// case-insensitive); it changes nothing else, every other class here already
+// spanning both cases.
 const MENTION_RUN = new RegExp(
-  `${AT_BOUNDARY}([A-Za-z0-9_]+)(?![A-Za-z0-9_]|@[A-Za-z0-9-]+\\.)`,
-  "gu"
+  `${AT_BOUNDARY}([A-Za-z0-9_]+)` +
+    String.raw`(?![A-Za-z0-9_]|@[A-Za-z0-9-]+\.|\.bsky\.social(?!\.?[\p{L}\p{N}_-]))`,
+  "giu"
 )
 
 // The half-typed mention the caret sits at the end of.

--- a/docs/architecture/mentions.md
+++ b/docs/architecture/mentions.md
@@ -22,6 +22,18 @@ else's account and is never touched; `@php@tags.vutuv.de` is a topic of ours and
 joins `hashtags/1` instead (issue #1330); a handle inside a code span/block is
 sample text, not a mention (matching what the renderer links).
 
+A **Bluesky** handle is the one `@` form that answers to neither rule, because
+it has no host half to ask about: `@hilwiller.bsky.social` writes the whole
+account as a domain. Read by the bare form it came out as the vutuv member
+`@hilwiller` followed by dead text, so a boosted post naming a Bluesky account
+linked whoever holds that handle here, and a member's own post naming one was
+refused with "the handle @hilwiller does not exist". The grammar therefore tries
+it before the bare form and the renderer links it out to
+`Vutuv.Bluesky.profile_url/1` — bsky.app, new tab, no mention card, since
+Bluesky is not a network this installation can follow anybody on. Only
+`*.bsky.social` counts: a handle on a custom domain looks exactly like an
+ordinary word in front of an abbreviation.
+
 Before that, `local_handles/1` dropped every `@user@host` hit by design, and the
 renderer sent an address on our own host to `https://vutuv.de/@ada` — the
 Mastodon-web convention applied to a host that is not Mastodon, a path vutuv
@@ -137,7 +149,11 @@ Two consequences worth knowing:
   account, and chipping the `@ada` in front of it would claim a member of ours
   had been named. An address on our own host is a real mention and the renderer
   links it, but it goes unchipped too — the client does not know which host is
-  ours, and a missing chip is the harmless direction.
+  ours, and a missing chip is the harmless direction. It refuses a Bluesky
+  handle for the same reason, and nothing fails when the two copies drift: the
+  server counts zero mentions in `@hilwiller.bsky.social` while the composer
+  would chip `@hilwiller`, ask whether that member exists and spend one of the
+  five mentions a post may carry.
 
 Out of scope on purpose: completing a remote `@user@host` address. Only local
 mentions become `Mention` tags in the outgoing Note (`VutuvWeb.Fediverse.Docs`),

--- a/lib/vutuv/bluesky.ex
+++ b/lib/vutuv/bluesky.ex
@@ -65,11 +65,32 @@ defmodule Vutuv.Bluesky do
       {:error, :transient}
   end
 
+  @doc """
+  Where a handle's account is read on the web: `https://bsky.app/profile/<handle>`.
+
+  The one place that address is written, and it fetches nothing — three
+  surfaces reach it. The profile card's link to a stored account
+  (`Vutuv.Profiles.SocialMediaAccount.url/1`, whose provider table therefore
+  lists no base for Bluesky), the `@name.bsky.social` a post or a message
+  mentions (`VutuvWeb.Markdown`, matching the same handle shape as part of the
+  entity grammar), and the post links this module builds below.
+
+  A leading `@` and a shouted spelling are taken off, because a stored account
+  is the one caller that can carry either: `normalize_handle/1` cleans what
+  goes *out to the network*, and a legacy row reaches the profile card without
+  passing it. A hostname is case-insensitive; bsky.app answers only the
+  lowercase form.
+  """
+  def profile_url(handle) when is_binary(handle) do
+    normalized = handle |> String.trim() |> String.trim_leading("@") |> String.downcase()
+    "https://bsky.app/profile/" <> normalized
+  end
+
   defp build_feed(handle, meta) do
     feed = %Feed{
       name: meta.name,
       handle: handle,
-      url: "https://bsky.app/profile/#{handle}",
+      url: profile_url(handle),
       avatar: nil,
       followers: meta.followers,
       posts: []
@@ -197,7 +218,7 @@ defmodule Vutuv.Bluesky do
          {:ok, created_at, _offset} <- DateTime.from_iso8601(created) do
       %Post{
         id: rkey,
-        url: "https://bsky.app/profile/#{handle}/post/#{rkey}",
+        url: profile_url(handle) <> "/post/" <> rkey,
         text: text,
         created_at: created_at
       }

--- a/lib/vutuv/mentions.ex
+++ b/lib/vutuv/mentions.ex
@@ -86,8 +86,33 @@ defmodule Vutuv.Mentions do
   # lookbehinds. The fediverse form is tried first, so `@a@b.social` is read as
   # one whole address rather than the local member `@a` followed by loose text;
   # the **host** then decides whose it is. Captures: 1 = fediverse
-  # user, 2 = fediverse host, 3 = local handle, 4 = hashtag (exactly one kind is
-  # set per hit).
+  # user, 2 = fediverse host, 3 = Bluesky handle, 4 = local handle, 5 = hashtag
+  # (exactly one kind is set per hit).
+  #
+  # A **Bluesky** handle is the odd one out: `@hilwiller.bsky.social` writes the
+  # whole account as a domain, with no second `@` to end a user part. Read by
+  # the bare form it comes out as the member `@hilwiller` plus dead text — so a
+  # boosted post naming a Bluesky account linked whichever vutuv member holds
+  # that handle, and a member's own post naming one was refused with "the handle
+  # @hilwiller does not exist". It therefore has to be tried before the bare
+  # form, and only `*.bsky.social` counts: a handle on a custom domain
+  # (`@stefan.example.de`) is the same shape as an ordinary word before a
+  # sentence's abbreviation and cannot be told apart from one — measured over
+  # the 7,443 stored bodies of a production copy, a rule that took any dotted
+  # domain found one real handle and three plain words (`@rki.de`,
+  # `@dc.uba.ar`, `@stadt-bremerhaven.de`), each of which it would have sent to
+  # bsky.app.
+  #
+  # Three small parts carry their weight. The `(?i:…)` reads a shouted host,
+  # because the fallback is not "no link" but the bare form's link to whichever
+  # member holds that first label — a hostname is case-insensitive and getting
+  # it wrong points at a person. The trailing lookahead keeps
+  # `@a.bsky.socialize` out, and its `\.?` keeps `@a.bsky.social.de` out, while
+  # still leaving a full stop after the handle in the sentence where it belongs.
+  # And the label is bounded at a DNS label's 63 octets rather than left open:
+  # unbounded it walks back through the whole `@`-token before rejecting one,
+  # which cost 2.97× the reductions of the old grammar on a body-length run
+  # (5.28× on a hyphenated one) and is back at parity bounded.
   #
   # A preceding `/` blocks the **bare** and `#` forms only. `/@user` is the
   # Mastodon-web path to a profile, so a lone handle glued to a slash is far
@@ -110,7 +135,7 @@ defmodule Vutuv.Mentions do
   # also turns the `\w` in the two lookbehinds Unicode-aware, which is the
   # intended reading of "not mid-token": `Grüße@ada` is as much one word as
   # `Gruesse@ada`, and neither is a mention.
-  @entity ~r"(?<![\w@])@([A-Za-z0-9_]+)@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)+)|(?<![\w@/])@([A-Za-z0-9_]+)|(?<![\w#/&])#([\p{L}\p{M}\p{Nd}_]+)"u
+  @entity ~r"(?<![\w@])@([A-Za-z0-9_]+)@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)+)|(?<![\w@])@([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?i:\.bsky\.social))(?!\.?[\w-])|(?<![\w@/])@([A-Za-z0-9_]+)|(?<![\w#/&])#([\p{L}\p{M}\p{Nd}_]+)"u
 
   # Code spans/blocks are skipped everywhere: a handle inside them is sample
   # text, never a link (the same call the renderer makes for `<code>`/`<pre>`).
@@ -804,8 +829,9 @@ defmodule Vutuv.Mentions do
   end
 
   # `Regex.scan` truncates trailing unmatched groups, so a hit's length says
-  # which kind it is: fediverse `["user", "host"]`, local `["", "", "handle"]`,
-  # hashtag `["", "", "", "hashtag"]`.
+  # which kind it is: fediverse `["user", "host"]`, Bluesky `["", "", "handle"]`,
+  # local `["", "", "", "handle"]`, hashtag `["", "", "", "", "hashtag"]`. A
+  # Bluesky handle names nobody here, so it falls through to the catch-all.
   #
   # An address on our **own** host is the same member written out in full — the
   # spelling every remote server uses to name one of us, and the one the
@@ -817,7 +843,7 @@ defmodule Vutuv.Mentions do
     if Fediverse.local_host?(host), do: [String.downcase(user)], else: []
   end
 
-  defp handle_of([_, _, handle | _]) when handle != "", do: [String.downcase(handle)]
+  defp handle_of([_, _, _bluesky, handle | _]) when handle != "", do: [String.downcase(handle)]
   defp handle_of(_), do: []
 
   defp scan_hashtags(chunk) do
@@ -826,8 +852,8 @@ defmodule Vutuv.Mentions do
     |> Enum.flat_map(&hashtag_of/1)
   end
 
-  # Same truncation rule as `handle_of/1`: only a hashtag hit has a fourth
-  # group, so anything shorter is one of the two `@` forms — and the `@` form on
+  # Same truncation rule as `handle_of/1`: only a hashtag hit has a fifth
+  # group, so anything shorter is one of the three `@` forms — and the `@` form on
   # our **tag** host is a topic of ours (`@php@tags.<our host>`, issue #1330),
   # which the renderer links to `/tags/:slug` exactly like the `#php` that means
   # the same thing. So it names a tag here too, and a post writing it is filed
@@ -839,7 +865,7 @@ defmodule Vutuv.Mentions do
     if Fediverse.tag_host?(host), do: [user], else: []
   end
 
-  defp hashtag_of([_, _, _, hashtag]) when hashtag != "", do: [hashtag]
+  defp hashtag_of([_, _, _, _, hashtag]) when hashtag != "", do: [hashtag]
   defp hashtag_of(_), do: []
 
   # Only the fediverse form on our own host has anything to shorten; a bare
@@ -867,10 +893,10 @@ defmodule Vutuv.Mentions do
 
   defp shorten_addresses_in_text(text) do
     Regex.replace(@entity, text, fn
-      whole, user, host, "", "" ->
+      whole, user, host, "", "", "" ->
         if user != "" and Fediverse.local_host?(host), do: "@" <> user, else: whole
 
-      whole, _user, _host, _handle, _hashtag ->
+      whole, _user, _host, _bluesky, _handle, _hashtag ->
         whole
     end)
   end
@@ -893,13 +919,13 @@ defmodule Vutuv.Mentions do
   # for a reason, and only the handle is what the rename changed.
   defp replace_old_mentions(chunk, old_n, new_n) do
     Regex.replace(@entity, chunk, fn
-      whole, "", "", handle, "" ->
+      whole, "", "", "", handle, "" ->
         if String.downcase(handle) == old_n, do: "@" <> new_n, else: whole
 
-      whole, user, host, "", "" ->
+      whole, user, host, "", "", "" ->
         if local_handle_match?(user, host, old_n), do: "@#{new_n}@#{host}", else: whole
 
-      whole, _user, _host, _handle, _hashtag ->
+      whole, _user, _host, _bluesky, _handle, _hashtag ->
         whole
     end)
   end
@@ -907,7 +933,7 @@ defmodule Vutuv.Mentions do
   defp local_match?([user, host | _], old_n) when user != "" and host != "",
     do: local_handle_match?(user, host, old_n)
 
-  defp local_match?([_, _, handle | _], old_n) when handle != "",
+  defp local_match?([_, _, _bluesky, handle | _], old_n) when handle != "",
     do: String.downcase(handle) == old_n
 
   defp local_match?(_, _), do: false

--- a/lib/vutuv/profiles/social_media_account.ex
+++ b/lib/vutuv/profiles/social_media_account.ex
@@ -4,6 +4,7 @@ defmodule Vutuv.Profiles.SocialMediaAccount do
   use VutuvWeb, :model
 
   alias PhoenixHTMLHelpers.Link, as: HTMLLink
+  alias Vutuv.Bluesky
 
   schema "social_media_accounts" do
     field(:provider, :string)
@@ -100,13 +101,15 @@ defmodule Vutuv.Profiles.SocialMediaAccount do
 
   def split_self_hosted(_value), do: :error
 
-  # Providers whose profile URL is a fixed base plus the bare handle. Mastodon
-  # is deliberately absent: it is federated, so the instance is part of the
-  # handle and the link is built by mastodon_url/1 instead.
+  # Providers whose profile URL is a fixed base plus the bare handle. Two are
+  # deliberately absent. Mastodon is federated, so the instance is part of the
+  # handle and the link is built by mastodon_url/1 instead. Bluesky's base is
+  # owned by `Vutuv.Bluesky.profile_url/1`, because the same address is written
+  # by a second reader — a `@name.bsky.social` inside a post or a message
+  # (`VutuvWeb.Markdown`) — which has no account row to read a base from.
   base_urls = [
     {"Facebook", "http://facebook.com/"},
     {"Twitter", "http://twitter.com/"},
-    {"Bluesky", "https://bsky.app/profile/"},
     {"Instagram", "http://instagram.com/"},
     {"Youtube", "http://youtube.com/channel/"},
     {"Snapchat", nil},
@@ -401,6 +404,10 @@ defmodule Vutuv.Profiles.SocialMediaAccount do
   def social_media_link(%__MODULE__{provider: "Mastodon"} = account),
     do: HTMLLink.link(get_display(account), to: url(account))
 
+  # Bluesky's link, through the module that owns that address (see base_urls).
+  def social_media_link(%__MODULE__{provider: "Bluesky"} = account),
+    do: HTMLLink.link(get_display(account), to: url(account))
+
   # A self-hosted forge carries its own host too, so its link is built by
   # url/1 the same way (see @self_hosted_providers).
   def social_media_link(%__MODULE__{provider: provider} = account)
@@ -425,6 +432,7 @@ defmodule Vutuv.Profiles.SocialMediaAccount do
   # no canonical URL scheme, e.g. Snapchat) — the agent documents
   # (VutuvWeb.AgentDocs) need a string, not a rendered link.
   def url(%__MODULE__{provider: "Mastodon", value: value}), do: mastodon_url(value)
+  def url(%__MODULE__{provider: "Bluesky", value: value}), do: Bluesky.profile_url(value)
 
   def url(%__MODULE__{provider: provider, value: value})
       when provider in @self_hosted_providers,

--- a/lib/vutuv_web/markdown.ex
+++ b/lib/vutuv_web/markdown.ex
@@ -28,6 +28,7 @@ defmodule VutuvWeb.Markdown do
 
   use Gettext, backend: VutuvWeb.Gettext
 
+  alias Vutuv.Bluesky
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Handle
   alias Vutuv.Mentions
@@ -76,16 +77,17 @@ defmodule VutuvWeb.Markdown do
   # into a `post-inline-image--*` modifier class — the served src stays clean.
   @image_alignments ~w(left right center)
 
-  # A fediverse handle `@user@host.tld`, a local `@handle` mention, or a
-  # `#hashtag`. The grammar itself lives in `Vutuv.Mentions` (the single source
-  # shared by rendering, mention-existence validation and the rename rewrite),
-  # so it can never drift from what those paths detect. The leading `@`/`#` must
-  # not sit mid-token (no email `a@b`, no `/path#frag`); the fediverse form is
-  # tried **first**, so `@a@b.social` is read as one whole address rather than
-  # the member `@a` plus loose text, and the **host** then decides where it
-  # points; handles/tags match permissively and are validated against the
-  # DB by `linkify_entities/1`. Captures: 1 = fediverse user, 2 = fediverse
-  # host, 3 = local handle, 4 = hashtag (exactly one kind is set per hit).
+  # A fediverse handle `@user@host.tld`, a Bluesky handle `@name.bsky.social`, a
+  # local `@handle` mention, or a `#hashtag`. The grammar itself lives in
+  # `Vutuv.Mentions` (the single source shared by rendering, mention-existence
+  # validation and the rename rewrite), so it can never drift from what those
+  # paths detect. The leading `@`/`#` must not sit mid-token (no email `a@b`, no
+  # `/path#frag`); the fediverse form is tried **first**, so `@a@b.social` is
+  # read as one whole address rather than the member `@a` plus loose text, and
+  # the **host** then decides where it points; handles/tags match permissively
+  # and are validated against the DB by `linkify_entities/1`. Captures:
+  # 1 = fediverse user, 2 = fediverse host, 3 = Bluesky handle, 4 = local
+  # handle, 5 = hashtag (exactly one kind is set per hit).
   @entity Mentions.entity_regex()
 
   # Inside these elements an entity is left as plain text (a handle/hashtag in a
@@ -242,7 +244,9 @@ defmodule VutuvWeb.Markdown do
 
   It rewrites the `rel` the two link builders above have already written
   (`open_links_in_new_tab/1` for URLs in the body, `linkify_entities/2` for a
-  `@user@host` handle), so the marker cannot be forgotten on one of them. Links
+  `@user@host` or `@name.bsky.social` handle — both through
+  `outbound_mention_anchor/3`, which is what keeps this one literal true for
+  every outbound mention), so the marker cannot be forgotten on one of them. Links
   to **our own** pages carry no `rel` at all — a `#hashtag` resolves to
   `/tags/:slug`, an address on our own host to that member's profile — so they
   are left alone: nofollowing our own pages would throw away the internal
@@ -964,13 +968,16 @@ defmodule VutuvWeb.Markdown do
   end
 
   # Hosts whose display keeps more than one leading path directory, because
-  # their meaningful unit sits deeper: GitHub is `/:owner/:repo`, and the New
-  # York Times dates an article, `/:year/:month/:day/:desk/<headline>`, so one
-  # directory leaves a bare "nytimes.com/2026/…" that names nothing while four
-  # carry the date and the section. Every other host still collapses after the
-  # first directory. The host is matched whole, never by suffix: a subdomain is
-  # a different site with its own path shape.
-  @dirs_by_host %{"github.com" => 2, "nytimes.com" => 4}
+  # their meaningful unit sits deeper: GitHub is `/:owner/:repo`, Bluesky is
+  # `/profile/:handle` (one directory leaves "bsky.app/profile/…", which names
+  # nobody — the handle is the whole point of a link to an account or to one of
+  # its posts), and the New York Times dates an article,
+  # `/:year/:month/:day/:desk/<headline>`, so one directory leaves a bare
+  # "nytimes.com/2026/…" that names nothing while four carry the date and the
+  # section. Every other host still collapses after the first directory. The
+  # host is matched whole, never by suffix: a subdomain is a different site with
+  # its own path shape.
+  @dirs_by_host %{"github.com" => 2, "bsky.app" => 2, "nytimes.com" => 4}
 
   # This installation's own host keeps TWO (a vutuv profile section is
   # `/:slug/<section>`, so the section — `/tags`, `/work_experiences` — is worth
@@ -1147,7 +1154,7 @@ defmodule VutuvWeb.Markdown do
       {[], [], [], false} ->
         html
 
-      {mentions, local_mentions, hashtags, _fediverse?} ->
+      {mentions, local_mentions, hashtags, _external?} ->
         # `:hashtags_only` drops the **bare** handles — in remote content a
         # `@name` names an account over there, not the vutuv member who happens
         # to share the handle. A fully-qualified address on our own host has no
@@ -1175,22 +1182,23 @@ defmodule VutuvWeb.Markdown do
   # The unique, lowercased {handles, own-host handles, hashtags} sitting in
   # linkable text.
   defp entity_candidates(tokens) do
-    {mentions, local_mentions, hashtags, fediverse?} =
+    {mentions, local_mentions, hashtags, external?} =
       reduce_linkable_text(tokens, {[], [], [], false}, fn text, acc ->
         @entity
         |> Regex.scan(text, capture: :all_but_first)
         |> Enum.reduce(acc, &collect_candidate/2)
       end)
 
-    {Enum.uniq(mentions), Enum.uniq(local_mentions), Enum.uniq(hashtags), fediverse?}
+    {Enum.uniq(mentions), Enum.uniq(local_mentions), Enum.uniq(hashtags), external?}
   end
 
   # `Regex.scan` truncates trailing unmatched groups, so each hit arrives at a
-  # different length: a fediverse handle as `["user", "host"]`, a mention as
-  # `["", "", "handle"]`, a hashtag as `["", "", "", "hashtag"]`. Dispatch on
-  # which group is set. An address on somebody else's host needs no DB lookup,
-  # so it only raises the `fediverse?` flag — that keeps the token walk from
-  # being skipped for a body whose only entities are foreign addresses.
+  # different length: a fediverse handle as `["user", "host"]`, a Bluesky handle
+  # as `["", "", "handle"]`, a mention as `["", "", "", "handle"]`, a hashtag as
+  # `["", "", "", "", "hashtag"]`. Dispatch on which group is set. An address on
+  # somebody else's host needs no DB lookup, and neither does a Bluesky handle,
+  # so both only raise the `external?` flag — that keeps the token walk from
+  # being skipped for a body whose only entities point somewhere else.
   #
   # Two of our own hosts wear that same shape and neither leaves the site. Our
   # **tag host** (issue #1330): `@php@tags.<host>` is a topic of this
@@ -1200,7 +1208,7 @@ defmodule VutuvWeb.Markdown do
   # page of ours, so its user part is a handle and gets looked up like a bare
   # `@ada` — kept in its own list because it resolves even in `:hashtags_only`
   # mode, where a bare handle deliberately does not.
-  defp collect_candidate([user, host | _], {mentions, local, hashtags, _fediverse?})
+  defp collect_candidate([user, host | _], {mentions, local, hashtags, _external?})
        when user != "" and host != "" do
     cond do
       Fediverse.tag_host?(host) -> {mentions, local, [String.downcase(user) | hashtags], true}
@@ -1209,12 +1217,16 @@ defmodule VutuvWeb.Markdown do
     end
   end
 
-  defp collect_candidate([_, _, handle | _], {mentions, local, hashtags, fediverse?})
-       when handle != "",
-       do: {[String.downcase(handle) | mentions], local, hashtags, fediverse?}
+  defp collect_candidate([_, _, bluesky | _], {mentions, local, hashtags, _external?})
+       when bluesky != "",
+       do: {mentions, local, hashtags, true}
 
-  defp collect_candidate([_, _, _, hashtag], {mentions, local, hashtags, fediverse?}),
-    do: {mentions, local, [String.downcase(hashtag) | hashtags], fediverse?}
+  defp collect_candidate([_, _, _, handle | _], {mentions, local, hashtags, external?})
+       when handle != "",
+       do: {[String.downcase(handle) | mentions], local, hashtags, external?}
+
+  defp collect_candidate([_, _, _, _, hashtag], {mentions, local, hashtags, external?}),
+    do: {mentions, local, [String.downcase(hashtag) | hashtags], external?}
 
   # Walks the token stream, applying `fun` to every text token outside a
   # skip element and leaving tags and skipped text untouched.
@@ -1260,9 +1272,17 @@ defmodule VutuvWeb.Markdown do
 
   defp link_entities_in_text(text, bare_users, address_users, tags, form) do
     Regex.replace(@entity, text, fn
-      whole, user, host, "", "" -> fediverse_link(whole, user, host, address_users, tags, form)
-      whole, "", "", handle, "" -> mention_link(whole, handle, bare_users, form)
-      whole, "", "", "", hashtag -> hashtag_link(whole, hashtag, tags)
+      whole, user, host, "", "", "" ->
+        fediverse_link(whole, user, host, address_users, tags, form)
+
+      whole, "", "", bluesky, "", "" ->
+        bluesky_link(whole, bluesky)
+
+      whole, "", "", "", handle, "" ->
+        mention_link(whole, handle, bare_users, form)
+
+      whole, "", "", "", "", hashtag ->
+        hashtag_link(whole, hashtag, tags)
     end)
   end
 
@@ -1347,11 +1367,30 @@ defmodule VutuvWeb.Markdown do
   # somebody else's server, which sanitizes it away on arrival anyway. Per
   # mention, per follower inbox.
   defp remote_actor_link(user, host, form) do
-    href = Handle.web_profile_url(user, host)
     hook = if form == :local, do: ~s( data-remote-actor="#{user}@#{host}"), else: ""
 
+    outbound_mention_anchor(Handle.web_profile_url(user, host), "@#{user}@#{host}", hook)
+  end
+
+  # `@name.bsky.social` is an account on Bluesky, which is not the fediverse and
+  # has no `@user@host` form: the whole handle is a domain. It links straight to
+  # the account on bsky.app, and it carries **no** `data-remote-actor` hook —
+  # the mention card behind that attribute offers a Follow button, and Bluesky
+  # is not a network this installation can follow anybody on. The label is what
+  # the author typed, the href the lowercased handle.
+  defp bluesky_link(whole, handle),
+    do: outbound_mention_anchor(Bluesky.profile_url(handle), whole)
+
+  # One anchor for every mention that names an account somewhere else. It opens
+  # in a new tab like the rest of what leaves the site, and its `rel` is the
+  # literal `mark_foreign_links/1` rewrites to add `ugc nofollow` on a cached
+  # remote body — so a third outbound network spelling that string for itself is
+  # a third place it can drift and quietly stop being marked. Both callers pass
+  # a validated charset (`[A-Za-z0-9_]` / `[A-Za-z0-9.-]`), so nothing needs
+  # escaping here.
+  defp outbound_mention_anchor(href, label, hook \\ "") do
     ~s(<a href="#{href}" target="_blank" rel="noopener noreferrer" class="mention"#{hook}>) <>
-      ~s(@#{user}@#{host}</a>)
+      ~s(#{label}</a>)
   end
 
   # A bare `@ada` is the everyday spelling here and the wrong one everywhere

--- a/test/vutuv/mentions_test.exs
+++ b/test/vutuv/mentions_test.exs
@@ -20,6 +20,14 @@ defmodule Vutuv.MentionsTest do
       assert Mentions.local_handles("say hi to @bob@geno.social") == []
     end
 
+    # A Bluesky handle is a whole domain behind the `@`, with no second `@` to
+    # end a user part — so the bare-handle form used to swallow its first label
+    # and report a mention of the vutuv member `@bob`, which is why a post
+    # naming a Bluesky account was refused as "the handle @bob does not exist".
+    test "a Bluesky handle is not a local mention" do
+      assert Mentions.local_handles("say hi to @bob.bsky.social") == []
+    end
+
     test "a #hashtag is not a mention" do
       assert Mentions.local_handles("#elixir is nice") == []
     end
@@ -87,6 +95,10 @@ defmodule Vutuv.MentionsTest do
     test "never touches emails, hashtags, other servers' addresses or code spans" do
       text = "mail bob@old.de, tag #old, boost @old@host.io, code `@old`"
       assert Mentions.rewrite(text, "old", "new") == {text, 0}
+    end
+
+    test "leaves a Bluesky handle that opens with the old name alone" do
+      assert Mentions.rewrite("@old.bsky.social", "old", "new") == {"@old.bsky.social", 0}
     end
 
     test "round-trips a code-only body byte-for-byte" do

--- a/test/vutuv_web/markdown_bluesky_test.exs
+++ b/test/vutuv_web/markdown_bluesky_test.exs
@@ -1,0 +1,155 @@
+defmodule VutuvWeb.MarkdownBlueskyTest do
+  @moduledoc """
+  A Bluesky handle `@name.bsky.social` links to that account on bsky.app.
+
+  It is written like a fediverse address and is not one: the whole thing after
+  the `@` is a domain, with no second `@` to end the user part. So the shared
+  entity grammar read `@hilwiller.bsky.social` as the local member `@hilwiller`
+  followed by dead text — which linked a boosted post's Bluesky mention to
+  whichever vutuv member happens to hold that handle, and refused to save a
+  member's own post naming one ("the handle @hilwiller does not exist").
+  """
+  # DB-backed: one case proves a real member of that name is not linked to.
+  use Vutuv.DataCase, async: true
+
+  import Vutuv.Factory
+
+  alias VutuvWeb.Markdown
+
+  @handle "@hilwiller.bsky.social"
+  @profile "https://bsky.app/profile/hilwiller.bsky.social"
+
+  defp render(text), do: text |> Markdown.render() |> Phoenix.HTML.safe_to_string()
+
+  defp render_post(text), do: text |> Markdown.render_post([]) |> Phoenix.HTML.safe_to_string()
+
+  describe "bluesky handles" do
+    test "a message links the handle to bsky.app in a new tab" do
+      html = render("Folge #{@handle} für Recherchen")
+
+      assert html =~ ~s(href="#{@profile}")
+      assert html =~ ~s(target="_blank")
+      assert html =~ ~s(rel="noopener noreferrer")
+      assert html =~ ">#{@handle}</a>"
+    end
+
+    test "a post links it the same way" do
+      html = render_post("Folge #{@handle} für Recherchen")
+
+      assert html =~ ~s(href="#{@profile}")
+      assert html =~ ~s(target="_blank")
+    end
+
+    test "a boosted remote post links it too, marked ugc nofollow" do
+      # The case that brought this up: a Mastodon post naming two Bluesky
+      # accounts, drawn as a card in the feed.
+      html =
+        Markdown.render_remote(
+          "#RiffTalk: @hilwiller.bsky.social und @latamreporter.bsky.social sprechen"
+        )
+
+      assert html =~ ~s(href="#{@profile}")
+      assert html =~ ~s(href="https://bsky.app/profile/latamreporter.bsky.social")
+      assert html =~ ~s(rel="ugc nofollow noopener noreferrer")
+    end
+
+    test "never links a member who happens to hold the first label" do
+      insert(:user, username: "hilwiller", first_name: "Hilde", last_name: "Willer")
+
+      html = render("Folge #{@handle}")
+
+      refute html =~ ~s(href="/hilwiller")
+      assert html =~ ~s(href="#{@profile}")
+      # and the tail is part of the link, not text stranded beside it
+      refute html =~ "</a>.bsky.social"
+    end
+
+    test "the href is lowercased, the typed spelling stays the label" do
+      html = render("see @Hilwiller.BSky.Social today")
+
+      assert html =~ ~s(href="#{@profile}")
+      assert html =~ ">@Hilwiller.BSky.Social</a>"
+    end
+
+    test "trailing sentence punctuation stays outside the link" do
+      html = render("Mehr bei #{@handle}.")
+
+      assert html =~ ~s(href="#{@profile}")
+      assert html =~ ">#{@handle}</a>"
+      refute html =~ "social.</a>"
+    end
+
+    test "a longer host that only starts like one is left alone" do
+      html = render("nichts an @hilwiller.bsky.socialize hier")
+
+      refute html =~ "bsky.app"
+      refute html =~ ~s(href="/hilwiller")
+    end
+
+    test "a deeper domain under that one is left alone too" do
+      # The `\\.?` half of the grammar's trailing guard: `@a.bsky.social.de` is
+      # somebody else's domain, not an account on Bluesky.
+      html = render("nichts an @hilwiller.bsky.social.de hier")
+
+      refute html =~ "bsky.app"
+    end
+
+    test "an email address on that domain is not a handle" do
+      html = render("schreib an post@hilwiller.bsky.social bitte")
+
+      refute html =~ "bsky.app"
+      assert html =~ "post@hilwiller.bsky.social"
+    end
+
+    test "a handle inside code is sample text" do
+      html = render("schreib `@hilwiller.bsky.social` so")
+
+      refute html =~ "bsky.app"
+    end
+
+    test "a handle inside a URL stays part of that URL's own link" do
+      html = render("siehe https://bsky.brid.gy/ap/@hilwiller.bsky.social hier")
+
+      assert html =~ ~s(href="https://bsky.brid.gy/ap/@hilwiller.bsky.social")
+      refute html =~ ~s(href="#{@profile}")
+    end
+
+    test "a pasted bsky.app link shows whose profile it is" do
+      html = render("siehe https://bsky.app/profile/hilwiller.bsky.social")
+
+      assert html =~ ~s(href="#{@profile}")
+      assert html =~ ">bsky.app/profile/hilwiller.bsky.social</a>"
+    end
+
+    test "a fediverse address on that host is still read as one" do
+      # `@ada@bsky.social` names a user part and a host, which is the other
+      # grammar — the Bluesky form has no second `@`.
+      html = render("hallo @ada@bsky.social")
+
+      assert html =~ ~s(href="https://bsky.social/@ada")
+      refute html =~ "bsky.app"
+    end
+  end
+
+  describe "the composer's copy of the grammar" do
+    # `MENTION_RUN` in the editor is the client half of `Vutuv.Mentions`'
+    # `@entity`, and nothing fails when the two drift: the composer would chip
+    # the `@hilwiller` in front of the dot, spend one of the five mentions a
+    # post may carry and ask the server whether that member exists — about a
+    # handle the renderer links out instead. There is no JS test runner here,
+    # so this is a static source check, like `markdown_editor_link_test.exs`.
+    @editor_js Path.expand("../../assets/js/markdown_editor.js", __DIR__)
+
+    test "the mention run excludes a Bluesky handle" do
+      js = File.read!(@editor_js)
+
+      assert js =~ ~S(\.bsky\.social),
+             "MENTION_RUN in markdown_editor.js must exclude `@name.bsky.social`, or the " <>
+               "composer chips a member who merely shares the handle's first label"
+
+      assert js =~ ~s("giu"),
+             "the mention run needs the `i` flag to read a shouted host the same way the " <>
+               "server's `(?i:…)` does"
+    end
+  end
+end


### PR DESCRIPTION
A post or message naming a Bluesky account read wrong. `@hilwiller.bsky.social` writes the whole account as a domain, with no second `@` to end a user part, so the shared entity grammar in `Vutuv.Mentions` saw the member `@hilwiller` plus dead text: a boosted post linked whoever holds that handle here, and a member's own post naming one was refused with "the handle @hilwiller does not exist".

The grammar now tries the Bluesky form before the bare one, and `VutuvWeb.Markdown` links it out to bsky.app in a new tab. Only `*.bsky.social` counts — over 7,443 stored bodies of a production copy, a rule taking any dotted domain found one real handle and three ordinary words (`@rki.de`, `@dc.uba.ar`, `@stadt-bremerhaven.de`).

Also: `Vutuv.Bluesky.profile_url/1` owns that address now, the composer's `MENTION_RUN` knows the form, and a pasted bsky.app link shows whose profile it is.

Surface: `/feed`, any post body. Smoke-tested at `/system/fediverse/account/:id` and in the composer.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01EQv59xBArphb1Xm1PUbs2h