### PR TITLE
Unfollowing a fediverse account stops the future, not the past

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -1571,7 +1571,18 @@ touched:
 
 Unfollowing sends a best-effort `Undo(Follow)` carrying the original activity id
 and deletes the row either way — it describes our member's intent, and they have
-withdrawn it. Switching federation off does that for every follow
+withdrawn it.
+
+It also writes a **span** (`Vutuv.Fediverse.PastFollow`, issue #1673): from when
+the follow began to the second it ended. Unfollowing means "stop sending me
+their posts", not "delete what I have already read", and without that record it
+meant both — worse here than on the vutuv side, because a cached copy is only
+held while somebody follows its author, so the unfollow deleted it outright.
+The span is read by the two remote feed sources and is a hold in
+`spare_held/1`, so the copies survive the purge; the module doc says what it
+does not record.
+
+Switching federation off does that for every follow
 (`drop_remote_follows/1`, the `drop_followers/1` symmetry), gated on
 `ever_federated?/1` rather than `federated?/1` for the reason revocation is: the
 withdrawal happens exactly when the switch is already off.
@@ -2149,8 +2160,9 @@ Retention is unchanged: a boosted copy lives under the ordinary six-month clock.
 What the boost buys it is the right to exist while **nobody here follows its
 author** — which is the normal case for a boost, and the reason the copy is here
 at all — so `purge_unfollowed_remote_posts/0` spares a post something still
-holds, exactly as it spares one a member reshared. An `Undo(Announce)` removes
-the boost row and nothing else; the post goes when nothing holds it any more.
+holds, exactly as it spares one a member reshared or one a past follow still
+covers. An `Undo(Announce)` removes the boost row and nothing else; the post
+goes when nothing holds it any more.
 
 ### When a followed account moves, dies or vanishes (issue #1168)
 
@@ -2288,8 +2300,9 @@ and which now carries an index for exactly this lookup.
 Any account, not only followed ones, which is what makes `fediverse_post_lookups`
 necessary: the copy usually has no follower holding it, and
 `purge_unfollowed_remote_posts/0` deletes precisely the copies nobody holds. It
-is the third exemption in `spare_held/1` beside a reshare (#1166) and a boost
-(#1167), under the same rule — it buys the right to live out the ordinary clock,
+is one of five exemptions in `spare_held/1`, beside a reshare (#1166), a boost
+(#1167), a quote (#1609) and an ended follow's span (#1673), under the same
+rule — it buys the right to live out the ordinary clock,
 never extra time, and `expires_at` counts from **receipt**, so an old post lives
 its full retention from the lookup rather than arriving already expired.
 

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -66,6 +66,7 @@ defmodule Vutuv.Fediverse do
   alias Vutuv.Fediverse.NoteEvent
   alias Vutuv.Fediverse.NoteLike
   alias Vutuv.Fediverse.NoteRepost
+  alias Vutuv.Fediverse.PastFollow
   alias Vutuv.Fediverse.PostBoost
   alias Vutuv.Fediverse.PostDelivery
   alias Vutuv.Fediverse.PostLike
@@ -93,6 +94,11 @@ defmodule Vutuv.Fediverse do
   alias Vutuv.Repo
   alias Vutuv.SearchText
   alias Vutuv.Social
+  # The local twin of `Vutuv.Fediverse.PastFollow`, renamed because both
+  # answer the same question about a different kind of follow and this
+  # module asks both: a member here reshared what an account out there
+  # wrote, so who put it in the feed is a member's follow.
+  alias Vutuv.Social.PastFollow, as: PastMemberFollow
   alias Vutuv.SocialFeed.Http
   alias Vutuv.Tags
   alias Vutuv.Tags.Tag
@@ -1484,9 +1490,12 @@ defmodule Vutuv.Fediverse do
       follow ->
         undo_remote_follow(owner, follow)
         Repo.delete(follow)
+        # Before the purge below, which reads it: the span is what keeps the
+        # posts this follow already delivered (issue #1673).
+        record_past_remote_follow(follow)
         # The cached posts existed because somebody here followed the author
         # (issue #1161). If nobody does any more, they go now rather than at the
-        # next sweep.
+        # next sweep — bar the ones a span still holds.
         purge_unfollowed_remote_posts([follow.remote_account_id])
         :ok
     end
@@ -1510,6 +1519,32 @@ defmodule Vutuv.Fediverse do
       nil -> {:error, :not_found}
       follow -> unfollow_remote(owner, follow.id)
     end
+  end
+
+  # Remembers how long a follow was in force, so what it delivered stays in the
+  # member's feed after it ends (issue #1673) and the cached copies it delivered
+  # survive the purge. The member-facing unfollow above calls it and nothing
+  # else does — see `Vutuv.Fediverse.PastFollow` for why a muted follow and a
+  # page's follow record nothing.
+  defp record_past_remote_follow(%Follow{muted: true}), do: :ok
+  defp record_past_remote_follow(%Follow{user_id: nil}), do: :ok
+
+  defp record_past_remote_follow(%Follow{} = follow) do
+    changeset =
+      PastFollow.changeset(%PastFollow{}, %{
+        user_id: follow.user_id,
+        remote_account_id: follow.remote_account_id,
+        # The follow row's own clock, in UTC: `timestamps/0` is naive here and
+        # everything the span is compared against is not.
+        started_at: DateTime.from_naive!(follow.inserted_at, "Etc/UTC"),
+        ended_at: DateTime.utc_now(:second)
+      })
+
+    # A failed insert (the account deleted mid-request) must not turn an
+    # unfollow into a 500: the span is a reading convenience, the unfollow is
+    # the member's actual instruction and it has already happened.
+    _ = Repo.insert(changeset)
+    :ok
   end
 
   @doc """
@@ -2016,9 +2051,24 @@ defmodule Vutuv.Fediverse do
     drop_note_reposts(user)
 
     {count, _} = Repo.delete_all(from(f in Follow, where: f.user_id == ^user.id))
+    # And the spans of the follows they ended earlier (issue #1673). Somebody
+    # switching this off or leaving asked to be out of it, so a hold on a
+    # stranger's cached post kept in their name is the opposite of the request
+    # — and without this the purge below would spare what it is here to remove.
+    # The delete hands back the accounts it freed, which are exactly the ones
+    # the purge would otherwise never look at: the member has no follow of them
+    # left to name them with.
+    {_, spanned_account_ids} =
+      Repo.delete_all(
+        from(w in PastFollow, where: w.user_id == ^user.id, select: w.remote_account_id)
+      )
+
     # Their cached posts existed because this member followed their authors
     # (issue #1161); for the ones nobody else here follows, that reason is gone.
-    purge_unfollowed_remote_posts(Enum.map(follows, & &1.remote_account_id))
+    purge_unfollowed_remote_posts(
+      Enum.uniq(Enum.map(follows, & &1.remote_account_id) ++ spanned_account_ids)
+    )
+
     count
   end
 
@@ -3001,14 +3051,19 @@ defmodule Vutuv.Fediverse do
     end
   end
 
+  # What `follow_sets/1` tags a span row with in its union: the three real
+  # `Vutuv.Fediverse.Follow` states are requested, accepted and moved, so this
+  # can never collide with one.
+  @past_follow_state "past"
+
   def feed_remote_posts(viewer, fetch_n, cursor, opts \\ [])
 
   def feed_remote_posts(%User{} = viewer, fetch_n, cursor, opts) do
     if enabled?() do
-      case followed_account_ids_by_state(viewer) do
-        # Most members follow nobody out there; for them this source is one
-        # cheap lookup and no post query at all.
-        {[], []} ->
+      case follow_sets(viewer) do
+        # Most members follow nobody out there, and never did; for them this
+        # source is one cheap lookup and no post query at all.
+        {[], [], []} ->
           []
 
         follows ->
@@ -3021,23 +3076,75 @@ defmodule Vutuv.Fediverse do
     end
   end
 
-  # The viewer's non-muted remote follows, split by what each one is allowed to
-  # show: an **accepted** follow sees everything that account posts, a pending
-  # one only its open audiences.
+  # The three account sets that can put a row in this member's feed, and what
+  # each one may show: an **accepted** follow sees everything that account
+  # posts, a **pending** one only its open audiences, and an account only an
+  # ended follow's span stands for (issue #1673) those same open audiences,
+  # from inside the span. Read as constant id lists rather than left to a join,
+  # and that is the whole point of both sources' shape — see
+  # `remote_posts_query/4`.
   #
-  # Read as two id lists rather than left to a join, and that is the whole
-  # point of this source's shape — see `remote_posts_query/4`.
-  defp followed_account_ids_by_state(%User{id: viewer_id}) do
-    from(f in Follow,
-      where: f.user_id == ^viewer_id and f.muted == false,
-      select: {f.remote_account_id, f.state}
-    )
-    |> Repo.all()
-    |> Enum.split_with(fn {_id, state} -> state == "accepted" end)
-    |> then(fn {accepted, pending} ->
-      {Enum.map(accepted, &elem(&1, 0)), Enum.map(pending, &elem(&1, 0))}
-    end)
+  # **One** round trip for all three, and one for both sources: most members
+  # follow nobody out there and never did, and this is then the entire cost of
+  # the remote half of their feed (`fediverse_remote_posts_source_test.exs`
+  # pins it at a single lookup). The boost source used to run its own booster
+  # query, which was byte-for-byte the accepted half of this one.
+  defp follow_sets(%User{id: viewer_id}) do
+    live =
+      from(f in Follow,
+        where: f.user_id == ^viewer_id,
+        select: %{account_id: f.remote_account_id, state: f.state, muted: f.muted}
+      )
+
+    spans =
+      from(w in PastFollow,
+        where: w.user_id == ^viewer_id,
+        select: %{
+          account_id: w.remote_account_id,
+          state: type(^@past_follow_state, :string),
+          muted: type(^false, :boolean)
+        }
+      )
+
+    live |> union_all(^spans) |> Repo.all() |> split_follow_sets()
   end
+
+  # A **currently muted** account is dropped from all three sets, whatever its
+  # spans say: muting means "their posts leave my feed", retroactively, so a
+  # span from an earlier spell of following must not be a way back in. Settled
+  # here, in memory, rather than as a `NOT IN` subquery on every read.
+  defp split_follow_sets(rows) do
+    muted = for %{account_id: id, muted: true} <- rows, into: MapSet.new(), do: id
+    heard = Enum.reject(rows, &MapSet.member?(muted, &1.account_id))
+    {accepted, rest} = Enum.split_with(heard, &(&1.state == "accepted"))
+    {past, pending} = Enum.split_with(rest, &(&1.state == @past_follow_state))
+
+    {account_ids(accepted), account_ids(pending), account_ids(past)}
+  end
+
+  defp account_ids(rows), do: rows |> Enum.map(& &1.account_id) |> Enum.uniq()
+
+  # Whether an ended follow was in force at the moment the row in `binding`
+  # carries in `field` — a cached post's `published_at`, a boost's
+  # `announced_at`. With a viewer it is this member's own follow; without one
+  # it asks whether **anybody** here held that span, which is the question
+  # `spare_held/1` puts to a copy nobody follows the author of any more.
+  #
+  # The upper bound is **exclusive** on purpose: every timestamp involved has
+  # second resolution, and letting through something from the very second of
+  # the unfollow would break the promise the member just made themselves. One
+  # function for all three readings so that rule has a single place to drift
+  # from — the purge's copy is the one where a drift silently *deletes* posts.
+  defp inside_past_remote_follow(binding, field) do
+    from(w in PastFollow,
+      where: w.remote_account_id == field(parent_as(^binding), :remote_account_id),
+      where: field(parent_as(^binding), ^field) >= w.started_at,
+      where: field(parent_as(^binding), ^field) < w.ended_at
+    )
+  end
+
+  defp inside_past_remote_follow(viewer_id, binding, field),
+    do: where(inside_past_remote_follow(binding, field), [w], w.user_id == ^viewer_id)
 
   # A counter needs the id and the timestamp and nothing else, and here that
   # really is all the database sends: no preloads and a two-column `SELECT`.
@@ -3080,14 +3187,31 @@ defmodule Vutuv.Fediverse do
   # The rows are identical to the join's — `fediverse_follows` is unique on
   # `(user_id, remote_account_id)`, so the join could never duplicate or drop a
   # post either. `remote_posts_source_test.exs` pins that.
-  defp remote_posts_query(%User{} = viewer, {accepted, pending}, fetch_n, cursor) do
+  #
+  # An **ended** follow reaches this feed through the same array (issue #1673):
+  # its account is in it, and the second clause then asks the span whether this
+  # particular post was published while the follow was in force. So the scan
+  # stays bounded by a constant array and the span costs one index probe on the
+  # rows that array already let through — never a plan that has to consider
+  # every cached post. A span shows open audiences only: the follow is over, and
+  # a followers-only post was never for a stranger.
+  defp remote_posts_query(
+         %User{id: viewer_id} = viewer,
+         {accepted, pending, past},
+         fetch_n,
+         cursor
+       ) do
     from(p in RemotePost,
+      as: :post,
       join: a in RemoteAccount,
       as: :remote_account,
       on: a.id == p.remote_account_id,
+      where: p.remote_account_id in ^Enum.uniq(accepted ++ pending ++ past),
       where:
         p.remote_account_id in ^accepted or
-          (p.remote_account_id in ^pending and p.audience in ^RemotePost.open_audiences()),
+          (p.audience in ^RemotePost.open_audiences() and
+             (p.remote_account_id in ^pending or
+                exists(subquery(inside_past_remote_follow(viewer_id, :post, :published_at))))),
       order_by: [desc: p.published_at, desc: p.id],
       limit: ^fetch_n
     )
@@ -3114,6 +3238,7 @@ defmodule Vutuv.Fediverse do
   def feed_remote_reposts(%User{id: viewer_id} = viewer, fetch_n, cursor, opts) do
     if enabled?() do
       from(r in PostRepost,
+        as: :repost,
         join: p in RemotePost,
         as: :language_source,
         on: p.id == r.remote_post_id,
@@ -3151,22 +3276,44 @@ defmodule Vutuv.Fediverse do
   # suspended account must not be able to keep doing while its case is open.
   defp scope_resharer(query, viewer_id, :mine), do: where(query, [r], r.user_id == ^viewer_id)
 
-  defp scope_resharer(query, viewer_id, :others) do
-    where(
-      query,
-      [r, resharer: resharer],
-      r.user_id != ^viewer_id and r.user_id in subquery(unmuted_followees(viewer_id)) and
+  # A dynamic all the way down: Ecto only interpolates one at the *top level* of
+  # a `where`, so the whole clause is built as one rather than `and`-ed into a
+  # keyword query.
+  defp scope_resharer(query, viewer_id, :others),
+    do:
+      where(query, ^dynamic([repost: r], r.user_id != ^viewer_id and ^from_a_followee(viewer_id)))
+
+  defp scope_resharer(query, viewer_id, _both),
+    do:
+      where(query, ^dynamic([repost: r], r.user_id == ^viewer_id or ^from_a_followee(viewer_id)))
+
+  # Somebody else whose reshare reaches this reader: a member they follow now,
+  # or one whose follow had not ended yet when the reshare was made (issue
+  # #1673). The second half is the local rule this module has to know too —
+  # unfollowing a member here already leaves their own posts in the scrollback
+  # (`Vutuv.Posts` reads the same spans), so what they passed on from another
+  # network vanishing while those stay is the same bug one table over.
+  #
+  # Read against the reshare's own time, since that is when it was delivered,
+  # and against a **member's** span: `followee_organization_id` is never set on
+  # a row that matches, because only members press this button. Two subplans in
+  # the filter rather than a semi-join, which costs nothing worth measuring on
+  # tables holding 84 and 0 rows — revisit it there before here.
+  defp from_a_followee(viewer_id) do
+    dynamic(
+      [repost: r, resharer: resharer],
+      (r.user_id in subquery(unmuted_followees(viewer_id)) or
+         exists(subquery(carried_by_past_member_follow(viewer_id)))) and
         account_confirmed_row(resharer) and not account_hidden_row(resharer)
     )
   end
 
-  defp scope_resharer(query, viewer_id, _both) do
-    where(
-      query,
-      [r, resharer: resharer],
-      r.user_id == ^viewer_id or
-        (r.user_id in subquery(unmuted_followees(viewer_id)) and
-           account_confirmed_row(resharer) and not account_hidden_row(resharer))
+  defp carried_by_past_member_follow(viewer_id) do
+    from(w in PastMemberFollow,
+      where: w.follower_id == ^viewer_id,
+      where: w.followee_id == parent_as(:repost).user_id,
+      where: parent_as(:repost).inserted_at >= w.started_at,
+      where: parent_as(:repost).inserted_at < w.ended_at
     )
   end
 
@@ -3284,12 +3431,7 @@ defmodule Vutuv.Fediverse do
   #
   # So this is what makes that index earn its keep beyond the first ten cards.
   defp remote_boosts_query(%User{id: viewer_id} = viewer, fetch_n, cursor, opts) do
-    boosters =
-      from(f in Follow,
-        where: f.user_id == ^viewer_id and f.muted == false and f.state == "accepted",
-        select: f.remote_account_id
-      )
-      |> Repo.all()
+    {boosters, _pending, past_boosters} = follow_sets(viewer)
 
     # The author's own follow is consulted too, not only the booster's: a
     # reader who muted an account out there muted *them*, and somebody else
@@ -3301,6 +3443,7 @@ defmodule Vutuv.Fediverse do
       )
 
     from(b in PostBoost,
+      as: :boost,
       join: a in RemoteAccount,
       as: :remote_account,
       on: a.id == b.remote_account_id,
@@ -3313,7 +3456,13 @@ defmodule Vutuv.Fediverse do
       left_join: author in RemoteAccount,
       as: :boosted_author,
       on: author.id == rp.remote_account_id,
-      where: b.remote_account_id in ^boosters,
+      where: b.remote_account_id in ^Enum.uniq(boosters ++ past_boosters),
+      # What a follow passed on while it stood keeps standing after it ends
+      # (issue #1673), read against the boost's own clock — the sharing is what
+      # arrived, so the sharing is what the span is asked about.
+      where:
+        b.remote_account_id in ^boosters or
+          exists(subquery(inside_past_remote_follow(viewer_id, :boost, :announced_at))),
       where: is_nil(rp.id) or rp.remote_account_id not in subquery(muted_authors),
       order_by: [desc: b.announced_at, desc: b.id],
       limit: ^fetch_n,
@@ -3939,8 +4088,14 @@ defmodule Vutuv.Fediverse do
   #     for a quote, since the quoted author is usually a stranger here, and
   #     sweeping the copy would turn a card in somebody's feed back into a bare
   #     link while they are looking at it.
+  #   * a member here **used to follow** its author and the copy is from inside
+  #     that span (issue #1673) — the one hold that answers this function's own
+  #     question with "yes, somebody did". Unfollowing ends the future, not the
+  #     past, so the posts that had already reached a reader stay in their feed;
+  #     without this every one of them would be deleted by the very unfollow
+  #     that is supposed to leave them alone.
   #
-  # None of the four buys extra time: they only buy the right to live out the
+  # None of the five buys extra time: they only buy the right to live out the
   # ordinary clock instead of being swept the moment the last follower of the
   # author walks away. The `:post` alias comes from `spare_reposted/2`, which is
   # why the others are added on top of it rather than beside it.
@@ -3949,11 +4104,14 @@ defmodule Vutuv.Fediverse do
     looked_up = from(l in PostLookup, where: l.remote_post_id == parent_as(:post).id)
     quoted = from(q in RemotePost, where: q.quoted_post_id == parent_as(:post).id)
 
+    spanned = inside_past_remote_follow(:post, :published_at)
+
     query
     |> spare_reposted(RemotePost)
     |> where([p], not exists(boosted))
     |> where([p], not exists(looked_up))
     |> where([p], not exists(quoted))
+    |> where([p], not exists(spanned))
   end
 
   @doc """
@@ -8588,6 +8746,7 @@ defmodule Vutuv.Fediverse do
   def feed_remote_reply_reposts(%User{id: viewer_id} = viewer, fetch_n, cursor, opts) do
     if enabled?() do
       from(r in NoteRepost,
+        as: :repost,
         join: n in Note,
         as: :language_source,
         on: n.id == r.note_id,

--- a/lib/vutuv/fediverse/past_follow.ex
+++ b/lib/vutuv/fediverse/past_follow.ex
@@ -1,0 +1,58 @@
+defmodule Vutuv.Fediverse.PastFollow do
+  @moduledoc """
+  The span an ended follow of an account on another network was in force
+  (issue #1673): `user_id` followed `remote_account_id` from `started_at` until
+  `ended_at`.
+
+  The twin of `Vutuv.Social.PastFollow`, whose moduledoc carries the shared
+  half: the feed reads the *current* follow set, so unfollowing used to take
+  the account's whole back catalogue with it, and a row here is what stays
+  behind. Posts published and boosts announced inside the span keep showing;
+  nothing after `ended_at` ever arrives. It records nothing for a **muted**
+  follow (the mute already hid the past) and nothing for a **page's** follow,
+  which is why the follower here is a member rather than the member-or-page
+  pair `Vutuv.Fediverse.Follow` carries — only members have a feed.
+
+  What is new on this side is a second job. A cached copy of a stranger's post
+  is only held here because somebody follows its author, so
+  `Vutuv.Fediverse.purge_unfollowed_remote_posts/1` deletes it the moment the
+  last follower walks away — which would delete exactly the posts a span
+  promises to keep. A span is therefore also a **hold** in `spare_held/1`, the
+  fifth beside a reshare (#1166), a boost (#1167), a lookup (#1211) and a quote
+  (#1609), buying what they buy: the right to live out the ordinary
+  `expires_at` clock, never a day past it. And a member switching federation
+  off or leaving takes their spans with them (`drop_remote_follows/1`) — they
+  asked to be out of it, so a hold kept in their name is the opposite of the
+  request.
+
+  Written at the member-facing unfollow chokepoint
+  (`Vutuv.Fediverse.unfollow_remote/2`) and nowhere else. Nothing here is a
+  permission: a span shows only what the account published to an **open**
+  audience (`Vutuv.Fediverse.RemotePost.open_audiences/0`), so a followers-only
+  post drops out of the feed the moment the follow ends, span or no span.
+  """
+
+  use VutuvWeb, :model
+
+  schema "fediverse_past_follows" do
+    belongs_to(:user, Vutuv.Accounts.User)
+    belongs_to(:remote_account, Vutuv.Fediverse.RemoteAccount)
+    # UTC rather than the naive stamps the local twin carries: these are
+    # compared against `fediverse_posts.published_at` and
+    # `fediverse_post_boosts.announced_at`, and every timestamp on this side of
+    # the border is a `utc_datetime`.
+    field(:started_at, :utc_datetime)
+    field(:ended_at, :utc_datetime)
+
+    timestamps()
+  end
+
+  @doc "A span from the follow that just ended."
+  def changeset(model, params) do
+    model
+    |> cast(params, [:user_id, :remote_account_id, :started_at, :ended_at])
+    |> validate_required([:user_id, :remote_account_id, :started_at, :ended_at])
+    |> foreign_key_constraint(:user_id)
+    |> foreign_key_constraint(:remote_account_id)
+  end
+end

--- a/priv/repo/migrations/20260904133114_create_fediverse_past_follows.exs
+++ b/priv/repo/migrations/20260904133114_create_fediverse_past_follows.exs
@@ -1,0 +1,44 @@
+defmodule Vutuv.Repo.Migrations.CreateFediversePastFollows do
+  @moduledoc """
+  The span an ended follow of an account on another network was in force, kept
+  after the follow row itself is gone (issue #1673) — the fediverse half of
+  `past_follows`. `Vutuv.Fediverse.PastFollow` says what it is for.
+
+  No unique index, and none is wanted: following and unfollowing the same
+  account twice leaves two spans, disjoint by construction since the second
+  begins after the first ended.
+
+  New table, so N-1 compatible: the running release neither reads nor writes it.
+  """
+  use Ecto.Migration
+
+  def change do
+    create table(:fediverse_past_follows) do
+      add(:user_id, references(:users, on_delete: :delete_all), null: false)
+
+      add(
+        :remote_account_id,
+        references(:fediverse_remote_accounts, on_delete: :delete_all),
+        null: false
+      )
+
+      # UTC, like every other timestamp on this side of the border and like the
+      # `fediverse_posts.published_at` and `fediverse_post_boosts.announced_at`
+      # these are compared against.
+      add(:started_at, :utc_datetime, null: false)
+      add(:ended_at, :utc_datetime, null: false)
+
+      timestamps()
+    end
+
+    # What the two feed sources ask, once per candidate row: "did this account
+    # reach me, and when". Both ends of the span ride along so the probe is
+    # index-only — the range test is the whole point of the lookup, and without
+    # them every probe would go to the heap for two timestamps.
+    create(index(:fediverse_past_follows, [:user_id, :remote_account_id, :started_at, :ended_at]))
+
+    # What the purge asks, which is the same question with nobody in it: "does
+    # anybody's span still hold this copy". Reader-first would be no use to it.
+    create(index(:fediverse_past_follows, [:remote_account_id, :started_at, :ended_at]))
+  end
+end

--- a/test/support/mastodon_helpers.ex
+++ b/test/support/mastodon_helpers.ex
@@ -190,12 +190,14 @@ defmodule Vutuv.MastodonHelpers do
   writes when the thing announced is a member's own (`post_id` set,
   `remote_post_id` nil).
   """
-  def boost(%RemoteAccount{} = account, %Post{} = post) do
+  def boost(%RemoteAccount{} = account, %Post{} = post, attrs \\ []) do
     Repo.insert!(%PostBoost{
       remote_account_id: account.id,
       post_id: post.id,
       activity_id: "https://social.example/activities/#{unique_suffix()}",
-      announced_at: DateTime.utc_now(:second)
+      # Overridable so a test can place the boost against a follow's span
+      # (issue #1673): the feed reads the announce time, not the post's.
+      announced_at: attrs[:announced_at] || DateTime.utc_now(:second)
     })
   end
 

--- a/test/support/posts_helpers.ex
+++ b/test/support/posts_helpers.ex
@@ -8,6 +8,9 @@ defmodule Vutuv.PostsHelpers do
   alias Vutuv.Posts.PostLike
   alias Vutuv.Posts.PostRepost
   alias Vutuv.Repo
+  alias Vutuv.Social
+  alias Vutuv.Social.Follow
+  alias Vutuv.Social.PastFollow
   alias Vutuv.ViewerClock
 
   @doc """
@@ -83,5 +86,39 @@ defmodule Vutuv.PostsHelpers do
   """
   def page_like!(post, page) do
     Repo.insert!(%PostLike{post_id: post.id, organization_id: page.id})
+  end
+
+  @doc """
+  `viewer` follows and unfollows `author` for real, then the recorded span
+  (issue #1673) is moved to `started_ago .. ended_ago` seconds before now, so
+  the test can put posts cleanly before, inside and after it.
+
+  Here rather than in a test file because both suites that read spans need it
+  and the subtlety is worth keeping in one place: the rewrite is scoped to the
+  span this call just wrote, so a test can lay down two spells of following
+  without the second rewriting the first.
+  """
+  def followed_between!(viewer, author, started_ago, ended_ago) do
+    started_at = NaiveDateTime.add(NaiveDateTime.utc_now(:second), -started_ago)
+    ended_at = NaiveDateTime.add(NaiveDateTime.utc_now(:second), -ended_ago)
+    Vutuv.Factory.follow!(viewer, author)
+
+    Repo.update_all(
+      from(f in Follow, where: f.follower_id == ^viewer.id and f.followee_id == ^author.id),
+      set: [inserted_at: started_at]
+    )
+
+    Social.unfollow!(viewer.id, Social.follow_id(viewer.id, author.id))
+
+    {1, nil} =
+      Repo.update_all(
+        from(w in PastFollow,
+          where: w.follower_id == ^viewer.id and w.followee_id == ^author.id,
+          where: w.started_at == ^started_at
+        ),
+        set: [ended_at: ended_at]
+      )
+
+    :ok
   end
 end

--- a/test/vutuv/fediverse_past_follows_test.exs
+++ b/test/vutuv/fediverse_past_follows_test.exs
@@ -1,0 +1,298 @@
+defmodule Vutuv.FediversePastFollowsTest do
+  @moduledoc """
+  Unfollowing an account on another network stops the future without erasing the
+  past (issue #1673) — the fediverse half of `feed_past_follows_test.exs`.
+
+  Two things had to change for it, and both are covered here. The feed reads the
+  *current* follow set, so an unfollow used to take the account's whole back
+  catalogue with it; and a cached copy of a stranger's post is only held here
+  while somebody follows its author, so the unfollow **deleted** those copies
+  outright. A span in `fediverse_past_follows` answers both: it is what the two
+  remote feed sources read, and it is a hold against the purge.
+
+  Every test places its posts against an explicit span rather than trusting
+  wall-clock ordering: the follow's `inserted_at`, the span's `ended_at` and a
+  post's `published_at` all have **second** resolution, so a test that just
+  follows, posts and unfollows puts all three in the same second and proves
+  nothing about the boundaries.
+  """
+  use Vutuv.DataCase, async: true
+
+  import Vutuv.MastodonHelpers
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.PastFollow
+  alias Vutuv.Fediverse.PostRepost
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Posts
+  alias Vutuv.PostsHelpers
+
+  defp member, do: insert(:activated_user, fediverse_followers?: true)
+
+  defp ago(seconds), do: DateTime.add(DateTime.utc_now(:second), -seconds)
+
+  defp account(handle), do: remote_account(handle: handle)
+
+  defp follow(user, account, attrs \\ []) do
+    Repo.insert!(%Follow{
+      user_id: user.id,
+      remote_account_id: account.id,
+      state: attrs[:state] || "accepted",
+      muted: attrs[:muted] || false,
+      follow_activity_id:
+        "https://vutuv.test/#{user.id}/actor#f/#{account.id}/#{System.unique_integer([:positive])}"
+    })
+  end
+
+  defp post(account, text, seconds_ago, audience \\ "public"),
+    do:
+      cached_post(account,
+        content_text: text,
+        audience: audience,
+        published_at: ago(seconds_ago)
+      )
+
+  # Follows and unfollows for real, then moves both ends of the recorded span,
+  # so the test can put posts cleanly before, inside and after it. The member
+  # twin is `Vutuv.PostsHelpers.followed_between!/4`.
+  defp followed_remote_between!(user, account, started_ago, ended_ago) do
+    started_at = ago(started_ago)
+    row = follow(user, account)
+
+    {1, nil} =
+      Repo.update_all(from(f in Follow, where: f.id == ^row.id),
+        set: [inserted_at: DateTime.to_naive(started_at)]
+      )
+
+    :ok = Fediverse.unfollow_remote(user, row.id)
+
+    # Scoped to the span this call just wrote (its start is the follow's), so a
+    # test can lay down two spells of following without the second rewriting
+    # the first.
+    {1, nil} =
+      Repo.update_all(
+        from(w in PastFollow,
+          where: w.user_id == ^user.id and w.remote_account_id == ^account.id,
+          where: w.started_at == ^started_at
+        ),
+        set: [ended_at: ago(ended_ago)]
+      )
+
+    :ok
+  end
+
+  defp feed_texts(user),
+    do: user |> Fediverse.feed_remote_posts(20, nil) |> Enum.map(& &1.remote_post.content_text)
+
+  defp spans(user), do: Repo.all(from(w in PastFollow, where: w.user_id == ^user.id))
+
+  describe "recording the span" do
+    test "an unfollow records when the follow began and when it ended" do
+      user = member()
+      them = account("alpha")
+      row = follow(user, them)
+
+      :ok = Fediverse.unfollow_remote(user, row.id)
+
+      assert [%PastFollow{} = span] = spans(user)
+      assert span.remote_account_id == them.id
+      assert span.started_at == DateTime.from_naive!(row.inserted_at, "Etc/UTC")
+      assert DateTime.diff(DateTime.utc_now(), span.ended_at) < 5
+    end
+
+    test "a muted follow records nothing, so unfollowing cannot undo the mute" do
+      user = member()
+      them = account("muted")
+      row = follow(user, them, muted: true)
+
+      :ok = Fediverse.unfollow_remote(user, row.id)
+
+      assert spans(user) == []
+    end
+
+    test "a page's unfollow records nothing: only members have a feed" do
+      page = insert(:organization)
+      them = account("page-follows")
+
+      row =
+        Repo.insert!(%Follow{
+          organization_id: page.id,
+          remote_account_id: them.id,
+          state: "accepted",
+          follow_activity_id: "https://vutuv.test/#{page.id}/actor#f/#{them.id}"
+        })
+
+      :ok = Fediverse.unfollow_remote(page, row.id)
+
+      assert Repo.aggregate(PastFollow, :count) == 0
+    end
+
+    test "leaving the fediverse takes the member's spans with it" do
+      user = member()
+      them = account("gone")
+      :ok = followed_remote_between!(user, them, 600, 300)
+      assert [_] = spans(user)
+
+      Fediverse.drop_remote_follows(user)
+
+      assert spans(user) == []
+    end
+  end
+
+  describe "what the feed still shows" do
+    test "posts from inside the span stay, newer and older ones do not" do
+      user = member()
+      them = account("beta")
+      post(them, "before the follow", 900)
+      post(them, "while I followed", 450)
+      post(them, "after I left", 60)
+
+      :ok = followed_remote_between!(user, them, 600, 300)
+
+      assert feed_texts(user) == ["while I followed"]
+    end
+
+    test "a followers-only post from inside the span drops out with the follow" do
+      user = member()
+      them = account("gamma")
+      post(them, "public, from inside", 450)
+      post(them, "followers only, from inside", 440, "followers")
+
+      :ok = followed_remote_between!(user, them, 600, 300)
+
+      assert feed_texts(user) == ["public, from inside"]
+    end
+
+    # Green with and without the span, and deliberately so: what enforces it is
+    # the accepted-follow branch, which carries no time bound at all. It is here
+    # to catch the day somebody narrows that branch to "since the follow began"
+    # and quietly makes a span the only way to see anything older.
+    test "following again shows everything since, spans and all" do
+      user = member()
+      them = account("delta")
+      post(them, "while I followed", 450)
+      post(them, "in between", 200)
+
+      :ok = followed_remote_between!(user, them, 600, 300)
+      follow(user, them)
+      post(them, "since I came back", 10)
+
+      assert feed_texts(user) == ["since I came back", "in between", "while I followed"]
+    end
+
+    test "muting the account again keeps its past out too" do
+      user = member()
+      them = account("epsilon")
+      post(them, "while I followed", 450)
+
+      :ok = followed_remote_between!(user, them, 600, 300)
+      follow(user, them, muted: true)
+
+      assert feed_texts(user) == []
+    end
+
+    test "a boost announced during the span stays, a later one does not" do
+      user = member()
+      them = account("zeta")
+      boost(them, boostable_post("shared while I followed"), announced_at: ago(450))
+      boost(them, boostable_post("shared after I left"), announced_at: ago(60))
+
+      :ok = followed_remote_between!(user, them, 600, 300)
+
+      assert boosted_bodies(user) == ["shared while I followed"]
+    end
+  end
+
+  describe "the cached copies" do
+    test "unfollowing keeps the copies from inside the span and drops the rest" do
+      user = member()
+      them = account("eta")
+      earlier = post(them, "before the follow", 900)
+      inside = post(them, "while I followed", 450)
+
+      :ok = followed_remote_between!(user, them, 600, 300)
+
+      assert Repo.get(RemotePost, inside.id)
+      refute Repo.get(RemotePost, earlier.id)
+    end
+
+    test "the hourly sweep leaves a spanned copy alone" do
+      user = member()
+      them = account("theta")
+      inside = post(them, "while I followed", 450)
+
+      :ok = followed_remote_between!(user, them, 600, 300)
+
+      assert Fediverse.purge_unfollowed_remote_posts() == 0
+      assert Repo.get(RemotePost, inside.id)
+    end
+
+    test "the span buys no extra time: the ceiling still takes the copy" do
+      user = member()
+      them = account("iota")
+      inside = post(them, "while I followed", 450)
+      :ok = followed_remote_between!(user, them, 600, 300)
+
+      Repo.update_all(from(p in RemotePost, where: p.id == ^inside.id),
+        set: [expires_at: ago(60)]
+      )
+
+      assert Fediverse.expire_due_remote_posts() == 1
+      refute Repo.get(RemotePost, inside.id)
+    end
+
+    test "leaving the fediverse drops the copies the spans were holding" do
+      user = member()
+      them = account("kappa")
+      inside = post(them, "while I followed", 450)
+      :ok = followed_remote_between!(user, them, 600, 300)
+      assert Repo.get(RemotePost, inside.id)
+
+      Fediverse.drop_remote_follows(user)
+
+      refute Repo.get(RemotePost, inside.id)
+    end
+  end
+
+  describe "what a member here passed on" do
+    test "a reshare made during the span stays after unfollowing them" do
+      user = member()
+      resharer = member()
+      them = account("lambda")
+
+      reshare!(resharer, post(them, "carried while I followed", 450), 450)
+      reshare!(resharer, post(them, "carried after I left", 60), 60)
+
+      :ok = PostsHelpers.followed_between!(user, resharer, 600, 300)
+
+      assert reshared_texts(user) == ["carried while I followed"]
+    end
+  end
+
+  # A vutuv member's own post, for the boost source: `post_id` boosts need no
+  # third server to resolve.
+  defp boostable_post(body), do: PostsHelpers.create_post!(federating_member(), %{body: body})
+
+  defp boosted_bodies(user) do
+    user
+    |> Posts.feed_page(limit: 20)
+    |> Map.fetch!(:entries)
+    |> Enum.filter(&(&1[:boosted_by] != nil))
+    |> Enum.map(& &1.post.body)
+  end
+
+  defp reshare!(resharer, remote_post, seconds_ago) do
+    row = Repo.insert!(%PostRepost{user_id: resharer.id, remote_post_id: remote_post.id})
+
+    {1, nil} =
+      Repo.update_all(from(r in PostRepost, where: r.id == ^row.id),
+        set: [inserted_at: DateTime.to_naive(ago(seconds_ago))]
+      )
+
+    :ok
+  end
+
+  defp reshared_texts(user),
+    do: user |> Fediverse.feed_remote_reposts(20, nil) |> Enum.map(& &1.remote_post.content_text)
+end

--- a/test/vutuv/feed_past_follows_test.exs
+++ b/test/vutuv/feed_past_follows_test.exs
@@ -47,35 +47,6 @@ defmodule Vutuv.FeedPastFollowsTest do
 
   defp feed_ids(viewer), do: Posts.feed_page(viewer).entries |> Enum.map(& &1.post.id)
 
-  # Follows and unfollows for real, then moves the recorded span to
-  # `started_ago .. ended_ago` seconds before now, so the test can put posts
-  # cleanly before, inside and after it.
-  defp followed_between!(viewer, author, started_ago, ended_ago) do
-    started_at = ago(started_ago)
-    follow!(viewer, author)
-
-    Repo.update_all(
-      from(f in Follow, where: f.follower_id == ^viewer.id and f.followee_id == ^author.id),
-      set: [inserted_at: started_at]
-    )
-
-    Social.unfollow!(viewer.id, Social.follow_id(viewer.id, author.id))
-
-    # Scoped to the span this call just wrote (its start is the follow's), so a
-    # test can lay down two spells of following without the second rewriting the
-    # first.
-    {1, nil} =
-      Repo.update_all(
-        from(w in PastFollow,
-          where: w.follower_id == ^viewer.id and w.followee_id == ^author.id,
-          where: w.started_at == ^started_at
-        ),
-        set: [ended_at: ago(ended_ago)]
-      )
-
-    :ok
-  end
-
   describe "recording the span" do
     test "an unfollow records when the follow began and when it ended" do
       viewer = user()


### PR DESCRIPTION
Unfollowing an account on another network emptied the reader's feed of everything that account had ever posted — and deleted the cached copies outright, since a copy is only held here while somebody follows its author. #1673 fixed this for vutuv accounts and left the fediverse half out on purpose.

`fediverse_past_follows` records the span a follow was in force. The two remote feed sources read it, and it is a fifth hold in `spare_held/1` so the purge leaves those copies alone — it buys no time past the ordinary `expires_at`. Open audiences only: a followers-only post still goes with the follow.

Also here: a member's reshares of remote posts follow the same rule now, and the fediverse half of a feed page costs one query instead of three.

Where: `Vutuv.Fediverse.unfollow_remote/2` and `feed_remote_posts/4`.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01VSsg39q3MyBe3pp4n7cuu7
