### PR TITLE
Take the growth thumbnail back out of the top bar

### DIFF
--- a/docs/architecture/company-pages.md
+++ b/docs/architecture/company-pages.md
@@ -123,7 +123,7 @@ the table (a deliberate call, they are the same quantity counted as well as it
 can still be counted), but the migration's moduledoc says so, and so does this
 paragraph.
 
-### The curve, drawn twice
+### The curve
 
 `VutuvWeb.CompanyHTML.growth_curve/1` on the investor page, plain server-rendered
 SVG. No chart library: the drawing is one path, a wash under it and two labels,
@@ -142,16 +142,10 @@ as a solid block with a flat lid. A zoom like that is only honest where
 something says what it spans, so the chart names both ends underneath itself:
 the first and last figure, and the first and last day.
 
-The same line is drawn a second time, as a **thumbnail in the top bar** beside
-the people total (`VutuvWeb.ShellLive`), 48×16 pixels of the last 30 days. It
-has no room for those end figures, which is why it says only "rising" and leaves
-"how far" to the number it sits beside. Both drawings come through
-`Vutuv.PeopleHistory.curve_points/3`, so how this curve is drawn is decided in
-one place; only the box and what is built around the line differ.
-
-The thumbnail is read from `:persistent_term`, never from the table: the bar is
-on every page, so it has to cost what the figure beside it costs (two atomics
-reads). `Vutuv.PeopleCounter` refreshes it on the tick it already reconciles the
-member count with, and writes only when the shape changed. While nothing is
-cached — the sub-second after boot, an installation younger than two days, a
-span that never moved — the bar simply shows the number.
+**The top bar showed this line as a 48×16 thumbnail for a day and does not any
+more** (shipped in #1992, taken out again on 2026-09-05: it read as odd in the
+chrome). What is left of it is worth keeping in mind before anyone tries again:
+at that size there is no room for the two end figures, so a zoomed axis has
+nothing to keep it honest, and a month in which nobody joined draws as a dash
+that reads like a broken image. The geometry stayed behind as
+`Vutuv.PeopleHistory.curve_points/3`, which the chart draws through.

--- a/lib/vutuv/people_counter.ex
+++ b/lib/vutuv/people_counter.ex
@@ -48,13 +48,6 @@ defmodule Vutuv.PeopleCounter do
   So a new Fediverse follower shows up within a minute rather than instantly,
   and there is exactly one place that decides what the figure means.
 
-  The member reconcile carries one more errand, because it is about the same
-  figure: it refreshes the growth thumbnail the pill draws beside the number
-  (`Vutuv.PeopleHistory.refresh_spark/0`). Those rows move once a day, so all
-  but two of those reads find the shape unchanged and write nothing — a
-  thirty-row read beside a COUNT over the whole members table, and one place
-  that decides how fresh the bar is.
-
   `VutuvWeb.ShellLive` subscribes and re-renders the top bar's pill on each
   `{:people_count, %{members:, fediverse:, total:}}` message, so the number
   ticks up while the page is open.
@@ -63,7 +56,6 @@ defmodule Vutuv.PeopleCounter do
 
   alias Vutuv.Accounts
   alias Vutuv.Fediverse
-  alias Vutuv.PeopleHistory
 
   @pubsub Vutuv.PubSub
   @topic "people_count"
@@ -215,11 +207,6 @@ defmodule Vutuv.PeopleCounter do
 
   def handle_info(:reconcile, state) do
     :atomics.put(state.ref, @members, Accounts.count_users())
-    # The top bar's growth thumbnail rides this tick rather than a timer of its
-    # own: same two populations, same bar, and this way it is seeded by the
-    # boot reconcile and heals itself afterwards, where a nightly refresh would
-    # leave a fresh release with no line until 23:59.
-    PeopleHistory.refresh_spark()
     schedule(:reconcile, state.reconcile_interval)
     {:noreply, state}
   end

--- a/lib/vutuv/people_history.ex
+++ b/lib/vutuv/people_history.ex
@@ -29,13 +29,6 @@ defmodule Vutuv.PeopleHistory do
   alias Vutuv.PeopleHistory.Snapshot
   alias Vutuv.Repo
 
-  # The top bar's thumbnail: how many days it draws and the box its points are
-  # laid out in (stretched to the bar's few pixels by `preserveAspectRatio`).
-  @spark_days 30
-  @spark_width 100
-  @spark_height 32
-  @spark_key {__MODULE__, :spark}
-
   # How much of the drawn span is kept clear above and below the line, so a
   # peak's stroke is not cut in half by the edge of the box.
   @curve_margin 0.15
@@ -112,81 +105,18 @@ defmodule Vutuv.PeopleHistory do
   end
 
   @doc """
-  The same curve as a thumbnail for the top bar: `%{points:, days:, view_box:}`
-  with the points ready for an SVG `polyline` in the box `view_box` names, or
-  `nil` while there is nothing to draw.
-
-  The box travels with the points on purpose: they mean nothing outside it, and
-  a shell that spelled its own `viewBox` would draw a silently clipped line the
-  day this one changes.
-
-  Read from `:persistent_term`, never from the database — the bar sits on every
-  page, so the figure beside it is two atomics reads (`Vutuv.PeopleCounter`)
-  and this has to be as cheap. `Vutuv.PeopleCounter` refreshes it on the timer
-  it already reconciles the member count with; until the first one lands (and
-  in tests, where that timer is off) this answers `nil` and the bar simply
-  shows the number, which is what it showed before.
-  """
-  def spark, do: :persistent_term.get(@spark_key, nil)
-
-  @doc """
-  Re-reads the last #{@spark_days} snapshots and caches the thumbnail.
-
-  Writes only when the geometry actually changed: the rows behind it move once
-  a day, and replacing a `:persistent_term` key costs a global scan whether or
-  not the value is new. The read is not skipped, and does not need to be — it
-  rides a tick that reads the whole member count beside it.
-  """
-  def refresh_spark do
-    spark = spark_geometry(series(@spark_days))
-
-    if spark != spark(), do: put_spark(spark)
-
-    spark
-  end
-
-  defp put_spark(nil), do: clear_spark()
-  defp put_spark(spark), do: :persistent_term.put(@spark_key, spark)
-
-  @doc "Drop the cached thumbnail (test cleanup, like the other caches here)."
-  def clear_spark, do: :persistent_term.erase(@spark_key)
-
-  @doc """
-  The thumbnail's geometry for a series, or `nil` where there is no line.
-
-  A flat line is left undrawn on purpose. At this size it is a dash, and a dash
-  beside the number reads as a chart that failed to load rather than as a week
-  in which nobody joined.
-
-  What the big curve adds and this one cannot, the two end figures that keep a
-  zoomed axis honest, has no room in the chrome — which is why this shape says
-  "rising" and the number beside it says how far.
-  """
-  def spark_geometry(series) do
-    if points = curve_points(series, @spark_width, @spark_height) do
-      first = List.first(series)
-      last = List.last(series)
-
-      %{
-        points: points,
-        days: Date.diff(last.day, first.day),
-        view_box: "0 0 #{@spark_width} #{@spark_height}"
-      }
-    end
-  end
-
-  @doc """
   The series as the points of an SVG `polyline` in a `width` x `height` box, or
   `nil` where there is no line to draw: fewer than two days, or a total that
   never moved.
 
-  Both drawings of this curve come through here — the chart on
-  `/system/investors` and the thumbnail in the top bar — so how it is drawn is
-  decided once. The vertical axis is the **span the data covers**, not zero to
-  peak: at four digits a month of growth is a couple of hundred people, and an
-  axis from zero draws that as a solid block with a flat lid. That zoom is only
-  honest where something says what it spans, which is why the big chart names
-  both ends underneath it.
+  The vertical axis is the **span the data covers**, not zero to peak: at four
+  digits a month of growth is a couple of hundred people, and an axis from zero
+  draws that as a solid block with a flat lid. That zoom is only honest where
+  something says what it spans, which is why the chart names both ends
+  underneath itself; a drawing too small to name them wants a different
+  treatment, not this one (see `docs/architecture/company-pages.md`).
+
+  The box is the caller's, though only the investor page's chart draws today.
   """
   def curve_points(series, _width, _height) when length(series) < 2, do: nil
 

--- a/lib/vutuv_web/live/shell_live.ex
+++ b/lib/vutuv_web/live/shell_live.ex
@@ -49,7 +49,6 @@ defmodule VutuvWeb.ShellLive do
   alias Vutuv.DayClock
   alias Vutuv.Organizations
   alias Vutuv.PeopleCounter
-  alias Vutuv.PeopleHistory
   alias Vutuv.PostRewrites
   alias Vutuv.Posts
   alias Vutuv.Prefs
@@ -288,13 +287,6 @@ defmodule VutuvWeb.ShellLive do
     # socket connects. Zero (the sub-second before the counter's first reconcile
     # seeds the cell) renders nothing.
     |> assign(:people_count, PeopleCounter.counts())
-    # The same total over the last month as a thumbnail beside it, so the bar
-    # says which way the number is going and not only where it stands. Read
-    # from `:persistent_term` like the figure itself (`PeopleHistory.spark/0`),
-    # so neither render pays a query for it; `nil` until the counter's first
-    # reconcile has cached one, and on an installation too young to have a
-    # curve.
-    |> assign(:people_spark, PeopleHistory.spark())
     # False until the first broadcast: the figure's span is keyed on its value
     # (see .people-total__figure in components.css), so without this gate the
     # first render would look like an insert and every page load would open with
@@ -1389,45 +1381,6 @@ defmodule VutuvWeb.ShellLive do
               <span class={@user_id && "hidden lg:inline"}>
                 {people_total_word(@people_count.total)}
               </span>
-              <%!-- The shape of the last month, hairline-thin and in the pill's
-                    own colour at 60 %, so it reads as a movement beside the
-                    figure rather than as a chart in the chrome, and follows the
-                    pill from slate to brand on hover instead of holding a
-                    colour of its own. From `lg` only: below that the bar has
-                    about 72px to spare (see the width note above) and this
-                    would spend two thirds of it on decoration. `hidden` +
-                    `lg:inline` rather than `lg:block`, because the previous
-                    release's stylesheet has to be able to hide it: a tab open
-                    across a deploy gets this markup patched into a document
-                    whose bundle only carries the classes already in use. --%>
-              <svg
-                :if={@people_spark}
-                viewBox={@people_spark.view_box}
-                preserveAspectRatio="none"
-                role="img"
-                class="hidden h-4 w-12 shrink-0 opacity-60 lg:inline"
-              >
-                <%!-- The `<title>` is both the tooltip and, on a `role="img"`,
-                      the accessible name — so it says what the line is once
-                      rather than twice, in the sentence the big chart on
-                      /system/investors already labels itself with. --%>
-                <title>
-                  {gettext("People here per day over the last %{days} days",
-                    days: @people_spark.days
-                  )}
-                </title>
-                <%!-- `vector-effect` keeps the line an even hairline once the
-                      viewBox is stretched to those twelve pixels of bar. --%>
-                <polyline
-                  points={@people_spark.points}
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  vector-effect="non-scaling-stroke"
-                />
-              </svg>
             </.link>
           </div>
 

--- a/lib/vutuv_web/views/company_html.ex
+++ b/lib/vutuv_web/views/company_html.ex
@@ -105,10 +105,9 @@ defmodule VutuvWeb.CompanyHTML do
   # The line and the wash under it as SVG point lists, plus what the caption
   # needs. `nil` where there is nothing to draw.
   #
-  # The line itself comes from `Vutuv.PeopleHistory.curve_points/3`, which the
-  # top bar's thumbnail draws through as well — one decision about how this
-  # curve is drawn, in the module that owns the rows. What stays here is what
-  # only this chart has: the wash under the line and the two end figures.
+  # The line itself comes from `Vutuv.PeopleHistory.curve_points/3`, in the
+  # module that owns the rows; what stays here is what only this chart has, the
+  # wash under the line and the two end figures.
   #
   # One line, the people total the top bar shows, rather than the two stacked
   # bands the two columns invite: the member half is two orders of magnitude

--- a/test/vutuv/people_history_test.exs
+++ b/test/vutuv/people_history_test.exs
@@ -5,9 +5,7 @@ defmodule Vutuv.PeopleHistoryTest do
   that the growth summary can only ever describe the rows the curve is drawn
   from.
   """
-  # Not async: the spark tests write the process-wide `:persistent_term` cache
-  # the top bar reads, which no sandbox transaction rolls back.
-  use Vutuv.DataCase, async: false
+  use Vutuv.DataCase, async: true
 
   alias Vutuv.BerlinTime
   alias Vutuv.Fediverse.Follower
@@ -102,7 +100,7 @@ defmodule Vutuv.PeopleHistoryTest do
     end
   end
 
-  describe "spark_geometry/1" do
+  describe "curve_points/3" do
     test "draws one point per day, rising up the box" do
       series = [
         %Snapshot{day: ~D[2026-07-01], members: 100, fediverse_accounts: 0},
@@ -110,76 +108,46 @@ defmodule Vutuv.PeopleHistoryTest do
         %Snapshot{day: ~D[2026-07-31], members: 200, fediverse_accounts: 0}
       ]
 
-      assert %{points: points, days: 30} = PeopleHistory.spark_geometry(series)
-
-      [{x_first, y_first}, {_, y_middle}, {x_last, y_last}] = parse(points)
+      [{x_first, y_first}, {_, y_middle}, {x_last, y_last}] =
+        series |> PeopleHistory.curve_points(600, 140) |> parse()
 
       # The line spans the box from edge to edge, and a rising total is drawn
       # rising: in SVG that means a FALLING y, since y counts down from the top.
       assert x_first == 0.0
-      assert x_last == 100.0
+      assert x_last == 600.0
       assert y_first > y_middle
       assert y_middle > y_last
 
       # It keeps a hair of air at both ends, or the stroke of a peak is cut in
       # half by the edge of the box.
       assert y_last > 0.0
-      assert y_first < 32.0
+      assert y_first < 140.0
     end
 
     test "draws nothing for a series that is not a line" do
-      # One day is no span, and a flat month is a dash at this size — which
-      # reads as a chart that failed to load rather than as a quiet month.
-      assert PeopleHistory.spark_geometry([]) == nil
-      assert PeopleHistory.spark_geometry([%Snapshot{day: ~D[2026-07-01], members: 1}]) == nil
+      # One day is no span, and a month that never moved is a flat lid: the
+      # chart renders nothing rather than a line saying nothing.
+      assert PeopleHistory.curve_points([], 600, 140) == nil
+
+      assert PeopleHistory.curve_points([%Snapshot{day: ~D[2026-07-01], members: 1}], 600, 140) ==
+               nil
 
       flat = [
         %Snapshot{day: ~D[2026-07-01], members: 100, fediverse_accounts: 5},
         %Snapshot{day: ~D[2026-07-31], members: 100, fediverse_accounts: 5}
       ]
 
-      assert PeopleHistory.spark_geometry(flat) == nil
+      assert PeopleHistory.curve_points(flat, 600, 140) == nil
     end
 
-    test "counts both populations, like the figure it sits beside" do
+    test "counts both populations, like the figure it is drawn beside" do
       series = [
         %Snapshot{day: ~D[2026-07-01], members: 100, fediverse_accounts: 0},
         %Snapshot{day: ~D[2026-07-31], members: 100, fediverse_accounts: 40}
       ]
 
       # Only the Fediverse half moved, and the line still has to show it.
-      assert PeopleHistory.spark_geometry(series)
-    end
-  end
-
-  describe "refresh_spark/0" do
-    setup do
-      on_exit(&PeopleHistory.clear_spark/0)
-    end
-
-    test "caches the thumbnail where the top bar can read it without a query" do
-      today = BerlinTime.today()
-      snapshot(Date.add(today, -2), 100, 0)
-      snapshot(Date.add(today, -1), 140, 0)
-      snapshot(today, 200, 0)
-
-      spark = PeopleHistory.refresh_spark()
-
-      assert %{points: _, days: 2} = spark
-      assert PeopleHistory.spark() == spark
-    end
-
-    test "forgets a cached thumbnail once there is no line left to draw" do
-      today = BerlinTime.today()
-      snapshot(Date.add(today, -1), 100, 0)
-      snapshot(today, 200, 0)
-
-      assert PeopleHistory.refresh_spark()
-
-      Repo.delete_all(Snapshot)
-
-      assert PeopleHistory.refresh_spark() == nil
-      assert PeopleHistory.spark() == nil
+      assert PeopleHistory.curve_points(series, 600, 140)
     end
   end
 

--- a/test/vutuv_web/live/shell_live_test.exs
+++ b/test/vutuv_web/live/shell_live_test.exs
@@ -3,8 +3,6 @@ defmodule VutuvWeb.ShellLiveTest do
 
   import Phoenix.LiveViewTest
 
-  alias Vutuv.BerlinTime
-  alias Vutuv.PeopleHistory
   alias Vutuv.Sessions
 
   @bell_badge ~s(a[title="Notifications"] span.bg-accent)
@@ -1147,46 +1145,6 @@ defmodule VutuvWeb.ShellLiveTest do
       broadcast_total(0)
 
       assert has_element?(view, "#people-total-slot")
-    end
-  end
-
-  # The month behind the figure, so the bar says which way the number is going
-  # and not only where it stands.
-  describe "the growth thumbnail beside the people total" do
-    setup do
-      today = BerlinTime.today()
-
-      for {day, members} <- [{-2, 100}, {-1, 140}, {0, 200}] do
-        PeopleHistory.record(Date.add(today, day), %{members: members, fediverse_accounts: 0})
-      end
-
-      # The shell reads the cache, never the table: the bar is on every page, so
-      # the line beside the figure has to cost what the figure costs.
-      spark = PeopleHistory.refresh_spark()
-      on_exit(&PeopleHistory.clear_spark/0)
-
-      %{spark: spark}
-    end
-
-    test "draws the line in the pill", %{conn: conn, spark: spark} do
-      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: %{})
-
-      broadcast_total(60_123)
-
-      assert has_element?(view, ~s|#people-total svg polyline[points="#{spark.points}"]|)
-    end
-
-    test "waits for `lg`, in a class the previous release already ships", %{conn: conn} do
-      # Below `lg` the bar has about 72px to spare and this would spend two
-      # thirds of it on decoration. `hidden` + `lg:inline` rather than
-      # `lg:block`: a tab open across a deploy gets this markup patched into a
-      # document whose stylesheet only carries the classes already in use, and a
-      # rule it does not have cannot hide anything.
-      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: %{})
-
-      broadcast_total(60_123)
-
-      assert has_element?(view, "#people-total svg.hidden.lg\\:inline")
     end
   end
 end


### PR DESCRIPTION
#1992 put a 48×16 growth thumbnail in the top bar next to the people total. It reads as odd in the chrome, so it goes again, one day later.

Two things that would have to be answered differently by a second attempt: at that size there is no room for the two end figures that keep a zoomed y-axis honest, and a month in which nobody joined draws as a dash that looks like a broken image. Both are noted in `docs/architecture/company-pages.md`.

Gone with it: the `:persistent_term` cache in `Vutuv.PeopleHistory` and its refresh on `Vutuv.PeopleCounter`'s reconcile tick. The bar shows the number again and nothing else. What stays is `PeopleHistory.curve_points/3` — the investor page's own chart draws through it now — and the written addition on `/system/investors`.

Where to look: the top bar on any page, `/system/investors`.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01XNvn9zM5ZqMe7RLjV2FfC1
