### PR TITLE
The OAuth consent screen offers the Mastodon-app switch itself

### DIFF
--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -886,4 +886,13 @@ is invalid", which sends a member looking for a mistake in their own text.
   on the next request. Because it ships off, both pages have to name the address
   a member types (from `Endpoint.host()`, never a literal) and link
   `/system/mastodon`; the adapter was otherwise undiscoverable from inside the
-  product, which is a worse failure than a missing endpoint.
+  product, which is a worse failure than a missing endpoint. The consent screen
+  is the other place a member meets the switch, usually for the first time: an
+  app sends them to `/oauth/authorize` with the switch still off, and a page
+  that only says "disabled" and points at the settings loses the app's flow on
+  the detour. So it offers the switch itself: a second form on the page posts
+  the settings page's own save (`PUT /settings/apps`, which takes a `return_to`
+  the way the mute routes do) and comes back to the same request with Allow
+  live, so there is one writer of the switch and of its
+  `mastodon_clients_changed` event; the settings link stays beside it. Only the
+  member's own switch: a page's stays its owner's decision, taken on the page.

--- a/lib/vutuv_web/controllers/oauth_controller.ex
+++ b/lib/vutuv_web/controllers/oauth_controller.ex
@@ -32,6 +32,10 @@ defmodule VutuvWeb.OauthController do
 
   @oob_redirect "urn:ietf:wg:oauth:2.0:oob"
 
+  # The request as the app sent it, carried by the consent form so that its
+  # POST lands on the request the page showed.
+  @authorize_keys ~w(response_type client_id redirect_uri scope state code_challenge code_challenge_method)
+
   # ── Consent (browser pipeline) ──
 
   def authorize(conn, params) do
@@ -42,11 +46,17 @@ defmodule VutuvWeb.OauthController do
 
           # The consent screen owns the form, so its policy is the one the
           # browser checks the POST's redirect against.
+          #
+          # `return_to` is this very request, for the member whose Mastodon-app
+          # switch is off: the screen offers the switch itself (posted to the
+          # settings page, which owns it), and a settings detour that did not
+          # come back here would lose the app's flow.
           conn
           |> ContentSecurityPolicy.allow_form_action(request.redirect_uri)
           |> render("authorize.html",
             request: request,
-            params: params,
+            authorize_params: Map.take(params, @authorize_keys),
+            return_to: current_path(conn),
             identities: identities,
             consent_scopes: consent_scopes(request, identities),
             consent_nonce: OAuth.new_consent_nonce()

--- a/lib/vutuv_web/controllers/settings_controller.ex
+++ b/lib/vutuv_web/controllers/settings_controller.ex
@@ -190,12 +190,17 @@ defmodule VutuvWeb.SettingsController do
   # to **this** account. A member who wants one does not necessarily want the
   # other, and the Fediverse page is where somebody goes who has already
   # decided about federation.
-  def update_apps(conn, %{"user" => params}) do
+  #
+  # The OAuth consent screen posts the switch here too, with a `return_to`
+  # back to the request it was on: a member usually meets the switch there,
+  # sent by the app with it still off, and a detour to this page would lose
+  # the app's flow. Validated like the mute routes' `return_to`.
+  def update_apps(conn, %{"user" => user_params} = params) do
     save(
       conn,
-      Map.take(params, ["mastodon_clients?"]),
+      Map.take(user_params, ["mastodon_clients?"]),
       "apps.html",
-      ~p"/settings/apps",
+      ControllerHelpers.safe_return_to(params["return_to"]) || ~p"/settings/apps",
       gettext("App settings saved."),
       event: "mastodon_clients_changed"
     )

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -1698,7 +1698,8 @@ defmodule VutuvWeb.Router do
     get("/organizations", SettingsController, :organizations)
     # The developer hub: connected apps, personal API tokens, and the one
     # switch that belongs with them — whether a Mastodon-compatible app may
-    # sign in to this account at all.
+    # sign in to this account at all. The OAuth consent screen posts that
+    # switch here too, with a `return_to` back to the request it was on.
     get("/apps", SettingsController, :apps)
     put("/apps", SettingsController, :update_apps)
     patch("/apps", SettingsController, :update_apps)

--- a/lib/vutuv_web/templates/oauth/authorize.html.heex
+++ b/lib/vutuv_web/templates/oauth/authorize.html.heex
@@ -32,9 +32,7 @@
     </p>
 
     <.form for={%{}} action={~p"/oauth/authorize"} class="mt-6">
-      <%= for key <- ~w(response_type client_id redirect_uri scope state code_challenge code_challenge_method) do %>
-        <input :if={@params[key]} type="hidden" name={key} value={@params[key]} />
-      <% end %>
+      <input :for={{key, value} <- @authorize_params} type="hidden" name={key} value={value} />
       <%!-- This page's own consent: however often it is submitted, it yields
             one authorization code (issue #1561, `Vutuv.ApiAuth.OAuth`). --%>
       <input type="hidden" name="consent_nonce" value={@consent_nonce} />
@@ -66,24 +64,58 @@
         value={hd(@identities).value}
       />
 
-      <p :if={@identities == []} class="mb-5 text-sm text-red-700 dark:text-red-300">
-        {gettext("Mastodon client access is disabled for every identity available to you.")}
-      </p>
+      <%!-- The member's Mastodon-app switch is off, and no page of theirs
+            offers an identity either. The button below presses that switch
+            from here (it belongs to the settings form under this one) and the
+            page comes back to this request with Allow live; the settings link
+            stays beside it for whoever wants to read up first. --%>
+      <div :if={@identities == []} class="mb-5 text-sm">
+        <p class="text-red-700 dark:text-red-300">
+          {gettext("Mastodon client access is disabled for every identity available to you.")}
+        </p>
+        <p class="mt-2 text-slate-600 dark:text-slate-400">
+          {gettext("Turn it on for your account and %{app} can be connected right here.",
+            app: @request.app.name
+          )}
+          <.link
+            navigate={~p"/settings/apps"}
+            class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+          >
+            {gettext("Open the app settings")} ›
+          </.link>
+        </p>
+      </div>
 
       <div class="flex gap-3">
         <.button
+          :if={@identities != []}
           type="submit"
           name="decision"
           value="allow"
           id="oauth-allow"
-          disabled={@identities == []}
         >
           {gettext("Allow access")}
+        </.button>
+        <.button :if={@identities == []} type="submit" form="oauth-enable-apps" id="oauth-enable">
+          {gettext("Turn on for my account")}
         </.button>
         <.button type="submit" name="decision" value="deny" id="oauth-deny" variant="secondary">
           {gettext("Deny")}
         </.button>
       </div>
+    </.form>
+
+    <%!-- The switch's form: the settings page's own save, a sibling rather
+          than a child because forms do not nest. --%>
+    <.form
+      :if={@identities == []}
+      for={%{}}
+      action={~p"/settings/apps"}
+      method="put"
+      id="oauth-enable-apps"
+    >
+      <input type="hidden" name="user[mastodon_clients?]" value="true" />
+      <input type="hidden" name="return_to" value={@return_to} />
     </.form>
   </section>
 </div>

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1068,22 +1068,22 @@ msgstr "Allgemeines"
 msgid "Verify"
 msgstr "Verifizieren"
 
-#: lib/vutuv/notifications/emailer.ex:281
+#: lib/vutuv/notifications/emailer.ex:282
 #, elixir-autogen
 msgid "Confirm your account deletion"
 msgstr "PIN zum Löschen eines vutuv-Kontos"
 
-#: lib/vutuv/notifications/emailer.ex:275
+#: lib/vutuv/notifications/emailer.ex:276
 #, elixir-autogen
 msgid "Confirm your email"
 msgstr "Weitere E-Mail-Adresse für ein vutuv-Konto bestätigen"
 
-#: lib/vutuv/notifications/emailer.ex:263
+#: lib/vutuv/notifications/emailer.ex:264
 #, elixir-autogen
 msgid "Confirm your vutuv account"
 msgstr "vutuv-Konto einrichten"
 
-#: lib/vutuv/notifications/emailer.ex:269
+#: lib/vutuv/notifications/emailer.ex:270
 #, elixir-autogen
 msgid "Login to vutuv"
 msgstr "vutuv Login-PIN"
@@ -1553,7 +1553,7 @@ msgstr "Verwandte Tags anzeigen"
 msgid "tag name"
 msgstr "Tag-Name"
 
-#: lib/vutuv/notifications/emailer.ex:321
+#: lib/vutuv/notifications/emailer.ex:322
 #, elixir-autogen
 msgid "vutuv Account verified"
 msgstr "verifizierter Account"
@@ -3568,42 +3568,42 @@ msgstr ""
 msgid "yes"
 msgstr "ja"
 
-#: lib/vutuv/notifications/emailer.ex:1003
+#: lib/vutuv/notifications/emailer.ex:1004
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr "Eine Verwarnung für Ihr vutuv-Konto"
 
-#: lib/vutuv/notifications/emailer.ex:1087
+#: lib/vutuv/notifications/emailer.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr "Moderation: %{count} Fälle warten"
 
-#: lib/vutuv/notifications/emailer.ex:1065
+#: lib/vutuv/notifications/emailer.ex:1066
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr "Moderation: Ein Profil wurde gemeldet"
 
-#: lib/vutuv/notifications/emailer.ex:977
+#: lib/vutuv/notifications/emailer.ex:978
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr "Der von Ihnen gemeldete Inhalt wurde überarbeitet"
 
-#: lib/vutuv/notifications/emailer.ex:970
+#: lib/vutuv/notifications/emailer.ex:971
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr "Ihr Inhalt auf vutuv wird geprüft"
 
-#: lib/vutuv/notifications/emailer.ex:963
+#: lib/vutuv/notifications/emailer.ex:964
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr "Ihr Inhalt auf vutuv wurde gemeldet und ist verborgen"
 
-#: lib/vutuv/notifications/emailer.ex:1017
+#: lib/vutuv/notifications/emailer.ex:1018
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr "Ihr vutuv-Konto wurde deaktiviert"
 
-#: lib/vutuv/notifications/emailer.ex:1010
+#: lib/vutuv/notifications/emailer.ex:1011
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr "Ihr vutuv-Konto ist gesperrt"
@@ -5078,7 +5078,7 @@ msgstr "API-Anwendungen"
 msgid "Active"
 msgstr "Aktiv"
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:81
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Allow access"
 msgstr "Zugriff erlauben"
@@ -5142,7 +5142,7 @@ msgstr ""
 "\"%{name}\" löschen? Alle Freigaben von Mitgliedern und alle Tokens dieser "
 "Anwendung funktionieren sofort nicht mehr."
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:84
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Deny"
 msgstr "Ablehnen"
@@ -5203,7 +5203,7 @@ msgstr ""
 "Eine pro Zeile. Exakte https://-URLs (http://localhost ist für die "
 "Entwicklung erlaubt). Die Autorisierung leitet nur an diese Adressen weiter."
 
-#: lib/vutuv_web/controllers/oauth_controller.ex:59
+#: lib/vutuv_web/controllers/oauth_controller.ex:69
 #, elixir-autogen, elixir-format
 msgid "Please log in to connect %{app} with your account."
 msgstr "Bitte melden Sie sich an, um %{app} mit Ihrem Konto zu verbinden."
@@ -5626,7 +5626,7 @@ msgstr "Fußzeilen-Navigation"
 msgid "View post"
 msgstr "Beitrag ansehen"
 
-#: lib/vutuv/notifications/emailer.ex:313
+#: lib/vutuv/notifications/emailer.ex:314
 #, elixir-autogen, elixir-format
 msgid "Someone tried to register with your email address"
 msgstr "Registrierungsversuch mit Ihrer E-Mail-Adresse"
@@ -5701,7 +5701,7 @@ msgstr ""
 msgid "Email addresses"
 msgstr "E-Mail-Adressen"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:591
+#: lib/vutuv_web/controllers/settings_controller.ex:596
 #, elixir-autogen, elixir-format
 msgid "Notification settings saved."
 msgstr "Benachrichtigungseinstellungen gespeichert."
@@ -5728,7 +5728,7 @@ msgstr "Fotos"
 msgid "Privacy"
 msgstr "Privatsphäre"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:225
+#: lib/vutuv_web/controllers/settings_controller.ex:230
 #, elixir-autogen, elixir-format
 msgid "Privacy settings saved."
 msgstr "Datenschutzeinstellungen gespeichert."
@@ -5819,12 +5819,12 @@ msgstr "z. B. Dr. oder Prof."
 msgid "e.g. Jr. or PhD"
 msgstr "z. B. jun. oder B.Sc."
 
-#: lib/vutuv/notifications/emailer.ex:415
+#: lib/vutuv/notifications/emailer.ex:416
 #, elixir-autogen, elixir-format
 msgid "@%{slug} endorsed you on vutuv"
 msgstr "@%{slug} hat Sie auf vutuv empfohlen"
 
-#: lib/vutuv/notifications/emailer.ex:401
+#: lib/vutuv/notifications/emailer.ex:402
 #, elixir-autogen, elixir-format
 msgid "@%{slug} started following you on vutuv"
 msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
@@ -5865,7 +5865,7 @@ msgstr "Benachrichtigungen in der App"
 msgid "New followers"
 msgstr "Neue Follower"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:563
+#: lib/vutuv_web/controllers/settings_controller.ex:568
 #, elixir-autogen, elixir-format
 msgid "Notification settings"
 msgstr "Benachrichtigungseinstellungen"
@@ -6065,12 +6065,12 @@ msgid_plural "%{count} minutes ago"
 msgstr[0] "vor %{count} Minute"
 msgstr[1] "vor %{count} Minuten"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:1057
+#: lib/vutuv_web/controllers/settings_controller.ex:1062
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr "Alle anderen Geräte wurden abgemeldet."
 
-#: lib/vutuv/notifications/emailer.ex:717
+#: lib/vutuv/notifications/emailer.ex:718
 #, elixir-autogen, elixir-format
 msgid "Another session was already active on your account."
 msgstr "Auf Ihrem Konto war bereits eine andere Sitzung aktiv."
@@ -6095,7 +6095,7 @@ msgstr "Von allen Geräten außer diesem abmelden?"
 msgid "Log this device out of your account?"
 msgstr "Dieses Gerät von Ihrem Konto abmelden?"
 
-#: lib/vutuv/notifications/emailer.ex:691
+#: lib/vutuv/notifications/emailer.ex:692
 #, elixir-autogen, elixir-format
 msgid "New sign-in to your vutuv account"
 msgstr "Neue Anmeldung bei Ihrem vutuv-Konto"
@@ -6105,12 +6105,12 @@ msgstr "Neue Anmeldung bei Ihrem vutuv-Konto"
 msgid "Signed-in devices"
 msgstr "Angemeldete Geräte"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:1044
+#: lib/vutuv_web/controllers/settings_controller.ex:1049
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr "Dieses Gerät wurde abgemeldet."
 
-#: lib/vutuv/notifications/emailer.ex:720
+#: lib/vutuv/notifications/emailer.ex:721
 #, elixir-autogen, elixir-format
 msgid "The location looks different from where you usually sign in."
 msgstr "Der Ort weicht von dem ab, von dem Sie sich üblicherweise anmelden."
@@ -6120,7 +6120,7 @@ msgstr "Der Ort weicht von dem ab, von dem Sie sich üblicherweise anmelden."
 msgid "This device"
 msgstr "Dieses Gerät"
 
-#: lib/vutuv/notifications/emailer.ex:714
+#: lib/vutuv/notifications/emailer.ex:715
 #, elixir-autogen, elixir-format
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
@@ -6485,7 +6485,7 @@ msgstr "Empfehlung zurücknehmen"
 msgid "Default map"
 msgstr "Standardkarte"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:850
+#: lib/vutuv_web/controllers/settings_controller.ex:855
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr "Karteneinstellungen gespeichert."
@@ -9009,8 +9009,8 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/components/ui.ex:1749
 #: lib/vutuv_web/components/ui.ex:5255
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
-#: lib/vutuv_web/controllers/settings_controller.ex:359
-#: lib/vutuv_web/controllers/settings_controller.ex:426
+#: lib/vutuv_web/controllers/settings_controller.ex:364
+#: lib/vutuv_web/controllers/settings_controller.ex:431
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:277
 #: lib/vutuv_web/live/organization_live/fediverse.ex:84
@@ -9045,7 +9045,7 @@ msgstr ""
 "als Link in Ihren Mastodon-Profileinstellungen ein, und Mastodon zeigt ihn "
 "grün als bestätigt an."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:439
+#: lib/vutuv_web/controllers/settings_controller.ex:444
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings saved."
 msgstr "Fediverse-Einstellungen gespeichert."
@@ -10990,7 +10990,7 @@ msgstr ""
 "Längere Beiträge erhalten einen „Weiterlesen“-Link. Mit 0 (oder leer) wird "
 "nie gekürzt."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:864
+#: lib/vutuv_web/controllers/settings_controller.ex:869
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr "Anzeige-Einstellungen für Beiträge gespeichert."
@@ -11049,7 +11049,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr "Standard der Installation (%{value})"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:896
+#: lib/vutuv_web/controllers/settings_controller.ex:901
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr "Karteneinstellungen auf die Standardwerte zurückgesetzt."
@@ -11068,7 +11068,7 @@ msgstr ""
 "Eigener Wert; leeren Sie das Feld, um zum Standard der Installation "
 "zurückzukehren."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:892
+#: lib/vutuv_web/controllers/settings_controller.ex:897
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -12357,7 +12357,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:462
 #: lib/vutuv_web/components/ui.ex:5282
-#: lib/vutuv_web/controllers/settings_controller.ex:215
+#: lib/vutuv_web/controllers/settings_controller.ex:220
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:538
@@ -12572,7 +12572,7 @@ msgstr "Bewerbungs-URL"
 msgid "Application e-mail"
 msgstr "Bewerbungs-E-Mail"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:116
+#: lib/vutuv_web/controllers/job_posting_controller.ex:117
 #, elixir-autogen, elixir-format
 msgid "Application: %{title}"
 msgstr "Bewerbung: %{title}"
@@ -12684,7 +12684,7 @@ msgstr "So bewerben Sie sich"
 msgid "Hybrid"
 msgstr "Hybrid"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:135
+#: lib/vutuv_web/controllers/job_posting_controller.ex:136
 #, elixir-autogen, elixir-format
 msgid "I'm interested in your posting: %{url}"
 msgstr "Ich interessiere mich für Ihre Anzeige: %{url}"
@@ -12828,7 +12828,7 @@ msgstr "Bitte bestätigen Sie zuerst Ihre E-Mail-Adresse."
 msgid "Please confirm your email address before posting a job."
 msgstr "Bitte bestätigen Sie Ihre E-Mail-Adresse, bevor Sie eine Stelle ausschreiben."
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:127
+#: lib/vutuv_web/controllers/job_posting_controller.ex:128
 #, elixir-autogen, elixir-format
 msgid "Please log in to message the poster."
 msgstr "Bitte melden Sie sich an, um die Anbieter:in anzuschreiben."
@@ -12881,7 +12881,7 @@ msgstr "Veröffentlichen"
 
 #: lib/vutuv/accounts/user.ex:1275
 #: lib/vutuv/jobs/job_posting.ex:166
-#: lib/vutuv/notifications/emailer.ex:565
+#: lib/vutuv/notifications/emailer.ex:566
 #: lib/vutuv_web/agent_docs/markdown.ex:532
 #: lib/vutuv_web/agent_docs/markdown.ex:534
 #: lib/vutuv_web/agent_docs/text.ex:547
@@ -12918,7 +12918,7 @@ msgstr "Gehalt"
 msgid "Salary on request"
 msgstr "Gehalt auf Anfrage"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:397
+#: lib/vutuv_web/controllers/settings_controller.ex:402
 #: lib/vutuv_web/live/job_posting_live/form.ex:379
 #, elixir-autogen, elixir-format
 msgid "Saved."
@@ -13016,12 +13016,12 @@ msgstr "Arbeitsort"
 msgid "You already have the maximum number of published postings."
 msgstr "Sie haben bereits die maximale Anzahl veröffentlichter Anzeigen."
 
-#: lib/vutuv/notifications/emailer.ex:1033
+#: lib/vutuv/notifications/emailer.ex:1034
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr "Ihre Stellenanzeige auf vutuv läuft bald ab"
 
-#: lib/vutuv/notifications/emailer.ex:911
+#: lib/vutuv/notifications/emailer.ex:912
 #, elixir-autogen, elixir-format
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr "Eine Domain Ihrer Organisationsseite auf vutuv entfällt bald"
@@ -13041,12 +13041,12 @@ msgstr "Nachweis fehlt"
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr "Der Nachweis dieser Domain war bei der letzten Prüfung nicht abrufbar. Stellen Sie ihn wieder her und prüfen Sie erneut, sonst verliert die Domain ihre Verifizierung."
 
-#: lib/vutuv/notifications/emailer.ex:908
+#: lib/vutuv/notifications/emailer.ex:909
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is about to lose its verification"
 msgstr "Ihre Organisationsseite auf vutuv verliert bald ihre Verifizierung"
 
-#: lib/vutuv/notifications/emailer.ex:954
+#: lib/vutuv/notifications/emailer.ex:955
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is no longer public"
 msgstr "Ihre Organisationsseite auf vutuv ist nicht mehr öffentlich"
@@ -13496,7 +13496,7 @@ msgstr "verifizierte Organisationsseite"
 msgid "—"
 msgstr "—"
 
-#: lib/vutuv/notifications/emailer.ex:514
+#: lib/vutuv/notifications/emailer.ex:515
 #, elixir-autogen, elixir-format
 msgid "%{count} new match for your saved searches"
 msgid_plural "%{count} new matches for your saved searches"
@@ -13508,7 +13508,7 @@ msgstr[1] "%{count} neue Treffer für Ihre gespeicherten Suchen"
 msgid "Alert frequency"
 msgstr "Häufigkeit der Benachrichtigung"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:778
+#: lib/vutuv_web/controllers/settings_controller.ex:783
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr "Benachrichtigung aktualisiert."
@@ -13582,13 +13582,13 @@ msgstr ""
 msgid "Save search"
 msgstr "Suche speichern"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:796
+#: lib/vutuv_web/controllers/settings_controller.ex:801
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr "Gespeicherte Suche gelöscht."
 
 #: lib/vutuv_web/components/ui.ex:5191
-#: lib/vutuv_web/controllers/settings_controller.ex:622
+#: lib/vutuv_web/controllers/settings_controller.ex:627
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13609,8 +13609,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3240
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:783
-#: lib/vutuv_web/controllers/settings_controller.ex:801
+#: lib/vutuv_web/controllers/settings_controller.ex:788
+#: lib/vutuv_web/controllers/settings_controller.ex:806
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:398
 #: lib/vutuv_web/live/organization_live/following.ex:291
 #: lib/vutuv_web/live/organization_live/following.ex:298
@@ -14060,7 +14060,7 @@ msgstr ""
 "Seite."
 
 #: lib/vutuv_web/components/ui.ex:5174
-#: lib/vutuv_web/controllers/settings_controller.ex:636
+#: lib/vutuv_web/controllers/settings_controller.ex:641
 #: lib/vutuv_web/live/post_live/feed.ex:710
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
@@ -14595,7 +14595,7 @@ msgstr "Bevorzugte Arbeitsform"
 msgid "Availability"
 msgstr "Verfügbarkeit"
 
-#: lib/vutuv/notifications/emailer.ex:995
+#: lib/vutuv/notifications/emailer.ex:996
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Eine automatische Prüfung hat ein Bild aus Ihrem vutuv-Konto entfernt"
@@ -14832,7 +14832,7 @@ msgstr "Konto, zu dem Sie umziehen"
 msgid "Cancel redirect"
 msgstr "Weiterleitung aufheben"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:491
+#: lib/vutuv_web/controllers/settings_controller.ex:496
 #, elixir-autogen, elixir-format
 msgid "Done. Your Fediverse followers have been asked to follow your new account, and new posts are no longer federated from here. Your vutuv profile is unchanged."
 msgstr "Fertig. Ihre Fediverse-Follower wurden gebeten, Ihrem neuen Konto zu folgen, und neue Beiträge werden von hier nicht mehr föderiert. Ihr vutuv-Profil bleibt unverändert."
@@ -14847,12 +14847,12 @@ msgstr "Tragen Sie unten die Adresse dieses Kontos ein und leiten Sie weiter."
 msgid "On your other account, add your vutuv handle"
 msgstr "Fügen Sie auf Ihrem anderen Konto Ihr vutuv-Handle"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:530
+#: lib/vutuv_web/controllers/settings_controller.ex:535
 #, elixir-autogen, elixir-format
 msgid "Please enter the full https address of the account you are moving to."
 msgstr "Bitte geben Sie die vollständige https-Adresse des Kontos ein, zu dem Sie umziehen."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:516
+#: lib/vutuv_web/controllers/settings_controller.ex:521
 #, elixir-autogen, elixir-format
 msgid "Redirect cancelled. Your posts federate from here again."
 msgstr "Weiterleitung aufgehoben. Ihre Beiträge werden wieder von hier föderiert."
@@ -14867,17 +14867,17 @@ msgstr "Meine Follower weiterleiten"
 msgid "Redirected on %{date}"
 msgstr "Weitergeleitet am %{date}"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:543
+#: lib/vutuv_web/controllers/settings_controller.ex:548
 #, elixir-autogen, elixir-format
 msgid "That account could not be reached. Check the address, and that the other server is online."
 msgstr "Dieses Konto war nicht erreichbar. Prüfen Sie die Adresse und ob der andere Server online ist."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:537
+#: lib/vutuv_web/controllers/settings_controller.ex:542
 #, elixir-autogen, elixir-format
 msgid "That account does not list your vutuv profile as an alias yet. Add this profile's address there first, then try again."
 msgstr "Dieses Konto führt Ihr vutuv-Profil noch nicht als Alias. Fügen Sie dort zuerst die Adresse dieses Profils hinzu und versuchen Sie es dann erneut."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:533
+#: lib/vutuv_web/controllers/settings_controller.ex:538
 #, elixir-autogen, elixir-format
 msgid "That is this account. Enter the account you are moving to."
 msgstr "Das ist dieses Konto. Geben Sie das Konto an, zu dem Sie umziehen."
@@ -14887,12 +14887,12 @@ msgstr "Das ist dieses Konto. Geben Sie das Konto an, zu dem Sie umziehen."
 msgid "This tells your Fediverse followers to follow your new account instead, and stops federating your posts from here. Your vutuv profile is not affected. Continue?"
 msgstr "Damit werden Ihre Fediverse-Follower gebeten, stattdessen Ihrem neuen Konto zu folgen, und Ihre Beiträge werden von hier nicht mehr föderiert. Ihr vutuv-Profil ist nicht betroffen. Fortfahren?"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:521
+#: lib/vutuv_web/controllers/settings_controller.ex:526
 #, elixir-autogen, elixir-format
 msgid "Turn on federation first, then you can redirect your followers."
 msgstr "Schalten Sie zuerst die Föderation ein, dann können Sie Ihre Follower weiterleiten."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:525
+#: lib/vutuv_web/controllers/settings_controller.ex:530
 #, elixir-autogen, elixir-format
 msgid "You can only move once every %{days} days."
 msgstr "Sie können nur alle %{days} Tage umziehen."
@@ -14915,7 +14915,7 @@ msgstr[1] "%{formatted} Empfehlungen"
 msgid "All endorsers"
 msgstr "Alle Empfehlenden"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:661
+#: lib/vutuv_web/controllers/settings_controller.ex:666
 #, elixir-autogen, elixir-format
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr "Filter hinzugefügt. Passende Beiträge sind jetzt in Ihrem Feed ausgeblendet."
@@ -14925,7 +14925,7 @@ msgstr "Filter hinzugefügt. Passende Beiträge sind jetzt in Ihrem Feed ausgebl
 msgid "Filter by a tag"
 msgstr "Nach einem Tag filtern"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:691
+#: lib/vutuv_web/controllers/settings_controller.ex:696
 #, elixir-autogen, elixir-format
 msgid "Filter removed."
 msgstr "Filter entfernt."
@@ -14941,7 +14941,7 @@ msgid "Match whole words only (word/phrase)"
 msgstr "Nur ganze Wörter treffen (Wort/Phrase)"
 
 #: lib/vutuv_web/components/ui.ex:5145
-#: lib/vutuv_web/controllers/settings_controller.ex:768
+#: lib/vutuv_web/controllers/settings_controller.ex:773
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
 #: lib/vutuv_web/templates/settings/mutes.html.heex:86
@@ -15037,7 +15037,7 @@ msgstr "Sie dürfen den Benutzernamen dieser Organisation nicht ändern."
 msgid "You have not muted anything yet."
 msgstr "Sie haben noch nichts stummgeschaltet."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:669
+#: lib/vutuv_web/controllers/settings_controller.ex:674
 #, elixir-autogen, elixir-format
 msgid "You have reached the maximum of %{count} filters."
 msgstr "Sie haben das Maximum von %{count} Filtern erreicht."
@@ -15259,7 +15259,7 @@ msgstr "Verwandte Themen"
 msgid "Moving to or away from another Fediverse account?"
 msgstr "Ziehen Sie zu einem anderen Fediverse-Konto um oder von dort zu vutuv?"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:381
+#: lib/vutuv_web/controllers/settings_controller.ex:386
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:201
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
@@ -16165,7 +16165,7 @@ msgstr "Bitte bestätigen Sie die Änderung, bevor wir Ihr Konto umbenennen."
 msgid "This confirmation expired. Please start again."
 msgstr "Diese Bestätigung ist abgelaufen. Bitte beginnen Sie von vorn."
 
-#: lib/vutuv/notifications/emailer.ex:295
+#: lib/vutuv/notifications/emailer.ex:296
 #, elixir-autogen, elixir-format
 msgid "Confirm your new username"
 msgstr "Bestätigen Sie Ihren neuen Benutzernamen"
@@ -17538,7 +17538,7 @@ msgstr "Ganze Beschreibung anzeigen"
 msgid "The most recent %{count} are shown. The rest are on their own server."
 msgstr "Die neuesten %{count} werden angezeigt. Der Rest liegt auf dem eigenen Server."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:742
+#: lib/vutuv_web/controllers/settings_controller.ex:747
 #: lib/vutuv_web/live/fediverse_account_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts are back in your feed."
@@ -18743,7 +18743,7 @@ msgstr "Meinen Namen bei Beiträgen zeigen, die mir gefallen"
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr "Wenn aus, sehen andere Mitglieder Sie nicht mehr bei den Likes eines Beitrags. Die Autorin oder der Autor des Beitrags sieht es weiterhin: In der Benachrichtigung von damals haben wir Sie namentlich genannt. Der Beitrag hat in beiden Fällen gleich viele Likes."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:991
+#: lib/vutuv_web/controllers/settings_controller.ex:996
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr "Ihre Likes folgen wieder dem Standardwert der Website."
@@ -19298,7 +19298,7 @@ msgstr "Wenn die Prüfung eines Ihrer Arbeitszeugnisse fertig ist. Das dauert ei
 msgid "Your employment reference has been reviewed."
 msgstr "Ihr Arbeitszeugnis wurde geprüft."
 
-#: lib/vutuv/notifications/emailer.ex:478
+#: lib/vutuv/notifications/emailer.ex:479
 #, elixir-autogen, elixir-format
 msgid "Your reference “%{title}” has been reviewed"
 msgstr "Ihr Zeugnis „%{title}“ wurde geprüft"
@@ -19374,7 +19374,7 @@ msgstr "Nur nötig, wenn Sie keine Datei zum Hochladen haben."
 msgid "Upload the PDF or the scan. We read the text out of it, and the review always reads that text, never the file itself."
 msgstr "Laden Sie das PDF oder den Scan hoch. Wir lesen den Text daraus aus, und die Prüfung liest immer diesen Text, nie die Datei selbst."
 
-#: lib/vutuv/notifications/emailer.ex:459
+#: lib/vutuv/notifications/emailer.ex:460
 #, elixir-autogen, elixir-format
 msgid "%{count} new notification on vutuv"
 msgid_plural "%{count} new notifications on vutuv"
@@ -19805,9 +19805,9 @@ msgid "Always keep"
 msgstr "Immer behalten"
 
 #: lib/vutuv_web/components/ui.ex:5249
-#: lib/vutuv_web/controllers/settings_controller.ex:249
-#: lib/vutuv_web/controllers/settings_controller.ex:328
-#: lib/vutuv_web/controllers/settings_controller.ex:340
+#: lib/vutuv_web/controllers/settings_controller.ex:254
+#: lib/vutuv_web/controllers/settings_controller.ex:333
+#: lib/vutuv_web/controllers/settings_controller.ex:345
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:20
 #: lib/vutuv_web/views/account_event_text.ex:254
 #, elixir-autogen, elixir-format
@@ -19968,12 +19968,12 @@ msgid_plural "Saving this rule deletes %{formatted} posts straight away. This ca
 msgstr[0] "Mit dieser Regel wird %{count} Beitrag sofort gelöscht. Das lässt sich nicht rückgängig machen."
 msgstr[1] "Mit dieser Regel werden %{formatted} Beiträge sofort gelöscht. Das lässt sich nicht rückgängig machen."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:309
+#: lib/vutuv_web/controllers/settings_controller.ex:314
 #, elixir-autogen, elixir-format
 msgid "Settings saved."
 msgstr "Einstellungen gespeichert."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:312
+#: lib/vutuv_web/controllers/settings_controller.ex:317
 #, elixir-autogen, elixir-format
 msgid "Settings saved. %{count} post was deleted."
 msgid_plural "Settings saved. %{formatted} posts were deleted."
@@ -20657,7 +20657,7 @@ msgstr "Diese Seite folgt noch niemandem auf einem anderen Netzwerk."
 msgid "Too many attempts for now. Try again later."
 msgstr "Zu viele Versuche. Bitte versuchen Sie es später erneut."
 
-#: lib/vutuv/notifications/emailer.ex:351
+#: lib/vutuv/notifications/emailer.ex:352
 #, elixir-autogen, elixir-format
 msgid "New message from %{sender} on vutuv"
 msgstr "Neue Nachricht von %{sender} auf vutuv"
@@ -21022,7 +21022,7 @@ msgstr "Wir haben diese Adresse abgerufen:"
 msgid "What is published there right now:"
 msgstr "Was dort im Moment veröffentlicht ist:"
 
-#: lib/vutuv/notifications/emailer.ex:934
+#: lib/vutuv/notifications/emailer.ex:935
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is verified"
 msgstr "Ihre Organisationsseite auf vutuv ist verifiziert"
@@ -21079,7 +21079,7 @@ msgstr "Konten stummschalten oder Stummschaltungen aufheben"
 msgid "Mastodon-compatible apps"
 msgstr "Mastodon-kompatible Apps"
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:70
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "Mastodon client access is disabled for every identity available to you."
 msgstr "Der Zugriff durch Mastodon-Clients ist für alle Ihnen verfügbaren Identitäten deaktiviert."
@@ -21089,7 +21089,7 @@ msgstr "Der Zugriff durch Mastodon-Clients ist für alle Ihnen verfügbaren Iden
 msgid "Read data visible to this identity"
 msgstr "Für diese Identität sichtbare Daten lesen"
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:44
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:42
 #, elixir-autogen, elixir-format
 msgid "Use this identity"
 msgstr "Diese Identität verwenden"
@@ -21335,7 +21335,7 @@ msgstr "Was Ihr Feed mit Beiträgen außerhalb Ihrer gewählten Sprachen macht: 
 msgid "Date & time"
 msgstr "Datum & Uhrzeit"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:836
+#: lib/vutuv_web/controllers/settings_controller.ex:841
 #, elixir-autogen, elixir-format
 msgid "Date and time settings reset to the site defaults."
 msgstr "Datum und Uhrzeit folgen wieder den Voreinstellungen der Website."
@@ -21350,7 +21350,7 @@ msgstr "Datumsformat"
 msgid "Germany, Austria, Switzerland"
 msgstr "Deutschland, Österreich, Schweiz"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:830
+#: lib/vutuv_web/controllers/settings_controller.ex:835
 #, elixir-autogen, elixir-format
 msgid "Language and region saved."
 msgstr "Sprache und Region gespeichert."
@@ -21477,7 +21477,7 @@ msgstr "Profilbild größer anzeigen"
 msgid "The page's Editorial team can use this organization as a separate identity in a compatible phone app, with the same rights they already have here. Those rights are checked again on every request."
 msgstr "Die Redaktion der Seite kann diese Organisation in einer kompatiblen Smartphone-App als eigene Identität verwenden, mit denselben Rechten, die sie hier schon hat. Diese Rechte werden bei jeder Anfrage erneut geprüft."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:199
+#: lib/vutuv_web/controllers/settings_controller.ex:204
 #, elixir-autogen, elixir-format
 msgid "App settings saved."
 msgstr "App-Einstellungen gespeichert."
@@ -21898,7 +21898,7 @@ msgstr "Weiter zu %{server}"
 msgid "E-mail to %{address}"
 msgstr "E-Mail an %{address}"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:109
+#: lib/vutuv_web/controllers/job_posting_controller.ex:110
 #, elixir-autogen, elixir-format
 msgid "The employer takes applications on their own website."
 msgstr "Das Unternehmen nimmt Bewerbungen auf der eigenen Webseite entgegen."
@@ -21908,7 +21908,7 @@ msgstr "Das Unternehmen nimmt Bewerbungen auf der eigenen Webseite entgegen."
 msgid "Write e-mail"
 msgstr "E-Mail schreiben"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:121
+#: lib/vutuv_web/controllers/job_posting_controller.ex:122
 #, elixir-autogen, elixir-format
 msgid "Your e-mail program opens with the subject filled in."
 msgstr "Ihr E-Mail-Programm öffnet sich mit ausgefülltem Betreff."
@@ -22324,12 +22324,12 @@ msgstr[1] "+%{formatted} weitere Beiträge"
 msgid "Browser tab"
 msgstr "Browser-Tab"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:916
+#: lib/vutuv_web/controllers/settings_controller.ex:921
 #, elixir-autogen, elixir-format
 msgid "Browser tab settings reset to the site defaults."
 msgstr "Einstellungen für den Browser-Tab auf die Website-Vorgaben zurückgesetzt."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:910
+#: lib/vutuv_web/controllers/settings_controller.ex:915
 #, elixir-autogen, elixir-format
 msgid "Browser tab settings saved."
 msgstr "Einstellungen für den Browser-Tab gespeichert."
@@ -23148,19 +23148,19 @@ msgstr "Diesen Entwurf für später behalten?"
 msgid "Describe the organization. Markdown is supported."
 msgstr "Beschreiben Sie die Organisation. Markdown wird unterstützt."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:930
+#: lib/vutuv_web/controllers/settings_controller.ex:935
 #: lib/vutuv_web/templates/settings/bandwidth.html.heex:9
 #: lib/vutuv_web/templates/settings/bandwidth.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Bandwidth"
 msgstr "Bandbreite"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:980
+#: lib/vutuv_web/controllers/settings_controller.ex:985
 #, elixir-autogen, elixir-format
 msgid "Bandwidth settings reset to the site defaults."
 msgstr "Einstellungen zur Bandbreite auf die Website-Vorgaben zurückgesetzt."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:940
+#: lib/vutuv_web/controllers/settings_controller.ex:945
 #, elixir-autogen, elixir-format
 msgid "Bandwidth settings saved."
 msgstr "Einstellungen zur Bandbreite gespeichert."
@@ -23813,7 +23813,7 @@ msgstr "Konten, deren Beiträge nicht in Ihrem Feed erscheinen, und Konten, dere
 msgid "Accounts you have silenced, and whose reposts you hide"
 msgstr "Konten, die Sie stummgeschaltet haben, und deren Reposts Sie ausblenden"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:754
+#: lib/vutuv_web/controllers/settings_controller.ex:759
 #: lib/vutuv_web/live/remote_post_actions.ex:112
 #, elixir-autogen, elixir-format
 msgid "Hidden. What they pass on stays out of your feed; their own posts do not."
@@ -23836,14 +23836,14 @@ msgid "Mute everything"
 msgstr "Ganz stummschalten"
 
 #: lib/vutuv_web/components/ui.ex:5152
-#: lib/vutuv_web/controllers/settings_controller.ex:706
+#: lib/vutuv_web/controllers/settings_controller.ex:711
 #: lib/vutuv_web/templates/settings/mutes.html.heex:1
 #: lib/vutuv_web/templates/settings/mutes.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Muted accounts"
 msgstr "Stummgeschaltete Konten"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:756
+#: lib/vutuv_web/controllers/settings_controller.ex:761
 #: lib/vutuv_web/live/fediverse_account_live.ex:260
 #: lib/vutuv_web/live/remote_post_actions.ex:121
 #, elixir-autogen, elixir-format
@@ -23865,7 +23865,7 @@ msgstr "Reposts ausgeblendet"
 msgid "Reposts only"
 msgstr "Nur Reposts"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:719
+#: lib/vutuv_web/controllers/settings_controller.ex:724
 #, elixir-autogen, elixir-format
 msgid "That account is gone."
 msgstr "Dieses Konto existiert nicht mehr."
@@ -23970,12 +23970,12 @@ msgstr "Die Beiträge dieses Monats, nach Tagen."
 msgid "Feed length"
 msgstr "Länge des Feeds"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:974
+#: lib/vutuv_web/controllers/settings_controller.ex:979
 #, elixir-autogen, elixir-format
 msgid "Feed length reset to the site default."
 msgstr "Die Länge Ihres Feeds folgt wieder der Voreinstellung."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:968
+#: lib/vutuv_web/controllers/settings_controller.ex:973
 #, elixir-autogen, elixir-format
 msgid "Feed settings saved."
 msgstr "Feed-Einstellungen gespeichert."
@@ -23991,7 +23991,7 @@ msgid "How many posts your feed shows before the “Load more” button, and how
 msgstr "Wie viele Beiträge Ihr Feed vor dem Knopf „Mehr laden“ zeigt und wie viele dieser Knopf ergänzt. Mehr Beiträge bedeuten eine längere Wartezeit auf die Seite."
 
 #: lib/vutuv_web/components/ui.ex:5222
-#: lib/vutuv_web/controllers/settings_controller.ex:958
+#: lib/vutuv_web/controllers/settings_controller.ex:963
 #: lib/vutuv_web/templates/settings/feed.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Posts in your feed"
@@ -24127,3 +24127,18 @@ msgstr "Die Website läuft, nur diese Adresse gibt es hier nicht. Wahrscheinlich
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr "Screenshot vergrößern"
+
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:84
+#, elixir-autogen, elixir-format
+msgid "Open the app settings"
+msgstr "App-Einstellungen öffnen"
+
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "Turn it on for your account and %{app} can be connected right here."
+msgstr "Schalten Sie ihn für Ihr Konto ein, dann können Sie %{app} gleich hier verbinden."
+
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:100
+#, elixir-autogen, elixir-format
+msgid "Turn on for my account"
+msgstr "Für mein Konto einschalten"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1049,22 +1049,22 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:281
+#: lib/vutuv/notifications/emailer.ex:282
 #, elixir-autogen
 msgid "Confirm your account deletion"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:275
+#: lib/vutuv/notifications/emailer.ex:276
 #, elixir-autogen
 msgid "Confirm your email"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:263
+#: lib/vutuv/notifications/emailer.ex:264
 #, elixir-autogen
 msgid "Confirm your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:269
+#: lib/vutuv/notifications/emailer.ex:270
 #, elixir-autogen
 msgid "Login to vutuv"
 msgstr ""
@@ -1528,7 +1528,7 @@ msgstr ""
 msgid "tag name"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:321
+#: lib/vutuv/notifications/emailer.ex:322
 #, elixir-autogen
 msgid "vutuv Account verified"
 msgstr ""
@@ -3472,42 +3472,42 @@ msgstr ""
 msgid "yes"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1003
+#: lib/vutuv/notifications/emailer.ex:1004
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1087
+#: lib/vutuv/notifications/emailer.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1065
+#: lib/vutuv/notifications/emailer.ex:1066
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:977
+#: lib/vutuv/notifications/emailer.ex:978
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:970
+#: lib/vutuv/notifications/emailer.ex:971
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:963
+#: lib/vutuv/notifications/emailer.ex:964
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1017
+#: lib/vutuv/notifications/emailer.ex:1018
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1010
+#: lib/vutuv/notifications/emailer.ex:1011
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr ""
@@ -4893,7 +4893,7 @@ msgstr ""
 msgid "Active"
 msgstr ""
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:81
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Allow access"
 msgstr ""
@@ -4955,7 +4955,7 @@ msgstr ""
 msgid "Delete \"%{name}\"? Every member authorization and every token of this application stops working immediately."
 msgstr ""
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:84
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Deny"
 msgstr ""
@@ -5010,7 +5010,7 @@ msgstr ""
 msgid "One per line. Exact https:// URLs (http://localhost is allowed for development). The authorization flow only ever redirects to these."
 msgstr ""
 
-#: lib/vutuv_web/controllers/oauth_controller.ex:59
+#: lib/vutuv_web/controllers/oauth_controller.ex:69
 #, elixir-autogen, elixir-format
 msgid "Please log in to connect %{app} with your account."
 msgstr ""
@@ -5408,7 +5408,7 @@ msgstr ""
 msgid "View post"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:313
+#: lib/vutuv/notifications/emailer.ex:314
 #, elixir-autogen, elixir-format
 msgid "Someone tried to register with your email address"
 msgstr ""
@@ -5482,7 +5482,7 @@ msgstr ""
 msgid "Email addresses"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:591
+#: lib/vutuv_web/controllers/settings_controller.ex:596
 #, elixir-autogen, elixir-format
 msgid "Notification settings saved."
 msgstr ""
@@ -5509,7 +5509,7 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:225
+#: lib/vutuv_web/controllers/settings_controller.ex:230
 #, elixir-autogen, elixir-format
 msgid "Privacy settings saved."
 msgstr ""
@@ -5598,12 +5598,12 @@ msgstr ""
 msgid "e.g. Jr. or PhD"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:415
+#: lib/vutuv/notifications/emailer.ex:416
 #, elixir-autogen, elixir-format
 msgid "@%{slug} endorsed you on vutuv"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:401
+#: lib/vutuv/notifications/emailer.ex:402
 #, elixir-autogen, elixir-format
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
@@ -5644,7 +5644,7 @@ msgstr ""
 msgid "New followers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:563
+#: lib/vutuv_web/controllers/settings_controller.ex:568
 #, elixir-autogen, elixir-format
 msgid "Notification settings"
 msgstr ""
@@ -5840,12 +5840,12 @@ msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:1057
+#: lib/vutuv_web/controllers/settings_controller.ex:1062
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:717
+#: lib/vutuv/notifications/emailer.ex:718
 #, elixir-autogen, elixir-format
 msgid "Another session was already active on your account."
 msgstr ""
@@ -5870,7 +5870,7 @@ msgstr ""
 msgid "Log this device out of your account?"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:691
+#: lib/vutuv/notifications/emailer.ex:692
 #, elixir-autogen, elixir-format
 msgid "New sign-in to your vutuv account"
 msgstr ""
@@ -5880,12 +5880,12 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:1044
+#: lib/vutuv_web/controllers/settings_controller.ex:1049
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:720
+#: lib/vutuv/notifications/emailer.ex:721
 #, elixir-autogen, elixir-format
 msgid "The location looks different from where you usually sign in."
 msgstr ""
@@ -5895,7 +5895,7 @@ msgstr ""
 msgid "This device"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:714
+#: lib/vutuv/notifications/emailer.ex:715
 #, elixir-autogen, elixir-format
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
@@ -6242,7 +6242,7 @@ msgstr ""
 msgid "Default map"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:850
+#: lib/vutuv_web/controllers/settings_controller.ex:855
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr ""
@@ -8598,8 +8598,8 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1749
 #: lib/vutuv_web/components/ui.ex:5255
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
-#: lib/vutuv_web/controllers/settings_controller.ex:359
-#: lib/vutuv_web/controllers/settings_controller.ex:426
+#: lib/vutuv_web/controllers/settings_controller.ex:364
+#: lib/vutuv_web/controllers/settings_controller.ex:431
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:277
 #: lib/vutuv_web/live/organization_live/fediverse.ex:84
@@ -8629,7 +8629,7 @@ msgstr ""
 msgid "as a link in your Mastodon profile settings, and Mastodon will show it as verified with a green check."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:439
+#: lib/vutuv_web/controllers/settings_controller.ex:444
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings saved."
 msgstr ""
@@ -10454,7 +10454,7 @@ msgstr ""
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:864
+#: lib/vutuv_web/controllers/settings_controller.ex:869
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr ""
@@ -10503,7 +10503,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:896
+#: lib/vutuv_web/controllers/settings_controller.ex:901
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr ""
@@ -10518,7 +10518,7 @@ msgstr ""
 msgid "Own value; blank the field to go back to the installation default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:892
+#: lib/vutuv_web/controllers/settings_controller.ex:897
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -11732,7 +11732,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:462
 #: lib/vutuv_web/components/ui.ex:5282
-#: lib/vutuv_web/controllers/settings_controller.ex:215
+#: lib/vutuv_web/controllers/settings_controller.ex:220
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:538
@@ -11934,7 +11934,7 @@ msgstr ""
 msgid "Application e-mail"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:116
+#: lib/vutuv_web/controllers/job_posting_controller.ex:117
 #, elixir-autogen, elixir-format
 msgid "Application: %{title}"
 msgstr ""
@@ -12046,7 +12046,7 @@ msgstr ""
 msgid "Hybrid"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:135
+#: lib/vutuv_web/controllers/job_posting_controller.ex:136
 #, elixir-autogen, elixir-format
 msgid "I'm interested in your posting: %{url}"
 msgstr ""
@@ -12190,7 +12190,7 @@ msgstr ""
 msgid "Please confirm your email address before posting a job."
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:127
+#: lib/vutuv_web/controllers/job_posting_controller.ex:128
 #, elixir-autogen, elixir-format
 msgid "Please log in to message the poster."
 msgstr ""
@@ -12243,7 +12243,7 @@ msgstr ""
 
 #: lib/vutuv/accounts/user.ex:1275
 #: lib/vutuv/jobs/job_posting.ex:166
-#: lib/vutuv/notifications/emailer.ex:565
+#: lib/vutuv/notifications/emailer.ex:566
 #: lib/vutuv_web/agent_docs/markdown.ex:532
 #: lib/vutuv_web/agent_docs/markdown.ex:534
 #: lib/vutuv_web/agent_docs/text.ex:547
@@ -12280,7 +12280,7 @@ msgstr ""
 msgid "Salary on request"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:397
+#: lib/vutuv_web/controllers/settings_controller.ex:402
 #: lib/vutuv_web/live/job_posting_live/form.ex:379
 #, elixir-autogen, elixir-format
 msgid "Saved."
@@ -12378,12 +12378,12 @@ msgstr ""
 msgid "You already have the maximum number of published postings."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1033
+#: lib/vutuv/notifications/emailer.ex:1034
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:911
+#: lib/vutuv/notifications/emailer.ex:912
 #, elixir-autogen, elixir-format
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr ""
@@ -12403,12 +12403,12 @@ msgstr ""
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:908
+#: lib/vutuv/notifications/emailer.ex:909
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is about to lose its verification"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:954
+#: lib/vutuv/notifications/emailer.ex:955
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is no longer public"
 msgstr ""
@@ -12858,7 +12858,7 @@ msgstr ""
 msgid "—"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:514
+#: lib/vutuv/notifications/emailer.ex:515
 #, elixir-autogen, elixir-format
 msgid "%{count} new match for your saved searches"
 msgid_plural "%{count} new matches for your saved searches"
@@ -12870,7 +12870,7 @@ msgstr[1] ""
 msgid "Alert frequency"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:778
+#: lib/vutuv_web/controllers/settings_controller.ex:783
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr ""
@@ -12939,13 +12939,13 @@ msgstr ""
 msgid "Save search"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:796
+#: lib/vutuv_web/controllers/settings_controller.ex:801
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5191
-#: lib/vutuv_web/controllers/settings_controller.ex:622
+#: lib/vutuv_web/controllers/settings_controller.ex:627
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -12965,8 +12965,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3240
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:783
-#: lib/vutuv_web/controllers/settings_controller.ex:801
+#: lib/vutuv_web/controllers/settings_controller.ex:788
+#: lib/vutuv_web/controllers/settings_controller.ex:806
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:398
 #: lib/vutuv_web/live/organization_live/following.ex:291
 #: lib/vutuv_web/live/organization_live/following.ex:298
@@ -13403,7 +13403,7 @@ msgid "Posts tagged with a tag you follow show up in your feed, and people known
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5174
-#: lib/vutuv_web/controllers/settings_controller.ex:636
+#: lib/vutuv_web/controllers/settings_controller.ex:641
 #: lib/vutuv_web/live/post_live/feed.ex:710
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
@@ -13930,7 +13930,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:995
+#: lib/vutuv/notifications/emailer.ex:996
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
@@ -14157,7 +14157,7 @@ msgstr ""
 msgid "Cancel redirect"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:491
+#: lib/vutuv_web/controllers/settings_controller.ex:496
 #, elixir-autogen, elixir-format
 msgid "Done. Your Fediverse followers have been asked to follow your new account, and new posts are no longer federated from here. Your vutuv profile is unchanged."
 msgstr ""
@@ -14172,12 +14172,12 @@ msgstr ""
 msgid "On your other account, add your vutuv handle"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:530
+#: lib/vutuv_web/controllers/settings_controller.ex:535
 #, elixir-autogen, elixir-format
 msgid "Please enter the full https address of the account you are moving to."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:516
+#: lib/vutuv_web/controllers/settings_controller.ex:521
 #, elixir-autogen, elixir-format
 msgid "Redirect cancelled. Your posts federate from here again."
 msgstr ""
@@ -14192,17 +14192,17 @@ msgstr ""
 msgid "Redirected on %{date}"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:543
+#: lib/vutuv_web/controllers/settings_controller.ex:548
 #, elixir-autogen, elixir-format
 msgid "That account could not be reached. Check the address, and that the other server is online."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:537
+#: lib/vutuv_web/controllers/settings_controller.ex:542
 #, elixir-autogen, elixir-format
 msgid "That account does not list your vutuv profile as an alias yet. Add this profile's address there first, then try again."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:533
+#: lib/vutuv_web/controllers/settings_controller.ex:538
 #, elixir-autogen, elixir-format
 msgid "That is this account. Enter the account you are moving to."
 msgstr ""
@@ -14212,12 +14212,12 @@ msgstr ""
 msgid "This tells your Fediverse followers to follow your new account instead, and stops federating your posts from here. Your vutuv profile is not affected. Continue?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:521
+#: lib/vutuv_web/controllers/settings_controller.ex:526
 #, elixir-autogen, elixir-format
 msgid "Turn on federation first, then you can redirect your followers."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:525
+#: lib/vutuv_web/controllers/settings_controller.ex:530
 #, elixir-autogen, elixir-format
 msgid "You can only move once every %{days} days."
 msgstr ""
@@ -14240,7 +14240,7 @@ msgstr[1] ""
 msgid "All endorsers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:661
+#: lib/vutuv_web/controllers/settings_controller.ex:666
 #, elixir-autogen, elixir-format
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
@@ -14250,7 +14250,7 @@ msgstr ""
 msgid "Filter by a tag"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:691
+#: lib/vutuv_web/controllers/settings_controller.ex:696
 #, elixir-autogen, elixir-format
 msgid "Filter removed."
 msgstr ""
@@ -14266,7 +14266,7 @@ msgid "Match whole words only (word/phrase)"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5145
-#: lib/vutuv_web/controllers/settings_controller.ex:768
+#: lib/vutuv_web/controllers/settings_controller.ex:773
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
 #: lib/vutuv_web/templates/settings/mutes.html.heex:86
@@ -14360,7 +14360,7 @@ msgstr ""
 msgid "You have not muted anything yet."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:669
+#: lib/vutuv_web/controllers/settings_controller.ex:674
 #, elixir-autogen, elixir-format
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
@@ -14582,7 +14582,7 @@ msgstr ""
 msgid "Moving to or away from another Fediverse account?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:381
+#: lib/vutuv_web/controllers/settings_controller.ex:386
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:201
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
@@ -15474,7 +15474,7 @@ msgstr ""
 msgid "This confirmation expired. Please start again."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:295
+#: lib/vutuv/notifications/emailer.ex:296
 #, elixir-autogen, elixir-format
 msgid "Confirm your new username"
 msgstr ""
@@ -16828,7 +16828,7 @@ msgstr ""
 msgid "The most recent %{count} are shown. The rest are on their own server."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:742
+#: lib/vutuv_web/controllers/settings_controller.ex:747
 #: lib/vutuv_web/live/fediverse_account_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts are back in your feed."
@@ -18017,7 +18017,7 @@ msgstr ""
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:991
+#: lib/vutuv_web/controllers/settings_controller.ex:996
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr ""
@@ -18570,7 +18570,7 @@ msgstr ""
 msgid "Your employment reference has been reviewed."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:478
+#: lib/vutuv/notifications/emailer.ex:479
 #, elixir-autogen, elixir-format
 msgid "Your reference “%{title}” has been reviewed"
 msgstr ""
@@ -18646,7 +18646,7 @@ msgstr ""
 msgid "Upload the PDF or the scan. We read the text out of it, and the review always reads that text, never the file itself."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:459
+#: lib/vutuv/notifications/emailer.ex:460
 #, elixir-autogen, elixir-format
 msgid "%{count} new notification on vutuv"
 msgid_plural "%{count} new notifications on vutuv"
@@ -19063,9 +19063,9 @@ msgid "Always keep"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5249
-#: lib/vutuv_web/controllers/settings_controller.ex:249
-#: lib/vutuv_web/controllers/settings_controller.ex:328
-#: lib/vutuv_web/controllers/settings_controller.ex:340
+#: lib/vutuv_web/controllers/settings_controller.ex:254
+#: lib/vutuv_web/controllers/settings_controller.ex:333
+#: lib/vutuv_web/controllers/settings_controller.ex:345
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:20
 #: lib/vutuv_web/views/account_event_text.ex:254
 #, elixir-autogen, elixir-format
@@ -19226,12 +19226,12 @@ msgid_plural "Saving this rule deletes %{formatted} posts straight away. This ca
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:309
+#: lib/vutuv_web/controllers/settings_controller.ex:314
 #, elixir-autogen, elixir-format
 msgid "Settings saved."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:312
+#: lib/vutuv_web/controllers/settings_controller.ex:317
 #, elixir-autogen, elixir-format
 msgid "Settings saved. %{count} post was deleted."
 msgid_plural "Settings saved. %{formatted} posts were deleted."
@@ -19915,7 +19915,7 @@ msgstr ""
 msgid "Too many attempts for now. Try again later."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:351
+#: lib/vutuv/notifications/emailer.ex:352
 #, elixir-autogen, elixir-format
 msgid "New message from %{sender} on vutuv"
 msgstr ""
@@ -20278,7 +20278,7 @@ msgstr ""
 msgid "What is published there right now:"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:934
+#: lib/vutuv/notifications/emailer.ex:935
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is verified"
 msgstr ""
@@ -20335,7 +20335,7 @@ msgstr ""
 msgid "Mastodon-compatible apps"
 msgstr ""
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:70
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "Mastodon client access is disabled for every identity available to you."
 msgstr ""
@@ -20345,7 +20345,7 @@ msgstr ""
 msgid "Read data visible to this identity"
 msgstr ""
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:44
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:42
 #, elixir-autogen, elixir-format
 msgid "Use this identity"
 msgstr ""
@@ -20574,7 +20574,7 @@ msgstr ""
 msgid "Date & time"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:836
+#: lib/vutuv_web/controllers/settings_controller.ex:841
 #, elixir-autogen, elixir-format
 msgid "Date and time settings reset to the site defaults."
 msgstr ""
@@ -20589,7 +20589,7 @@ msgstr ""
 msgid "Germany, Austria, Switzerland"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:830
+#: lib/vutuv_web/controllers/settings_controller.ex:835
 #, elixir-autogen, elixir-format
 msgid "Language and region saved."
 msgstr ""
@@ -20716,7 +20716,7 @@ msgstr ""
 msgid "The page's Editorial team can use this organization as a separate identity in a compatible phone app, with the same rights they already have here. Those rights are checked again on every request."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:199
+#: lib/vutuv_web/controllers/settings_controller.ex:204
 #, elixir-autogen, elixir-format
 msgid "App settings saved."
 msgstr ""
@@ -21137,7 +21137,7 @@ msgstr ""
 msgid "E-mail to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:109
+#: lib/vutuv_web/controllers/job_posting_controller.ex:110
 #, elixir-autogen, elixir-format
 msgid "The employer takes applications on their own website."
 msgstr ""
@@ -21147,7 +21147,7 @@ msgstr ""
 msgid "Write e-mail"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:121
+#: lib/vutuv_web/controllers/job_posting_controller.ex:122
 #, elixir-autogen, elixir-format
 msgid "Your e-mail program opens with the subject filled in."
 msgstr ""
@@ -21544,12 +21544,12 @@ msgstr[1] ""
 msgid "Browser tab"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:916
+#: lib/vutuv_web/controllers/settings_controller.ex:921
 #, elixir-autogen, elixir-format
 msgid "Browser tab settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:910
+#: lib/vutuv_web/controllers/settings_controller.ex:915
 #, elixir-autogen, elixir-format
 msgid "Browser tab settings saved."
 msgstr ""
@@ -22357,19 +22357,19 @@ msgstr ""
 msgid "Describe the organization. Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:930
+#: lib/vutuv_web/controllers/settings_controller.ex:935
 #: lib/vutuv_web/templates/settings/bandwidth.html.heex:9
 #: lib/vutuv_web/templates/settings/bandwidth.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Bandwidth"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:980
+#: lib/vutuv_web/controllers/settings_controller.ex:985
 #, elixir-autogen, elixir-format
 msgid "Bandwidth settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:940
+#: lib/vutuv_web/controllers/settings_controller.ex:945
 #, elixir-autogen, elixir-format
 msgid "Bandwidth settings saved."
 msgstr ""
@@ -23022,7 +23022,7 @@ msgstr ""
 msgid "Accounts you have silenced, and whose reposts you hide"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:754
+#: lib/vutuv_web/controllers/settings_controller.ex:759
 #: lib/vutuv_web/live/remote_post_actions.ex:112
 #, elixir-autogen, elixir-format
 msgid "Hidden. What they pass on stays out of your feed; their own posts do not."
@@ -23045,14 +23045,14 @@ msgid "Mute everything"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5152
-#: lib/vutuv_web/controllers/settings_controller.ex:706
+#: lib/vutuv_web/controllers/settings_controller.ex:711
 #: lib/vutuv_web/templates/settings/mutes.html.heex:1
 #: lib/vutuv_web/templates/settings/mutes.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Muted accounts"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:756
+#: lib/vutuv_web/controllers/settings_controller.ex:761
 #: lib/vutuv_web/live/fediverse_account_live.ex:260
 #: lib/vutuv_web/live/remote_post_actions.ex:121
 #, elixir-autogen, elixir-format
@@ -23074,7 +23074,7 @@ msgstr ""
 msgid "Reposts only"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:719
+#: lib/vutuv_web/controllers/settings_controller.ex:724
 #, elixir-autogen, elixir-format
 msgid "That account is gone."
 msgstr ""
@@ -23179,12 +23179,12 @@ msgstr ""
 msgid "Feed length"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:974
+#: lib/vutuv_web/controllers/settings_controller.ex:979
 #, elixir-autogen, elixir-format
 msgid "Feed length reset to the site default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:968
+#: lib/vutuv_web/controllers/settings_controller.ex:973
 #, elixir-autogen, elixir-format
 msgid "Feed settings saved."
 msgstr ""
@@ -23200,7 +23200,7 @@ msgid "How many posts your feed shows before the “Load more” button, and how
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5222
-#: lib/vutuv_web/controllers/settings_controller.ex:958
+#: lib/vutuv_web/controllers/settings_controller.ex:963
 #: lib/vutuv_web/templates/settings/feed.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Posts in your feed"
@@ -23335,4 +23335,19 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:5883
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
+msgstr ""
+
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:84
+#, elixir-autogen, elixir-format
+msgid "Open the app settings"
+msgstr ""
+
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "Turn it on for your account and %{app} can be connected right here."
+msgstr ""
+
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:100
+#, elixir-autogen, elixir-format
+msgid "Turn on for my account"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1047,22 +1047,22 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:281
+#: lib/vutuv/notifications/emailer.ex:282
 #, elixir-autogen
 msgid "Confirm your account deletion"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:275
+#: lib/vutuv/notifications/emailer.ex:276
 #, elixir-autogen
 msgid "Confirm your email"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:263
+#: lib/vutuv/notifications/emailer.ex:264
 #, elixir-autogen
 msgid "Confirm your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:269
+#: lib/vutuv/notifications/emailer.ex:270
 #, elixir-autogen
 msgid "Login to vutuv"
 msgstr ""
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "tag name"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:321
+#: lib/vutuv/notifications/emailer.ex:322
 #, elixir-autogen
 msgid "vutuv Account verified"
 msgstr ""
@@ -3470,42 +3470,42 @@ msgstr ""
 msgid "yes"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1003
+#: lib/vutuv/notifications/emailer.ex:1004
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1087
+#: lib/vutuv/notifications/emailer.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1065
+#: lib/vutuv/notifications/emailer.ex:1066
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:977
+#: lib/vutuv/notifications/emailer.ex:978
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:970
+#: lib/vutuv/notifications/emailer.ex:971
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:963
+#: lib/vutuv/notifications/emailer.ex:964
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1017
+#: lib/vutuv/notifications/emailer.ex:1018
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1010
+#: lib/vutuv/notifications/emailer.ex:1011
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr ""
@@ -4891,7 +4891,7 @@ msgstr ""
 msgid "Active"
 msgstr ""
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:81
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Allow access"
 msgstr ""
@@ -4953,7 +4953,7 @@ msgstr ""
 msgid "Delete \"%{name}\"? Every member authorization and every token of this application stops working immediately."
 msgstr ""
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:84
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Deny"
 msgstr ""
@@ -5008,7 +5008,7 @@ msgstr ""
 msgid "One per line. Exact https:// URLs (http://localhost is allowed for development). The authorization flow only ever redirects to these."
 msgstr ""
 
-#: lib/vutuv_web/controllers/oauth_controller.ex:59
+#: lib/vutuv_web/controllers/oauth_controller.ex:69
 #, elixir-autogen, elixir-format
 msgid "Please log in to connect %{app} with your account."
 msgstr ""
@@ -5406,7 +5406,7 @@ msgstr ""
 msgid "View post"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:313
+#: lib/vutuv/notifications/emailer.ex:314
 #, elixir-autogen, elixir-format
 msgid "Someone tried to register with your email address"
 msgstr ""
@@ -5480,7 +5480,7 @@ msgstr ""
 msgid "Email addresses"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:591
+#: lib/vutuv_web/controllers/settings_controller.ex:596
 #, elixir-autogen, elixir-format
 msgid "Notification settings saved."
 msgstr ""
@@ -5507,7 +5507,7 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:225
+#: lib/vutuv_web/controllers/settings_controller.ex:230
 #, elixir-autogen, elixir-format
 msgid "Privacy settings saved."
 msgstr ""
@@ -5596,12 +5596,12 @@ msgstr ""
 msgid "e.g. Jr. or PhD"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:415
+#: lib/vutuv/notifications/emailer.ex:416
 #, elixir-autogen, elixir-format
 msgid "@%{slug} endorsed you on vutuv"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:401
+#: lib/vutuv/notifications/emailer.ex:402
 #, elixir-autogen, elixir-format
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
@@ -5642,7 +5642,7 @@ msgstr ""
 msgid "New followers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:563
+#: lib/vutuv_web/controllers/settings_controller.ex:568
 #, elixir-autogen, elixir-format
 msgid "Notification settings"
 msgstr ""
@@ -5838,12 +5838,12 @@ msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:1057
+#: lib/vutuv_web/controllers/settings_controller.ex:1062
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:717
+#: lib/vutuv/notifications/emailer.ex:718
 #, elixir-autogen, elixir-format
 msgid "Another session was already active on your account."
 msgstr ""
@@ -5868,7 +5868,7 @@ msgstr ""
 msgid "Log this device out of your account?"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:691
+#: lib/vutuv/notifications/emailer.ex:692
 #, elixir-autogen, elixir-format
 msgid "New sign-in to your vutuv account"
 msgstr ""
@@ -5878,12 +5878,12 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:1044
+#: lib/vutuv_web/controllers/settings_controller.ex:1049
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:720
+#: lib/vutuv/notifications/emailer.ex:721
 #, elixir-autogen, elixir-format
 msgid "The location looks different from where you usually sign in."
 msgstr ""
@@ -5893,7 +5893,7 @@ msgstr ""
 msgid "This device"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:714
+#: lib/vutuv/notifications/emailer.ex:715
 #, elixir-autogen, elixir-format
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
@@ -6240,7 +6240,7 @@ msgstr ""
 msgid "Default map"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:850
+#: lib/vutuv_web/controllers/settings_controller.ex:855
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr ""
@@ -8596,8 +8596,8 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1749
 #: lib/vutuv_web/components/ui.ex:5255
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
-#: lib/vutuv_web/controllers/settings_controller.ex:359
-#: lib/vutuv_web/controllers/settings_controller.ex:426
+#: lib/vutuv_web/controllers/settings_controller.ex:364
+#: lib/vutuv_web/controllers/settings_controller.ex:431
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:277
 #: lib/vutuv_web/live/organization_live/fediverse.ex:84
@@ -8627,7 +8627,7 @@ msgstr ""
 msgid "as a link in your Mastodon profile settings, and Mastodon will show it as verified with a green check."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:439
+#: lib/vutuv_web/controllers/settings_controller.ex:444
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings saved."
 msgstr ""
@@ -10452,7 +10452,7 @@ msgstr ""
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:864
+#: lib/vutuv_web/controllers/settings_controller.ex:869
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr ""
@@ -10501,7 +10501,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:896
+#: lib/vutuv_web/controllers/settings_controller.ex:901
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr ""
@@ -10516,7 +10516,7 @@ msgstr ""
 msgid "Own value; blank the field to go back to the installation default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:892
+#: lib/vutuv_web/controllers/settings_controller.ex:897
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -11730,7 +11730,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:462
 #: lib/vutuv_web/components/ui.ex:5282
-#: lib/vutuv_web/controllers/settings_controller.ex:215
+#: lib/vutuv_web/controllers/settings_controller.ex:220
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:538
@@ -11932,7 +11932,7 @@ msgstr ""
 msgid "Application e-mail"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:116
+#: lib/vutuv_web/controllers/job_posting_controller.ex:117
 #, elixir-autogen, elixir-format
 msgid "Application: %{title}"
 msgstr ""
@@ -12044,7 +12044,7 @@ msgstr ""
 msgid "Hybrid"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:135
+#: lib/vutuv_web/controllers/job_posting_controller.ex:136
 #, elixir-autogen, elixir-format
 msgid "I'm interested in your posting: %{url}"
 msgstr ""
@@ -12188,7 +12188,7 @@ msgstr ""
 msgid "Please confirm your email address before posting a job."
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:127
+#: lib/vutuv_web/controllers/job_posting_controller.ex:128
 #, elixir-autogen, elixir-format
 msgid "Please log in to message the poster."
 msgstr ""
@@ -12241,7 +12241,7 @@ msgstr ""
 
 #: lib/vutuv/accounts/user.ex:1275
 #: lib/vutuv/jobs/job_posting.ex:166
-#: lib/vutuv/notifications/emailer.ex:565
+#: lib/vutuv/notifications/emailer.ex:566
 #: lib/vutuv_web/agent_docs/markdown.ex:532
 #: lib/vutuv_web/agent_docs/markdown.ex:534
 #: lib/vutuv_web/agent_docs/text.ex:547
@@ -12278,7 +12278,7 @@ msgstr ""
 msgid "Salary on request"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:397
+#: lib/vutuv_web/controllers/settings_controller.ex:402
 #: lib/vutuv_web/live/job_posting_live/form.ex:379
 #, elixir-autogen, elixir-format
 msgid "Saved."
@@ -12376,12 +12376,12 @@ msgstr ""
 msgid "You already have the maximum number of published postings."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1033
+#: lib/vutuv/notifications/emailer.ex:1034
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:911
+#: lib/vutuv/notifications/emailer.ex:912
 #, elixir-autogen, elixir-format
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr ""
@@ -12401,12 +12401,12 @@ msgstr ""
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:908
+#: lib/vutuv/notifications/emailer.ex:909
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is about to lose its verification"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:954
+#: lib/vutuv/notifications/emailer.ex:955
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is no longer public"
 msgstr ""
@@ -12856,7 +12856,7 @@ msgstr ""
 msgid "—"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:514
+#: lib/vutuv/notifications/emailer.ex:515
 #, elixir-autogen, elixir-format
 msgid "%{count} new match for your saved searches"
 msgid_plural "%{count} new matches for your saved searches"
@@ -12868,7 +12868,7 @@ msgstr[1] ""
 msgid "Alert frequency"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:778
+#: lib/vutuv_web/controllers/settings_controller.ex:783
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr ""
@@ -12937,13 +12937,13 @@ msgstr ""
 msgid "Save search"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:796
+#: lib/vutuv_web/controllers/settings_controller.ex:801
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5191
-#: lib/vutuv_web/controllers/settings_controller.ex:622
+#: lib/vutuv_web/controllers/settings_controller.ex:627
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -12963,8 +12963,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3240
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:783
-#: lib/vutuv_web/controllers/settings_controller.ex:801
+#: lib/vutuv_web/controllers/settings_controller.ex:788
+#: lib/vutuv_web/controllers/settings_controller.ex:806
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:398
 #: lib/vutuv_web/live/organization_live/following.ex:291
 #: lib/vutuv_web/live/organization_live/following.ex:298
@@ -13401,7 +13401,7 @@ msgid "Posts tagged with a tag you follow show up in your feed, and people known
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5174
-#: lib/vutuv_web/controllers/settings_controller.ex:636
+#: lib/vutuv_web/controllers/settings_controller.ex:641
 #: lib/vutuv_web/live/post_live/feed.ex:710
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
@@ -13928,7 +13928,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:995
+#: lib/vutuv/notifications/emailer.ex:996
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
@@ -14155,7 +14155,7 @@ msgstr ""
 msgid "Cancel redirect"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:491
+#: lib/vutuv_web/controllers/settings_controller.ex:496
 #, elixir-autogen, elixir-format
 msgid "Done. Your Fediverse followers have been asked to follow your new account, and new posts are no longer federated from here. Your vutuv profile is unchanged."
 msgstr ""
@@ -14170,12 +14170,12 @@ msgstr ""
 msgid "On your other account, add your vutuv handle"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:530
+#: lib/vutuv_web/controllers/settings_controller.ex:535
 #, elixir-autogen, elixir-format
 msgid "Please enter the full https address of the account you are moving to."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:516
+#: lib/vutuv_web/controllers/settings_controller.ex:521
 #, elixir-autogen, elixir-format
 msgid "Redirect cancelled. Your posts federate from here again."
 msgstr ""
@@ -14190,17 +14190,17 @@ msgstr ""
 msgid "Redirected on %{date}"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:543
+#: lib/vutuv_web/controllers/settings_controller.ex:548
 #, elixir-autogen, elixir-format
 msgid "That account could not be reached. Check the address, and that the other server is online."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:537
+#: lib/vutuv_web/controllers/settings_controller.ex:542
 #, elixir-autogen, elixir-format
 msgid "That account does not list your vutuv profile as an alias yet. Add this profile's address there first, then try again."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:533
+#: lib/vutuv_web/controllers/settings_controller.ex:538
 #, elixir-autogen, elixir-format
 msgid "That is this account. Enter the account you are moving to."
 msgstr ""
@@ -14210,12 +14210,12 @@ msgstr ""
 msgid "This tells your Fediverse followers to follow your new account instead, and stops federating your posts from here. Your vutuv profile is not affected. Continue?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:521
+#: lib/vutuv_web/controllers/settings_controller.ex:526
 #, elixir-autogen, elixir-format
 msgid "Turn on federation first, then you can redirect your followers."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:525
+#: lib/vutuv_web/controllers/settings_controller.ex:530
 #, elixir-autogen, elixir-format
 msgid "You can only move once every %{days} days."
 msgstr ""
@@ -14238,7 +14238,7 @@ msgstr[1] ""
 msgid "All endorsers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:661
+#: lib/vutuv_web/controllers/settings_controller.ex:666
 #, elixir-autogen, elixir-format
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
@@ -14248,7 +14248,7 @@ msgstr ""
 msgid "Filter by a tag"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:691
+#: lib/vutuv_web/controllers/settings_controller.ex:696
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filter removed."
 msgstr ""
@@ -14264,7 +14264,7 @@ msgid "Match whole words only (word/phrase)"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5145
-#: lib/vutuv_web/controllers/settings_controller.ex:768
+#: lib/vutuv_web/controllers/settings_controller.ex:773
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
 #: lib/vutuv_web/templates/settings/mutes.html.heex:86
@@ -14358,7 +14358,7 @@ msgstr ""
 msgid "You have not muted anything yet."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:669
+#: lib/vutuv_web/controllers/settings_controller.ex:674
 #, elixir-autogen, elixir-format
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
@@ -14580,7 +14580,7 @@ msgstr ""
 msgid "Moving to or away from another Fediverse account?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:381
+#: lib/vutuv_web/controllers/settings_controller.ex:386
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:201
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
@@ -15472,7 +15472,7 @@ msgstr ""
 msgid "This confirmation expired. Please start again."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:295
+#: lib/vutuv/notifications/emailer.ex:296
 #, elixir-autogen, elixir-format
 msgid "Confirm your new username"
 msgstr ""
@@ -16826,7 +16826,7 @@ msgstr ""
 msgid "The most recent %{count} are shown. The rest are on their own server."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:742
+#: lib/vutuv_web/controllers/settings_controller.ex:747
 #: lib/vutuv_web/live/fediverse_account_live.ex:262
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unmuted. Their posts are back in your feed."
@@ -18015,7 +18015,7 @@ msgstr ""
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:991
+#: lib/vutuv_web/controllers/settings_controller.ex:996
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr ""
@@ -18568,7 +18568,7 @@ msgstr ""
 msgid "Your employment reference has been reviewed."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:478
+#: lib/vutuv/notifications/emailer.ex:479
 #, elixir-autogen, elixir-format
 msgid "Your reference “%{title}” has been reviewed"
 msgstr ""
@@ -18644,7 +18644,7 @@ msgstr ""
 msgid "Upload the PDF or the scan. We read the text out of it, and the review always reads that text, never the file itself."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:459
+#: lib/vutuv/notifications/emailer.ex:460
 #, elixir-autogen, elixir-format
 msgid "%{count} new notification on vutuv"
 msgid_plural "%{count} new notifications on vutuv"
@@ -19061,9 +19061,9 @@ msgid "Always keep"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5249
-#: lib/vutuv_web/controllers/settings_controller.ex:249
-#: lib/vutuv_web/controllers/settings_controller.ex:328
-#: lib/vutuv_web/controllers/settings_controller.ex:340
+#: lib/vutuv_web/controllers/settings_controller.ex:254
+#: lib/vutuv_web/controllers/settings_controller.ex:333
+#: lib/vutuv_web/controllers/settings_controller.ex:345
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:20
 #: lib/vutuv_web/views/account_event_text.ex:254
 #, elixir-autogen, elixir-format
@@ -19224,12 +19224,12 @@ msgid_plural "Saving this rule deletes %{formatted} posts straight away. This ca
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:309
+#: lib/vutuv_web/controllers/settings_controller.ex:314
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Settings saved."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:312
+#: lib/vutuv_web/controllers/settings_controller.ex:317
 #, elixir-autogen, elixir-format
 msgid "Settings saved. %{count} post was deleted."
 msgid_plural "Settings saved. %{formatted} posts were deleted."
@@ -19913,7 +19913,7 @@ msgstr ""
 msgid "Too many attempts for now. Try again later."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:351
+#: lib/vutuv/notifications/emailer.ex:352
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New message from %{sender} on vutuv"
 msgstr ""
@@ -20276,7 +20276,7 @@ msgstr ""
 msgid "What is published there right now:"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:934
+#: lib/vutuv/notifications/emailer.ex:935
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is verified"
 msgstr ""
@@ -20333,7 +20333,7 @@ msgstr ""
 msgid "Mastodon-compatible apps"
 msgstr ""
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:70
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "Mastodon client access is disabled for every identity available to you."
 msgstr ""
@@ -20343,7 +20343,7 @@ msgstr ""
 msgid "Read data visible to this identity"
 msgstr ""
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:44
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:42
 #, elixir-autogen, elixir-format
 msgid "Use this identity"
 msgstr ""
@@ -20572,7 +20572,7 @@ msgstr ""
 msgid "Date & time"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:836
+#: lib/vutuv_web/controllers/settings_controller.ex:841
 #, elixir-autogen, elixir-format
 msgid "Date and time settings reset to the site defaults."
 msgstr ""
@@ -20587,7 +20587,7 @@ msgstr ""
 msgid "Germany, Austria, Switzerland"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:830
+#: lib/vutuv_web/controllers/settings_controller.ex:835
 #, elixir-autogen, elixir-format
 msgid "Language and region saved."
 msgstr ""
@@ -20714,7 +20714,7 @@ msgstr ""
 msgid "The page's Editorial team can use this organization as a separate identity in a compatible phone app, with the same rights they already have here. Those rights are checked again on every request."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:199
+#: lib/vutuv_web/controllers/settings_controller.ex:204
 #, elixir-autogen, elixir-format
 msgid "App settings saved."
 msgstr ""
@@ -21135,7 +21135,7 @@ msgstr ""
 msgid "E-mail to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:109
+#: lib/vutuv_web/controllers/job_posting_controller.ex:110
 #, elixir-autogen, elixir-format
 msgid "The employer takes applications on their own website."
 msgstr ""
@@ -21145,7 +21145,7 @@ msgstr ""
 msgid "Write e-mail"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:121
+#: lib/vutuv_web/controllers/job_posting_controller.ex:122
 #, elixir-autogen, elixir-format
 msgid "Your e-mail program opens with the subject filled in."
 msgstr ""
@@ -21542,12 +21542,12 @@ msgstr[1] ""
 msgid "Browser tab"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:916
+#: lib/vutuv_web/controllers/settings_controller.ex:921
 #, elixir-autogen, elixir-format
 msgid "Browser tab settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:910
+#: lib/vutuv_web/controllers/settings_controller.ex:915
 #, elixir-autogen, elixir-format
 msgid "Browser tab settings saved."
 msgstr ""
@@ -22355,19 +22355,19 @@ msgstr ""
 msgid "Describe the organization. Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:930
+#: lib/vutuv_web/controllers/settings_controller.ex:935
 #: lib/vutuv_web/templates/settings/bandwidth.html.heex:9
 #: lib/vutuv_web/templates/settings/bandwidth.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Bandwidth"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:980
+#: lib/vutuv_web/controllers/settings_controller.ex:985
 #, elixir-autogen, elixir-format
 msgid "Bandwidth settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:940
+#: lib/vutuv_web/controllers/settings_controller.ex:945
 #, elixir-autogen, elixir-format
 msgid "Bandwidth settings saved."
 msgstr ""
@@ -23020,7 +23020,7 @@ msgstr ""
 msgid "Accounts you have silenced, and whose reposts you hide"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:754
+#: lib/vutuv_web/controllers/settings_controller.ex:759
 #: lib/vutuv_web/live/remote_post_actions.ex:112
 #, elixir-autogen, elixir-format
 msgid "Hidden. What they pass on stays out of your feed; their own posts do not."
@@ -23043,14 +23043,14 @@ msgid "Mute everything"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5152
-#: lib/vutuv_web/controllers/settings_controller.ex:706
+#: lib/vutuv_web/controllers/settings_controller.ex:711
 #: lib/vutuv_web/templates/settings/mutes.html.heex:1
 #: lib/vutuv_web/templates/settings/mutes.html.heex:3
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Muted accounts"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:756
+#: lib/vutuv_web/controllers/settings_controller.ex:761
 #: lib/vutuv_web/live/fediverse_account_live.ex:260
 #: lib/vutuv_web/live/remote_post_actions.ex:121
 #, elixir-autogen, elixir-format, fuzzy
@@ -23072,7 +23072,7 @@ msgstr ""
 msgid "Reposts only"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:719
+#: lib/vutuv_web/controllers/settings_controller.ex:724
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That account is gone."
 msgstr ""
@@ -23177,12 +23177,12 @@ msgstr ""
 msgid "Feed length"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:974
+#: lib/vutuv_web/controllers/settings_controller.ex:979
 #, elixir-autogen, elixir-format
 msgid "Feed length reset to the site default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:968
+#: lib/vutuv_web/controllers/settings_controller.ex:973
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Feed settings saved."
 msgstr ""
@@ -23198,7 +23198,7 @@ msgid "How many posts your feed shows before the “Load more” button, and how
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5222
-#: lib/vutuv_web/controllers/settings_controller.ex:958
+#: lib/vutuv_web/controllers/settings_controller.ex:963
 #: lib/vutuv_web/templates/settings/feed.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Posts in your feed"
@@ -23333,4 +23333,19 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:5883
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
+msgstr ""
+
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:84
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Open the app settings"
+msgstr ""
+
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "Turn it on for your account and %{app} can be connected right here."
+msgstr ""
+
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:100
+#, elixir-autogen, elixir-format
+msgid "Turn on for my account"
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -1069,22 +1069,22 @@ msgstr "Informazioni generali"
 msgid "Verify"
 msgstr "Verifica"
 
-#: lib/vutuv/notifications/emailer.ex:281
+#: lib/vutuv/notifications/emailer.ex:282
 #, elixir-autogen
 msgid "Confirm your account deletion"
 msgstr "Confermi l'eliminazione del Suo account"
 
-#: lib/vutuv/notifications/emailer.ex:275
+#: lib/vutuv/notifications/emailer.ex:276
 #, elixir-autogen
 msgid "Confirm your email"
 msgstr "Confermi il Suo indirizzo e-mail"
 
-#: lib/vutuv/notifications/emailer.ex:263
+#: lib/vutuv/notifications/emailer.ex:264
 #, elixir-autogen
 msgid "Confirm your vutuv account"
 msgstr "Confermi il Suo account vutuv"
 
-#: lib/vutuv/notifications/emailer.ex:269
+#: lib/vutuv/notifications/emailer.ex:270
 #, elixir-autogen
 msgid "Login to vutuv"
 msgstr "Accedi a vutuv"
@@ -1556,7 +1556,7 @@ msgstr "Vedi tag correlati"
 msgid "tag name"
 msgstr "nome del tag"
 
-#: lib/vutuv/notifications/emailer.ex:321
+#: lib/vutuv/notifications/emailer.ex:322
 #, elixir-autogen
 msgid "vutuv Account verified"
 msgstr "Account vutuv verificato"
@@ -3576,42 +3576,42 @@ msgstr ""
 msgid "yes"
 msgstr "sì"
 
-#: lib/vutuv/notifications/emailer.ex:1003
+#: lib/vutuv/notifications/emailer.ex:1004
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr "Un avvertimento per il Suo account vutuv"
 
-#: lib/vutuv/notifications/emailer.ex:1087
+#: lib/vutuv/notifications/emailer.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr "Moderazione: %{count} casi in attesa"
 
-#: lib/vutuv/notifications/emailer.ex:1065
+#: lib/vutuv/notifications/emailer.ex:1066
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr "Moderazione: un profilo è stato segnalato"
 
-#: lib/vutuv/notifications/emailer.ex:977
+#: lib/vutuv/notifications/emailer.ex:978
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr "Il contenuto che ha segnalato è stato corretto"
 
-#: lib/vutuv/notifications/emailer.ex:970
+#: lib/vutuv/notifications/emailer.ex:971
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr "Un Suo contenuto su vutuv è in esame"
 
-#: lib/vutuv/notifications/emailer.ex:963
+#: lib/vutuv/notifications/emailer.ex:964
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr "Un Suo contenuto su vutuv è stato segnalato ed è nascosto"
 
-#: lib/vutuv/notifications/emailer.ex:1017
+#: lib/vutuv/notifications/emailer.ex:1018
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr "Il Suo account vutuv è stato disattivato"
 
-#: lib/vutuv/notifications/emailer.ex:1010
+#: lib/vutuv/notifications/emailer.ex:1011
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr "Il Suo account vutuv è sospeso"
@@ -5079,7 +5079,7 @@ msgstr "Applicazioni API"
 msgid "Active"
 msgstr "Attiva"
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:81
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Allow access"
 msgstr "Consenti l'accesso"
@@ -5143,7 +5143,7 @@ msgstr ""
 "Eliminare \"%{name}\"? Ogni autorizzazione dei membri e ogni token di questa"
 " applicazione smette subito di funzionare."
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:84
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Deny"
 msgstr "Nega"
@@ -5203,7 +5203,7 @@ msgstr ""
 "Uno per riga. URL https:// esatti (http://localhost è ammesso in fase di "
 "sviluppo). Il flusso di autorizzazione reindirizza solo a questi."
 
-#: lib/vutuv_web/controllers/oauth_controller.ex:59
+#: lib/vutuv_web/controllers/oauth_controller.ex:69
 #, elixir-autogen, elixir-format
 msgid "Please log in to connect %{app} with your account."
 msgstr "Acceda per collegare %{app} al Suo account."
@@ -5623,7 +5623,7 @@ msgstr "Navigazione a piè di pagina"
 msgid "View post"
 msgstr "Vedi il post"
 
-#: lib/vutuv/notifications/emailer.ex:313
+#: lib/vutuv/notifications/emailer.ex:314
 #, elixir-autogen, elixir-format
 msgid "Someone tried to register with your email address"
 msgstr "Qualcuno ha provato a registrarsi con il Suo indirizzo e-mail"
@@ -5697,7 +5697,7 @@ msgstr "Scarichi in un unico file tutto ciò che vutuv conserva su di Lei."
 msgid "Email addresses"
 msgstr "Indirizzi e-mail"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:591
+#: lib/vutuv_web/controllers/settings_controller.ex:596
 #, elixir-autogen, elixir-format
 msgid "Notification settings saved."
 msgstr "Impostazioni delle notifiche salvate."
@@ -5724,7 +5724,7 @@ msgstr "Foto"
 msgid "Privacy"
 msgstr "Privacy"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:225
+#: lib/vutuv_web/controllers/settings_controller.ex:230
 #, elixir-autogen, elixir-format
 msgid "Privacy settings saved."
 msgstr "Impostazioni della privacy salvate."
@@ -5815,12 +5815,12 @@ msgstr "ad esempio Dott. o Prof."
 msgid "e.g. Jr. or PhD"
 msgstr "ad esempio Jr. o PhD"
 
-#: lib/vutuv/notifications/emailer.ex:415
+#: lib/vutuv/notifications/emailer.ex:416
 #, elixir-autogen, elixir-format
 msgid "@%{slug} endorsed you on vutuv"
 msgstr "@%{slug} L'ha confermata su vutuv"
 
-#: lib/vutuv/notifications/emailer.ex:401
+#: lib/vutuv/notifications/emailer.ex:402
 #, elixir-autogen, elixir-format
 msgid "@%{slug} started following you on vutuv"
 msgstr "@%{slug} ha iniziato a seguirla su vutuv"
@@ -5861,7 +5861,7 @@ msgstr "Notifiche nell'app"
 msgid "New followers"
 msgstr "Nuovi follower"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:563
+#: lib/vutuv_web/controllers/settings_controller.ex:568
 #, elixir-autogen, elixir-format
 msgid "Notification settings"
 msgstr "Impostazioni delle notifiche"
@@ -6060,12 +6060,12 @@ msgid_plural "%{count} minutes ago"
 msgstr[0] "%{count} minuto fa"
 msgstr[1] "%{count} minuti fa"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:1057
+#: lib/vutuv_web/controllers/settings_controller.ex:1062
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr "Tutti gli altri dispositivi sono stati disconnessi."
 
-#: lib/vutuv/notifications/emailer.ex:717
+#: lib/vutuv/notifications/emailer.ex:718
 #, elixir-autogen, elixir-format
 msgid "Another session was already active on your account."
 msgstr "Sul Suo account era già attiva un'altra sessione."
@@ -6090,7 +6090,7 @@ msgstr "Disconnettere ogni dispositivo tranne questo?"
 msgid "Log this device out of your account?"
 msgstr "Disconnettere questo dispositivo dal Suo account?"
 
-#: lib/vutuv/notifications/emailer.ex:691
+#: lib/vutuv/notifications/emailer.ex:692
 #, elixir-autogen, elixir-format
 msgid "New sign-in to your vutuv account"
 msgstr "Nuovo accesso al Suo account vutuv"
@@ -6100,12 +6100,12 @@ msgstr "Nuovo accesso al Suo account vutuv"
 msgid "Signed-in devices"
 msgstr "Dispositivi connessi"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:1044
+#: lib/vutuv_web/controllers/settings_controller.ex:1049
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr "Quel dispositivo è stato disconnesso."
 
-#: lib/vutuv/notifications/emailer.ex:720
+#: lib/vutuv/notifications/emailer.ex:721
 #, elixir-autogen, elixir-format
 msgid "The location looks different from where you usually sign in."
 msgstr "La posizione è diversa da quella da cui accede di solito."
@@ -6115,7 +6115,7 @@ msgstr "La posizione è diversa da quella da cui accede di solito."
 msgid "This device"
 msgstr "Questo dispositivo"
 
-#: lib/vutuv/notifications/emailer.ex:714
+#: lib/vutuv/notifications/emailer.ex:715
 #, elixir-autogen, elixir-format
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr "È il primo accesso che vediamo da questo dispositivo o browser."
@@ -6475,7 +6475,7 @@ msgstr "Ritira la conferma"
 msgid "Default map"
 msgstr "Mappa predefinita"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:850
+#: lib/vutuv_web/controllers/settings_controller.ex:855
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr "Preferenze delle mappe salvate."
@@ -8986,8 +8986,8 @@ msgstr "La scriva in Amministrazione › Pagine legali"
 #: lib/vutuv_web/components/ui.ex:1749
 #: lib/vutuv_web/components/ui.ex:5255
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
-#: lib/vutuv_web/controllers/settings_controller.ex:359
-#: lib/vutuv_web/controllers/settings_controller.ex:426
+#: lib/vutuv_web/controllers/settings_controller.ex:364
+#: lib/vutuv_web/controllers/settings_controller.ex:431
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:277
 #: lib/vutuv_web/live/organization_live/fediverse.ex:84
@@ -9021,7 +9021,7 @@ msgstr ""
 "come link nelle impostazioni del Suo profilo Mastodon, e Mastodon lo "
 "mostrerà come verificato con una spunta verde."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:439
+#: lib/vutuv_web/controllers/settings_controller.ex:444
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings saved."
 msgstr "Impostazioni del Fediverso salvate."
@@ -10958,7 +10958,7 @@ msgstr ""
 "I post più lunghi ricevono un link “Leggi tutto”. Imposti 0 (o lasci vuoto) "
 "per non accorciare mai."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:864
+#: lib/vutuv_web/controllers/settings_controller.ex:869
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr "Impostazioni di visualizzazione dei post salvate."
@@ -11015,7 +11015,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr "Valore predefinito dell'installazione (%{value})"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:896
+#: lib/vutuv_web/controllers/settings_controller.ex:901
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr "Preferenze delle mappe riportate ai valori predefiniti del sito."
@@ -11034,7 +11034,7 @@ msgstr ""
 "Valore proprio; svuoti il campo per tornare al valore predefinito "
 "dell'installazione."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:892
+#: lib/vutuv_web/controllers/settings_controller.ex:897
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -12341,7 +12341,7 @@ msgstr "Organizzazione sbloccata."
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:462
 #: lib/vutuv_web/components/ui.ex:5282
-#: lib/vutuv_web/controllers/settings_controller.ex:215
+#: lib/vutuv_web/controllers/settings_controller.ex:220
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:538
@@ -12559,7 +12559,7 @@ msgstr "URL per la candidatura"
 msgid "Application e-mail"
 msgstr "Indirizzo e-mail per la candidatura"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:116
+#: lib/vutuv_web/controllers/job_posting_controller.ex:117
 #, elixir-autogen, elixir-format
 msgid "Application: %{title}"
 msgstr "Candidatura: %{title}"
@@ -12671,7 +12671,7 @@ msgstr "Come candidarsi"
 msgid "Hybrid"
 msgstr "Ibrido"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:135
+#: lib/vutuv_web/controllers/job_posting_controller.ex:136
 #, elixir-autogen, elixir-format
 msgid "I'm interested in your posting: %{url}"
 msgstr "Mi interessa il Suo annuncio: %{url}"
@@ -12820,7 +12820,7 @@ msgid "Please confirm your email address before posting a job."
 msgstr ""
 "Confermi il Suo indirizzo e-mail prima di pubblicare un annuncio di lavoro."
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:127
+#: lib/vutuv_web/controllers/job_posting_controller.ex:128
 #, elixir-autogen, elixir-format
 msgid "Please log in to message the poster."
 msgstr "Acceda per scrivere a chi ha pubblicato."
@@ -12873,7 +12873,7 @@ msgstr "Pubblica"
 
 #: lib/vutuv/accounts/user.ex:1275
 #: lib/vutuv/jobs/job_posting.ex:166
-#: lib/vutuv/notifications/emailer.ex:565
+#: lib/vutuv/notifications/emailer.ex:566
 #: lib/vutuv_web/agent_docs/markdown.ex:532
 #: lib/vutuv_web/agent_docs/markdown.ex:534
 #: lib/vutuv_web/agent_docs/text.ex:547
@@ -12910,7 +12910,7 @@ msgstr "Retribuzione"
 msgid "Salary on request"
 msgstr "Retribuzione su richiesta"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:397
+#: lib/vutuv_web/controllers/settings_controller.ex:402
 #: lib/vutuv_web/live/job_posting_live/form.ex:379
 #, elixir-autogen, elixir-format
 msgid "Saved."
@@ -13013,12 +13013,12 @@ msgstr "Modalità di lavoro"
 msgid "You already have the maximum number of published postings."
 msgstr "Ha già raggiunto il numero massimo di annunci pubblicati."
 
-#: lib/vutuv/notifications/emailer.ex:1033
+#: lib/vutuv/notifications/emailer.ex:1034
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr "Il Suo annuncio di lavoro su vutuv scade a breve"
 
-#: lib/vutuv/notifications/emailer.ex:911
+#: lib/vutuv/notifications/emailer.ex:912
 #, elixir-autogen, elixir-format
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr ""
@@ -13043,12 +13043,12 @@ msgstr ""
 "dominio. La ripristini e controlli di nuovo, altrimenti il dominio perde la "
 "verifica."
 
-#: lib/vutuv/notifications/emailer.ex:908
+#: lib/vutuv/notifications/emailer.ex:909
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is about to lose its verification"
 msgstr "La Sua pagina di organizzazione su vutuv sta per perdere la verifica"
 
-#: lib/vutuv/notifications/emailer.ex:954
+#: lib/vutuv/notifications/emailer.ex:955
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is no longer public"
 msgstr "La Sua pagina di organizzazione su vutuv non è più pubblica"
@@ -13531,7 +13531,7 @@ msgstr "pagina di organizzazione verificata"
 msgid "—"
 msgstr "—"
 
-#: lib/vutuv/notifications/emailer.ex:514
+#: lib/vutuv/notifications/emailer.ex:515
 #, elixir-autogen, elixir-format
 msgid "%{count} new match for your saved searches"
 msgid_plural "%{count} new matches for your saved searches"
@@ -13543,7 +13543,7 @@ msgstr[1] "%{count} nuove corrispondenze per le Sue ricerche salvate"
 msgid "Alert frequency"
 msgstr "Frequenza degli avvisi"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:778
+#: lib/vutuv_web/controllers/settings_controller.ex:783
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr "Avviso aggiornato."
@@ -13616,13 +13616,13 @@ msgstr ""
 msgid "Save search"
 msgstr "Salva la ricerca"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:796
+#: lib/vutuv_web/controllers/settings_controller.ex:801
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr "Ricerca salvata eliminata."
 
 #: lib/vutuv_web/components/ui.ex:5191
-#: lib/vutuv_web/controllers/settings_controller.ex:622
+#: lib/vutuv_web/controllers/settings_controller.ex:627
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13643,8 +13643,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3240
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:783
-#: lib/vutuv_web/controllers/settings_controller.ex:801
+#: lib/vutuv_web/controllers/settings_controller.ex:788
+#: lib/vutuv_web/controllers/settings_controller.ex:806
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:398
 #: lib/vutuv_web/live/organization_live/following.ex:291
 #: lib/vutuv_web/live/organization_live/following.ex:298
@@ -14137,7 +14137,7 @@ msgstr ""
 "dalla sua pagina."
 
 #: lib/vutuv_web/components/ui.ex:5174
-#: lib/vutuv_web/controllers/settings_controller.ex:636
+#: lib/vutuv_web/controllers/settings_controller.ex:641
 #: lib/vutuv_web/live/post_live/feed.ex:710
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
@@ -14685,7 +14685,7 @@ msgstr "Modalità di lavoro preferita"
 msgid "Availability"
 msgstr "Disponibilità"
 
-#: lib/vutuv/notifications/emailer.ex:995
+#: lib/vutuv/notifications/emailer.ex:996
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Un controllo automatico ha rimosso un'immagine dal Suo account vutuv"
@@ -14935,7 +14935,7 @@ msgstr "Account verso cui si sta spostando"
 msgid "Cancel redirect"
 msgstr "Annulla il reindirizzamento"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:491
+#: lib/vutuv_web/controllers/settings_controller.ex:496
 #, elixir-autogen, elixir-format
 msgid "Done. Your Fediverse followers have been asked to follow your new account, and new posts are no longer federated from here. Your vutuv profile is unchanged."
 msgstr ""
@@ -14955,14 +14955,14 @@ msgstr ""
 msgid "On your other account, add your vutuv handle"
 msgstr "Sull'altro Suo account, aggiunga il Suo handle vutuv"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:530
+#: lib/vutuv_web/controllers/settings_controller.ex:535
 #, elixir-autogen, elixir-format
 msgid "Please enter the full https address of the account you are moving to."
 msgstr ""
 "Inserisca l'indirizzo https completo dell'account verso cui si sta "
 "spostando."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:516
+#: lib/vutuv_web/controllers/settings_controller.ex:521
 #, elixir-autogen, elixir-format
 msgid "Redirect cancelled. Your posts federate from here again."
 msgstr ""
@@ -14978,21 +14978,21 @@ msgstr "Reindirizza i miei follower"
 msgid "Redirected on %{date}"
 msgstr "Reindirizzati il %{date}"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:543
+#: lib/vutuv_web/controllers/settings_controller.ex:548
 #, elixir-autogen, elixir-format
 msgid "That account could not be reached. Check the address, and that the other server is online."
 msgstr ""
 "Non è stato possibile raggiungere quell'account. Controlli l'indirizzo e che"
 " l'altro server sia online."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:537
+#: lib/vutuv_web/controllers/settings_controller.ex:542
 #, elixir-autogen, elixir-format
 msgid "That account does not list your vutuv profile as an alias yet. Add this profile's address there first, then try again."
 msgstr ""
 "Quell'account non indica ancora il Suo profilo vutuv come alias. Aggiunga "
 "prima lì l'indirizzo di questo profilo, poi riprovi."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:533
+#: lib/vutuv_web/controllers/settings_controller.ex:538
 #, elixir-autogen, elixir-format
 msgid "That is this account. Enter the account you are moving to."
 msgstr ""
@@ -15006,12 +15006,12 @@ msgstr ""
 "interrompe la federazione dei Suoi post da qui. Il Suo profilo vutuv non "
 "viene toccato. Continuare?"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:521
+#: lib/vutuv_web/controllers/settings_controller.ex:526
 #, elixir-autogen, elixir-format
 msgid "Turn on federation first, then you can redirect your followers."
 msgstr "Attivi prima la federazione, poi potrà reindirizzare i Suoi follower."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:525
+#: lib/vutuv_web/controllers/settings_controller.ex:530
 #, elixir-autogen, elixir-format
 msgid "You can only move once every %{days} days."
 msgstr "Può spostarsi solo una volta ogni %{days} giorni."
@@ -15034,7 +15034,7 @@ msgstr[1] "%{formatted} conferme"
 msgid "All endorsers"
 msgstr "Tutti quelli che hanno confermato"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:661
+#: lib/vutuv_web/controllers/settings_controller.ex:666
 #, elixir-autogen, elixir-format
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
@@ -15045,7 +15045,7 @@ msgstr ""
 msgid "Filter by a tag"
 msgstr "Filtra per tag"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:691
+#: lib/vutuv_web/controllers/settings_controller.ex:696
 #, elixir-autogen, elixir-format
 msgid "Filter removed."
 msgstr "Filtro rimosso."
@@ -15065,7 +15065,7 @@ msgid "Match whole words only (word/phrase)"
 msgstr "Corrispondenza solo su parole intere (parola o frase)"
 
 #: lib/vutuv_web/components/ui.ex:5145
-#: lib/vutuv_web/controllers/settings_controller.ex:768
+#: lib/vutuv_web/controllers/settings_controller.ex:773
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
 #: lib/vutuv_web/templates/settings/mutes.html.heex:86
@@ -15168,7 +15168,7 @@ msgstr "Non ha i permessi per modificare l'handle di questa organizzazione."
 msgid "You have not muted anything yet."
 msgstr "Non ha ancora silenziato nulla."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:669
+#: lib/vutuv_web/controllers/settings_controller.ex:674
 #, elixir-autogen, elixir-format
 msgid "You have reached the maximum of %{count} filters."
 msgstr "Ha raggiunto il massimo di %{count} filtri."
@@ -15420,7 +15420,7 @@ msgstr "Correlati"
 msgid "Moving to or away from another Fediverse account?"
 msgstr "Si sta spostando verso o da un altro account del Fediverso?"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:381
+#: lib/vutuv_web/controllers/settings_controller.ex:386
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:201
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
@@ -16387,7 +16387,7 @@ msgstr "Confermi la modifica prima che rinominiamo il Suo account."
 msgid "This confirmation expired. Please start again."
 msgstr "Questa conferma è scaduta. Ricominci da capo."
 
-#: lib/vutuv/notifications/emailer.ex:295
+#: lib/vutuv/notifications/emailer.ex:296
 #, elixir-autogen, elixir-format
 msgid "Confirm your new username"
 msgstr "Confermi il Suo nuovo nome utente"
@@ -17863,7 +17863,7 @@ msgstr "Mostra tutta la descrizione"
 msgid "The most recent %{count} are shown. The rest are on their own server."
 msgstr "Sono mostrati i %{count} più recenti. Gli altri sono sul loro server."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:742
+#: lib/vutuv_web/controllers/settings_controller.ex:747
 #: lib/vutuv_web/live/fediverse_account_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts are back in your feed."
@@ -19234,7 +19234,7 @@ msgstr ""
 "ha ricevuto quando ha messo Mi piace. In ogni caso il post mantiene lo "
 "stesso numero di Mi piace."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:991
+#: lib/vutuv_web/controllers/settings_controller.ex:996
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr "I Suoi Mi piace tornano a seguire il valore predefinito del sito."
@@ -19820,7 +19820,7 @@ msgstr ""
 msgid "Your employment reference has been reviewed."
 msgstr "Il Suo attestato di lavoro è stato analizzato."
 
-#: lib/vutuv/notifications/emailer.ex:478
+#: lib/vutuv/notifications/emailer.ex:479
 #, elixir-autogen, elixir-format
 msgid "Your reference “%{title}” has been reviewed"
 msgstr "Il Suo attestato “%{title}” è stato analizzato"
@@ -19911,7 +19911,7 @@ msgstr ""
 "Carichi il PDF o la scansione. Ne estraiamo il testo, e l'analisi legge "
 "sempre quel testo, mai il file stesso."
 
-#: lib/vutuv/notifications/emailer.ex:459
+#: lib/vutuv/notifications/emailer.ex:460
 #, elixir-autogen, elixir-format
 msgid "%{count} new notification on vutuv"
 msgid_plural "%{count} new notifications on vutuv"
@@ -20380,9 +20380,9 @@ msgid "Always keep"
 msgstr "Conserva sempre"
 
 #: lib/vutuv_web/components/ui.ex:5249
-#: lib/vutuv_web/controllers/settings_controller.ex:249
-#: lib/vutuv_web/controllers/settings_controller.ex:328
-#: lib/vutuv_web/controllers/settings_controller.ex:340
+#: lib/vutuv_web/controllers/settings_controller.ex:254
+#: lib/vutuv_web/controllers/settings_controller.ex:333
+#: lib/vutuv_web/controllers/settings_controller.ex:345
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:20
 #: lib/vutuv_web/views/account_event_text.ex:254
 #, elixir-autogen, elixir-format
@@ -20566,12 +20566,12 @@ msgstr[1] ""
 "Salvando questa regola vengono eliminati subito %{formatted} post. "
 "L'operazione non si può annullare."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:309
+#: lib/vutuv_web/controllers/settings_controller.ex:314
 #, elixir-autogen, elixir-format
 msgid "Settings saved."
 msgstr "Impostazioni salvate."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:312
+#: lib/vutuv_web/controllers/settings_controller.ex:317
 #, elixir-autogen, elixir-format
 msgid "Settings saved. %{count} post was deleted."
 msgid_plural "Settings saved. %{formatted} posts were deleted."
@@ -21318,7 +21318,7 @@ msgstr "Questa pagina non segue ancora nessuno su un'altra rete."
 msgid "Too many attempts for now. Try again later."
 msgstr "Per ora troppi tentativi. Riprovi più tardi."
 
-#: lib/vutuv/notifications/emailer.ex:351
+#: lib/vutuv/notifications/emailer.ex:352
 #, elixir-autogen, elixir-format
 msgid "New message from %{sender} on vutuv"
 msgstr "Nuovo messaggio da %{sender} su vutuv"
@@ -21736,7 +21736,7 @@ msgstr "Abbiamo scaricato questo indirizzo:"
 msgid "What is published there right now:"
 msgstr "Cosa è pubblicato lì in questo momento:"
 
-#: lib/vutuv/notifications/emailer.ex:934
+#: lib/vutuv/notifications/emailer.ex:935
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is verified"
 msgstr "La Sua pagina di organizzazione su vutuv è verificata"
@@ -21793,7 +21793,7 @@ msgstr "Silenziare o riattivare account"
 msgid "Mastodon-compatible apps"
 msgstr "App compatibili con Mastodon"
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:70
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "Mastodon client access is disabled for every identity available to you."
 msgstr ""
@@ -21805,7 +21805,7 @@ msgstr ""
 msgid "Read data visible to this identity"
 msgstr "Leggere i dati visibili a questa identità"
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:44
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:42
 #, elixir-autogen, elixir-format
 msgid "Use this identity"
 msgstr "Usa questa identità"
@@ -22055,7 +22055,7 @@ msgstr ""
 msgid "Date & time"
 msgstr "Data e ora"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:836
+#: lib/vutuv_web/controllers/settings_controller.ex:841
 #, elixir-autogen, elixir-format
 msgid "Date and time settings reset to the site defaults."
 msgstr "Impostazioni di data e ora riportate ai valori predefiniti del sito."
@@ -22070,7 +22070,7 @@ msgstr "Formato della data"
 msgid "Germany, Austria, Switzerland"
 msgstr "Germania, Austria, Svizzera"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:830
+#: lib/vutuv_web/controllers/settings_controller.ex:835
 #, elixir-autogen, elixir-format
 msgid "Language and region saved."
 msgstr "Lingua e regione salvate."
@@ -22217,7 +22217,7 @@ msgstr ""
 "separata in un'app per telefono compatibile, con gli stessi diritti che ha "
 "già qui. Quei diritti vengono ricontrollati a ogni richiesta."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:199
+#: lib/vutuv_web/controllers/settings_controller.ex:204
 #, elixir-autogen, elixir-format
 msgid "App settings saved."
 msgstr "Impostazioni delle app salvate."
@@ -22691,7 +22691,7 @@ msgstr "Prosegui verso %{server}"
 msgid "E-mail to %{address}"
 msgstr "E-mail a %{address}"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:109
+#: lib/vutuv_web/controllers/job_posting_controller.ex:110
 #, elixir-autogen, elixir-format
 msgid "The employer takes applications on their own website."
 msgstr "Il datore di lavoro raccoglie le candidature sul proprio sito web."
@@ -22701,7 +22701,7 @@ msgstr "Il datore di lavoro raccoglie le candidature sul proprio sito web."
 msgid "Write e-mail"
 msgstr "Scrivi un'e-mail"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:121
+#: lib/vutuv_web/controllers/job_posting_controller.ex:122
 #, elixir-autogen, elixir-format
 msgid "Your e-mail program opens with the subject filled in."
 msgstr "Il Suo programma di posta si apre con l'oggetto già compilato."
@@ -23125,12 +23125,12 @@ msgstr[1] "+%{formatted} altri post"
 msgid "Browser tab"
 msgstr "Scheda del browser"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:916
+#: lib/vutuv_web/controllers/settings_controller.ex:921
 #, elixir-autogen, elixir-format
 msgid "Browser tab settings reset to the site defaults."
 msgstr "Impostazioni della scheda del browser ripristinate ai valori predefiniti del sito."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:910
+#: lib/vutuv_web/controllers/settings_controller.ex:915
 #, elixir-autogen, elixir-format
 msgid "Browser tab settings saved."
 msgstr "Impostazioni della scheda del browser salvate."
@@ -23948,19 +23948,19 @@ msgstr "Conservare questa bozza per dopo?"
 msgid "Describe the organization. Markdown is supported."
 msgstr "Descriva l'organizzazione. Markdown è supportato."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:930
+#: lib/vutuv_web/controllers/settings_controller.ex:935
 #: lib/vutuv_web/templates/settings/bandwidth.html.heex:9
 #: lib/vutuv_web/templates/settings/bandwidth.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Bandwidth"
 msgstr "Larghezza di banda"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:980
+#: lib/vutuv_web/controllers/settings_controller.ex:985
 #, elixir-autogen, elixir-format
 msgid "Bandwidth settings reset to the site defaults."
 msgstr "Impostazioni della larghezza di banda ripristinate ai valori predefiniti del sito."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:940
+#: lib/vutuv_web/controllers/settings_controller.ex:945
 #, elixir-autogen, elixir-format
 msgid "Bandwidth settings saved."
 msgstr "Impostazioni della larghezza di banda salvate."
@@ -24613,7 +24613,7 @@ msgstr "Account i cui post non compaiono nel Suo feed e account di cui ha nascos
 msgid "Accounts you have silenced, and whose reposts you hide"
 msgstr "Account che ha silenziato e account di cui nasconde le ripubblicazioni"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:754
+#: lib/vutuv_web/controllers/settings_controller.ex:759
 #: lib/vutuv_web/live/remote_post_actions.ex:112
 #, elixir-autogen, elixir-format
 msgid "Hidden. What they pass on stays out of your feed; their own posts do not."
@@ -24636,14 +24636,14 @@ msgid "Mute everything"
 msgstr "Silenzia tutto"
 
 #: lib/vutuv_web/components/ui.ex:5152
-#: lib/vutuv_web/controllers/settings_controller.ex:706
+#: lib/vutuv_web/controllers/settings_controller.ex:711
 #: lib/vutuv_web/templates/settings/mutes.html.heex:1
 #: lib/vutuv_web/templates/settings/mutes.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Muted accounts"
 msgstr "Account silenziati"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:756
+#: lib/vutuv_web/controllers/settings_controller.ex:761
 #: lib/vutuv_web/live/fediverse_account_live.ex:260
 #: lib/vutuv_web/live/remote_post_actions.ex:121
 #, elixir-autogen, elixir-format
@@ -24665,7 +24665,7 @@ msgstr "Ripubblicazioni nascoste"
 msgid "Reposts only"
 msgstr "Solo ripubblicazioni"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:719
+#: lib/vutuv_web/controllers/settings_controller.ex:724
 #, elixir-autogen, elixir-format
 msgid "That account is gone."
 msgstr "Questo account non esiste più."
@@ -24770,12 +24770,12 @@ msgstr ""
 msgid "Feed length"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:974
+#: lib/vutuv_web/controllers/settings_controller.ex:979
 #, elixir-autogen, elixir-format
 msgid "Feed length reset to the site default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:968
+#: lib/vutuv_web/controllers/settings_controller.ex:973
 #, elixir-autogen, elixir-format
 msgid "Feed settings saved."
 msgstr "Impostazioni del feed salvate."
@@ -24791,7 +24791,7 @@ msgid "How many posts your feed shows before the “Load more” button, and how
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5222
-#: lib/vutuv_web/controllers/settings_controller.ex:958
+#: lib/vutuv_web/controllers/settings_controller.ex:963
 #: lib/vutuv_web/templates/settings/feed.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Posts in your feed"
@@ -24927,3 +24927,18 @@ msgstr "Il sito funziona, è questo indirizzo a non essere uno dei nostri. Proba
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr "Ingrandisci lo screenshot"
+
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:84
+#, elixir-autogen, elixir-format
+msgid "Open the app settings"
+msgstr "Apri le impostazioni delle app"
+
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "Turn it on for your account and %{app} can be connected right here."
+msgstr "Attivalo per il tuo account e potrai collegare %{app} direttamente da qui."
+
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:100
+#, elixir-autogen, elixir-format
+msgid "Turn on for my account"
+msgstr "Attiva per il mio account"

--- a/test/vutuv_web/controllers/oauth_consent_switch_test.exs
+++ b/test/vutuv_web/controllers/oauth_consent_switch_test.exs
@@ -1,0 +1,117 @@
+defmodule VutuvWeb.OauthConsentSwitchTest do
+  @moduledoc """
+  A member whose Mastodon-app switch is off meets it on the consent screen,
+  sent there by the app: the screen offers the switch itself and comes back to
+  the same request with Allow live, and links the settings page beside it.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  import Vutuv.MastodonHelpers
+
+  alias Plug.Conn.Query
+  alias Vutuv.AccountEvents.AccountEvent
+
+  setup %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    refute user.mastodon_clients?
+
+    {:ok, conn: conn, user: user, app: register_mastodon_app()}
+  end
+
+  defp query(app) do
+    %{
+      "response_type" => "code",
+      "client_id" => app.client_id,
+      "redirect_uri" => hd(app.redirect_uris),
+      "scope" => "read"
+    }
+  end
+
+  defp consent_page(conn, app), do: get(conn, ~p"/oauth/authorize?#{query(app)}")
+
+  # The switch form as the page rendered it, so the test presses what the
+  # member presses: its `action=` and the fields it carries, encoded and decoded
+  # the way a browser's submit reaches the controller (`user[…]` nests).
+  defp switch_form(page) do
+    [form] = elements(page.resp_body, "form#oauth-enable-apps")
+    [action] = LazyHTML.attribute(form, "action")
+
+    fields =
+      form
+      |> LazyHTML.query(~s(input[type="hidden"]))
+      |> Map.new(&{hd(LazyHTML.attribute(&1, "name")), hd(LazyHTML.attribute(&1, "value"))})
+      |> Query.encode()
+      |> Query.decode()
+
+    {action, fields}
+  end
+
+  test "with the switch off, the screen offers it and links the setting", %{
+    conn: conn,
+    app: app
+  } do
+    page = consent_page(conn, app)
+    body = html_response(page, 200)
+
+    assert body =~ "Mastodon client access is disabled for every identity available to you."
+    assert body =~ ~s(href="/settings/apps")
+    assert body =~ ~s(form="oauth-enable-apps")
+    refute body =~ "oauth-allow"
+
+    {action, fields} = switch_form(page)
+    assert action == "/settings/apps"
+    assert fields["_method"] == "put"
+    assert fields["user"] == %{"mastodon_clients?" => "true"}
+    assert fields["return_to"] == ~p"/oauth/authorize?#{query(app)}"
+  end
+
+  test "one press turns the switch on and lands back on the same request", %{
+    conn: conn,
+    user: user,
+    app: app
+  } do
+    {action, fields} = conn |> consent_page(app) |> switch_form()
+
+    response = post(conn, action, fields)
+    assert redirected_to(response) == ~p"/oauth/authorize?#{query(app)}"
+    assert Repo.reload!(user).mastodon_clients?
+
+    assert %AccountEvent{details: %{"enabled" => true}} =
+             Repo.get_by!(AccountEvent, user_id: user.id, kind: "mastodon_clients_changed")
+
+    body = conn |> consent_page(app) |> html_response(200)
+    assert body =~ "oauth-allow"
+    refute body =~ "oauth-enable-apps"
+    refute body =~ ~s(href="/settings/apps")
+    refute body =~ "Mastodon client access is disabled"
+  end
+
+  # The short labels are the likeliest to be fuzzy-filled by a catalog merge,
+  # so the German is asserted by name.
+  test "in German, offer, link and switch read as written", %{conn: conn, app: app} do
+    # `recycle/1` first: the login already sent a response on this conn, and a
+    # sent conn refuses a new request header. The header survives the
+    # recycling the later requests do on their own.
+    conn = conn |> recycle() |> put_req_header("accept-language", "de-DE,de")
+    page = consent_page(conn, app)
+    body = html_response(page, 200)
+
+    assert body =~
+             "Schalten Sie ihn für Ihr Konto ein, dann können Sie Pocket Client gleich hier verbinden."
+
+    assert body =~ "App-Einstellungen öffnen"
+    assert body =~ "Für mein Konto einschalten"
+
+    {action, fields} = switch_form(page)
+    response = post(conn, action, fields)
+    body = response |> get(redirected_to(response)) |> html_response(200)
+    assert body =~ "App-Einstellungen gespeichert."
+    assert body =~ "Zugriff erlauben"
+  end
+
+  test "logged out, the switch is not for pressing", %{conn: conn, app: app} do
+    {action, fields} = conn |> consent_page(app) |> switch_form()
+
+    assert redirected_to(post(build_conn(), action, fields)) == ~p"/"
+  end
+end


### PR DESCRIPTION
A member sent to `/oauth/authorize` by a Mastodon app with their app switch still off only read that access is disabled, with a greyed-out Allow and no way forward except a settings detour the app's flow does not survive.

The consent screen now offers the switch itself: below the red line sits a sentence, a link to `/settings/apps`, and the button "Turn on for my account" in place of Allow. One press posts the settings page's own save (`PUT /settings/apps`, which now takes a `return_to` like the mute routes), lands back on the same request with Allow live, and logs the usual `mastodon_clients_changed` event. No new endpoint, one writer of the switch.

Entry points: `VutuvWeb.OauthController.authorize/2`, `SettingsController.update_apps/2`, `templates/oauth/authorize.html.heex`. New test `oauth_consent_switch_test.exs`, German strings asserted. Hot deploy.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_014iZHGJz3CbsZh4uugk9wBp
