### PR TITLE
Document the static 502 page in front of the reverse proxy

### DIFF
--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -299,6 +299,36 @@ enable `Plug.SSL`/`force_ssl`: the blue/green deploy's health gate curls
 `Plug.SSL` would redirect and break the deploy. HSTS therefore belongs here in
 the nginx TLS terminator, which every internet install already runs.
 
+### A page for the outage the app cannot answer itself
+
+vutuv renders its own 404 and 500 (`VutuvWeb.ErrorHTML`), and the 500 tells the
+visitor that a new version takes up to `DEPLOY_MINUTES` and who to write to if
+it takes longer. But the app can only render that page while it is running. When
+it answers nothing at all — both slots down, a crash loop, an OOM — nginx sends
+its own bare "502 Bad Gateway", which names nobody. Put a static file in front
+of that:
+
+```nginx
+    error_page 502 504 @offline;
+    location @offline {
+        root /var/www/vutuv-maintenance;
+        rewrite ^ /offline.html break;
+        add_header Retry-After 60 always;
+        add_header Cache-Control "no-store" always;
+    }
+```
+
+Write `offline.html` with its styling inlined and no reference to `/assets` —
+whatever is broken, this page must not need it — and say the same thing the 500
+card says, in your own operator's name. Do **not** turn on
+`proxy_intercept_errors`: a 500 or a 404 the app rendered itself is a page with
+words on it and must reach the reader untouched.
+
+A normal deploy never gets here, since the old slot keeps serving until the new
+one passes `/health`; this is for the unplanned outage. Planned downtime is a
+separate switch and deserves its own page — ours is a `maintenance.html` behind
+`error_page 503`, gated on a file an operator touches by hand.
+
 ### Static assets (optional, but worth it on a slow link)
 
 By default every `/assets/` request is proxied to the app, which serves the


### PR DESCRIPTION
Follow-up to #2002. That PR gave the 500 page words: the site is offline, a new version takes up to `DEPLOY_MINUTES`, write to the operator if it takes longer. But the app can only render that while it is running — when it answers nothing at all, the reverse proxy sends its own bare "502 Bad Gateway", which names nobody.

The nginx section of `docs/ADMINS.md` now says how to catch that with a static file, and why `proxy_intercept_errors` must stay off: a 404 or 500 the app rendered itself is a page with words on it and has to reach the reader untouched. It also separates the two cases an operator will otherwise conflate — the unplanned outage this covers, and planned downtime, which deserves its own page behind its own switch.

The page itself is live on our production host, checked against an internal probe that proxies to a dead port.

An AI agent wrote this text in my name. I know that is problematic.

https://claude.ai/code/session_01FGdRzoLeKNYWtudYAU5grA
