### PR TITLE
Spell the investor page's sum out, and draw its curve in the top bar

### DIFF
--- a/docs/architecture/company-pages.md
+++ b/docs/architecture/company-pages.md
@@ -69,6 +69,14 @@ They are the same figures `/system/nodeinfo/2.1` already publishes, plus the
 Fediverse reach (`Vutuv.Fediverse.distinct_follower_count/0` and
 `follower_host_count/0`).
 
+Beside the two figure tiles the page **spells the addition out**: members plus
+Fediverse accounts equals the total in the top bar, set as a written addition of
+three labelled rows (`InvestorsDoc.people_sum_rows/1`), because investors have
+asked how that number comes about and a figure nobody can decompose is a figure
+nobody believes. The agent-format siblings say the same arithmetic as one
+sentence (`people_sum/1`) — a column of digits has nothing to line up against in
+a text file. Both read the same `facts` map.
+
 The page is deliberately two cards: a contact card carrying the h1, and those
 figures. It once carried the whole pitch (positioning against LinkedIn, the
 gated-community argument, the cost base, a growth curve) and was cut back to
@@ -115,27 +123,35 @@ the table (a deliberate call, they are the same quantity counted as well as it
 can still be counted), but the migration's moduledoc says so, and so does this
 paragraph.
 
-### The curve (built, currently not on any page)
+### The curve, drawn twice
 
-`VutuvWeb.CompanyHTML.growth_chart/1`, plain server-rendered SVG. No chart
-library: the drawing is two paths and a few labels, and a JavaScript bundle for
-that would be paid for by every reader of every other page.
+`VutuvWeb.CompanyHTML.growth_curve/1` on the investor page, plain server-rendered
+SVG. No chart library: the drawing is one path, a wash under it and two labels,
+and a JavaScript bundle for that would be paid for by every reader of every
+other page.
 
-**The investor page dropped it on 2026-08-16 and nothing renders it today.** The
-component and its geometry tests stay, and the recorder keeps writing a row a
-day, on purpose: the snapshots cannot be recovered afterwards, so stopping now
-would mean the curve comes back with an empty past. Putting it back is one
-`<.growth_chart series={...} />`.
+**One line, the people total**, rather than a band per population: the member
+half is two orders of magnitude larger than the Fediverse half, so on any shared
+scale the smaller band is a hairline along the top and says nothing. Which half
+moved is said in words under the chart (`InvestorsDoc.growth_sentence/1`), where
+it can be said exactly.
 
-It is a filled area for the members here and a line above it for the people
-total, so the gap between the two *is* the Fediverse share. A second line
-against the same axis would lie flat on the floor (the two figures are two
-orders of magnitude apart), and giving it its own axis would suggest they are
-comparable in size.
+**The y-axis is the span the data covers, not zero to peak** — at four digits a
+month of growth is a couple of hundred people, and an axis from zero draws that
+as a solid block with a flat lid. A zoom like that is only honest where
+something says what it spans, so the chart names both ends underneath itself:
+the first and last figure, and the first and last day.
 
-**The y-axis starts at zero.** Both figures are running totals in the thousands
-that grow by a few a day, so an axis cropped to the data's own range turns a
-couple of percent into a mountain. On an investor page that is the one chart
-trick that must not be played, and `company_controller_test.exs` pins the
-scaling to coordinates rather than to a rendered path string, so a "nicer"
-axis cannot slip in unnoticed.
+The same line is drawn a second time, as a **thumbnail in the top bar** beside
+the people total (`VutuvWeb.ShellLive`), 48×16 pixels of the last 30 days. It
+has no room for those end figures, which is why it says only "rising" and leaves
+"how far" to the number it sits beside. Both drawings come through
+`Vutuv.PeopleHistory.curve_points/3`, so how this curve is drawn is decided in
+one place; only the box and what is built around the line differ.
+
+The thumbnail is read from `:persistent_term`, never from the table: the bar is
+on every page, so it has to cost what the figure beside it costs (two atomics
+reads). `Vutuv.PeopleCounter` refreshes it on the tick it already reconciles the
+member count with, and writes only when the shape changed. While nothing is
+cached — the sub-second after boot, an installation younger than two days, a
+span that never moved — the bar simply shows the number.

--- a/lib/vutuv/people_counter.ex
+++ b/lib/vutuv/people_counter.ex
@@ -48,6 +48,13 @@ defmodule Vutuv.PeopleCounter do
   So a new Fediverse follower shows up within a minute rather than instantly,
   and there is exactly one place that decides what the figure means.
 
+  The member reconcile carries one more errand, because it is about the same
+  figure: it refreshes the growth thumbnail the pill draws beside the number
+  (`Vutuv.PeopleHistory.refresh_spark/0`). Those rows move once a day, so all
+  but two of those reads find the shape unchanged and write nothing — a
+  thirty-row read beside a COUNT over the whole members table, and one place
+  that decides how fresh the bar is.
+
   `VutuvWeb.ShellLive` subscribes and re-renders the top bar's pill on each
   `{:people_count, %{members:, fediverse:, total:}}` message, so the number
   ticks up while the page is open.
@@ -56,6 +63,7 @@ defmodule Vutuv.PeopleCounter do
 
   alias Vutuv.Accounts
   alias Vutuv.Fediverse
+  alias Vutuv.PeopleHistory
 
   @pubsub Vutuv.PubSub
   @topic "people_count"
@@ -207,6 +215,11 @@ defmodule Vutuv.PeopleCounter do
 
   def handle_info(:reconcile, state) do
     :atomics.put(state.ref, @members, Accounts.count_users())
+    # The top bar's growth thumbnail rides this tick rather than a timer of its
+    # own: same two populations, same bar, and this way it is seeded by the
+    # boot reconcile and heals itself afterwards, where a nightly refresh would
+    # leave a fresh release with no line until 23:59.
+    PeopleHistory.refresh_spark()
     schedule(:reconcile, state.reconcile_interval)
     {:noreply, state}
   end

--- a/lib/vutuv/people_history.ex
+++ b/lib/vutuv/people_history.ex
@@ -29,6 +29,17 @@ defmodule Vutuv.PeopleHistory do
   alias Vutuv.PeopleHistory.Snapshot
   alias Vutuv.Repo
 
+  # The top bar's thumbnail: how many days it draws and the box its points are
+  # laid out in (stretched to the bar's few pixels by `preserveAspectRatio`).
+  @spark_days 30
+  @spark_width 100
+  @spark_height 32
+  @spark_key {__MODULE__, :spark}
+
+  # How much of the drawn span is kept clear above and below the line, so a
+  # peak's stroke is not cut in half by the edge of the box.
+  @curve_margin 0.15
+
   @doc """
   Writes (or rewrites) the snapshot for `day`, defaulting to the German
   calendar day that is ending. Counting happens here rather than in the caller
@@ -99,4 +110,106 @@ defmodule Vutuv.PeopleHistory do
       total: Snapshot.total(last) - Snapshot.total(first)
     }
   end
+
+  @doc """
+  The same curve as a thumbnail for the top bar: `%{points:, days:, view_box:}`
+  with the points ready for an SVG `polyline` in the box `view_box` names, or
+  `nil` while there is nothing to draw.
+
+  The box travels with the points on purpose: they mean nothing outside it, and
+  a shell that spelled its own `viewBox` would draw a silently clipped line the
+  day this one changes.
+
+  Read from `:persistent_term`, never from the database — the bar sits on every
+  page, so the figure beside it is two atomics reads (`Vutuv.PeopleCounter`)
+  and this has to be as cheap. `Vutuv.PeopleCounter` refreshes it on the timer
+  it already reconciles the member count with; until the first one lands (and
+  in tests, where that timer is off) this answers `nil` and the bar simply
+  shows the number, which is what it showed before.
+  """
+  def spark, do: :persistent_term.get(@spark_key, nil)
+
+  @doc """
+  Re-reads the last #{@spark_days} snapshots and caches the thumbnail.
+
+  Writes only when the geometry actually changed: the rows behind it move once
+  a day, and replacing a `:persistent_term` key costs a global scan whether or
+  not the value is new. The read is not skipped, and does not need to be — it
+  rides a tick that reads the whole member count beside it.
+  """
+  def refresh_spark do
+    spark = spark_geometry(series(@spark_days))
+
+    if spark != spark(), do: put_spark(spark)
+
+    spark
+  end
+
+  defp put_spark(nil), do: clear_spark()
+  defp put_spark(spark), do: :persistent_term.put(@spark_key, spark)
+
+  @doc "Drop the cached thumbnail (test cleanup, like the other caches here)."
+  def clear_spark, do: :persistent_term.erase(@spark_key)
+
+  @doc """
+  The thumbnail's geometry for a series, or `nil` where there is no line.
+
+  A flat line is left undrawn on purpose. At this size it is a dash, and a dash
+  beside the number reads as a chart that failed to load rather than as a week
+  in which nobody joined.
+
+  What the big curve adds and this one cannot, the two end figures that keep a
+  zoomed axis honest, has no room in the chrome — which is why this shape says
+  "rising" and the number beside it says how far.
+  """
+  def spark_geometry(series) do
+    if points = curve_points(series, @spark_width, @spark_height) do
+      first = List.first(series)
+      last = List.last(series)
+
+      %{
+        points: points,
+        days: Date.diff(last.day, first.day),
+        view_box: "0 0 #{@spark_width} #{@spark_height}"
+      }
+    end
+  end
+
+  @doc """
+  The series as the points of an SVG `polyline` in a `width` x `height` box, or
+  `nil` where there is no line to draw: fewer than two days, or a total that
+  never moved.
+
+  Both drawings of this curve come through here — the chart on
+  `/system/investors` and the thumbnail in the top bar — so how it is drawn is
+  decided once. The vertical axis is the **span the data covers**, not zero to
+  peak: at four digits a month of growth is a couple of hundred people, and an
+  axis from zero draws that as a solid block with a flat lid. That zoom is only
+  honest where something says what it spans, which is why the big chart names
+  both ends underneath it.
+  """
+  def curve_points(series, _width, _height) when length(series) < 2, do: nil
+
+  def curve_points(series, width, height) do
+    totals = Enum.map(series, &Snapshot.total/1)
+    {low, high} = Enum.min_max(totals)
+
+    if high > low do
+      margin = (high - low) * @curve_margin
+      bottom = low - margin
+      span = high + margin - bottom
+      steps = length(series) - 1
+
+      totals
+      |> Enum.with_index()
+      |> Enum.map_join(" ", fn {total, index} ->
+        x = index / steps * width
+        y = height - (total - bottom) / span * height
+
+        coordinate(x) <> "," <> coordinate(y)
+      end)
+    end
+  end
+
+  defp coordinate(value), do: :erlang.float_to_binary(value, decimals: 1)
 end

--- a/lib/vutuv_web/agent_docs/investors_doc.ex
+++ b/lib/vutuv_web/agent_docs/investors_doc.ex
@@ -148,7 +148,11 @@ defmodule VutuvWeb.AgentDocs.InvestorsDoc do
 
   @doc """
   The sum in the top bar written out as the arithmetic it is: the two tiles it
-  adds and the figure they add up to.
+  adds and the figure they add up to, as one sentence for the agent formats.
+
+  The HTML sets the same three figures as a written addition
+  (`people_sum_rows/1`); both read them from the same `facts` map, so they
+  cannot disagree.
 
   Investors have asked how that number comes about, which is the whole reason
   it is spelled out — a figure nobody can decompose is a figure nobody
@@ -170,13 +174,52 @@ defmodule VutuvWeb.AgentDocs.InvestorsDoc do
   end
 
   @doc """
-  What that sum means, in the one sentence the equation above cannot say.
+  The three lines of the addition above, as an ordered list of
+  `%{key:, sign:, value:, label:}`: the two summands and the figure they add up
+  to, the last one keyed `:total`.
+
+  A stacked addition rather than a sentence, because that is how a person reads
+  an arithmetic they were about to check anyway — the digits line up under each
+  other and the rule replaces the "=". The agent formats keep the sentence
+  (`people_sum/1`), where a column of numbers has nothing to align against.
+  Both read the same `facts` map, so the two shapes cannot name different
+  figures; the test that says so is in `company_controller_test.exs`, because
+  only discipline keeps them naming the same **summands** if a third population
+  is ever added.
+
+  The labels are the tiles' own msgids on purpose: the addition stands beside
+  those tiles, and a row that called the same figure something else would read
+  as a different figure.
+  """
+  def people_sum_rows(facts) do
+    [
+      %{
+        key: :members,
+        sign: nil,
+        value: UI.delimited_count(facts.members),
+        label: gettext("Members")
+      },
+      %{
+        key: :fediverse,
+        sign: "+",
+        value: UI.delimited_count(facts.fediverse_accounts),
+        label: gettext("Fediverse accounts")
+      },
+      %{
+        key: :total,
+        sign: nil,
+        value: UI.delimited_count(facts.members + facts.fediverse_accounts),
+        label: gettext("People")
+      }
+    ]
+  end
+
+  @doc """
+  What that sum means, in the one sentence the addition above cannot say.
   `/system/members` spells out the rest for whoever wants it.
   """
   def counter_explainer do
-    gettext(
-      "That total is the number in the top bar. Nobody is counted twice: an account following five things here is one account, and a member who also follows from elsewhere is already in the first figure."
-    )
+    gettext("A Fediverse account following several profiles here still counts as one person.")
   end
 
   @doc """

--- a/lib/vutuv_web/live/shell_live.ex
+++ b/lib/vutuv_web/live/shell_live.ex
@@ -49,6 +49,7 @@ defmodule VutuvWeb.ShellLive do
   alias Vutuv.DayClock
   alias Vutuv.Organizations
   alias Vutuv.PeopleCounter
+  alias Vutuv.PeopleHistory
   alias Vutuv.PostRewrites
   alias Vutuv.Posts
   alias Vutuv.Prefs
@@ -287,6 +288,13 @@ defmodule VutuvWeb.ShellLive do
     # socket connects. Zero (the sub-second before the counter's first reconcile
     # seeds the cell) renders nothing.
     |> assign(:people_count, PeopleCounter.counts())
+    # The same total over the last month as a thumbnail beside it, so the bar
+    # says which way the number is going and not only where it stands. Read
+    # from `:persistent_term` like the figure itself (`PeopleHistory.spark/0`),
+    # so neither render pays a query for it; `nil` until the counter's first
+    # reconcile has cached one, and on an installation too young to have a
+    # curve.
+    |> assign(:people_spark, PeopleHistory.spark())
     # False until the first broadcast: the figure's span is keyed on its value
     # (see .people-total__figure in components.css), so without this gate the
     # first render would look like an insert and every page load would open with
@@ -1381,6 +1389,45 @@ defmodule VutuvWeb.ShellLive do
               <span class={@user_id && "hidden lg:inline"}>
                 {people_total_word(@people_count.total)}
               </span>
+              <%!-- The shape of the last month, hairline-thin and in the pill's
+                    own colour at 60 %, so it reads as a movement beside the
+                    figure rather than as a chart in the chrome, and follows the
+                    pill from slate to brand on hover instead of holding a
+                    colour of its own. From `lg` only: below that the bar has
+                    about 72px to spare (see the width note above) and this
+                    would spend two thirds of it on decoration. `hidden` +
+                    `lg:inline` rather than `lg:block`, because the previous
+                    release's stylesheet has to be able to hide it: a tab open
+                    across a deploy gets this markup patched into a document
+                    whose bundle only carries the classes already in use. --%>
+              <svg
+                :if={@people_spark}
+                viewBox={@people_spark.view_box}
+                preserveAspectRatio="none"
+                role="img"
+                class="hidden h-4 w-12 shrink-0 opacity-60 lg:inline"
+              >
+                <%!-- The `<title>` is both the tooltip and, on a `role="img"`,
+                      the accessible name — so it says what the line is once
+                      rather than twice, in the sentence the big chart on
+                      /system/investors already labels itself with. --%>
+                <title>
+                  {gettext("People here per day over the last %{days} days",
+                    days: @people_spark.days
+                  )}
+                </title>
+                <%!-- `vector-effect` keeps the line an even hairline once the
+                      viewBox is stretched to those twelve pixels of bar. --%>
+                <polyline
+                  points={@people_spark.points}
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  vector-effect="non-scaling-stroke"
+                />
+              </svg>
             </.link>
           </div>
 

--- a/lib/vutuv_web/templates/company/investors.html.heex
+++ b/lib/vutuv_web/templates/company/investors.html.heex
@@ -41,12 +41,38 @@
         <%!-- The arithmetic behind the figure in the top bar, beside the two
               tiles it adds: investors have asked how that number comes about,
               and the answer is an addition whose summands are right there.
-              `tabular-nums` so the digits line up as an equation rather than
-              as prose. --%>
-        <p class="tabular-nums font-semibold text-slate-900 dark:text-white">
-          {InvestorsDoc.people_sum(@facts)}
-        </p>
-        <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+              Set as a written addition rather than as one line of prose — a
+              reader checking a sum reads it down the page, so the sign gets a
+              column of its own, `tabular-nums` puts every digit on the same
+              grid, and the rule over the last row does the work of the "=".
+              The label column takes the rest of the width (`1fr`) and wraps
+              instead of pushing the row sideways. --%>
+        <div class="grid grid-cols-[auto_1fr] items-baseline gap-x-3 tabular-nums">
+          <%= for row <- InvestorsDoc.people_sum_rows(@facts) do %>
+            <%!-- Sign and figure share ONE cell, so the rule over the last row
+                  runs under both of them instead of breaking into a stray dash
+                  beside the number. `justify-between` puts the sign at the left
+                  edge of the column and every figure flush right, which with
+                  `tabular-nums` is what lines the digits up. --%>
+            <span
+              data-sum-row={row.key}
+              class={[
+                "flex items-baseline justify-between gap-3 font-semibold text-slate-900 dark:text-white",
+                row.key == :total && "border-t border-slate-300 pt-1 dark:border-slate-600"
+              ]}
+            >
+              <span>{row.sign}</span>
+              <span>{row.value}</span>
+            </span>
+            <span class={[
+              "min-w-0 text-slate-700 dark:text-slate-300",
+              row.key == :total && "pt-1 font-semibold text-slate-900 dark:text-white"
+            ]}>
+              {row.label}
+            </span>
+          <% end %>
+        </div>
+        <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">
           {InvestorsDoc.counter_explainer()}
         </p>
       </div>

--- a/lib/vutuv_web/views/company_html.ex
+++ b/lib/vutuv_web/views/company_html.ex
@@ -10,6 +10,7 @@ defmodule VutuvWeb.CompanyHTML do
   """
   use VutuvWeb, :html
 
+  alias Vutuv.PeopleHistory
   alias Vutuv.PeopleHistory.Snapshot
   alias Vutuv.ViewerClock
   alias VutuvWeb.AgentDocs.InvestorsDoc
@@ -104,32 +105,20 @@ defmodule VutuvWeb.CompanyHTML do
   # The line and the wash under it as SVG point lists, plus what the caption
   # needs. `nil` where there is nothing to draw.
   #
+  # The line itself comes from `Vutuv.PeopleHistory.curve_points/3`, which the
+  # top bar's thumbnail draws through as well — one decision about how this
+  # curve is drawn, in the module that owns the rows. What stays here is what
+  # only this chart has: the wash under the line and the two end figures.
+  #
   # One line, the people total the top bar shows, rather than the two stacked
   # bands the two columns invite: the member half is two orders of magnitude
   # larger than the Fediverse half, so on any shared scale the smaller band is a
   # hairline along the top and says nothing. Which half moved is in the sentence
   # under the chart instead, where it can be said in words.
-  defp curve_geometry(series) when length(series) < 2, do: nil
-
   defp curve_geometry(series) do
-    totals = Enum.map(series, &Snapshot.total/1)
-    {low, high} = Enum.min_max(totals)
-
-    if high > low do
-      # A margin above and below, so the line does not run along either edge.
-      margin = (high - low) * 0.15
-      bottom = low - margin
-      span = high + margin - bottom
-      steps = length(series) - 1
-
-      x = fn index -> index / steps * 600 end
-      y = fn value -> 140 - (value - bottom) / span * 140 end
-
-      line = Enum.map(Enum.with_index(totals), fn {total, i} -> {x.(i), y.(total)} end)
+    if line_points = PeopleHistory.curve_points(series, 600, 140) do
       first = List.first(series)
       last = List.last(series)
-
-      line_points = points(line)
 
       %{
         line: line_points,
@@ -139,15 +128,9 @@ defmodule VutuvWeb.CompanyHTML do
         days: Date.diff(last.day, first.day),
         first_day: ViewerClock.format(first.day, :short_date),
         last_day: ViewerClock.format(last.day, :short_date),
-        first_value: delimited_count(List.first(totals)),
-        last_value: delimited_count(List.last(totals))
+        first_value: delimited_count(Snapshot.total(first)),
+        last_value: delimited_count(Snapshot.total(last))
       }
     end
-  end
-
-  defp points(pairs) do
-    Enum.map_join(pairs, " ", fn {x, y} ->
-      :erlang.float_to_binary(x, decimals: 1) <> "," <> :erlang.float_to_binary(y, decimals: 1)
-    end)
   end
 end

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -439,8 +439,8 @@ msgstr "Einloggen"
 msgid "Log Out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/live/shell_live.ex:1561
-#: lib/vutuv_web/live/shell_live.ex:1637
+#: lib/vutuv_web/live/shell_live.ex:1608
+#: lib/vutuv_web/live/shell_live.ex:1684
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -454,8 +454,8 @@ msgid "Middle Name"
 msgstr "Zweiter Vorname"
 
 #: lib/vutuv_web/live/notification_live/index.ex:1351
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:263
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:271
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:298
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:306
 #, elixir-autogen
 msgid "More"
 msgstr "Mehr"
@@ -645,8 +645,8 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
-#: lib/vutuv_web/live/shell_live.ex:1430
-#: lib/vutuv_web/live/shell_live.ex:1617
+#: lib/vutuv_web/live/shell_live.ex:1477
+#: lib/vutuv_web/live/shell_live.ex:1664
 #: lib/vutuv_web/live/tag_live/timeline.ex:319
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
@@ -1159,7 +1159,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:63
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1537
+#: lib/vutuv_web/live/shell_live.ex:1584
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1602,7 +1602,7 @@ msgstr "Adressen von %{name}"
 msgid "Admin control panel"
 msgstr "Admin-Bereich"
 
-#: lib/vutuv_web/live/shell_live.ex:1635
+#: lib/vutuv_web/live/shell_live.ex:1682
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Mitteilungen"
@@ -1702,7 +1702,7 @@ msgstr "Empfehlen"
 #: lib/vutuv_web/live/organization_live/show.ex:579
 #: lib/vutuv_web/live/organization_live/show.ex:616
 #: lib/vutuv_web/live/post_live/feed.ex:943
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:250
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
 #: lib/vutuv_web/templates/user/show.html.heex:1325
 #: lib/vutuv_web/views/user_html.ex:633
 #, elixir-autogen, elixir-format
@@ -1722,7 +1722,7 @@ msgstr ""
 " von jemandem, den Sie kennen oder interessant finden, und klicken Sie auf "
 "Folgen!"
 
-#: lib/vutuv_web/live/shell_live.ex:1556
+#: lib/vutuv_web/live/shell_live.ex:1603
 #: lib/vutuv_web/views/settings_html.ex:299
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1754,8 +1754,8 @@ msgstr "Nachricht"
 #: lib/vutuv_web/controllers/page_controller.ex:218
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1448
-#: lib/vutuv_web/live/shell_live.ex:1634
+#: lib/vutuv_web/live/shell_live.ex:1495
+#: lib/vutuv_web/live/shell_live.ex:1681
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1787,7 +1787,7 @@ msgstr "Noch nichts Neues."
 #: lib/vutuv_web/controllers/page_controller.ex:219
 #: lib/vutuv_web/live/notification_live/index.ex:152
 #: lib/vutuv_web/live/notification_live/index.ex:457
-#: lib/vutuv_web/live/shell_live.ex:1460
+#: lib/vutuv_web/live/shell_live.ex:1507
 #: lib/vutuv_web/templates/layout/app.html.heex:159
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2147,8 +2147,8 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/live/post_live/feed.ex:345
 #: lib/vutuv_web/live/post_live/feed.ex:3088
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1282
-#: lib/vutuv_web/live/shell_live.ex:1607
+#: lib/vutuv_web/live/shell_live.ex:1290
+#: lib/vutuv_web/live/shell_live.ex:1654
 #: lib/vutuv_web/templates/layout/app.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2225,7 +2225,6 @@ msgstr "Posten"
 msgid "Post deleted successfully."
 msgstr "Beitrag erfolgreich gelöscht."
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:70
 #: lib/vutuv_web/agent_docs/post_doc.ex:242
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/post_controller.ex:90
@@ -2237,7 +2236,6 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:348
 #: lib/vutuv_web/live/search_live.ex:832
-#: lib/vutuv_web/templates/company/investors.html.heex:39
 #: lib/vutuv_web/templates/settings/preferences.html.heex:275
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
@@ -2252,7 +2250,8 @@ msgstr "Weiterlesen"
 
 #: lib/vutuv_web/components/post_components.ex:4118
 #: lib/vutuv_web/live/fediverse_account_live.ex:360
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:201
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr "Weniger anzeigen"
@@ -2328,7 +2327,7 @@ msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
 #: lib/vutuv_web/components/ui.ex:5363
-#: lib/vutuv_web/live/shell_live.ex:1503
+#: lib/vutuv_web/live/shell_live.ex:1550
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:246
@@ -2421,8 +2420,8 @@ msgstr "Lesezeichen setzen"
 #: lib/vutuv_web/agent_docs/markdown.ex:1201
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:1440
-#: lib/vutuv_web/live/shell_live.ex:1508
+#: lib/vutuv_web/live/shell_live.ex:1487
+#: lib/vutuv_web/live/shell_live.ex:1555
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2442,7 +2441,7 @@ msgstr "Gefällt mir"
 #: lib/vutuv_web/components/post_components.ex:6025
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:1511
+#: lib/vutuv_web/live/shell_live.ex:1558
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2526,10 +2525,8 @@ msgstr "Willkommen bei vutuv!"
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:71
 #: lib/vutuv_web/components/post_components.ex:422
 #: lib/vutuv_web/live/notification_live/index.ex:1348
-#: lib/vutuv_web/templates/company/investors.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
@@ -3216,7 +3213,7 @@ msgid "Private message"
 msgstr "Private Nachricht"
 
 #: lib/vutuv_web/components/ui.ex:4973
-#: lib/vutuv_web/live/shell_live.ex:1314
+#: lib/vutuv_web/live/shell_live.ex:1322
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -4758,6 +4755,7 @@ msgstr "Keine Ergebnisse für \"%{query}\""
 msgid "Not an exact match, but sounds like your search."
 msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 
+#: lib/vutuv_web/agent_docs/investors_doc.ex:212
 #: lib/vutuv_web/agent_docs/markdown.ex:463
 #: lib/vutuv_web/agent_docs/text.ex:481
 #: lib/vutuv_web/components/saved_search_components.ex:57
@@ -5527,7 +5525,7 @@ msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
 msgid "Content under review"
 msgstr "Inhalte in Prüfung"
 
-#: lib/vutuv_web/live/shell_live.ex:1490
+#: lib/vutuv_web/live/shell_live.ex:1537
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Kontomenü"
@@ -5549,7 +5547,7 @@ msgstr "Menüs und Dialoge schließen"
 msgid "General"
 msgstr "Allgemeines"
 
-#: lib/vutuv_web/live/shell_live.ex:1547
+#: lib/vutuv_web/live/shell_live.ex:1594
 #: lib/vutuv_web/templates/layout/app.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5568,7 +5566,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:276
-#: lib/vutuv_web/live/shell_live.ex:1527
+#: lib/vutuv_web/live/shell_live.ex:1574
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5623,8 +5621,8 @@ msgstr "Nächster Beitrag im Feed"
 msgid "Previous post in the feed"
 msgstr "Vorheriger Beitrag im Feed"
 
-#: lib/vutuv_web/live/shell_live.ex:1270
-#: lib/vutuv_web/live/shell_live.ex:1588
+#: lib/vutuv_web/live/shell_live.ex:1278
+#: lib/vutuv_web/live/shell_live.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Hauptnavigation"
@@ -6882,7 +6880,7 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_account_live.ex:396
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:320
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:230
 #, elixir-autogen, elixir-format
@@ -6910,7 +6908,7 @@ msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:320
 #: lib/vutuv_web/templates/settings/filters.html.heex:111
 #: lib/vutuv_web/templates/user/show.html.heex:230
 #, elixir-autogen, elixir-format
@@ -7141,7 +7139,8 @@ msgstr "Markdown wird unterstützt (Überschriften, Fett, Listen, Links)."
 msgid "Maximum age"
 msgstr "Höchstalter"
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:67
+#: lib/vutuv_web/agent_docs/investors_doc.ex:69
+#: lib/vutuv_web/agent_docs/investors_doc.ex:200
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:592
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:665
 #: lib/vutuv_web/live/admin/user_detail_live.ex:64
@@ -7153,7 +7152,7 @@ msgstr "Höchstalter"
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:45
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:90
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:9
-#: lib/vutuv_web/templates/company/investors.html.heex:29
+#: lib/vutuv_web/templates/company/investors.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Members"
 msgstr "Mitglieder"
@@ -12374,7 +12373,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1518
+#: lib/vutuv_web/live/shell_live.ex:1565
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:79
@@ -12717,7 +12716,7 @@ msgstr "Stellenbezeichnung"
 #: lib/vutuv_web/live/job_board_live.ex:47
 #: lib/vutuv_web/live/job_board_live.ex:265
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1322
+#: lib/vutuv_web/live/shell_live.ex:1330
 #: lib/vutuv_web/templates/layout/app.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -14414,7 +14413,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] "Empfohlen von %{name} und %{formatted} weiteren"
 msgstr[1] "Empfohlen von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/live/shell_live.ex:699
+#: lib/vutuv_web/live/shell_live.ex:707
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -16075,7 +16074,7 @@ msgstr "Diese Antwort können Sie nicht entfernen."
 #: lib/vutuv_web/components/post_components.ex:1399
 #: lib/vutuv_web/components/post_components.ex:1599
 #: lib/vutuv_web/components/post_components.ex:2987
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:331
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Original ansehen"
@@ -17538,6 +17537,7 @@ msgid "Paste an address from Mastodon and friends to open its page here."
 msgstr "Fügen Sie eine Adresse von Mastodon und Co. ein, um die zugehörige Seite hier zu öffnen."
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:357
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "Show the whole description"
 msgstr "Ganze Beschreibung anzeigen"
@@ -18773,7 +18773,7 @@ msgstr "%{address} (nur diese Seite)"
 msgid "%{address} (whole website)"
 msgstr "%{address} (ganze Website)"
 
-#: lib/vutuv_web/markdown.ex:385
+#: lib/vutuv_web/markdown.ex:372
 #, elixir-autogen, elixir-format
 msgid "Verified webpage of the author (%{address})"
 msgstr "Verifizierte Webseite der Autorin oder des Autors (%{address})"
@@ -20480,7 +20480,7 @@ msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."
 msgid "A post in an organization's name is always public."
 msgstr "Ein Beitrag im Namen einer Organisation ist immer öffentlich."
 
-#: lib/vutuv_web/live/shell_live.ex:1228
+#: lib/vutuv_web/live/shell_live.ex:1236
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr "Seite öffnen"
@@ -20500,7 +20500,7 @@ msgstr "Beendet, im Namen einer Organisation zu schreiben"
 msgid "Write as %{name} for now"
 msgstr "Vorerst als %{name} schreiben"
 
-#: lib/vutuv_web/live/shell_live.ex:1238
+#: lib/vutuv_web/live/shell_live.ex:1246
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr "Wieder als ich selbst schreiben"
@@ -20510,7 +20510,7 @@ msgstr "Wieder als ich selbst schreiben"
 msgid "You are writing as %{name} now."
 msgstr "Sie schreiben jetzt als %{name}."
 
-#: lib/vutuv_web/live/shell_live.ex:1214
+#: lib/vutuv_web/live/shell_live.ex:1222
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr "Sie schreiben als %{name}."
@@ -20874,21 +20874,21 @@ msgstr "Sie folgen #%{tag} hier bereits."
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr "Sie sind selbst auf diesem vutuv. Sie folgen #%{tag} jetzt direkt hier."
 
-#: lib/vutuv_web/live/shell_live.ex:743
+#: lib/vutuv_web/live/shell_live.ex:751
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] "%{formatted} Person"
 msgstr[1] "%{formatted} Personen"
 
-#: lib/vutuv_web/live/shell_live.ex:730
+#: lib/vutuv_web/live/shell_live.ex:738
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] "Person"
 msgstr[1] "Personen"
 
-#: lib/vutuv_web/live/shell_live.ex:765
+#: lib/vutuv_web/live/shell_live.ex:773
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -21988,7 +21988,7 @@ msgstr "%{handle} nicht mehr folgen? Die Beiträge verschwinden aus Ihrem Feed."
 msgid "Unfollowed. Their posts leave your feed."
 msgstr "Nicht mehr gefolgt. Die Beiträge verschwinden aus Ihrem Feed."
 
-#: lib/vutuv_web/live/shell_live.ex:1188
+#: lib/vutuv_web/live/shell_live.ex:1196
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr "Erlauben"
@@ -22003,12 +22003,12 @@ msgstr "Jetzt fragen"
 msgid "Browser notifications"
 msgstr "Browser-Benachrichtigungen"
 
-#: lib/vutuv_web/live/shell_live.ex:1046
+#: lib/vutuv_web/live/shell_live.ex:1054
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr "Neue Nachricht"
 
-#: lib/vutuv_web/live/shell_live.ex:1191
+#: lib/vutuv_web/live/shell_live.ex:1199
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Jetzt nicht"
@@ -22048,7 +22048,7 @@ msgstr "Dieser Browser zeigt sie an."
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr "Wenn etwas eintrifft, während vutuv in einem Tab offen ist, den Sie gerade nicht ansehen, kann Ihr Browser es als Benachrichtigung anzeigen. Aus, solange Sie es nicht einschalten."
 
-#: lib/vutuv_web/live/shell_live.ex:1185
+#: lib/vutuv_web/live/shell_live.ex:1193
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr "Sie haben Browser-Benachrichtigungen eingeschaltet. Dieser Browser wurde noch nicht um Erlaubnis gebeten."
@@ -22088,12 +22088,12 @@ msgstr "Test-Benachrichtigung senden"
 msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
 msgstr "Gesendet. Wenn nichts erschienen ist, hält Ihr System sie zurück. Prüfen Sie „Nicht stören“ und Ihre Benachrichtigungseinstellungen."
 
-#: lib/vutuv_web/live/shell_live.ex:838
+#: lib/vutuv_web/live/shell_live.ex:846
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr "Test-Benachrichtigung"
 
-#: lib/vutuv_web/live/shell_live.ex:839
+#: lib/vutuv_web/live/shell_live.ex:847
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr "So sieht es aus, wenn auf vutuv etwas für Sie eintrifft."
@@ -22333,7 +22333,7 @@ msgstr "In %{language} übersetzen"
 msgid "Translated into %{language}."
 msgstr "Wird in %{language} übersetzt."
 
-#: lib/vutuv_web/live/shell_live.ex:979
+#: lib/vutuv_web/live/shell_live.ex:987
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -22459,7 +22459,7 @@ msgstr "Neue Nachricht auf vutuv"
 msgid "No connection"
 msgstr "Keine Verbindung"
 
-#: lib/vutuv_web/live/shell_live.ex:1118
+#: lib/vutuv_web/live/shell_live.ex:1126
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr "Neu laden"
@@ -22951,7 +22951,7 @@ msgstr "Passwortmanager wie Bitwarden übernehmen daraus den ganzen Eintrag: Nam
 msgid "Scan it with the device that has the app"
 msgstr "Mit dem Gerät scannen, auf dem die App läuft"
 
-#: lib/vutuv_web/live/shell_live.ex:1100
+#: lib/vutuv_web/live/shell_live.ex:1108
 #, elixir-autogen, elixir-format
 msgid "A new version is ready."
 msgstr "Neue Version bereit."
@@ -23107,7 +23107,7 @@ msgid_plural "%{formatted} posts here"
 msgstr[0] "%{formatted} Beitrag hier"
 msgstr[1] "%{formatted} Beiträge hier"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:296
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "Address copied"
 msgstr "Adresse kopiert"
@@ -23117,17 +23117,17 @@ msgstr "Adresse kopiert"
 msgid "Another network"
 msgstr "Anderes Netzwerk"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:299
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:334
 #, elixir-autogen, elixir-format
 msgid "Copy address"
 msgstr "Adresse kopieren"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:152
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "Latest here"
 msgstr "Zuletzt hier"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:291
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:326
 #, elixir-autogen, elixir-format
 msgid "Mute %{host}"
 msgstr "%{host} stummschalten"
@@ -23147,7 +23147,7 @@ msgstr "Wirklich entfolgen?"
 msgid "Really withdraw?"
 msgstr "Anfrage wirklich zurückziehen?"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:290
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:325
 #, elixir-autogen, elixir-format
 msgid "Unmute %{host}"
 msgstr "%{host} wieder einschalten"
@@ -23199,7 +23199,7 @@ msgstr "Wenn Ihre Verbindung langsam ist oder Ihr Datenvolumen begrenzt, kann vu
 msgid "Low-bandwidth mode"
 msgstr "Datensparmodus"
 
-#: lib/vutuv_web/live/shell_live.ex:1629
+#: lib/vutuv_web/live/shell_live.ex:1676
 #, elixir-autogen, elixir-format
 msgctxt "phone tab bar"
 msgid "Write"
@@ -23356,7 +23356,7 @@ msgstr "bandbreite langsam internet mobil daten sparen datensparmodus volumen sc
 msgid "Appearance"
 msgstr "Darstellung"
 
-#: lib/vutuv_web/live/shell_live.ex:1655
+#: lib/vutuv_web/live/shell_live.ex:1702
 #, elixir-autogen, elixir-format
 msgid "%{count} video in progress"
 msgid_plural "%{count} videos in progress"
@@ -23611,7 +23611,7 @@ msgid_plural "%{formatted} random vutuv accounts that are open to offers."
 msgstr[0] "Ein zufälliger vutuv Account, der offen für Angebote ist."
 msgstr[1] "%{formatted} zufällige vutuv Accounts, die offen für Angebote sind."
 
-#: lib/vutuv_web/live/shell_live.ex:713
+#: lib/vutuv_web/live/shell_live.ex:721
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post in your feed"
 msgid_plural "%{formatted} new posts in your feed"
@@ -23648,76 +23648,66 @@ msgstr "Ihr Feed zeigt, was die Konten schreiben, denen Sie folgen. Hier sind ei
 msgid "Your public posts then also appear on {mastodon}, for example."
 msgstr "Ihre öffentlichen Beiträge erscheinen dann auch z.B. auf {mastodon}."
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:197
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:232
 #, elixir-autogen, elixir-format
 msgid "%{formatted} older post"
 msgid_plural "%{formatted} older posts"
 msgstr[0] "%{formatted} älterer Beitrag"
 msgstr[1] "%{formatted} ältere Beiträge"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:312
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:347
 #, elixir-autogen, elixir-format
 msgid "Their page here"
 msgstr "Kontoseite hier"
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:83
+#: lib/vutuv_web/agent_docs/investors_doc.ex:81
 #, elixir-autogen, elixir-format
 msgid "A professional network that works without an account"
 msgstr "Ein Berufsnetzwerk, das ohne Konto funktioniert"
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:69
-#: lib/vutuv_web/templates/company/investors.html.heex:36
-#, elixir-autogen, elixir-format
-msgid "Active this half year"
-msgstr "Dieses Halbjahr aktiv"
-
-#: lib/vutuv_web/agent_docs/investors_doc.ex:68
-#: lib/vutuv_web/templates/company/investors.html.heex:31
-#, elixir-autogen, elixir-format
-msgid "Active this month"
-msgstr "Diesen Monat aktiv"
-
-#: lib/vutuv_web/agent_docs/investors_doc.ex:141
+#: lib/vutuv_web/agent_docs/investors_doc.ex:139
 #, elixir-autogen, elixir-format
 msgid "Advertising instead of a paywall"
 msgstr "Anzeigen statt Bezahlschranke"
 
-#: lib/vutuv_web/templates/company/investors.html.heex:137
+#: lib/vutuv_web/templates/company/investors.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "Create an account"
 msgstr "Konto anlegen"
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:72
-#: lib/vutuv_web/templates/company/investors.html.heex:42
+#: lib/vutuv_web/agent_docs/investors_doc.ex:70
+#: lib/vutuv_web/agent_docs/investors_doc.ex:206
+#: lib/vutuv_web/templates/company/investors.html.heex:29
 #, elixir-autogen, elixir-format
 msgid "Fediverse accounts"
 msgstr "Fediverse-Konten"
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:73
+#: lib/vutuv_web/agent_docs/investors_doc.ex:71
 #, elixir-autogen, elixir-format
 msgid "Fediverse servers"
 msgstr "Fediverse-Server"
 
-#: lib/vutuv_web/templates/company/investors.html.heex:45
+#: lib/vutuv_web/templates/company/investors.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "From %{formatted} server"
 msgid_plural "From %{formatted} servers"
 msgstr[0] "Von %{formatted} Server"
 msgstr[1] "Von %{formatted} Servern"
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:254
+#: lib/vutuv_web/agent_docs/investors_doc.ex:295
 #: lib/vutuv_web/controllers/company_controller.ex:56
 #: lib/vutuv_web/templates/layout/app.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Investors"
 msgstr "Investoren"
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:208
+#: lib/vutuv_web/agent_docs/investors_doc.ex:249
 #, elixir-autogen, elixir-format
 msgid "Over these %{days} days %{total} people arrived, %{members} of them as members here."
 msgstr "In diesen %{days} Tagen sind %{total} Menschen dazugekommen, davon %{members} als Mitglieder hier."
 
-#: lib/vutuv_web/views/company_html.ex:71
+#: lib/vutuv_web/live/shell_live.ex:1415
+#: lib/vutuv_web/views/company_html.ex:76
 #, elixir-autogen, elixir-format
 msgid "People here per day over the last %{days} days"
 msgstr "Menschen hier pro Tag über die letzten %{days} Tage"
@@ -23728,20 +23718,15 @@ msgstr "Menschen hier pro Tag über die letzten %{days} Tage"
 msgid "Press material: %{url}"
 msgstr "Pressematerial: %{url}"
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:111
+#: lib/vutuv_web/agent_docs/investors_doc.ex:109
 #, elixir-autogen, elixir-format
 msgid "Readable without an account"
 msgstr "Ohne Konto lesbar"
 
-#: lib/vutuv_web/templates/company/investors.html.heex:142
+#: lib/vutuv_web/templates/company/investors.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Send a message"
 msgstr "Nachricht schreiben"
-
-#: lib/vutuv_web/templates/company/investors.html.heex:33
-#, elixir-autogen, elixir-format
-msgid "Signed in within 30 days"
-msgstr "In den letzten 30 Tagen angemeldet"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:375
 #: lib/vutuv_web/agent_docs/text.ex:349
@@ -23752,7 +23737,7 @@ msgstr "Wo wir stehen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:382
 #: lib/vutuv_web/agent_docs/text.ex:356
-#: lib/vutuv_web/templates/company/investors.html.heex:82
+#: lib/vutuv_web/templates/company/investors.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Why this is worth building"
 msgstr "Warum sich das lohnt"
@@ -23765,17 +23750,17 @@ msgstr "Schreiben Sie hier: %{url}"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:388
 #: lib/vutuv_web/agent_docs/text.ex:358
-#: lib/vutuv_web/templates/company/investors.html.heex:120
+#: lib/vutuv_web/templates/company/investors.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Write to me"
 msgstr "Schreiben Sie mir"
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:220
+#: lib/vutuv_web/agent_docs/investors_doc.ex:261
 #, elixir-autogen, elixir-format
 msgid "Write to me here, on vutuv. Creating an account takes a minute and costs nothing, and you will have seen the product before the first sentence about it."
 msgstr "Schreiben Sie mir hier, auf vutuv. Ein Konto anzulegen dauert eine Minute und kostet nichts, und Sie haben das Produkt gesehen, bevor der erste Satz darüber fällt."
 
-#: lib/vutuv_web/templates/company/investors.html.heex:125
+#: lib/vutuv_web/templates/company/investors.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "My profile:"
 msgstr "Mein Profil:"
@@ -23786,17 +23771,17 @@ msgstr "Mein Profil:"
 msgid "My profile: %{url}"
 msgstr "Mein Profil: %{url}"
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:143
+#: lib/vutuv_web/agent_docs/investors_doc.ex:141
 #, elixir-autogen, elixir-format
 msgid "Text ads are to carry the operation, which is why there is no premium tier and will not be one. Nothing is held back from somebody who will not pay for it, and a paid tier is the single thing that stops most people from ever starting. Leaving it out is what lets the network grow, and only a growing network makes the ads worth anything."
 msgstr "Den Betrieb sollen Textanzeigen tragen, deshalb gibt es keine Premium-Stufe und wird es auch keine geben. Niemandem wird etwas vorenthalten, weil er nicht dafür zahlt, und genau diese Bezahlstufe hält die meisten davon ab, überhaupt anzufangen. Sie wegzulassen lässt das Netzwerk wachsen, und erst ein wachsendes Netzwerk macht die Anzeigen etwas wert."
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:119
+#: lib/vutuv_web/agent_docs/investors_doc.ex:117
 #, elixir-autogen, elixir-format
 msgid "Fast pages win"
 msgstr "Schnelle Seiten gewinnen"
 
-#: lib/vutuv_web/templates/company/investors.html.heex:101
+#: lib/vutuv_web/templates/company/investors.html.heex:108
 #, elixir-autogen, elixir-format
 msgid "Source:"
 msgstr "Quelle:"
@@ -23807,37 +23792,37 @@ msgstr "Quelle:"
 msgid "Source: %{source}"
 msgstr "Quelle: %{source}"
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:121
+#: lib/vutuv_web/agent_docs/investors_doc.ex:119
 #, elixir-autogen, elixir-format
 msgid "A page that answers in milliseconds is not a matter of polish, it decides whether somebody stays. Google had 55 and Deloitte measure that across 37 European and American brands and more than 30 million sessions: a tenth of a second faster raised conversions by 8.4% in retail and by 10.1% in travel."
 msgstr "Eine Seite, die in Millisekunden antwortet, ist keine Frage des Feinschliffs, sie entscheidet, ob jemand bleibt. Google ließ das von 55 und Deloitte über 37 europäische und amerikanische Marken und mehr als 30 Millionen Sitzungen messen: eine Zehntelsekunde schneller hob die Conversion im Handel um 8,4 % und im Reisebereich um 10,1 %."
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:113
+#: lib/vutuv_web/agent_docs/investors_doc.ex:111
 #, elixir-autogen, elixir-format
 msgid "LinkedIn shows a profile to whoever is logged in and asks everybody else to sign up first. Everybody who is inside knows the other half: you go looking for one person and get a feed, suggestions you did not ask for, and a note that the rest is behind Premium. A vutuv profile is an ordinary public web page: a search engine indexes it, an AI agent reads it as Markdown, JSON or vCard, and a person who has never heard of us reads it without handing over an address first. That is why somebody arrives at all, and why a member puts their work here."
 msgstr "LinkedIn zeigt ein Profil nur, wer angemeldet ist, und bittet alle anderen erst einmal zur Registrierung. Und wer drin ist, kennt die andere Hälfte: Man sucht einen einzigen Menschen und bekommt einen Feed, ungefragte Vorschläge und den Hinweis, dass der Rest hinter Premium liegt. Ein vutuv-Profil ist eine ganz normale öffentliche Webseite: Suchmaschinen nehmen sie auf, KI-Agenten lesen sie als Markdown, JSON oder vCard, und wer noch nie von uns gehört hat, liest sie, ohne vorher eine Adresse herauszugeben. Deshalb kommt überhaupt jemand her, und deshalb stellen Mitglieder ihre Arbeit hierhin."
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:132
+#: lib/vutuv_web/agent_docs/investors_doc.ex:130
 #, elixir-autogen, elixir-format
 msgid "Networks are not equal, and neither are the markets on them: in 2025 the ITU counted 84% of people in high-income countries with access to 5G against 4% in low-income ones, and somebody online in a wealthy country moves nearly eight times as much mobile data as somebody in a poor one. A site that assumes a fast line is shut to most of them in practice. A vutuv page loads less data than a LinkedIn page to begin with, and a data-saving mode cuts that again for anybody on a slow connection or paying by the megabyte."
 msgstr "Netze sind nicht gleich, und die Märkte darauf sind es auch nicht: Die ITU zählte 2025 in Ländern mit hohem Einkommen 84 % der Menschen mit 5G-Zugang, in Ländern mit niedrigem Einkommen 4 %, und wer in einem wohlhabenden Land online ist, bewegt fast achtmal so viele mobile Daten wie jemand in einem armen. Eine Seite, die eine schnelle Leitung voraussetzt, ist für die meisten davon praktisch geschlossen. Eine vutuv-Seite lädt von Haus aus weniger Daten als eine LinkedIn-Seite, und ein Schmalband-Modus senkt die Menge noch einmal, für alle mit langsamer Verbindung oder mit einem Tarif, der jedes Megabyte kostet."
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:130
+#: lib/vutuv_web/agent_docs/investors_doc.ex:128
 #, elixir-autogen, elixir-format
 msgid "The market behind the slow connection"
 msgstr "Der Markt hinter der langsamen Leitung"
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:166
+#: lib/vutuv_web/agent_docs/investors_doc.ex:168
 #, elixir-autogen, elixir-format
 msgid "%{members} members + %{fediverse} Fediverse accounts = %{total} people"
 msgstr "%{members} Mitglieder + %{fediverse} Fediverse-Konten = %{total} Personen"
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:179
-#, elixir-autogen, elixir-format
-msgid "That total is the number in the top bar. Nobody is counted twice: an account following five things here is one account, and a member who also follows from elsewhere is already in the first figure."
-msgstr "Diese Summe steht oben in der Navigationsleiste. Doppelt gezählt wird niemand: Ein Konto, das hier fünf Dingen folgt, ist ein Konto, und wer hier Mitglied ist und zusätzlich von außen folgt, steckt schon in der ersten Zahl."
-
-#: lib/vutuv_web/agent_docs/investors_doc.ex:91
+#: lib/vutuv_web/agent_docs/investors_doc.ex:89
 #, elixir-autogen, elixir-format
 msgid "This page is for potential investors. It says what vutuv is, where the network stands today, and how it is meant to earn money one day."
 msgstr "Diese Seite richtet sich an potentielle Investoren. Sie sagt, was vutuv ist, wo das Netzwerk heute steht und womit es eines Tages Geld verdienen soll."
+
+#: lib/vutuv_web/agent_docs/investors_doc.ex:222
+#, elixir-autogen, elixir-format
+msgid "A Fediverse account following several profiles here still counts as one person."
+msgstr "Ein Fediverse-Konto, das hier mehreren Profilen folgt, zählt trotzdem als eine Person."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -439,8 +439,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1561
-#: lib/vutuv_web/live/shell_live.ex:1637
+#: lib/vutuv_web/live/shell_live.ex:1608
+#: lib/vutuv_web/live/shell_live.ex:1684
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -454,8 +454,8 @@ msgid "Middle Name"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:1351
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:263
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:271
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:298
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:306
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -645,8 +645,8 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
-#: lib/vutuv_web/live/shell_live.ex:1430
-#: lib/vutuv_web/live/shell_live.ex:1617
+#: lib/vutuv_web/live/shell_live.ex:1477
+#: lib/vutuv_web/live/shell_live.ex:1664
 #: lib/vutuv_web/live/tag_live/timeline.ex:319
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
@@ -1140,7 +1140,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:63
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1537
+#: lib/vutuv_web/live/shell_live.ex:1584
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1575,7 +1575,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1635
+#: lib/vutuv_web/live/shell_live.ex:1682
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1675,7 +1675,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/show.ex:579
 #: lib/vutuv_web/live/organization_live/show.ex:616
 #: lib/vutuv_web/live/post_live/feed.ex:943
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:250
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
 #: lib/vutuv_web/templates/user/show.html.heex:1325
 #: lib/vutuv_web/views/user_html.ex:633
 #, elixir-autogen, elixir-format
@@ -1692,7 +1692,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1556
+#: lib/vutuv_web/live/shell_live.ex:1603
 #: lib/vutuv_web/views/settings_html.ex:299
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lib/vutuv_web/controllers/page_controller.ex:218
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1448
-#: lib/vutuv_web/live/shell_live.ex:1634
+#: lib/vutuv_web/live/shell_live.ex:1495
+#: lib/vutuv_web/live/shell_live.ex:1681
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1757,7 +1757,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/page_controller.ex:219
 #: lib/vutuv_web/live/notification_live/index.ex:152
 #: lib/vutuv_web/live/notification_live/index.ex:457
-#: lib/vutuv_web/live/shell_live.ex:1460
+#: lib/vutuv_web/live/shell_live.ex:1507
 #: lib/vutuv_web/templates/layout/app.html.heex:159
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2109,8 +2109,8 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/feed.ex:345
 #: lib/vutuv_web/live/post_live/feed.ex:3088
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1282
-#: lib/vutuv_web/live/shell_live.ex:1607
+#: lib/vutuv_web/live/shell_live.ex:1290
+#: lib/vutuv_web/live/shell_live.ex:1654
 #: lib/vutuv_web/templates/layout/app.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2185,7 +2185,6 @@ msgstr ""
 msgid "Post deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:70
 #: lib/vutuv_web/agent_docs/post_doc.ex:242
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/post_controller.ex:90
@@ -2197,7 +2196,6 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:348
 #: lib/vutuv_web/live/search_live.ex:832
-#: lib/vutuv_web/templates/company/investors.html.heex:39
 #: lib/vutuv_web/templates/settings/preferences.html.heex:275
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
@@ -2212,7 +2210,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:4118
 #: lib/vutuv_web/live/fediverse_account_live.ex:360
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:201
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
@@ -2286,7 +2285,7 @@ msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5363
-#: lib/vutuv_web/live/shell_live.ex:1503
+#: lib/vutuv_web/live/shell_live.ex:1550
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:246
@@ -2379,8 +2378,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1201
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:1440
-#: lib/vutuv_web/live/shell_live.ex:1508
+#: lib/vutuv_web/live/shell_live.ex:1487
+#: lib/vutuv_web/live/shell_live.ex:1555
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2400,7 +2399,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:6025
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:1511
+#: lib/vutuv_web/live/shell_live.ex:1558
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2484,10 +2483,8 @@ msgstr ""
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:71
 #: lib/vutuv_web/components/post_components.ex:422
 #: lib/vutuv_web/live/notification_live/index.ex:1348
-#: lib/vutuv_web/templates/company/investors.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
@@ -3150,7 +3147,7 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4973
-#: lib/vutuv_web/live/shell_live.ex:1314
+#: lib/vutuv_web/live/shell_live.ex:1322
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -4592,6 +4589,7 @@ msgstr ""
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
 
+#: lib/vutuv_web/agent_docs/investors_doc.ex:212
 #: lib/vutuv_web/agent_docs/markdown.ex:463
 #: lib/vutuv_web/agent_docs/text.ex:481
 #: lib/vutuv_web/components/saved_search_components.ex:57
@@ -5309,7 +5307,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1490
+#: lib/vutuv_web/live/shell_live.ex:1537
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5331,7 +5329,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1547
+#: lib/vutuv_web/live/shell_live.ex:1594
 #: lib/vutuv_web/templates/layout/app.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5350,7 +5348,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:276
-#: lib/vutuv_web/live/shell_live.ex:1527
+#: lib/vutuv_web/live/shell_live.ex:1574
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5405,8 +5403,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1270
-#: lib/vutuv_web/live/shell_live.ex:1588
+#: lib/vutuv_web/live/shell_live.ex:1278
+#: lib/vutuv_web/live/shell_live.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -6610,7 +6608,7 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_account_live.ex:396
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:320
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:230
 #, elixir-autogen, elixir-format
@@ -6638,7 +6636,7 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:320
 #: lib/vutuv_web/templates/settings/filters.html.heex:111
 #: lib/vutuv_web/templates/user/show.html.heex:230
 #, elixir-autogen, elixir-format
@@ -6858,7 +6856,8 @@ msgstr ""
 msgid "Maximum age"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:67
+#: lib/vutuv_web/agent_docs/investors_doc.ex:69
+#: lib/vutuv_web/agent_docs/investors_doc.ex:200
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:592
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:665
 #: lib/vutuv_web/live/admin/user_detail_live.ex:64
@@ -6870,7 +6869,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:45
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:90
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:9
-#: lib/vutuv_web/templates/company/investors.html.heex:29
+#: lib/vutuv_web/templates/company/investors.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Members"
 msgstr ""
@@ -11749,7 +11748,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1518
+#: lib/vutuv_web/live/shell_live.ex:1565
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:79
@@ -12079,7 +12078,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:47
 #: lib/vutuv_web/live/job_board_live.ex:265
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1322
+#: lib/vutuv_web/live/shell_live.ex:1330
 #: lib/vutuv_web/templates/layout/app.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -13755,7 +13754,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:699
+#: lib/vutuv_web/live/shell_live.ex:707
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -15384,7 +15383,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1399
 #: lib/vutuv_web/components/post_components.ex:1599
 #: lib/vutuv_web/components/post_components.ex:2987
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:331
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -16828,6 +16827,7 @@ msgid "Paste an address from Mastodon and friends to open its page here."
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:357
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "Show the whole description"
 msgstr ""
@@ -18047,7 +18047,7 @@ msgstr ""
 msgid "%{address} (whole website)"
 msgstr ""
 
-#: lib/vutuv_web/markdown.ex:385
+#: lib/vutuv_web/markdown.ex:372
 #, elixir-autogen, elixir-format
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
@@ -19738,7 +19738,7 @@ msgstr ""
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1228
+#: lib/vutuv_web/live/shell_live.ex:1236
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr ""
@@ -19758,7 +19758,7 @@ msgstr ""
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1238
+#: lib/vutuv_web/live/shell_live.ex:1246
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -19768,7 +19768,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1214
+#: lib/vutuv_web/live/shell_live.ex:1222
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -20132,21 +20132,21 @@ msgstr ""
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:743
+#: lib/vutuv_web/live/shell_live.ex:751
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:730
+#: lib/vutuv_web/live/shell_live.ex:738
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:765
+#: lib/vutuv_web/live/shell_live.ex:773
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -21227,7 +21227,7 @@ msgstr ""
 msgid "Unfollowed. Their posts leave your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1188
+#: lib/vutuv_web/live/shell_live.ex:1196
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr ""
@@ -21242,12 +21242,12 @@ msgstr ""
 msgid "Browser notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1046
+#: lib/vutuv_web/live/shell_live.ex:1054
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1191
+#: lib/vutuv_web/live/shell_live.ex:1199
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
@@ -21287,7 +21287,7 @@ msgstr ""
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1185
+#: lib/vutuv_web/live/shell_live.ex:1193
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -21327,12 +21327,12 @@ msgstr ""
 msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:838
+#: lib/vutuv_web/live/shell_live.ex:846
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:839
+#: lib/vutuv_web/live/shell_live.ex:847
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr ""
@@ -21553,7 +21553,7 @@ msgstr ""
 msgid "Translated into %{language}."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:979
+#: lib/vutuv_web/live/shell_live.ex:987
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -21672,7 +21672,7 @@ msgstr ""
 msgid "No connection"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1118
+#: lib/vutuv_web/live/shell_live.ex:1126
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr ""
@@ -22160,7 +22160,7 @@ msgstr ""
 msgid "Scan it with the device that has the app"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1100
+#: lib/vutuv_web/live/shell_live.ex:1108
 #, elixir-autogen, elixir-format
 msgid "A new version is ready."
 msgstr ""
@@ -22316,7 +22316,7 @@ msgid_plural "%{formatted} posts here"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:296
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "Address copied"
 msgstr ""
@@ -22326,17 +22326,17 @@ msgstr ""
 msgid "Another network"
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:299
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:334
 #, elixir-autogen, elixir-format
 msgid "Copy address"
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:152
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "Latest here"
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:291
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:326
 #, elixir-autogen, elixir-format
 msgid "Mute %{host}"
 msgstr ""
@@ -22356,7 +22356,7 @@ msgstr ""
 msgid "Really withdraw?"
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:290
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:325
 #, elixir-autogen, elixir-format
 msgid "Unmute %{host}"
 msgstr ""
@@ -22408,7 +22408,7 @@ msgstr ""
 msgid "Low-bandwidth mode"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1629
+#: lib/vutuv_web/live/shell_live.ex:1676
 #, elixir-autogen, elixir-format
 msgctxt "phone tab bar"
 msgid "Write"
@@ -22565,7 +22565,7 @@ msgstr ""
 msgid "Appearance"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1655
+#: lib/vutuv_web/live/shell_live.ex:1702
 #, elixir-autogen, elixir-format
 msgid "%{count} video in progress"
 msgid_plural "%{count} videos in progress"
@@ -22820,7 +22820,7 @@ msgid_plural "%{formatted} random vutuv accounts that are open to offers."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:713
+#: lib/vutuv_web/live/shell_live.ex:721
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post in your feed"
 msgid_plural "%{formatted} new posts in your feed"
@@ -22857,76 +22857,66 @@ msgstr ""
 msgid "Your public posts then also appear on {mastodon}, for example."
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:197
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:232
 #, elixir-autogen, elixir-format
 msgid "%{formatted} older post"
 msgid_plural "%{formatted} older posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:312
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:347
 #, elixir-autogen, elixir-format
 msgid "Their page here"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:83
+#: lib/vutuv_web/agent_docs/investors_doc.ex:81
 #, elixir-autogen, elixir-format
 msgid "A professional network that works without an account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:69
-#: lib/vutuv_web/templates/company/investors.html.heex:36
-#, elixir-autogen, elixir-format
-msgid "Active this half year"
-msgstr ""
-
-#: lib/vutuv_web/agent_docs/investors_doc.ex:68
-#: lib/vutuv_web/templates/company/investors.html.heex:31
-#, elixir-autogen, elixir-format
-msgid "Active this month"
-msgstr ""
-
-#: lib/vutuv_web/agent_docs/investors_doc.ex:141
+#: lib/vutuv_web/agent_docs/investors_doc.ex:139
 #, elixir-autogen, elixir-format
 msgid "Advertising instead of a paywall"
 msgstr ""
 
-#: lib/vutuv_web/templates/company/investors.html.heex:137
+#: lib/vutuv_web/templates/company/investors.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "Create an account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:72
-#: lib/vutuv_web/templates/company/investors.html.heex:42
+#: lib/vutuv_web/agent_docs/investors_doc.ex:70
+#: lib/vutuv_web/agent_docs/investors_doc.ex:206
+#: lib/vutuv_web/templates/company/investors.html.heex:29
 #, elixir-autogen, elixir-format
 msgid "Fediverse accounts"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:73
+#: lib/vutuv_web/agent_docs/investors_doc.ex:71
 #, elixir-autogen, elixir-format
 msgid "Fediverse servers"
 msgstr ""
 
-#: lib/vutuv_web/templates/company/investors.html.heex:45
+#: lib/vutuv_web/templates/company/investors.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "From %{formatted} server"
 msgid_plural "From %{formatted} servers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:254
+#: lib/vutuv_web/agent_docs/investors_doc.ex:295
 #: lib/vutuv_web/controllers/company_controller.ex:56
 #: lib/vutuv_web/templates/layout/app.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Investors"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:208
+#: lib/vutuv_web/agent_docs/investors_doc.ex:249
 #, elixir-autogen, elixir-format
 msgid "Over these %{days} days %{total} people arrived, %{members} of them as members here."
 msgstr ""
 
-#: lib/vutuv_web/views/company_html.ex:71
+#: lib/vutuv_web/live/shell_live.ex:1415
+#: lib/vutuv_web/views/company_html.ex:76
 #, elixir-autogen, elixir-format
 msgid "People here per day over the last %{days} days"
 msgstr ""
@@ -22937,19 +22927,14 @@ msgstr ""
 msgid "Press material: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:111
+#: lib/vutuv_web/agent_docs/investors_doc.ex:109
 #, elixir-autogen, elixir-format
 msgid "Readable without an account"
 msgstr ""
 
-#: lib/vutuv_web/templates/company/investors.html.heex:142
+#: lib/vutuv_web/templates/company/investors.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Send a message"
-msgstr ""
-
-#: lib/vutuv_web/templates/company/investors.html.heex:33
-#, elixir-autogen, elixir-format
-msgid "Signed in within 30 days"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:375
@@ -22961,7 +22946,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:382
 #: lib/vutuv_web/agent_docs/text.ex:356
-#: lib/vutuv_web/templates/company/investors.html.heex:82
+#: lib/vutuv_web/templates/company/investors.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Why this is worth building"
 msgstr ""
@@ -22974,17 +22959,17 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:388
 #: lib/vutuv_web/agent_docs/text.ex:358
-#: lib/vutuv_web/templates/company/investors.html.heex:120
+#: lib/vutuv_web/templates/company/investors.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Write to me"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:220
+#: lib/vutuv_web/agent_docs/investors_doc.ex:261
 #, elixir-autogen, elixir-format
 msgid "Write to me here, on vutuv. Creating an account takes a minute and costs nothing, and you will have seen the product before the first sentence about it."
 msgstr ""
 
-#: lib/vutuv_web/templates/company/investors.html.heex:125
+#: lib/vutuv_web/templates/company/investors.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "My profile:"
 msgstr ""
@@ -22995,17 +22980,17 @@ msgstr ""
 msgid "My profile: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:143
+#: lib/vutuv_web/agent_docs/investors_doc.ex:141
 #, elixir-autogen, elixir-format
 msgid "Text ads are to carry the operation, which is why there is no premium tier and will not be one. Nothing is held back from somebody who will not pay for it, and a paid tier is the single thing that stops most people from ever starting. Leaving it out is what lets the network grow, and only a growing network makes the ads worth anything."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:119
+#: lib/vutuv_web/agent_docs/investors_doc.ex:117
 #, elixir-autogen, elixir-format
 msgid "Fast pages win"
 msgstr ""
 
-#: lib/vutuv_web/templates/company/investors.html.heex:101
+#: lib/vutuv_web/templates/company/investors.html.heex:108
 #, elixir-autogen, elixir-format
 msgid "Source:"
 msgstr ""
@@ -23016,37 +23001,37 @@ msgstr ""
 msgid "Source: %{source}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:121
+#: lib/vutuv_web/agent_docs/investors_doc.ex:119
 #, elixir-autogen, elixir-format
 msgid "A page that answers in milliseconds is not a matter of polish, it decides whether somebody stays. Google had 55 and Deloitte measure that across 37 European and American brands and more than 30 million sessions: a tenth of a second faster raised conversions by 8.4% in retail and by 10.1% in travel."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:113
+#: lib/vutuv_web/agent_docs/investors_doc.ex:111
 #, elixir-autogen, elixir-format
 msgid "LinkedIn shows a profile to whoever is logged in and asks everybody else to sign up first. Everybody who is inside knows the other half: you go looking for one person and get a feed, suggestions you did not ask for, and a note that the rest is behind Premium. A vutuv profile is an ordinary public web page: a search engine indexes it, an AI agent reads it as Markdown, JSON or vCard, and a person who has never heard of us reads it without handing over an address first. That is why somebody arrives at all, and why a member puts their work here."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:132
+#: lib/vutuv_web/agent_docs/investors_doc.ex:130
 #, elixir-autogen, elixir-format
 msgid "Networks are not equal, and neither are the markets on them: in 2025 the ITU counted 84% of people in high-income countries with access to 5G against 4% in low-income ones, and somebody online in a wealthy country moves nearly eight times as much mobile data as somebody in a poor one. A site that assumes a fast line is shut to most of them in practice. A vutuv page loads less data than a LinkedIn page to begin with, and a data-saving mode cuts that again for anybody on a slow connection or paying by the megabyte."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:130
+#: lib/vutuv_web/agent_docs/investors_doc.ex:128
 #, elixir-autogen, elixir-format
 msgid "The market behind the slow connection"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:166
+#: lib/vutuv_web/agent_docs/investors_doc.ex:168
 #, elixir-autogen, elixir-format
 msgid "%{members} members + %{fediverse} Fediverse accounts = %{total} people"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:179
-#, elixir-autogen, elixir-format
-msgid "That total is the number in the top bar. Nobody is counted twice: an account following five things here is one account, and a member who also follows from elsewhere is already in the first figure."
-msgstr ""
-
-#: lib/vutuv_web/agent_docs/investors_doc.ex:91
+#: lib/vutuv_web/agent_docs/investors_doc.ex:89
 #, elixir-autogen, elixir-format
 msgid "This page is for potential investors. It says what vutuv is, where the network stands today, and how it is meant to earn money one day."
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/investors_doc.ex:222
+#, elixir-autogen, elixir-format
+msgid "A Fediverse account following several profiles here still counts as one person."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -437,8 +437,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1561
-#: lib/vutuv_web/live/shell_live.ex:1637
+#: lib/vutuv_web/live/shell_live.ex:1608
+#: lib/vutuv_web/live/shell_live.ex:1684
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -452,8 +452,8 @@ msgid "Middle Name"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:1351
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:263
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:271
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:298
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:306
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -643,8 +643,8 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
-#: lib/vutuv_web/live/shell_live.ex:1430
-#: lib/vutuv_web/live/shell_live.ex:1617
+#: lib/vutuv_web/live/shell_live.ex:1477
+#: lib/vutuv_web/live/shell_live.ex:1664
 #: lib/vutuv_web/live/tag_live/timeline.ex:319
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
@@ -1138,7 +1138,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:63
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1537
+#: lib/vutuv_web/live/shell_live.ex:1584
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1573,7 +1573,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1635
+#: lib/vutuv_web/live/shell_live.ex:1682
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1673,7 +1673,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/show.ex:579
 #: lib/vutuv_web/live/organization_live/show.ex:616
 #: lib/vutuv_web/live/post_live/feed.ex:943
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:250
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
 #: lib/vutuv_web/templates/user/show.html.heex:1325
 #: lib/vutuv_web/views/user_html.ex:633
 #, elixir-autogen, elixir-format
@@ -1690,7 +1690,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1556
+#: lib/vutuv_web/live/shell_live.ex:1603
 #: lib/vutuv_web/views/settings_html.ex:299
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1722,8 +1722,8 @@ msgstr ""
 #: lib/vutuv_web/controllers/page_controller.ex:218
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1448
-#: lib/vutuv_web/live/shell_live.ex:1634
+#: lib/vutuv_web/live/shell_live.ex:1495
+#: lib/vutuv_web/live/shell_live.ex:1681
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1755,7 +1755,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/page_controller.ex:219
 #: lib/vutuv_web/live/notification_live/index.ex:152
 #: lib/vutuv_web/live/notification_live/index.ex:457
-#: lib/vutuv_web/live/shell_live.ex:1460
+#: lib/vutuv_web/live/shell_live.ex:1507
 #: lib/vutuv_web/templates/layout/app.html.heex:159
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2107,8 +2107,8 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/feed.ex:345
 #: lib/vutuv_web/live/post_live/feed.ex:3088
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1282
-#: lib/vutuv_web/live/shell_live.ex:1607
+#: lib/vutuv_web/live/shell_live.ex:1290
+#: lib/vutuv_web/live/shell_live.ex:1654
 #: lib/vutuv_web/templates/layout/app.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2183,7 +2183,6 @@ msgstr ""
 msgid "Post deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:70
 #: lib/vutuv_web/agent_docs/post_doc.ex:242
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/post_controller.ex:90
@@ -2195,7 +2194,6 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:348
 #: lib/vutuv_web/live/search_live.ex:832
-#: lib/vutuv_web/templates/company/investors.html.heex:39
 #: lib/vutuv_web/templates/settings/preferences.html.heex:275
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
@@ -2210,7 +2208,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:4118
 #: lib/vutuv_web/live/fediverse_account_live.ex:360
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:201
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
@@ -2284,7 +2283,7 @@ msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5363
-#: lib/vutuv_web/live/shell_live.ex:1503
+#: lib/vutuv_web/live/shell_live.ex:1550
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:246
@@ -2377,8 +2376,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1201
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:1440
-#: lib/vutuv_web/live/shell_live.ex:1508
+#: lib/vutuv_web/live/shell_live.ex:1487
+#: lib/vutuv_web/live/shell_live.ex:1555
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2398,7 +2397,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:6025
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:1511
+#: lib/vutuv_web/live/shell_live.ex:1558
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2482,10 +2481,8 @@ msgstr ""
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:71
 #: lib/vutuv_web/components/post_components.ex:422
 #: lib/vutuv_web/live/notification_live/index.ex:1348
-#: lib/vutuv_web/templates/company/investors.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
@@ -3148,7 +3145,7 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4973
-#: lib/vutuv_web/live/shell_live.ex:1314
+#: lib/vutuv_web/live/shell_live.ex:1322
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -4590,6 +4587,7 @@ msgstr ""
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
 
+#: lib/vutuv_web/agent_docs/investors_doc.ex:212
 #: lib/vutuv_web/agent_docs/markdown.ex:463
 #: lib/vutuv_web/agent_docs/text.ex:481
 #: lib/vutuv_web/components/saved_search_components.ex:57
@@ -5307,7 +5305,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1490
+#: lib/vutuv_web/live/shell_live.ex:1537
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5329,7 +5327,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1547
+#: lib/vutuv_web/live/shell_live.ex:1594
 #: lib/vutuv_web/templates/layout/app.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5348,7 +5346,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:276
-#: lib/vutuv_web/live/shell_live.ex:1527
+#: lib/vutuv_web/live/shell_live.ex:1574
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5403,8 +5401,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1270
-#: lib/vutuv_web/live/shell_live.ex:1588
+#: lib/vutuv_web/live/shell_live.ex:1278
+#: lib/vutuv_web/live/shell_live.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -6608,7 +6606,7 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_account_live.ex:396
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:320
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:230
 #, elixir-autogen, elixir-format
@@ -6636,7 +6634,7 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:320
 #: lib/vutuv_web/templates/settings/filters.html.heex:111
 #: lib/vutuv_web/templates/user/show.html.heex:230
 #, elixir-autogen, elixir-format
@@ -6856,7 +6854,8 @@ msgstr ""
 msgid "Maximum age"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:67
+#: lib/vutuv_web/agent_docs/investors_doc.ex:69
+#: lib/vutuv_web/agent_docs/investors_doc.ex:200
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:592
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:665
 #: lib/vutuv_web/live/admin/user_detail_live.ex:64
@@ -6868,7 +6867,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:45
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:90
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:9
-#: lib/vutuv_web/templates/company/investors.html.heex:29
+#: lib/vutuv_web/templates/company/investors.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Members"
 msgstr ""
@@ -11747,7 +11746,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1518
+#: lib/vutuv_web/live/shell_live.ex:1565
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:79
@@ -12077,7 +12076,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:47
 #: lib/vutuv_web/live/job_board_live.ex:265
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1322
+#: lib/vutuv_web/live/shell_live.ex:1330
 #: lib/vutuv_web/templates/layout/app.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -13753,7 +13752,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:699
+#: lib/vutuv_web/live/shell_live.ex:707
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -15382,7 +15381,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1399
 #: lib/vutuv_web/components/post_components.ex:1599
 #: lib/vutuv_web/components/post_components.ex:2987
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:331
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -16826,6 +16825,7 @@ msgid "Paste an address from Mastodon and friends to open its page here."
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:357
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "Show the whole description"
 msgstr ""
@@ -18045,7 +18045,7 @@ msgstr ""
 msgid "%{address} (whole website)"
 msgstr ""
 
-#: lib/vutuv_web/markdown.ex:385
+#: lib/vutuv_web/markdown.ex:372
 #, elixir-autogen, elixir-format
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
@@ -19736,7 +19736,7 @@ msgstr ""
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1228
+#: lib/vutuv_web/live/shell_live.ex:1236
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Open the page"
 msgstr ""
@@ -19756,7 +19756,7 @@ msgstr ""
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1238
+#: lib/vutuv_web/live/shell_live.ex:1246
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -19766,7 +19766,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1214
+#: lib/vutuv_web/live/shell_live.ex:1222
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -20130,21 +20130,21 @@ msgstr ""
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:743
+#: lib/vutuv_web/live/shell_live.ex:751
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:730
+#: lib/vutuv_web/live/shell_live.ex:738
 #, elixir-autogen, elixir-format, fuzzy
 msgid "person"
 msgid_plural "people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:765
+#: lib/vutuv_web/live/shell_live.ex:773
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -21225,7 +21225,7 @@ msgstr ""
 msgid "Unfollowed. Their posts leave your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1188
+#: lib/vutuv_web/live/shell_live.ex:1196
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr ""
@@ -21240,12 +21240,12 @@ msgstr ""
 msgid "Browser notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1046
+#: lib/vutuv_web/live/shell_live.ex:1054
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1191
+#: lib/vutuv_web/live/shell_live.ex:1199
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
@@ -21285,7 +21285,7 @@ msgstr ""
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1185
+#: lib/vutuv_web/live/shell_live.ex:1193
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -21325,12 +21325,12 @@ msgstr ""
 msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:838
+#: lib/vutuv_web/live/shell_live.ex:846
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:839
+#: lib/vutuv_web/live/shell_live.ex:847
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr ""
@@ -21551,7 +21551,7 @@ msgstr ""
 msgid "Translated into %{language}."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:979
+#: lib/vutuv_web/live/shell_live.ex:987
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -21670,7 +21670,7 @@ msgstr ""
 msgid "No connection"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1118
+#: lib/vutuv_web/live/shell_live.ex:1126
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr ""
@@ -22158,7 +22158,7 @@ msgstr ""
 msgid "Scan it with the device that has the app"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1100
+#: lib/vutuv_web/live/shell_live.ex:1108
 #, elixir-autogen, elixir-format, fuzzy
 msgid "A new version is ready."
 msgstr ""
@@ -22314,7 +22314,7 @@ msgid_plural "%{formatted} posts here"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:296
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "Address copied"
 msgstr ""
@@ -22324,17 +22324,17 @@ msgstr ""
 msgid "Another network"
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:299
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:334
 #, elixir-autogen, elixir-format
 msgid "Copy address"
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:152
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "Latest here"
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:291
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:326
 #, elixir-autogen, elixir-format
 msgid "Mute %{host}"
 msgstr ""
@@ -22354,7 +22354,7 @@ msgstr ""
 msgid "Really withdraw?"
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:290
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:325
 #, elixir-autogen, elixir-format
 msgid "Unmute %{host}"
 msgstr ""
@@ -22406,7 +22406,7 @@ msgstr ""
 msgid "Low-bandwidth mode"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1629
+#: lib/vutuv_web/live/shell_live.ex:1676
 #, elixir-autogen, elixir-format
 msgctxt "phone tab bar"
 msgid "Write"
@@ -22563,7 +22563,7 @@ msgstr ""
 msgid "Appearance"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1655
+#: lib/vutuv_web/live/shell_live.ex:1702
 #, elixir-autogen, elixir-format
 msgid "%{count} video in progress"
 msgid_plural "%{count} videos in progress"
@@ -22818,7 +22818,7 @@ msgid_plural "%{formatted} random vutuv accounts that are open to offers."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:713
+#: lib/vutuv_web/live/shell_live.ex:721
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post in your feed"
 msgid_plural "%{formatted} new posts in your feed"
@@ -22855,76 +22855,66 @@ msgstr ""
 msgid "Your public posts then also appear on {mastodon}, for example."
 msgstr ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:197
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:232
 #, elixir-autogen, elixir-format
 msgid "%{formatted} older post"
 msgid_plural "%{formatted} older posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:312
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:347
 #, elixir-autogen, elixir-format
 msgid "Their page here"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:83
+#: lib/vutuv_web/agent_docs/investors_doc.ex:81
 #, elixir-autogen, elixir-format
 msgid "A professional network that works without an account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:69
-#: lib/vutuv_web/templates/company/investors.html.heex:36
-#, elixir-autogen, elixir-format
-msgid "Active this half year"
-msgstr ""
-
-#: lib/vutuv_web/agent_docs/investors_doc.ex:68
-#: lib/vutuv_web/templates/company/investors.html.heex:31
-#, elixir-autogen, elixir-format
-msgid "Active this month"
-msgstr ""
-
-#: lib/vutuv_web/agent_docs/investors_doc.ex:141
+#: lib/vutuv_web/agent_docs/investors_doc.ex:139
 #, elixir-autogen, elixir-format
 msgid "Advertising instead of a paywall"
 msgstr ""
 
-#: lib/vutuv_web/templates/company/investors.html.heex:137
+#: lib/vutuv_web/templates/company/investors.html.heex:149
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create an account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:72
-#: lib/vutuv_web/templates/company/investors.html.heex:42
+#: lib/vutuv_web/agent_docs/investors_doc.ex:70
+#: lib/vutuv_web/agent_docs/investors_doc.ex:206
+#: lib/vutuv_web/templates/company/investors.html.heex:29
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Fediverse accounts"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:73
+#: lib/vutuv_web/agent_docs/investors_doc.ex:71
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Fediverse servers"
 msgstr ""
 
-#: lib/vutuv_web/templates/company/investors.html.heex:45
+#: lib/vutuv_web/templates/company/investors.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "From %{formatted} server"
 msgid_plural "From %{formatted} servers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:254
+#: lib/vutuv_web/agent_docs/investors_doc.ex:295
 #: lib/vutuv_web/controllers/company_controller.ex:56
 #: lib/vutuv_web/templates/layout/app.html.heex:110
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Investors"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:208
+#: lib/vutuv_web/agent_docs/investors_doc.ex:249
 #, elixir-autogen, elixir-format
 msgid "Over these %{days} days %{total} people arrived, %{members} of them as members here."
 msgstr ""
 
-#: lib/vutuv_web/views/company_html.ex:71
+#: lib/vutuv_web/live/shell_live.ex:1415
+#: lib/vutuv_web/views/company_html.ex:76
 #, elixir-autogen, elixir-format
 msgid "People here per day over the last %{days} days"
 msgstr ""
@@ -22935,19 +22925,14 @@ msgstr ""
 msgid "Press material: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:111
+#: lib/vutuv_web/agent_docs/investors_doc.ex:109
 #, elixir-autogen, elixir-format
 msgid "Readable without an account"
 msgstr ""
 
-#: lib/vutuv_web/templates/company/investors.html.heex:142
+#: lib/vutuv_web/templates/company/investors.html.heex:154
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send a message"
-msgstr ""
-
-#: lib/vutuv_web/templates/company/investors.html.heex:33
-#, elixir-autogen, elixir-format
-msgid "Signed in within 30 days"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:375
@@ -22959,7 +22944,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:382
 #: lib/vutuv_web/agent_docs/text.ex:356
-#: lib/vutuv_web/templates/company/investors.html.heex:82
+#: lib/vutuv_web/templates/company/investors.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Why this is worth building"
 msgstr ""
@@ -22972,17 +22957,17 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:388
 #: lib/vutuv_web/agent_docs/text.ex:358
-#: lib/vutuv_web/templates/company/investors.html.heex:120
+#: lib/vutuv_web/templates/company/investors.html.heex:127
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Write to me"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:220
+#: lib/vutuv_web/agent_docs/investors_doc.ex:261
 #, elixir-autogen, elixir-format
 msgid "Write to me here, on vutuv. Creating an account takes a minute and costs nothing, and you will have seen the product before the first sentence about it."
 msgstr ""
 
-#: lib/vutuv_web/templates/company/investors.html.heex:125
+#: lib/vutuv_web/templates/company/investors.html.heex:137
 #, elixir-autogen, elixir-format, fuzzy
 msgid "My profile:"
 msgstr ""
@@ -22993,17 +22978,17 @@ msgstr ""
 msgid "My profile: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:143
+#: lib/vutuv_web/agent_docs/investors_doc.ex:141
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Text ads are to carry the operation, which is why there is no premium tier and will not be one. Nothing is held back from somebody who will not pay for it, and a paid tier is the single thing that stops most people from ever starting. Leaving it out is what lets the network grow, and only a growing network makes the ads worth anything."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:119
+#: lib/vutuv_web/agent_docs/investors_doc.ex:117
 #, elixir-autogen, elixir-format
 msgid "Fast pages win"
 msgstr ""
 
-#: lib/vutuv_web/templates/company/investors.html.heex:101
+#: lib/vutuv_web/templates/company/investors.html.heex:108
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Source:"
 msgstr ""
@@ -23014,37 +22999,37 @@ msgstr ""
 msgid "Source: %{source}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:121
+#: lib/vutuv_web/agent_docs/investors_doc.ex:119
 #, elixir-autogen, elixir-format, fuzzy
 msgid "A page that answers in milliseconds is not a matter of polish, it decides whether somebody stays. Google had 55 and Deloitte measure that across 37 European and American brands and more than 30 million sessions: a tenth of a second faster raised conversions by 8.4% in retail and by 10.1% in travel."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:113
+#: lib/vutuv_web/agent_docs/investors_doc.ex:111
 #, elixir-autogen, elixir-format
 msgid "LinkedIn shows a profile to whoever is logged in and asks everybody else to sign up first. Everybody who is inside knows the other half: you go looking for one person and get a feed, suggestions you did not ask for, and a note that the rest is behind Premium. A vutuv profile is an ordinary public web page: a search engine indexes it, an AI agent reads it as Markdown, JSON or vCard, and a person who has never heard of us reads it without handing over an address first. That is why somebody arrives at all, and why a member puts their work here."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:132
+#: lib/vutuv_web/agent_docs/investors_doc.ex:130
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Networks are not equal, and neither are the markets on them: in 2025 the ITU counted 84% of people in high-income countries with access to 5G against 4% in low-income ones, and somebody online in a wealthy country moves nearly eight times as much mobile data as somebody in a poor one. A site that assumes a fast line is shut to most of them in practice. A vutuv page loads less data than a LinkedIn page to begin with, and a data-saving mode cuts that again for anybody on a slow connection or paying by the megabyte."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:130
+#: lib/vutuv_web/agent_docs/investors_doc.ex:128
 #, elixir-autogen, elixir-format
 msgid "The market behind the slow connection"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:166
+#: lib/vutuv_web/agent_docs/investors_doc.ex:168
 #, elixir-autogen, elixir-format
 msgid "%{members} members + %{fediverse} Fediverse accounts = %{total} people"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:179
-#, elixir-autogen, elixir-format
-msgid "That total is the number in the top bar. Nobody is counted twice: an account following five things here is one account, and a member who also follows from elsewhere is already in the first figure."
-msgstr ""
-
-#: lib/vutuv_web/agent_docs/investors_doc.ex:91
+#: lib/vutuv_web/agent_docs/investors_doc.ex:89
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This page is for potential investors. It says what vutuv is, where the network stands today, and how it is meant to earn money one day."
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/investors_doc.ex:222
+#, elixir-autogen, elixir-format
+msgid "A Fediverse account following several profiles here still counts as one person."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -441,8 +441,8 @@ msgstr "Accedi"
 msgid "Log Out"
 msgstr "Esci"
 
-#: lib/vutuv_web/live/shell_live.ex:1561
-#: lib/vutuv_web/live/shell_live.ex:1637
+#: lib/vutuv_web/live/shell_live.ex:1608
+#: lib/vutuv_web/live/shell_live.ex:1684
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -456,8 +456,8 @@ msgid "Middle Name"
 msgstr "Secondo nome"
 
 #: lib/vutuv_web/live/notification_live/index.ex:1351
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:263
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:271
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:298
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:306
 #, elixir-autogen
 msgid "More"
 msgstr "Altro"
@@ -647,8 +647,8 @@ msgstr "Salva"
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
-#: lib/vutuv_web/live/shell_live.ex:1430
-#: lib/vutuv_web/live/shell_live.ex:1617
+#: lib/vutuv_web/live/shell_live.ex:1477
+#: lib/vutuv_web/live/shell_live.ex:1664
 #: lib/vutuv_web/live/tag_live/timeline.ex:319
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
@@ -1161,7 +1161,7 @@ msgstr "Aggiungi localizzazione"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:63
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1537
+#: lib/vutuv_web/live/shell_live.ex:1584
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1603,7 +1603,7 @@ msgstr "Indirizzi di %{name}"
 msgid "Admin control panel"
 msgstr "Pannello di amministrazione"
 
-#: lib/vutuv_web/live/shell_live.ex:1635
+#: lib/vutuv_web/live/shell_live.ex:1682
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Avvisi"
@@ -1703,7 +1703,7 @@ msgstr "Conferma"
 #: lib/vutuv_web/live/organization_live/show.ex:579
 #: lib/vutuv_web/live/organization_live/show.ex:616
 #: lib/vutuv_web/live/post_live/feed.ex:943
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:250
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
 #: lib/vutuv_web/templates/user/show.html.heex:1325
 #: lib/vutuv_web/views/user_html.ex:633
 #, elixir-autogen, elixir-format
@@ -1722,7 +1722,7 @@ msgstr ""
 "Sembra che non segua ancora nessuno. Apra il profilo di una persona che "
 "conosce o che La incuriosisce e prema il pulsante «Segui»."
 
-#: lib/vutuv_web/live/shell_live.ex:1556
+#: lib/vutuv_web/live/shell_live.ex:1603
 #: lib/vutuv_web/views/settings_html.ex:299
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1754,8 +1754,8 @@ msgstr "Messaggio"
 #: lib/vutuv_web/controllers/page_controller.ex:218
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1448
-#: lib/vutuv_web/live/shell_live.ex:1634
+#: lib/vutuv_web/live/shell_live.ex:1495
+#: lib/vutuv_web/live/shell_live.ex:1681
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1787,7 +1787,7 @@ msgstr "Ancora nessuna novità."
 #: lib/vutuv_web/controllers/page_controller.ex:219
 #: lib/vutuv_web/live/notification_live/index.ex:152
 #: lib/vutuv_web/live/notification_live/index.ex:457
-#: lib/vutuv_web/live/shell_live.ex:1460
+#: lib/vutuv_web/live/shell_live.ex:1507
 #: lib/vutuv_web/templates/layout/app.html.heex:159
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2149,8 +2149,8 @@ msgstr "Modifica il post"
 #: lib/vutuv_web/live/post_live/feed.ex:345
 #: lib/vutuv_web/live/post_live/feed.ex:3088
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1282
-#: lib/vutuv_web/live/shell_live.ex:1607
+#: lib/vutuv_web/live/shell_live.ex:1290
+#: lib/vutuv_web/live/shell_live.ex:1654
 #: lib/vutuv_web/templates/layout/app.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2227,7 +2227,6 @@ msgstr "Pubblica"
 msgid "Post deleted successfully."
 msgstr "Post eliminato."
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:70
 #: lib/vutuv_web/agent_docs/post_doc.ex:242
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/post_controller.ex:90
@@ -2239,7 +2238,6 @@ msgstr "Post eliminato."
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:348
 #: lib/vutuv_web/live/search_live.ex:832
-#: lib/vutuv_web/templates/company/investors.html.heex:39
 #: lib/vutuv_web/templates/settings/preferences.html.heex:275
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
@@ -2254,7 +2252,8 @@ msgstr "Leggi tutto"
 
 #: lib/vutuv_web/components/post_components.ex:4118
 #: lib/vutuv_web/live/fediverse_account_live.ex:360
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:201
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr "Mostra meno"
@@ -2330,7 +2329,7 @@ msgid "Upload failed."
 msgstr "Caricamento non riuscito."
 
 #: lib/vutuv_web/components/ui.ex:5363
-#: lib/vutuv_web/live/shell_live.ex:1503
+#: lib/vutuv_web/live/shell_live.ex:1550
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:246
@@ -2423,8 +2422,8 @@ msgstr "Salva"
 #: lib/vutuv_web/agent_docs/markdown.ex:1201
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:1440
-#: lib/vutuv_web/live/shell_live.ex:1508
+#: lib/vutuv_web/live/shell_live.ex:1487
+#: lib/vutuv_web/live/shell_live.ex:1555
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2444,7 +2443,7 @@ msgstr "Mi piace"
 #: lib/vutuv_web/components/post_components.ex:6025
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:1511
+#: lib/vutuv_web/live/shell_live.ex:1558
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2528,10 +2527,8 @@ msgstr "Benvenuto su vutuv."
 msgid "Only public posts can be answered."
 msgstr "Solo ai post pubblici si può rispondere."
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:71
 #: lib/vutuv_web/components/post_components.ex:422
 #: lib/vutuv_web/live/notification_live/index.ex:1348
-#: lib/vutuv_web/templates/company/investors.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Risposte"
@@ -3225,7 +3222,7 @@ msgid "Private message"
 msgstr "Messaggio privato"
 
 #: lib/vutuv_web/components/ui.ex:4973
-#: lib/vutuv_web/live/shell_live.ex:1314
+#: lib/vutuv_web/live/shell_live.ex:1322
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -4767,6 +4764,7 @@ msgstr "Nessun risultato per \"%{query}\""
 msgid "Not an exact match, but sounds like your search."
 msgstr "Non è una corrispondenza esatta, ma somiglia alla Sua ricerca."
 
+#: lib/vutuv_web/agent_docs/investors_doc.ex:212
 #: lib/vutuv_web/agent_docs/markdown.ex:463
 #: lib/vutuv_web/agent_docs/text.ex:481
 #: lib/vutuv_web/components/saved_search_components.ex:57
@@ -5524,7 +5522,7 @@ msgstr "Non può più rispondere a questo post."
 msgid "Content under review"
 msgstr "Contenuto in esame"
 
-#: lib/vutuv_web/live/shell_live.ex:1490
+#: lib/vutuv_web/live/shell_live.ex:1537
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Menu dell'account"
@@ -5546,7 +5544,7 @@ msgstr "Chiudi menu e finestre"
 msgid "General"
 msgstr "Generale"
 
-#: lib/vutuv_web/live/shell_live.ex:1547
+#: lib/vutuv_web/live/shell_live.ex:1594
 #: lib/vutuv_web/templates/layout/app.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5565,7 +5563,7 @@ msgstr "Navigazione"
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:276
-#: lib/vutuv_web/live/shell_live.ex:1527
+#: lib/vutuv_web/live/shell_live.ex:1574
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5620,8 +5618,8 @@ msgstr "Post successivo nel feed"
 msgid "Previous post in the feed"
 msgstr "Post precedente nel feed"
 
-#: lib/vutuv_web/live/shell_live.ex:1270
-#: lib/vutuv_web/live/shell_live.ex:1588
+#: lib/vutuv_web/live/shell_live.ex:1278
+#: lib/vutuv_web/live/shell_live.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Navigazione principale"
@@ -6874,7 +6872,7 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_account_live.ex:396
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:320
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:230
 #, elixir-autogen, elixir-format
@@ -6902,7 +6900,7 @@ msgstr "Rimuovere questo collegamento? Smetterà di seguire questa persona."
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:320
 #: lib/vutuv_web/templates/settings/filters.html.heex:111
 #: lib/vutuv_web/templates/user/show.html.heex:230
 #, elixir-autogen, elixir-format
@@ -7131,7 +7129,8 @@ msgstr "Markdown è supportato (titoli, grassetto, elenchi, link)."
 msgid "Maximum age"
 msgstr "Età massima"
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:67
+#: lib/vutuv_web/agent_docs/investors_doc.ex:69
+#: lib/vutuv_web/agent_docs/investors_doc.ex:200
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:592
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:665
 #: lib/vutuv_web/live/admin/user_detail_live.ex:64
@@ -7143,7 +7142,7 @@ msgstr "Età massima"
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:45
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:90
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:9
-#: lib/vutuv_web/templates/company/investors.html.heex:29
+#: lib/vutuv_web/templates/company/investors.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Members"
 msgstr "Membri"
@@ -12358,7 +12357,7 @@ msgstr "Organizzazione sbloccata."
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1518
+#: lib/vutuv_web/live/shell_live.ex:1565
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:79
@@ -12704,7 +12703,7 @@ msgstr "Titolo della posizione"
 #: lib/vutuv_web/live/job_board_live.ex:47
 #: lib/vutuv_web/live/job_board_live.ex:265
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1322
+#: lib/vutuv_web/live/shell_live.ex:1330
 #: lib/vutuv_web/templates/layout/app.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -14501,7 +14500,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] "Confermato da %{name} e da %{formatted} altro"
 msgstr[1] "Confermato da %{name} e da altri %{formatted}"
 
-#: lib/vutuv_web/live/shell_live.ex:699
+#: lib/vutuv_web/live/shell_live.ex:707
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -16289,7 +16288,7 @@ msgstr "Questa risposta non spetta a Lei rimuoverla."
 #: lib/vutuv_web/components/post_components.ex:1399
 #: lib/vutuv_web/components/post_components.ex:1599
 #: lib/vutuv_web/components/post_components.ex:2987
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:331
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Vedi l'originale"
@@ -17863,6 +17862,7 @@ msgid "Paste an address from Mastodon and friends to open its page here."
 msgstr "Incolli un indirizzo da Mastodon e affini per aprirne qui la pagina."
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:357
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "Show the whole description"
 msgstr "Mostra tutta la descrizione"
@@ -19264,7 +19264,7 @@ msgstr "%{address} (solo questa pagina)"
 msgid "%{address} (whole website)"
 msgstr "%{address} (intero sito web)"
 
-#: lib/vutuv_web/markdown.ex:385
+#: lib/vutuv_web/markdown.ex:372
 #, elixir-autogen, elixir-format
 msgid "Verified webpage of the author (%{address})"
 msgstr "Pagina web verificata dell'autore (%{address})"
@@ -21130,7 +21130,7 @@ msgstr "Non può più scrivere a nome di questa organizzazione."
 msgid "A post in an organization's name is always public."
 msgstr "Un post a nome di un'organizzazione è sempre pubblico."
 
-#: lib/vutuv_web/live/shell_live.ex:1228
+#: lib/vutuv_web/live/shell_live.ex:1236
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr "Apri la pagina"
@@ -21150,7 +21150,7 @@ msgstr "Ha smesso di scrivere come organizzazione"
 msgid "Write as %{name} for now"
 msgstr "Scrivi come %{name} per ora"
 
-#: lib/vutuv_web/live/shell_live.ex:1238
+#: lib/vutuv_web/live/shell_live.ex:1246
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr "Torna a scrivere come me stesso"
@@ -21160,7 +21160,7 @@ msgstr "Torna a scrivere come me stesso"
 msgid "You are writing as %{name} now."
 msgstr "Ora sta scrivendo come %{name}."
 
-#: lib/vutuv_web/live/shell_live.ex:1214
+#: lib/vutuv_web/live/shell_live.ex:1222
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr "Sta scrivendo come %{name}."
@@ -21571,21 +21571,21 @@ msgstr "Segue già #%{tag} qui."
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr "Anche Lei è su questo vutuv, quindi ora segue #%{tag} proprio qui."
 
-#: lib/vutuv_web/live/shell_live.ex:743
+#: lib/vutuv_web/live/shell_live.ex:751
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] "%{formatted} persona"
 msgstr[1] "%{formatted} persone"
 
-#: lib/vutuv_web/live/shell_live.ex:730
+#: lib/vutuv_web/live/shell_live.ex:738
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] "persona"
 msgstr[1] "persone"
 
-#: lib/vutuv_web/live/shell_live.ex:765
+#: lib/vutuv_web/live/shell_live.ex:773
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -22783,7 +22783,7 @@ msgstr "Smettere di seguire %{handle}? I suoi post spariscono dal Suo feed."
 msgid "Unfollowed. Their posts leave your feed."
 msgstr "Non lo segue più. I suoi post spariscono dal Suo feed."
 
-#: lib/vutuv_web/live/shell_live.ex:1188
+#: lib/vutuv_web/live/shell_live.ex:1196
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr "Consenti"
@@ -22798,12 +22798,12 @@ msgstr "Chiedi ora"
 msgid "Browser notifications"
 msgstr "Notifiche del browser"
 
-#: lib/vutuv_web/live/shell_live.ex:1046
+#: lib/vutuv_web/live/shell_live.ex:1054
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr "Nuovo messaggio"
 
-#: lib/vutuv_web/live/shell_live.ex:1191
+#: lib/vutuv_web/live/shell_live.ex:1199
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Non ora"
@@ -22853,7 +22853,7 @@ msgstr ""
 "guardando, il Suo browser può mostrarlo come notifica. Disattivate finché "
 "non le attiva."
 
-#: lib/vutuv_web/live/shell_live.ex:1185
+#: lib/vutuv_web/live/shell_live.ex:1193
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -22899,12 +22899,12 @@ msgstr ""
 "Inviata. Se non è comparso nulla, è il Suo sistema a trattenerla. Controlli "
 "la modalità Non disturbare e le impostazioni delle notifiche."
 
-#: lib/vutuv_web/live/shell_live.ex:838
+#: lib/vutuv_web/live/shell_live.ex:846
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr "Notifica di prova"
 
-#: lib/vutuv_web/live/shell_live.ex:839
+#: lib/vutuv_web/live/shell_live.ex:847
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr "Ecco come si presenta vutuv quando arriva qualcosa."
@@ -23134,7 +23134,7 @@ msgstr "Traducili in %{language}"
 msgid "Translated into %{language}."
 msgstr "Vengono tradotti in %{language}."
 
-#: lib/vutuv_web/live/shell_live.ex:979
+#: lib/vutuv_web/live/shell_live.ex:987
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -23259,7 +23259,7 @@ msgstr "Nuovo messaggio su vutuv"
 msgid "No connection"
 msgstr "Nessuna connessione"
 
-#: lib/vutuv_web/live/shell_live.ex:1118
+#: lib/vutuv_web/live/shell_live.ex:1126
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr "Ricarica"
@@ -23751,7 +23751,7 @@ msgstr "I gestori di password come Bitwarden ne ricavano l'intera voce: nome, ac
 msgid "Scan it with the device that has the app"
 msgstr "Da scansionare con il dispositivo su cui è installata l'app"
 
-#: lib/vutuv_web/live/shell_live.ex:1100
+#: lib/vutuv_web/live/shell_live.ex:1108
 #, elixir-autogen, elixir-format
 msgid "A new version is ready."
 msgstr "È pronta una nuova versione."
@@ -23907,7 +23907,7 @@ msgid_plural "%{formatted} posts here"
 msgstr[0] "%{formatted} post qui"
 msgstr[1] "%{formatted} post qui"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:296
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "Address copied"
 msgstr "Indirizzo copiato"
@@ -23917,17 +23917,17 @@ msgstr "Indirizzo copiato"
 msgid "Another network"
 msgstr "Un'altra rete"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:299
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:334
 #, elixir-autogen, elixir-format
 msgid "Copy address"
 msgstr "Copia indirizzo"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:152
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "Latest here"
 msgstr "Ultimo qui"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:291
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:326
 #, elixir-autogen, elixir-format
 msgid "Mute %{host}"
 msgstr "Silenzia %{host}"
@@ -23947,7 +23947,7 @@ msgstr "Smettere davvero di seguire?"
 msgid "Really withdraw?"
 msgstr "Ritirare davvero la richiesta?"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:290
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:325
 #, elixir-autogen, elixir-format
 msgid "Unmute %{host}"
 msgstr "Riattiva %{host}"
@@ -23999,7 +23999,7 @@ msgstr "Se la Sua connessione è lenta o a consumo, vutuv può tralasciare le pa
 msgid "Low-bandwidth mode"
 msgstr "Modalità risparmio dati"
 
-#: lib/vutuv_web/live/shell_live.ex:1629
+#: lib/vutuv_web/live/shell_live.ex:1676
 #, elixir-autogen, elixir-format
 msgctxt "phone tab bar"
 msgid "Write"
@@ -24156,7 +24156,7 @@ msgstr "banda lento internet mobile risparmio dati volume compressione immagini 
 msgid "Appearance"
 msgstr "Aspetto"
 
-#: lib/vutuv_web/live/shell_live.ex:1655
+#: lib/vutuv_web/live/shell_live.ex:1702
 #, elixir-autogen, elixir-format
 msgid "%{count} video in progress"
 msgid_plural "%{count} videos in progress"
@@ -24411,7 +24411,7 @@ msgid_plural "%{formatted} random vutuv accounts that are open to offers."
 msgstr[0] "Un account vutuv scelto a caso, aperto a proposte."
 msgstr[1] "%{formatted} account vutuv scelti a caso, aperti a proposte."
 
-#: lib/vutuv_web/live/shell_live.ex:713
+#: lib/vutuv_web/live/shell_live.ex:721
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post in your feed"
 msgid_plural "%{formatted} new posts in your feed"
@@ -24448,76 +24448,66 @@ msgstr "Il tuo feed mostra quello che scrivono gli account che segui. Eccone alc
 msgid "Your public posts then also appear on {mastodon}, for example."
 msgstr "I tuoi post pubblici compaiono poi anche su {mastodon}, per esempio."
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:197
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:232
 #, elixir-autogen, elixir-format
 msgid "%{formatted} older post"
 msgid_plural "%{formatted} older posts"
 msgstr[0] "%{formatted} post più vecchio"
 msgstr[1] "%{formatted} post più vecchi"
 
-#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:312
+#: lib/vutuv_web/templates/remote_actor_card/card.html.heex:347
 #, elixir-autogen, elixir-format
 msgid "Their page here"
 msgstr "Pagina account qui"
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:83
+#: lib/vutuv_web/agent_docs/investors_doc.ex:81
 #, elixir-autogen, elixir-format
 msgid "A professional network that works without an account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:69
-#: lib/vutuv_web/templates/company/investors.html.heex:36
-#, elixir-autogen, elixir-format
-msgid "Active this half year"
-msgstr ""
-
-#: lib/vutuv_web/agent_docs/investors_doc.ex:68
-#: lib/vutuv_web/templates/company/investors.html.heex:31
-#, elixir-autogen, elixir-format
-msgid "Active this month"
-msgstr ""
-
-#: lib/vutuv_web/agent_docs/investors_doc.ex:141
+#: lib/vutuv_web/agent_docs/investors_doc.ex:139
 #, elixir-autogen, elixir-format
 msgid "Advertising instead of a paywall"
 msgstr ""
 
-#: lib/vutuv_web/templates/company/investors.html.heex:137
+#: lib/vutuv_web/templates/company/investors.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "Create an account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:72
-#: lib/vutuv_web/templates/company/investors.html.heex:42
+#: lib/vutuv_web/agent_docs/investors_doc.ex:70
+#: lib/vutuv_web/agent_docs/investors_doc.ex:206
+#: lib/vutuv_web/templates/company/investors.html.heex:29
 #, elixir-autogen, elixir-format
 msgid "Fediverse accounts"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:73
+#: lib/vutuv_web/agent_docs/investors_doc.ex:71
 #, elixir-autogen, elixir-format
 msgid "Fediverse servers"
 msgstr ""
 
-#: lib/vutuv_web/templates/company/investors.html.heex:45
+#: lib/vutuv_web/templates/company/investors.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "From %{formatted} server"
 msgid_plural "From %{formatted} servers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:254
+#: lib/vutuv_web/agent_docs/investors_doc.ex:295
 #: lib/vutuv_web/controllers/company_controller.ex:56
 #: lib/vutuv_web/templates/layout/app.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Investors"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:208
+#: lib/vutuv_web/agent_docs/investors_doc.ex:249
 #, elixir-autogen, elixir-format
 msgid "Over these %{days} days %{total} people arrived, %{members} of them as members here."
 msgstr ""
 
-#: lib/vutuv_web/views/company_html.ex:71
+#: lib/vutuv_web/live/shell_live.ex:1415
+#: lib/vutuv_web/views/company_html.ex:76
 #, elixir-autogen, elixir-format
 msgid "People here per day over the last %{days} days"
 msgstr ""
@@ -24528,19 +24518,14 @@ msgstr ""
 msgid "Press material: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:111
+#: lib/vutuv_web/agent_docs/investors_doc.ex:109
 #, elixir-autogen, elixir-format
 msgid "Readable without an account"
 msgstr ""
 
-#: lib/vutuv_web/templates/company/investors.html.heex:142
+#: lib/vutuv_web/templates/company/investors.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Send a message"
-msgstr ""
-
-#: lib/vutuv_web/templates/company/investors.html.heex:33
-#, elixir-autogen, elixir-format
-msgid "Signed in within 30 days"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:375
@@ -24552,7 +24537,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:382
 #: lib/vutuv_web/agent_docs/text.ex:356
-#: lib/vutuv_web/templates/company/investors.html.heex:82
+#: lib/vutuv_web/templates/company/investors.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Why this is worth building"
 msgstr ""
@@ -24565,17 +24550,17 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:388
 #: lib/vutuv_web/agent_docs/text.ex:358
-#: lib/vutuv_web/templates/company/investors.html.heex:120
+#: lib/vutuv_web/templates/company/investors.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Write to me"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:220
+#: lib/vutuv_web/agent_docs/investors_doc.ex:261
 #, elixir-autogen, elixir-format
 msgid "Write to me here, on vutuv. Creating an account takes a minute and costs nothing, and you will have seen the product before the first sentence about it."
 msgstr ""
 
-#: lib/vutuv_web/templates/company/investors.html.heex:125
+#: lib/vutuv_web/templates/company/investors.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "My profile:"
 msgstr ""
@@ -24586,17 +24571,17 @@ msgstr ""
 msgid "My profile: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:143
+#: lib/vutuv_web/agent_docs/investors_doc.ex:141
 #, elixir-autogen, elixir-format
 msgid "Text ads are to carry the operation, which is why there is no premium tier and will not be one. Nothing is held back from somebody who will not pay for it, and a paid tier is the single thing that stops most people from ever starting. Leaving it out is what lets the network grow, and only a growing network makes the ads worth anything."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:119
+#: lib/vutuv_web/agent_docs/investors_doc.ex:117
 #, elixir-autogen, elixir-format
 msgid "Fast pages win"
 msgstr ""
 
-#: lib/vutuv_web/templates/company/investors.html.heex:101
+#: lib/vutuv_web/templates/company/investors.html.heex:108
 #, elixir-autogen, elixir-format
 msgid "Source:"
 msgstr ""
@@ -24607,37 +24592,37 @@ msgstr ""
 msgid "Source: %{source}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:121
+#: lib/vutuv_web/agent_docs/investors_doc.ex:119
 #, elixir-autogen, elixir-format
 msgid "A page that answers in milliseconds is not a matter of polish, it decides whether somebody stays. Google had 55 and Deloitte measure that across 37 European and American brands and more than 30 million sessions: a tenth of a second faster raised conversions by 8.4% in retail and by 10.1% in travel."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:113
+#: lib/vutuv_web/agent_docs/investors_doc.ex:111
 #, elixir-autogen, elixir-format
 msgid "LinkedIn shows a profile to whoever is logged in and asks everybody else to sign up first. Everybody who is inside knows the other half: you go looking for one person and get a feed, suggestions you did not ask for, and a note that the rest is behind Premium. A vutuv profile is an ordinary public web page: a search engine indexes it, an AI agent reads it as Markdown, JSON or vCard, and a person who has never heard of us reads it without handing over an address first. That is why somebody arrives at all, and why a member puts their work here."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:132
+#: lib/vutuv_web/agent_docs/investors_doc.ex:130
 #, elixir-autogen, elixir-format
 msgid "Networks are not equal, and neither are the markets on them: in 2025 the ITU counted 84% of people in high-income countries with access to 5G against 4% in low-income ones, and somebody online in a wealthy country moves nearly eight times as much mobile data as somebody in a poor one. A site that assumes a fast line is shut to most of them in practice. A vutuv page loads less data than a LinkedIn page to begin with, and a data-saving mode cuts that again for anybody on a slow connection or paying by the megabyte."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:130
+#: lib/vutuv_web/agent_docs/investors_doc.ex:128
 #, elixir-autogen, elixir-format
 msgid "The market behind the slow connection"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:166
+#: lib/vutuv_web/agent_docs/investors_doc.ex:168
 #, elixir-autogen, elixir-format
 msgid "%{members} members + %{fediverse} Fediverse accounts = %{total} people"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/investors_doc.ex:179
-#, elixir-autogen, elixir-format
-msgid "That total is the number in the top bar. Nobody is counted twice: an account following five things here is one account, and a member who also follows from elsewhere is already in the first figure."
-msgstr ""
-
-#: lib/vutuv_web/agent_docs/investors_doc.ex:91
+#: lib/vutuv_web/agent_docs/investors_doc.ex:89
 #, elixir-autogen, elixir-format
 msgid "This page is for potential investors. It says what vutuv is, where the network stands today, and how it is meant to earn money one day."
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/investors_doc.ex:222
+#, elixir-autogen, elixir-format
+msgid "A Fediverse account following several profiles here still counts as one person."
 msgstr ""

--- a/test/vutuv/people_history_test.exs
+++ b/test/vutuv/people_history_test.exs
@@ -5,7 +5,9 @@ defmodule Vutuv.PeopleHistoryTest do
   that the growth summary can only ever describe the rows the curve is drawn
   from.
   """
-  use Vutuv.DataCase, async: true
+  # Not async: the spark tests write the process-wide `:persistent_term` cache
+  # the top bar reads, which no sandbox transaction rolls back.
+  use Vutuv.DataCase, async: false
 
   alias Vutuv.BerlinTime
   alias Vutuv.Fediverse.Follower
@@ -98,5 +100,97 @@ defmodule Vutuv.PeopleHistoryTest do
       assert PeopleHistory.growth([]) == nil
       assert PeopleHistory.growth([%Snapshot{day: ~D[2026-07-01], members: 1}]) == nil
     end
+  end
+
+  describe "spark_geometry/1" do
+    test "draws one point per day, rising up the box" do
+      series = [
+        %Snapshot{day: ~D[2026-07-01], members: 100, fediverse_accounts: 0},
+        %Snapshot{day: ~D[2026-07-16], members: 150, fediverse_accounts: 0},
+        %Snapshot{day: ~D[2026-07-31], members: 200, fediverse_accounts: 0}
+      ]
+
+      assert %{points: points, days: 30} = PeopleHistory.spark_geometry(series)
+
+      [{x_first, y_first}, {_, y_middle}, {x_last, y_last}] = parse(points)
+
+      # The line spans the box from edge to edge, and a rising total is drawn
+      # rising: in SVG that means a FALLING y, since y counts down from the top.
+      assert x_first == 0.0
+      assert x_last == 100.0
+      assert y_first > y_middle
+      assert y_middle > y_last
+
+      # It keeps a hair of air at both ends, or the stroke of a peak is cut in
+      # half by the edge of the box.
+      assert y_last > 0.0
+      assert y_first < 32.0
+    end
+
+    test "draws nothing for a series that is not a line" do
+      # One day is no span, and a flat month is a dash at this size — which
+      # reads as a chart that failed to load rather than as a quiet month.
+      assert PeopleHistory.spark_geometry([]) == nil
+      assert PeopleHistory.spark_geometry([%Snapshot{day: ~D[2026-07-01], members: 1}]) == nil
+
+      flat = [
+        %Snapshot{day: ~D[2026-07-01], members: 100, fediverse_accounts: 5},
+        %Snapshot{day: ~D[2026-07-31], members: 100, fediverse_accounts: 5}
+      ]
+
+      assert PeopleHistory.spark_geometry(flat) == nil
+    end
+
+    test "counts both populations, like the figure it sits beside" do
+      series = [
+        %Snapshot{day: ~D[2026-07-01], members: 100, fediverse_accounts: 0},
+        %Snapshot{day: ~D[2026-07-31], members: 100, fediverse_accounts: 40}
+      ]
+
+      # Only the Fediverse half moved, and the line still has to show it.
+      assert PeopleHistory.spark_geometry(series)
+    end
+  end
+
+  describe "refresh_spark/0" do
+    setup do
+      on_exit(&PeopleHistory.clear_spark/0)
+    end
+
+    test "caches the thumbnail where the top bar can read it without a query" do
+      today = BerlinTime.today()
+      snapshot(Date.add(today, -2), 100, 0)
+      snapshot(Date.add(today, -1), 140, 0)
+      snapshot(today, 200, 0)
+
+      spark = PeopleHistory.refresh_spark()
+
+      assert %{points: _, days: 2} = spark
+      assert PeopleHistory.spark() == spark
+    end
+
+    test "forgets a cached thumbnail once there is no line left to draw" do
+      today = BerlinTime.today()
+      snapshot(Date.add(today, -1), 100, 0)
+      snapshot(today, 200, 0)
+
+      assert PeopleHistory.refresh_spark()
+
+      Repo.delete_all(Snapshot)
+
+      assert PeopleHistory.refresh_spark() == nil
+      assert PeopleHistory.spark() == nil
+    end
+  end
+
+  # The point list back as `{x, y}` pairs, so a test can say what the line does
+  # rather than match a string of coordinates.
+  defp parse(points) do
+    points
+    |> String.split(" ")
+    |> Enum.map(fn pair ->
+      [x, y] = String.split(pair, ",")
+      {String.to_float(x), String.to_float(y)}
+    end)
   end
 end

--- a/test/vutuv_web/controllers/company_controller_test.exs
+++ b/test/vutuv_web/controllers/company_controller_test.exs
@@ -16,6 +16,7 @@ defmodule VutuvWeb.CompanyControllerTest do
   alias Vutuv.Repo
   alias VutuvWeb.AgentDocs.InvestorsDoc
   alias VutuvWeb.AgentDocs.MediaKitDoc
+  alias VutuvWeb.UI
 
   # The creating migration backfills 30 days, so the table is never empty even
   # in a fresh test database. Each test states its own history.
@@ -125,16 +126,41 @@ defmodule VutuvWeb.CompanyControllerTest do
 
     test "shows the arithmetic behind the number in the top bar", %{conn: conn} do
       # Investors have asked how that figure comes about, which is why the
-      # addition is spelled out rather than described.
+      # addition is spelled out rather than described. The HTML sets it as a
+      # written addition — three labelled rows and a rule over the last one —
+      # so the rows are asserted by name here rather than by their figures,
+      # which at three members are single digits any page would match.
       insert(:activated_user)
       insert(:activated_user)
       insert(:activated_user)
+
+      facts = InvestorsDoc.facts()
+      [_members, fediverse, total] = rows = InvestorsDoc.people_sum_rows(facts)
+
+      assert fediverse.sign == "+"
+      assert total.value == UI.delimited_count(facts.members + facts.fediverse_accounts)
 
       html = conn |> get(~p"/system/investors") |> html_response(200)
 
-      assert html =~ "3 members + 0 Fediverse accounts = 3 people"
-      assert html =~ "That total is the number in the top bar"
-      assert html =~ "Nobody is counted twice"
+      for row <- rows do
+        assert html =~ ~s|data-sum-row="#{row.key}"|
+        assert html =~ row.label
+      end
+
+      assert html =~ "A Fediverse account following several profiles here"
+
+      # The agent formats say the same arithmetic as one sentence, and every
+      # figure of the addition has to appear in it: the two shapes read the
+      # same `facts` map, so they cannot disagree about a number — but nothing
+      # stops one of them from growing a third summand alone.
+      sentence = InvestorsDoc.people_sum(facts)
+
+      for row <- rows do
+        assert sentence =~ row.value
+      end
+
+      markdown = conn |> get(~p"/system/investors" <> ".md") |> response(200)
+      assert markdown =~ "3 members + 0 Fediverse accounts = 3 people"
     end
 
     test "the two tiles it adds are the ones the top bar counts", %{conn: conn} do
@@ -152,8 +178,8 @@ defmodule VutuvWeb.CompanyControllerTest do
       assert facts.members == Accounts.count_users()
       assert facts.fediverse_accounts == Fediverse.distinct_follower_count()
 
-      html = conn |> get(~p"/system/investors") |> html_response(200)
-      assert html =~ "= #{facts.members + facts.fediverse_accounts} people"
+      markdown = conn |> get(~p"/system/investors" <> ".md") |> response(200)
+      assert markdown =~ "= #{facts.members + facts.fediverse_accounts} people"
     end
 
     test "makes the case against LinkedIn's sign-up wall", %{conn: conn} do
@@ -254,10 +280,10 @@ defmodule VutuvWeb.CompanyControllerTest do
       assert html =~ "Quelle:"
       assert html =~ "Anzeigen statt Bezahlschranke"
       assert html =~ "Wo wir stehen"
-      assert html =~ "Mitglieder + "
-      assert html =~ " = "
-      assert html =~ "Diese Summe steht oben in der Navigationsleiste"
       assert html =~ "Mitglieder"
+      assert html =~ "Fediverse-Konten"
+      assert html =~ "Personen"
+      assert html =~ "Ein Fediverse-Konto, das hier mehreren Profilen folgt"
 
       # The English page must not show through anywhere.
       refute html =~ "Where we are"

--- a/test/vutuv_web/live/shell_live_test.exs
+++ b/test/vutuv_web/live/shell_live_test.exs
@@ -3,6 +3,8 @@ defmodule VutuvWeb.ShellLiveTest do
 
   import Phoenix.LiveViewTest
 
+  alias Vutuv.BerlinTime
+  alias Vutuv.PeopleHistory
   alias Vutuv.Sessions
 
   @bell_badge ~s(a[title="Notifications"] span.bg-accent)
@@ -1145,6 +1147,46 @@ defmodule VutuvWeb.ShellLiveTest do
       broadcast_total(0)
 
       assert has_element?(view, "#people-total-slot")
+    end
+  end
+
+  # The month behind the figure, so the bar says which way the number is going
+  # and not only where it stands.
+  describe "the growth thumbnail beside the people total" do
+    setup do
+      today = BerlinTime.today()
+
+      for {day, members} <- [{-2, 100}, {-1, 140}, {0, 200}] do
+        PeopleHistory.record(Date.add(today, day), %{members: members, fediverse_accounts: 0})
+      end
+
+      # The shell reads the cache, never the table: the bar is on every page, so
+      # the line beside the figure has to cost what the figure costs.
+      spark = PeopleHistory.refresh_spark()
+      on_exit(&PeopleHistory.clear_spark/0)
+
+      %{spark: spark}
+    end
+
+    test "draws the line in the pill", %{conn: conn, spark: spark} do
+      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: %{})
+
+      broadcast_total(60_123)
+
+      assert has_element?(view, ~s|#people-total svg polyline[points="#{spark.points}"]|)
+    end
+
+    test "waits for `lg`, in a class the previous release already ships", %{conn: conn} do
+      # Below `lg` the bar has about 72px to spare and this would spend two
+      # thirds of it on decoration. `hidden` + `lg:inline` rather than
+      # `lg:block`: a tab open across a deploy gets this markup patched into a
+      # document whose stylesheet only carries the classes already in use, and a
+      # rule it does not have cannot hide anything.
+      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: %{})
+
+      broadcast_total(60_123)
+
+      assert has_element?(view, "#people-total svg.hidden.lg\\:inline")
     end
   end
 end


### PR DESCRIPTION
On `/system/investors` the sum of the two figure tiles was one sentence to read. It is now a written addition: three labelled rows and a rule over the total, digits lined up. The paragraph under it is one sentence instead of three. The agent formats (`.md`/`.txt`/`.json`/`.xml`) keep the one-line sentence, since a column of digits has nothing to line up against there; both shapes read the same `facts` map.

The top bar draws the same curve as a 48×16 thumbnail beside the people total, so the number says which way it is going. It comes from `:persistent_term` (no query per page), shows from `lg` up, and both drawings now go through one `Vutuv.PeopleHistory.curve_points/3` — the big chart's own geometry is unchanged.

Where to look: `/system/investors`, the top bar on any page, `VutuvWeb.ShellLive`.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01XNvn9zM5ZqMe7RLjV2FfC1
