### PR TITLE
Show the answered post above the answer on a post permalink

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -7820,6 +7820,40 @@ defmodule Vutuv.Fediverse do
         do: post.id
   end
 
+  @doc """
+  Whether a page open to **everyone** may show this cached post — the arm
+  `remote_post_readable?/2` deliberately does not have, because it answers for a
+  signed-in party and a public page has readers who are nobody.
+
+  Two halves, and both are already spelled in SQL by the two viewer-independent
+  public readers here (`Vutuv.Tags.Timeline.remote_posts_query/1` and
+  `recent_public_remote_posts/1`): outright `public` — never `unlisted`, whose
+  whole meaning is "keep me off discovery surfaces" — and still inside the
+  retention ceiling, which is the claim to hold somebody else's post at all, so
+  a row the sweep has not reached yet is not one to keep publishing.
+  """
+  def publicly_readable_remote_post?(%RemotePost{expires_at: %DateTime{} = expires} = post),
+    do: RemotePost.public?(post) and DateTime.after?(expires, DateTime.utc_now(:second))
+
+  def publicly_readable_remote_post?(_post), do: false
+
+  @doc """
+  The same for a page of them, and the function a **public surface** asks
+  instead of `readable_remote_post_ids/2`: an anonymous reader gets
+  `publicly_readable_remote_post?/1`, a signed-in one the ordinary answer,
+  their own accepted follow included. One call, so a caller serving both never
+  has to hold the difference itself.
+  """
+  def publicly_readable_remote_post_ids(posts, nil) do
+    for post <- posts,
+        publicly_readable_remote_post?(post),
+        into: MapSet.new(),
+        do: post.id
+  end
+
+  def publicly_readable_remote_post_ids(posts, party),
+    do: readable_remote_post_ids(posts, party)
+
   # Claims one slot from the member's hourly like budget. `:ok`, or
   # `{:error, :like_capped}`.
   #

--- a/lib/vutuv/fediverse/remote_post.ex
+++ b/lib/vutuv/fediverse/remote_post.ex
@@ -194,6 +194,16 @@ defmodule Vutuv.Fediverse.RemotePost do
   def open?(%__MODULE__{audience: audience}), do: audience in @open_audiences
 
   @doc """
+  Whether the author addressed it to the public collection outright — stricter
+  than `open?/1`, which also takes `unlisted` in. The twin of
+  `Vutuv.Fediverse.Note.public?/1`, and the column half of what a page open to
+  everyone may show (`Vutuv.Fediverse.publicly_readable_remote_post?/1` adds the
+  retention half).
+  """
+  def public?(%__MODULE__{audience: "public"}), do: true
+  def public?(%__MODULE__{}), do: false
+
+  @doc """
   Whether the author put the post behind a content warning, or marked it
   sensitive. Either one closes the lid: the card shows the warning (or a plain
   "sensitive" line) and reveals the text on a click, which is the one thing the

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -3713,9 +3713,8 @@ defmodule Vutuv.Posts do
   # answer with nothing to read above it used to be.
   #
   # It rides `remote_reply_ref`, already preloaded with its account
-  # (`post_preloads/0`), so this costs no lookup — only the same three batch
-  # reads a remote card needs anywhere (its pictures, the reader's marks, the
-  # reader's follow), run once for the page. `taken` keeps a post that already
+  # (`post_preloads/0`), so finding one costs no lookup; what it costs beyond
+  # that is `decorate_remote_parents/2` below. `taken` keeps a post that already
   # has a card **further up the feed** from getting a second one; a post whose
   # own row is on *this* page is not in it — that row steps aside instead, see
   # `settle_remote_cards/5`.
@@ -3727,40 +3726,79 @@ defmodule Vutuv.Posts do
           Vutuv.Fediverse.subject_key(parent) not in taken,
           do: %{post_id: post.id, remote_post: parent}
 
-    case Enum.uniq_by(parents, &parent_key/1) do
+    case decorate_remote_parents(parents, viewer) do
+      empty when empty == %{} -> entries
+      by_post -> Enum.map(entries, &claim_remote_parents(&1, by_post))
+    end
+  end
+
+  @doc """
+  The cached post each of these posts answers (issue #1165), as the card the
+  renderer draws above it: `%{post_id => card}`, and `%{}` where none of them
+  answers anything out there.
+
+  What `attach_remote_parents/3` builds for the feed, for a caller holding a
+  plain list of posts instead of feed entries — the permalink's conversation
+  (`VutuvWeb.PostLive.Thread`), which is the page a link to such an answer
+  lands on and was the one place that showed the answer without what it
+  answers.
+  """
+  def remote_parents(posts, viewer) do
+    parents =
+      for post <- posts,
+          %RemotePost{} = parent <- [remote_parent(post)],
+          do: %{post_id: post.id, remote_post: parent}
+
+    decorate_remote_parents(parents, viewer)
+  end
+
+  # The shared tail of both callers: one card per cached post, only the ones
+  # this reader may read, and the batch reads a remote card needs, run once for
+  # the page rather than once per card. Nothing to draw means no read at all.
+  #
+  # **One card per cached post per page**, the rule `dedupe_remote/1`,
+  # `collapse_reposts/1` and `attach_thread_notes/3` already hold for the other
+  # kinds — and here it is not about repetition. The card's action bar is a
+  # LiveComponent keyed by the cached post
+  # (`RemoteActionsComponent.dom_id(:remote_post, id)`), so a second card emits
+  # a duplicate LiveView id, which raises inside `render_pending_components/6`
+  # during the **static** render: the page 500s rather than degrading. Two
+  # members answering the same post out there is ordinary behaviour, and the
+  # first such pair in the database took /feed down for every reader who had
+  # both answers on one page (2026-08-28). So the deduped list decides where
+  # the card renders as well as which reads run: the answers that do not claim
+  # it keep their "Replying to …" line, which is what this feature replaced and
+  # still beats an error page.
+  defp decorate_remote_parents(parents, viewer) do
+    case parents |> Enum.uniq_by(&parent_key/1) |> readable_parents(viewer) do
       [] ->
-        entries
+        %{}
 
       unique ->
-        # **One card per cached post per page**, the rule `dedupe_remote/1`,
-        # `collapse_reposts/1` and `attach_thread_notes/3` already hold for the
-        # other kinds — and here it is not about repetition. The card's action
-        # bar is a LiveComponent keyed by the cached post
-        # (`RemoteActionsComponent.dom_id(:remote_post, id)`), so a second card
-        # emits a duplicate LiveView id, which raises inside
-        # `render_pending_components/6` during the **static** render: the page
-        # 500s rather than degrading. Two members answering the same post out
-        # there is ordinary behaviour, and the first such pair in the database
-        # took /feed down for every reader who had both answers on one page
-        # (2026-08-28).
-        #
-        # `unique` therefore decides where the card renders as well as which
-        # batch reads run, and the placement is built from the decorated list
-        # itself — the older version kept a second list to re-expand from, and
-        # a comment saying the repeats "must not pay for the batch reads, not
-        # the places they render" is exactly how the trap was rationalised.
-        # The answers that do not claim it keep their "Replying to …" line,
-        # which is what this feature replaced and still beats an error page.
-        by_post =
-          unique
-          |> attach_remote_images()
-          |> attach_remote_quotes()
-          |> attach_remote_follows(viewer)
-          |> attach_remote_likes(viewer)
-          |> Map.new(&{&1.post_id, &1})
-
-        Enum.map(entries, &claim_remote_parents(&1, by_post))
+        unique
+        |> attach_remote_images()
+        |> attach_remote_quotes()
+        |> attach_remote_follows(viewer)
+        |> attach_remote_likes(viewer)
+        |> Map.new(&{&1.post_id, &1})
     end
+  end
+
+  # Whose audience lets *this* reader see it — never the audience the answer's
+  # author had. Answering a followers-only post in public is refused
+  # (`Fediverse.check_remote_post_reply/2`), but an audience narrows *after* the
+  # answer often enough that the composer re-reads the row for exactly that, and
+  # a card drawn above a public answer would then hand the post to every reader
+  # of that answer. The permalink is a public page, so the question is
+  # `Fediverse.publicly_readable_remote_post_ids/2` rather than the signed-in
+  # one, and an open parent — nearly all of them — costs no query either way.
+  defp readable_parents(parents, viewer) do
+    readable =
+      parents
+      |> Enum.map(& &1.remote_post)
+      |> Vutuv.Fediverse.publicly_readable_remote_post_ids(viewer)
+
+    Enum.filter(parents, &MapSet.member?(readable, &1.remote_post.id))
   end
 
   defp parent_key(%{remote_post: post}), do: Vutuv.Fediverse.subject_key(post)

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -1180,10 +1180,26 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   defp in_reply_to_line(%{url: nil, author: author}),
     do: "> " <> gettext("In reply to a deleted post by %{name}.", name: author)
 
-  defp in_reply_to_line(%{url: url, author: author}) do
+  defp in_reply_to_line(%{url: url, author: author} = ref) do
     author_link = md_link(author, url)
-    "> " <> gettext("In reply to a post by %{name}.", name: author_link)
+    "> " <> gettext("In reply to a post by %{name}.", name: author_link) <> answered_words(ref)
   end
+
+  # The words of the post answered, when the document carries them — an answer
+  # to another network (issue #1165), whose HTML page draws that post as a card
+  # above the answer. Inside the same blockquote, so it cannot be read as this
+  # post's own body, and escaped as text like every other stranger's writing
+  # here: it must not be able to mint links in our document.
+  defp answered_words(%{content_warning: warning} = ref) when is_binary(warning) do
+    "\n>\n> " <> gettext("Content warning") <> ": " <> md_text(warning) <> answered_text(ref)
+  end
+
+  defp answered_words(ref), do: answered_text(ref)
+
+  defp answered_text(%{text: text}) when is_binary(text) and text != "",
+    do: "\n>\n" <> Enum.map_join(String.split(text, "\n"), "\n", &("> " <> md_text(&1)))
+
+  defp answered_text(_ref), do: ""
 
   defp tags_line([]), do: nil
   defp tags_line(tags), do: "Tags: " <> Enum.map_join(tags, ", ", &"##{&1}")

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -670,9 +670,27 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
     end
   end
 
+  # `text` is the same words the HTML page draws above the answer as a card, so
+  # it is here under the same gate: our copy of the post, and only while a page
+  # open to everyone may show it (`Fediverse.publicly_readable_remote_post?/1`).
+  # Without it the `.md` sibling of an answer would name the post and withhold
+  # what it says while the page beside it prints both — and the reply written
+  # from out there, four fields further down, has carried its text since #1069.
+  # The handle and the origin URI come off the sidecar either way: they outlive
+  # our copy, which is the whole reason that row keeps them.
   defp remote_in_reply_to(%{remote_reply_ref: %PostRemoteReply{} = ref})
-       when is_binary(ref.handle),
-       do: %{url: ref.in_reply_to_uri, author: ref.handle, network: "fediverse"}
+       when is_binary(ref.handle) do
+    %{url: ref.in_reply_to_uri, author: ref.handle, network: "fediverse"}
+    |> Map.merge(remote_parent_words(ref.remote_post))
+  end
 
   defp remote_in_reply_to(_post), do: nil
+
+  defp remote_parent_words(%RemotePost{} = parent) do
+    if Fediverse.publicly_readable_remote_post?(parent),
+      do: %{text: parent.content_text, content_warning: parent.summary},
+      else: %{}
+  end
+
+  defp remote_parent_words(_parent), do: %{}
 end

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -816,8 +816,22 @@ defmodule VutuvWeb.AgentDocs.Text do
   defp in_reply_to_line(%{url: nil, author: author}),
     do: gettext("In reply to a deleted post by %{name}.", name: author)
 
-  defp in_reply_to_line(%{url: url, author: author}),
-    do: gettext("In reply to a post by %{name}.", name: author) <> " #{url}"
+  defp in_reply_to_line(%{url: url, author: author} = ref),
+    do:
+      gettext("In reply to a post by %{name}.", name: author) <> " #{url}" <> answered_words(ref)
+
+  # The words of the post answered, when the document carries them (issue
+  # #1165) — indented under the line naming its author, the way a reply from
+  # another network is indented under its own.
+  defp answered_words(%{content_warning: warning} = ref) when is_binary(warning),
+    do: "\n  " <> gettext("Content warning") <> ": #{warning}" <> answered_text(ref)
+
+  defp answered_words(ref), do: answered_text(ref)
+
+  defp answered_text(%{text: text}) when is_binary(text) and text != "",
+    do: "\n" <> indent_block(text, "  ")
+
+  defp answered_text(_ref), do: ""
 
   defp tags_line([]), do: nil
   defp tags_line(tags), do: "Tags: " <> Enum.join(tags, ", ")

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -965,7 +965,18 @@ defmodule VutuvWeb.PostComponents do
       entry_id: assigns.entry_id
     }
 
-    (ancestors ++ [leaf])
+    assemble_conversation(ancestors ++ [leaf], assigns)
+  end
+
+  # The assembly order of a conversation, for both surfaces that build one: the
+  # reply tree, the "Replying to" banner on whatever ended up a root, the
+  # replies from other networks woven in among the siblings, and the cached post
+  # an answer answers hung above it. Four stages that have to be remembered
+  # together, which is why they are written once — the permalink was missing the
+  # last of them for exactly as long as the two callers each spelled the list
+  # out for themselves.
+  defp assemble_conversation(cards, assigns) do
+    cards
     |> Posts.thread_forest()
     |> banner_on_roots()
     |> weave_remote_replies(
@@ -3292,6 +3303,13 @@ defmodule VutuvWeb.PostComponents do
         "one card, never the replies around it"
   )
 
+  attr(:remote_parents, :map,
+    default: %{},
+    doc:
+      "`%{post_id => card}` (`Vutuv.Posts.remote_parents/2`) for a post here " <>
+        "that answers one out there (issue #1165) — drawn above it, the way the feed draws it"
+  )
+
   attr(:conn_or_socket, :any, required: true)
   attr(:translations, :map, default: nil)
 
@@ -3329,6 +3347,7 @@ defmodule VutuvWeb.PostComponents do
   attr(:remote_replies, :map, default: %{})
   attr(:note_marks, :any, default: nil)
   attr(:likers, :any, default: nil)
+  attr(:remote_parents, :map, default: %{}, doc: "as on `thread_conversation/1`")
   attr(:conn_or_socket, :any, required: true)
   attr(:translations, :map, default: nil)
 
@@ -3407,6 +3426,12 @@ defmodule VutuvWeb.PostComponents do
   # is the first card on the page, the one case where the focused post has no
   # context above it and the page must not jump on arrival.
   defp conversation_nodes(posts, top_id, assigns) do
+    # A post with the card it answers drawn above it is no longer the page's
+    # first card, so the focus scrolls into view like any other post with
+    # context over it. Decided once, here, rather than as a second condition
+    # every card then evaluates.
+    top_id = if is_map_key(assigns.remote_parents, top_id), do: nil, else: top_id
+
     posts
     |> Enum.map(fn post ->
       focus? = post.id == assigns.focus_id
@@ -3427,13 +3452,7 @@ defmodule VutuvWeb.PostComponents do
         scroll?: assigns.auto_scroll? and focus? and post.id != top_id
       }
     end)
-    |> Posts.thread_forest()
-    |> banner_on_roots()
-    |> weave_remote_replies(
-      assigns[:remote_replies] || %{},
-      assigns.viewer,
-      assigns[:note_marks] || fn _note -> nil end
-    )
+    |> assemble_conversation(assigns)
   end
 
   # Hangs the replies written on other networks (issue #1069) under the posts

--- a/lib/vutuv_web/live/post_live/thread.ex
+++ b/lib/vutuv_web/live/post_live/thread.ex
@@ -5,6 +5,12 @@ defmodule VutuvWeb.PostLive.Thread do
   pattern: the controller keeps owning the URL, the agent-format negotiation
   and the page chrome; the socket owns the conversation card).
 
+  A conversation does not stop at the site's edge in either direction. The post
+  a member here answered on **another network** (issue #1165) is drawn above
+  their answer, the card the feed draws — until this, a permalink to that answer
+  showed a "Replying to @user@host" line and no way to what was being answered,
+  which is the half of the exchange the reader arrived for.
+
   Replies written on **other networks** (issues #1069 and #1071) are woven into
   the same conversation as ordinary siblings, in time order, wearing their own
   card (`VutuvWeb.PostComponents.remote_reply_card/1`); `Vutuv.Fediverse.list_notes/2`
@@ -55,12 +61,22 @@ defmodule VutuvWeb.PostLive.Thread do
   alias VutuvWeb.Live.InitAssigns
   alias VutuvWeb.Live.MountHandoff
   alias VutuvWeb.Live.PostTranslations
+  alias VutuvWeb.Live.RemoteImages
+  alias VutuvWeb.Live.RemotePostActions
   alias VutuvWeb.Live.RemoteReplyActions
   alias VutuvWeb.PostLive.ActionsComponent
 
   # The origin's like/repost figures on a card from another network tick
   # while this page is open (issue #1283). One line, no handler.
   on_mount(VutuvWeb.Live.RemoteCounts)
+
+  # And a picture on the cached post drawn above an answer (issue #1165)
+  # appears the moment there is something to show of it — the promise its
+  # waiting tile prints here as on every other surface. The hook's `:assigns`
+  # mode does not fit: those pictures ride the parent cards rather than an
+  # `@images` assign, so this host takes the bare subscription and writes the
+  # one `handle_info/2` that mode asks of it, below.
+  on_mount(RemoteImages)
 
   @impl true
   def mount(_params, session, socket) do
@@ -157,6 +173,24 @@ defmodule VutuvWeb.PostLive.Thread do
     {:noreply, take_down(socket, id, &RemoteReplyActions.report/2)}
   end
 
+  # The ⋯ menu of the cached post an answer here answers (issue #1165). Report
+  # deletes our copy, so the card has to leave; unfollowing may delete it too
+  # (nobody here follows the author any more), so both re-window. Mute keeps it,
+  # as it does on the cached post's own page: the reader asked to see less of
+  # that account in their feed, not to read this exchange with its first half
+  # missing.
+  def handle_event("report-remote-post", %{"id" => id}, socket) do
+    RemotePostActions.report(socket, id, &load_window/1)
+  end
+
+  def handle_event("mute-remote-account", %{"id" => account_id}, socket) do
+    RemotePostActions.mute(socket, account_id, & &1)
+  end
+
+  def handle_event("unfollow-remote-account", %{"id" => account_id}, socket) do
+    RemotePostActions.unfollow(socket, account_id, &load_window/1)
+  end
+
   @impl true
   def handle_event("translate", %{"kind" => kind, "id" => id}, socket) do
     case PostTranslations.request(socket.assigns.current_user, kind, id) do
@@ -216,6 +250,24 @@ defmodule VutuvWeb.PostLive.Thread do
     {:noreply, load_window(socket)}
   end
 
+  # A picture of the cached post drawn above an answer landed, or cleared the
+  # scan. `RemoteImages` speaks in feed entries, and the parents a feed entry
+  # nests are exactly this map (`Vutuv.Posts.remote_parents/2` builds both), so
+  # the page hands it an entry with nothing else on it and gets the timeline's
+  # own two steps: the cheap "not mine" test every open page needs — they all
+  # hear about every picture — and a re-read of that one card, rather than a
+  # whole re-window for a picture that changes nothing else on the page.
+  def handle_info({:remote_images_changed, %{remote_post_id: id}}, socket) do
+    entry = %{remote_parents: socket.assigns.remote_parents}
+
+    if RemoteImages.draws?(entry, id) do
+      entry = RemoteImages.restate_entry(entry, id, RemoteImages.pictures(id))
+      {:noreply, assign(socket, :remote_parents, entry.remote_parents)}
+    else
+      {:noreply, socket}
+    end
+  end
+
   def handle_info(_other, socket), do: {:noreply, socket}
 
   defp visible_focus(post_id, viewer) do
@@ -246,6 +298,7 @@ defmodule VutuvWeb.PostLive.Thread do
         |> assign(:focus, nil)
         |> assign(:likers, nil)
         |> assign(:remote_replies, %{})
+        |> assign(:remote_parents, %{})
         |> assign(:note_marks, Fediverse.mark_lookup([], nil))
 
       post ->
@@ -300,6 +353,7 @@ defmodule VutuvWeb.PostLive.Thread do
         |> assign(:window, window)
         |> assign(:focus, Enum.find(posts, &(&1.id == post.id)) || post)
         |> assign(:engagement, engagement)
+        |> assign(:remote_parents, Posts.remote_parents(posts, viewer))
         |> assign(:likers, likers(post, viewer, engagement[post.id]))
         |> assign(:viewer_follows, follows)
         |> assign(:remote_replies, remote)
@@ -417,12 +471,14 @@ defmodule VutuvWeb.PostLive.Thread do
       <%= cond do %>
         <% is_nil(@window) -> %>
           <div id="post-thread-gone"></div>
-        <% @window.mode == :all and @window.total == 1 and @remote_replies == %{} -> %>
+        <% @window.mode == :all and @window.total == 1 and @remote_replies == %{} and
+             @remote_parents == %{} -> %>
           <%!-- No conversation at all: the post stands alone as its own card.
           The author's Edit/Delete live in the card's own ⋯ menu. A post with no
-          vutuv replies but an answer from another network (issue #1069) is not
-          this case — it falls through to the conversation below, which is what
-          weaves that answer in. --%>
+          vutuv replies but an answer from another network (issue #1069), or one
+          that answers a post out there (issue #1165), is not this case — it
+          falls through to the conversation below, which is what weaves the one
+          in and draws the other above it. --%>
           <.post_card
             post={@focus}
             viewer={@current_user}
@@ -448,6 +504,7 @@ defmodule VutuvWeb.PostLive.Thread do
                 viewer_follows={@viewer_follows}
                 engagement={@engagement}
                 remote_replies={@remote_replies}
+                remote_parents={@remote_parents}
                 note_marks={@note_marks}
                 likers={@likers}
                 auto_scroll?={@auto_scroll?}
@@ -462,6 +519,7 @@ defmodule VutuvWeb.PostLive.Thread do
                 viewer_follows={@viewer_follows}
                 engagement={@engagement}
                 remote_replies={@remote_replies}
+                remote_parents={@remote_parents}
                 note_marks={@note_marks}
                 likers={@likers}
                 auto_scroll?={@auto_scroll?}

--- a/test/vutuv_web/live/post_thread_remote_parent_test.exs
+++ b/test/vutuv_web/live/post_thread_remote_parent_test.exs
@@ -1,0 +1,182 @@
+defmodule VutuvWeb.PostThreadRemoteParentTest do
+  @moduledoc """
+  The post out there that a member's answer answers (issue #1165), on the
+  **permalink** of that answer.
+
+  The feed has drawn it above the answer since 2026-09-01; the permalink had
+  only the "Replying to @user@host" line, and that line leads to the account,
+  not to the post. So the one page a shared link to such an answer lands on was
+  the page that showed half the exchange — which is what this covers, together
+  with the audience question a public page has to ask before drawing somebody
+  else's post, and the agent formats of that same page.
+
+  Not async: answering a cached post claims from `Vutuv.RateLimiter`, a shared
+  ETS table the SQL sandbox does not roll back.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Vutuv.MastodonHelpers
+
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Posts
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    :ok
+  end
+
+  @remote "was da draussen steht"
+  @answer "meine Antwort darauf"
+
+  # A cached post from another network and a member's public answer to it.
+  defp exchange do
+    remote = cached_post(remote_account(), content_text: @remote)
+    {:ok, post} = Posts.create_remote_post_reply(federating_member(), remote, %{body: @answer})
+
+    {remote, post}
+  end
+
+  # The author narrowed their audience after the answer was written, and the
+  # edit reached our copy — the one way a followers-only post ends up behind a
+  # public answer, since writing that answer is refused
+  # (`Fediverse.check_remote_post_reply/2`).
+  defp narrow(remote),
+    do: remote |> Ecto.Changeset.change(%{audience: "followers"}) |> Repo.update!()
+
+  # The permalink's conversation, as the controller embeds it: signed out with
+  # no cookie session, signed in with the one a login left behind.
+  defp thread_view(post, cookie \\ %{}) do
+    session = Map.merge(cookie, %{"post_id" => post.id, "locale" => "en"})
+
+    live_isolated(build_conn(), VutuvWeb.PostLive.Thread, session: session)
+  end
+
+  defp member_session do
+    {conn, user} = build_conn() |> Plug.Test.init_test_session(%{}) |> create_and_login_user()
+
+    {user, Plug.Conn.get_session(conn)}
+  end
+
+  test "the post being answered is drawn above the answer, and takes its banner" do
+    {remote, post} = exchange()
+    {_reader, session} = member_session()
+
+    {:ok, view, _html} = thread_view(post, session)
+    html = render(view)
+
+    assert html =~ @answer
+    assert html =~ @remote
+    assert :binary.match(html, @remote) < :binary.match(html, @answer)
+
+    # The card above says what the line said, so the line goes: two of them is
+    # the same fact twice, once as prose and once as the thing itself.
+    refute has_element?(view, ~s([data-reply-banner="remote"]))
+
+    # And the card is the way on to our copy's own page, which is what the
+    # reader could not reach from here at all.
+    assert has_element?(view, ~s(a[href="/system/fediverse/post/#{remote.id}"]))
+  end
+
+  test "a reader who is not signed in gets a public one too" do
+    {_remote, post} = exchange()
+
+    {:ok, view, _html} = thread_view(post)
+
+    assert render(view) =~ @remote
+  end
+
+  test "a parent whose audience narrowed afterwards is not drawn on the public page" do
+    {remote, post} = exchange()
+    narrow(remote)
+
+    {:ok, view, _html} = thread_view(post)
+    html = render(view)
+
+    refute html =~ @remote
+    assert html =~ @answer
+
+    # The line the card replaced is back, naming who was answered without
+    # repeating what they wrote.
+    assert has_element?(view, ~s([data-reply-banner="remote"]))
+  end
+
+  test "a signed-in follower still reads a followers-only parent" do
+    {remote, post} = exchange()
+    narrow(remote)
+
+    {reader, session} = member_session()
+
+    Repo.insert!(%Follow{
+      user_id: reader.id,
+      remote_account_id: remote.remote_account_id,
+      state: "accepted",
+      follow_activity_id: "https://vutuv.test/#{reader.id}/actor#f/#{remote.remote_account_id}"
+    })
+
+    {:ok, view, _html} = thread_view(post, session)
+
+    assert render(view) =~ @remote
+  end
+
+  test "an expired copy is not drawn on the public page" do
+    # The retention ceiling is the claim to hold somebody else's post at all,
+    # so a row the sweep has not reached yet is not one to keep publishing —
+    # the rule the tag timeline and the federated timeline already spell in SQL.
+    # A copy survives its ceiling when a member here reshared it, which is
+    # exactly a copy an answer can also hang off.
+    {remote, post} = exchange()
+
+    remote
+    |> Ecto.Changeset.change(%{expires_at: DateTime.add(DateTime.utc_now(:second), -60)})
+    |> Repo.update!()
+
+    {:ok, view, _html} = thread_view(post)
+
+    refute render(view) =~ @remote
+  end
+
+  test "the parent card's menu events are handled here" do
+    # A surface that renders the cached card must handle all three of its ⋯
+    # events — an unhandled `phx-click` takes the LiveView down, so a button
+    # that kills the page is the failure this pins.
+    {remote, post} = exchange()
+    {_reader, session} = member_session()
+
+    {:ok, view, _html} = thread_view(post, session)
+
+    render_click(view, "mute-remote-account", %{"id" => remote.remote_account_id})
+    render_click(view, "unfollow-remote-account", %{"id" => remote.remote_account_id})
+    render_click(view, "report-remote-post", %{"id" => remote.id})
+
+    # The report deleted our copy, so the card is gone and the answer stands
+    # under the line again.
+    html = render(view)
+    refute html =~ @remote
+    assert html =~ @answer
+  end
+
+  describe "agent formats" do
+    test "the words the page draws travel with every format" do
+      {_remote, post} = exchange()
+      path = Posts.path(post)
+
+      for extension <- ~w(md txt json xml) do
+        assert get(build_conn(), "#{path}.#{extension}").resp_body =~ @remote,
+               "the .#{extension} sibling withheld what the page shows"
+      end
+    end
+
+    test "a parent the page may not draw is named but not quoted" do
+      {remote, post} = exchange()
+      narrow(remote)
+
+      body = build_conn() |> get("#{Posts.path(post)}.md") |> response(200)
+
+      refute body =~ @remote
+      # The handle and the origin URI ride the sidecar, so they outlive both
+      # the audience change and our copy itself.
+      assert body =~ remote.remote_account.handle
+    end
+  end
+end


### PR DESCRIPTION
A vutuv answer to a post on another network stood alone on its own permalink,
above a "Replying to @user@host" line that led to the account rather than to
what was answered. There was no way up the thread from the page a shared link
lands on. The feed has drawn that cached post above the answer since 2026-09-01;
this is the same card on `VutuvWeb.PostLive.Thread`.

The reason it was missing: the four-stage assembly of a conversation was spelled
out twice in `VutuvWeb.PostComponents`, and the permalink's copy stopped after
three. It is now one `assemble_conversation/2`.

Two things ride along. Visibility is decided against the **reader**, not the
answering member (`Fediverse.publicly_readable_remote_post_ids/2`): signed out
that is an outright public post inside its retention ceiling, signed in the
reader's own accepted follow. The feed had no such check at all. And because the
HTML page now prints the answered post's words, so do the `.md`/`.txt`/`.json`/
`.xml` siblings of that URL, the way a reply from another network has since
\#1069.

Try it on any `/<handle>/posts/<id>` whose post answers a fediverse post.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01LcukwaT7DsFqp6GPB7YjdY
