### PR TITLE
The application subject loses its plus signs

### DIFF
--- a/lib/vutuv/mailto.ex
+++ b/lib/vutuv/mailto.ex
@@ -1,0 +1,31 @@
+defmodule Vutuv.Mailto do
+  @moduledoc """
+  Builds a `mailto:` URL, so the one rule that is easy to get wrong is written
+  down once.
+
+  **A `mailto:` query is percent-encoded, never form-encoded** (RFC 6068): a
+  `+` there is a literal plus sign and not a space. `URI.encode_query/1` and
+  `URI.encode_www_form/1` produce exactly that plus, so a subject built with
+  them reaches the reader as `Bewerbung:+Senior+Elixir+Developer` in every mail
+  client that follows the spec — which is most of them, Apple Mail and
+  Thunderbird included. Some webmail handlers read the `+` as a space anyway,
+  which is why the mistake survives being looked at.
+
+  It has one home because it had four: the job board's apply button, the
+  unsubscribe fallback, the operator contact on the error pages, and the media
+  kit's press address.
+  """
+
+  @doc """
+  `mailto:address`, with an optional prefilled subject.
+
+  The subject is plain text, not a pre-encoded string: encoding is this
+  function's job and doing it twice would show the reader the `%20`.
+  """
+  def to(address, subject \\ nil)
+
+  def to(address, nil) when is_binary(address), do: "mailto:" <> address
+
+  def to(address, subject) when is_binary(address) and is_binary(subject),
+    do: to(address) <> "?subject=" <> URI.encode(subject, &URI.char_unreserved?/1)
+end

--- a/lib/vutuv/notifications/emailer.ex
+++ b/lib/vutuv/notifications/emailer.ex
@@ -32,6 +32,7 @@ defmodule Vutuv.Notifications.Emailer do
   alias Vutuv.Accounts
   alias Vutuv.Accounts.User
   alias Vutuv.Identity
+  alias Vutuv.Mailto
   alias Vutuv.Notifications.Bounces
   alias Vutuv.Operator
   alias Vutuv.Organizations.Organization
@@ -51,7 +52,7 @@ defmodule Vutuv.Notifications.Emailer do
   defp from_email, do: from_address() |> elem(1)
 
   # One-click unsubscribe fallback; follows the configured From address.
-  defp unsubscribe_mailto, do: "mailto:#{from_email()}?subject=unsubscribe"
+  defp unsubscribe_mailto, do: Mailto.to(from_email(), "unsubscribe")
 
   defp from_domain, do: from_email() |> String.split("@") |> List.last()
 

--- a/lib/vutuv/operator.ex
+++ b/lib/vutuv/operator.ex
@@ -22,6 +22,8 @@ defmodule Vutuv.Operator do
   `name/0` here would hand the next author the wrong one of the two.
   """
 
+  alias Vutuv.Mailto
+
   @doc "The `{name, address}` pair, for anything that addresses an email."
   def recipient, do: Application.fetch_env!(:vutuv, :operator_recipient)
 
@@ -31,15 +33,6 @@ defmodule Vutuv.Operator do
   @doc "The address to write to."
   def contact_email, do: elem(recipient(), 1)
 
-  @doc """
-  A `mailto:` URL for that address, optionally with a prefilled subject.
-
-  The subject is percent-encoded rather than form-encoded: in a `mailto:` a
-  `+` is a literal plus and not a space (RFC 6068), so `URI.encode_query/1`
-  would hand the mail client a subject full of them.
-  """
-  def contact_mailto, do: "mailto:" <> contact_email()
-
-  def contact_mailto(subject),
-    do: contact_mailto() <> "?subject=" <> URI.encode(subject, &URI.char_unreserved?/1)
+  @doc "A `mailto:` for that address, optionally with a prefilled subject."
+  def contact_mailto(subject \\ nil), do: Mailto.to(contact_email(), subject)
 end

--- a/lib/vutuv_web/controllers/job_posting_controller.ex
+++ b/lib/vutuv_web/controllers/job_posting_controller.ex
@@ -14,6 +14,7 @@ defmodule VutuvWeb.JobPostingController do
   use VutuvWeb, :controller
 
   alias Vutuv.Jobs
+  alias Vutuv.Mailto
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.AgentDocs.JobBoardDoc
   alias VutuvWeb.AgentDocs.JobPostingDoc
@@ -113,11 +114,11 @@ defmodule VutuvWeb.JobPostingController do
   defp do_apply(conn, %{apply_kind: :email, apply_email: email} = posting, _viewer)
        when is_binary(email) do
     Jobs.increment_apply_click(posting)
-    subject = URI.encode_www_form(gettext("Application: %{title}", title: posting.title))
+    subject = gettext("Application: %{title}", title: posting.title)
 
     ControllerHelpers.hand_off(
       conn,
-      "mailto:#{email}?subject=#{subject}",
+      Mailto.to(email, subject),
       gettext("Your e-mail program opens with the subject filled in.")
     )
   end

--- a/test/vutuv/mailto_test.exs
+++ b/test/vutuv/mailto_test.exs
@@ -1,0 +1,35 @@
+defmodule Vutuv.MailtoTest do
+  @moduledoc """
+  The one rule this module exists for: a `mailto:` query is percent-encoded,
+  never form-encoded. `URI.encode_www_form/1` was what the job board's apply
+  button used, so a two-word job title reached the applicant's mail client as
+  `Bewerbung:+Senior+Elixir+Developer`.
+  """
+  use ExUnit.Case, async: true
+
+  alias Vutuv.Mailto
+
+  test "a space is %20, never a plus" do
+    url = Mailto.to("jobs@acme.example", "Application: Senior Elixir Developer")
+
+    assert url == "mailto:jobs@acme.example?subject=Application%3A%20Senior%20Elixir%20Developer"
+    refute url =~ "+"
+  end
+
+  # A plus a member really typed has to survive as a plus, which is the other
+  # half of the same rule.
+  test "a plus in the subject is encoded, not passed through" do
+    assert Mailto.to("a@b.example", "C++") == "mailto:a@b.example?subject=C%2B%2B"
+  end
+
+  test "no subject, no query" do
+    assert Mailto.to("a@b.example") == "mailto:a@b.example"
+    assert Mailto.to("a@b.example", nil) == "mailto:a@b.example"
+  end
+
+  # German subjects are the normal case here, and a mail client that is handed
+  # a raw umlaut in a URL is entitled to mangle it.
+  test "non-ASCII is escaped" do
+    assert Mailto.to("a@b.example", "Grüße") == "mailto:a@b.example?subject=Gr%C3%BC%C3%9Fe"
+  end
+end

--- a/test/vutuv_web/controllers/outbound_hand_off_test.exs
+++ b/test/vutuv_web/controllers/outbound_hand_off_test.exs
@@ -78,13 +78,23 @@ defmodule VutuvWeb.OutboundHandOffTest do
 
     test "a mailto waits for the click", %{conn: conn} do
       posting =
-        publish_job!(nil, %{"apply_kind" => "email", "apply_email" => "jobs@acme.example"})
+        publish_job!(nil, %{
+          "apply_kind" => "email",
+          "apply_email" => "jobs@acme.example",
+          "title" => "Senior Elixir Developer"
+        })
 
       conn = post(conn, ~p"/jobs/#{posting.slug}/apply")
 
       body = html_response(conn, 200)
       assert body =~ ~s|href="mailto:jobs@acme.example?subject=|
       assert body =~ "jobs@acme.example"
+
+      # A `mailto:` query is percent-encoded, not form-encoded (RFC 6068), so a
+      # `+` here is a literal plus the applicant would read in their subject
+      # line.
+      assert body =~ "Senior%20Elixir%20Developer"
+      refute body =~ "Senior+Elixir+Developer"
 
       # A browser hands a URL to an external program on a user gesture, not on
       # a page's say-so, so this one is a button and not a self-forward.


### PR DESCRIPTION
A job posting's Apply button opens the applicant's mail program with the subject filled in (`JobPostingController.do_apply/3`), and built it with `URI.encode_www_form/1`. In a `mailto:` a `+` is a literal plus and not a space (RFC 6068), so a two-word job title arrived as `Bewerbung:+Senior+Elixir+Developer` in Apple Mail and Thunderbird. Some webmail handlers read the `+` as a space anyway, which is why the mistake survives being looked at.

`Vutuv.Mailto.to/2` now builds the URL in one place, because four places built it: the apply button, the unsubscribe fallback, the operator contact on the error pages (#2002), and the media kit's press address. The rule and the reason are in its moduledoc.

The regression test is calibrated — with the old encoding it goes red on `Senior%20Elixir%20Developer`.

An AI agent wrote this text in my name. I know that is problematic.

https://claude.ai/code/session_01FGdRzoLeKNYWtudYAU5grA
