### PR TITLE
A post calendar so search engines can reach every post

### DIFF
--- a/docs/architecture/agents-and-seo.md
+++ b/docs/architecture/agents-and-seo.md
@@ -314,6 +314,59 @@ canonical URL name a different document every time.
 It lives under `/system/` — the one reserved word all future site pages share,
 so new pages stop burning root path words members could have as handles.
 
+## Post calendar (`/system/posts`)
+
+The same idea as the member directory, applied to the posts: a browsable
+archive by day, and the crawl surface for search engines that follow links
+rather than reading `/sitemap.xml`.
+
+It closes a real gap. Every public post permalink is in the sitemap, but until
+this page existed **nothing on the site linked to the post of somebody a
+visitor does not already follow** — the feed is login-only, the landing page
+shows screenshots instead of live posts, and a member's archive is reachable
+only once you are on their profile. A crawler that browses links met no post at
+all, and Google's own discovery of a post rested entirely on how often it
+re-fetched a sitemap child (see issue #1995 on the missing `<lastmod>`).
+
+Three levels, each bounded, so no page ever loads an unbounded row set:
+`/system/posts` is the overview of every month that has posts (a row per year,
+twelve tiles, muted where the month is empty), `/system/posts/:year/:month` is
+that month as a calendar grid whose days with posts are links (with prev/next
+links to the nearest month that has any, so the chain never dead-ends in a
+gap), and `/system/posts/:year/:month/:day` lists that day's posts, paginated
+at `Vutuv.PostCalendar.per_page/0` (50) like the directory's letter pages. From
+the footer, any post is three clicks away.
+
+`Vutuv.PostCalendar` holds two sets apart, the way `Vutuv.Directory` does.
+`listed_posts/0` is what the calendar **shows and counts**: readable by anybody
+(`Vutuv.Posts.scope_visible/2` with no viewer) and written by a confirmed
+member or a publicly visible page — left joins with an explicit branch per
+author kind, never an inner join to `users`, which would silently drop every
+post published in an organization's name.
+
+Narrower is the set whose **permalink is linked and whose first line is
+quoted**, and that question has one owner: **`Vutuv.Identity.indexable?/1`**,
+beside `hidden?/1` on the protocol, which answers it for a member (`noindex?`)
+and for a page (`seo?` plus public visibility) alike. `Vutuv.Sitemap` asks the
+same two flags as SQL, so the calendar can never link a post the sitemap
+withholds — a test asserts that pair directly, because it is the one thing
+about this page that would silently walk a crawler around a member's opt-out.
+A post whose author opted out keeps its row (the day's count would otherwise be
+short) and loses both the link and the quote. The agent-format siblings
+(`.md`/`.txt`/`.json`/`.xml`, `ListDocs.build_post_calendar_*`) are built from
+the controller's own rows, so a document can never quote what the page
+withholds; the drift test asserts both halves.
+
+One index carries all three pages: `posts(published_on, id)`. Without it the
+prev/next month lookup is a sequential scan of the whole archive, twice per
+month page (measured 312 shared buffers against 9).
+
+The day is `posts.published_on` (the German calendar day at insert time, never
+moved by an edit), the same column the author archive at
+`/:slug/posts/2026/03/17` files by, so a post sits under the same date in both
+places. Only the overview is in the sitemap; the month and day pages are what
+its links are for.
+
 ## Link previews (Open Graph)
 
 Every HTML page carries `og:*` + `twitter:card` tags derived in one chokepoint

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -1596,6 +1596,8 @@ defmodule Vutuv.Accounts.User do
 
     def hidden?(user), do: not Vutuv.Moderation.profile_visible_to?(user, nil)
 
+    def indexable?(user), do: not user.noindex? and not hidden?(user)
+
     def topic(user), do: "user:#{user.id}"
 
     def ap_type(_user), do: "Person"

--- a/lib/vutuv/identity.ex
+++ b/lib/vutuv/identity.ex
@@ -57,6 +57,20 @@ defprotocol Vutuv.Identity do
   """
   def hidden?(identity)
 
+  @doc """
+  Whether search engines and AI agents may index what this identity publishes:
+  a member who did not opt out (`noindex?`), a page that is publicly visible
+  and carries `seo?`. Hidden identities are never indexable, so this is
+  `hidden?/1` plus the opt-out.
+
+  The one answer to "is this open to crawlers", which `Vutuv.Sitemap` asks as
+  SQL and the post calendar (`Vutuv.PostCalendar`) asks per row when it decides
+  whether a post gets its permalink. It had three derivations before, and
+  `VutuvWeb.AgentDocs.PostDoc.robots_axes/2`'s docstring is the war story of
+  what happens when they disagree.
+  """
+  def indexable?(identity)
+
   @doc ~S|The identity's PubSub topic: `"user:<id>"` / `"organization:<id>"`.|
   def topic(identity)
 

--- a/lib/vutuv/organizations/organization.ex
+++ b/lib/vutuv/organizations/organization.ex
@@ -292,6 +292,8 @@ defmodule Vutuv.Organizations.Organization do
 
     def hidden?(organization), do: not Vutuv.Organizations.public_visible?(organization)
 
+    def indexable?(organization), do: Vutuv.Organizations.indexable?(organization)
+
     def topic(organization), do: "organization:#{organization.id}"
 
     def ap_type(_organization), do: "Organization"

--- a/lib/vutuv/post_calendar.ex
+++ b/lib/vutuv/post_calendar.ex
@@ -1,0 +1,197 @@
+defmodule Vutuv.PostCalendar do
+  @moduledoc """
+  The queries behind the public post calendar (`/system/posts`): every public
+  post, filed under the day it was written, so a reader — or a crawler that
+  follows links rather than reading `/sitemap.xml` — can walk the whole archive
+  from one page in the footer.
+
+  It is the posts' `Vutuv.Directory`. The member directory answers "who is
+  filed under M"; this one answers "what was written on 17 March", and it
+  exists for the same reason: `/sitemap.xml` lists every post permalink, but
+  nothing on the site *links* to a post of somebody you do not already follow,
+  so a crawler that never fetches the sitemap never meets one. The calendar is
+  the link path.
+
+  ## Two sets, one rule
+
+  `listed_posts/0` is what the calendar shows and counts: posts anybody may
+  read (`Vutuv.Posts.scope_visible/2` with no viewer — no denials, not frozen,
+  author not moderation-hidden) whose author is a confirmed member or a
+  publicly visible page.
+
+  Narrower is the set whose **permalink is linked** and whose first line is
+  quoted, and that question is not asked here: it is
+  `Vutuv.Identity.indexable?/1`, the one owner of "is this author open to
+  crawlers", which `Vutuv.Sitemap` asks as SQL over the same two flags
+  (`noindex?` on a member, `seo?` on a page). A calendar that linked a post the
+  sitemap withholds would walk a crawler straight around the member's opt-out.
+  The row itself stays: without it a day would claim fewer posts than were
+  written on it.
+
+  The day is `posts.published_on`, the German calendar day at insert time
+  (`Vutuv.BerlinTime`), never moved by an edit — the same column the author
+  archive at `/:slug/posts/2026/03/17` files by, so a post sits under the same
+  date in both places.
+  """
+
+  import Ecto.Query
+  import Vutuv.Moderation.Query, only: [account_confirmed_row: 1]
+  import Vutuv.Organizations.Query, only: [organization_public_row: 1]
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Organizations.Organization
+  alias Vutuv.Pages
+  alias Vutuv.Posts
+  alias Vutuv.Posts.Post
+  alias Vutuv.Repo
+
+  # The member directory's page size rather than the site-wide 250: a day page
+  # is browsed, and a shorter page with a visible pager beats one long scroll.
+  @per_page 50
+
+  @doc "How many posts one day page holds before the pager takes over."
+  def per_page, do: @per_page
+
+  @doc """
+  One entry per month that has posts, newest first, as
+  `%{year: y, month: m, count: n}`.
+
+  Only months that have something in them: an empty month is a muted tile on
+  the overview, and there is nothing to count for it.
+  """
+  def month_counts do
+    # `::date` in the fragment rather than a bare `date_trunc`: without the cast
+    # Postgres answers a timestamp and Postgrex hands back a NaiveDateTime,
+    # which is a different shape for the same thing. The cast makes the column
+    # what it already is, a calendar month's first day.
+    listed_posts()
+    |> group_by([p], fragment("date_trunc('month', ?)::date", p.published_on))
+    |> order_by([p], desc: fragment("date_trunc('month', ?)::date", p.published_on))
+    |> select([p], {fragment("date_trunc('month', ?)::date", p.published_on), count(p.id)})
+    |> Repo.all()
+    |> Enum.map(fn {%Date{year: year, month: month}, count} ->
+      %{year: year, month: month, count: count}
+    end)
+  end
+
+  @doc """
+  The post count per day of one month, as a `%{Date.t() => count}` map — what
+  the month grid shades its cells from, and what decides which of them is a
+  link.
+  """
+  def day_counts(%Date{} = month) do
+    first = Date.beginning_of_month(month)
+
+    listed_posts()
+    |> where([p], p.published_on >= ^first and p.published_on <= ^Date.end_of_month(first))
+    |> group_by([p], p.published_on)
+    |> select([p], {p.published_on, count(p.id)})
+    |> Repo.all()
+    |> Map.new()
+  end
+
+  @doc """
+  One page of a day's posts as `%{posts: posts, total: total}`, oldest first
+  (the order they were written in — the id is a UUID v7, so its order is
+  creation order), paged by the `?page` param at `per_page/0` posts.
+
+  Both author associations are preloaded, because every row needs its author's
+  name, its permalink (`Vutuv.Posts.path/1`) and the search-engine flag that
+  decides whether it gets one.
+  """
+  def day_page(%Date{} = date, params) do
+    base = where(listed_posts(), [p], p.published_on == ^date)
+    total = Repo.aggregate(base, :count)
+
+    posts =
+      base
+      |> order_by([p], asc: p.id)
+      |> Pages.paginate(params, total, @per_page)
+      |> preload([:user, :organization])
+      |> Repo.all()
+
+    %{posts: posts, total: total}
+  end
+
+  @doc """
+  The nearest month before and after `month` that has posts, as
+  `%{previous: date | nil, next: date | nil}` (each at its first day).
+
+  The month-to-month chain the grid pages along. It steps to the nearest month
+  with something in it rather than to the literal neighbour, so a gap in the
+  archive is one click rather than a run of empty pages a crawler has to walk
+  (and it is what makes the arrows honest at the two ends).
+  """
+  def neighbour_months(%Date{} = month) do
+    first = Date.beginning_of_month(month)
+
+    %{
+      previous: edge_month(dynamic([p], p.published_on < ^first), :desc),
+      next: edge_month(dynamic([p], p.published_on > ^Date.end_of_month(first)), :asc)
+    }
+  end
+
+  defp edge_month(condition, direction) do
+    listed_posts()
+    |> where(^condition)
+    |> order_by([p], [{^direction, p.published_on}])
+    |> limit(1)
+    |> select([p], p.published_on)
+    |> Repo.one()
+    |> case do
+      %Date{} = date -> Date.beginning_of_month(date)
+      nil -> nil
+    end
+  end
+
+  @doc """
+  The `:year/:month[/:day]` segments of a calendar URL as a `Date`, or
+  `:error` — the month pages pass no day and get that month's first.
+
+  One function for both levels, and the same bounds the author archive's
+  `/:slug/posts/2026/03/17` uses (`VutuvWeb.PostController`): a four-digit year,
+  and `Date.new/3` for the rest, so it need not know about February. Two
+  spellings of "which archive URL exists" would eventually answer differently
+  for the same date.
+  """
+  def parse_date(year, month, day \\ "1") do
+    with {:ok, year} when year in 1000..9999 <- integer(year),
+         {:ok, month} <- integer(month),
+         {:ok, day} <- integer(day),
+         {:ok, date} <- Date.new(year, month, day) do
+      {:ok, date}
+    else
+      _invalid -> :error
+    end
+  end
+
+  # A bare `String.to_integer/1` raises on anything else, and these segments are
+  # whatever the URL says. Trailing characters are rejected too ("3x" is not a
+  # month), so one spelling of a month reaches the canonical URL.
+  defp integer(value) do
+    case Integer.parse(value) do
+      {n, ""} when n >= 0 -> {:ok, n}
+      _not_a_number -> :error
+    end
+  end
+
+  @doc """
+  The posts the calendar lists: readable by anybody, by an author the site
+  shows publicly.
+
+  Left joins with an explicit branch per author kind, never an inner join to
+  `users`: a post published in a page's name carries `user_id: nil`, and an
+  inner join drops every one of them without a word (issues #1334/#1336).
+  """
+  def listed_posts do
+    Post
+    |> Posts.scope_visible(nil)
+    |> join(:left, [p], u in User, on: u.id == p.user_id)
+    |> join(:left, [p], o in Organization, on: o.id == p.organization_id)
+    |> where(
+      [p, u, o],
+      (not is_nil(p.user_id) and account_confirmed_row(u)) or
+        (not is_nil(p.organization_id) and organization_public_row(o))
+    )
+  end
+end

--- a/lib/vutuv/sitemap.ex
+++ b/lib/vutuv/sitemap.ex
@@ -14,6 +14,7 @@ defmodule Vutuv.Sitemap do
   """
 
   import Ecto.Query
+  import Vutuv.Moderation.Query, only: [account_confirmed_row: 1]
 
   alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
@@ -35,6 +36,10 @@ defmodule Vutuv.Sitemap do
                   "/datenschutzerklaerung",
                   "/nutzungsbedingungen",
                   "/system/members",
+                  # The post calendar's overview only, like the member
+                  # directory above it: its month and day pages are reached by
+                  # following its links, which is the whole point of it.
+                  "/system/posts",
                   "/system/markdown",
                   "/organizations",
                   "/jobs",
@@ -177,11 +182,20 @@ defmodule Vutuv.Sitemap do
 
   # scope_visible(nil) already drops restricted posts, frozen posts and
   # moderation-hidden authors; the join adds the member-level conditions.
+  #
+  # The confirmed test is `account_confirmed_row/1`, the shared gate every
+  # listing query uses, and not a bare `u.email_confirmed?`: that one reads a
+  # legacy NULL as unconfirmed, so this sitemap advertised such a member's
+  # profile (`indexable_users/0` goes through `Directory`, which treats NULL as
+  # confirmed) while withholding every post they wrote. 33 members carry that
+  # NULL today and none of them has posted, so the two spellings differ by no
+  # rows at all — which is exactly why the one that agrees with the rest of the
+  # site is the one to keep.
   defp indexable_posts do
     Post
     |> Posts.scope_visible(nil)
     |> join(:inner, [p], u in assoc(p, :user))
-    |> where([p, u], u.email_confirmed? and not u.noindex?)
+    |> where([p, u], account_confirmed_row(u) and not u.noindex?)
   end
 
   # A post published in an organization's name (issue #1334) is public by

--- a/lib/vutuv_web/agent_docs/list_docs.ex
+++ b/lib/vutuv_web/agent_docs/list_docs.ex
@@ -15,6 +15,7 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
 
   use Gettext, backend: VutuvWeb.Gettext
 
+  alias Vutuv.Identity
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.AgentDocs.JobPostingDoc
   alias VutuvWeb.AgentDocs.PostDoc
@@ -210,6 +211,94 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
       total: total,
       people: Enum.map(people, &person_entry(&1, work_info_by_id, tags_by_id))
     })
+  end
+
+  @doc """
+  The post calendar's overview (`/system/posts`): every month that has posts,
+  with its count and its own URL.
+  """
+  def build_post_calendar_index(months, title, description) do
+    AgentDocs.doc_meta("post_calendar", "/system/posts")
+    |> Map.merge(%{
+      title: title,
+      # Title and description come from the controller, which hands the same two
+      # strings to the HTML page: like the directory's, the sentence carries no
+      # figure — the total rides its own field, where it is data.
+      description: description,
+      total: Enum.sum_by(months, & &1.count),
+      months:
+        Enum.map(months, fn %{year: year, month: month, count: count} ->
+          %{
+            date: Date.new!(year, month, 1),
+            count: count,
+            url: AgentDocs.abs_url("/system/posts/#{year}/#{month}")
+          }
+        end)
+    })
+  end
+
+  @doc """
+  One month of the post calendar (`/system/posts/:year/:month`): the days that
+  have posts, each with its count and its URL.
+
+  The title dates itself in ISO, `Post calendar · 2026-08`, where the page says
+  "Beiträge im August 2026": these documents render in English by default
+  (`VutuvWeb.AgentDocs`), and a German date shape inside an English title is the
+  one part of it a machine reader could misread. It is the shape the author
+  archive's own document already uses.
+  """
+  def build_post_calendar_month(%Date{} = month, counts) do
+    AgentDocs.doc_meta("post_calendar_month", "/system/posts/#{month.year}/#{month.month}")
+    |> Map.merge(%{
+      title: "#{gettext("Post calendar")} · #{Calendar.strftime(month, "%Y-%m")}",
+      description: gettext("The posts written that month, by day."),
+      year: month.year,
+      month: month.month,
+      total: counts |> Map.values() |> Enum.sum(),
+      days:
+        counts
+        |> Enum.sort_by(fn {date, _count} -> date end, Date)
+        |> Enum.map(fn {date, count} ->
+          %{
+            date: date,
+            count: count,
+            url: AgentDocs.abs_url("/system/posts/#{date.year}/#{date.month}/#{date.day}")
+          }
+        end)
+    })
+  end
+
+  @doc """
+  One day of the post calendar (`/system/posts/:year/:month/:day`).
+
+  The entries are the controller's own rows, so this document and the HTML page
+  name the same posts and link exactly the same ones. An entry whose author is
+  not open to search engines carries the author and no URL here as there — a
+  document quoting the post the page deliberately does not quote would be the
+  member's opt-out leaking out the side.
+  """
+  def build_post_calendar_day(%Date{} = date, entries, total) do
+    path = "/system/posts/#{date.year}/#{date.month}/#{date.day}"
+
+    AgentDocs.doc_meta("post_calendar_day", path)
+    |> Map.merge(%{
+      title: "#{gettext("Post calendar")} · #{Date.to_iso8601(date)}",
+      description: gettext("The posts written that day."),
+      date: date,
+      total: total,
+      posts: Enum.map(entries, &post_calendar_entry/1)
+    })
+  end
+
+  # `Identity.ref/1` is the one author object the API, the post JSON and every
+  # other agent doc carry, so a reader meets the same shape here; `url: nil` is
+  # what says the post is listed and not linked, the same nil the page reads.
+  defp post_calendar_entry(entry) do
+    %{
+      author: Identity.ref(entry.author),
+      url: entry.path && AgentDocs.abs_url(entry.path),
+      text: entry.text
+    }
   end
 
   defp person_entry(user, work_info_by_id, tags_by_id \\ %{}),

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -337,6 +337,44 @@ defmodule VutuvWeb.AgentDocs.Markdown do
     |> join_blocks()
   end
 
+  # The post calendar's overview (/system/posts): the months that have posts.
+  def render(%{type: "post_calendar"} = doc) do
+    [
+      frontmatter(doc),
+      "# #{doc.title}",
+      doc.description,
+      Enum.map_join(doc.months, "\n", fn month ->
+        "- #{Calendar.strftime(month.date, "%Y-%m")} (#{month.count}): #{month.url}"
+      end)
+    ]
+    |> join_blocks()
+  end
+
+  # One month of it: the days that have posts.
+  def render(%{type: "post_calendar_month"} = doc) do
+    [
+      frontmatter(doc),
+      "# #{doc.title}",
+      doc.description,
+      Enum.map_join(doc.days, "\n", fn day ->
+        "- #{Date.to_iso8601(day.date)} (#{day.count}): #{day.url}"
+      end)
+    ]
+    |> join_blocks()
+  end
+
+  # One day of it. A post whose author is not open to search engines is named
+  # by its author alone — no link, no first line — exactly as on the page.
+  def render(%{type: "post_calendar_day"} = doc) do
+    [
+      frontmatter(doc),
+      "# #{doc.title}",
+      doc.description,
+      Enum.map_join(doc.posts, "\n", &calendar_post_line/1)
+    ]
+    |> join_blocks()
+  end
+
   # The /ads offer page (VutuvWeb.AgentDocs.AdsDoc). The rules and the facts
   # form one loose bullet list (blank-line separated, like every other list),
   # not several one-item lists.
@@ -430,10 +468,15 @@ defmodule VutuvWeb.AgentDocs.Markdown do
     |> join_blocks()
   end
 
-  # The pages this member follows (issue #1336), under their own heading rather
-  # than among the people: a reader has to be able to tell a person from an
-  # organization. Only the Following document carries the key, so every other
-  # people list skips the block entirely.
+  # One post of a calendar day. A row with no `url` is a post whose author is
+  # not open to search engines: the controller has already put the line saying
+  # so where the post's own words would be, so this only decides whether the
+  # line is a link.
+  defp calendar_post_line(%{url: nil} = post), do: "- #{post.author.name}: #{post.text}"
+
+  defp calendar_post_line(post),
+    do: "- #{post.author.name}: #{md_link(post.text, post.url)}"
+
   # The citation under an investor-page claim that rests on somebody else's
   # measurement. `nil` for the claims that stand on their own.
   defp case_source(nil), do: nil
@@ -441,6 +484,10 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   defp case_source(%{label: label, url: url}),
     do: gettext("Source: %{source}", source: md_link(label, url))
 
+  # The pages this member follows (issue #1336), under their own heading rather
+  # than among the people: a reader has to be able to tell a person from an
+  # organization. Only the Following document carries the key, so every other
+  # people list skips the block entirely.
   defp followed_organizations(%{organizations: [_ | _] = organizations}) do
     join_blocks([
       "## " <> gettext("Organizations"),

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -319,6 +319,43 @@ defmodule VutuvWeb.AgentDocs.Text do
     |> join_blocks()
   end
 
+  # The post calendar's overview (/system/posts): the months that have posts.
+  def render(%{type: "post_calendar"} = doc) do
+    [
+      heading(doc.title),
+      doc.description,
+      Enum.map(doc.months, fn month ->
+        "- #{Calendar.strftime(month.date, "%Y-%m")} (#{month.count}): #{month.url}"
+      end),
+      footer(doc)
+    ]
+    |> join_blocks()
+  end
+
+  # One month of it: the days that have posts.
+  def render(%{type: "post_calendar_month"} = doc) do
+    [
+      heading(doc.title),
+      doc.description,
+      Enum.map(doc.days, fn day ->
+        "- #{Date.to_iso8601(day.date)} (#{day.count}): #{day.url}"
+      end),
+      footer(doc)
+    ]
+    |> join_blocks()
+  end
+
+  # One day of it.
+  def render(%{type: "post_calendar_day"} = doc) do
+    [
+      heading(doc.title),
+      doc.description,
+      Enum.map(doc.posts, &calendar_post_line/1),
+      footer(doc)
+    ]
+    |> join_blocks()
+  end
+
   # The /ads offer page (VutuvWeb.AgentDocs.AdsDoc).
   def render(%{type: "advertising"} = doc) do
     [
@@ -400,9 +437,13 @@ defmodule VutuvWeb.AgentDocs.Text do
     |> join_blocks()
   end
 
-  # The pages this member follows (issue #1336) — the plain-text twin of the
-  # Markdown block, under their own heading so a reader can tell a person from
-  # an organization. Absent on every other people list.
+  # One post of a calendar day, the plain-text twin of the Markdown line: a row
+  # with no `url` is a post whose author is not open to search engines, and the
+  # line the controller put there already says so.
+  defp calendar_post_line(%{url: nil} = post), do: "- #{post.author.name}: #{post.text}"
+
+  defp calendar_post_line(post), do: "- #{post.author.name}: #{post.text} (#{post.url})"
+
   # One claim of the investor page's case, with the citation under it where the
   # claim rests on somebody else's measurement.
   defp case_point_text(%{source: nil} = point), do: "#{point.title}\n\n#{point.body}"
@@ -413,6 +454,9 @@ defmodule VutuvWeb.AgentDocs.Text do
     "#{point.title}\n\n#{point.body}\n\n#{source}"
   end
 
+  # The pages this member follows (issue #1336) — the plain-text twin of the
+  # Markdown block, under their own heading so a reader can tell a person from
+  # an organization. Absent on every other people list.
   defp followed_organizations(%{organizations: [_ | _] = organizations}) do
     join_blocks([
       gettext("Organizations"),

--- a/lib/vutuv_web/controllers/page_controller.ex
+++ b/lib/vutuv_web/controllers/page_controller.ex
@@ -421,6 +421,8 @@ defmodule VutuvWeb.PageController do
   - `/tags/<tag>` — a tag and its most endorsed members
   - `/system/members` — the member directory: every member, filed by last-name
     initial at `/system/members/<a-z|other>`, plus a name search on the index
+  - `/system/posts` — the post calendar: every month that has posts, one month at
+    `/system/posts/<year>/<month>`, one day at `/system/posts/<year>/<month>/<day>`
   - `/system/markdown` — what members may write in a post: the Markdown
     reference, also raw at `/system/markdown.md` (`?lang=` for {{locales}})
   - `/system/mastodon` — how to reach this installation from a Mastodon-compatible

--- a/lib/vutuv_web/controllers/post_calendar_controller.ex
+++ b/lib/vutuv_web/controllers/post_calendar_controller.ex
@@ -1,0 +1,140 @@
+defmodule VutuvWeb.PostCalendarController do
+  @moduledoc """
+  The public post calendar: `/system/posts` is the overview of every month
+  that has posts, `/system/posts/:year/:month` one month as a calendar grid,
+  and `/system/posts/:year/:month/:day` the posts written on that day.
+
+  It is to the posts what `VutuvWeb.DirectoryController` is to the members: a
+  browsable index for people, and the crawl surface for search engines that
+  follow links instead of reading `/sitemap.xml`. Until it existed, nothing on
+  the site linked to the post of somebody you do not already follow — the feed
+  is login-only and the landing page shows screenshots — so a crawler that
+  never fetched the sitemap never met one.
+
+  A row is listed for every post anybody may read, and only a post whose author
+  is open to search engines carries its permalink and its first line
+  (`Vutuv.PostCalendar.crawlable?/1`, the set `Vutuv.Sitemap` advertises). Also
+  served as Markdown / text / JSON / XML; keep the templates and the doc
+  builders in sync (`agent_docs_drift_test.exs`).
+  """
+
+  use VutuvWeb, :controller
+
+  import VutuvWeb.UI, only: [month_name: 1]
+
+  alias Vutuv.Identity
+  alias Vutuv.PostCalendar
+  alias Vutuv.Posts
+  alias Vutuv.ViewerClock
+  alias VutuvWeb.AgentDocs
+  alias VutuvWeb.AgentDocs.ListDocs
+  alias VutuvWeb.ControllerHelpers
+  alias VutuvWeb.PostTeaser
+
+  def index(conn, _params) do
+    months = PostCalendar.month_counts()
+    title = gettext("Post calendar")
+    # The page's one sentence, said once and handed to both renderings: the
+    # HTML prints it under the heading and the documents carry it as their
+    # `description`, so the two cannot describe this page differently.
+    description = gettext("Every public post on vutuv, filed under the day it was written.")
+
+    AgentDocs.respond(conn,
+      html: fn conn ->
+        render(conn, "index.html", page_title: title, description: description, months: months)
+      end,
+      doc: fn -> ListDocs.build_post_calendar_index(months, title, description) end
+    )
+  end
+
+  def month(conn, %{"year" => year, "month" => month}) do
+    case PostCalendar.parse_date(year, month) do
+      {:ok, date} -> show_month(conn, date)
+      :error -> ControllerHelpers.render_error(conn, 404)
+    end
+  end
+
+  defp show_month(conn, date) do
+    counts = PostCalendar.day_counts(date)
+    title = gettext("Posts in %{month} %{year}", month: month_name(date.month), year: date.year)
+
+    AgentDocs.respond(conn,
+      html: fn conn ->
+        render(conn, "month.html",
+          page_title: title,
+          title: title,
+          month: date,
+          counts: counts,
+          # The neighbouring months, so a crawler (and a reader) can walk the
+          # archive month by month without going back to the overview. Only
+          # months that have something in them, and never into the future.
+          neighbours: PostCalendar.neighbour_months(date)
+        )
+      end,
+      doc: fn -> ListDocs.build_post_calendar_month(date, counts) end
+    )
+  end
+
+  def day(conn, %{"year" => year, "month" => month, "day" => day} = params) do
+    case PostCalendar.parse_date(year, month, day) do
+      {:ok, date} -> show_day(conn, date, params)
+      :error -> ControllerHelpers.render_error(conn, 404)
+    end
+  end
+
+  defp show_day(conn, date, params) do
+    %{posts: posts, total: total} = PostCalendar.day_page(date, params)
+    entries = Enum.map(posts, &entry/1)
+    title = gettext("Posts on %{date}", date: ViewerClock.format(date, :date))
+
+    AgentDocs.respond(conn,
+      html: fn conn ->
+        render(conn, "day.html",
+          page_title: title,
+          title: title,
+          day: date,
+          entries: entries,
+          total: total,
+          per_page: PostCalendar.per_page()
+        )
+      end,
+      doc: fn -> ListDocs.build_post_calendar_day(date, entries, total) end
+    )
+  end
+
+  # One row of a day, built once and handed to both the template and the doc
+  # builder, so the two cannot disagree about which post was linked. The author
+  # travels as the identity itself, so each rendering asks it for what it needs
+  # (`Identity.path/1` for the page's link, `Identity.ref/1` for the document's
+  # author object) instead of being handed a flattened copy.
+  #
+  # A post whose author is not open to search engines keeps its place in the day
+  # — the count would otherwise be short — and loses the two things that would
+  # carry it into an index anyway: `path` is nil, so nothing links it, and its
+  # own first line gives way to the line saying why. One nil decides both, in
+  # both renderings.
+  defp entry(post) do
+    author = Posts.author(post)
+
+    if Identity.indexable?(author) do
+      %{id: post.id, author: author, path: Posts.path(post), text: teaser(post)}
+    else
+      %{
+        id: post.id,
+        author: author,
+        path: nil,
+        text: gettext("Post not open to search engines")
+      }
+    end
+  end
+
+  # `PostTeaser.plain_line/2` answers `""` for a post with no words in it — a
+  # photograph, a lone video — and an empty string is a link with nothing to
+  # click. Such a post says what it is instead.
+  defp teaser(post) do
+    case PostTeaser.plain_line(post) do
+      "" -> gettext("Post without text")
+      line -> line
+    end
+  end
+end

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -737,6 +737,16 @@ defmodule VutuvWeb.Router do
     get("/system/members", DirectoryController, :index)
     get("/system/members/:letter", DirectoryController, :show)
 
+    # The public post calendar: the same idea applied to the posts. Nothing on
+    # this site links to the post of somebody a visitor does not already follow
+    # — the feed is login-only and the landing page shows screenshots — so a
+    # crawler that follows links rather than reading /sitemap.xml never met one
+    # until this existed. Three levels, each bounded: months, then the days of
+    # one month, then one day's posts with a pager.
+    get("/system/posts", PostCalendarController, :index)
+    get("/system/posts/:year/:month", PostCalendarController, :month)
+    get("/system/posts/:year/:month/:day", PostCalendarController, :day)
+
     # How to format a post: the member-facing Markdown reference, in the
     # reader's language, with the raw file under `/system/markdown.md`. Public
     # (a member reads it before they have written anything) and under /system/

--- a/lib/vutuv_web/templates/layout/app.html.heex
+++ b/lib/vutuv_web/templates/layout/app.html.heex
@@ -76,6 +76,7 @@ finger-sized target instead of a word in a paragraph. --%>
         <h2 class={footer_heading_class}>{gettext("Network")}</h2>
         <ul class="mt-2">
           <li><.link href={~p"/system/members"} class={footer_link_class}>{gettext("Member directory")}</.link></li>
+          <li><.link href={~p"/system/posts"} class={footer_link_class}>{gettext("Post calendar")}</.link></li>
           <li><.link href={~p"/organizations"} class={footer_link_class}>{gettext("Organizations")}</.link></li>
           <li><.link href={~p"/jobs"} class={footer_link_class}>{gettext("Jobs")}</.link></li>
         </ul>

--- a/lib/vutuv_web/templates/post_calendar/day.html.heex
+++ b/lib/vutuv_web/templates/post_calendar/day.html.heex
@@ -1,0 +1,52 @@
+<.page_header
+  title={@title}
+  crumbs={[
+    {gettext("Home"), ~p"/"},
+    {gettext("Post calendar"), ~p"/system/posts"},
+    {"#{month_name(@day.month)} #{@day.year}", ~p"/system/posts/#{@day.year}/#{@day.month}"},
+    viewer_date(@day)
+  ]}
+/>
+
+<div class="card-list">
+  <section class="card">
+    <p :if={@total > 0}>
+      {ngettext("One post", "%{formatted} posts", @total, formatted: delimited_count(@total))}
+    </p>
+
+    <%= if @entries == [] do %>
+      <p class="card__empty">{gettext("No posts on this day.")}</p>
+    <% else %>
+      <%!-- One row per post: who wrote it, then its first line as the link to
+      the post itself. A row with no `path` is a post whose author is not open
+      to search engines: it keeps its place so the day's count adds up, and its
+      line says that instead of quoting the post — neither this page nor a
+      crawler carries the post's own words past that choice. --%>
+      <ul class="mt-4 divide-y divide-slate-200 dark:divide-slate-800">
+        <li :for={entry <- @entries} class="py-3 first:pt-0 last:pb-0">
+          <p class="mb-0 text-sm">
+            <.link
+              href={author_path(entry)}
+              rel={!entry.path && "nofollow"}
+              class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+            >
+              {author_name(entry)}
+            </.link>
+          </p>
+
+          <p class="mb-0 mt-1 text-slate-800 dark:text-slate-200">
+            <%= if entry.path do %>
+              <.link href={entry.path} class="text-slate-800 dark:text-slate-200">
+                {entry.text}
+              </.link>
+            <% else %>
+              <span class="text-sm text-slate-600 dark:text-slate-400">{entry.text}</span>
+            <% end %>
+          </p>
+        </li>
+      </ul>
+    <% end %>
+
+    <.pager params={@conn.params} total={@total} per_page={@per_page} />
+  </section>
+</div>

--- a/lib/vutuv_web/templates/post_calendar/index.html.heex
+++ b/lib/vutuv_web/templates/post_calendar/index.html.heex
@@ -1,0 +1,42 @@
+<.page_header
+  title={gettext("Post calendar")}
+  crumbs={[{gettext("Home"), ~p"/"}, gettext("Post calendar")]}
+/>
+
+<div class="card-list">
+  <section class="card">
+    <%!-- The page's one sentence, handed down by the controller so the agent
+    formats carry the same words. No figure: this is an index, and an index that
+    opens with a total reads as a statistics page. The counts ride the tiles as
+    `data-count` (invisible, and what the tests read) and the documents, where a
+    machine reader has no calendar in front of them. --%>
+    <p>{@description}</p>
+
+    <%= if @months == [] do %>
+      <p class="card__empty">{gettext("Nothing has been written here yet.")}</p>
+    <% else %>
+      <%!-- One row per year, twelve tiles each: a month with posts is a link,
+      an empty one a muted tile, so the year always shows whole. Two clicks
+      from here reach any day, three any post — which is what makes this the
+      crawl path the sitemap alone never was. --%>
+      <div :for={row <- year_rows(@months)} class="mt-6">
+        <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-400">
+          {row.year}
+        </h2>
+
+        <nav
+          aria-label={gettext("Posts in %{year}", year: row.year)}
+          class="mt-2 grid grid-cols-3 gap-2 sm:grid-cols-6"
+        >
+          <.tile
+            :for={entry <- row.months}
+            href={if(entry.count > 0, do: ~p"/system/posts/#{row.year}/#{entry.month}")}
+            key={month_key(row.year, entry.month)}
+            count={entry.count}
+            label={month_name(entry.month)}
+          />
+        </nav>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/lib/vutuv_web/templates/post_calendar/month.html.heex
+++ b/lib/vutuv_web/templates/post_calendar/month.html.heex
@@ -1,0 +1,83 @@
+<.page_header
+  title={@title}
+  crumbs={[
+    {gettext("Home"), ~p"/"},
+    {gettext("Post calendar"), ~p"/system/posts"},
+    "#{month_name(@month.month)} #{@month.year}"
+  ]}
+/>
+
+<div class="card-list">
+  <section class="card">
+    <%!-- The month-to-month chain: each arrow steps to the nearest month that
+    has posts, so a gap in the archive is one click rather than a run of empty
+    pages, and a crawler can walk the whole history from either end. --%>
+    <nav
+      aria-label={gettext("Neighbouring months")}
+      class="flex items-center justify-between gap-2 text-sm"
+    >
+      <%= if @neighbours.previous do %>
+        <a
+          href={~p"/system/posts/#{@neighbours.previous.year}/#{@neighbours.previous.month}"}
+          rel="prev"
+          class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+        >
+          ‹ {month_name(@neighbours.previous.month)} {@neighbours.previous.year}
+        </a>
+      <% else %>
+        <span></span>
+      <% end %>
+
+      <%= if @neighbours.next do %>
+        <a
+          href={~p"/system/posts/#{@neighbours.next.year}/#{@neighbours.next.month}"}
+          rel="next"
+          class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+        >
+          {month_name(@neighbours.next.month)} {@neighbours.next.year} ›
+        </a>
+      <% else %>
+        <span></span>
+      <% end %>
+    </nav>
+
+    <%!-- The same seven headings every other calendar on the site draws
+    (`VutuvWeb.UI.weekday_initials/0`), already translated in every locale. --%>
+    <div class="mt-6 grid grid-cols-7 gap-1 text-center text-[10px] font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-400">
+      <span :for={initial <- weekday_initials()}>{initial}</span>
+    </div>
+
+    <div class="mt-1 grid grid-cols-7 gap-1">
+      <%!-- A cell from a neighbouring month is drawn, never linked: the arrows
+      above lead there, and a link out of the grid would file the same day under
+      two months. --%>
+      <%= for cell <- month_grid(@month) do %>
+        <% count = if(cell.in_month?, do: Map.get(@counts, cell.date, 0), else: 0) %>
+        <.tile
+          square
+          faded={!cell.in_month?}
+          href={
+            if(count > 0,
+              do: ~p"/system/posts/#{cell.date.year}/#{cell.date.month}/#{cell.date.day}"
+            )
+          }
+          key={if(cell.in_month?, do: Date.to_iso8601(cell.date))}
+          count={count}
+          title={
+            if(count > 0,
+              do:
+                ngettext("One post", "%{formatted} posts", count,
+                  formatted: delimited_count(count)
+                )
+            )
+          }
+          label={to_string(cell.date.day)}
+        />
+      <% end %>
+    </div>
+
+    <p :if={Enum.empty?(@counts)} class="card__empty">
+      {gettext("No posts in this month yet.")}
+    </p>
+  </section>
+</div>

--- a/lib/vutuv_web/views/post_calendar_html.ex
+++ b/lib/vutuv_web/views/post_calendar_html.ex
@@ -1,0 +1,106 @@
+defmodule VutuvWeb.PostCalendarHTML do
+  @moduledoc false
+  use VutuvWeb, :html
+
+  alias Vutuv.Identity
+  alias Vutuv.ViewerClock
+  alias VutuvWeb.Live.FeedTimeTravel
+
+  embed_templates("../templates/post_calendar/*")
+
+  @doc """
+  One tile of a calendar grid: a link when there is something behind it, a
+  muted square when there is not.
+
+  All three shapes on this page are the same tile — a month on the overview, a
+  day in the month grid, a day from a neighbouring month at the edges of it —
+  so the Tailwind strings live here instead of being written out twice across
+  two templates. `key` + `count` become the `data-` pair the tests read;
+  `faded` is the neighbouring-month cell, dimmer still and carrying no data
+  because it belongs to another page.
+  """
+  attr(:href, :any, default: nil, doc: "nil renders the muted square instead of a link")
+  attr(:key, :string, default: nil)
+  attr(:count, :integer, default: 0)
+  attr(:label, :string, required: true)
+  attr(:title, :string, default: nil)
+  attr(:faded, :boolean, default: false)
+  attr(:square, :boolean, default: false, doc: "day cells are square, month tiles are not")
+
+  def tile(assigns) do
+    ~H"""
+    <a
+      :if={@href}
+      href={@href}
+      data-key={@key}
+      data-count={@count}
+      title={@title}
+      class={[
+        tile_shape(@square),
+        "font-semibold text-brand-700 ring-1 ring-slate-200",
+        "hover:bg-brand-50 dark:text-brand-100 dark:ring-slate-800 dark:hover:bg-brand-900/40"
+      ]}
+    >
+      {@label}
+    </a>
+    <span
+      :if={!@href}
+      data-key={@key}
+      data-count={@key && "0"}
+      class={[
+        tile_shape(@square),
+        "text-slate-600 dark:text-slate-400",
+        !@faded && "font-semibold opacity-40 ring-1 ring-slate-200 dark:ring-slate-800",
+        @faded && "opacity-20"
+      ]}
+    >
+      {@label}
+    </span>
+    """
+  end
+
+  defp tile_shape(true), do: "flex aspect-square items-center justify-center rounded-lg text-sm"
+  defp tile_shape(false), do: "flex items-center justify-center rounded-lg px-2 py-3 text-sm"
+
+  @doc """
+  The six-week grid of a month, as `%{date:, in_month?:}` cells.
+
+  The feed calendar's own grid (`FeedTimeTravel.month_grid/1`), so the two
+  calendars on this site put a given day in the same square. That one is a
+  LiveView with a heatmap and this one a page of links, but the arithmetic of
+  where a month starts is the same arithmetic.
+  """
+  def month_grid(%Date{} = month), do: FeedTimeTravel.month_grid(month)
+
+  @doc "A calendar day in the reader's own date shape (`Vutuv.ViewerClock`)."
+  def viewer_date(%Date{} = date), do: ViewerClock.format(date, :date)
+
+  @doc "The `2026-03` key a month tile carries for the tests to read."
+  def month_key(year, month), do: "#{year}-#{String.pad_leading(to_string(month), 2, "0")}"
+
+  @doc "The author's visible name / profile path, whichever kind of author it is."
+  def author_name(entry), do: Identity.display_name(entry.author)
+  def author_path(entry), do: Identity.path(entry.author)
+
+  @doc """
+  The years the overview draws, newest first, each with the twelve months of
+  that year and the count the calendar holds for it.
+
+  Built from the counted months rather than from a range of years: a year the
+  archive does not reach is one nobody can browse into, so it draws no row at
+  all — while a year with a single post in December still shows its full twelve
+  tiles, eleven of them muted, because a calendar that skipped them would leave
+  the reader guessing whether the months exist.
+  """
+  def year_rows(months) do
+    by_year = Enum.group_by(months, & &1.year)
+
+    by_year
+    |> Map.keys()
+    |> Enum.sort(:desc)
+    |> Enum.map(fn year ->
+      counts = Map.new(by_year[year], &{&1.month, &1.count})
+      %{year: year, months: Enum.map(1..12, &%{month: &1, count: Map.get(counts, &1, 0)})}
+    end)
+  end
+end

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr "Language: de\n"
 
 #: lib/vutuv_web/controllers/page_controller.ex:241
-#: lib/vutuv_web/templates/layout/app.html.heex:117
+#: lib/vutuv_web/templates/layout/app.html.heex:118
 #, elixir-autogen
 msgid "About us"
 msgstr "Impressum"
@@ -100,10 +100,10 @@ msgstr "Avatar"
 msgid "Birthdate"
 msgstr "Geburtstag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:629
-#: lib/vutuv_web/agent_docs/markdown.ex:630
-#: lib/vutuv_web/agent_docs/text.ex:592
-#: lib/vutuv_web/agent_docs/text.ex:593
+#: lib/vutuv_web/agent_docs/markdown.ex:676
+#: lib/vutuv_web/agent_docs/markdown.ex:677
+#: lib/vutuv_web/agent_docs/text.ex:636
+#: lib/vutuv_web/agent_docs/text.ex:637
 #: lib/vutuv_web/templates/user/show.html.heex:1132
 #, elixir-autogen
 msgid "Birthday"
@@ -306,14 +306,14 @@ msgstr "Lebenslauf"
 msgid "Fax"
 msgstr "Fax"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:615
+#: lib/vutuv_web/agent_docs/markdown.ex:662
 #: lib/vutuv_web/templates/user/edit.html.heex:164
 #, elixir-autogen
 msgid "First Name"
 msgstr "Vorname"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:650
-#: lib/vutuv_web/agent_docs/text.ex:613
+#: lib/vutuv_web/agent_docs/markdown.ex:697
+#: lib/vutuv_web/agent_docs/text.ex:657
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
@@ -323,8 +323,8 @@ msgstr "Vorname"
 msgid "Followers"
 msgstr "Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:651
-#: lib/vutuv_web/agent_docs/text.ex:614
+#: lib/vutuv_web/agent_docs/markdown.ex:698
+#: lib/vutuv_web/agent_docs/text.ex:658
 #: lib/vutuv_web/components/fediverse_components.ex:468
 #: lib/vutuv_web/components/ui.ex:2964
 #: lib/vutuv_web/components/ui.ex:2999
@@ -359,7 +359,10 @@ msgstr "Ihr Gratis-Konto ist in nicht mal 30 Sekunden fertig."
 
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:4
-#: lib/vutuv_web/templates/layout/app.html.heex:156
+#: lib/vutuv_web/templates/layout/app.html.heex:157
+#: lib/vutuv_web/templates/post_calendar/day.html.heex:4
+#: lib/vutuv_web/templates/post_calendar/index.html.heex:3
+#: lib/vutuv_web/templates/post_calendar/month.html.heex:4
 #, elixir-autogen
 msgid "Home"
 msgstr "Startseite"
@@ -380,7 +383,7 @@ msgstr "Stellenbezeichnung"
 msgid "Language"
 msgstr "Sprache"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:617
+#: lib/vutuv_web/agent_docs/markdown.ex:664
 #: lib/vutuv_web/templates/user/edit.html.heex:169
 #, elixir-autogen
 msgid "Last Name"
@@ -439,15 +442,15 @@ msgstr "Einloggen"
 msgid "Log Out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/live/shell_live.ex:1608
-#: lib/vutuv_web/live/shell_live.ex:1684
+#: lib/vutuv_web/live/shell_live.ex:1561
+#: lib/vutuv_web/live/shell_live.ex:1637
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
 msgid "Log in"
 msgstr "Einloggen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:616
+#: lib/vutuv_web/agent_docs/markdown.ex:663
 #: lib/vutuv_web/templates/user/edit.html.heex:174
 #, elixir-autogen
 msgid "Middle Name"
@@ -484,7 +487,7 @@ msgstr "Name"
 msgid "New"
 msgstr "Neu"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:619
+#: lib/vutuv_web/agent_docs/markdown.ex:666
 #: lib/vutuv_web/templates/user/edit.html.heex:179
 #, elixir-autogen
 msgid "Nickname"
@@ -565,7 +568,7 @@ msgstr "Telefonnummer wurde gelöscht."
 msgid "Phone number updated successfully."
 msgstr "Telefonnummer wurde geändert."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:614
+#: lib/vutuv_web/agent_docs/markdown.ex:661
 #: lib/vutuv_web/templates/user/edit.html.heex:184
 #, elixir-autogen
 msgid "Prefix"
@@ -645,13 +648,13 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
-#: lib/vutuv_web/live/shell_live.ex:1477
-#: lib/vutuv_web/live/shell_live.ex:1664
+#: lib/vutuv_web/live/shell_live.ex:1430
+#: lib/vutuv_web/live/shell_live.ex:1617
 #: lib/vutuv_web/live/tag_live/timeline.ex:333
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
-#: lib/vutuv_web/templates/layout/app.html.heex:161
+#: lib/vutuv_web/templates/layout/app.html.heex:162
 #, elixir-autogen
 msgid "Search"
 msgstr "Suche"
@@ -744,7 +747,7 @@ msgstr "Etwas ist schiefgelaufen"
 msgid "Submit a bugreport or a feature request."
 msgstr "Fehler auf der Seite melden."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:618
+#: lib/vutuv_web/agent_docs/markdown.ex:665
 #: lib/vutuv_web/templates/user/edit.html.heex:189
 #, elixir-autogen
 msgid "Suffix"
@@ -1159,7 +1162,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:63
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1584
+#: lib/vutuv_web/live/shell_live.ex:1537
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1370,11 +1373,11 @@ msgid "Tag urls"
 msgstr "Tag-URLs"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
-#: lib/vutuv_web/agent_docs/markdown.ex:522
-#: lib/vutuv_web/agent_docs/markdown.ex:1163
+#: lib/vutuv_web/agent_docs/markdown.ex:569
+#: lib/vutuv_web/agent_docs/markdown.ex:1210
 #: lib/vutuv_web/agent_docs/text.ex:31
-#: lib/vutuv_web/agent_docs/text.ex:540
-#: lib/vutuv_web/agent_docs/text.ex:806
+#: lib/vutuv_web/agent_docs/text.ex:584
+#: lib/vutuv_web/agent_docs/text.ex:850
 #: lib/vutuv_web/components/ui.ex:5004
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
@@ -1602,7 +1605,7 @@ msgstr "Adressen von %{name}"
 msgid "Admin control panel"
 msgstr "Admin-Bereich"
 
-#: lib/vutuv_web/live/shell_live.ex:1682
+#: lib/vutuv_web/live/shell_live.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Mitteilungen"
@@ -1632,8 +1635,8 @@ msgstr "Schauen Sie in Ihr Postfach"
 #: lib/vutuv_web/live/post_live/composer.ex:1876
 #: lib/vutuv_web/live/post_live/composer.ex:2839
 #: lib/vutuv_web/live/post_live/composer.ex:3105
-#: lib/vutuv_web/templates/layout/app.html.heex:194
-#: lib/vutuv_web/templates/layout/app.html.heex:200
+#: lib/vutuv_web/templates/layout/app.html.heex:195
+#: lib/vutuv_web/templates/layout/app.html.heex:201
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
 #: lib/vutuv_web/views/layout_html.ex:142
 #, elixir-autogen, elixir-format
@@ -1653,7 +1656,7 @@ msgid "Confirm account deletion"
 msgstr "Kontolöschung bestätigen"
 
 #: lib/vutuv_web/controllers/page_controller.ex:245
-#: lib/vutuv_web/templates/layout/app.html.heex:123
+#: lib/vutuv_web/templates/layout/app.html.heex:124
 #: lib/vutuv_web/templates/page/index.html.heex:321
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
@@ -1661,7 +1664,7 @@ msgid "Datenschutzerklärung"
 msgstr "Datenschutzerklärung"
 
 #: lib/vutuv_web/controllers/page_controller.ex:251
-#: lib/vutuv_web/templates/layout/app.html.heex:124
+#: lib/vutuv_web/templates/layout/app.html.heex:125
 #: lib/vutuv_web/templates/page/index.html.heex:321
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
@@ -1722,7 +1725,7 @@ msgstr ""
 " von jemandem, den Sie kennen oder interessant finden, und klicken Sie auf "
 "Folgen!"
 
-#: lib/vutuv_web/live/shell_live.ex:1603
+#: lib/vutuv_web/live/shell_live.ex:1556
 #: lib/vutuv_web/views/settings_html.ex:311
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1754,9 +1757,9 @@ msgstr "Nachricht"
 #: lib/vutuv_web/controllers/page_controller.ex:218
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1495
-#: lib/vutuv_web/live/shell_live.ex:1681
-#: lib/vutuv_web/templates/layout/app.html.heex:158
+#: lib/vutuv_web/live/shell_live.ex:1448
+#: lib/vutuv_web/live/shell_live.ex:1634
+#: lib/vutuv_web/templates/layout/app.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Nachrichten"
@@ -1787,8 +1790,8 @@ msgstr "Noch nichts Neues."
 #: lib/vutuv_web/controllers/page_controller.ex:219
 #: lib/vutuv_web/live/notification_live/index.ex:152
 #: lib/vutuv_web/live/notification_live/index.ex:457
-#: lib/vutuv_web/live/shell_live.ex:1507
-#: lib/vutuv_web/templates/layout/app.html.heex:159
+#: lib/vutuv_web/live/shell_live.ex:1460
+#: lib/vutuv_web/templates/layout/app.html.heex:160
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Notifications"
@@ -1816,12 +1819,12 @@ msgid "Send"
 msgstr "Senden"
 
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:35
-#: lib/vutuv_web/templates/layout/app.html.heex:87
+#: lib/vutuv_web/templates/layout/app.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "Source"
 msgstr "Quellcode"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:90
+#: lib/vutuv_web/templates/layout/app.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Submit a bug report or feature request"
 msgstr "Fehler melden oder Feature vorschlagen"
@@ -2147,9 +2150,9 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/live/post_live/feed.ex:345
 #: lib/vutuv_web/live/post_live/feed.ex:3114
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1290
-#: lib/vutuv_web/live/shell_live.ex:1654
-#: lib/vutuv_web/templates/layout/app.html.heex:157
+#: lib/vutuv_web/live/shell_live.ex:1282
+#: lib/vutuv_web/live/shell_live.ex:1607
+#: lib/vutuv_web/templates/layout/app.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Feed"
 msgstr "Feed"
@@ -2327,7 +2330,7 @@ msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
 #: lib/vutuv_web/components/ui.ex:5373
-#: lib/vutuv_web/live/shell_live.ex:1550
+#: lib/vutuv_web/live/shell_live.ex:1503
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:258
@@ -2417,11 +2420,11 @@ msgstr "Alle Beiträge"
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1217
+#: lib/vutuv_web/agent_docs/markdown.ex:1264
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:525
-#: lib/vutuv_web/live/shell_live.ex:1487
-#: lib/vutuv_web/live/shell_live.ex:1555
+#: lib/vutuv_web/live/shell_live.ex:1440
+#: lib/vutuv_web/live/shell_live.ex:1508
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2437,11 +2440,11 @@ msgstr "Lesezeichen"
 msgid "Like"
 msgstr "Gefällt mir"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1216
+#: lib/vutuv_web/agent_docs/markdown.ex:1263
 #: lib/vutuv_web/components/post_components.ex:6106
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:522
-#: lib/vutuv_web/live/shell_live.ex:1558
+#: lib/vutuv_web/live/shell_live.ex:1511
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2832,8 +2835,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] "+1 weiteres Tag"
 msgstr[1] "+%{formatted} weitere Tags"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:652
-#: lib/vutuv_web/agent_docs/text.ex:615
+#: lib/vutuv_web/agent_docs/markdown.ex:699
+#: lib/vutuv_web/agent_docs/text.ex:659
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2985,10 +2988,10 @@ msgstr "Gibt es etwas, das unsere Admins wissen sollten? (optional)"
 msgid "Bullying or harassment"
 msgstr "Mobbing oder Belästigung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:347
-#: lib/vutuv_web/agent_docs/text.ex:328
+#: lib/vutuv_web/agent_docs/markdown.ex:385
+#: lib/vutuv_web/agent_docs/text.ex:365
 #: lib/vutuv_web/controllers/page_controller.ex:81
-#: lib/vutuv_web/templates/layout/app.html.heex:125
+#: lib/vutuv_web/templates/layout/app.html.heex:126
 #: lib/vutuv_web/templates/page/community.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Community guidelines"
@@ -3213,7 +3216,7 @@ msgid "Private message"
 msgstr "Private Nachricht"
 
 #: lib/vutuv_web/components/ui.ex:4973
-#: lib/vutuv_web/live/shell_live.ex:1322
+#: lib/vutuv_web/live/shell_live.ex:1314
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3945,12 +3948,12 @@ msgstr "gemeldete Nachricht"
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:759
+#: lib/vutuv_web/agent_docs/markdown.ex:806
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr "%{count} Empfehlungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1338
+#: lib/vutuv_web/agent_docs/markdown.ex:1385
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} auf dieser Seite, weitere mit ?page=N"
@@ -3964,16 +3967,16 @@ msgstr "%{count} Beiträge von %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:91
 #: lib/vutuv_web/agent_docs/markdown.ex:204
 #: lib/vutuv_web/agent_docs/markdown.ex:218
-#: lib/vutuv_web/agent_docs/markdown.ex:1163
+#: lib/vutuv_web/agent_docs/markdown.ex:1210
 #: lib/vutuv_web/agent_docs/text.ex:86
 #: lib/vutuv_web/agent_docs/text.ex:187
 #: lib/vutuv_web/agent_docs/text.ex:201
-#: lib/vutuv_web/agent_docs/text.ex:806
+#: lib/vutuv_web/agent_docs/text.ex:850
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr "%{count} insgesamt"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:46
+#: lib/vutuv_web/agent_docs/list_docs.ex:47
 #, elixir-autogen, elixir-format
 msgid "Followers of %{name}"
 msgstr "Follower von %{name}"
@@ -3987,28 +3990,28 @@ msgstr "Follower von %{name}"
 msgid "Images"
 msgstr "Bilder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1181
-#: lib/vutuv_web/agent_docs/text.ex:817
+#: lib/vutuv_web/agent_docs/markdown.ex:1228
+#: lib/vutuv_web/agent_docs/text.ex:861
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr "Antwort auf einen gelöschten Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1178
-#: lib/vutuv_web/agent_docs/text.ex:814
+#: lib/vutuv_web/agent_docs/markdown.ex:1225
+#: lib/vutuv_web/agent_docs/text.ex:858
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr "Antwort auf einen gelöschten Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1185
-#: lib/vutuv_web/agent_docs/markdown.ex:1431
-#: lib/vutuv_web/agent_docs/text.ex:821
-#: lib/vutuv_web/agent_docs/text.ex:890
+#: lib/vutuv_web/agent_docs/markdown.ex:1232
+#: lib/vutuv_web/agent_docs/markdown.ex:1478
+#: lib/vutuv_web/agent_docs/text.ex:865
+#: lib/vutuv_web/agent_docs/text.ex:934
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr "Antwort auf einen Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:587
-#: lib/vutuv_web/agent_docs/text.ex:578
+#: lib/vutuv_web/agent_docs/markdown.ex:634
+#: lib/vutuv_web/agent_docs/text.ex:622
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr "Mitglied seit"
@@ -4019,7 +4022,7 @@ msgstr "Mitglied seit"
 msgid "Most endorsed members"
 msgstr "Am häufigsten empfohlene Mitglieder"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:47
+#: lib/vutuv_web/agent_docs/list_docs.ex:48
 #, elixir-autogen, elixir-format
 msgid "People %{name} follows"
 msgstr "Wem %{name} folgt"
@@ -4047,23 +4050,23 @@ msgstr "Beitrag von %{name}"
 msgid "Posts (%{count} total)"
 msgstr "Beiträge (insgesamt %{count})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:581
-#: lib/vutuv_web/agent_docs/text.ex:572
+#: lib/vutuv_web/agent_docs/markdown.ex:628
+#: lib/vutuv_web/agent_docs/text.ex:616
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr "Verifiziertes Profil: ja"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1109
+#: lib/vutuv_web/agent_docs/markdown.ex:1156
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr "repostet von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:971
+#: lib/vutuv_web/agent_docs/markdown.ex:1018
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr "heute"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:972
+#: lib/vutuv_web/agent_docs/markdown.ex:1019
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr "bis %{date}"
@@ -4073,7 +4076,7 @@ msgstr "bis %{date}"
 msgid "This page in %{language}: %{url}"
 msgstr "Diese Seite auf %{language}: %{url}"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:48
+#: lib/vutuv_web/agent_docs/list_docs.ex:49
 #, elixir-autogen, elixir-format
 msgid "Connections of %{name}"
 msgstr "Vernetzungen von %{name}"
@@ -4118,7 +4121,7 @@ msgstr "Anzeigentext"
 #: lib/vutuv_web/templates/ad/index.html.heex:7
 #: lib/vutuv_web/templates/ad/new.html.heex:4
 #: lib/vutuv_web/templates/ad/preview.html.heex:2
-#: lib/vutuv_web/templates/layout/app.html.heex:115
+#: lib/vutuv_web/templates/layout/app.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "Advertising"
 msgstr "Werbung"
@@ -4141,8 +4144,8 @@ msgstr ""
 msgid "Billing name"
 msgstr "Name für die Rechnung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:361
-#: lib/vutuv_web/agent_docs/text.ex:336
+#: lib/vutuv_web/agent_docs/markdown.ex:399
+#: lib/vutuv_web/agent_docs/text.ex:373
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr "Online buchen (Login erforderlich): %{url}"
@@ -4195,8 +4198,8 @@ msgstr "Tag"
 msgid "Markdown is supported. At most %{max} characters."
 msgstr "Markdown wird unterstützt. Höchstens %{max} Zeichen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:351
-#: lib/vutuv_web/agent_docs/text.ex:332
+#: lib/vutuv_web/agent_docs/markdown.ex:389
+#: lib/vutuv_web/agent_docs/text.ex:369
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4212,8 +4215,8 @@ msgstr "Ein Tag. Eine Anzeige. Alle Besucher."
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr "Eine reine Textanzeige pro Kalendertag, gesehen von allen Besuchern."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:348
-#: lib/vutuv_web/agent_docs/text.ex:329
+#: lib/vutuv_web/agent_docs/markdown.ex:386
+#: lib/vutuv_web/agent_docs/text.ex:366
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4447,14 +4450,14 @@ msgstr "gebucht am"
 msgid "deleted account"
 msgstr "gelöschtes Konto"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:353
-#: lib/vutuv_web/agent_docs/text.ex:334
+#: lib/vutuv_web/agent_docs/markdown.ex:391
+#: lib/vutuv_web/agent_docs/text.ex:371
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr "Bereits gebucht"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:349
-#: lib/vutuv_web/agent_docs/text.ex:330
+#: lib/vutuv_web/agent_docs/markdown.ex:387
+#: lib/vutuv_web/agent_docs/text.ex:367
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr "Buchungszeitraum"
@@ -4756,8 +4759,8 @@ msgid "Not an exact match, but sounds like your search."
 msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 
 #: lib/vutuv_web/agent_docs/investors_doc.ex:212
-#: lib/vutuv_web/agent_docs/markdown.ex:463
-#: lib/vutuv_web/agent_docs/text.ex:481
+#: lib/vutuv_web/agent_docs/markdown.ex:510
+#: lib/vutuv_web/agent_docs/text.ex:525
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/notification_live/index.ex:657
 #: lib/vutuv_web/live/notification_live/index.ex:1350
@@ -4873,7 +4876,7 @@ msgstr "API-Token erstellen"
 #: lib/vutuv_web/templates/dev_app/show.html.heex:4
 #: lib/vutuv_web/templates/dev_doc/show.html.heex:14
 #: lib/vutuv_web/templates/dev_webhook/new.html.heex:4
-#: lib/vutuv_web/templates/layout/app.html.heex:84
+#: lib/vutuv_web/templates/layout/app.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Developers"
 msgstr "Entwickler"
@@ -5469,7 +5472,7 @@ msgstr "KI-Agenten und LLMs dürfen dieses Profil nutzen"
 msgid "API token (%{date})"
 msgstr "API-Token (%{date})"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:86
+#: lib/vutuv_web/templates/layout/app.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "API documentation"
 msgstr "API-Dokumentation"
@@ -5525,35 +5528,35 @@ msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
 msgid "Content under review"
 msgstr "Inhalte in Prüfung"
 
-#: lib/vutuv_web/live/shell_live.ex:1537
+#: lib/vutuv_web/live/shell_live.ex:1490
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Kontomenü"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:310
 #: lib/vutuv_web/live/admin/screenshot_live.ex:420
-#: lib/vutuv_web/templates/layout/app.html.heex:163
+#: lib/vutuv_web/templates/layout/app.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Aktionen"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:173
+#: lib/vutuv_web/templates/layout/app.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Close menus and dialogs"
 msgstr "Menüs und Dialoge schließen"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:170
+#: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "General"
 msgstr "Allgemeines"
 
-#: lib/vutuv_web/live/shell_live.ex:1594
-#: lib/vutuv_web/templates/layout/app.html.heex:189
+#: lib/vutuv_web/live/shell_live.ex:1547
+#: lib/vutuv_web/templates/layout/app.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
 msgstr "Tastaturkürzel"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:154
+#: lib/vutuv_web/templates/layout/app.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "Navigation"
 msgstr "Navigation"
@@ -5566,7 +5569,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:276
-#: lib/vutuv_web/live/shell_live.ex:1574
+#: lib/vutuv_web/live/shell_live.ex:1527
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5580,17 +5583,17 @@ msgstr "Navigation"
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:172
+#: lib/vutuv_web/templates/layout/app.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "Show this help"
 msgstr "Diese Hilfe anzeigen"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:165
+#: lib/vutuv_web/templates/layout/app.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "Write a new post"
 msgstr "Beitrag schreiben"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:160
+#: lib/vutuv_web/templates/layout/app.html.heex:161
 #: lib/vutuv_web/views/page_html.ex:551
 #, elixir-autogen, elixir-format
 msgid "Your profile"
@@ -5611,18 +5614,18 @@ msgstr "Ein paar schnelle Schritte, damit andere Sie finden und erkennen."
 msgid "Add a profile photo"
 msgstr "Profilfoto hinzufügen"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:167
+#: lib/vutuv_web/templates/layout/app.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Next post in the feed"
 msgstr "Nächster Beitrag im Feed"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:168
+#: lib/vutuv_web/templates/layout/app.html.heex:169
 #, elixir-autogen, elixir-format
 msgid "Previous post in the feed"
 msgstr "Vorheriger Beitrag im Feed"
 
-#: lib/vutuv_web/live/shell_live.ex:1278
-#: lib/vutuv_web/live/shell_live.ex:1635
+#: lib/vutuv_web/live/shell_live.ex:1270
+#: lib/vutuv_web/live/shell_live.ex:1588
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Hauptnavigation"
@@ -6372,8 +6375,8 @@ msgid_plural "%{count} years old"
 msgstr[0] "%{count} Jahr"
 msgstr[1] "%{count} Jahre"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:631
-#: lib/vutuv_web/agent_docs/text.ex:594
+#: lib/vutuv_web/agent_docs/markdown.ex:678
+#: lib/vutuv_web/agent_docs/text.ex:638
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr "Alter"
@@ -6447,7 +6450,7 @@ msgstr "Tagesbericht öffnen"
 msgid "Previous day"
 msgstr "Vorheriger Tag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1216
+#: lib/vutuv_web/agent_docs/markdown.ex:1263
 #: lib/vutuv_web/components/post_components.ex:422
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
@@ -6543,7 +6546,7 @@ msgstr ""
 msgid "Endorsed"
 msgstr "Empfohlen am"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:140
+#: lib/vutuv_web/agent_docs/list_docs.ex:141
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Members who endorsed %{name} for %{tag}"
@@ -6563,7 +6566,7 @@ msgstr "Noch keine Empfehlungen."
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1176
+#: lib/vutuv_web/agent_docs/markdown.ex:1223
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr "empfohlen am %{date}"
@@ -7814,27 +7817,27 @@ msgstr "Feed von %{name}"
 msgid "The vutuv newsfeed of %{name}"
 msgstr "Der vutuv-Newsfeed von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1343
+#: lib/vutuv_web/agent_docs/markdown.ex:1390
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr "Ihr Feed ist leer."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1346
+#: lib/vutuv_web/agent_docs/markdown.ex:1393
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr "%{count} Beiträge auf dieser Seite"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1353
+#: lib/vutuv_web/agent_docs/markdown.ex:1400
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "weitere Beiträge verfügbar, ?cursor=%{cursor} anhängen"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:141
+#: lib/vutuv_web/templates/layout/app.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Last change: %{date} at %{time}"
 msgstr "Stand: %{date}, %{time} Uhr"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:141
+#: lib/vutuv_web/templates/layout/app.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Last commit (Berlin time)"
 msgstr "Letzter Commit (Berliner Zeit)"
@@ -8872,7 +8875,7 @@ msgstr "Ungültig"
 msgid "Invalid address (skipped)"
 msgstr "Ungültige Adresse (übersprungen)"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:179
+#: lib/vutuv_web/agent_docs/list_docs.ex:180
 #: lib/vutuv_web/controllers/directory_controller.ex:54
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
@@ -8888,7 +8891,7 @@ msgstr "Mitgliederverzeichnis"
 msgid "Members by initial"
 msgstr "Mitglieder nach Anfangsbuchstaben"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:202
+#: lib/vutuv_web/agent_docs/list_docs.ex:203
 #: lib/vutuv_web/controllers/directory_controller.ex:86
 #: lib/vutuv_web/templates/directory/show.html.heex:2
 #, elixir-autogen, elixir-format
@@ -8907,7 +8910,7 @@ msgid_plural "%{formatted} members"
 msgstr[0] "Ein Mitglied"
 msgstr[1] "%{formatted} Mitglieder"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:208
+#: lib/vutuv_web/agent_docs/list_docs.ex:209
 #, elixir-autogen, elixir-format
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
@@ -9016,10 +9019,10 @@ msgstr "Die Seite wurde veröffentlicht."
 msgid "Write it under Admin › Legal pages"
 msgstr "Unter Admin › Rechtstexte verfassen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:641
-#: lib/vutuv_web/agent_docs/markdown.ex:645
-#: lib/vutuv_web/agent_docs/text.ex:604
-#: lib/vutuv_web/agent_docs/text.ex:608
+#: lib/vutuv_web/agent_docs/markdown.ex:688
+#: lib/vutuv_web/agent_docs/markdown.ex:692
+#: lib/vutuv_web/agent_docs/text.ex:648
+#: lib/vutuv_web/agent_docs/text.ex:652
 #: lib/vutuv_web/components/organization_components.ex:276
 #: lib/vutuv_web/components/ui.ex:1695
 #: lib/vutuv_web/components/ui.ex:5145
@@ -9154,13 +9157,13 @@ msgstr "Ihr Profil als Lebenslauf"
 msgid "Higher Education"
 msgstr "Studium"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:849
+#: lib/vutuv_web/agent_docs/markdown.ex:896
 #: lib/vutuv_web/views/education_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr "Schulbildung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:848
+#: lib/vutuv_web/agent_docs/markdown.ex:895
 #: lib/vutuv_web/views/education_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -9196,7 +9199,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] "Repostet von %{name} und %{formatted} weiteren"
 msgstr[1] "Repostet von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1112
+#: lib/vutuv_web/agent_docs/markdown.ex:1159
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr "repostet von %{name} und %{count} weiteren"
@@ -9448,8 +9451,8 @@ msgstr "Ehren-Tag"
 msgid "Honor tag (only site admins can assign it)"
 msgstr "Ehren-Tag (nur Admins können es vergeben)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:661
-#: lib/vutuv_web/agent_docs/text.ex:622
+#: lib/vutuv_web/agent_docs/markdown.ex:708
+#: lib/vutuv_web/agent_docs/text.ex:666
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr "Ehren-Tag"
@@ -9873,8 +9876,8 @@ msgstr "Walisisch"
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:583
-#: lib/vutuv_web/agent_docs/text.ex:574
+#: lib/vutuv_web/agent_docs/markdown.ex:630
+#: lib/vutuv_web/agent_docs/text.ex:618
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
@@ -9988,7 +9991,7 @@ msgstr[1] "%{count} Zertifikate oder Lizenzen"
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:965
+#: lib/vutuv_web/agent_docs/markdown.ex:1012
 #: lib/vutuv_web/views/qualification_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -10068,7 +10071,7 @@ msgstr "Läuft nicht ab"
 msgid "Expired"
 msgstr "Abgelaufen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:940
+#: lib/vutuv_web/agent_docs/markdown.ex:987
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr "ID: %{id}"
@@ -10085,7 +10088,7 @@ msgstr "Ausgestellt"
 msgid "Issuer"
 msgstr "Aussteller"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:964
+#: lib/vutuv_web/agent_docs/markdown.ex:1011
 #: lib/vutuv_web/views/qualification_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -10115,7 +10118,7 @@ msgstr "Nachweis"
 msgid "Verification link"
 msgstr "Nachweislink"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:938
+#: lib/vutuv_web/agent_docs/markdown.ex:985
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr "ausgestellt %{date}"
@@ -10130,7 +10133,7 @@ msgstr "z. B. AWS Solutions Architect – Associate"
 msgid "e.g. Amazon Web Services"
 msgstr "z. B. Amazon Web Services"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:939
+#: lib/vutuv_web/agent_docs/markdown.ex:986
 #: lib/vutuv_web/views/qualification_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "valid until %{date}"
@@ -10148,7 +10151,7 @@ msgstr ""
 msgid "Preferred"
 msgstr "Bevorzugt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:776
+#: lib/vutuv_web/agent_docs/markdown.ex:823
 #: lib/vutuv_web/live/section_reorder_live.ex:287
 #: lib/vutuv_web/views/language_html.ex:114
 #, elixir-autogen, elixir-format
@@ -10646,21 +10649,21 @@ msgstr ""
 " von einer gedruckten Kennwortliste an, eingegeben im normalen PIN-Feld. "
 "Ihre PIN per E-Mail funktioniert immer weiter."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:736
+#: lib/vutuv_web/agent_docs/markdown.ex:783
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] "%{count} Follower"
 msgstr[1] "%{count} Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:734
+#: lib/vutuv_web/agent_docs/markdown.ex:781
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] "%{count} Repository"
 msgstr[1] "%{count} Repositories"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:732
+#: lib/vutuv_web/agent_docs/markdown.ex:779
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10722,12 +10725,12 @@ msgstr ""
 "Wenn deaktiviert, zeigt die Social-Media-Karte Ihre Konten nur als einfache "
 "Links."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:750
+#: lib/vutuv_web/agent_docs/markdown.ex:797
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr "zuletzt aktiv %{date}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:737
+#: lib/vutuv_web/agent_docs/markdown.ex:784
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr "seit %{date}"
@@ -11760,8 +11763,8 @@ msgstr "Alias hinzugefügt."
 msgid "Alias removed."
 msgstr "Alias entfernt."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:455
-#: lib/vutuv_web/agent_docs/text.ex:474
+#: lib/vutuv_web/agent_docs/markdown.ex:502
+#: lib/vutuv_web/agent_docs/text.ex:518
 #: lib/vutuv_web/live/organization_live/edit.ex:384
 #: lib/vutuv_web/live/organization_live/show.ex:930
 #: lib/vutuv_web/templates/tag/single_card.html.heex:14
@@ -11988,8 +11991,8 @@ msgstr "ausstehend"
 msgid "primary"
 msgstr "primär"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:476
-#: lib/vutuv_web/agent_docs/text.ex:494
+#: lib/vutuv_web/agent_docs/markdown.ex:523
+#: lib/vutuv_web/agent_docs/text.ex:538
 #: lib/vutuv_web/live/admin/organization_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -12118,8 +12121,8 @@ msgstr "Per Rück-Link verifizieren"
 msgid "Verify via file"
 msgstr "Per Datei verifizieren"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:985
-#: lib/vutuv_web/agent_docs/text.ex:750
+#: lib/vutuv_web/agent_docs/markdown.ex:1032
+#: lib/vutuv_web/agent_docs/text.ex:794
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr "verifizierte Webseite"
@@ -12155,8 +12158,8 @@ msgstr "Verknüpft mit {name}"
 msgid "Remove link"
 msgstr "Verknüpfung entfernen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:467
-#: lib/vutuv_web/agent_docs/text.ex:485
+#: lib/vutuv_web/agent_docs/markdown.ex:514
+#: lib/vutuv_web/agent_docs/text.ex:529
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr "ehemalig"
@@ -12367,18 +12370,18 @@ msgstr "Organisationsrolle"
 msgid "Organization unfrozen."
 msgstr "Organisation wieder freigegeben."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:446
+#: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
-#: lib/vutuv_web/agent_docs/text.ex:418
+#: lib/vutuv_web/agent_docs/text.ex:462
 #: lib/vutuv_web/components/ui.ex:5172
 #: lib/vutuv_web/controllers/settings_controller.ex:215
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:538
-#: lib/vutuv_web/live/shell_live.ex:1565
+#: lib/vutuv_web/live/shell_live.ex:1518
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
-#: lib/vutuv_web/templates/layout/app.html.heex:79
+#: lib/vutuv_web/templates/layout/app.html.heex:80
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Organizations"
@@ -12639,9 +12642,9 @@ msgid "Edit posting"
 msgstr "Anzeige bearbeiten"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:282
-#: lib/vutuv_web/agent_docs/markdown.ex:507
+#: lib/vutuv_web/agent_docs/markdown.ex:554
 #: lib/vutuv_web/agent_docs/text.ex:266
-#: lib/vutuv_web/agent_docs/text.ex:525
+#: lib/vutuv_web/agent_docs/text.ex:569
 #: lib/vutuv_web/live/admin/job_live.ex:340
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
 #: lib/vutuv_web/views/account_event_text.ex:225
@@ -12655,9 +12658,9 @@ msgid "Employer name (optional)"
 msgstr "Name des Arbeitgebers (optional)"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:283
-#: lib/vutuv_web/agent_docs/markdown.ex:508
+#: lib/vutuv_web/agent_docs/markdown.ex:555
 #: lib/vutuv_web/agent_docs/text.ex:267
-#: lib/vutuv_web/agent_docs/text.ex:526
+#: lib/vutuv_web/agent_docs/text.ex:570
 #: lib/vutuv_web/live/job_board_live.ex:526
 #: lib/vutuv_web/live/job_posting_live/form.ex:499
 #, elixir-autogen, elixir-format
@@ -12718,8 +12721,8 @@ msgstr "Stellenbezeichnung"
 #: lib/vutuv_web/live/job_board_live.ex:47
 #: lib/vutuv_web/live/job_board_live.ex:265
 #: lib/vutuv_web/live/post_live/saved.ex:541
-#: lib/vutuv_web/live/shell_live.ex:1330
-#: lib/vutuv_web/templates/layout/app.html.heex:80
+#: lib/vutuv_web/live/shell_live.ex:1322
+#: lib/vutuv_web/templates/layout/app.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Jobs"
 msgstr "Jobs"
@@ -12729,12 +12732,12 @@ msgstr "Jobs"
 msgid "Let search engines index this posting."
 msgstr "Suchmaschinen dürfen diese Anzeige indexieren."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:482
-#: lib/vutuv_web/agent_docs/markdown.ex:485
-#: lib/vutuv_web/agent_docs/markdown.ex:487
-#: lib/vutuv_web/agent_docs/text.ex:500
-#: lib/vutuv_web/agent_docs/text.ex:503
-#: lib/vutuv_web/agent_docs/text.ex:505
+#: lib/vutuv_web/agent_docs/markdown.ex:529
+#: lib/vutuv_web/agent_docs/markdown.ex:532
+#: lib/vutuv_web/agent_docs/markdown.ex:534
+#: lib/vutuv_web/agent_docs/text.ex:544
+#: lib/vutuv_web/agent_docs/text.ex:547
+#: lib/vutuv_web/agent_docs/text.ex:549
 #: lib/vutuv_web/live/job_posting_live/form.ex:549
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -12869,9 +12872,9 @@ msgid "Postal code"
 msgstr "Postleitzahl"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:287
-#: lib/vutuv_web/agent_docs/markdown.ex:512
+#: lib/vutuv_web/agent_docs/markdown.ex:559
 #: lib/vutuv_web/agent_docs/text.ex:271
-#: lib/vutuv_web/agent_docs/text.ex:530
+#: lib/vutuv_web/agent_docs/text.ex:574
 #: lib/vutuv_web/live/job_posting_live/show.ex:156
 #, elixir-autogen, elixir-format
 msgid "Posted"
@@ -12896,10 +12899,10 @@ msgstr "Veröffentlichen"
 #: lib/vutuv/accounts/user.ex:1264
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
-#: lib/vutuv_web/agent_docs/markdown.ex:485
-#: lib/vutuv_web/agent_docs/markdown.ex:487
-#: lib/vutuv_web/agent_docs/text.ex:503
-#: lib/vutuv_web/agent_docs/text.ex:505
+#: lib/vutuv_web/agent_docs/markdown.ex:532
+#: lib/vutuv_web/agent_docs/markdown.ex:534
+#: lib/vutuv_web/agent_docs/text.ex:547
+#: lib/vutuv_web/agent_docs/text.ex:549
 #: lib/vutuv_web/components/job_components.ex:140
 #: lib/vutuv_web/components/job_components.ex:141
 #, elixir-autogen, elixir-format
@@ -12920,9 +12923,9 @@ msgid "Required"
 msgstr "Erforderlich"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:286
-#: lib/vutuv_web/agent_docs/markdown.ex:511
+#: lib/vutuv_web/agent_docs/markdown.ex:558
 #: lib/vutuv_web/agent_docs/text.ex:270
-#: lib/vutuv_web/agent_docs/text.ex:529
+#: lib/vutuv_web/agent_docs/text.ex:573
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr "Gehalt"
@@ -13017,9 +13020,9 @@ msgid "Working student"
 msgstr "Werkstudent:in"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:284
-#: lib/vutuv_web/agent_docs/markdown.ex:509
+#: lib/vutuv_web/agent_docs/markdown.ex:556
 #: lib/vutuv_web/agent_docs/text.ex:268
-#: lib/vutuv_web/agent_docs/text.ex:527
+#: lib/vutuv_web/agent_docs/text.ex:571
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
 #, elixir-autogen, elixir-format
 msgid "Workplace"
@@ -13219,13 +13222,13 @@ msgstr "%{km} km"
 msgid "All countries"
 msgstr "Alle Länder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:530
+#: lib/vutuv_web/agent_docs/markdown.ex:577
 #: lib/vutuv_web/templates/tag/show.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr "Alle Stellen mit diesem Tag"
 
-#: lib/vutuv_web/agent_docs/text.ex:547
+#: lib/vutuv_web/agent_docs/text.ex:591
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr "Alle Stellen mit diesem Tag: %{url}"
@@ -13291,10 +13294,10 @@ msgstr "Noch keine Stellenanzeigen."
 msgid "No matching positions. Try adjusting the filters."
 msgstr "Keine passenden Stellen. Passen Sie die Filter an."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:528
-#: lib/vutuv_web/agent_docs/markdown.ex:540
-#: lib/vutuv_web/agent_docs/text.ex:545
-#: lib/vutuv_web/agent_docs/text.ex:557
+#: lib/vutuv_web/agent_docs/markdown.ex:575
+#: lib/vutuv_web/agent_docs/markdown.ex:587
+#: lib/vutuv_web/agent_docs/text.ex:589
+#: lib/vutuv_web/agent_docs/text.ex:601
 #: lib/vutuv_web/live/organization_live/show.ex:833
 #: lib/vutuv_web/templates/tag/show.html.heex:78
 #, elixir-autogen, elixir-format
@@ -14240,7 +14243,7 @@ msgstr "hat %{count} neue Einträge im Lebenslauf:"
 msgid "Audiobook"
 msgstr "Hörbuch"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1305
+#: lib/vutuv_web/agent_docs/markdown.ex:1352
 #: lib/vutuv_web/components/post_components.ex:5565
 #, elixir-autogen, elixir-format
 msgid "Book review"
@@ -14261,7 +14264,7 @@ msgstr "DVD/Blu-ray"
 msgid "E-book"
 msgstr "E-Book"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1305
+#: lib/vutuv_web/agent_docs/markdown.ex:1352
 #: lib/vutuv_web/components/post_components.ex:5564
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -14351,7 +14354,7 @@ msgstr "Qualifikation"
 msgid "With qualification:"
 msgstr "Mit Qualifikation:"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:805
+#: lib/vutuv_web/agent_docs/markdown.ex:852
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
@@ -14416,7 +14419,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] "Empfohlen von %{name} und %{formatted} weiteren"
 msgstr[1] "Empfohlen von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/live/shell_live.ex:707
+#: lib/vutuv_web/live/shell_live.ex:699
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -14440,19 +14443,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] "Für %{formatted} Job genutzt"
 msgstr[1] "Für %{formatted} Jobs genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:954
+#: lib/vutuv_web/agent_docs/markdown.ex:1001
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr "aktuell genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:953
+#: lib/vutuv_web/agent_docs/markdown.ex:1000
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] "für %{count} Job genutzt"
 msgstr[1] "für %{count} Jobs genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:959
+#: lib/vutuv_web/agent_docs/markdown.ex:1006
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -14532,8 +14535,8 @@ msgstr "Hochgeladener Nachweis für %{name}"
 msgid "View the uploaded proof (%{label})"
 msgstr "Hochgeladenen Nachweis ansehen (%{label})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:891
-#: lib/vutuv_web/agent_docs/text.ex:729
+#: lib/vutuv_web/agent_docs/markdown.ex:938
+#: lib/vutuv_web/agent_docs/text.ex:773
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr "Nachweis"
@@ -14597,8 +14600,8 @@ msgstr "Wie möchten Sie arbeiten?"
 msgid "Skip for now"
 msgstr "Erstmal überspringen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:585
-#: lib/vutuv_web/agent_docs/text.ex:576
+#: lib/vutuv_web/agent_docs/markdown.ex:632
+#: lib/vutuv_web/agent_docs/text.ex:620
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr "Bevorzugte Arbeitsform"
@@ -15200,7 +15203,7 @@ msgstr "%{blocked} Server blockiert, am aktivsten eingehend: %{host}."
 msgid "none yet"
 msgstr "noch keiner"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1252
+#: lib/vutuv_web/agent_docs/markdown.ex:1299
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr "Reaktionen aus anderen Netzwerken"
@@ -15584,8 +15587,8 @@ msgstr "%{server} hat nicht geantwortet. Kopieren Sie stattdessen die Adresse ob
 msgid "Your server"
 msgstr "Ihr Server"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:642
-#: lib/vutuv_web/agent_docs/text.ex:605
+#: lib/vutuv_web/agent_docs/markdown.ex:689
+#: lib/vutuv_web/agent_docs/text.ex:649
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr "umgezogen nach %{address}"
@@ -15980,7 +15983,7 @@ msgid_plural "%{formatted} reposts"
 msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1254
+#: lib/vutuv_web/agent_docs/markdown.ex:1301
 #: lib/vutuv_web/components/post_components.ex:6010
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
@@ -15991,10 +15994,10 @@ msgstr "Bereits in den Zahlen oben enthalten."
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem Beitrag, gekennzeichnet als aus einem anderen Netzwerk. Wir speichern eine Kopie für bis zu sechs Monate und prüfen ab und zu, ob sie dort noch veröffentlicht ist; löscht sie die Autorin oder der Autor, verschwindet auch unsere. Sie können jede einzelne Antwort entfernen, und wenn Sie das hier ausschalten, werden alle gelöscht."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1194
-#: lib/vutuv_web/agent_docs/markdown.ex:1452
-#: lib/vutuv_web/agent_docs/text.ex:827
-#: lib/vutuv_web/agent_docs/text.ex:904
+#: lib/vutuv_web/agent_docs/markdown.ex:1241
+#: lib/vutuv_web/agent_docs/markdown.ex:1499
+#: lib/vutuv_web/agent_docs/text.ex:871
+#: lib/vutuv_web/agent_docs/text.ex:948
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr "Inhaltswarnung"
@@ -16018,7 +16021,7 @@ msgstr "Vom Mitglied entfernt"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:135
 #: lib/vutuv_web/agent_docs/markdown.ex:167
-#: lib/vutuv_web/agent_docs/markdown.ex:1253
+#: lib/vutuv_web/agent_docs/markdown.ex:1300
 #: lib/vutuv_web/agent_docs/text.ex:124
 #: lib/vutuv_web/agent_docs/text.ex:153
 #, elixir-autogen, elixir-format
@@ -16076,7 +16079,7 @@ msgstr "Danke. Die Antwort wurde sofort gelöscht."
 msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1454
+#: lib/vutuv_web/agent_docs/markdown.ex:1501
 #: lib/vutuv_web/components/post_components.ex:1411
 #: lib/vutuv_web/components/post_components.ex:1611
 #: lib/vutuv_web/components/post_components.ex:3019
@@ -16784,13 +16787,13 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr "Nicht mehr angeheftet. Der Beitrag ist wieder ein normaler Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1095
+#: lib/vutuv_web/agent_docs/markdown.ex:1142
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr "angehefteter Beitrag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:579
-#: lib/vutuv_web/agent_docs/text.ex:567
+#: lib/vutuv_web/agent_docs/markdown.ex:626
+#: lib/vutuv_web/agent_docs/text.ex:611
 #: lib/vutuv_web/templates/user/edit.html.heex:219
 #: lib/vutuv_web/templates/user/show.html.heex:262
 #: lib/vutuv_web/views/account_event_text.ex:213
@@ -16842,8 +16845,8 @@ msgstr "CC BY-SA 4.0 (Namensnennung, gleiche Bedingungen)"
 msgid "CC0 1.0 (no rights reserved)"
 msgstr "CC0 1.0 (keine Rechte vorbehalten)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1371
-#: lib/vutuv_web/agent_docs/text.ex:858
+#: lib/vutuv_web/agent_docs/markdown.ex:1418
+#: lib/vutuv_web/agent_docs/text.ex:902
 #: lib/vutuv_web/live/post_live/composer.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Cover"
@@ -16854,8 +16857,8 @@ msgstr "Titelbild"
 msgid "Describe the photo for people who can't see it"
 msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1382
-#: lib/vutuv_web/agent_docs/text.ex:871
+#: lib/vutuv_web/agent_docs/markdown.ex:1429
+#: lib/vutuv_web/agent_docs/text.ex:915
 #: lib/vutuv_web/components/ui.ex:3126
 #, elixir-autogen, elixir-format
 msgid "Download the original"
@@ -16912,8 +16915,8 @@ msgstr "Foto wird geprüft"
 msgid "Photo options"
 msgstr "Foto-Einstellungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1415
-#: lib/vutuv_web/agent_docs/text.ex:846
+#: lib/vutuv_web/agent_docs/markdown.ex:1462
+#: lib/vutuv_web/agent_docs/text.ex:890
 #: lib/vutuv_web/components/post_components.ex:4808
 #, elixir-autogen, elixir-format
 msgid "Photos:"
@@ -17074,13 +17077,13 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exakte Datei gibt ihn weiter."
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1272
+#: lib/vutuv_web/agent_docs/markdown.ex:1319
 #: lib/vutuv_web/components/post_components.ex:6048
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1270
+#: lib/vutuv_web/agent_docs/markdown.ex:1317
 #: lib/vutuv_web/components/post_components.ex:6045
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
@@ -17708,7 +17711,7 @@ msgstr "Variante"
 msgid "What is being measured"
 msgstr "Was gemessen wird"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1072
+#: lib/vutuv_web/agent_docs/markdown.ex:1119
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
@@ -17872,8 +17875,8 @@ msgstr "Profil verifizieren"
 msgid "We could not reach the network just now. Please try again in a moment."
 msgstr "Wir konnten das Netzwerk gerade nicht erreichen. Bitte versuchen Sie es gleich noch einmal."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:999
-#: lib/vutuv_web/agent_docs/text.ex:651
+#: lib/vutuv_web/agent_docs/markdown.ex:1046
+#: lib/vutuv_web/agent_docs/text.ex:695
 #, elixir-autogen, elixir-format
 msgid "verified profile"
 msgstr "verifiziertes Profil"
@@ -18171,12 +18174,12 @@ msgstr "Kacheln füllen"
 msgid "Whole photos"
 msgstr "Ganze Fotos"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:166
+#: lib/vutuv_web/templates/layout/app.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Send the post or message you are writing"
 msgstr "Beitrag oder Nachricht absenden, während Sie schreiben"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:227
+#: lib/vutuv_web/templates/layout/app.html.heex:228
 #, elixir-autogen, elixir-format
 msgid "The single-key shortcuts pause while you type, and are off on phones and tablets."
 msgstr "Die Einzeltasten-Kürzel pausieren, während Sie tippen, und sind auf Telefonen und Tablets aus."
@@ -18727,7 +18730,7 @@ msgstr "Höchstens %{max} Tags. Entfernen Sie eines, um ein anderes hinzuzufüge
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder, denen er gefällt. Hier legen Sie fest, ob Sie zu diesen Gesichtern gehören."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1240
+#: lib/vutuv_web/agent_docs/markdown.ex:1287
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
@@ -18769,12 +18772,12 @@ msgstr "Wenn aus, sehen andere Mitglieder Sie nicht mehr bei den Likes eines Bei
 msgid "Your likes follow the site default again."
 msgstr "Ihre Likes folgen wieder dem Standardwert der Website."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1295
+#: lib/vutuv_web/agent_docs/markdown.ex:1342
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr "%{address} (nur diese Seite)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1292
+#: lib/vutuv_web/agent_docs/markdown.ex:1339
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr "%{address} (ganze Website)"
@@ -18784,7 +18787,7 @@ msgstr "%{address} (ganze Website)"
 msgid "Verified webpage of the author (%{address})"
 msgstr "Verifizierte Webseite der Autorin oder des Autors (%{address})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1284
+#: lib/vutuv_web/agent_docs/markdown.ex:1331
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
@@ -19120,7 +19123,7 @@ msgstr "Weder den Prompt noch das Modell haben wir geschrieben."
 msgid "Employment references of %{name}"
 msgstr "Arbeitszeugnisse von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:873
+#: lib/vutuv_web/agent_docs/markdown.ex:920
 #, elixir-autogen, elixir-format
 msgid "document"
 msgstr "Dokument"
@@ -20486,7 +20489,7 @@ msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."
 msgid "A post in an organization's name is always public."
 msgstr "Ein Beitrag im Namen einer Organisation ist immer öffentlich."
 
-#: lib/vutuv_web/live/shell_live.ex:1236
+#: lib/vutuv_web/live/shell_live.ex:1228
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr "Seite öffnen"
@@ -20506,7 +20509,7 @@ msgstr "Beendet, im Namen einer Organisation zu schreiben"
 msgid "Write as %{name} for now"
 msgstr "Vorerst als %{name} schreiben"
 
-#: lib/vutuv_web/live/shell_live.ex:1246
+#: lib/vutuv_web/live/shell_live.ex:1238
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr "Wieder als ich selbst schreiben"
@@ -20516,7 +20519,7 @@ msgstr "Wieder als ich selbst schreiben"
 msgid "You are writing as %{name} now."
 msgstr "Sie schreiben jetzt als %{name}."
 
-#: lib/vutuv_web/live/shell_live.ex:1222
+#: lib/vutuv_web/live/shell_live.ex:1214
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr "Sie schreiben als %{name}."
@@ -20880,21 +20883,21 @@ msgstr "Sie folgen #%{tag} hier bereits."
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr "Sie sind selbst auf diesem vutuv. Sie folgen #%{tag} jetzt direkt hier."
 
-#: lib/vutuv_web/live/shell_live.ex:751
+#: lib/vutuv_web/live/shell_live.ex:743
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] "%{formatted} Person"
 msgstr[1] "%{formatted} Personen"
 
-#: lib/vutuv_web/live/shell_live.ex:738
+#: lib/vutuv_web/live/shell_live.ex:730
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] "Person"
 msgstr[1] "Personen"
 
-#: lib/vutuv_web/live/shell_live.ex:773
+#: lib/vutuv_web/live/shell_live.ex:765
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -21153,12 +21156,12 @@ msgstr "Unter diesem Alias wurde kein sichtbares lokales Konto gefunden."
 msgid "You are not allowed to change this organization."
 msgstr "Sie dürfen diese Organisation nicht ändern."
 
-#: lib/vutuv_web/templates/layout/app.html.heex:96
+#: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Company"
 msgstr "Unternehmen"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:121
+#: lib/vutuv_web/templates/layout/app.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Legal"
 msgstr "Rechtliches"
@@ -21994,7 +21997,7 @@ msgstr "%{handle} nicht mehr folgen? Die Beiträge verschwinden aus Ihrem Feed."
 msgid "Unfollowed. Their posts leave your feed."
 msgstr "Nicht mehr gefolgt. Die Beiträge verschwinden aus Ihrem Feed."
 
-#: lib/vutuv_web/live/shell_live.ex:1196
+#: lib/vutuv_web/live/shell_live.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr "Erlauben"
@@ -22009,12 +22012,12 @@ msgstr "Jetzt fragen"
 msgid "Browser notifications"
 msgstr "Browser-Benachrichtigungen"
 
-#: lib/vutuv_web/live/shell_live.ex:1054
+#: lib/vutuv_web/live/shell_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr "Neue Nachricht"
 
-#: lib/vutuv_web/live/shell_live.ex:1199
+#: lib/vutuv_web/live/shell_live.ex:1191
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Jetzt nicht"
@@ -22054,7 +22057,7 @@ msgstr "Dieser Browser zeigt sie an."
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr "Wenn etwas eintrifft, während vutuv in einem Tab offen ist, den Sie gerade nicht ansehen, kann Ihr Browser es als Benachrichtigung anzeigen. Aus, solange Sie es nicht einschalten."
 
-#: lib/vutuv_web/live/shell_live.ex:1193
+#: lib/vutuv_web/live/shell_live.ex:1185
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr "Sie haben Browser-Benachrichtigungen eingeschaltet. Dieser Browser wurde noch nicht um Erlaubnis gebeten."
@@ -22094,12 +22097,12 @@ msgstr "Test-Benachrichtigung senden"
 msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
 msgstr "Gesendet. Wenn nichts erschienen ist, hält Ihr System sie zurück. Prüfen Sie „Nicht stören“ und Ihre Benachrichtigungseinstellungen."
 
-#: lib/vutuv_web/live/shell_live.ex:846
+#: lib/vutuv_web/live/shell_live.ex:838
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr "Test-Benachrichtigung"
 
-#: lib/vutuv_web/live/shell_live.ex:847
+#: lib/vutuv_web/live/shell_live.ex:839
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr "So sieht es aus, wenn auf vutuv etwas für Sie eintrifft."
@@ -22339,7 +22342,7 @@ msgstr "In %{language} übersetzen"
 msgid "Translated into %{language}."
 msgstr "Wird in %{language} übersetzt."
 
-#: lib/vutuv_web/live/shell_live.ex:987
+#: lib/vutuv_web/live/shell_live.ex:979
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -22465,7 +22468,7 @@ msgstr "Neue Nachricht auf vutuv"
 msgid "No connection"
 msgstr "Keine Verbindung"
 
-#: lib/vutuv_web/live/shell_live.ex:1126
+#: lib/vutuv_web/live/shell_live.ex:1118
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr "Neu laden"
@@ -22553,7 +22556,7 @@ msgstr "Welche Namen durchsucht werden"
 msgid "All vutuv members, filed alphabetically by last name."
 msgstr "Alle vutuv Mitglieder, alphabetisch nach Nachname sortiert."
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:194
+#: lib/vutuv_web/agent_docs/list_docs.ex:195
 #, elixir-autogen, elixir-format
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr "Alle vutuv Mitglieder, gruppiert nach dem Anfangsbuchstaben des Nachnamens."
@@ -22957,7 +22960,7 @@ msgstr "Passwortmanager wie Bitwarden übernehmen daraus den ganzen Eintrag: Nam
 msgid "Scan it with the device that has the app"
 msgstr "Mit dem Gerät scannen, auf dem die App läuft"
 
-#: lib/vutuv_web/live/shell_live.ex:1108
+#: lib/vutuv_web/live/shell_live.ex:1100
 #, elixir-autogen, elixir-format
 msgid "A new version is ready."
 msgstr "Neue Version bereit."
@@ -22979,12 +22982,12 @@ msgstr[1] "Neu (%{formatted}):"
 msgid "Quoted post"
 msgstr "Zitierter Beitrag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1088
+#: lib/vutuv_web/agent_docs/markdown.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Quotes %{name}: %{url}"
 msgstr "Zitiert %{name}: %{url}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1085
+#: lib/vutuv_web/agent_docs/markdown.ex:1132
 #, elixir-autogen, elixir-format
 msgid "Quotes %{url}"
 msgstr "Zitiert %{url}"
@@ -23044,6 +23047,7 @@ msgid_plural "%{formatted} shares"
 msgstr[0] "%{formatted} Mal geteilt"
 msgstr[1] "%{formatted} Mal geteilt"
 
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:136
 #: lib/vutuv_web/live/notification_live/index.ex:838
 #, elixir-autogen, elixir-format
 msgid "Post without text"
@@ -23205,7 +23209,7 @@ msgstr "Wenn Ihre Verbindung langsam ist oder Ihr Datenvolumen begrenzt, kann vu
 msgid "Low-bandwidth mode"
 msgstr "Datensparmodus"
 
-#: lib/vutuv_web/live/shell_live.ex:1676
+#: lib/vutuv_web/live/shell_live.ex:1629
 #, elixir-autogen, elixir-format
 msgctxt "phone tab bar"
 msgid "Write"
@@ -23362,7 +23366,7 @@ msgstr "bandbreite langsam internet mobil daten sparen datensparmodus volumen sc
 msgid "Appearance"
 msgstr "Darstellung"
 
-#: lib/vutuv_web/live/shell_live.ex:1702
+#: lib/vutuv_web/live/shell_live.ex:1655
 #, elixir-autogen, elixir-format
 msgid "%{count} video in progress"
 msgid_plural "%{count} videos in progress"
@@ -23466,10 +23470,10 @@ msgstr "Dieser Beitrag wartet noch auf Sie"
 msgid "This video could not be converted."
 msgstr "Dieses Video konnte nicht umgewandelt werden."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1367
-#: lib/vutuv_web/agent_docs/markdown.ex:1370
-#: lib/vutuv_web/agent_docs/text.ex:855
-#: lib/vutuv_web/agent_docs/text.ex:856
+#: lib/vutuv_web/agent_docs/markdown.ex:1414
+#: lib/vutuv_web/agent_docs/markdown.ex:1417
+#: lib/vutuv_web/agent_docs/text.ex:899
+#: lib/vutuv_web/agent_docs/text.ex:900
 #: lib/vutuv_web/components/post_components.ex:2501
 #: lib/vutuv_web/components/video_components.ex:126
 #: lib/vutuv_web/live/post_live/composer.ex:2458
@@ -23594,22 +23598,22 @@ msgstr "Mitglieder mit diesen Tags:"
 msgid "The fields the most members carry, and how many of them do."
 msgstr "Die Fachgebiete mit den meisten Mitgliedern, und wie viele es jeweils sind."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1138
-#: lib/vutuv_web/agent_docs/text.ex:779
+#: lib/vutuv_web/agent_docs/markdown.ex:1185
+#: lib/vutuv_web/agent_docs/text.ex:823
 #: lib/vutuv_web/live/job_board_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "What members here work on"
 msgstr "Woran die Mitglieder hier arbeiten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1130
-#: lib/vutuv_web/agent_docs/text.ex:771
+#: lib/vutuv_web/agent_docs/markdown.ex:1177
+#: lib/vutuv_web/agent_docs/text.ex:815
 #: lib/vutuv_web/live/job_board_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "Who you would reach"
 msgstr "Wen Sie hier erreichen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1131
-#: lib/vutuv_web/agent_docs/text.ex:772
+#: lib/vutuv_web/agent_docs/markdown.ex:1178
+#: lib/vutuv_web/agent_docs/text.ex:816
 #: lib/vutuv_web/live/job_board_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "One random vutuv account that is open to offers."
@@ -23617,7 +23621,7 @@ msgid_plural "%{formatted} random vutuv accounts that are open to offers."
 msgstr[0] "Ein zufälliger vutuv Account, der offen für Angebote ist."
 msgstr[1] "%{formatted} zufällige vutuv Accounts, die offen für Angebote sind."
 
-#: lib/vutuv_web/live/shell_live.ex:721
+#: lib/vutuv_web/live/shell_live.ex:713
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post in your feed"
 msgid_plural "%{formatted} new posts in your feed"
@@ -23702,7 +23706,7 @@ msgstr[1] "Von %{formatted} Servern"
 
 #: lib/vutuv_web/agent_docs/investors_doc.ex:295
 #: lib/vutuv_web/controllers/company_controller.ex:56
-#: lib/vutuv_web/templates/layout/app.html.heex:110
+#: lib/vutuv_web/templates/layout/app.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "Investors"
 msgstr "Investoren"
@@ -23712,14 +23716,13 @@ msgstr "Investoren"
 msgid "Over these %{days} days %{total} people arrived, %{members} of them as members here."
 msgstr "In diesen %{days} Tagen sind %{total} Menschen dazugekommen, davon %{members} als Mitglieder hier."
 
-#: lib/vutuv_web/live/shell_live.ex:1415
 #: lib/vutuv_web/views/company_html.ex:76
 #, elixir-autogen, elixir-format
 msgid "People here per day over the last %{days} days"
 msgstr "Menschen hier pro Tag über die letzten %{days} Tage"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:392
-#: lib/vutuv_web/agent_docs/text.ex:362
+#: lib/vutuv_web/agent_docs/markdown.ex:430
+#: lib/vutuv_web/agent_docs/text.ex:399
 #, elixir-autogen, elixir-format
 msgid "Press material: %{url}"
 msgstr "Pressematerial: %{url}"
@@ -23734,28 +23737,28 @@ msgstr "Ohne Konto lesbar"
 msgid "Send a message"
 msgstr "Nachricht schreiben"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:375
-#: lib/vutuv_web/agent_docs/text.ex:349
+#: lib/vutuv_web/agent_docs/markdown.ex:413
+#: lib/vutuv_web/agent_docs/text.ex:386
 #: lib/vutuv_web/templates/company/investors.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Where we are"
 msgstr "Wo wir stehen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:382
-#: lib/vutuv_web/agent_docs/text.ex:356
+#: lib/vutuv_web/agent_docs/markdown.ex:420
+#: lib/vutuv_web/agent_docs/text.ex:393
 #: lib/vutuv_web/templates/company/investors.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Why this is worth building"
 msgstr "Warum sich das lohnt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:391
-#: lib/vutuv_web/agent_docs/text.ex:361
+#: lib/vutuv_web/agent_docs/markdown.ex:429
+#: lib/vutuv_web/agent_docs/text.ex:398
 #, elixir-autogen, elixir-format
 msgid "Write here: %{url}"
 msgstr "Schreiben Sie hier: %{url}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:388
-#: lib/vutuv_web/agent_docs/text.ex:358
+#: lib/vutuv_web/agent_docs/markdown.ex:426
+#: lib/vutuv_web/agent_docs/text.ex:395
 #: lib/vutuv_web/templates/company/investors.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Write to me"
@@ -23771,8 +23774,8 @@ msgstr "Schreiben Sie mir hier, auf vutuv. Ein Konto anzulegen dauert eine Minut
 msgid "My profile:"
 msgstr "Mein Profil:"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:390
-#: lib/vutuv_web/agent_docs/text.ex:360
+#: lib/vutuv_web/agent_docs/markdown.ex:428
+#: lib/vutuv_web/agent_docs/text.ex:397
 #, elixir-autogen, elixir-format
 msgid "My profile: %{url}"
 msgstr "Mein Profil: %{url}"
@@ -23792,8 +23795,8 @@ msgstr "Schnelle Seiten gewinnen"
 msgid "Source:"
 msgstr "Quelle:"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:442
-#: lib/vutuv_web/agent_docs/text.ex:411
+#: lib/vutuv_web/agent_docs/markdown.ex:485
+#: lib/vutuv_web/agent_docs/text.ex:452
 #, elixir-autogen, elixir-format
 msgid "Source: %{source}"
 msgstr "Quelle: %{source}"
@@ -23919,3 +23922,76 @@ msgstr "stumm stummschalten stummschaltung ausblenden verbergen konto account re
 #, elixir-autogen, elixir-format
 msgid "muted on the follow itself"
 msgstr "über das Folgen stummgeschaltet"
+
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:40
+#, elixir-autogen, elixir-format
+msgid "Every public post on vutuv, filed under the day it was written."
+msgstr "Alle öffentlichen Beiträge auf vutuv, sortiert nach dem Tag, an dem sie geschrieben wurden."
+
+#: lib/vutuv_web/templates/post_calendar/month.html.heex:16
+#, elixir-autogen, elixir-format
+msgid "Neighbouring months"
+msgstr "Benachbarte Monate"
+
+#: lib/vutuv_web/templates/post_calendar/month.html.heex:80
+#, elixir-autogen, elixir-format
+msgid "No posts in this month yet."
+msgstr "In diesem Monat wurde noch nichts geschrieben."
+
+#: lib/vutuv_web/templates/post_calendar/day.html.heex:18
+#, elixir-autogen, elixir-format
+msgid "No posts on this day."
+msgstr "An diesem Tag wurde nichts geschrieben."
+
+#: lib/vutuv_web/templates/post_calendar/index.html.heex:16
+#, elixir-autogen, elixir-format
+msgid "Nothing has been written here yet."
+msgstr "Hier wurde noch nichts geschrieben."
+
+#: lib/vutuv_web/templates/post_calendar/day.html.heex:14
+#: lib/vutuv_web/templates/post_calendar/month.html.heex:69
+#, elixir-autogen, elixir-format
+msgid "One post"
+msgid_plural "%{formatted} posts"
+msgstr[0] "Ein Beitrag"
+msgstr[1] "%{formatted} Beiträge"
+
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:36
+#: lib/vutuv_web/templates/layout/app.html.heex:79
+#: lib/vutuv_web/templates/post_calendar/day.html.heex:5
+#: lib/vutuv_web/templates/post_calendar/index.html.heex:2
+#: lib/vutuv_web/templates/post_calendar/index.html.heex:3
+#: lib/vutuv_web/templates/post_calendar/month.html.heex:5
+#, elixir-autogen, elixir-format
+msgid "Post calendar"
+msgstr "Beitragskalender"
+
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:126
+#, elixir-autogen, elixir-format
+msgid "Post not open to search engines"
+msgstr "Beitrag ohne Freigabe für Suchmaschinen"
+
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:59
+#, elixir-autogen, elixir-format
+msgid "Posts in %{month} %{year}"
+msgstr "Beiträge im %{month} %{year}"
+
+#: lib/vutuv_web/templates/post_calendar/index.html.heex:28
+#, elixir-autogen, elixir-format
+msgid "Posts in %{year}"
+msgstr "Beiträge aus %{year}"
+
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:88
+#, elixir-autogen, elixir-format
+msgid "Posts on %{date}"
+msgstr "Beiträge vom %{date}"
+
+#: lib/vutuv_web/agent_docs/list_docs.ex:280
+#, elixir-autogen, elixir-format
+msgid "The posts written that day."
+msgstr "Die Beiträge dieses Tages."
+
+#: lib/vutuv_web/agent_docs/list_docs.ex:248
+#, elixir-autogen, elixir-format
+msgid "The posts written that month, by day."
+msgstr "Die Beiträge dieses Monats, nach Tagen."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -12,7 +12,7 @@ msgstr ""
 "Language: INSERT LANGUAGE HERE\n"
 
 #: lib/vutuv_web/controllers/page_controller.ex:241
-#: lib/vutuv_web/templates/layout/app.html.heex:117
+#: lib/vutuv_web/templates/layout/app.html.heex:118
 #, elixir-autogen
 msgid "About us"
 msgstr ""
@@ -102,10 +102,10 @@ msgstr ""
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:629
-#: lib/vutuv_web/agent_docs/markdown.ex:630
-#: lib/vutuv_web/agent_docs/text.ex:592
-#: lib/vutuv_web/agent_docs/text.ex:593
+#: lib/vutuv_web/agent_docs/markdown.ex:676
+#: lib/vutuv_web/agent_docs/markdown.ex:677
+#: lib/vutuv_web/agent_docs/text.ex:636
+#: lib/vutuv_web/agent_docs/text.ex:637
 #: lib/vutuv_web/templates/user/show.html.heex:1132
 #, elixir-autogen
 msgid "Birthday"
@@ -306,14 +306,14 @@ msgstr ""
 msgid "Fax"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:615
+#: lib/vutuv_web/agent_docs/markdown.ex:662
 #: lib/vutuv_web/templates/user/edit.html.heex:164
 #, elixir-autogen
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:650
-#: lib/vutuv_web/agent_docs/text.ex:613
+#: lib/vutuv_web/agent_docs/markdown.ex:697
+#: lib/vutuv_web/agent_docs/text.ex:657
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
@@ -323,8 +323,8 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:651
-#: lib/vutuv_web/agent_docs/text.ex:614
+#: lib/vutuv_web/agent_docs/markdown.ex:698
+#: lib/vutuv_web/agent_docs/text.ex:658
 #: lib/vutuv_web/components/fediverse_components.ex:468
 #: lib/vutuv_web/components/ui.ex:2964
 #: lib/vutuv_web/components/ui.ex:2999
@@ -359,7 +359,10 @@ msgstr ""
 
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:4
-#: lib/vutuv_web/templates/layout/app.html.heex:156
+#: lib/vutuv_web/templates/layout/app.html.heex:157
+#: lib/vutuv_web/templates/post_calendar/day.html.heex:4
+#: lib/vutuv_web/templates/post_calendar/index.html.heex:3
+#: lib/vutuv_web/templates/post_calendar/month.html.heex:4
 #, elixir-autogen
 msgid "Home"
 msgstr ""
@@ -380,7 +383,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:617
+#: lib/vutuv_web/agent_docs/markdown.ex:664
 #: lib/vutuv_web/templates/user/edit.html.heex:169
 #, elixir-autogen
 msgid "Last Name"
@@ -439,15 +442,15 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1608
-#: lib/vutuv_web/live/shell_live.ex:1684
+#: lib/vutuv_web/live/shell_live.ex:1561
+#: lib/vutuv_web/live/shell_live.ex:1637
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
 msgid "Log in"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:616
+#: lib/vutuv_web/agent_docs/markdown.ex:663
 #: lib/vutuv_web/templates/user/edit.html.heex:174
 #, elixir-autogen
 msgid "Middle Name"
@@ -484,7 +487,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:619
+#: lib/vutuv_web/agent_docs/markdown.ex:666
 #: lib/vutuv_web/templates/user/edit.html.heex:179
 #, elixir-autogen
 msgid "Nickname"
@@ -565,7 +568,7 @@ msgstr ""
 msgid "Phone number updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:614
+#: lib/vutuv_web/agent_docs/markdown.ex:661
 #: lib/vutuv_web/templates/user/edit.html.heex:184
 #, elixir-autogen
 msgid "Prefix"
@@ -645,13 +648,13 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
-#: lib/vutuv_web/live/shell_live.ex:1477
-#: lib/vutuv_web/live/shell_live.ex:1664
+#: lib/vutuv_web/live/shell_live.ex:1430
+#: lib/vutuv_web/live/shell_live.ex:1617
 #: lib/vutuv_web/live/tag_live/timeline.ex:333
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
-#: lib/vutuv_web/templates/layout/app.html.heex:161
+#: lib/vutuv_web/templates/layout/app.html.heex:162
 #, elixir-autogen
 msgid "Search"
 msgstr ""
@@ -744,7 +747,7 @@ msgstr ""
 msgid "Submit a bugreport or a feature request."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:618
+#: lib/vutuv_web/agent_docs/markdown.ex:665
 #: lib/vutuv_web/templates/user/edit.html.heex:189
 #, elixir-autogen
 msgid "Suffix"
@@ -1140,7 +1143,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:63
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1584
+#: lib/vutuv_web/live/shell_live.ex:1537
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1348,11 +1351,11 @@ msgid "Tag urls"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
-#: lib/vutuv_web/agent_docs/markdown.ex:522
-#: lib/vutuv_web/agent_docs/markdown.ex:1163
+#: lib/vutuv_web/agent_docs/markdown.ex:569
+#: lib/vutuv_web/agent_docs/markdown.ex:1210
 #: lib/vutuv_web/agent_docs/text.ex:31
-#: lib/vutuv_web/agent_docs/text.ex:540
-#: lib/vutuv_web/agent_docs/text.ex:806
+#: lib/vutuv_web/agent_docs/text.ex:584
+#: lib/vutuv_web/agent_docs/text.ex:850
 #: lib/vutuv_web/components/ui.ex:5004
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
@@ -1575,7 +1578,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1682
+#: lib/vutuv_web/live/shell_live.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1605,8 +1608,8 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/composer.ex:1876
 #: lib/vutuv_web/live/post_live/composer.ex:2839
 #: lib/vutuv_web/live/post_live/composer.ex:3105
-#: lib/vutuv_web/templates/layout/app.html.heex:194
-#: lib/vutuv_web/templates/layout/app.html.heex:200
+#: lib/vutuv_web/templates/layout/app.html.heex:195
+#: lib/vutuv_web/templates/layout/app.html.heex:201
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
 #: lib/vutuv_web/views/layout_html.ex:142
 #, elixir-autogen, elixir-format
@@ -1626,7 +1629,7 @@ msgid "Confirm account deletion"
 msgstr ""
 
 #: lib/vutuv_web/controllers/page_controller.ex:245
-#: lib/vutuv_web/templates/layout/app.html.heex:123
+#: lib/vutuv_web/templates/layout/app.html.heex:124
 #: lib/vutuv_web/templates/page/index.html.heex:321
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
@@ -1634,7 +1637,7 @@ msgid "Datenschutzerklärung"
 msgstr ""
 
 #: lib/vutuv_web/controllers/page_controller.ex:251
-#: lib/vutuv_web/templates/layout/app.html.heex:124
+#: lib/vutuv_web/templates/layout/app.html.heex:125
 #: lib/vutuv_web/templates/page/index.html.heex:321
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
@@ -1692,7 +1695,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1603
+#: lib/vutuv_web/live/shell_live.ex:1556
 #: lib/vutuv_web/views/settings_html.ex:311
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1724,9 +1727,9 @@ msgstr ""
 #: lib/vutuv_web/controllers/page_controller.ex:218
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1495
-#: lib/vutuv_web/live/shell_live.ex:1681
-#: lib/vutuv_web/templates/layout/app.html.heex:158
+#: lib/vutuv_web/live/shell_live.ex:1448
+#: lib/vutuv_web/live/shell_live.ex:1634
+#: lib/vutuv_web/templates/layout/app.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
@@ -1757,8 +1760,8 @@ msgstr ""
 #: lib/vutuv_web/controllers/page_controller.ex:219
 #: lib/vutuv_web/live/notification_live/index.ex:152
 #: lib/vutuv_web/live/notification_live/index.ex:457
-#: lib/vutuv_web/live/shell_live.ex:1507
-#: lib/vutuv_web/templates/layout/app.html.heex:159
+#: lib/vutuv_web/live/shell_live.ex:1460
+#: lib/vutuv_web/templates/layout/app.html.heex:160
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Notifications"
@@ -1786,12 +1789,12 @@ msgid "Send"
 msgstr ""
 
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:35
-#: lib/vutuv_web/templates/layout/app.html.heex:87
+#: lib/vutuv_web/templates/layout/app.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "Source"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:90
+#: lib/vutuv_web/templates/layout/app.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Submit a bug report or feature request"
 msgstr ""
@@ -2109,9 +2112,9 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/feed.ex:345
 #: lib/vutuv_web/live/post_live/feed.ex:3114
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1290
-#: lib/vutuv_web/live/shell_live.ex:1654
-#: lib/vutuv_web/templates/layout/app.html.heex:157
+#: lib/vutuv_web/live/shell_live.ex:1282
+#: lib/vutuv_web/live/shell_live.ex:1607
+#: lib/vutuv_web/templates/layout/app.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Feed"
 msgstr ""
@@ -2285,7 +2288,7 @@ msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5373
-#: lib/vutuv_web/live/shell_live.ex:1550
+#: lib/vutuv_web/live/shell_live.ex:1503
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:258
@@ -2375,11 +2378,11 @@ msgstr ""
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1217
+#: lib/vutuv_web/agent_docs/markdown.ex:1264
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:525
-#: lib/vutuv_web/live/shell_live.ex:1487
-#: lib/vutuv_web/live/shell_live.ex:1555
+#: lib/vutuv_web/live/shell_live.ex:1440
+#: lib/vutuv_web/live/shell_live.ex:1508
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2395,11 +2398,11 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1216
+#: lib/vutuv_web/agent_docs/markdown.ex:1263
 #: lib/vutuv_web/components/post_components.ex:6106
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:522
-#: lib/vutuv_web/live/shell_live.ex:1558
+#: lib/vutuv_web/live/shell_live.ex:1511
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2788,8 +2791,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:652
-#: lib/vutuv_web/agent_docs/text.ex:615
+#: lib/vutuv_web/agent_docs/markdown.ex:699
+#: lib/vutuv_web/agent_docs/text.ex:659
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2941,10 +2944,10 @@ msgstr ""
 msgid "Bullying or harassment"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:347
-#: lib/vutuv_web/agent_docs/text.ex:328
+#: lib/vutuv_web/agent_docs/markdown.ex:385
+#: lib/vutuv_web/agent_docs/text.ex:365
 #: lib/vutuv_web/controllers/page_controller.ex:81
-#: lib/vutuv_web/templates/layout/app.html.heex:125
+#: lib/vutuv_web/templates/layout/app.html.heex:126
 #: lib/vutuv_web/templates/page/community.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Community guidelines"
@@ -3147,7 +3150,7 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4973
-#: lib/vutuv_web/live/shell_live.ex:1322
+#: lib/vutuv_web/live/shell_live.ex:1314
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3824,12 +3827,12 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:759
+#: lib/vutuv_web/agent_docs/markdown.ex:806
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1338
+#: lib/vutuv_web/agent_docs/markdown.ex:1385
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3843,16 +3846,16 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:91
 #: lib/vutuv_web/agent_docs/markdown.ex:204
 #: lib/vutuv_web/agent_docs/markdown.ex:218
-#: lib/vutuv_web/agent_docs/markdown.ex:1163
+#: lib/vutuv_web/agent_docs/markdown.ex:1210
 #: lib/vutuv_web/agent_docs/text.ex:86
 #: lib/vutuv_web/agent_docs/text.ex:187
 #: lib/vutuv_web/agent_docs/text.ex:201
-#: lib/vutuv_web/agent_docs/text.ex:806
+#: lib/vutuv_web/agent_docs/text.ex:850
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:46
+#: lib/vutuv_web/agent_docs/list_docs.ex:47
 #, elixir-autogen, elixir-format
 msgid "Followers of %{name}"
 msgstr ""
@@ -3866,28 +3869,28 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1181
-#: lib/vutuv_web/agent_docs/text.ex:817
+#: lib/vutuv_web/agent_docs/markdown.ex:1228
+#: lib/vutuv_web/agent_docs/text.ex:861
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1178
-#: lib/vutuv_web/agent_docs/text.ex:814
+#: lib/vutuv_web/agent_docs/markdown.ex:1225
+#: lib/vutuv_web/agent_docs/text.ex:858
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1185
-#: lib/vutuv_web/agent_docs/markdown.ex:1431
-#: lib/vutuv_web/agent_docs/text.ex:821
-#: lib/vutuv_web/agent_docs/text.ex:890
+#: lib/vutuv_web/agent_docs/markdown.ex:1232
+#: lib/vutuv_web/agent_docs/markdown.ex:1478
+#: lib/vutuv_web/agent_docs/text.ex:865
+#: lib/vutuv_web/agent_docs/text.ex:934
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:587
-#: lib/vutuv_web/agent_docs/text.ex:578
+#: lib/vutuv_web/agent_docs/markdown.ex:634
+#: lib/vutuv_web/agent_docs/text.ex:622
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
@@ -3898,7 +3901,7 @@ msgstr ""
 msgid "Most endorsed members"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:47
+#: lib/vutuv_web/agent_docs/list_docs.ex:48
 #, elixir-autogen, elixir-format
 msgid "People %{name} follows"
 msgstr ""
@@ -3926,23 +3929,23 @@ msgstr ""
 msgid "Posts (%{count} total)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:581
-#: lib/vutuv_web/agent_docs/text.ex:572
+#: lib/vutuv_web/agent_docs/markdown.ex:628
+#: lib/vutuv_web/agent_docs/text.ex:616
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1109
+#: lib/vutuv_web/agent_docs/markdown.ex:1156
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:971
+#: lib/vutuv_web/agent_docs/markdown.ex:1018
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:972
+#: lib/vutuv_web/agent_docs/markdown.ex:1019
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -3952,7 +3955,7 @@ msgstr ""
 msgid "This page in %{language}: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:48
+#: lib/vutuv_web/agent_docs/list_docs.ex:49
 #, elixir-autogen, elixir-format
 msgid "Connections of %{name}"
 msgstr ""
@@ -3997,7 +4000,7 @@ msgstr ""
 #: lib/vutuv_web/templates/ad/index.html.heex:7
 #: lib/vutuv_web/templates/ad/new.html.heex:4
 #: lib/vutuv_web/templates/ad/preview.html.heex:2
-#: lib/vutuv_web/templates/layout/app.html.heex:115
+#: lib/vutuv_web/templates/layout/app.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "Advertising"
 msgstr ""
@@ -4018,8 +4021,8 @@ msgstr ""
 msgid "Billing name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:361
-#: lib/vutuv_web/agent_docs/text.ex:336
+#: lib/vutuv_web/agent_docs/markdown.ex:399
+#: lib/vutuv_web/agent_docs/text.ex:373
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr ""
@@ -4072,8 +4075,8 @@ msgstr ""
 msgid "Markdown is supported. At most %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:351
-#: lib/vutuv_web/agent_docs/text.ex:332
+#: lib/vutuv_web/agent_docs/markdown.ex:389
+#: lib/vutuv_web/agent_docs/text.ex:369
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4089,8 +4092,8 @@ msgstr ""
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:348
-#: lib/vutuv_web/agent_docs/text.ex:329
+#: lib/vutuv_web/agent_docs/markdown.ex:386
+#: lib/vutuv_web/agent_docs/text.ex:366
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4304,14 +4307,14 @@ msgstr ""
 msgid "deleted account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:353
-#: lib/vutuv_web/agent_docs/text.ex:334
+#: lib/vutuv_web/agent_docs/markdown.ex:391
+#: lib/vutuv_web/agent_docs/text.ex:371
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:349
-#: lib/vutuv_web/agent_docs/text.ex:330
+#: lib/vutuv_web/agent_docs/markdown.ex:387
+#: lib/vutuv_web/agent_docs/text.ex:367
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr ""
@@ -4590,8 +4593,8 @@ msgid "Not an exact match, but sounds like your search."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/investors_doc.ex:212
-#: lib/vutuv_web/agent_docs/markdown.ex:463
-#: lib/vutuv_web/agent_docs/text.ex:481
+#: lib/vutuv_web/agent_docs/markdown.ex:510
+#: lib/vutuv_web/agent_docs/text.ex:525
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/notification_live/index.ex:657
 #: lib/vutuv_web/live/notification_live/index.ex:1350
@@ -4703,7 +4706,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/show.html.heex:4
 #: lib/vutuv_web/templates/dev_doc/show.html.heex:14
 #: lib/vutuv_web/templates/dev_webhook/new.html.heex:4
-#: lib/vutuv_web/templates/layout/app.html.heex:84
+#: lib/vutuv_web/templates/layout/app.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Developers"
 msgstr ""
@@ -5256,7 +5259,7 @@ msgstr ""
 msgid "API token (%{date})"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:86
+#: lib/vutuv_web/templates/layout/app.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "API documentation"
 msgstr ""
@@ -5307,35 +5310,35 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1537
+#: lib/vutuv_web/live/shell_live.ex:1490
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:310
 #: lib/vutuv_web/live/admin/screenshot_live.ex:420
-#: lib/vutuv_web/templates/layout/app.html.heex:163
+#: lib/vutuv_web/templates/layout/app.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:173
+#: lib/vutuv_web/templates/layout/app.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Close menus and dialogs"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:170
+#: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1594
-#: lib/vutuv_web/templates/layout/app.html.heex:189
+#: lib/vutuv_web/live/shell_live.ex:1547
+#: lib/vutuv_web/templates/layout/app.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:154
+#: lib/vutuv_web/templates/layout/app.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "Navigation"
 msgstr ""
@@ -5348,7 +5351,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:276
-#: lib/vutuv_web/live/shell_live.ex:1574
+#: lib/vutuv_web/live/shell_live.ex:1527
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5362,17 +5365,17 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:172
+#: lib/vutuv_web/templates/layout/app.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "Show this help"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:165
+#: lib/vutuv_web/templates/layout/app.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "Write a new post"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:160
+#: lib/vutuv_web/templates/layout/app.html.heex:161
 #: lib/vutuv_web/views/page_html.ex:551
 #, elixir-autogen, elixir-format
 msgid "Your profile"
@@ -5393,18 +5396,18 @@ msgstr ""
 msgid "Add a profile photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:167
+#: lib/vutuv_web/templates/layout/app.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Next post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:168
+#: lib/vutuv_web/templates/layout/app.html.heex:169
 #, elixir-autogen, elixir-format
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1278
-#: lib/vutuv_web/live/shell_live.ex:1635
+#: lib/vutuv_web/live/shell_live.ex:1270
+#: lib/vutuv_web/live/shell_live.ex:1588
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -6133,8 +6136,8 @@ msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:631
-#: lib/vutuv_web/agent_docs/text.ex:594
+#: lib/vutuv_web/agent_docs/markdown.ex:678
+#: lib/vutuv_web/agent_docs/text.ex:638
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6206,7 +6209,7 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1216
+#: lib/vutuv_web/agent_docs/markdown.ex:1263
 #: lib/vutuv_web/components/post_components.ex:422
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
@@ -6296,7 +6299,7 @@ msgstr ""
 msgid "Endorsed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:140
+#: lib/vutuv_web/agent_docs/list_docs.ex:141
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Members who endorsed %{name} for %{tag}"
@@ -6316,7 +6319,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1176
+#: lib/vutuv_web/agent_docs/markdown.ex:1223
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -7503,27 +7506,27 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1343
+#: lib/vutuv_web/agent_docs/markdown.ex:1390
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1346
+#: lib/vutuv_web/agent_docs/markdown.ex:1393
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1353
+#: lib/vutuv_web/agent_docs/markdown.ex:1400
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:141
+#: lib/vutuv_web/templates/layout/app.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Last change: %{date} at %{time}"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:141
+#: lib/vutuv_web/templates/layout/app.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Last commit (Berlin time)"
 msgstr ""
@@ -8474,7 +8477,7 @@ msgstr ""
 msgid "Invalid address (skipped)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:179
+#: lib/vutuv_web/agent_docs/list_docs.ex:180
 #: lib/vutuv_web/controllers/directory_controller.ex:54
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
@@ -8490,7 +8493,7 @@ msgstr ""
 msgid "Members by initial"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:202
+#: lib/vutuv_web/agent_docs/list_docs.ex:203
 #: lib/vutuv_web/controllers/directory_controller.ex:86
 #: lib/vutuv_web/templates/directory/show.html.heex:2
 #, elixir-autogen, elixir-format
@@ -8509,7 +8512,7 @@ msgid_plural "%{formatted} members"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:208
+#: lib/vutuv_web/agent_docs/list_docs.ex:209
 #, elixir-autogen, elixir-format
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
@@ -8605,10 +8608,10 @@ msgstr ""
 msgid "Write it under Admin › Legal pages"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:641
-#: lib/vutuv_web/agent_docs/markdown.ex:645
-#: lib/vutuv_web/agent_docs/text.ex:604
-#: lib/vutuv_web/agent_docs/text.ex:608
+#: lib/vutuv_web/agent_docs/markdown.ex:688
+#: lib/vutuv_web/agent_docs/markdown.ex:692
+#: lib/vutuv_web/agent_docs/text.ex:648
+#: lib/vutuv_web/agent_docs/text.ex:652
 #: lib/vutuv_web/components/organization_components.ex:276
 #: lib/vutuv_web/components/ui.ex:1695
 #: lib/vutuv_web/components/ui.ex:5145
@@ -8734,13 +8737,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:849
+#: lib/vutuv_web/agent_docs/markdown.ex:896
 #: lib/vutuv_web/views/education_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:848
+#: lib/vutuv_web/agent_docs/markdown.ex:895
 #: lib/vutuv_web/views/education_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8773,7 +8776,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1112
+#: lib/vutuv_web/agent_docs/markdown.ex:1159
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8998,8 +9001,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:661
-#: lib/vutuv_web/agent_docs/text.ex:622
+#: lib/vutuv_web/agent_docs/markdown.ex:708
+#: lib/vutuv_web/agent_docs/text.ex:666
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9423,8 +9426,8 @@ msgstr ""
 msgid "Yoruba"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:583
-#: lib/vutuv_web/agent_docs/text.ex:574
+#: lib/vutuv_web/agent_docs/markdown.ex:630
+#: lib/vutuv_web/agent_docs/text.ex:618
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr ""
@@ -9527,7 +9530,7 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:965
+#: lib/vutuv_web/agent_docs/markdown.ex:1012
 #: lib/vutuv_web/views/qualification_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9607,7 +9610,7 @@ msgstr ""
 msgid "Expired"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:940
+#: lib/vutuv_web/agent_docs/markdown.ex:987
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9624,7 +9627,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:964
+#: lib/vutuv_web/agent_docs/markdown.ex:1011
 #: lib/vutuv_web/views/qualification_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9651,7 +9654,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:938
+#: lib/vutuv_web/agent_docs/markdown.ex:985
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9666,7 +9669,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:939
+#: lib/vutuv_web/agent_docs/markdown.ex:986
 #: lib/vutuv_web/views/qualification_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "valid until %{date}"
@@ -9682,7 +9685,7 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:776
+#: lib/vutuv_web/agent_docs/markdown.ex:823
 #: lib/vutuv_web/live/section_reorder_live.ex:287
 #: lib/vutuv_web/views/language_html.ex:114
 #, elixir-autogen, elixir-format
@@ -10137,21 +10140,21 @@ msgstr ""
 msgid "Sign in with a one-time code (OTP) from an authenticator app or from a printed code list, typed into the normal PIN field. Your emailed PIN always keeps working."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:736
+#: lib/vutuv_web/agent_docs/markdown.ex:783
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:734
+#: lib/vutuv_web/agent_docs/markdown.ex:781
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:732
+#: lib/vutuv_web/agent_docs/markdown.ex:779
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10208,12 +10211,12 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:750
+#: lib/vutuv_web/agent_docs/markdown.ex:797
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:737
+#: lib/vutuv_web/agent_docs/markdown.ex:784
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -11170,8 +11173,8 @@ msgstr ""
 msgid "Alias removed."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:455
-#: lib/vutuv_web/agent_docs/text.ex:474
+#: lib/vutuv_web/agent_docs/markdown.ex:502
+#: lib/vutuv_web/agent_docs/text.ex:518
 #: lib/vutuv_web/live/organization_live/edit.ex:384
 #: lib/vutuv_web/live/organization_live/show.ex:930
 #: lib/vutuv_web/templates/tag/single_card.html.heex:14
@@ -11392,8 +11395,8 @@ msgstr ""
 msgid "primary"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:476
-#: lib/vutuv_web/agent_docs/text.ex:494
+#: lib/vutuv_web/agent_docs/markdown.ex:523
+#: lib/vutuv_web/agent_docs/text.ex:538
 #: lib/vutuv_web/live/admin/organization_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -11516,8 +11519,8 @@ msgstr ""
 msgid "Verify via file"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:985
-#: lib/vutuv_web/agent_docs/text.ex:750
+#: lib/vutuv_web/agent_docs/markdown.ex:1032
+#: lib/vutuv_web/agent_docs/text.ex:794
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -11553,8 +11556,8 @@ msgstr ""
 msgid "Remove link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:467
-#: lib/vutuv_web/agent_docs/text.ex:485
+#: lib/vutuv_web/agent_docs/markdown.ex:514
+#: lib/vutuv_web/agent_docs/text.ex:529
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr ""
@@ -11742,18 +11745,18 @@ msgstr ""
 msgid "Organization unfrozen."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:446
+#: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
-#: lib/vutuv_web/agent_docs/text.ex:418
+#: lib/vutuv_web/agent_docs/text.ex:462
 #: lib/vutuv_web/components/ui.ex:5172
 #: lib/vutuv_web/controllers/settings_controller.ex:215
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:538
-#: lib/vutuv_web/live/shell_live.ex:1565
+#: lib/vutuv_web/live/shell_live.ex:1518
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
-#: lib/vutuv_web/templates/layout/app.html.heex:79
+#: lib/vutuv_web/templates/layout/app.html.heex:80
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Organizations"
@@ -12001,9 +12004,9 @@ msgid "Edit posting"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:282
-#: lib/vutuv_web/agent_docs/markdown.ex:507
+#: lib/vutuv_web/agent_docs/markdown.ex:554
 #: lib/vutuv_web/agent_docs/text.ex:266
-#: lib/vutuv_web/agent_docs/text.ex:525
+#: lib/vutuv_web/agent_docs/text.ex:569
 #: lib/vutuv_web/live/admin/job_live.ex:340
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
 #: lib/vutuv_web/views/account_event_text.ex:225
@@ -12017,9 +12020,9 @@ msgid "Employer name (optional)"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:283
-#: lib/vutuv_web/agent_docs/markdown.ex:508
+#: lib/vutuv_web/agent_docs/markdown.ex:555
 #: lib/vutuv_web/agent_docs/text.ex:267
-#: lib/vutuv_web/agent_docs/text.ex:526
+#: lib/vutuv_web/agent_docs/text.ex:570
 #: lib/vutuv_web/live/job_board_live.ex:526
 #: lib/vutuv_web/live/job_posting_live/form.ex:499
 #, elixir-autogen, elixir-format
@@ -12080,8 +12083,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:47
 #: lib/vutuv_web/live/job_board_live.ex:265
 #: lib/vutuv_web/live/post_live/saved.ex:541
-#: lib/vutuv_web/live/shell_live.ex:1330
-#: lib/vutuv_web/templates/layout/app.html.heex:80
+#: lib/vutuv_web/live/shell_live.ex:1322
+#: lib/vutuv_web/templates/layout/app.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Jobs"
 msgstr ""
@@ -12091,12 +12094,12 @@ msgstr ""
 msgid "Let search engines index this posting."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:482
-#: lib/vutuv_web/agent_docs/markdown.ex:485
-#: lib/vutuv_web/agent_docs/markdown.ex:487
-#: lib/vutuv_web/agent_docs/text.ex:500
-#: lib/vutuv_web/agent_docs/text.ex:503
-#: lib/vutuv_web/agent_docs/text.ex:505
+#: lib/vutuv_web/agent_docs/markdown.ex:529
+#: lib/vutuv_web/agent_docs/markdown.ex:532
+#: lib/vutuv_web/agent_docs/markdown.ex:534
+#: lib/vutuv_web/agent_docs/text.ex:544
+#: lib/vutuv_web/agent_docs/text.ex:547
+#: lib/vutuv_web/agent_docs/text.ex:549
 #: lib/vutuv_web/live/job_posting_live/form.ex:549
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -12231,9 +12234,9 @@ msgid "Postal code"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:287
-#: lib/vutuv_web/agent_docs/markdown.ex:512
+#: lib/vutuv_web/agent_docs/markdown.ex:559
 #: lib/vutuv_web/agent_docs/text.ex:271
-#: lib/vutuv_web/agent_docs/text.ex:530
+#: lib/vutuv_web/agent_docs/text.ex:574
 #: lib/vutuv_web/live/job_posting_live/show.ex:156
 #, elixir-autogen, elixir-format
 msgid "Posted"
@@ -12258,10 +12261,10 @@ msgstr ""
 #: lib/vutuv/accounts/user.ex:1264
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
-#: lib/vutuv_web/agent_docs/markdown.ex:485
-#: lib/vutuv_web/agent_docs/markdown.ex:487
-#: lib/vutuv_web/agent_docs/text.ex:503
-#: lib/vutuv_web/agent_docs/text.ex:505
+#: lib/vutuv_web/agent_docs/markdown.ex:532
+#: lib/vutuv_web/agent_docs/markdown.ex:534
+#: lib/vutuv_web/agent_docs/text.ex:547
+#: lib/vutuv_web/agent_docs/text.ex:549
 #: lib/vutuv_web/components/job_components.ex:140
 #: lib/vutuv_web/components/job_components.ex:141
 #, elixir-autogen, elixir-format
@@ -12282,9 +12285,9 @@ msgid "Required"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:286
-#: lib/vutuv_web/agent_docs/markdown.ex:511
+#: lib/vutuv_web/agent_docs/markdown.ex:558
 #: lib/vutuv_web/agent_docs/text.ex:270
-#: lib/vutuv_web/agent_docs/text.ex:529
+#: lib/vutuv_web/agent_docs/text.ex:573
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr ""
@@ -12379,9 +12382,9 @@ msgid "Working student"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:284
-#: lib/vutuv_web/agent_docs/markdown.ex:509
+#: lib/vutuv_web/agent_docs/markdown.ex:556
 #: lib/vutuv_web/agent_docs/text.ex:268
-#: lib/vutuv_web/agent_docs/text.ex:527
+#: lib/vutuv_web/agent_docs/text.ex:571
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
 #, elixir-autogen, elixir-format
 msgid "Workplace"
@@ -12581,13 +12584,13 @@ msgstr ""
 msgid "All countries"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:530
+#: lib/vutuv_web/agent_docs/markdown.ex:577
 #: lib/vutuv_web/templates/tag/show.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:547
+#: lib/vutuv_web/agent_docs/text.ex:591
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr ""
@@ -12653,10 +12656,10 @@ msgstr ""
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:528
-#: lib/vutuv_web/agent_docs/markdown.ex:540
-#: lib/vutuv_web/agent_docs/text.ex:545
-#: lib/vutuv_web/agent_docs/text.ex:557
+#: lib/vutuv_web/agent_docs/markdown.ex:575
+#: lib/vutuv_web/agent_docs/markdown.ex:587
+#: lib/vutuv_web/agent_docs/text.ex:589
+#: lib/vutuv_web/agent_docs/text.ex:601
 #: lib/vutuv_web/live/organization_live/show.ex:833
 #: lib/vutuv_web/templates/tag/show.html.heex:78
 #, elixir-autogen, elixir-format
@@ -13581,7 +13584,7 @@ msgstr ""
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1305
+#: lib/vutuv_web/agent_docs/markdown.ex:1352
 #: lib/vutuv_web/components/post_components.ex:5565
 #, elixir-autogen, elixir-format
 msgid "Book review"
@@ -13602,7 +13605,7 @@ msgstr ""
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1305
+#: lib/vutuv_web/agent_docs/markdown.ex:1352
 #: lib/vutuv_web/components/post_components.ex:5564
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -13692,7 +13695,7 @@ msgstr ""
 msgid "With qualification:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:805
+#: lib/vutuv_web/agent_docs/markdown.ex:852
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr ""
@@ -13757,7 +13760,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:707
+#: lib/vutuv_web/live/shell_live.ex:699
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -13781,19 +13784,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:954
+#: lib/vutuv_web/agent_docs/markdown.ex:1001
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:953
+#: lib/vutuv_web/agent_docs/markdown.ex:1000
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:959
+#: lib/vutuv_web/agent_docs/markdown.ex:1006
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -13873,8 +13876,8 @@ msgstr ""
 msgid "View the uploaded proof (%{label})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:891
-#: lib/vutuv_web/agent_docs/text.ex:729
+#: lib/vutuv_web/agent_docs/markdown.ex:938
+#: lib/vutuv_web/agent_docs/text.ex:773
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
@@ -13932,8 +13935,8 @@ msgstr ""
 msgid "Skip for now"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:585
-#: lib/vutuv_web/agent_docs/text.ex:576
+#: lib/vutuv_web/agent_docs/markdown.ex:632
+#: lib/vutuv_web/agent_docs/text.ex:620
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr ""
@@ -14523,7 +14526,7 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1252
+#: lib/vutuv_web/agent_docs/markdown.ex:1299
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr ""
@@ -14907,8 +14910,8 @@ msgstr ""
 msgid "Your server"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:642
-#: lib/vutuv_web/agent_docs/text.ex:605
+#: lib/vutuv_web/agent_docs/markdown.ex:689
+#: lib/vutuv_web/agent_docs/text.ex:649
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr ""
@@ -15289,7 +15292,7 @@ msgid_plural "%{formatted} reposts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1254
+#: lib/vutuv_web/agent_docs/markdown.ex:1301
 #: lib/vutuv_web/components/post_components.ex:6010
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
@@ -15300,10 +15303,10 @@ msgstr ""
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1194
-#: lib/vutuv_web/agent_docs/markdown.ex:1452
-#: lib/vutuv_web/agent_docs/text.ex:827
-#: lib/vutuv_web/agent_docs/text.ex:904
+#: lib/vutuv_web/agent_docs/markdown.ex:1241
+#: lib/vutuv_web/agent_docs/markdown.ex:1499
+#: lib/vutuv_web/agent_docs/text.ex:871
+#: lib/vutuv_web/agent_docs/text.ex:948
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr ""
@@ -15327,7 +15330,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:135
 #: lib/vutuv_web/agent_docs/markdown.ex:167
-#: lib/vutuv_web/agent_docs/markdown.ex:1253
+#: lib/vutuv_web/agent_docs/markdown.ex:1300
 #: lib/vutuv_web/agent_docs/text.ex:124
 #: lib/vutuv_web/agent_docs/text.ex:153
 #, elixir-autogen, elixir-format
@@ -15385,7 +15388,7 @@ msgstr ""
 msgid "That reply is not yours to remove."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1454
+#: lib/vutuv_web/agent_docs/markdown.ex:1501
 #: lib/vutuv_web/components/post_components.ex:1411
 #: lib/vutuv_web/components/post_components.ex:1611
 #: lib/vutuv_web/components/post_components.ex:3019
@@ -16087,13 +16090,13 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1095
+#: lib/vutuv_web/agent_docs/markdown.ex:1142
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:579
-#: lib/vutuv_web/agent_docs/text.ex:567
+#: lib/vutuv_web/agent_docs/markdown.ex:626
+#: lib/vutuv_web/agent_docs/text.ex:611
 #: lib/vutuv_web/templates/user/edit.html.heex:219
 #: lib/vutuv_web/templates/user/show.html.heex:262
 #: lib/vutuv_web/views/account_event_text.ex:213
@@ -16141,8 +16144,8 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1371
-#: lib/vutuv_web/agent_docs/text.ex:858
+#: lib/vutuv_web/agent_docs/markdown.ex:1418
+#: lib/vutuv_web/agent_docs/text.ex:902
 #: lib/vutuv_web/live/post_live/composer.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Cover"
@@ -16153,8 +16156,8 @@ msgstr ""
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1382
-#: lib/vutuv_web/agent_docs/text.ex:871
+#: lib/vutuv_web/agent_docs/markdown.ex:1429
+#: lib/vutuv_web/agent_docs/text.ex:915
 #: lib/vutuv_web/components/ui.ex:3126
 #, elixir-autogen, elixir-format
 msgid "Download the original"
@@ -16211,8 +16214,8 @@ msgstr ""
 msgid "Photo options"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1415
-#: lib/vutuv_web/agent_docs/text.ex:846
+#: lib/vutuv_web/agent_docs/markdown.ex:1462
+#: lib/vutuv_web/agent_docs/text.ex:890
 #: lib/vutuv_web/components/post_components.ex:4808
 #, elixir-autogen, elixir-format
 msgid "Photos:"
@@ -16373,13 +16376,13 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1272
+#: lib/vutuv_web/agent_docs/markdown.ex:1319
 #: lib/vutuv_web/components/post_components.ex:6048
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1270
+#: lib/vutuv_web/agent_docs/markdown.ex:1317
 #: lib/vutuv_web/components/post_components.ex:6045
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
@@ -16998,7 +17001,7 @@ msgstr ""
 msgid "What is being measured"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1072
+#: lib/vutuv_web/agent_docs/markdown.ex:1119
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
@@ -17149,8 +17152,8 @@ msgstr ""
 msgid "We could not reach the network just now. Please try again in a moment."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:999
-#: lib/vutuv_web/agent_docs/text.ex:651
+#: lib/vutuv_web/agent_docs/markdown.ex:1046
+#: lib/vutuv_web/agent_docs/text.ex:695
 #, elixir-autogen, elixir-format
 msgid "verified profile"
 msgstr ""
@@ -17448,12 +17451,12 @@ msgstr ""
 msgid "Whole photos"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:166
+#: lib/vutuv_web/templates/layout/app.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Send the post or message you are writing"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:227
+#: lib/vutuv_web/templates/layout/app.html.heex:228
 #, elixir-autogen, elixir-format
 msgid "The single-key shortcuts pause while you type, and are off on phones and tablets."
 msgstr ""
@@ -18001,7 +18004,7 @@ msgstr ""
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1240
+#: lib/vutuv_web/agent_docs/markdown.ex:1287
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr ""
@@ -18043,12 +18046,12 @@ msgstr ""
 msgid "Your likes follow the site default again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1295
+#: lib/vutuv_web/agent_docs/markdown.ex:1342
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1292
+#: lib/vutuv_web/agent_docs/markdown.ex:1339
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr ""
@@ -18058,7 +18061,7 @@ msgstr ""
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1284
+#: lib/vutuv_web/agent_docs/markdown.ex:1331
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
@@ -18392,7 +18395,7 @@ msgstr ""
 msgid "Employment references of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:873
+#: lib/vutuv_web/agent_docs/markdown.ex:920
 #, elixir-autogen, elixir-format
 msgid "document"
 msgstr ""
@@ -19744,7 +19747,7 @@ msgstr ""
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1236
+#: lib/vutuv_web/live/shell_live.ex:1228
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr ""
@@ -19764,7 +19767,7 @@ msgstr ""
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1246
+#: lib/vutuv_web/live/shell_live.ex:1238
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -19774,7 +19777,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1222
+#: lib/vutuv_web/live/shell_live.ex:1214
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -20138,21 +20141,21 @@ msgstr ""
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:751
+#: lib/vutuv_web/live/shell_live.ex:743
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:738
+#: lib/vutuv_web/live/shell_live.ex:730
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:773
+#: lib/vutuv_web/live/shell_live.ex:765
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -20409,12 +20412,12 @@ msgstr ""
 msgid "You are not allowed to change this organization."
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:96
+#: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Company"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:121
+#: lib/vutuv_web/templates/layout/app.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Legal"
 msgstr ""
@@ -21233,7 +21236,7 @@ msgstr ""
 msgid "Unfollowed. Their posts leave your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1196
+#: lib/vutuv_web/live/shell_live.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr ""
@@ -21248,12 +21251,12 @@ msgstr ""
 msgid "Browser notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1054
+#: lib/vutuv_web/live/shell_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1199
+#: lib/vutuv_web/live/shell_live.ex:1191
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
@@ -21293,7 +21296,7 @@ msgstr ""
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1193
+#: lib/vutuv_web/live/shell_live.ex:1185
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -21333,12 +21336,12 @@ msgstr ""
 msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:846
+#: lib/vutuv_web/live/shell_live.ex:838
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:847
+#: lib/vutuv_web/live/shell_live.ex:839
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr ""
@@ -21559,7 +21562,7 @@ msgstr ""
 msgid "Translated into %{language}."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:987
+#: lib/vutuv_web/live/shell_live.ex:979
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -21678,7 +21681,7 @@ msgstr ""
 msgid "No connection"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1126
+#: lib/vutuv_web/live/shell_live.ex:1118
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr ""
@@ -21766,7 +21769,7 @@ msgstr ""
 msgid "All vutuv members, filed alphabetically by last name."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:194
+#: lib/vutuv_web/agent_docs/list_docs.ex:195
 #, elixir-autogen, elixir-format
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr ""
@@ -22166,7 +22169,7 @@ msgstr ""
 msgid "Scan it with the device that has the app"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1108
+#: lib/vutuv_web/live/shell_live.ex:1100
 #, elixir-autogen, elixir-format
 msgid "A new version is ready."
 msgstr ""
@@ -22188,12 +22191,12 @@ msgstr[1] ""
 msgid "Quoted post"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1088
+#: lib/vutuv_web/agent_docs/markdown.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Quotes %{name}: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1085
+#: lib/vutuv_web/agent_docs/markdown.ex:1132
 #, elixir-autogen, elixir-format
 msgid "Quotes %{url}"
 msgstr ""
@@ -22253,6 +22256,7 @@ msgid_plural "%{formatted} shares"
 msgstr[0] ""
 msgstr[1] ""
 
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:136
 #: lib/vutuv_web/live/notification_live/index.ex:838
 #, elixir-autogen, elixir-format
 msgid "Post without text"
@@ -22414,7 +22418,7 @@ msgstr ""
 msgid "Low-bandwidth mode"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1676
+#: lib/vutuv_web/live/shell_live.ex:1629
 #, elixir-autogen, elixir-format
 msgctxt "phone tab bar"
 msgid "Write"
@@ -22571,7 +22575,7 @@ msgstr ""
 msgid "Appearance"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1702
+#: lib/vutuv_web/live/shell_live.ex:1655
 #, elixir-autogen, elixir-format
 msgid "%{count} video in progress"
 msgid_plural "%{count} videos in progress"
@@ -22675,10 +22679,10 @@ msgstr ""
 msgid "This video could not be converted."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1367
-#: lib/vutuv_web/agent_docs/markdown.ex:1370
-#: lib/vutuv_web/agent_docs/text.ex:855
-#: lib/vutuv_web/agent_docs/text.ex:856
+#: lib/vutuv_web/agent_docs/markdown.ex:1414
+#: lib/vutuv_web/agent_docs/markdown.ex:1417
+#: lib/vutuv_web/agent_docs/text.ex:899
+#: lib/vutuv_web/agent_docs/text.ex:900
 #: lib/vutuv_web/components/post_components.ex:2501
 #: lib/vutuv_web/components/video_components.ex:126
 #: lib/vutuv_web/live/post_live/composer.ex:2458
@@ -22803,22 +22807,22 @@ msgstr ""
 msgid "The fields the most members carry, and how many of them do."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1138
-#: lib/vutuv_web/agent_docs/text.ex:779
+#: lib/vutuv_web/agent_docs/markdown.ex:1185
+#: lib/vutuv_web/agent_docs/text.ex:823
 #: lib/vutuv_web/live/job_board_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "What members here work on"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1130
-#: lib/vutuv_web/agent_docs/text.ex:771
+#: lib/vutuv_web/agent_docs/markdown.ex:1177
+#: lib/vutuv_web/agent_docs/text.ex:815
 #: lib/vutuv_web/live/job_board_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "Who you would reach"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1131
-#: lib/vutuv_web/agent_docs/text.ex:772
+#: lib/vutuv_web/agent_docs/markdown.ex:1178
+#: lib/vutuv_web/agent_docs/text.ex:816
 #: lib/vutuv_web/live/job_board_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "One random vutuv account that is open to offers."
@@ -22826,7 +22830,7 @@ msgid_plural "%{formatted} random vutuv accounts that are open to offers."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:721
+#: lib/vutuv_web/live/shell_live.ex:713
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post in your feed"
 msgid_plural "%{formatted} new posts in your feed"
@@ -22911,7 +22915,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/investors_doc.ex:295
 #: lib/vutuv_web/controllers/company_controller.ex:56
-#: lib/vutuv_web/templates/layout/app.html.heex:110
+#: lib/vutuv_web/templates/layout/app.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "Investors"
 msgstr ""
@@ -22921,14 +22925,13 @@ msgstr ""
 msgid "Over these %{days} days %{total} people arrived, %{members} of them as members here."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1415
 #: lib/vutuv_web/views/company_html.ex:76
 #, elixir-autogen, elixir-format
 msgid "People here per day over the last %{days} days"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:392
-#: lib/vutuv_web/agent_docs/text.ex:362
+#: lib/vutuv_web/agent_docs/markdown.ex:430
+#: lib/vutuv_web/agent_docs/text.ex:399
 #, elixir-autogen, elixir-format
 msgid "Press material: %{url}"
 msgstr ""
@@ -22943,28 +22946,28 @@ msgstr ""
 msgid "Send a message"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:375
-#: lib/vutuv_web/agent_docs/text.ex:349
+#: lib/vutuv_web/agent_docs/markdown.ex:413
+#: lib/vutuv_web/agent_docs/text.ex:386
 #: lib/vutuv_web/templates/company/investors.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Where we are"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:382
-#: lib/vutuv_web/agent_docs/text.ex:356
+#: lib/vutuv_web/agent_docs/markdown.ex:420
+#: lib/vutuv_web/agent_docs/text.ex:393
 #: lib/vutuv_web/templates/company/investors.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Why this is worth building"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:391
-#: lib/vutuv_web/agent_docs/text.ex:361
+#: lib/vutuv_web/agent_docs/markdown.ex:429
+#: lib/vutuv_web/agent_docs/text.ex:398
 #, elixir-autogen, elixir-format
 msgid "Write here: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:388
-#: lib/vutuv_web/agent_docs/text.ex:358
+#: lib/vutuv_web/agent_docs/markdown.ex:426
+#: lib/vutuv_web/agent_docs/text.ex:395
 #: lib/vutuv_web/templates/company/investors.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Write to me"
@@ -22980,8 +22983,8 @@ msgstr ""
 msgid "My profile:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:390
-#: lib/vutuv_web/agent_docs/text.ex:360
+#: lib/vutuv_web/agent_docs/markdown.ex:428
+#: lib/vutuv_web/agent_docs/text.ex:397
 #, elixir-autogen, elixir-format
 msgid "My profile: %{url}"
 msgstr ""
@@ -23001,8 +23004,8 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:442
-#: lib/vutuv_web/agent_docs/text.ex:411
+#: lib/vutuv_web/agent_docs/markdown.ex:485
+#: lib/vutuv_web/agent_docs/text.ex:452
 #, elixir-autogen, elixir-format
 msgid "Source: %{source}"
 msgstr ""
@@ -23127,4 +23130,77 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/mutes.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "muted on the follow itself"
+msgstr ""
+
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:40
+#, elixir-autogen, elixir-format
+msgid "Every public post on vutuv, filed under the day it was written."
+msgstr ""
+
+#: lib/vutuv_web/templates/post_calendar/month.html.heex:16
+#, elixir-autogen, elixir-format
+msgid "Neighbouring months"
+msgstr ""
+
+#: lib/vutuv_web/templates/post_calendar/month.html.heex:80
+#, elixir-autogen, elixir-format
+msgid "No posts in this month yet."
+msgstr ""
+
+#: lib/vutuv_web/templates/post_calendar/day.html.heex:18
+#, elixir-autogen, elixir-format
+msgid "No posts on this day."
+msgstr ""
+
+#: lib/vutuv_web/templates/post_calendar/index.html.heex:16
+#, elixir-autogen, elixir-format
+msgid "Nothing has been written here yet."
+msgstr ""
+
+#: lib/vutuv_web/templates/post_calendar/day.html.heex:14
+#: lib/vutuv_web/templates/post_calendar/month.html.heex:69
+#, elixir-autogen, elixir-format
+msgid "One post"
+msgid_plural "%{formatted} posts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:36
+#: lib/vutuv_web/templates/layout/app.html.heex:79
+#: lib/vutuv_web/templates/post_calendar/day.html.heex:5
+#: lib/vutuv_web/templates/post_calendar/index.html.heex:2
+#: lib/vutuv_web/templates/post_calendar/index.html.heex:3
+#: lib/vutuv_web/templates/post_calendar/month.html.heex:5
+#, elixir-autogen, elixir-format
+msgid "Post calendar"
+msgstr ""
+
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:126
+#, elixir-autogen, elixir-format
+msgid "Post not open to search engines"
+msgstr ""
+
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:59
+#, elixir-autogen, elixir-format
+msgid "Posts in %{month} %{year}"
+msgstr ""
+
+#: lib/vutuv_web/templates/post_calendar/index.html.heex:28
+#, elixir-autogen, elixir-format
+msgid "Posts in %{year}"
+msgstr ""
+
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:88
+#, elixir-autogen, elixir-format
+msgid "Posts on %{date}"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/list_docs.ex:280
+#, elixir-autogen, elixir-format
+msgid "The posts written that day."
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/list_docs.ex:248
+#, elixir-autogen, elixir-format
+msgid "The posts written that month, by day."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr "Language: en\n"
 
 #: lib/vutuv_web/controllers/page_controller.ex:241
-#: lib/vutuv_web/templates/layout/app.html.heex:117
+#: lib/vutuv_web/templates/layout/app.html.heex:118
 #, elixir-autogen
 msgid "About us"
 msgstr ""
@@ -100,10 +100,10 @@ msgstr ""
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:629
-#: lib/vutuv_web/agent_docs/markdown.ex:630
-#: lib/vutuv_web/agent_docs/text.ex:592
-#: lib/vutuv_web/agent_docs/text.ex:593
+#: lib/vutuv_web/agent_docs/markdown.ex:676
+#: lib/vutuv_web/agent_docs/markdown.ex:677
+#: lib/vutuv_web/agent_docs/text.ex:636
+#: lib/vutuv_web/agent_docs/text.ex:637
 #: lib/vutuv_web/templates/user/show.html.heex:1132
 #, elixir-autogen
 msgid "Birthday"
@@ -304,14 +304,14 @@ msgstr ""
 msgid "Fax"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:615
+#: lib/vutuv_web/agent_docs/markdown.ex:662
 #: lib/vutuv_web/templates/user/edit.html.heex:164
 #, elixir-autogen
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:650
-#: lib/vutuv_web/agent_docs/text.ex:613
+#: lib/vutuv_web/agent_docs/markdown.ex:697
+#: lib/vutuv_web/agent_docs/text.ex:657
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
@@ -321,8 +321,8 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:651
-#: lib/vutuv_web/agent_docs/text.ex:614
+#: lib/vutuv_web/agent_docs/markdown.ex:698
+#: lib/vutuv_web/agent_docs/text.ex:658
 #: lib/vutuv_web/components/fediverse_components.ex:468
 #: lib/vutuv_web/components/ui.ex:2964
 #: lib/vutuv_web/components/ui.ex:2999
@@ -357,7 +357,10 @@ msgstr ""
 
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:4
-#: lib/vutuv_web/templates/layout/app.html.heex:156
+#: lib/vutuv_web/templates/layout/app.html.heex:157
+#: lib/vutuv_web/templates/post_calendar/day.html.heex:4
+#: lib/vutuv_web/templates/post_calendar/index.html.heex:3
+#: lib/vutuv_web/templates/post_calendar/month.html.heex:4
 #, elixir-autogen
 msgid "Home"
 msgstr ""
@@ -378,7 +381,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:617
+#: lib/vutuv_web/agent_docs/markdown.ex:664
 #: lib/vutuv_web/templates/user/edit.html.heex:169
 #, elixir-autogen
 msgid "Last Name"
@@ -437,15 +440,15 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1608
-#: lib/vutuv_web/live/shell_live.ex:1684
+#: lib/vutuv_web/live/shell_live.ex:1561
+#: lib/vutuv_web/live/shell_live.ex:1637
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
 msgid "Log in"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:616
+#: lib/vutuv_web/agent_docs/markdown.ex:663
 #: lib/vutuv_web/templates/user/edit.html.heex:174
 #, elixir-autogen
 msgid "Middle Name"
@@ -482,7 +485,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:619
+#: lib/vutuv_web/agent_docs/markdown.ex:666
 #: lib/vutuv_web/templates/user/edit.html.heex:179
 #, elixir-autogen
 msgid "Nickname"
@@ -563,7 +566,7 @@ msgstr ""
 msgid "Phone number updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:614
+#: lib/vutuv_web/agent_docs/markdown.ex:661
 #: lib/vutuv_web/templates/user/edit.html.heex:184
 #, elixir-autogen
 msgid "Prefix"
@@ -643,13 +646,13 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
-#: lib/vutuv_web/live/shell_live.ex:1477
-#: lib/vutuv_web/live/shell_live.ex:1664
+#: lib/vutuv_web/live/shell_live.ex:1430
+#: lib/vutuv_web/live/shell_live.ex:1617
 #: lib/vutuv_web/live/tag_live/timeline.ex:333
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
-#: lib/vutuv_web/templates/layout/app.html.heex:161
+#: lib/vutuv_web/templates/layout/app.html.heex:162
 #, elixir-autogen
 msgid "Search"
 msgstr ""
@@ -742,7 +745,7 @@ msgstr ""
 msgid "Submit a bugreport or a feature request."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:618
+#: lib/vutuv_web/agent_docs/markdown.ex:665
 #: lib/vutuv_web/templates/user/edit.html.heex:189
 #, elixir-autogen
 msgid "Suffix"
@@ -1138,7 +1141,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:63
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1584
+#: lib/vutuv_web/live/shell_live.ex:1537
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1346,11 +1349,11 @@ msgid "Tag urls"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
-#: lib/vutuv_web/agent_docs/markdown.ex:522
-#: lib/vutuv_web/agent_docs/markdown.ex:1163
+#: lib/vutuv_web/agent_docs/markdown.ex:569
+#: lib/vutuv_web/agent_docs/markdown.ex:1210
 #: lib/vutuv_web/agent_docs/text.ex:31
-#: lib/vutuv_web/agent_docs/text.ex:540
-#: lib/vutuv_web/agent_docs/text.ex:806
+#: lib/vutuv_web/agent_docs/text.ex:584
+#: lib/vutuv_web/agent_docs/text.ex:850
 #: lib/vutuv_web/components/ui.ex:5004
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
@@ -1573,7 +1576,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1682
+#: lib/vutuv_web/live/shell_live.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1603,8 +1606,8 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/composer.ex:1876
 #: lib/vutuv_web/live/post_live/composer.ex:2839
 #: lib/vutuv_web/live/post_live/composer.ex:3105
-#: lib/vutuv_web/templates/layout/app.html.heex:194
-#: lib/vutuv_web/templates/layout/app.html.heex:200
+#: lib/vutuv_web/templates/layout/app.html.heex:195
+#: lib/vutuv_web/templates/layout/app.html.heex:201
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
 #: lib/vutuv_web/views/layout_html.ex:142
 #, elixir-autogen, elixir-format
@@ -1624,7 +1627,7 @@ msgid "Confirm account deletion"
 msgstr ""
 
 #: lib/vutuv_web/controllers/page_controller.ex:245
-#: lib/vutuv_web/templates/layout/app.html.heex:123
+#: lib/vutuv_web/templates/layout/app.html.heex:124
 #: lib/vutuv_web/templates/page/index.html.heex:321
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
@@ -1632,7 +1635,7 @@ msgid "Datenschutzerklärung"
 msgstr ""
 
 #: lib/vutuv_web/controllers/page_controller.ex:251
-#: lib/vutuv_web/templates/layout/app.html.heex:124
+#: lib/vutuv_web/templates/layout/app.html.heex:125
 #: lib/vutuv_web/templates/page/index.html.heex:321
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
@@ -1690,7 +1693,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1603
+#: lib/vutuv_web/live/shell_live.ex:1556
 #: lib/vutuv_web/views/settings_html.ex:311
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1722,9 +1725,9 @@ msgstr ""
 #: lib/vutuv_web/controllers/page_controller.ex:218
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1495
-#: lib/vutuv_web/live/shell_live.ex:1681
-#: lib/vutuv_web/templates/layout/app.html.heex:158
+#: lib/vutuv_web/live/shell_live.ex:1448
+#: lib/vutuv_web/live/shell_live.ex:1634
+#: lib/vutuv_web/templates/layout/app.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
@@ -1755,8 +1758,8 @@ msgstr ""
 #: lib/vutuv_web/controllers/page_controller.ex:219
 #: lib/vutuv_web/live/notification_live/index.ex:152
 #: lib/vutuv_web/live/notification_live/index.ex:457
-#: lib/vutuv_web/live/shell_live.ex:1507
-#: lib/vutuv_web/templates/layout/app.html.heex:159
+#: lib/vutuv_web/live/shell_live.ex:1460
+#: lib/vutuv_web/templates/layout/app.html.heex:160
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Notifications"
@@ -1784,12 +1787,12 @@ msgid "Send"
 msgstr ""
 
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:35
-#: lib/vutuv_web/templates/layout/app.html.heex:87
+#: lib/vutuv_web/templates/layout/app.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "Source"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:90
+#: lib/vutuv_web/templates/layout/app.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Submit a bug report or feature request"
 msgstr ""
@@ -2107,9 +2110,9 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/feed.ex:345
 #: lib/vutuv_web/live/post_live/feed.ex:3114
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1290
-#: lib/vutuv_web/live/shell_live.ex:1654
-#: lib/vutuv_web/templates/layout/app.html.heex:157
+#: lib/vutuv_web/live/shell_live.ex:1282
+#: lib/vutuv_web/live/shell_live.ex:1607
+#: lib/vutuv_web/templates/layout/app.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Feed"
 msgstr ""
@@ -2283,7 +2286,7 @@ msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5373
-#: lib/vutuv_web/live/shell_live.ex:1550
+#: lib/vutuv_web/live/shell_live.ex:1503
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:258
@@ -2373,11 +2376,11 @@ msgstr ""
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1217
+#: lib/vutuv_web/agent_docs/markdown.ex:1264
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:525
-#: lib/vutuv_web/live/shell_live.ex:1487
-#: lib/vutuv_web/live/shell_live.ex:1555
+#: lib/vutuv_web/live/shell_live.ex:1440
+#: lib/vutuv_web/live/shell_live.ex:1508
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2393,11 +2396,11 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1216
+#: lib/vutuv_web/agent_docs/markdown.ex:1263
 #: lib/vutuv_web/components/post_components.ex:6106
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:522
-#: lib/vutuv_web/live/shell_live.ex:1558
+#: lib/vutuv_web/live/shell_live.ex:1511
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2786,8 +2789,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:652
-#: lib/vutuv_web/agent_docs/text.ex:615
+#: lib/vutuv_web/agent_docs/markdown.ex:699
+#: lib/vutuv_web/agent_docs/text.ex:659
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2939,10 +2942,10 @@ msgstr ""
 msgid "Bullying or harassment"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:347
-#: lib/vutuv_web/agent_docs/text.ex:328
+#: lib/vutuv_web/agent_docs/markdown.ex:385
+#: lib/vutuv_web/agent_docs/text.ex:365
 #: lib/vutuv_web/controllers/page_controller.ex:81
-#: lib/vutuv_web/templates/layout/app.html.heex:125
+#: lib/vutuv_web/templates/layout/app.html.heex:126
 #: lib/vutuv_web/templates/page/community.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Community guidelines"
@@ -3145,7 +3148,7 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4973
-#: lib/vutuv_web/live/shell_live.ex:1322
+#: lib/vutuv_web/live/shell_live.ex:1314
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3822,12 +3825,12 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:759
+#: lib/vutuv_web/agent_docs/markdown.ex:806
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1338
+#: lib/vutuv_web/agent_docs/markdown.ex:1385
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3841,16 +3844,16 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:91
 #: lib/vutuv_web/agent_docs/markdown.ex:204
 #: lib/vutuv_web/agent_docs/markdown.ex:218
-#: lib/vutuv_web/agent_docs/markdown.ex:1163
+#: lib/vutuv_web/agent_docs/markdown.ex:1210
 #: lib/vutuv_web/agent_docs/text.ex:86
 #: lib/vutuv_web/agent_docs/text.ex:187
 #: lib/vutuv_web/agent_docs/text.ex:201
-#: lib/vutuv_web/agent_docs/text.ex:806
+#: lib/vutuv_web/agent_docs/text.ex:850
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:46
+#: lib/vutuv_web/agent_docs/list_docs.ex:47
 #, elixir-autogen, elixir-format
 msgid "Followers of %{name}"
 msgstr ""
@@ -3864,28 +3867,28 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1181
-#: lib/vutuv_web/agent_docs/text.ex:817
+#: lib/vutuv_web/agent_docs/markdown.ex:1228
+#: lib/vutuv_web/agent_docs/text.ex:861
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1178
-#: lib/vutuv_web/agent_docs/text.ex:814
+#: lib/vutuv_web/agent_docs/markdown.ex:1225
+#: lib/vutuv_web/agent_docs/text.ex:858
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1185
-#: lib/vutuv_web/agent_docs/markdown.ex:1431
-#: lib/vutuv_web/agent_docs/text.ex:821
-#: lib/vutuv_web/agent_docs/text.ex:890
+#: lib/vutuv_web/agent_docs/markdown.ex:1232
+#: lib/vutuv_web/agent_docs/markdown.ex:1478
+#: lib/vutuv_web/agent_docs/text.ex:865
+#: lib/vutuv_web/agent_docs/text.ex:934
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:587
-#: lib/vutuv_web/agent_docs/text.ex:578
+#: lib/vutuv_web/agent_docs/markdown.ex:634
+#: lib/vutuv_web/agent_docs/text.ex:622
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
@@ -3896,7 +3899,7 @@ msgstr ""
 msgid "Most endorsed members"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:47
+#: lib/vutuv_web/agent_docs/list_docs.ex:48
 #, elixir-autogen, elixir-format
 msgid "People %{name} follows"
 msgstr ""
@@ -3924,23 +3927,23 @@ msgstr ""
 msgid "Posts (%{count} total)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:581
-#: lib/vutuv_web/agent_docs/text.ex:572
+#: lib/vutuv_web/agent_docs/markdown.ex:628
+#: lib/vutuv_web/agent_docs/text.ex:616
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1109
+#: lib/vutuv_web/agent_docs/markdown.ex:1156
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:971
+#: lib/vutuv_web/agent_docs/markdown.ex:1018
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:972
+#: lib/vutuv_web/agent_docs/markdown.ex:1019
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -3950,7 +3953,7 @@ msgstr ""
 msgid "This page in %{language}: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:48
+#: lib/vutuv_web/agent_docs/list_docs.ex:49
 #, elixir-autogen, elixir-format
 msgid "Connections of %{name}"
 msgstr ""
@@ -3995,7 +3998,7 @@ msgstr ""
 #: lib/vutuv_web/templates/ad/index.html.heex:7
 #: lib/vutuv_web/templates/ad/new.html.heex:4
 #: lib/vutuv_web/templates/ad/preview.html.heex:2
-#: lib/vutuv_web/templates/layout/app.html.heex:115
+#: lib/vutuv_web/templates/layout/app.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "Advertising"
 msgstr ""
@@ -4016,8 +4019,8 @@ msgstr ""
 msgid "Billing name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:361
-#: lib/vutuv_web/agent_docs/text.ex:336
+#: lib/vutuv_web/agent_docs/markdown.ex:399
+#: lib/vutuv_web/agent_docs/text.ex:373
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr ""
@@ -4070,8 +4073,8 @@ msgstr ""
 msgid "Markdown is supported. At most %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:351
-#: lib/vutuv_web/agent_docs/text.ex:332
+#: lib/vutuv_web/agent_docs/markdown.ex:389
+#: lib/vutuv_web/agent_docs/text.ex:369
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4087,8 +4090,8 @@ msgstr ""
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:348
-#: lib/vutuv_web/agent_docs/text.ex:329
+#: lib/vutuv_web/agent_docs/markdown.ex:386
+#: lib/vutuv_web/agent_docs/text.ex:366
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4302,14 +4305,14 @@ msgstr ""
 msgid "deleted account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:353
-#: lib/vutuv_web/agent_docs/text.ex:334
+#: lib/vutuv_web/agent_docs/markdown.ex:391
+#: lib/vutuv_web/agent_docs/text.ex:371
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:349
-#: lib/vutuv_web/agent_docs/text.ex:330
+#: lib/vutuv_web/agent_docs/markdown.ex:387
+#: lib/vutuv_web/agent_docs/text.ex:367
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr ""
@@ -4588,8 +4591,8 @@ msgid "Not an exact match, but sounds like your search."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/investors_doc.ex:212
-#: lib/vutuv_web/agent_docs/markdown.ex:463
-#: lib/vutuv_web/agent_docs/text.ex:481
+#: lib/vutuv_web/agent_docs/markdown.ex:510
+#: lib/vutuv_web/agent_docs/text.ex:525
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/notification_live/index.ex:657
 #: lib/vutuv_web/live/notification_live/index.ex:1350
@@ -4701,7 +4704,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/show.html.heex:4
 #: lib/vutuv_web/templates/dev_doc/show.html.heex:14
 #: lib/vutuv_web/templates/dev_webhook/new.html.heex:4
-#: lib/vutuv_web/templates/layout/app.html.heex:84
+#: lib/vutuv_web/templates/layout/app.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Developers"
 msgstr ""
@@ -5254,7 +5257,7 @@ msgstr ""
 msgid "API token (%{date})"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:86
+#: lib/vutuv_web/templates/layout/app.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "API documentation"
 msgstr ""
@@ -5305,35 +5308,35 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1537
+#: lib/vutuv_web/live/shell_live.ex:1490
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:310
 #: lib/vutuv_web/live/admin/screenshot_live.ex:420
-#: lib/vutuv_web/templates/layout/app.html.heex:163
+#: lib/vutuv_web/templates/layout/app.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:173
+#: lib/vutuv_web/templates/layout/app.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Close menus and dialogs"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:170
+#: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1594
-#: lib/vutuv_web/templates/layout/app.html.heex:189
+#: lib/vutuv_web/live/shell_live.ex:1547
+#: lib/vutuv_web/templates/layout/app.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:154
+#: lib/vutuv_web/templates/layout/app.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "Navigation"
 msgstr ""
@@ -5346,7 +5349,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:276
-#: lib/vutuv_web/live/shell_live.ex:1574
+#: lib/vutuv_web/live/shell_live.ex:1527
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5360,17 +5363,17 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:172
+#: lib/vutuv_web/templates/layout/app.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "Show this help"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:165
+#: lib/vutuv_web/templates/layout/app.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "Write a new post"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:160
+#: lib/vutuv_web/templates/layout/app.html.heex:161
 #: lib/vutuv_web/views/page_html.ex:551
 #, elixir-autogen, elixir-format
 msgid "Your profile"
@@ -5391,18 +5394,18 @@ msgstr ""
 msgid "Add a profile photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:167
+#: lib/vutuv_web/templates/layout/app.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Next post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:168
+#: lib/vutuv_web/templates/layout/app.html.heex:169
 #, elixir-autogen, elixir-format
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1278
-#: lib/vutuv_web/live/shell_live.ex:1635
+#: lib/vutuv_web/live/shell_live.ex:1270
+#: lib/vutuv_web/live/shell_live.ex:1588
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -6131,8 +6134,8 @@ msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:631
-#: lib/vutuv_web/agent_docs/text.ex:594
+#: lib/vutuv_web/agent_docs/markdown.ex:678
+#: lib/vutuv_web/agent_docs/text.ex:638
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6204,7 +6207,7 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1216
+#: lib/vutuv_web/agent_docs/markdown.ex:1263
 #: lib/vutuv_web/components/post_components.ex:422
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
@@ -6294,7 +6297,7 @@ msgstr ""
 msgid "Endorsed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:140
+#: lib/vutuv_web/agent_docs/list_docs.ex:141
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Members who endorsed %{name} for %{tag}"
@@ -6314,7 +6317,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1176
+#: lib/vutuv_web/agent_docs/markdown.ex:1223
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -7501,27 +7504,27 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1343
+#: lib/vutuv_web/agent_docs/markdown.ex:1390
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1346
+#: lib/vutuv_web/agent_docs/markdown.ex:1393
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1353
+#: lib/vutuv_web/agent_docs/markdown.ex:1400
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:141
+#: lib/vutuv_web/templates/layout/app.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Last change: %{date} at %{time}"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:141
+#: lib/vutuv_web/templates/layout/app.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Last commit (Berlin time)"
 msgstr ""
@@ -8472,7 +8475,7 @@ msgstr ""
 msgid "Invalid address (skipped)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:179
+#: lib/vutuv_web/agent_docs/list_docs.ex:180
 #: lib/vutuv_web/controllers/directory_controller.ex:54
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
@@ -8488,7 +8491,7 @@ msgstr ""
 msgid "Members by initial"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:202
+#: lib/vutuv_web/agent_docs/list_docs.ex:203
 #: lib/vutuv_web/controllers/directory_controller.ex:86
 #: lib/vutuv_web/templates/directory/show.html.heex:2
 #, elixir-autogen, elixir-format
@@ -8507,7 +8510,7 @@ msgid_plural "%{formatted} members"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:208
+#: lib/vutuv_web/agent_docs/list_docs.ex:209
 #, elixir-autogen, elixir-format
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
@@ -8603,10 +8606,10 @@ msgstr ""
 msgid "Write it under Admin › Legal pages"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:641
-#: lib/vutuv_web/agent_docs/markdown.ex:645
-#: lib/vutuv_web/agent_docs/text.ex:604
-#: lib/vutuv_web/agent_docs/text.ex:608
+#: lib/vutuv_web/agent_docs/markdown.ex:688
+#: lib/vutuv_web/agent_docs/markdown.ex:692
+#: lib/vutuv_web/agent_docs/text.ex:648
+#: lib/vutuv_web/agent_docs/text.ex:652
 #: lib/vutuv_web/components/organization_components.ex:276
 #: lib/vutuv_web/components/ui.ex:1695
 #: lib/vutuv_web/components/ui.ex:5145
@@ -8732,13 +8735,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:849
+#: lib/vutuv_web/agent_docs/markdown.ex:896
 #: lib/vutuv_web/views/education_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:848
+#: lib/vutuv_web/agent_docs/markdown.ex:895
 #: lib/vutuv_web/views/education_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8771,7 +8774,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1112
+#: lib/vutuv_web/agent_docs/markdown.ex:1159
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8996,8 +8999,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:661
-#: lib/vutuv_web/agent_docs/text.ex:622
+#: lib/vutuv_web/agent_docs/markdown.ex:708
+#: lib/vutuv_web/agent_docs/text.ex:666
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9421,8 +9424,8 @@ msgstr ""
 msgid "Yoruba"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:583
-#: lib/vutuv_web/agent_docs/text.ex:574
+#: lib/vutuv_web/agent_docs/markdown.ex:630
+#: lib/vutuv_web/agent_docs/text.ex:618
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr ""
@@ -9525,7 +9528,7 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:965
+#: lib/vutuv_web/agent_docs/markdown.ex:1012
 #: lib/vutuv_web/views/qualification_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9605,7 +9608,7 @@ msgstr ""
 msgid "Expired"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:940
+#: lib/vutuv_web/agent_docs/markdown.ex:987
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9622,7 +9625,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:964
+#: lib/vutuv_web/agent_docs/markdown.ex:1011
 #: lib/vutuv_web/views/qualification_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9649,7 +9652,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:938
+#: lib/vutuv_web/agent_docs/markdown.ex:985
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9664,7 +9667,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:939
+#: lib/vutuv_web/agent_docs/markdown.ex:986
 #: lib/vutuv_web/views/qualification_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "valid until %{date}"
@@ -9680,7 +9683,7 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:776
+#: lib/vutuv_web/agent_docs/markdown.ex:823
 #: lib/vutuv_web/live/section_reorder_live.ex:287
 #: lib/vutuv_web/views/language_html.ex:114
 #, elixir-autogen, elixir-format
@@ -10135,21 +10138,21 @@ msgstr ""
 msgid "Sign in with a one-time code (OTP) from an authenticator app or from a printed code list, typed into the normal PIN field. Your emailed PIN always keeps working."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:736
+#: lib/vutuv_web/agent_docs/markdown.ex:783
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:734
+#: lib/vutuv_web/agent_docs/markdown.ex:781
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:732
+#: lib/vutuv_web/agent_docs/markdown.ex:779
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10206,12 +10209,12 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:750
+#: lib/vutuv_web/agent_docs/markdown.ex:797
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:737
+#: lib/vutuv_web/agent_docs/markdown.ex:784
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -11168,8 +11171,8 @@ msgstr ""
 msgid "Alias removed."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:455
-#: lib/vutuv_web/agent_docs/text.ex:474
+#: lib/vutuv_web/agent_docs/markdown.ex:502
+#: lib/vutuv_web/agent_docs/text.ex:518
 #: lib/vutuv_web/live/organization_live/edit.ex:384
 #: lib/vutuv_web/live/organization_live/show.ex:930
 #: lib/vutuv_web/templates/tag/single_card.html.heex:14
@@ -11390,8 +11393,8 @@ msgstr ""
 msgid "primary"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:476
-#: lib/vutuv_web/agent_docs/text.ex:494
+#: lib/vutuv_web/agent_docs/markdown.ex:523
+#: lib/vutuv_web/agent_docs/text.ex:538
 #: lib/vutuv_web/live/admin/organization_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -11514,8 +11517,8 @@ msgstr ""
 msgid "Verify via file"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:985
-#: lib/vutuv_web/agent_docs/text.ex:750
+#: lib/vutuv_web/agent_docs/markdown.ex:1032
+#: lib/vutuv_web/agent_docs/text.ex:794
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -11551,8 +11554,8 @@ msgstr ""
 msgid "Remove link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:467
-#: lib/vutuv_web/agent_docs/text.ex:485
+#: lib/vutuv_web/agent_docs/markdown.ex:514
+#: lib/vutuv_web/agent_docs/text.ex:529
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr ""
@@ -11740,18 +11743,18 @@ msgstr ""
 msgid "Organization unfrozen."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:446
+#: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
-#: lib/vutuv_web/agent_docs/text.ex:418
+#: lib/vutuv_web/agent_docs/text.ex:462
 #: lib/vutuv_web/components/ui.ex:5172
 #: lib/vutuv_web/controllers/settings_controller.ex:215
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:538
-#: lib/vutuv_web/live/shell_live.ex:1565
+#: lib/vutuv_web/live/shell_live.ex:1518
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
-#: lib/vutuv_web/templates/layout/app.html.heex:79
+#: lib/vutuv_web/templates/layout/app.html.heex:80
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Organizations"
@@ -11999,9 +12002,9 @@ msgid "Edit posting"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:282
-#: lib/vutuv_web/agent_docs/markdown.ex:507
+#: lib/vutuv_web/agent_docs/markdown.ex:554
 #: lib/vutuv_web/agent_docs/text.ex:266
-#: lib/vutuv_web/agent_docs/text.ex:525
+#: lib/vutuv_web/agent_docs/text.ex:569
 #: lib/vutuv_web/live/admin/job_live.ex:340
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
 #: lib/vutuv_web/views/account_event_text.ex:225
@@ -12015,9 +12018,9 @@ msgid "Employer name (optional)"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:283
-#: lib/vutuv_web/agent_docs/markdown.ex:508
+#: lib/vutuv_web/agent_docs/markdown.ex:555
 #: lib/vutuv_web/agent_docs/text.ex:267
-#: lib/vutuv_web/agent_docs/text.ex:526
+#: lib/vutuv_web/agent_docs/text.ex:570
 #: lib/vutuv_web/live/job_board_live.ex:526
 #: lib/vutuv_web/live/job_posting_live/form.ex:499
 #, elixir-autogen, elixir-format
@@ -12078,8 +12081,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:47
 #: lib/vutuv_web/live/job_board_live.ex:265
 #: lib/vutuv_web/live/post_live/saved.ex:541
-#: lib/vutuv_web/live/shell_live.ex:1330
-#: lib/vutuv_web/templates/layout/app.html.heex:80
+#: lib/vutuv_web/live/shell_live.ex:1322
+#: lib/vutuv_web/templates/layout/app.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Jobs"
 msgstr ""
@@ -12089,12 +12092,12 @@ msgstr ""
 msgid "Let search engines index this posting."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:482
-#: lib/vutuv_web/agent_docs/markdown.ex:485
-#: lib/vutuv_web/agent_docs/markdown.ex:487
-#: lib/vutuv_web/agent_docs/text.ex:500
-#: lib/vutuv_web/agent_docs/text.ex:503
-#: lib/vutuv_web/agent_docs/text.ex:505
+#: lib/vutuv_web/agent_docs/markdown.ex:529
+#: lib/vutuv_web/agent_docs/markdown.ex:532
+#: lib/vutuv_web/agent_docs/markdown.ex:534
+#: lib/vutuv_web/agent_docs/text.ex:544
+#: lib/vutuv_web/agent_docs/text.ex:547
+#: lib/vutuv_web/agent_docs/text.ex:549
 #: lib/vutuv_web/live/job_posting_live/form.ex:549
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -12229,9 +12232,9 @@ msgid "Postal code"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:287
-#: lib/vutuv_web/agent_docs/markdown.ex:512
+#: lib/vutuv_web/agent_docs/markdown.ex:559
 #: lib/vutuv_web/agent_docs/text.ex:271
-#: lib/vutuv_web/agent_docs/text.ex:530
+#: lib/vutuv_web/agent_docs/text.ex:574
 #: lib/vutuv_web/live/job_posting_live/show.ex:156
 #, elixir-autogen, elixir-format
 msgid "Posted"
@@ -12256,10 +12259,10 @@ msgstr ""
 #: lib/vutuv/accounts/user.ex:1264
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
-#: lib/vutuv_web/agent_docs/markdown.ex:485
-#: lib/vutuv_web/agent_docs/markdown.ex:487
-#: lib/vutuv_web/agent_docs/text.ex:503
-#: lib/vutuv_web/agent_docs/text.ex:505
+#: lib/vutuv_web/agent_docs/markdown.ex:532
+#: lib/vutuv_web/agent_docs/markdown.ex:534
+#: lib/vutuv_web/agent_docs/text.ex:547
+#: lib/vutuv_web/agent_docs/text.ex:549
 #: lib/vutuv_web/components/job_components.ex:140
 #: lib/vutuv_web/components/job_components.ex:141
 #, elixir-autogen, elixir-format
@@ -12280,9 +12283,9 @@ msgid "Required"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:286
-#: lib/vutuv_web/agent_docs/markdown.ex:511
+#: lib/vutuv_web/agent_docs/markdown.ex:558
 #: lib/vutuv_web/agent_docs/text.ex:270
-#: lib/vutuv_web/agent_docs/text.ex:529
+#: lib/vutuv_web/agent_docs/text.ex:573
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr ""
@@ -12377,9 +12380,9 @@ msgid "Working student"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:284
-#: lib/vutuv_web/agent_docs/markdown.ex:509
+#: lib/vutuv_web/agent_docs/markdown.ex:556
 #: lib/vutuv_web/agent_docs/text.ex:268
-#: lib/vutuv_web/agent_docs/text.ex:527
+#: lib/vutuv_web/agent_docs/text.ex:571
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
 #, elixir-autogen, elixir-format
 msgid "Workplace"
@@ -12579,13 +12582,13 @@ msgstr ""
 msgid "All countries"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:530
+#: lib/vutuv_web/agent_docs/markdown.ex:577
 #: lib/vutuv_web/templates/tag/show.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:547
+#: lib/vutuv_web/agent_docs/text.ex:591
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr ""
@@ -12651,10 +12654,10 @@ msgstr ""
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:528
-#: lib/vutuv_web/agent_docs/markdown.ex:540
-#: lib/vutuv_web/agent_docs/text.ex:545
-#: lib/vutuv_web/agent_docs/text.ex:557
+#: lib/vutuv_web/agent_docs/markdown.ex:575
+#: lib/vutuv_web/agent_docs/markdown.ex:587
+#: lib/vutuv_web/agent_docs/text.ex:589
+#: lib/vutuv_web/agent_docs/text.ex:601
 #: lib/vutuv_web/live/organization_live/show.ex:833
 #: lib/vutuv_web/templates/tag/show.html.heex:78
 #, elixir-autogen, elixir-format
@@ -13579,7 +13582,7 @@ msgstr ""
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1305
+#: lib/vutuv_web/agent_docs/markdown.ex:1352
 #: lib/vutuv_web/components/post_components.ex:5565
 #, elixir-autogen, elixir-format
 msgid "Book review"
@@ -13600,7 +13603,7 @@ msgstr ""
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1305
+#: lib/vutuv_web/agent_docs/markdown.ex:1352
 #: lib/vutuv_web/components/post_components.ex:5564
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -13690,7 +13693,7 @@ msgstr ""
 msgid "With qualification:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:805
+#: lib/vutuv_web/agent_docs/markdown.ex:852
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr ""
@@ -13755,7 +13758,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:707
+#: lib/vutuv_web/live/shell_live.ex:699
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -13779,19 +13782,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:954
+#: lib/vutuv_web/agent_docs/markdown.ex:1001
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:953
+#: lib/vutuv_web/agent_docs/markdown.ex:1000
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:959
+#: lib/vutuv_web/agent_docs/markdown.ex:1006
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -13871,8 +13874,8 @@ msgstr ""
 msgid "View the uploaded proof (%{label})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:891
-#: lib/vutuv_web/agent_docs/text.ex:729
+#: lib/vutuv_web/agent_docs/markdown.ex:938
+#: lib/vutuv_web/agent_docs/text.ex:773
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
@@ -13930,8 +13933,8 @@ msgstr ""
 msgid "Skip for now"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:585
-#: lib/vutuv_web/agent_docs/text.ex:576
+#: lib/vutuv_web/agent_docs/markdown.ex:632
+#: lib/vutuv_web/agent_docs/text.ex:620
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr ""
@@ -14521,7 +14524,7 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1252
+#: lib/vutuv_web/agent_docs/markdown.ex:1299
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr ""
@@ -14905,8 +14908,8 @@ msgstr ""
 msgid "Your server"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:642
-#: lib/vutuv_web/agent_docs/text.ex:605
+#: lib/vutuv_web/agent_docs/markdown.ex:689
+#: lib/vutuv_web/agent_docs/text.ex:649
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr ""
@@ -15287,7 +15290,7 @@ msgid_plural "%{formatted} reposts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1254
+#: lib/vutuv_web/agent_docs/markdown.ex:1301
 #: lib/vutuv_web/components/post_components.ex:6010
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
@@ -15298,10 +15301,10 @@ msgstr ""
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1194
-#: lib/vutuv_web/agent_docs/markdown.ex:1452
-#: lib/vutuv_web/agent_docs/text.ex:827
-#: lib/vutuv_web/agent_docs/text.ex:904
+#: lib/vutuv_web/agent_docs/markdown.ex:1241
+#: lib/vutuv_web/agent_docs/markdown.ex:1499
+#: lib/vutuv_web/agent_docs/text.ex:871
+#: lib/vutuv_web/agent_docs/text.ex:948
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Content warning"
 msgstr ""
@@ -15325,7 +15328,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:135
 #: lib/vutuv_web/agent_docs/markdown.ex:167
-#: lib/vutuv_web/agent_docs/markdown.ex:1253
+#: lib/vutuv_web/agent_docs/markdown.ex:1300
 #: lib/vutuv_web/agent_docs/text.ex:124
 #: lib/vutuv_web/agent_docs/text.ex:153
 #, elixir-autogen, elixir-format
@@ -15383,7 +15386,7 @@ msgstr ""
 msgid "That reply is not yours to remove."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1454
+#: lib/vutuv_web/agent_docs/markdown.ex:1501
 #: lib/vutuv_web/components/post_components.ex:1411
 #: lib/vutuv_web/components/post_components.ex:1611
 #: lib/vutuv_web/components/post_components.ex:3019
@@ -16085,13 +16088,13 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1095
+#: lib/vutuv_web/agent_docs/markdown.ex:1142
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:579
-#: lib/vutuv_web/agent_docs/text.ex:567
+#: lib/vutuv_web/agent_docs/markdown.ex:626
+#: lib/vutuv_web/agent_docs/text.ex:611
 #: lib/vutuv_web/templates/user/edit.html.heex:219
 #: lib/vutuv_web/templates/user/show.html.heex:262
 #: lib/vutuv_web/views/account_event_text.ex:213
@@ -16139,8 +16142,8 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1371
-#: lib/vutuv_web/agent_docs/text.ex:858
+#: lib/vutuv_web/agent_docs/markdown.ex:1418
+#: lib/vutuv_web/agent_docs/text.ex:902
 #: lib/vutuv_web/live/post_live/composer.ex:2661
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
@@ -16151,8 +16154,8 @@ msgstr ""
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1382
-#: lib/vutuv_web/agent_docs/text.ex:871
+#: lib/vutuv_web/agent_docs/markdown.ex:1429
+#: lib/vutuv_web/agent_docs/text.ex:915
 #: lib/vutuv_web/components/ui.ex:3126
 #, elixir-autogen, elixir-format
 msgid "Download the original"
@@ -16209,8 +16212,8 @@ msgstr ""
 msgid "Photo options"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1415
-#: lib/vutuv_web/agent_docs/text.ex:846
+#: lib/vutuv_web/agent_docs/markdown.ex:1462
+#: lib/vutuv_web/agent_docs/text.ex:890
 #: lib/vutuv_web/components/post_components.ex:4808
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
@@ -16371,13 +16374,13 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1272
+#: lib/vutuv_web/agent_docs/markdown.ex:1319
 #: lib/vutuv_web/components/post_components.ex:6048
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1270
+#: lib/vutuv_web/agent_docs/markdown.ex:1317
 #: lib/vutuv_web/components/post_components.ex:6045
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
@@ -16996,7 +16999,7 @@ msgstr ""
 msgid "What is being measured"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1072
+#: lib/vutuv_web/agent_docs/markdown.ex:1119
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
@@ -17147,8 +17150,8 @@ msgstr ""
 msgid "We could not reach the network just now. Please try again in a moment."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:999
-#: lib/vutuv_web/agent_docs/text.ex:651
+#: lib/vutuv_web/agent_docs/markdown.ex:1046
+#: lib/vutuv_web/agent_docs/text.ex:695
 #, elixir-autogen, elixir-format, fuzzy
 msgid "verified profile"
 msgstr ""
@@ -17446,12 +17449,12 @@ msgstr ""
 msgid "Whole photos"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:166
+#: lib/vutuv_web/templates/layout/app.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Send the post or message you are writing"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:227
+#: lib/vutuv_web/templates/layout/app.html.heex:228
 #, elixir-autogen, elixir-format
 msgid "The single-key shortcuts pause while you type, and are off on phones and tablets."
 msgstr ""
@@ -17999,7 +18002,7 @@ msgstr ""
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1240
+#: lib/vutuv_web/agent_docs/markdown.ex:1287
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr ""
@@ -18041,12 +18044,12 @@ msgstr ""
 msgid "Your likes follow the site default again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1295
+#: lib/vutuv_web/agent_docs/markdown.ex:1342
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1292
+#: lib/vutuv_web/agent_docs/markdown.ex:1339
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr ""
@@ -18056,7 +18059,7 @@ msgstr ""
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1284
+#: lib/vutuv_web/agent_docs/markdown.ex:1331
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
@@ -18390,7 +18393,7 @@ msgstr ""
 msgid "Employment references of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:873
+#: lib/vutuv_web/agent_docs/markdown.ex:920
 #, elixir-autogen, elixir-format, fuzzy
 msgid "document"
 msgstr ""
@@ -19742,7 +19745,7 @@ msgstr ""
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1236
+#: lib/vutuv_web/live/shell_live.ex:1228
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Open the page"
 msgstr ""
@@ -19762,7 +19765,7 @@ msgstr ""
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1246
+#: lib/vutuv_web/live/shell_live.ex:1238
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -19772,7 +19775,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1222
+#: lib/vutuv_web/live/shell_live.ex:1214
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -20136,21 +20139,21 @@ msgstr ""
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:751
+#: lib/vutuv_web/live/shell_live.ex:743
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:738
+#: lib/vutuv_web/live/shell_live.ex:730
 #, elixir-autogen, elixir-format, fuzzy
 msgid "person"
 msgid_plural "people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:773
+#: lib/vutuv_web/live/shell_live.ex:765
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -20407,12 +20410,12 @@ msgstr ""
 msgid "You are not allowed to change this organization."
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:96
+#: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Company"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:121
+#: lib/vutuv_web/templates/layout/app.html.heex:122
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Legal"
 msgstr ""
@@ -21231,7 +21234,7 @@ msgstr ""
 msgid "Unfollowed. Their posts leave your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1196
+#: lib/vutuv_web/live/shell_live.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr ""
@@ -21246,12 +21249,12 @@ msgstr ""
 msgid "Browser notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1054
+#: lib/vutuv_web/live/shell_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1199
+#: lib/vutuv_web/live/shell_live.ex:1191
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
@@ -21291,7 +21294,7 @@ msgstr ""
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1193
+#: lib/vutuv_web/live/shell_live.ex:1185
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -21331,12 +21334,12 @@ msgstr ""
 msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:846
+#: lib/vutuv_web/live/shell_live.ex:838
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:847
+#: lib/vutuv_web/live/shell_live.ex:839
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr ""
@@ -21557,7 +21560,7 @@ msgstr ""
 msgid "Translated into %{language}."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:987
+#: lib/vutuv_web/live/shell_live.ex:979
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -21676,7 +21679,7 @@ msgstr ""
 msgid "No connection"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1126
+#: lib/vutuv_web/live/shell_live.ex:1118
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr ""
@@ -21764,7 +21767,7 @@ msgstr ""
 msgid "All vutuv members, filed alphabetically by last name."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:194
+#: lib/vutuv_web/agent_docs/list_docs.ex:195
 #, elixir-autogen, elixir-format
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr ""
@@ -22164,7 +22167,7 @@ msgstr ""
 msgid "Scan it with the device that has the app"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1108
+#: lib/vutuv_web/live/shell_live.ex:1100
 #, elixir-autogen, elixir-format, fuzzy
 msgid "A new version is ready."
 msgstr ""
@@ -22186,12 +22189,12 @@ msgstr[1] ""
 msgid "Quoted post"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1088
+#: lib/vutuv_web/agent_docs/markdown.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Quotes %{name}: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1085
+#: lib/vutuv_web/agent_docs/markdown.ex:1132
 #, elixir-autogen, elixir-format
 msgid "Quotes %{url}"
 msgstr ""
@@ -22251,6 +22254,7 @@ msgid_plural "%{formatted} shares"
 msgstr[0] ""
 msgstr[1] ""
 
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:136
 #: lib/vutuv_web/live/notification_live/index.ex:838
 #, elixir-autogen, elixir-format
 msgid "Post without text"
@@ -22412,7 +22416,7 @@ msgstr ""
 msgid "Low-bandwidth mode"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1676
+#: lib/vutuv_web/live/shell_live.ex:1629
 #, elixir-autogen, elixir-format
 msgctxt "phone tab bar"
 msgid "Write"
@@ -22569,7 +22573,7 @@ msgstr ""
 msgid "Appearance"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1702
+#: lib/vutuv_web/live/shell_live.ex:1655
 #, elixir-autogen, elixir-format
 msgid "%{count} video in progress"
 msgid_plural "%{count} videos in progress"
@@ -22673,10 +22677,10 @@ msgstr ""
 msgid "This video could not be converted."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1367
-#: lib/vutuv_web/agent_docs/markdown.ex:1370
-#: lib/vutuv_web/agent_docs/text.ex:855
-#: lib/vutuv_web/agent_docs/text.ex:856
+#: lib/vutuv_web/agent_docs/markdown.ex:1414
+#: lib/vutuv_web/agent_docs/markdown.ex:1417
+#: lib/vutuv_web/agent_docs/text.ex:899
+#: lib/vutuv_web/agent_docs/text.ex:900
 #: lib/vutuv_web/components/post_components.ex:2501
 #: lib/vutuv_web/components/video_components.ex:126
 #: lib/vutuv_web/live/post_live/composer.ex:2458
@@ -22801,22 +22805,22 @@ msgstr ""
 msgid "The fields the most members carry, and how many of them do."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1138
-#: lib/vutuv_web/agent_docs/text.ex:779
+#: lib/vutuv_web/agent_docs/markdown.ex:1185
+#: lib/vutuv_web/agent_docs/text.ex:823
 #: lib/vutuv_web/live/job_board_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "What members here work on"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1130
-#: lib/vutuv_web/agent_docs/text.ex:771
+#: lib/vutuv_web/agent_docs/markdown.ex:1177
+#: lib/vutuv_web/agent_docs/text.ex:815
 #: lib/vutuv_web/live/job_board_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "Who you would reach"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1131
-#: lib/vutuv_web/agent_docs/text.ex:772
+#: lib/vutuv_web/agent_docs/markdown.ex:1178
+#: lib/vutuv_web/agent_docs/text.ex:816
 #: lib/vutuv_web/live/job_board_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "One random vutuv account that is open to offers."
@@ -22824,7 +22828,7 @@ msgid_plural "%{formatted} random vutuv accounts that are open to offers."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:721
+#: lib/vutuv_web/live/shell_live.ex:713
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post in your feed"
 msgid_plural "%{formatted} new posts in your feed"
@@ -22909,7 +22913,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/investors_doc.ex:295
 #: lib/vutuv_web/controllers/company_controller.ex:56
-#: lib/vutuv_web/templates/layout/app.html.heex:110
+#: lib/vutuv_web/templates/layout/app.html.heex:111
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Investors"
 msgstr ""
@@ -22919,14 +22923,13 @@ msgstr ""
 msgid "Over these %{days} days %{total} people arrived, %{members} of them as members here."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1415
 #: lib/vutuv_web/views/company_html.ex:76
 #, elixir-autogen, elixir-format
 msgid "People here per day over the last %{days} days"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:392
-#: lib/vutuv_web/agent_docs/text.ex:362
+#: lib/vutuv_web/agent_docs/markdown.ex:430
+#: lib/vutuv_web/agent_docs/text.ex:399
 #, elixir-autogen, elixir-format
 msgid "Press material: %{url}"
 msgstr ""
@@ -22941,28 +22944,28 @@ msgstr ""
 msgid "Send a message"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:375
-#: lib/vutuv_web/agent_docs/text.ex:349
+#: lib/vutuv_web/agent_docs/markdown.ex:413
+#: lib/vutuv_web/agent_docs/text.ex:386
 #: lib/vutuv_web/templates/company/investors.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Where we are"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:382
-#: lib/vutuv_web/agent_docs/text.ex:356
+#: lib/vutuv_web/agent_docs/markdown.ex:420
+#: lib/vutuv_web/agent_docs/text.ex:393
 #: lib/vutuv_web/templates/company/investors.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Why this is worth building"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:391
-#: lib/vutuv_web/agent_docs/text.ex:361
+#: lib/vutuv_web/agent_docs/markdown.ex:429
+#: lib/vutuv_web/agent_docs/text.ex:398
 #, elixir-autogen, elixir-format
 msgid "Write here: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:388
-#: lib/vutuv_web/agent_docs/text.ex:358
+#: lib/vutuv_web/agent_docs/markdown.ex:426
+#: lib/vutuv_web/agent_docs/text.ex:395
 #: lib/vutuv_web/templates/company/investors.html.heex:127
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Write to me"
@@ -22978,8 +22981,8 @@ msgstr ""
 msgid "My profile:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:390
-#: lib/vutuv_web/agent_docs/text.ex:360
+#: lib/vutuv_web/agent_docs/markdown.ex:428
+#: lib/vutuv_web/agent_docs/text.ex:397
 #, elixir-autogen, elixir-format
 msgid "My profile: %{url}"
 msgstr ""
@@ -22999,8 +23002,8 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:442
-#: lib/vutuv_web/agent_docs/text.ex:411
+#: lib/vutuv_web/agent_docs/markdown.ex:485
+#: lib/vutuv_web/agent_docs/text.ex:452
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Source: %{source}"
 msgstr ""
@@ -23125,4 +23128,77 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/mutes.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "muted on the follow itself"
+msgstr ""
+
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:40
+#, elixir-autogen, elixir-format
+msgid "Every public post on vutuv, filed under the day it was written."
+msgstr ""
+
+#: lib/vutuv_web/templates/post_calendar/month.html.heex:16
+#, elixir-autogen, elixir-format
+msgid "Neighbouring months"
+msgstr ""
+
+#: lib/vutuv_web/templates/post_calendar/month.html.heex:80
+#, elixir-autogen, elixir-format
+msgid "No posts in this month yet."
+msgstr ""
+
+#: lib/vutuv_web/templates/post_calendar/day.html.heex:18
+#, elixir-autogen, elixir-format
+msgid "No posts on this day."
+msgstr ""
+
+#: lib/vutuv_web/templates/post_calendar/index.html.heex:16
+#, elixir-autogen, elixir-format
+msgid "Nothing has been written here yet."
+msgstr ""
+
+#: lib/vutuv_web/templates/post_calendar/day.html.heex:14
+#: lib/vutuv_web/templates/post_calendar/month.html.heex:69
+#, elixir-autogen, elixir-format, fuzzy
+msgid "One post"
+msgid_plural "%{formatted} posts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:36
+#: lib/vutuv_web/templates/layout/app.html.heex:79
+#: lib/vutuv_web/templates/post_calendar/day.html.heex:5
+#: lib/vutuv_web/templates/post_calendar/index.html.heex:2
+#: lib/vutuv_web/templates/post_calendar/index.html.heex:3
+#: lib/vutuv_web/templates/post_calendar/month.html.heex:5
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Post calendar"
+msgstr ""
+
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:126
+#, elixir-autogen, elixir-format
+msgid "Post not open to search engines"
+msgstr ""
+
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:59
+#, elixir-autogen, elixir-format
+msgid "Posts in %{month} %{year}"
+msgstr ""
+
+#: lib/vutuv_web/templates/post_calendar/index.html.heex:28
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Posts in %{year}"
+msgstr ""
+
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:88
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Posts on %{date}"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/list_docs.ex:280
+#, elixir-autogen, elixir-format
+msgid "The posts written that day."
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/list_docs.ex:248
+#, elixir-autogen, elixir-format
+msgid "The posts written that month, by day."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -12,7 +12,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: lib/vutuv_web/controllers/page_controller.ex:241
-#: lib/vutuv_web/templates/layout/app.html.heex:117
+#: lib/vutuv_web/templates/layout/app.html.heex:118
 #, elixir-autogen
 msgid "About us"
 msgstr "Note legali"
@@ -102,10 +102,10 @@ msgstr "Immagine del profilo"
 msgid "Birthdate"
 msgstr "Data di nascita"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:629
-#: lib/vutuv_web/agent_docs/markdown.ex:630
-#: lib/vutuv_web/agent_docs/text.ex:592
-#: lib/vutuv_web/agent_docs/text.ex:593
+#: lib/vutuv_web/agent_docs/markdown.ex:676
+#: lib/vutuv_web/agent_docs/markdown.ex:677
+#: lib/vutuv_web/agent_docs/text.ex:636
+#: lib/vutuv_web/agent_docs/text.ex:637
 #: lib/vutuv_web/templates/user/show.html.heex:1132
 #, elixir-autogen
 msgid "Birthday"
@@ -306,14 +306,14 @@ msgstr "Esperienza"
 msgid "Fax"
 msgstr "Fax"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:615
+#: lib/vutuv_web/agent_docs/markdown.ex:662
 #: lib/vutuv_web/templates/user/edit.html.heex:164
 #, elixir-autogen
 msgid "First Name"
 msgstr "Nome"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:650
-#: lib/vutuv_web/agent_docs/text.ex:613
+#: lib/vutuv_web/agent_docs/markdown.ex:697
+#: lib/vutuv_web/agent_docs/text.ex:657
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
@@ -323,8 +323,8 @@ msgstr "Nome"
 msgid "Followers"
 msgstr "Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:651
-#: lib/vutuv_web/agent_docs/text.ex:614
+#: lib/vutuv_web/agent_docs/markdown.ex:698
+#: lib/vutuv_web/agent_docs/text.ex:658
 #: lib/vutuv_web/components/fediverse_components.ex:468
 #: lib/vutuv_web/components/ui.ex:2964
 #: lib/vutuv_web/components/ui.ex:2999
@@ -359,7 +359,10 @@ msgstr "Inizi subito: bastano 30 secondi."
 
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:4
-#: lib/vutuv_web/templates/layout/app.html.heex:156
+#: lib/vutuv_web/templates/layout/app.html.heex:157
+#: lib/vutuv_web/templates/post_calendar/day.html.heex:4
+#: lib/vutuv_web/templates/post_calendar/index.html.heex:3
+#: lib/vutuv_web/templates/post_calendar/month.html.heex:4
 #, elixir-autogen
 msgid "Home"
 msgstr "Home"
@@ -382,7 +385,7 @@ msgstr "Qualifica"
 msgid "Language"
 msgstr "Lingua"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:617
+#: lib/vutuv_web/agent_docs/markdown.ex:664
 #: lib/vutuv_web/templates/user/edit.html.heex:169
 #, elixir-autogen
 msgid "Last Name"
@@ -441,15 +444,15 @@ msgstr "Accedi"
 msgid "Log Out"
 msgstr "Esci"
 
-#: lib/vutuv_web/live/shell_live.ex:1608
-#: lib/vutuv_web/live/shell_live.ex:1684
+#: lib/vutuv_web/live/shell_live.ex:1561
+#: lib/vutuv_web/live/shell_live.ex:1637
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
 msgid "Log in"
 msgstr "Accedi"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:616
+#: lib/vutuv_web/agent_docs/markdown.ex:663
 #: lib/vutuv_web/templates/user/edit.html.heex:174
 #, elixir-autogen
 msgid "Middle Name"
@@ -486,7 +489,7 @@ msgstr "Nome"
 msgid "New"
 msgstr "Nuovo"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:619
+#: lib/vutuv_web/agent_docs/markdown.ex:666
 #: lib/vutuv_web/templates/user/edit.html.heex:179
 #, elixir-autogen
 msgid "Nickname"
@@ -567,7 +570,7 @@ msgstr "Numero di telefono eliminato."
 msgid "Phone number updated successfully."
 msgstr "Numero di telefono aggiornato."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:614
+#: lib/vutuv_web/agent_docs/markdown.ex:661
 #: lib/vutuv_web/templates/user/edit.html.heex:184
 #, elixir-autogen
 msgid "Prefix"
@@ -647,13 +650,13 @@ msgstr "Salva"
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
-#: lib/vutuv_web/live/shell_live.ex:1477
-#: lib/vutuv_web/live/shell_live.ex:1664
+#: lib/vutuv_web/live/shell_live.ex:1430
+#: lib/vutuv_web/live/shell_live.ex:1617
 #: lib/vutuv_web/live/tag_live/timeline.ex:333
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
-#: lib/vutuv_web/templates/layout/app.html.heex:161
+#: lib/vutuv_web/templates/layout/app.html.heex:162
 #, elixir-autogen
 msgid "Search"
 msgstr "Cerca"
@@ -746,7 +749,7 @@ msgstr "Qualcosa è andato storto"
 msgid "Submit a bugreport or a feature request."
 msgstr "Segnali un problema o proponga una funzione."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:618
+#: lib/vutuv_web/agent_docs/markdown.ex:665
 #: lib/vutuv_web/templates/user/edit.html.heex:189
 #, elixir-autogen
 msgid "Suffix"
@@ -1161,7 +1164,7 @@ msgstr "Aggiungi localizzazione"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:63
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1584
+#: lib/vutuv_web/live/shell_live.ex:1537
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1371,11 +1374,11 @@ msgid "Tag urls"
 msgstr "URL dei tag"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
-#: lib/vutuv_web/agent_docs/markdown.ex:522
-#: lib/vutuv_web/agent_docs/markdown.ex:1163
+#: lib/vutuv_web/agent_docs/markdown.ex:569
+#: lib/vutuv_web/agent_docs/markdown.ex:1210
 #: lib/vutuv_web/agent_docs/text.ex:31
-#: lib/vutuv_web/agent_docs/text.ex:540
-#: lib/vutuv_web/agent_docs/text.ex:806
+#: lib/vutuv_web/agent_docs/text.ex:584
+#: lib/vutuv_web/agent_docs/text.ex:850
 #: lib/vutuv_web/components/ui.ex:5004
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
@@ -1603,7 +1606,7 @@ msgstr "Indirizzi di %{name}"
 msgid "Admin control panel"
 msgstr "Pannello di amministrazione"
 
-#: lib/vutuv_web/live/shell_live.ex:1682
+#: lib/vutuv_web/live/shell_live.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Avvisi"
@@ -1633,8 +1636,8 @@ msgstr "Controlli la Sua casella di posta"
 #: lib/vutuv_web/live/post_live/composer.ex:1876
 #: lib/vutuv_web/live/post_live/composer.ex:2839
 #: lib/vutuv_web/live/post_live/composer.ex:3105
-#: lib/vutuv_web/templates/layout/app.html.heex:194
-#: lib/vutuv_web/templates/layout/app.html.heex:200
+#: lib/vutuv_web/templates/layout/app.html.heex:195
+#: lib/vutuv_web/templates/layout/app.html.heex:201
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:28
 #: lib/vutuv_web/views/layout_html.ex:142
 #, elixir-autogen, elixir-format
@@ -1654,7 +1657,7 @@ msgid "Confirm account deletion"
 msgstr "Confermi l'eliminazione dell'account"
 
 #: lib/vutuv_web/controllers/page_controller.ex:245
-#: lib/vutuv_web/templates/layout/app.html.heex:123
+#: lib/vutuv_web/templates/layout/app.html.heex:124
 #: lib/vutuv_web/templates/page/index.html.heex:321
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
@@ -1662,7 +1665,7 @@ msgid "Datenschutzerklärung"
 msgstr "Informativa sulla privacy"
 
 #: lib/vutuv_web/controllers/page_controller.ex:251
-#: lib/vutuv_web/templates/layout/app.html.heex:124
+#: lib/vutuv_web/templates/layout/app.html.heex:125
 #: lib/vutuv_web/templates/page/index.html.heex:321
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
@@ -1722,7 +1725,7 @@ msgstr ""
 "Sembra che non segua ancora nessuno. Apra il profilo di una persona che "
 "conosce o che La incuriosisce e prema il pulsante «Segui»."
 
-#: lib/vutuv_web/live/shell_live.ex:1603
+#: lib/vutuv_web/live/shell_live.ex:1556
 #: lib/vutuv_web/views/settings_html.ex:311
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1754,9 +1757,9 @@ msgstr "Messaggio"
 #: lib/vutuv_web/controllers/page_controller.ex:218
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1495
-#: lib/vutuv_web/live/shell_live.ex:1681
-#: lib/vutuv_web/templates/layout/app.html.heex:158
+#: lib/vutuv_web/live/shell_live.ex:1448
+#: lib/vutuv_web/live/shell_live.ex:1634
+#: lib/vutuv_web/templates/layout/app.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Messaggi"
@@ -1787,8 +1790,8 @@ msgstr "Ancora nessuna novità."
 #: lib/vutuv_web/controllers/page_controller.ex:219
 #: lib/vutuv_web/live/notification_live/index.ex:152
 #: lib/vutuv_web/live/notification_live/index.ex:457
-#: lib/vutuv_web/live/shell_live.ex:1507
-#: lib/vutuv_web/templates/layout/app.html.heex:159
+#: lib/vutuv_web/live/shell_live.ex:1460
+#: lib/vutuv_web/templates/layout/app.html.heex:160
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Notifications"
@@ -1816,12 +1819,12 @@ msgid "Send"
 msgstr "Invia"
 
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:35
-#: lib/vutuv_web/templates/layout/app.html.heex:87
+#: lib/vutuv_web/templates/layout/app.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "Source"
 msgstr "Codice sorgente"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:90
+#: lib/vutuv_web/templates/layout/app.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Submit a bug report or feature request"
 msgstr "Segnali un problema o proponga una funzione"
@@ -2149,9 +2152,9 @@ msgstr "Modifica il post"
 #: lib/vutuv_web/live/post_live/feed.ex:345
 #: lib/vutuv_web/live/post_live/feed.ex:3114
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1290
-#: lib/vutuv_web/live/shell_live.ex:1654
-#: lib/vutuv_web/templates/layout/app.html.heex:157
+#: lib/vutuv_web/live/shell_live.ex:1282
+#: lib/vutuv_web/live/shell_live.ex:1607
+#: lib/vutuv_web/templates/layout/app.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Feed"
 msgstr "Feed"
@@ -2329,7 +2332,7 @@ msgid "Upload failed."
 msgstr "Caricamento non riuscito."
 
 #: lib/vutuv_web/components/ui.ex:5373
-#: lib/vutuv_web/live/shell_live.ex:1550
+#: lib/vutuv_web/live/shell_live.ex:1503
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:258
@@ -2419,11 +2422,11 @@ msgstr "Tutti i post"
 msgid "Bookmark"
 msgstr "Salva"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1217
+#: lib/vutuv_web/agent_docs/markdown.ex:1264
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:525
-#: lib/vutuv_web/live/shell_live.ex:1487
-#: lib/vutuv_web/live/shell_live.ex:1555
+#: lib/vutuv_web/live/shell_live.ex:1440
+#: lib/vutuv_web/live/shell_live.ex:1508
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2439,11 +2442,11 @@ msgstr "Salvati"
 msgid "Like"
 msgstr "Mi piace"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1216
+#: lib/vutuv_web/agent_docs/markdown.ex:1263
 #: lib/vutuv_web/components/post_components.ex:6106
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:522
-#: lib/vutuv_web/live/shell_live.ex:1558
+#: lib/vutuv_web/live/shell_live.ex:1511
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2839,8 +2842,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] "+1 altro tag"
 msgstr[1] "+%{formatted} altri tag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:652
-#: lib/vutuv_web/agent_docs/text.ex:615
+#: lib/vutuv_web/agent_docs/markdown.ex:699
+#: lib/vutuv_web/agent_docs/text.ex:659
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2998,10 +3001,10 @@ msgstr "Qualcosa che i nostri amministratori dovrebbero sapere? (facoltativo)"
 msgid "Bullying or harassment"
 msgstr "Bullismo o molestie"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:347
-#: lib/vutuv_web/agent_docs/text.ex:328
+#: lib/vutuv_web/agent_docs/markdown.ex:385
+#: lib/vutuv_web/agent_docs/text.ex:365
 #: lib/vutuv_web/controllers/page_controller.ex:81
-#: lib/vutuv_web/templates/layout/app.html.heex:125
+#: lib/vutuv_web/templates/layout/app.html.heex:126
 #: lib/vutuv_web/templates/page/community.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Community guidelines"
@@ -3222,7 +3225,7 @@ msgid "Private message"
 msgstr "Messaggio privato"
 
 #: lib/vutuv_web/components/ui.ex:4973
-#: lib/vutuv_web/live/shell_live.ex:1322
+#: lib/vutuv_web/live/shell_live.ex:1314
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3955,12 +3958,12 @@ msgstr "messaggio segnalato"
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Scorra dentro il riquadro, o prema per aprire l'immagine intera."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:759
+#: lib/vutuv_web/agent_docs/markdown.ex:806
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr "%{count} conferme"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1338
+#: lib/vutuv_web/agent_docs/markdown.ex:1385
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} in questa pagina, usi ?page=N"
@@ -3974,16 +3977,16 @@ msgstr "%{count} post di %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:91
 #: lib/vutuv_web/agent_docs/markdown.ex:204
 #: lib/vutuv_web/agent_docs/markdown.ex:218
-#: lib/vutuv_web/agent_docs/markdown.ex:1163
+#: lib/vutuv_web/agent_docs/markdown.ex:1210
 #: lib/vutuv_web/agent_docs/text.ex:86
 #: lib/vutuv_web/agent_docs/text.ex:187
 #: lib/vutuv_web/agent_docs/text.ex:201
-#: lib/vutuv_web/agent_docs/text.ex:806
+#: lib/vutuv_web/agent_docs/text.ex:850
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr "%{count} in totale"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:46
+#: lib/vutuv_web/agent_docs/list_docs.ex:47
 #, elixir-autogen, elixir-format
 msgid "Followers of %{name}"
 msgstr "Follower di %{name}"
@@ -3997,28 +4000,28 @@ msgstr "Follower di %{name}"
 msgid "Images"
 msgstr "Immagini"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1181
-#: lib/vutuv_web/agent_docs/text.ex:817
+#: lib/vutuv_web/agent_docs/markdown.ex:1228
+#: lib/vutuv_web/agent_docs/text.ex:861
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr "In risposta a un post eliminato di %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1178
-#: lib/vutuv_web/agent_docs/text.ex:814
+#: lib/vutuv_web/agent_docs/markdown.ex:1225
+#: lib/vutuv_web/agent_docs/text.ex:858
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr "In risposta a un post eliminato."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1185
-#: lib/vutuv_web/agent_docs/markdown.ex:1431
-#: lib/vutuv_web/agent_docs/text.ex:821
-#: lib/vutuv_web/agent_docs/text.ex:890
+#: lib/vutuv_web/agent_docs/markdown.ex:1232
+#: lib/vutuv_web/agent_docs/markdown.ex:1478
+#: lib/vutuv_web/agent_docs/text.ex:865
+#: lib/vutuv_web/agent_docs/text.ex:934
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr "In risposta a un post di %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:587
-#: lib/vutuv_web/agent_docs/text.ex:578
+#: lib/vutuv_web/agent_docs/markdown.ex:634
+#: lib/vutuv_web/agent_docs/text.ex:622
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr "Membro da"
@@ -4029,7 +4032,7 @@ msgstr "Membro da"
 msgid "Most endorsed members"
 msgstr "Membri più confermati"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:47
+#: lib/vutuv_web/agent_docs/list_docs.ex:48
 #, elixir-autogen, elixir-format
 msgid "People %{name} follows"
 msgstr "Persone seguite da %{name}"
@@ -4057,23 +4060,23 @@ msgstr "Post di %{name}"
 msgid "Posts (%{count} total)"
 msgstr "Post (%{count} in totale)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:581
-#: lib/vutuv_web/agent_docs/text.ex:572
+#: lib/vutuv_web/agent_docs/markdown.ex:628
+#: lib/vutuv_web/agent_docs/text.ex:616
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr "Profilo verificato: sì"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1109
+#: lib/vutuv_web/agent_docs/markdown.ex:1156
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr "ripubblicato da %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:971
+#: lib/vutuv_web/agent_docs/markdown.ex:1018
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr "oggi"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:972
+#: lib/vutuv_web/agent_docs/markdown.ex:1019
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr "fino al %{date}"
@@ -4083,7 +4086,7 @@ msgstr "fino al %{date}"
 msgid "This page in %{language}: %{url}"
 msgstr "Questa pagina in %{language}: %{url}"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:48
+#: lib/vutuv_web/agent_docs/list_docs.ex:49
 #, elixir-autogen, elixir-format
 msgid "Connections of %{name}"
 msgstr "Collegamenti di %{name}"
@@ -4128,7 +4131,7 @@ msgstr "Testo della pubblicità"
 #: lib/vutuv_web/templates/ad/index.html.heex:7
 #: lib/vutuv_web/templates/ad/new.html.heex:4
 #: lib/vutuv_web/templates/ad/preview.html.heex:2
-#: lib/vutuv_web/templates/layout/app.html.heex:115
+#: lib/vutuv_web/templates/layout/app.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "Advertising"
 msgstr "Pubblicità"
@@ -4151,8 +4154,8 @@ msgstr ""
 msgid "Billing name"
 msgstr "Intestazione della fattura"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:361
-#: lib/vutuv_web/agent_docs/text.ex:336
+#: lib/vutuv_web/agent_docs/markdown.ex:399
+#: lib/vutuv_web/agent_docs/text.ex:373
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr "Prenoti online (serve l'accesso): %{url}"
@@ -4205,8 +4208,8 @@ msgstr "Giorno"
 msgid "Markdown is supported. At most %{max} characters."
 msgstr "Markdown è supportato. Al massimo %{max} caratteri."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:351
-#: lib/vutuv_web/agent_docs/text.ex:332
+#: lib/vutuv_web/agent_docs/markdown.ex:389
+#: lib/vutuv_web/agent_docs/text.ex:369
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4223,8 +4226,8 @@ msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr ""
 "Una sola pubblicità di solo testo al giorno, vista da tutti i visitatori."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:348
-#: lib/vutuv_web/agent_docs/text.ex:329
+#: lib/vutuv_web/agent_docs/markdown.ex:386
+#: lib/vutuv_web/agent_docs/text.ex:366
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4459,14 +4462,14 @@ msgstr "prenotata il"
 msgid "deleted account"
 msgstr "account eliminato"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:353
-#: lib/vutuv_web/agent_docs/text.ex:334
+#: lib/vutuv_web/agent_docs/markdown.ex:391
+#: lib/vutuv_web/agent_docs/text.ex:371
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr "Già prenotato"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:349
-#: lib/vutuv_web/agent_docs/text.ex:330
+#: lib/vutuv_web/agent_docs/markdown.ex:387
+#: lib/vutuv_web/agent_docs/text.ex:367
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr "Periodo di prenotazione"
@@ -4765,8 +4768,8 @@ msgid "Not an exact match, but sounds like your search."
 msgstr "Non è una corrispondenza esatta, ma somiglia alla Sua ricerca."
 
 #: lib/vutuv_web/agent_docs/investors_doc.ex:212
-#: lib/vutuv_web/agent_docs/markdown.ex:463
-#: lib/vutuv_web/agent_docs/text.ex:481
+#: lib/vutuv_web/agent_docs/markdown.ex:510
+#: lib/vutuv_web/agent_docs/text.ex:525
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/notification_live/index.ex:657
 #: lib/vutuv_web/live/notification_live/index.ex:1350
@@ -4880,7 +4883,7 @@ msgstr "Crei un token di accesso"
 #: lib/vutuv_web/templates/dev_app/show.html.heex:4
 #: lib/vutuv_web/templates/dev_doc/show.html.heex:14
 #: lib/vutuv_web/templates/dev_webhook/new.html.heex:4
-#: lib/vutuv_web/templates/layout/app.html.heex:84
+#: lib/vutuv_web/templates/layout/app.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Developers"
 msgstr "Sviluppatori"
@@ -5467,7 +5470,7 @@ msgstr "Consentire agli agenti IA e agli LLM di usare il mio profilo"
 msgid "API token (%{date})"
 msgstr "Token API (%{date})"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:86
+#: lib/vutuv_web/templates/layout/app.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "API documentation"
 msgstr "Documentazione dell'API"
@@ -5522,35 +5525,35 @@ msgstr "Non può più rispondere a questo post."
 msgid "Content under review"
 msgstr "Contenuto in esame"
 
-#: lib/vutuv_web/live/shell_live.ex:1537
+#: lib/vutuv_web/live/shell_live.ex:1490
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Menu dell'account"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:310
 #: lib/vutuv_web/live/admin/screenshot_live.ex:420
-#: lib/vutuv_web/templates/layout/app.html.heex:163
+#: lib/vutuv_web/templates/layout/app.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Azioni"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:173
+#: lib/vutuv_web/templates/layout/app.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Close menus and dialogs"
 msgstr "Chiudi menu e finestre"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:170
+#: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "General"
 msgstr "Generale"
 
-#: lib/vutuv_web/live/shell_live.ex:1594
-#: lib/vutuv_web/templates/layout/app.html.heex:189
+#: lib/vutuv_web/live/shell_live.ex:1547
+#: lib/vutuv_web/templates/layout/app.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
 msgstr "Scorciatoie da tastiera"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:154
+#: lib/vutuv_web/templates/layout/app.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "Navigation"
 msgstr "Navigazione"
@@ -5563,7 +5566,7 @@ msgstr "Navigazione"
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:276
-#: lib/vutuv_web/live/shell_live.ex:1574
+#: lib/vutuv_web/live/shell_live.ex:1527
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5577,17 +5580,17 @@ msgstr "Navigazione"
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:172
+#: lib/vutuv_web/templates/layout/app.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "Show this help"
 msgstr "Mostra questa guida"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:165
+#: lib/vutuv_web/templates/layout/app.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "Write a new post"
 msgstr "Scrivi un nuovo post"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:160
+#: lib/vutuv_web/templates/layout/app.html.heex:161
 #: lib/vutuv_web/views/page_html.ex:551
 #, elixir-autogen, elixir-format
 msgid "Your profile"
@@ -5608,18 +5611,18 @@ msgstr "Pochi passaggi veloci perché le persone La trovino e La riconoscano."
 msgid "Add a profile photo"
 msgstr "Aggiungi una foto del profilo"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:167
+#: lib/vutuv_web/templates/layout/app.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Next post in the feed"
 msgstr "Post successivo nel feed"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:168
+#: lib/vutuv_web/templates/layout/app.html.heex:169
 #, elixir-autogen, elixir-format
 msgid "Previous post in the feed"
 msgstr "Post precedente nel feed"
 
-#: lib/vutuv_web/live/shell_live.ex:1278
-#: lib/vutuv_web/live/shell_live.ex:1635
+#: lib/vutuv_web/live/shell_live.ex:1270
+#: lib/vutuv_web/live/shell_live.ex:1588
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Navigazione principale"
@@ -6362,8 +6365,8 @@ msgid_plural "%{count} years old"
 msgstr[0] "%{count} anno"
 msgstr[1] "%{count} anni"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:631
-#: lib/vutuv_web/agent_docs/text.ex:594
+#: lib/vutuv_web/agent_docs/markdown.ex:678
+#: lib/vutuv_web/agent_docs/text.ex:638
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr "Età"
@@ -6437,7 +6440,7 @@ msgstr "Apri il rapporto giornaliero"
 msgid "Previous day"
 msgstr "Giorno precedente"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1216
+#: lib/vutuv_web/agent_docs/markdown.ex:1263
 #: lib/vutuv_web/components/post_components.ex:422
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
@@ -6533,7 +6536,7 @@ msgstr ""
 msgid "Endorsed"
 msgstr "Confermato"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:140
+#: lib/vutuv_web/agent_docs/list_docs.ex:141
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Members who endorsed %{name} for %{tag}"
@@ -6553,7 +6556,7 @@ msgstr "Ancora nessuna conferma."
 msgid "and %{count} more"
 msgstr "e altri %{count}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1176
+#: lib/vutuv_web/agent_docs/markdown.ex:1223
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr "confermato il %{date}"
@@ -7802,27 +7805,27 @@ msgstr "Feed di %{name}"
 msgid "The vutuv newsfeed of %{name}"
 msgstr "Il feed di notizie vutuv di %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1343
+#: lib/vutuv_web/agent_docs/markdown.ex:1390
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr "Il Suo feed è vuoto."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1346
+#: lib/vutuv_web/agent_docs/markdown.ex:1393
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr "%{count} post in questa pagina"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1353
+#: lib/vutuv_web/agent_docs/markdown.ex:1400
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "altri post disponibili, aggiunga ?cursor=%{cursor}"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:141
+#: lib/vutuv_web/templates/layout/app.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Last change: %{date} at %{time}"
 msgstr "Aggiornato il %{date} alle %{time}"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:141
+#: lib/vutuv_web/templates/layout/app.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Last commit (Berlin time)"
 msgstr "Ultimo commit (ora di Berlino)"
@@ -8850,7 +8853,7 @@ msgstr "Non valido"
 msgid "Invalid address (skipped)"
 msgstr "Indirizzo non valido (saltato)"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:179
+#: lib/vutuv_web/agent_docs/list_docs.ex:180
 #: lib/vutuv_web/controllers/directory_controller.ex:54
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
@@ -8866,7 +8869,7 @@ msgstr "Elenco dei membri"
 msgid "Members by initial"
 msgstr "Membri per iniziale"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:202
+#: lib/vutuv_web/agent_docs/list_docs.ex:203
 #: lib/vutuv_web/controllers/directory_controller.ex:86
 #: lib/vutuv_web/templates/directory/show.html.heex:2
 #, elixir-autogen, elixir-format
@@ -8885,7 +8888,7 @@ msgid_plural "%{formatted} members"
 msgstr[0] "Un membro"
 msgstr[1] "%{formatted} membri"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:208
+#: lib/vutuv_web/agent_docs/list_docs.ex:209
 #, elixir-autogen, elixir-format
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr "La pagina %{letter} dell'elenco dei membri, ordinata per cognome."
@@ -8993,10 +8996,10 @@ msgstr "La pagina è stata pubblicata."
 msgid "Write it under Admin › Legal pages"
 msgstr "La scriva in Amministrazione › Pagine legali"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:641
-#: lib/vutuv_web/agent_docs/markdown.ex:645
-#: lib/vutuv_web/agent_docs/text.ex:604
-#: lib/vutuv_web/agent_docs/text.ex:608
+#: lib/vutuv_web/agent_docs/markdown.ex:688
+#: lib/vutuv_web/agent_docs/markdown.ex:692
+#: lib/vutuv_web/agent_docs/text.ex:648
+#: lib/vutuv_web/agent_docs/text.ex:652
 #: lib/vutuv_web/components/organization_components.ex:276
 #: lib/vutuv_web/components/ui.ex:1695
 #: lib/vutuv_web/components/ui.ex:5145
@@ -9129,13 +9132,13 @@ msgstr "Il Suo profilo come CV"
 msgid "Higher Education"
 msgstr "Istruzione universitaria"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:849
+#: lib/vutuv_web/agent_docs/markdown.ex:896
 #: lib/vutuv_web/views/education_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr "Istruzione scolastica"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:848
+#: lib/vutuv_web/agent_docs/markdown.ex:895
 #: lib/vutuv_web/views/education_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -9170,7 +9173,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] "Ripubblicato da %{name} e da %{formatted} altro"
 msgstr[1] "Ripubblicato da %{name} e da altri %{formatted}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1112
+#: lib/vutuv_web/agent_docs/markdown.ex:1159
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr "ripubblicato da %{name} e da altri %{count}"
@@ -9419,8 +9422,8 @@ msgstr "Tag d'onore"
 msgid "Honor tag (only site admins can assign it)"
 msgstr "Tag d'onore (può assegnarlo solo un amministratore del sito)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:661
-#: lib/vutuv_web/agent_docs/text.ex:622
+#: lib/vutuv_web/agent_docs/markdown.ex:708
+#: lib/vutuv_web/agent_docs/text.ex:666
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr "tag d'onore"
@@ -9844,8 +9847,8 @@ msgstr "Gallese"
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:583
-#: lib/vutuv_web/agent_docs/text.ex:574
+#: lib/vutuv_web/agent_docs/markdown.ex:630
+#: lib/vutuv_web/agent_docs/text.ex:618
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr "Situazione lavorativa"
@@ -9958,7 +9961,7 @@ msgstr[1] "%{count} certificati o abilitazioni"
 msgid "Add a certificate or license"
 msgstr "Aggiungi un certificato o un'abilitazione"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:965
+#: lib/vutuv_web/agent_docs/markdown.ex:1012
 #: lib/vutuv_web/views/qualification_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -10038,7 +10041,7 @@ msgstr "Non scade"
 msgid "Expired"
 msgstr "Scaduto"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:940
+#: lib/vutuv_web/agent_docs/markdown.ex:987
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr "ID: %{id}"
@@ -10055,7 +10058,7 @@ msgstr "Rilasciato"
 msgid "Issuer"
 msgstr "Ente rilasciante"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:964
+#: lib/vutuv_web/agent_docs/markdown.ex:1011
 #: lib/vutuv_web/views/qualification_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -10085,7 +10088,7 @@ msgstr "Documento di prova"
 msgid "Verification link"
 msgstr "Link di verifica"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:938
+#: lib/vutuv_web/agent_docs/markdown.ex:985
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr "conseguito il %{date}"
@@ -10100,7 +10103,7 @@ msgstr "ad esempio AWS Solutions Architect – Associate"
 msgid "e.g. Amazon Web Services"
 msgstr "ad esempio Amazon Web Services"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:939
+#: lib/vutuv_web/agent_docs/markdown.ex:986
 #: lib/vutuv_web/views/qualification_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "valid until %{date}"
@@ -10118,7 +10121,7 @@ msgstr ""
 msgid "Preferred"
 msgstr "Preferita"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:776
+#: lib/vutuv_web/agent_docs/markdown.ex:823
 #: lib/vutuv_web/live/section_reorder_live.ex:287
 #: lib/vutuv_web/views/language_html.ex:114
 #, elixir-autogen, elixir-format
@@ -10614,21 +10617,21 @@ msgstr ""
 "elenco stampato, digitandolo nel normale campo del PIN. Il Suo PIN via "
 "e-mail continua sempre a funzionare."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:736
+#: lib/vutuv_web/agent_docs/markdown.ex:783
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] "%{count} follower"
 msgstr[1] "%{count} follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:734
+#: lib/vutuv_web/agent_docs/markdown.ex:781
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] "%{count} repository"
 msgstr[1] "%{count} repository"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:732
+#: lib/vutuv_web/agent_docs/markdown.ex:779
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10690,12 +10693,12 @@ msgstr ""
 "Se disattivo, la scheda Social media elenca i Suoi account come semplici "
 "link."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:750
+#: lib/vutuv_web/agent_docs/markdown.ex:797
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr "ultima attività il %{date}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:737
+#: lib/vutuv_web/agent_docs/markdown.ex:784
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr "dal %{date}"
@@ -11730,8 +11733,8 @@ msgstr "Alias aggiunto."
 msgid "Alias removed."
 msgstr "Alias rimosso."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:455
-#: lib/vutuv_web/agent_docs/text.ex:474
+#: lib/vutuv_web/agent_docs/markdown.ex:502
+#: lib/vutuv_web/agent_docs/text.ex:518
 #: lib/vutuv_web/live/organization_live/edit.ex:384
 #: lib/vutuv_web/live/organization_live/show.ex:930
 #: lib/vutuv_web/templates/tag/single_card.html.heex:14
@@ -11956,8 +11959,8 @@ msgstr "in attesa"
 msgid "primary"
 msgstr "principale"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:476
-#: lib/vutuv_web/agent_docs/text.ex:494
+#: lib/vutuv_web/agent_docs/markdown.ex:523
+#: lib/vutuv_web/agent_docs/text.ex:538
 #: lib/vutuv_web/live/admin/organization_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -12086,8 +12089,8 @@ msgstr "Verifica tramite link di ritorno"
 msgid "Verify via file"
 msgstr "Verifica tramite file"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:985
-#: lib/vutuv_web/agent_docs/text.ex:750
+#: lib/vutuv_web/agent_docs/markdown.ex:1032
+#: lib/vutuv_web/agent_docs/text.ex:794
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr "pagina web verificata"
@@ -12124,8 +12127,8 @@ msgstr "Collegata a {name}"
 msgid "Remove link"
 msgstr "Rimuovi il collegamento"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:467
-#: lib/vutuv_web/agent_docs/text.ex:485
+#: lib/vutuv_web/agent_docs/markdown.ex:514
+#: lib/vutuv_web/agent_docs/text.ex:529
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr "precedente"
@@ -12351,18 +12354,18 @@ msgstr "Ruolo nell'organizzazione"
 msgid "Organization unfrozen."
 msgstr "Organizzazione sbloccata."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:446
+#: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
-#: lib/vutuv_web/agent_docs/text.ex:418
+#: lib/vutuv_web/agent_docs/text.ex:462
 #: lib/vutuv_web/components/ui.ex:5172
 #: lib/vutuv_web/controllers/settings_controller.ex:215
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:538
-#: lib/vutuv_web/live/shell_live.ex:1565
+#: lib/vutuv_web/live/shell_live.ex:1518
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
-#: lib/vutuv_web/templates/layout/app.html.heex:79
+#: lib/vutuv_web/templates/layout/app.html.heex:80
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Organizations"
@@ -12626,9 +12629,9 @@ msgid "Edit posting"
 msgstr "Modifica l'annuncio"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:282
-#: lib/vutuv_web/agent_docs/markdown.ex:507
+#: lib/vutuv_web/agent_docs/markdown.ex:554
 #: lib/vutuv_web/agent_docs/text.ex:266
-#: lib/vutuv_web/agent_docs/text.ex:525
+#: lib/vutuv_web/agent_docs/text.ex:569
 #: lib/vutuv_web/live/admin/job_live.ex:340
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
 #: lib/vutuv_web/views/account_event_text.ex:225
@@ -12642,9 +12645,9 @@ msgid "Employer name (optional)"
 msgstr "Nome del datore di lavoro (facoltativo)"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:283
-#: lib/vutuv_web/agent_docs/markdown.ex:508
+#: lib/vutuv_web/agent_docs/markdown.ex:555
 #: lib/vutuv_web/agent_docs/text.ex:267
-#: lib/vutuv_web/agent_docs/text.ex:526
+#: lib/vutuv_web/agent_docs/text.ex:570
 #: lib/vutuv_web/live/job_board_live.ex:526
 #: lib/vutuv_web/live/job_posting_live/form.ex:499
 #, elixir-autogen, elixir-format
@@ -12705,8 +12708,8 @@ msgstr "Titolo della posizione"
 #: lib/vutuv_web/live/job_board_live.ex:47
 #: lib/vutuv_web/live/job_board_live.ex:265
 #: lib/vutuv_web/live/post_live/saved.ex:541
-#: lib/vutuv_web/live/shell_live.ex:1330
-#: lib/vutuv_web/templates/layout/app.html.heex:80
+#: lib/vutuv_web/live/shell_live.ex:1322
+#: lib/vutuv_web/templates/layout/app.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Jobs"
 msgstr "Lavoro"
@@ -12716,12 +12719,12 @@ msgstr "Lavoro"
 msgid "Let search engines index this posting."
 msgstr "Consenti ai motori di ricerca di indicizzare questo annuncio."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:482
-#: lib/vutuv_web/agent_docs/markdown.ex:485
-#: lib/vutuv_web/agent_docs/markdown.ex:487
-#: lib/vutuv_web/agent_docs/text.ex:500
-#: lib/vutuv_web/agent_docs/text.ex:503
-#: lib/vutuv_web/agent_docs/text.ex:505
+#: lib/vutuv_web/agent_docs/markdown.ex:529
+#: lib/vutuv_web/agent_docs/markdown.ex:532
+#: lib/vutuv_web/agent_docs/markdown.ex:534
+#: lib/vutuv_web/agent_docs/text.ex:544
+#: lib/vutuv_web/agent_docs/text.ex:547
+#: lib/vutuv_web/agent_docs/text.ex:549
 #: lib/vutuv_web/live/job_posting_live/form.ex:549
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -12861,9 +12864,9 @@ msgid "Postal code"
 msgstr "CAP"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:287
-#: lib/vutuv_web/agent_docs/markdown.ex:512
+#: lib/vutuv_web/agent_docs/markdown.ex:559
 #: lib/vutuv_web/agent_docs/text.ex:271
-#: lib/vutuv_web/agent_docs/text.ex:530
+#: lib/vutuv_web/agent_docs/text.ex:574
 #: lib/vutuv_web/live/job_posting_live/show.ex:156
 #, elixir-autogen, elixir-format
 msgid "Posted"
@@ -12888,10 +12891,10 @@ msgstr "Pubblica"
 #: lib/vutuv/accounts/user.ex:1264
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
-#: lib/vutuv_web/agent_docs/markdown.ex:485
-#: lib/vutuv_web/agent_docs/markdown.ex:487
-#: lib/vutuv_web/agent_docs/text.ex:503
-#: lib/vutuv_web/agent_docs/text.ex:505
+#: lib/vutuv_web/agent_docs/markdown.ex:532
+#: lib/vutuv_web/agent_docs/markdown.ex:534
+#: lib/vutuv_web/agent_docs/text.ex:547
+#: lib/vutuv_web/agent_docs/text.ex:549
 #: lib/vutuv_web/components/job_components.ex:140
 #: lib/vutuv_web/components/job_components.ex:141
 #, elixir-autogen, elixir-format
@@ -12912,9 +12915,9 @@ msgid "Required"
 msgstr "Richiesto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:286
-#: lib/vutuv_web/agent_docs/markdown.ex:511
+#: lib/vutuv_web/agent_docs/markdown.ex:558
 #: lib/vutuv_web/agent_docs/text.ex:270
-#: lib/vutuv_web/agent_docs/text.ex:529
+#: lib/vutuv_web/agent_docs/text.ex:573
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr "Retribuzione"
@@ -13014,9 +13017,9 @@ msgid "Working student"
 msgstr "Studente lavoratore"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:284
-#: lib/vutuv_web/agent_docs/markdown.ex:509
+#: lib/vutuv_web/agent_docs/markdown.ex:556
 #: lib/vutuv_web/agent_docs/text.ex:268
-#: lib/vutuv_web/agent_docs/text.ex:527
+#: lib/vutuv_web/agent_docs/text.ex:571
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
 #, elixir-autogen, elixir-format
 msgid "Workplace"
@@ -13244,13 +13247,13 @@ msgstr "%{km} km"
 msgid "All countries"
 msgstr "Tutti i paesi"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:530
+#: lib/vutuv_web/agent_docs/markdown.ex:577
 #: lib/vutuv_web/templates/tag/show.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr "Tutti gli annunci con questo tag"
 
-#: lib/vutuv_web/agent_docs/text.ex:547
+#: lib/vutuv_web/agent_docs/text.ex:591
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr "Tutti gli annunci con questo tag: %{url}"
@@ -13316,10 +13319,10 @@ msgstr "Ancora nessun annuncio di lavoro."
 msgid "No matching positions. Try adjusting the filters."
 msgstr "Nessuna posizione corrispondente. Provi a modificare i filtri."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:528
-#: lib/vutuv_web/agent_docs/markdown.ex:540
-#: lib/vutuv_web/agent_docs/text.ex:545
-#: lib/vutuv_web/agent_docs/text.ex:557
+#: lib/vutuv_web/agent_docs/markdown.ex:575
+#: lib/vutuv_web/agent_docs/markdown.ex:587
+#: lib/vutuv_web/agent_docs/text.ex:589
+#: lib/vutuv_web/agent_docs/text.ex:601
 #: lib/vutuv_web/live/organization_live/show.ex:833
 #: lib/vutuv_web/templates/tag/show.html.heex:78
 #, elixir-autogen, elixir-format
@@ -14325,7 +14328,7 @@ msgstr "ha aggiunto %{count} nuove voci al proprio CV:"
 msgid "Audiobook"
 msgstr "Audiolibro"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1305
+#: lib/vutuv_web/agent_docs/markdown.ex:1352
 #: lib/vutuv_web/components/post_components.ex:5565
 #, elixir-autogen, elixir-format
 msgid "Book review"
@@ -14346,7 +14349,7 @@ msgstr "DVD/Blu-ray"
 msgid "E-book"
 msgstr "E-book"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1305
+#: lib/vutuv_web/agent_docs/markdown.ex:1352
 #: lib/vutuv_web/components/post_components.ex:5564
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -14438,7 +14441,7 @@ msgstr "Certificazione"
 msgid "With qualification:"
 msgstr "Con certificazione:"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:805
+#: lib/vutuv_web/agent_docs/markdown.ex:852
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr "Con certificazione: %{name}"
@@ -14503,7 +14506,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] "Confermato da %{name} e da %{formatted} altro"
 msgstr[1] "Confermato da %{name} e da altri %{formatted}"
 
-#: lib/vutuv_web/live/shell_live.ex:707
+#: lib/vutuv_web/live/shell_live.ex:699
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -14527,19 +14530,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] "Usato per %{formatted} impiego"
 msgstr[1] "Usato per %{formatted} impieghi"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:954
+#: lib/vutuv_web/agent_docs/markdown.ex:1001
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr "attualmente in uso"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:953
+#: lib/vutuv_web/agent_docs/markdown.ex:1000
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] "usato per %{count} impiego"
 msgstr[1] "usato per %{count} impieghi"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:959
+#: lib/vutuv_web/agent_docs/markdown.ex:1006
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -14623,8 +14626,8 @@ msgstr "Prova caricata per %{name}"
 msgid "View the uploaded proof (%{label})"
 msgstr "Vedi la prova caricata (%{label})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:891
-#: lib/vutuv_web/agent_docs/text.ex:729
+#: lib/vutuv_web/agent_docs/markdown.ex:938
+#: lib/vutuv_web/agent_docs/text.ex:773
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr "documento di prova"
@@ -14687,8 +14690,8 @@ msgstr "Come vuole lavorare?"
 msgid "Skip for now"
 msgstr "Salta per ora"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:585
-#: lib/vutuv_web/agent_docs/text.ex:576
+#: lib/vutuv_web/agent_docs/markdown.ex:632
+#: lib/vutuv_web/agent_docs/text.ex:620
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr "Modalità di lavoro preferita"
@@ -15350,7 +15353,7 @@ msgstr "%{blocked} server bloccati, il più attivo in entrata: %{host}."
 msgid "none yet"
 msgstr "ancora nessuno"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1252
+#: lib/vutuv_web/agent_docs/markdown.ex:1299
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr "Reazioni da altre reti"
@@ -15777,8 +15780,8 @@ msgstr ""
 msgid "Your server"
 msgstr "Il Suo server"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:642
-#: lib/vutuv_web/agent_docs/text.ex:605
+#: lib/vutuv_web/agent_docs/markdown.ex:689
+#: lib/vutuv_web/agent_docs/text.ex:649
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr "spostato a %{address}"
@@ -16188,7 +16191,7 @@ msgid_plural "%{formatted} reposts"
 msgstr[0] "%{formatted} ripubblicazione"
 msgstr[1] "%{formatted} ripubblicazioni"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1254
+#: lib/vutuv_web/agent_docs/markdown.ex:1301
 #: lib/vutuv_web/components/post_components.ex:6010
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
@@ -16204,10 +16207,10 @@ msgstr ""
 " se l'autore la elimina, sparisce anche la nostra. Può rimuovere qualsiasi "
 "singola risposta, e disattivando questa opzione vengono eliminate tutte."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1194
-#: lib/vutuv_web/agent_docs/markdown.ex:1452
-#: lib/vutuv_web/agent_docs/text.ex:827
-#: lib/vutuv_web/agent_docs/text.ex:904
+#: lib/vutuv_web/agent_docs/markdown.ex:1241
+#: lib/vutuv_web/agent_docs/markdown.ex:1499
+#: lib/vutuv_web/agent_docs/text.ex:871
+#: lib/vutuv_web/agent_docs/text.ex:948
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr "Avviso sul contenuto"
@@ -16231,7 +16234,7 @@ msgstr "Rimossa dal membro"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:135
 #: lib/vutuv_web/agent_docs/markdown.ex:167
-#: lib/vutuv_web/agent_docs/markdown.ex:1253
+#: lib/vutuv_web/agent_docs/markdown.ex:1300
 #: lib/vutuv_web/agent_docs/text.ex:124
 #: lib/vutuv_web/agent_docs/text.ex:153
 #, elixir-autogen, elixir-format
@@ -16290,7 +16293,7 @@ msgstr "Grazie. La risposta è stata eliminata subito."
 msgid "That reply is not yours to remove."
 msgstr "Questa risposta non spetta a Lei rimuoverla."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1454
+#: lib/vutuv_web/agent_docs/markdown.ex:1501
 #: lib/vutuv_web/components/post_components.ex:1411
 #: lib/vutuv_web/components/post_components.ex:1611
 #: lib/vutuv_web/components/post_components.ex:3019
@@ -17027,13 +17030,13 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr "Non più fissato. Il post torna a essere un post normale."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1095
+#: lib/vutuv_web/agent_docs/markdown.ex:1142
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr "post fissato"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:579
-#: lib/vutuv_web/agent_docs/text.ex:567
+#: lib/vutuv_web/agent_docs/markdown.ex:626
+#: lib/vutuv_web/agent_docs/text.ex:611
 #: lib/vutuv_web/templates/user/edit.html.heex:219
 #: lib/vutuv_web/templates/user/show.html.heex:262
 #: lib/vutuv_web/views/account_event_text.ex:213
@@ -17085,8 +17088,8 @@ msgstr "CC BY-SA 4.0 (attribuzione, stessa licenza)"
 msgid "CC0 1.0 (no rights reserved)"
 msgstr "CC0 1.0 (nessun diritto riservato)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1371
-#: lib/vutuv_web/agent_docs/text.ex:858
+#: lib/vutuv_web/agent_docs/markdown.ex:1418
+#: lib/vutuv_web/agent_docs/text.ex:902
 #: lib/vutuv_web/live/post_live/composer.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Cover"
@@ -17097,8 +17100,8 @@ msgstr "Copertina"
 msgid "Describe the photo for people who can't see it"
 msgstr "Descriva la foto per chi non può vederla"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1382
-#: lib/vutuv_web/agent_docs/text.ex:871
+#: lib/vutuv_web/agent_docs/markdown.ex:1429
+#: lib/vutuv_web/agent_docs/text.ex:915
 #: lib/vutuv_web/components/ui.ex:3126
 #, elixir-autogen, elixir-format
 msgid "Download the original"
@@ -17157,8 +17160,8 @@ msgstr "La foto è in fase di controllo"
 msgid "Photo options"
 msgstr "Opzioni della foto"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1415
-#: lib/vutuv_web/agent_docs/text.ex:846
+#: lib/vutuv_web/agent_docs/markdown.ex:1462
+#: lib/vutuv_web/agent_docs/text.ex:890
 #: lib/vutuv_web/components/post_components.ex:4808
 #, elixir-autogen, elixir-format
 msgid "Photos:"
@@ -17345,13 +17348,13 @@ msgstr[1] ""
 "Alcune di queste foto portano con sé il luogo in cui sono state scattate, e "
 "il file esatto lo rivela."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1272
+#: lib/vutuv_web/agent_docs/markdown.ex:1319
 #: lib/vutuv_web/components/post_components.ex:6048
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "A %{handle} è piaciuto"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1270
+#: lib/vutuv_web/agent_docs/markdown.ex:1317
 #: lib/vutuv_web/components/post_components.ex:6045
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
@@ -18062,7 +18065,7 @@ msgstr "Variante"
 msgid "What is being measured"
 msgstr "Cosa viene misurato"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1072
+#: lib/vutuv_web/agent_docs/markdown.ex:1119
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
@@ -18229,8 +18232,8 @@ msgid "We could not reach the network just now. Please try again in a moment."
 msgstr ""
 "Al momento non siamo riusciti a raggiungere la rete. Riprovi tra poco."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:999
-#: lib/vutuv_web/agent_docs/text.ex:651
+#: lib/vutuv_web/agent_docs/markdown.ex:1046
+#: lib/vutuv_web/agent_docs/text.ex:695
 #, elixir-autogen, elixir-format
 msgid "verified profile"
 msgstr "profilo verificato"
@@ -18559,12 +18562,12 @@ msgstr "Riempi le caselle"
 msgid "Whole photos"
 msgstr "Foto intere"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:166
+#: lib/vutuv_web/templates/layout/app.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Send the post or message you are writing"
 msgstr "Invia il post o il messaggio che sta scrivendo"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:227
+#: lib/vutuv_web/templates/layout/app.html.heex:228
 #, elixir-autogen, elixir-format
 msgid "The single-key shortcuts pause while you type, and are off on phones and tablets."
 msgstr ""
@@ -19212,7 +19215,7 @@ msgstr ""
 "La pagina di un post mostra i membri a cui è piaciuto, subito sotto il "
 "contatore. Questa impostazione decide se Lei è tra quei volti."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1240
+#: lib/vutuv_web/agent_docs/markdown.ex:1287
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr "Piace a"
@@ -19260,12 +19263,12 @@ msgstr ""
 msgid "Your likes follow the site default again."
 msgstr "I Suoi Mi piace tornano a seguire il valore predefinito del sito."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1295
+#: lib/vutuv_web/agent_docs/markdown.ex:1342
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr "%{address} (solo questa pagina)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1292
+#: lib/vutuv_web/agent_docs/markdown.ex:1339
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr "%{address} (intero sito web)"
@@ -19275,7 +19278,7 @@ msgstr "%{address} (intero sito web)"
 msgid "Verified webpage of the author (%{address})"
 msgstr "Pagina web verificata dell'autore (%{address})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1284
+#: lib/vutuv_web/agent_docs/markdown.ex:1331
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr "Pagine web verificate dell'autore collegate qui: %{addresses}"
@@ -19629,7 +19632,7 @@ msgstr "Non abbiamo scritto né il prompt né il modello."
 msgid "Employment references of %{name}"
 msgstr "Attestati di lavoro di %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:873
+#: lib/vutuv_web/agent_docs/markdown.ex:920
 #, elixir-autogen, elixir-format
 msgid "document"
 msgstr "documento"
@@ -21136,7 +21139,7 @@ msgstr "Non può più scrivere a nome di questa organizzazione."
 msgid "A post in an organization's name is always public."
 msgstr "Un post a nome di un'organizzazione è sempre pubblico."
 
-#: lib/vutuv_web/live/shell_live.ex:1236
+#: lib/vutuv_web/live/shell_live.ex:1228
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr "Apri la pagina"
@@ -21156,7 +21159,7 @@ msgstr "Ha smesso di scrivere come organizzazione"
 msgid "Write as %{name} for now"
 msgstr "Scrivi come %{name} per ora"
 
-#: lib/vutuv_web/live/shell_live.ex:1246
+#: lib/vutuv_web/live/shell_live.ex:1238
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr "Torna a scrivere come me stesso"
@@ -21166,7 +21169,7 @@ msgstr "Torna a scrivere come me stesso"
 msgid "You are writing as %{name} now."
 msgstr "Ora sta scrivendo come %{name}."
 
-#: lib/vutuv_web/live/shell_live.ex:1222
+#: lib/vutuv_web/live/shell_live.ex:1214
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr "Sta scrivendo come %{name}."
@@ -21577,21 +21580,21 @@ msgstr "Segue già #%{tag} qui."
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr "Anche Lei è su questo vutuv, quindi ora segue #%{tag} proprio qui."
 
-#: lib/vutuv_web/live/shell_live.ex:751
+#: lib/vutuv_web/live/shell_live.ex:743
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] "%{formatted} persona"
 msgstr[1] "%{formatted} persone"
 
-#: lib/vutuv_web/live/shell_live.ex:738
+#: lib/vutuv_web/live/shell_live.ex:730
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] "persona"
 msgstr[1] "persone"
 
-#: lib/vutuv_web/live/shell_live.ex:773
+#: lib/vutuv_web/live/shell_live.ex:765
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -21871,12 +21874,12 @@ msgstr "Nessun account locale visibile ha questo handle."
 msgid "You are not allowed to change this organization."
 msgstr "Non ha i permessi per modificare questa organizzazione."
 
-#: lib/vutuv_web/templates/layout/app.html.heex:96
+#: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Company"
 msgstr "Azienda"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:121
+#: lib/vutuv_web/templates/layout/app.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Legal"
 msgstr "Note legali"
@@ -22789,7 +22792,7 @@ msgstr "Smettere di seguire %{handle}? I suoi post spariscono dal Suo feed."
 msgid "Unfollowed. Their posts leave your feed."
 msgstr "Non lo segue più. I suoi post spariscono dal Suo feed."
 
-#: lib/vutuv_web/live/shell_live.ex:1196
+#: lib/vutuv_web/live/shell_live.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr "Consenti"
@@ -22804,12 +22807,12 @@ msgstr "Chiedi ora"
 msgid "Browser notifications"
 msgstr "Notifiche del browser"
 
-#: lib/vutuv_web/live/shell_live.ex:1054
+#: lib/vutuv_web/live/shell_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr "Nuovo messaggio"
 
-#: lib/vutuv_web/live/shell_live.ex:1199
+#: lib/vutuv_web/live/shell_live.ex:1191
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Non ora"
@@ -22859,7 +22862,7 @@ msgstr ""
 "guardando, il Suo browser può mostrarlo come notifica. Disattivate finché "
 "non le attiva."
 
-#: lib/vutuv_web/live/shell_live.ex:1193
+#: lib/vutuv_web/live/shell_live.ex:1185
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -22905,12 +22908,12 @@ msgstr ""
 "Inviata. Se non è comparso nulla, è il Suo sistema a trattenerla. Controlli "
 "la modalità Non disturbare e le impostazioni delle notifiche."
 
-#: lib/vutuv_web/live/shell_live.ex:846
+#: lib/vutuv_web/live/shell_live.ex:838
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr "Notifica di prova"
 
-#: lib/vutuv_web/live/shell_live.ex:847
+#: lib/vutuv_web/live/shell_live.ex:839
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr "Ecco come si presenta vutuv quando arriva qualcosa."
@@ -23140,7 +23143,7 @@ msgstr "Traducili in %{language}"
 msgid "Translated into %{language}."
 msgstr "Vengono tradotti in %{language}."
 
-#: lib/vutuv_web/live/shell_live.ex:987
+#: lib/vutuv_web/live/shell_live.ex:979
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -23265,7 +23268,7 @@ msgstr "Nuovo messaggio su vutuv"
 msgid "No connection"
 msgstr "Nessuna connessione"
 
-#: lib/vutuv_web/live/shell_live.ex:1126
+#: lib/vutuv_web/live/shell_live.ex:1118
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr "Ricarica"
@@ -23353,7 +23356,7 @@ msgstr "Quali nomi cercare"
 msgid "All vutuv members, filed alphabetically by last name."
 msgstr "Tutti i membri vutuv, in ordine alfabetico per cognome."
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:194
+#: lib/vutuv_web/agent_docs/list_docs.ex:195
 #, elixir-autogen, elixir-format
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr "Tutti i membri vutuv, raggruppati per la prima lettera del cognome."
@@ -23757,7 +23760,7 @@ msgstr "I gestori di password come Bitwarden ne ricavano l'intera voce: nome, ac
 msgid "Scan it with the device that has the app"
 msgstr "Da scansionare con il dispositivo su cui è installata l'app"
 
-#: lib/vutuv_web/live/shell_live.ex:1108
+#: lib/vutuv_web/live/shell_live.ex:1100
 #, elixir-autogen, elixir-format
 msgid "A new version is ready."
 msgstr "È pronta una nuova versione."
@@ -23779,12 +23782,12 @@ msgstr[1] "Nuovi (%{formatted}):"
 msgid "Quoted post"
 msgstr "Post citato"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1088
+#: lib/vutuv_web/agent_docs/markdown.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Quotes %{name}: %{url}"
 msgstr "Cita %{name}: %{url}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1085
+#: lib/vutuv_web/agent_docs/markdown.ex:1132
 #, elixir-autogen, elixir-format
 msgid "Quotes %{url}"
 msgstr "Cita %{url}"
@@ -23844,6 +23847,7 @@ msgid_plural "%{formatted} shares"
 msgstr[0] "%{formatted} condivisione"
 msgstr[1] "%{formatted} condivisioni"
 
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:136
 #: lib/vutuv_web/live/notification_live/index.ex:838
 #, elixir-autogen, elixir-format
 msgid "Post without text"
@@ -24005,7 +24009,7 @@ msgstr "Se la Sua connessione è lenta o a consumo, vutuv può tralasciare le pa
 msgid "Low-bandwidth mode"
 msgstr "Modalità risparmio dati"
 
-#: lib/vutuv_web/live/shell_live.ex:1676
+#: lib/vutuv_web/live/shell_live.ex:1629
 #, elixir-autogen, elixir-format
 msgctxt "phone tab bar"
 msgid "Write"
@@ -24162,7 +24166,7 @@ msgstr "banda lento internet mobile risparmio dati volume compressione immagini 
 msgid "Appearance"
 msgstr "Aspetto"
 
-#: lib/vutuv_web/live/shell_live.ex:1702
+#: lib/vutuv_web/live/shell_live.ex:1655
 #, elixir-autogen, elixir-format
 msgid "%{count} video in progress"
 msgid_plural "%{count} videos in progress"
@@ -24266,10 +24270,10 @@ msgstr "Questo post La sta ancora aspettando"
 msgid "This video could not be converted."
 msgstr "Questo video non può essere convertito."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1367
-#: lib/vutuv_web/agent_docs/markdown.ex:1370
-#: lib/vutuv_web/agent_docs/text.ex:855
-#: lib/vutuv_web/agent_docs/text.ex:856
+#: lib/vutuv_web/agent_docs/markdown.ex:1414
+#: lib/vutuv_web/agent_docs/markdown.ex:1417
+#: lib/vutuv_web/agent_docs/text.ex:899
+#: lib/vutuv_web/agent_docs/text.ex:900
 #: lib/vutuv_web/components/post_components.ex:2501
 #: lib/vutuv_web/components/video_components.ex:126
 #: lib/vutuv_web/live/post_live/composer.ex:2458
@@ -24394,22 +24398,22 @@ msgstr "Membri con questi tag:"
 msgid "The fields the most members carry, and how many of them do."
 msgstr "Gli ambiti con più membri, e quanti sono per ciascuno."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1138
-#: lib/vutuv_web/agent_docs/text.ex:779
+#: lib/vutuv_web/agent_docs/markdown.ex:1185
+#: lib/vutuv_web/agent_docs/text.ex:823
 #: lib/vutuv_web/live/job_board_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "What members here work on"
 msgstr "Di cosa si occupano i membri qui"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1130
-#: lib/vutuv_web/agent_docs/text.ex:771
+#: lib/vutuv_web/agent_docs/markdown.ex:1177
+#: lib/vutuv_web/agent_docs/text.ex:815
 #: lib/vutuv_web/live/job_board_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "Who you would reach"
 msgstr "Chi raggiungerebbe"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1131
-#: lib/vutuv_web/agent_docs/text.ex:772
+#: lib/vutuv_web/agent_docs/markdown.ex:1178
+#: lib/vutuv_web/agent_docs/text.ex:816
 #: lib/vutuv_web/live/job_board_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "One random vutuv account that is open to offers."
@@ -24417,7 +24421,7 @@ msgid_plural "%{formatted} random vutuv accounts that are open to offers."
 msgstr[0] "Un account vutuv scelto a caso, aperto a proposte."
 msgstr[1] "%{formatted} account vutuv scelti a caso, aperti a proposte."
 
-#: lib/vutuv_web/live/shell_live.ex:721
+#: lib/vutuv_web/live/shell_live.ex:713
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post in your feed"
 msgid_plural "%{formatted} new posts in your feed"
@@ -24502,7 +24506,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/investors_doc.ex:295
 #: lib/vutuv_web/controllers/company_controller.ex:56
-#: lib/vutuv_web/templates/layout/app.html.heex:110
+#: lib/vutuv_web/templates/layout/app.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "Investors"
 msgstr ""
@@ -24512,14 +24516,13 @@ msgstr ""
 msgid "Over these %{days} days %{total} people arrived, %{members} of them as members here."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1415
 #: lib/vutuv_web/views/company_html.ex:76
 #, elixir-autogen, elixir-format
 msgid "People here per day over the last %{days} days"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:392
-#: lib/vutuv_web/agent_docs/text.ex:362
+#: lib/vutuv_web/agent_docs/markdown.ex:430
+#: lib/vutuv_web/agent_docs/text.ex:399
 #, elixir-autogen, elixir-format
 msgid "Press material: %{url}"
 msgstr ""
@@ -24534,28 +24537,28 @@ msgstr ""
 msgid "Send a message"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:375
-#: lib/vutuv_web/agent_docs/text.ex:349
+#: lib/vutuv_web/agent_docs/markdown.ex:413
+#: lib/vutuv_web/agent_docs/text.ex:386
 #: lib/vutuv_web/templates/company/investors.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Where we are"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:382
-#: lib/vutuv_web/agent_docs/text.ex:356
+#: lib/vutuv_web/agent_docs/markdown.ex:420
+#: lib/vutuv_web/agent_docs/text.ex:393
 #: lib/vutuv_web/templates/company/investors.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Why this is worth building"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:391
-#: lib/vutuv_web/agent_docs/text.ex:361
+#: lib/vutuv_web/agent_docs/markdown.ex:429
+#: lib/vutuv_web/agent_docs/text.ex:398
 #, elixir-autogen, elixir-format
 msgid "Write here: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:388
-#: lib/vutuv_web/agent_docs/text.ex:358
+#: lib/vutuv_web/agent_docs/markdown.ex:426
+#: lib/vutuv_web/agent_docs/text.ex:395
 #: lib/vutuv_web/templates/company/investors.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Write to me"
@@ -24571,8 +24574,8 @@ msgstr ""
 msgid "My profile:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:390
-#: lib/vutuv_web/agent_docs/text.ex:360
+#: lib/vutuv_web/agent_docs/markdown.ex:428
+#: lib/vutuv_web/agent_docs/text.ex:397
 #, elixir-autogen, elixir-format
 msgid "My profile: %{url}"
 msgstr ""
@@ -24592,8 +24595,8 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:442
-#: lib/vutuv_web/agent_docs/text.ex:411
+#: lib/vutuv_web/agent_docs/markdown.ex:485
+#: lib/vutuv_web/agent_docs/text.ex:452
 #, elixir-autogen, elixir-format
 msgid "Source: %{source}"
 msgstr ""
@@ -24719,3 +24722,76 @@ msgstr "silenzia silenziare nascondere account ripubblicazioni boost feed"
 #, elixir-autogen, elixir-format
 msgid "muted on the follow itself"
 msgstr "silenziato direttamente dove lo segue"
+
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:40
+#, elixir-autogen, elixir-format
+msgid "Every public post on vutuv, filed under the day it was written."
+msgstr ""
+
+#: lib/vutuv_web/templates/post_calendar/month.html.heex:16
+#, elixir-autogen, elixir-format
+msgid "Neighbouring months"
+msgstr ""
+
+#: lib/vutuv_web/templates/post_calendar/month.html.heex:80
+#, elixir-autogen, elixir-format
+msgid "No posts in this month yet."
+msgstr ""
+
+#: lib/vutuv_web/templates/post_calendar/day.html.heex:18
+#, elixir-autogen, elixir-format
+msgid "No posts on this day."
+msgstr ""
+
+#: lib/vutuv_web/templates/post_calendar/index.html.heex:16
+#, elixir-autogen, elixir-format
+msgid "Nothing has been written here yet."
+msgstr ""
+
+#: lib/vutuv_web/templates/post_calendar/day.html.heex:14
+#: lib/vutuv_web/templates/post_calendar/month.html.heex:69
+#, elixir-autogen, elixir-format
+msgid "One post"
+msgid_plural "%{formatted} posts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:36
+#: lib/vutuv_web/templates/layout/app.html.heex:79
+#: lib/vutuv_web/templates/post_calendar/day.html.heex:5
+#: lib/vutuv_web/templates/post_calendar/index.html.heex:2
+#: lib/vutuv_web/templates/post_calendar/index.html.heex:3
+#: lib/vutuv_web/templates/post_calendar/month.html.heex:5
+#, elixir-autogen, elixir-format
+msgid "Post calendar"
+msgstr ""
+
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:126
+#, elixir-autogen, elixir-format
+msgid "Post not open to search engines"
+msgstr ""
+
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:59
+#, elixir-autogen, elixir-format
+msgid "Posts in %{month} %{year}"
+msgstr ""
+
+#: lib/vutuv_web/templates/post_calendar/index.html.heex:28
+#, elixir-autogen, elixir-format
+msgid "Posts in %{year}"
+msgstr ""
+
+#: lib/vutuv_web/controllers/post_calendar_controller.ex:88
+#, elixir-autogen, elixir-format
+msgid "Posts on %{date}"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/list_docs.ex:280
+#, elixir-autogen, elixir-format
+msgid "The posts written that day."
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/list_docs.ex:248
+#, elixir-autogen, elixir-format
+msgid "The posts written that month, by day."
+msgstr ""

--- a/priv/repo/migrations/20260905063748_add_posts_published_on_index.exs
+++ b/priv/repo/migrations/20260905063748_add_posts_published_on_index.exs
@@ -1,0 +1,26 @@
+defmodule Vutuv.Repo.Migrations.AddPostsPublishedOnIndex do
+  use Ecto.Migration
+
+  @moduledoc """
+  The index the post calendar (`/system/posts`) reads by.
+
+  `posts_user_id_published_on_index` exists, but `published_on` is its *second*
+  column and Postgres 17 has no btree skip scan, so a query that names the day
+  and not the author walks the whole index. Measured against the dev copy of
+  production (768 posts): the calendar's prev/next month lookup — an
+  `ORDER BY published_on DESC LIMIT 1` that runs twice per month page — cost 312
+  shared buffers as a sequential scan and 9 with this index, an early-stopping
+  index scan. That gap grows with the archive; the page is linked from every
+  footer.
+
+  `id` rides along so the day page's `published_on = $1 ORDER BY id` is one
+  ordered walk, and because a btree scans backwards, the same index serves the
+  previous-month lookup without a `DESC` twin.
+
+  A plain addition: N-1 compatible in one deploy.
+  """
+
+  def change do
+    create(index(:posts, [:published_on, :id]))
+  end
+end

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -1154,6 +1154,42 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     assert Jason.decode!(rendered.json)["type"] == "listing"
   end
 
+  test "post calendar overview and day page in every format", %{user: user} do
+    today = Vutuv.BerlinTime.today()
+    insert(:post, user: user, published_on: today, body: "A calendar entry worth indexing")
+
+    overview = formats_for("/system/posts")
+    assert_fact_everywhere(overview, "/system/posts/#{today.year}/#{today.month}")
+    assert Jason.decode!(overview.json)["type"] == "post_calendar"
+
+    day = formats_for("/system/posts/#{today.year}/#{today.month}/#{today.day}")
+    assert_fact_everywhere(day, "A calendar entry worth indexing")
+    assert_fact_everywhere(day, "Gradient")
+    assert Jason.decode!(day.json)["type"] == "post_calendar_day"
+  end
+
+  test "an opted-out author's post is named in every format and quoted in none" do
+    # The calendar lists the row so the day's count adds up, and drops the
+    # permalink and the first line — the whole point of the opt-out. A document
+    # that carried either would be the page's own restraint leaking out the
+    # side, which is exactly what this asserts across all four formats.
+    today = Vutuv.BerlinTime.today()
+    opted_out = insert_activated_user(last_name: "Optout", noindex?: true)
+    post = insert(:post, user: opted_out, published_on: today, body: "Words nobody may index")
+
+    rendered = formats_for("/system/posts/#{today.year}/#{today.month}/#{today.day}")
+
+    assert_fact_everywhere(rendered, "Optout")
+
+    for {format, body} <- rendered do
+      refute body =~ "Words nobody may index",
+             "an opted-out member's post was quoted in the #{format} version"
+
+      refute body =~ post.id,
+             "an opted-out member's post was linked in the #{format} version"
+    end
+  end
+
   test "every profile section page serves its facts in all formats", %{tag: tag} do
     facts = %{
       work_experiences: ["Bridge Engineer", "Span AG", "Building things"],

--- a/test/vutuv_web/controllers/post_calendar_controller_test.exs
+++ b/test/vutuv_web/controllers/post_calendar_controller_test.exs
@@ -1,0 +1,246 @@
+defmodule VutuvWeb.PostCalendarControllerTest do
+  @moduledoc """
+  The public post calendar (`/system/posts`, `/system/posts/:year/:month` and
+  `/system/posts/:year/:month/:day`): the crawl surface for the posts, the way
+  `/system/members` is the crawl surface for the profiles.
+
+  Two things these tests are mostly about. A day page lists **every** post
+  written that day, and only a post whose author is open to search engines
+  carries its permalink and its first line — the opt-out (`noindex?` on a
+  member, `seo?` on a page) is exactly the set `Vutuv.Sitemap` advertises, so
+  the two can never disagree about what a crawler may walk to. And a post
+  published in a page's name is listed like a member's: the nullable
+  `user_id`/`organization_id` pair drops organization rows out of any query
+  that inner-joins `users`, silently.
+  """
+
+  use VutuvWeb.ConnCase, async: true
+
+  alias Vutuv.Posts.PostDenial
+  alias Vutuv.Repo
+
+  @day ~D[2026-03-17]
+  @other_day ~D[2026-02-04]
+
+  setup do
+    author = insert_activated_user(first_name: "Greta", last_name: "Gradient")
+
+    post =
+      insert(:post,
+        user: author,
+        published_on: @day,
+        body: "A bridge over the Rhine, and how it was built"
+      )
+
+    %{author: author, post: post}
+  end
+
+  describe "GET /system/posts (the overview)" do
+    test "links every month that has posts and dims the rest", %{conn: conn} do
+      # An activated author, here and everywhere below: an unconfirmed account
+      # is listed nowhere on the site, so a post of theirs would be missing from
+      # the calendar for a reason that has nothing to do with what is under test.
+      insert(:post,
+        user: insert_activated_user(),
+        published_on: @other_day,
+        body: "Something in February"
+      )
+
+      html = get(conn, ~p"/system/posts") |> html_response(200)
+
+      assert html =~ "Post calendar"
+      assert html =~ ~p"/system/posts/2026/3"
+      assert html =~ ~p"/system/posts/2026/2"
+      # A month nobody wrote in is a muted tile, never a link into an empty page.
+      refute html =~ ~p"/system/posts/2026/7"
+    end
+
+    test "counts a post whose author opted out of search engines", %{conn: conn} do
+      # The tile count is what decides whether a month is a link, so it counts
+      # what the day page lists — not the narrower set the day page links.
+      opted_out = insert_activated_user(noindex?: true)
+      insert(:post, user: opted_out, published_on: @other_day, body: "Quiet one")
+
+      html = get(conn, ~p"/system/posts") |> html_response(200)
+
+      assert html =~ ~s(data-key="2026-02" data-count="1")
+    end
+  end
+
+  describe "GET /system/posts/:year/:month (one month)" do
+    test "links the days that have posts", %{conn: conn} do
+      html = get(conn, ~p"/system/posts/2026/3") |> html_response(200)
+
+      assert html =~ ~p"/system/posts/2026/3/17"
+      refute html =~ ~p"/system/posts/2026/3/18"
+      assert html =~ ~s(data-count="1")
+    end
+
+    test "a month with no posts renders its grid and says so", %{conn: conn} do
+      html = get(conn, ~p"/system/posts/2026/7") |> html_response(200)
+
+      assert html =~ "No posts in this month yet."
+      refute html =~ ~p"/system/posts/2026/7/1"
+    end
+
+    test "an impossible month is a 404", %{conn: conn} do
+      assert conn |> get(~p"/system/posts/2026/13") |> response(404)
+      assert conn |> get("/system/posts/notayear/3") |> response(404)
+    end
+  end
+
+  describe "GET /system/posts/:year/:month/:day (one day)" do
+    test "lists the day's posts with their permalink and first line", %{
+      conn: conn,
+      post: post,
+      author: author
+    } do
+      html = get(conn, ~p"/system/posts/2026/3/17") |> html_response(200)
+
+      assert html =~ "A bridge over the Rhine"
+      assert html =~ ~p"/#{author.username}/posts/#{post.id}"
+      assert html =~ "Gradient"
+    end
+
+    test "a post from an author who opted out is listed but never linked", %{conn: conn} do
+      opted_out = insert_activated_user(first_name: "Otto", last_name: "Opt-Out", noindex?: true)
+
+      quiet =
+        insert(:post, user: opted_out, published_on: @day, body: "Nobody may index this line")
+
+      html = get(conn, ~p"/system/posts/2026/3/17") |> html_response(200)
+
+      # Listed: the day says two posts were written, and names who wrote them.
+      assert html =~ "Opt-Out"
+      assert html =~ "Post not open to search engines"
+      # Not linked, and not quoted: a permalink here would walk a crawler
+      # straight past the opt-out, and the first line would put the post's own
+      # words on an indexable page.
+      refute html =~ ~p"/#{opted_out.username}/posts/#{quiet.id}"
+      refute html =~ "Nobody may index this line"
+    end
+
+    test "lists a post published in an organization's name", %{conn: conn} do
+      organization = insert(:organization, name: "Span AG", slug: "span-ag")
+
+      post =
+        insert(:post,
+          user: nil,
+          organization: organization,
+          published_on: @day,
+          body: "We finished the span"
+        )
+
+      html = get(conn, ~p"/system/posts/2026/3/17") |> html_response(200)
+
+      assert html =~ "Span AG"
+      assert html =~ "We finished the span"
+      assert html =~ ~p"/organizations/span-ag/posts/#{post.id}"
+    end
+
+    test "a post nobody may read is nowhere in the calendar", %{conn: conn} do
+      hidden =
+        insert(:post, user: insert_activated_user(), published_on: @day, body: "Only for a few")
+
+      Repo.insert!(%PostDenial{post_id: hidden.id, wildcard: "everyone"})
+
+      html = get(conn, ~p"/system/posts/2026/3/17") |> html_response(200)
+      refute html =~ "Only for a few"
+
+      # And it is not in the count either, or the calendar would advertise a day
+      # with one more post on it than anybody can see.
+      month = get(conn, ~p"/system/posts/2026/3") |> html_response(200)
+      assert month =~ ~s(data-count="1")
+    end
+
+    test "paginates a busy day and reaches the rest on page two", %{conn: conn} do
+      # One over a page, so page two holds exactly one post and the pager has to
+      # exist for it to be reachable at all — a crawler that never sees the
+      # second page never sees those posts.
+      per_page = Vutuv.PostCalendar.per_page()
+      author = insert_activated_user()
+
+      for n <- 1..per_page do
+        insert(:post, user: author, published_on: @day, body: "Bulk post #{n}")
+      end
+
+      first = get(conn, ~p"/system/posts/2026/3/17") |> html_response(200)
+      assert first =~ "?page=2"
+
+      second = get(conn, ~p"/system/posts/2026/3/17?page=2") |> html_response(200)
+      assert second =~ "Bulk post" or second =~ "A bridge over the Rhine"
+
+      # Every post of the day is on one page or the other.
+      for n <- 1..per_page do
+        assert first =~ "Bulk post #{n}" or second =~ "Bulk post #{n}"
+      end
+    end
+
+    test "an impossible day is a 404", %{conn: conn} do
+      assert conn |> get(~p"/system/posts/2026/2/30") |> response(404)
+    end
+  end
+
+  describe "in German" do
+    # vutuv is a German site, and `gettext.extract --merge` fuzzy-fills a new
+    # msgid with the translation of whatever string it looks similar to — this
+    # page's own labels came back as "Veröffentlicht" and "Als %{name}
+    # veröffentlichen", both of them confident nonsense that no English check
+    # would ever see. So every new German string is asserted by name.
+    setup %{conn: conn} do
+      %{conn: put_req_header(conn, "accept-language", "de-DE,de")}
+    end
+
+    test "the overview, a month and a day are German", %{conn: conn} do
+      overview = get(conn, ~p"/system/posts") |> html_response(200)
+      assert overview =~ "Beitragskalender"
+      assert overview =~ "Alle öffentlichen Beiträge auf vutuv"
+
+      month = get(conn, ~p"/system/posts/2026/3") |> html_response(200)
+      assert month =~ "Beiträge im März 2026"
+      assert month =~ "Benachbarte Monate"
+
+      day = get(conn, ~p"/system/posts/2026/3/17") |> html_response(200)
+      assert day =~ "Beiträge vom"
+      assert day =~ "Ein Beitrag"
+    end
+
+    test "an opted-out author's row says so in German", %{conn: conn} do
+      opted_out = insert_activated_user(noindex?: true)
+      insert(:post, user: opted_out, published_on: @day, body: "Nicht indexieren")
+
+      html = get(conn, ~p"/system/posts/2026/3/17") |> html_response(200)
+      assert html =~ "Beitrag ohne Freigabe für Suchmaschinen"
+    end
+  end
+
+  describe "the calendar as a crawl surface" do
+    test "the footer links it from every page", %{conn: conn} do
+      html = get(conn, ~p"/") |> html_response(200)
+      assert html =~ ~p"/system/posts"
+    end
+
+    test "the sitemap advertises the overview", %{conn: conn} do
+      xml = get(conn, ~p"/sitemaps/static.xml") |> response(200)
+      assert xml =~ "/system/posts</loc>"
+    end
+
+    test "links exactly the posts the sitemap advertises", %{conn: conn, post: post} do
+      # The two answers to "may a crawler walk to this post" have to agree, or
+      # the calendar hands a crawler a URL the sitemap deliberately withholds.
+      # They agree by construction now — both read `Identity.indexable?/1` —
+      # and this asserts it over the pair that used to be spelled twice.
+      opted_out = insert_activated_user(noindex?: true)
+      quiet = insert(:post, user: opted_out, published_on: @day, body: "Not for the index")
+
+      day = get(conn, ~p"/system/posts/2026/3/17") |> html_response(200)
+      sitemap = get(conn, ~p"/sitemaps/posts-1.xml") |> response(200)
+
+      assert day =~ post.id
+      assert sitemap =~ post.id
+
+      refute day =~ quiet.id
+      refute sitemap =~ quiet.id
+    end
+  end
+end


### PR DESCRIPTION
Nothing on this site linked to the post of somebody you do not already follow: the feed needs a login, the landing page shows screenshots, and a crawler that follows links rather than reading `/sitemap.xml` met no post at all.

`/system/posts` is the post calendar, the member directory's twin for posts: every month that has posts, `/system/posts/2026/8` as a grid of days, `/system/posts/2026/8/25` as that day's list, 50 per page. In the footer's Network column, in the sitemap, with the `.md`/`.txt`/`.json`/`.xml` siblings.

A post is linked and quoted only where its author is open to search engines. That question has one owner now, `Vutuv.Identity.indexable?/1`, which `Vutuv.Sitemap` asks as SQL; a test asserts the two agree. A post whose author opted out keeps its row so the day's count adds up, and says so instead of quoting.

Also: an index on `posts(published_on, id)`, without which the prev/next lookup scans the archive twice per month page.

Two calls I would like you to check: listing an opted-out author's row at all, and the German footer label "Beitragskalender".

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_016oiCa7PhpHvmzheVeQestR
