### PR TITLE
Report a text, photo or video that is not the poster's to publish

### DIFF
--- a/docs/architecture/moderation.md
+++ b/docs/architecture/moderation.md
@@ -3,9 +3,9 @@
 Any member can report a post, a private message, a whole profile, a verified
 organization page or a job posting (quiet "Report" affordances on every post
 card, message bubble, profile footer, organization page and job posting;
-categories: not family-friendly, bullying/harassment, spam, other — a job
-posting instead offers *misleading job ad* / spam / other, gated per content
-type in `Report.categories_for/1`).
+categories: not family-friendly, bullying/harassment, spam, **copyright**, other
+— a job posting instead offers *misleading job ad* / spam / copyright / other,
+gated per content type in `Report.categories_for/1`).
 
 The same freeze → case → strike machinery covers every content type; `frozen_at`
 lives on the reported row and its context's visibility chokepoint reads it. For
@@ -25,8 +25,41 @@ escalates).
 
 Silence for 72h escalates too (`Vutuv.Moderation.Sweeper`), so the admin queue
 at `/admin/moderation` (a LiveView; the case page rules reload-free and drops
-back to the queue) only carries disputes, ignored cases, re-reports and profile
-cases.
+back to the queue) only carries disputes, ignored cases, re-reports, profile
+cases — and every open copyright case (see below).
+
+## The copyright notice (issue #2008)
+
+"Uses a text, photo or video without the rights holder's permission" is offered
+on every report form **except** the private-message one — nothing was published
+there, so there is nothing for a rights holder to have taken down. It is the one
+category that is a *legal* notice rather than a house-rule complaint, and three
+things follow from that.
+
+**It is only accepted complete.** `Report.changeset/3` requires the note (which
+work, where the original can be seen) and a good-faith declaration whenever the
+category is `copyright`. The declaration is a **virtual** field, not a column:
+the changeset refuses the category without it, so a stored copyright report *is*
+the record that it was made, and a column would be a second copy free to drift.
+The check sits in the changeset rather than in the controller, so the Mastodon
+report API cannot file half a notice either (it has no field for the
+declaration, so it cannot file one at all — a client sending that category gets
+a 422).
+
+**It is in the admin queue from the moment it is filed.** The trust ladder is
+untouched — a trusted reporter still freezes the content and still leaves the
+owner their 72h self-service window, an untrusted one still only flags — but
+`Moderation.list_queue/0` and `open_queue_count/0` also take an open case with
+a copyright report in any status, `pending_owner` included, via an `EXISTS`
+on the reports (`queue_query/0`).
+
+**An edit no longer settles it.** For every other category the owner's edit
+unfreezes the content and closes the case; for a copyright case
+`Moderation.content_edited/1` keeps the freeze, logs the edit and escalates, so
+a human decides whether the revision removed the work. Delete and dispute are
+unchanged. The owner's case page says so (`ModerationCaseHTML.copyright?/1`
+picks the wording); the *email* still describes the generic edit, which issue
+#2010 rewrites.
 
 Admin rulings are one click: **uphold** (owner gets a strike: warning → one-week
 suspension → permanent deactivation; strikes expire after 12 months) or

--- a/lib/vutuv/moderation.ex
+++ b/lib/vutuv/moderation.ex
@@ -10,6 +10,13 @@ defmodule Vutuv.Moderation do
   (escalates to the admin queue). Silence for #{72} hours escalates too, so
   admins only ever see disputes, ignored cases, re-reports and profile cases.
 
+  A **copyright** complaint is the exception to the last two sentences: it is a
+  legal notice, so it sits in the admin queue from the moment it is filed
+  (`list_queue/0`) and an owner's edit does not settle it — it escalates
+  instead (`content_edited/1`). Delete and dispute work as they do everywhere
+  else. `Vutuv.Moderation.Report` refuses the category without the explanation
+  and the reporter's good-faith declaration.
+
   Reports from reporters with a bad track record (`trusted_reporter?/1`)
   never freeze anything; they only flag the content for admin review. Whole
   profiles are never frozen by a single report — that takes a second,
@@ -81,6 +88,10 @@ defmodule Vutuv.Moderation do
   # issue a second strike. Mirrors Case.open_statuses/0 as a compile-time list
   # usable in guards.
   @open_statuses Case.open_statuses()
+
+  # The statuses that put a case in front of an admin on their own. A copyright
+  # case joins the queue from any open status — see queue_query/0.
+  @queue_statuses ~w(escalated flagged)
 
   ## Reporting
 
@@ -563,25 +574,49 @@ defmodule Vutuv.Moderation do
   revised. A later re-report of the same content skips self-service and goes
   straight to the admins (see `report_content/3`). Edits during an escalated
   case change nothing — the case is with the admins.
+
+  A copyright complaint is the exception: the claim is that the work was never
+  the owner's to publish, and no rewrite settles that. The edit is recorded,
+  the content stays hidden and the case escalates for a human to check.
   """
   def content_edited(content) do
     case open_case_for(content) do
       %Case{status: "pending_owner"} = case_record ->
-        unfreeze_content(content)
+        # The reports are needed either way — to read the category here, and by
+        # the reporters' notice on the ordinary branch — so load them once.
+        case_record = Repo.preload(case_record, reports: :reporter)
 
-        updated =
-          update_case!(case_record, %{
-            status: "resolved_edited",
-            resolved_at: NaiveDateTime.utc_now(:second)
-          })
-
-        log(updated, nil, "content_edited")
-        Notifier.reporters_content_revised(updated)
-        :ok
+        if copyright_case?(case_record),
+          do: hand_edit_to_admins(case_record),
+          else: resolve_edited(content, case_record)
 
       _ ->
         :ok
     end
+  end
+
+  defp resolve_edited(content, %Case{} = case_record) do
+    unfreeze_content(content)
+
+    updated =
+      update_case!(case_record, %{
+        status: "resolved_edited",
+        resolved_at: NaiveDateTime.utc_now(:second)
+      })
+
+    log(updated, nil, "content_edited")
+    Notifier.reporters_content_revised(updated)
+    :ok
+  end
+
+  # No unfreeze and no "revised" notice: the reporters' claim is about the
+  # work, not about its wording. The case was already in the queue, so this
+  # only moves it to the front of it, with the edit in the History timeline
+  # the admin reads.
+  defp hand_edit_to_admins(%Case{} = case_record) do
+    updated = update_case!(case_record, case_params("escalated"))
+    log(updated, nil, "content_edited")
+    :ok
   end
 
   @doc """
@@ -611,21 +646,48 @@ defmodule Vutuv.Moderation do
 
   @doc "The admin queue: escalated cases first (oldest first), then flagged."
   def list_queue do
-    from(c in Case,
-      where: c.status in ["escalated", "flagged"],
-      order_by: [
-        asc: fragment("CASE WHEN ? = 'escalated' THEN 0 ELSE 1 END", c.status),
-        asc: c.inserted_at
-      ],
-      preload: [:owner, reports: :reporter]
+    queue_query()
+    |> order_by([c],
+      asc: fragment("CASE WHEN ? = 'escalated' THEN 0 ELSE 1 END", c.status),
+      asc: c.inserted_at
     )
+    |> preload([:owner, reports: :reporter])
     |> Repo.all()
   end
 
   @doc "How many cases wait for an admin (the badge + digest number)."
   def open_queue_count do
-    Repo.aggregate(from(c in Case, where: c.status in ["escalated", "flagged"]), :count)
+    Repo.aggregate(queue_query(), :count)
   end
+
+  # An ordinary frozen case spends its first 72 hours with its owner and only
+  # reaches an admin if the deadline passes or the owner disputes. A copyright
+  # complaint is a legal notice and cannot wait that long, so it joins the queue
+  # in any open status while the owner keeps their self-service window.
+  defp queue_query do
+    from(c in Case,
+      as: :case,
+      where: c.status in ^@open_statuses,
+      where:
+        c.status in ^@queue_statuses or
+          exists(subquery(where(copyright_reports(), [r], r.case_id == parent_as(:case).id)))
+    )
+  end
+
+  defp copyright_reports do
+    from(r in Report, where: r.category == ^Report.copyright_category())
+  end
+
+  @doc """
+  Whether this case carries a copyright complaint. Takes the preloaded reports
+  if they are there and looks them up if they are not, so the answer never
+  depends on whether the caller remembered a preload.
+  """
+  def copyright_case?(%Case{reports: reports}) when is_list(reports),
+    do: Enum.any?(reports, &Report.copyright?/1)
+
+  def copyright_case?(%Case{id: case_id}),
+    do: Repo.exists?(where(copyright_reports(), [r], r.case_id == ^case_id))
 
   @doc """
   How many open cases (any open status: frozen-pending-owner, flagged or

--- a/lib/vutuv/moderation/report.ex
+++ b/lib/vutuv/moderation/report.ex
@@ -3,15 +3,24 @@ defmodule Vutuv.Moderation.Report do
 
   use VutuvWeb, :model
 
-  @categories ~w(family bullying spam other)
+  @copyright "copyright"
+  @categories ~w(family bullying spam copyright other)
+  # A private message is not published, so there is nothing for a rights holder
+  # to have taken down. Written as the exception rather than as a second list,
+  # so a category added above cannot silently skip the message form.
+  @message_categories @categories -- [@copyright]
   # Job postings get a specific first category; "family"/"bullying" rarely apply.
-  @job_categories ~w(misleading_job spam other)
+  @job_categories ~w(misleading_job spam copyright other)
   @max_note_length 2_000
 
   schema "moderation_reports" do
     field(:category, :string)
     field(:note, :string)
     field(:abusive?, :boolean, default: false)
+    # Deliberately not stored: the changeset refuses the copyright category
+    # without it, so a stored copyright report IS the record that the
+    # declaration was made.
+    field(:good_faith?, :boolean, virtual: true, default: false)
 
     belongs_to(:case, Vutuv.Moderation.Case)
     belongs_to(:reporter, Vutuv.Accounts.User)
@@ -22,6 +31,17 @@ defmodule Vutuv.Moderation.Report do
   def categories, do: @categories
 
   @doc """
+  The category for "this is not yours to publish". The one complaint that is a
+  legal notice rather than a house-rule one, so several places downstream ask
+  for it by name rather than by string.
+  """
+  def copyright_category, do: @copyright
+
+  @doc "Whether this report — or this bare category string — is a copyright complaint."
+  def copyright?(%__MODULE__{category: category}), do: copyright?(category)
+  def copyright?(category), do: category == @copyright
+
+  @doc """
   The note's character cap — the changeset's `validate_length` and the form's
   `maxlength` both read it, so they cannot disagree.
   """
@@ -29,6 +49,7 @@ defmodule Vutuv.Moderation.Report do
 
   @doc "The report categories offered for a given content type (wire string)."
   def categories_for("job_posting"), do: @job_categories
+  def categories_for("message"), do: @message_categories
   def categories_for(_type), do: @categories
 
   @doc """
@@ -36,14 +57,53 @@ defmodule Vutuv.Moderation.Report do
   accepted categories to the ones that type actually offers, so a crafted POST
   can't slip an off-type category (e.g. `misleading_job` on a profile report)
   past the form — the same `categories_for/1` gate the form renders from.
+
+  Every message is a whole sentence addressed to the reporter, because the
+  report form has no per-field error slots and shows them as one banner. They
+  are extracted for translation through
+  `VutuvWeb.ErrorHelpers.__error_message_extraction_anchors__/0`.
   """
   def changeset(report, params \\ %{}, content_type \\ nil) do
+    pick_one = "Please pick a category."
+
     report
-    |> cast(params, [:category, :note])
+    |> cast(params, [:category, :note, :good_faith?])
     |> update_change(:note, &String.trim/1)
-    |> validate_required([:category])
-    |> validate_inclusion(:category, categories_for(content_type))
-    |> validate_length(:note, max: @max_note_length)
+    |> validate_required([:category], message: pick_one)
+    |> validate_inclusion(:category, categories_for(content_type), message: pick_one)
+    |> validate_length(:note, max: @max_note_length, message: "Your note is too long.")
+    |> validate_copyright_notice()
     |> unique_constraint([:case_id, :reporter_id])
+  end
+
+  # A copyright complaint only means something as a complete notice: which work
+  # it is and where the original can be seen (the note), plus the reporter's
+  # declaration that the use really is unauthorized. Both are checked here, at
+  # the one place every report passes, so no route can file half a notice and
+  # still get the freeze and the admin queue that the category buys.
+  defp validate_copyright_notice(changeset) do
+    if copyright?(get_field(changeset, :category)) do
+      changeset
+      |> validate_required([:note],
+        message: "Please tell us which work it is and where the original can be seen."
+      )
+      |> validate_good_faith()
+    else
+      changeset
+    end
+  end
+
+  # Spelled out rather than `validate_acceptance/3`, which only fires when the
+  # parameter is present — and an unticked checkbox sends nothing at all.
+  defp validate_good_faith(changeset) do
+    if get_field(changeset, :good_faith?) do
+      changeset
+    else
+      add_error(
+        changeset,
+        :good_faith?,
+        "Please confirm that you are making this claim in good faith."
+      )
+    end
   end
 end

--- a/lib/vutuv_web/controllers/report_controller.ex
+++ b/lib/vutuv_web/controllers/report_controller.ex
@@ -13,8 +13,10 @@ defmodule VutuvWeb.ReportController do
   alias Vutuv.Accounts.User
   alias Vutuv.Chat
   alias Vutuv.Moderation
+  alias Vutuv.Moderation.Report
   alias Vutuv.Posts
   alias VutuvWeb.ControllerHelpers
+  alias VutuvWeb.ErrorHelpers
 
   def new(conn, %{"type" => type, "id" => id} = params) do
     case Moderation.fetch_content(type, id) do
@@ -25,7 +27,11 @@ defmodule VutuvWeb.ReportController do
         reporter = conn.assigns[:current_user]
 
         if Moderation.can_report?(reporter, content) do
-          render_report_form(conn, reporter, content, type, id, params)
+          render_report_form(conn, reporter, content,
+            content_type: type,
+            content_id: id,
+            return_to: ControllerHelpers.safe_return_to(params["return_to"])
+          )
         else
           # Mirror create's authorization: never preview content the reporter
           # has no right to see (a private DM, a restricted post).
@@ -36,20 +42,23 @@ defmodule VutuvWeb.ReportController do
 
   def new(conn, _params), do: ControllerHelpers.render_error(conn, 404)
 
-  defp render_report_form(conn, reporter, content, type, id, params) do
+  defp render_report_form(conn, reporter, content, assigns) do
     # A reporter tied to the owner must understand BEFORE sending that
     # the report separates the two of them (and thereby de-facto reveals
     # who reported). Strangers keep the plain anonymity promise.
     severs = Moderation.would_sever_relationship?(reporter, content)
 
-    render(conn, "new.html",
+    defaults = [
       page_title: gettext("Report content"),
-      content_type: type,
-      content_id: id,
       preview: preview(content),
       severed_owner: if(severs, do: Moderation.content_owner(content)),
-      return_to: ControllerHelpers.safe_return_to(params["return_to"])
-    )
+      # The form is sticky through the report itself, so a rejected submission
+      # comes back the way the reporter left it.
+      report: %Report{},
+      errors: []
+    ]
+
+    render(conn, "new.html", Keyword.merge(defaults, assigns))
   end
 
   def create(conn, %{"report" => %{"type" => type, "id" => id} = report_params}) do
@@ -83,15 +92,33 @@ defmodule VutuvWeb.ReportController do
           {:error, :not_allowed} ->
             ControllerHelpers.render_error(conn, 404)
 
-          {:error, %Ecto.Changeset{}} ->
+          # Back to the form rather than a redirect + flash: a copyright notice
+          # carries a written explanation the reporter must not lose to a
+          # missing checkbox.
+          {:error, %Ecto.Changeset{} = changeset} ->
             conn
-            |> put_flash(:error, gettext("Please pick a category."))
-            |> redirect(to: ~p"/reports/new?type=#{type}&id=#{id}")
+            |> put_status(:unprocessable_entity)
+            |> render_report_form(reporter, content,
+              content_type: type,
+              content_id: id,
+              return_to: return_to,
+              report: Ecto.Changeset.apply_changes(changeset),
+              errors: report_errors(changeset)
+            )
         end
     end
   end
 
   def create(conn, _params), do: ControllerHelpers.render_error(conn, 404)
+
+  # Everything the reporter has to change, in their words. `Report`'s changeset
+  # writes whole sentences, so nothing here has to guess one from a field name;
+  # `errors` is newest-first, hence the reverse.
+  defp report_errors(%Ecto.Changeset{errors: errors}) do
+    errors
+    |> Enum.reverse()
+    |> Enum.map(fn {_field, error} -> ErrorHelpers.translate_error(error) end)
+  end
 
   # The reporter's confirmation. A whole-profile report (the spam case) says the
   # moderators have been notified and will review the account, so reporting no

--- a/lib/vutuv_web/templates/moderation_case/show.html.heex
+++ b/lib/vutuv_web/templates/moderation_case/show.html.heex
@@ -38,8 +38,16 @@
           :if={@case.content_type == "post" and @content}
           class="flex items-center justify-between gap-4 rounded-lg border border-slate-200 p-3 dark:border-slate-700"
         >
+          <%!-- A rewrite does not answer "this work is not yours to publish",
+                so a copyright case must not promise the post comes straight
+                back — an admin checks the revision first. --%>
           <p class="text-sm text-slate-600 dark:text-slate-400">
-            {gettext("Fix it. An edited post is visible again immediately.")}
+            {if Moderation.copyright_case?(@case),
+              do:
+                gettext(
+                  "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."
+                ),
+              else: gettext("Fix it. An edited post is visible again immediately.")}
           </p>
           <.button variant="secondary" href={~p"/posts/#{@case.content_id}/edit"}>
             {gettext("Edit")}

--- a/lib/vutuv_web/templates/page/community.html.heex
+++ b/lib/vutuv_web/templates/page/community.html.heex
@@ -40,6 +40,16 @@
       </div>
       <div>
         <dt class="font-semibold text-slate-900 dark:text-white">
+          {gettext("Publish only what you hold the rights to")}
+        </dt>
+        <dd class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+          {gettext(
+            "Texts, photos and videos belong to whoever made them. Post your own work, or work you have permission to use. A rights holder can report content here, and such a complaint is decided by one of our admins - an edit does not settle it."
+          )}
+        </dd>
+      </div>
+      <div>
+        <dt class="font-semibold text-slate-900 dark:text-white">
           {gettext("Report honestly")}
         </dt>
         <dd class="mt-1 text-sm text-slate-600 dark:text-slate-400">

--- a/lib/vutuv_web/templates/report/new.html.heex
+++ b/lib/vutuv_web/templates/report/new.html.heex
@@ -45,7 +45,30 @@
       {@preview}
     </blockquote>
 
-    <form action={~p"/reports"} method="post" class="mt-5">
+    <div :if={@errors != []} id="report-error" class="alert alert-danger mt-4" role="alert">
+      <svg
+        class="alert__icon"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        aria-hidden="true"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M12 9v4m0 4h.01M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"
+        />
+      </svg>
+      <p>{Enum.join(@errors, " ")}</p>
+    </div>
+
+    <%!-- `group` + the `has-[…]:` variants below are what reveals the copyright
+          block: the form is plain HTML, so the reveal must work with no
+          JavaScript at all. Nothing here is `required` in the markup — a
+          hidden required control blocks the submit of every other category —
+          so the completeness of a copyright notice is the changeset's job. --%>
+    <form id="report-form" action={~p"/reports"} method="post" class="group mt-5">
       <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
       <input type="hidden" name="report[type]" value={@content_type} />
       <input type="hidden" name="report[id]" value={@content_id} />
@@ -54,15 +77,16 @@
       <fieldset class="space-y-2">
         <legend class="sr-only">{gettext("Why are you reporting this?")}</legend>
         <label
-          :for={category <- Vutuv.Moderation.Report.categories_for(@content_type)}
+          :for={category <- Report.categories_for(@content_type)}
           class="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200 p-3 transition hover:border-brand-400 has-checked:border-brand-500 has-checked:bg-brand-50 dark:border-slate-700 dark:hover:border-brand-500 dark:has-checked:bg-brand-900/30"
         >
           <input
             type="radio"
             name="report[category]"
             value={category}
+            checked={@report.category == category}
             required
-            class="mt-1 accent-brand-600"
+            class={["mt-1 accent-brand-600", Report.copyright?(category) && "report-copyright-choice"]}
           />
           <span>
             <span class="block font-semibold text-slate-900 dark:text-white">
@@ -77,14 +101,41 @@
 
       <label class="mt-4 block">
         <span class="text-sm font-semibold text-slate-700 dark:text-slate-300">
-          {gettext("Anything our admins should know? (optional)")}
+          <span class="group-has-[.report-copyright-choice:checked]:hidden">
+            {gettext("Anything our admins should know? (optional)")}
+          </span>
+          <span
+            :if={copyright_offered?(@content_type)}
+            class="hidden group-has-[.report-copyright-choice:checked]:inline"
+          >
+            {gettext("Which work is it, and where can the original be seen? (required)")}
+          </span>
         </span>
         <textarea
           name="report[note]"
           rows="3"
-          maxlength={Vutuv.Moderation.Report.max_note_length()}
+          maxlength={Report.max_note_length()}
           class={[input_class(), "mt-1 resize-y"]}
-        ></textarea>
+        >{@report.note}</textarea>
+      </label>
+
+      <label
+        :if={copyright_offered?(@content_type)}
+        id="report-good-faith"
+        class="mt-4 hidden cursor-pointer items-start gap-3 rounded-lg border border-slate-200 p-3 group-has-[.report-copyright-choice:checked]:flex dark:border-slate-700"
+      >
+        <input
+          type="checkbox"
+          name="report[good_faith?]"
+          value="true"
+          checked={@report.good_faith?}
+          class="mt-1 accent-brand-600"
+        />
+        <span class="text-sm text-slate-600 dark:text-slate-400">
+          {gettext(
+            "I declare in good faith that this use is authorized neither by the rights holder nor by law."
+          )}
+        </span>
       </label>
 
       <p class="mt-3 text-xs text-slate-600 dark:text-slate-400">

--- a/lib/vutuv_web/views/error_helpers.ex
+++ b/lib/vutuv_web/views/error_helpers.ex
@@ -119,6 +119,14 @@ defmodule VutuvWeb.ErrorHelpers do
       # Vutuv.Tags.Tag, a name of punctuation only.
       dgettext_noop("errors", "must not be only punctuation"),
       dgettext_noop("errors", "\"%{tag}\" is only punctuation, not a tag."),
+      # Vutuv.Moderation.Report, the report form's one error banner (issue #2008).
+      dgettext_noop("errors", "Please pick a category."),
+      dgettext_noop("errors", "Your note is too long."),
+      dgettext_noop(
+        "errors",
+        "Please tell us which work it is and where the original can be seen."
+      ),
+      dgettext_noop("errors", "Please confirm that you are making this claim in good faith."),
       # Vutuv.Posts, the post tag cap (issue #1237).
       dgettext_noop("errors", "Please use at most %{max} tags."),
       # Vutuv.Mentions, the per-post mention cap (anti-spam).

--- a/lib/vutuv_web/views/moderation_case_html.ex
+++ b/lib/vutuv_web/views/moderation_case_html.ex
@@ -2,6 +2,7 @@ defmodule VutuvWeb.ModerationCaseHTML do
   @moduledoc false
   use VutuvWeb, :html
 
+  alias Vutuv.Moderation
   alias Vutuv.Moderation.Case
 
   embed_templates("../templates/moderation_case/*")

--- a/lib/vutuv_web/views/report_html.ex
+++ b/lib/vutuv_web/views/report_html.ex
@@ -2,6 +2,8 @@ defmodule VutuvWeb.ReportHTML do
   @moduledoc false
   use VutuvWeb, :html
 
+  alias Vutuv.Moderation.Report
+
   embed_templates("../templates/report/*")
 
   @doc """
@@ -12,6 +14,10 @@ defmodule VutuvWeb.ReportHTML do
   def category_label("bullying"), do: gettext("Bullying or harassment")
   def category_label("spam"), do: gettext("Spam or scam")
   def category_label("misleading_job"), do: gettext("Misleading job posting")
+
+  def category_label("copyright"),
+    do: gettext("Uses a text, photo or video without the rights holder's permission")
+
   def category_label(_), do: gettext("Something else")
 
   @doc "The helper line under each category on the report form."
@@ -24,5 +30,12 @@ defmodule VutuvWeb.ReportHTML do
   def category_hint("misleading_job"),
     do: gettext("A fake, misleading or discriminatory job advertisement.")
 
+  def category_hint("copyright"),
+    do: gettext("Tell us which work it is and where the original can be seen.")
+
   def category_hint(_), do: gettext("Tell us more in the note below.")
+
+  @doc "Whether this content type's form carries the copyright notice at all."
+  def copyright_offered?(content_type),
+    do: Report.copyright_category() in Report.categories_for(content_type)
 end

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -123,7 +123,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:113
-#: lib/vutuv_web/templates/report/new.html.heex:103
+#: lib/vutuv_web/templates/report/new.html.heex:154
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:255
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
@@ -172,7 +172,7 @@ msgstr "%{name} konnte nicht zurückgefolgt werden."
 #: lib/vutuv_web/live/admin/user_delete_live.ex:167
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:28
 #: lib/vutuv_web/templates/dev_app/show.html.heex:135
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:59
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:67
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:70
 #, elixir-autogen
 msgid "Delete"
@@ -224,7 +224,7 @@ msgstr "Download"
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:6
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:45
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:53
 #: lib/vutuv_web/templates/user/show.html.heex:1124
 #, elixir-autogen
 msgid "Edit"
@@ -1199,7 +1199,7 @@ msgstr "Alle Tag-Synonyme"
 msgid "All tag urls"
 msgstr "Alle Tag-URLs"
 
-#: lib/vutuv_web/components/post_components.ex:4437
+#: lib/vutuv_web/components/post_components.ex:4439
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:619
@@ -2228,13 +2228,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:4310
-#: lib/vutuv_web/components/post_components.ex:4314
+#: lib/vutuv_web/components/post_components.ex:4312
+#: lib/vutuv_web/components/post_components.ex:4316
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:4311
+#: lib/vutuv_web/components/post_components.ex:4313
 #: lib/vutuv_web/live/fediverse_account_live.ex:387
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2336,22 +2336,22 @@ msgstr "Was gibt's Neues? Markdown wird unterstützt."
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:5895
+#: lib/vutuv_web/components/post_components.ex:5936
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:5899
+#: lib/vutuv_web/components/post_components.ex:5940
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:5897
+#: lib/vutuv_web/components/post_components.ex:5938
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:5898
+#: lib/vutuv_web/components/post_components.ex:5939
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2396,7 +2396,7 @@ msgid "All posts"
 msgstr "Alle Beiträge"
 
 #: lib/vutuv_web/components/post_components.ex:2104
-#: lib/vutuv_web/components/post_components.ex:5995
+#: lib/vutuv_web/components/post_components.ex:6036
 #: lib/vutuv_web/components/ui.ex:4131
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
@@ -2415,7 +2415,7 @@ msgid "Bookmarks"
 msgstr "Lesezeichen"
 
 #: lib/vutuv_web/components/post_components.ex:2055
-#: lib/vutuv_web/components/post_components.ex:6233
+#: lib/vutuv_web/components/post_components.ex:6274
 #: lib/vutuv_web/components/ui.ex:4117
 #: lib/vutuv_web/live/notification_live/index.ex:1512
 #: lib/vutuv_web/views/user_html.ex:481
@@ -2424,7 +2424,7 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1263
-#: lib/vutuv_web/components/post_components.ex:6243
+#: lib/vutuv_web/components/post_components.ex:6284
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:522
 #: lib/vutuv_web/live/shell_live.ex:1523
@@ -2445,13 +2445,13 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:5983
+#: lib/vutuv_web/components/post_components.ex:6024
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
 #: lib/vutuv_web/components/post_components.ex:2103
-#: lib/vutuv_web/components/post_components.ex:5994
+#: lib/vutuv_web/components/post_components.ex:6035
 #: lib/vutuv_web/live/post_live/saved.ex:818
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
@@ -2459,26 +2459,26 @@ msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
 #: lib/vutuv_web/components/post_components.ex:2084
-#: lib/vutuv_web/components/post_components.ex:5979
+#: lib/vutuv_web/components/post_components.ex:6020
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
 #: lib/vutuv_web/components/post_components.ex:2372
-#: lib/vutuv_web/components/post_components.ex:5041
+#: lib/vutuv_web/components/post_components.ex:5043
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
 #: lib/vutuv_web/components/post_components.ex:2083
-#: lib/vutuv_web/components/post_components.ex:5978
+#: lib/vutuv_web/components/post_components.ex:6019
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
 #: lib/vutuv_web/components/post_components.ex:2054
-#: lib/vutuv_web/components/post_components.ex:6232
+#: lib/vutuv_web/components/post_components.ex:6273
 #: lib/vutuv_web/live/post_live/saved.ex:817
 #: lib/vutuv_web/views/user_html.ex:481
 #, elixir-autogen, elixir-format
@@ -2506,7 +2506,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:6287
+#: lib/vutuv_web/components/post_components.ex:6328
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2518,8 +2518,8 @@ msgid "Replies"
 msgstr "Antworten"
 
 #: lib/vutuv_web/components/post_components.ex:2068
-#: lib/vutuv_web/components/post_components.ex:6270
-#: lib/vutuv_web/components/post_components.ex:6271
+#: lib/vutuv_web/components/post_components.ex:6311
+#: lib/vutuv_web/components/post_components.ex:6312
 #: lib/vutuv_web/live/notification_live/index.ex:1010
 #: lib/vutuv_web/live/notification_live/index.ex:1509
 #: lib/vutuv_web/live/post_live/reply.ex:49
@@ -2864,7 +2864,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:5896
+#: lib/vutuv_web/components/post_components.ex:5937
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -2951,22 +2951,22 @@ msgstr "Eine Meldung zu Ihrem Inhalt wurde verworfen; er ist wieder sichtbar."
 msgid "Abusive"
 msgstr "Missbräuchlich"
 
-#: lib/vutuv_web/views/moderation_case_html.ex:26
+#: lib/vutuv_web/views/moderation_case_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "An admin confirmed the report. The content stays hidden."
 msgstr "Ein Admin hat die Meldung bestätigt. Der Inhalt bleibt verborgen."
 
-#: lib/vutuv_web/views/moderation_case_html.ex:29
+#: lib/vutuv_web/views/moderation_case_html.ex:30
 #, elixir-autogen, elixir-format
 msgid "An admin dismissed the report. The content is visible again."
 msgstr "Ein Admin hat die Meldung verworfen. Der Inhalt ist wieder sichtbar."
 
-#: lib/vutuv_web/templates/report/new.html.heex:80
+#: lib/vutuv_web/templates/report/new.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Anything our admins should know? (optional)"
 msgstr "Gibt es etwas, das unsere Admins wissen sollten? (optional)"
 
-#: lib/vutuv_web/views/report_html.ex:12
+#: lib/vutuv_web/views/report_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Bullying or harassment"
 msgstr "Mobbing oder Belästigung"
@@ -2980,7 +2980,7 @@ msgstr "Mobbing oder Belästigung"
 msgid "Community guidelines"
 msgstr "Community-Richtlinien"
 
-#: lib/vutuv_web/templates/page/community.html.heex:68
+#: lib/vutuv_web/templates/page/community.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Confirmed violations follow three steps: a warning, then a one-week suspension, then permanent deactivation. Strikes expire after twelve months."
 msgstr ""
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "Current version (edited since the report)"
 msgstr "Aktuelle Version (seit der Meldung bearbeitet)"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:57
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "Delete this content permanently?"
 msgstr "Diesen Inhalt endgültig löschen?"
@@ -3022,7 +3022,7 @@ msgstr ""
 msgid "Escalated"
 msgstr "Eskaliert"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:42
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "Fix it. An edited post is visible again immediately."
 msgstr "Korrigieren. Ein bearbeiteter Beitrag ist sofort wieder sichtbar."
@@ -3032,14 +3032,14 @@ msgstr "Korrigieren. Ein bearbeiteter Beitrag ist sofort wieder sichtbar."
 msgid "Flagged"
 msgstr "Markiert"
 
-#: lib/vutuv_web/views/moderation_case_html.ex:17
+#: lib/vutuv_web/views/moderation_case_html.ex:18
 #, elixir-autogen, elixir-format
 msgid "Hidden until one of our admins has ruled. You do not need to do anything."
 msgstr ""
 "Verborgen, bis einer unserer Admins entschieden hat. Sie müssen nichts "
 "weiter tun."
 
-#: lib/vutuv_web/views/moderation_case_html.ex:11
+#: lib/vutuv_web/views/moderation_case_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Hidden. You can settle this yourself - see below."
 msgstr "Verborgen. Sie können das selbst klären, siehe unten."
@@ -3075,7 +3075,7 @@ msgstr "Moderationsfall"
 msgid "Moderation queue"
 msgstr "Moderations-Warteschlange"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:68
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "My content is fine"
 msgstr "Mein Inhalt ist in Ordnung"
@@ -3124,7 +3124,7 @@ msgstr ""
 "Niemand sonst kann ihn gerade sehen. Sie haben 72 Stunden, um das selbst zu "
 "klären; danach entscheiden unsere Admins. Drei Wege:"
 
-#: lib/vutuv_web/views/report_html.ex:11
+#: lib/vutuv_web/views/report_html.ex:13
 #, elixir-autogen, elixir-format
 msgid "Not family-friendly"
 msgstr "Nicht familienfreundlich"
@@ -3134,7 +3134,7 @@ msgstr "Nicht familienfreundlich"
 msgid "Nothing here - none of your content is currently reported."
 msgstr "Nichts zu sehen, keiner Ihrer Inhalte ist derzeit gemeldet."
 
-#: lib/vutuv_web/views/report_html.ex:19
+#: lib/vutuv_web/views/report_html.ex:25
 #, elixir-autogen, elixir-format
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
@@ -3181,12 +3181,7 @@ msgstr "Eröffnet"
 msgid "Owner"
 msgstr "Besitzer"
 
-#: lib/vutuv_web/controllers/report_controller.ex:88
-#, elixir-autogen, elixir-format
-msgid "Please pick a category."
-msgstr "Bitte wählen Sie eine Kategorie."
-
-#: lib/vutuv_web/templates/report/new.html.heex:91
+#: lib/vutuv_web/templates/report/new.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Please report honestly. Reporting to harm someone breaks our"
 msgstr ""
@@ -3218,7 +3213,7 @@ msgstr "Meldung ablehnen"
 msgid "Rejected"
 msgstr "Abgelehnt"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:51
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:59
 #, elixir-autogen, elixir-format
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
@@ -3232,12 +3227,12 @@ msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 msgid "Report"
 msgstr "Melden"
 
-#: lib/vutuv_web/controllers/report_controller.ex:46
+#: lib/vutuv_web/controllers/report_controller.ex:52
 #, elixir-autogen, elixir-format
 msgid "Report content"
 msgstr "Inhalt melden"
 
-#: lib/vutuv_web/templates/page/community.html.heex:43
+#: lib/vutuv_web/templates/page/community.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Report honestly"
 msgstr "Ehrlich melden"
@@ -3278,7 +3273,7 @@ msgstr "Gemeldet als"
 msgid "Reported content"
 msgstr "Gemeldete Inhalte"
 
-#: lib/vutuv_web/templates/page/community.html.heex:58
+#: lib/vutuv_web/templates/page/community.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Reported content is hidden right away while the report is handled. Nobody is publicly marked."
 msgstr ""
@@ -3305,7 +3300,7 @@ msgstr "Melder-Bilanz"
 msgid "Reports"
 msgstr "Meldungen"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:75
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:83
 #, elixir-autogen, elixir-format
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
@@ -3319,7 +3314,7 @@ msgstr ""
 msgid "Review"
 msgstr "Ansehen"
 
-#: lib/vutuv_web/templates/page/community.html.heex:46
+#: lib/vutuv_web/templates/page/community.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "See something that breaks these rules? Report it - every post, message and profile has a report option, and reports are anonymous. But reporting is not a weapon: deliberately false reports count as bullying and earn the reporter the same strikes."
 msgstr ""
@@ -3329,32 +3324,32 @@ msgstr ""
 "Meldungen gelten als Mobbing und bringen dem Melder dieselben "
 "Verwarnungspunkte ein."
 
-#: lib/vutuv_web/templates/report/new.html.heex:105
+#: lib/vutuv_web/templates/report/new.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "Send report"
 msgstr "Meldung absenden"
 
-#: lib/vutuv_web/views/moderation_case_html.ex:20
+#: lib/vutuv_web/views/moderation_case_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "Settled: the content was deleted."
 msgstr "Erledigt: Der Inhalt wurde gelöscht."
 
-#: lib/vutuv_web/views/moderation_case_html.ex:23
+#: lib/vutuv_web/views/moderation_case_html.ex:24
 #, elixir-autogen, elixir-format
 msgid "Settled: you revised the content and it is visible again."
 msgstr "Erledigt: Sie haben den Inhalt überarbeitet, er ist wieder sichtbar."
 
-#: lib/vutuv_web/views/report_html.ex:15
+#: lib/vutuv_web/views/report_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "Something else"
 msgstr "Etwas anderes"
 
-#: lib/vutuv_web/views/report_html.ex:13
+#: lib/vutuv_web/views/report_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "Spam or scam"
 msgstr "Spam oder Betrug"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:65
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "Stand by it. It stays hidden until one of our admins has ruled."
 msgstr ""
@@ -3380,17 +3375,17 @@ msgstr ""
 msgid "Status"
 msgstr "Status"
 
-#: lib/vutuv_web/views/report_html.ex:21
+#: lib/vutuv_web/views/report_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "Targets, demeans or threatens a person."
 msgstr "Zielt auf eine Person, würdigt sie herab oder bedroht sie."
 
-#: lib/vutuv_web/views/report_html.ex:27
+#: lib/vutuv_web/views/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Tell us more in the note below."
 msgstr "Beschreiben Sie es in der Notiz unten genauer."
 
-#: lib/vutuv_web/controllers/report_controller.ex:109
+#: lib/vutuv_web/controllers/report_controller.ex:136
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. We take it from here."
 msgstr "Danke für Ihre Meldung. Wir übernehmen ab hier."
@@ -3400,7 +3395,7 @@ msgstr "Danke für Ihre Meldung. Wir übernehmen ab hier."
 msgid "The content in question"
 msgstr "Der betreffende Inhalt"
 
-#: lib/vutuv_web/templates/page/community.html.heex:63
+#: lib/vutuv_web/templates/page/community.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "The owner is notified and can delete the content, fix it (it becomes visible again immediately) or stand by it - then our admins decide."
 msgstr ""
@@ -3467,7 +3462,7 @@ msgstr ""
 "Verstanden. Der Inhalt bleibt verborgen, bis einer unserer Admins "
 "entschieden hat."
 
-#: lib/vutuv_web/views/report_html.ex:22
+#: lib/vutuv_web/views/report_html.ex:28
 #, elixir-autogen, elixir-format
 msgid "Unwanted advertising, fraud or fake activity."
 msgstr "Unerwünschte Werbung, Betrug oder gefälschte Aktivität."
@@ -3477,12 +3472,12 @@ msgstr "Unerwünschte Werbung, Betrug oder gefälschte Aktivität."
 msgid "Uphold the report"
 msgstr "Meldung bestätigen"
 
-#: lib/vutuv_web/views/moderation_case_html.ex:14
+#: lib/vutuv_web/views/moderation_case_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "Visible. Our admins will take a look."
 msgstr "Sichtbar. Unsere Admins schauen sich den Fall an."
 
-#: lib/vutuv_web/templates/page/community.html.heex:54
+#: lib/vutuv_web/templates/page/community.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "What happens after a report"
 msgstr "Was nach einer Meldung passiert"
@@ -3492,7 +3487,7 @@ msgstr "Was nach einer Meldung passiert"
 msgid "Who reports, and how it holds up"
 msgstr "Wer meldet, und wie sich das bewährt"
 
-#: lib/vutuv_web/templates/report/new.html.heex:55
+#: lib/vutuv_web/templates/report/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Why are you reporting this?"
 msgstr "Warum melden Sie das?"
@@ -3505,12 +3500,12 @@ msgstr ""
 "Ablehnungen in einem Jahr verlieren das sofortige Einfrieren; ihre Meldungen"
 " markieren nur noch zur Prüfung."
 
-#: lib/vutuv_web/controllers/report_controller.ex:74
+#: lib/vutuv_web/controllers/report_controller.ex:83
 #, elixir-autogen, elixir-format
 msgid "You already reported this. Our team is on it."
 msgstr "Sie haben das bereits gemeldet. Unser Team kümmert sich darum."
 
-#: lib/vutuv_web/controllers/report_controller.ex:80
+#: lib/vutuv_web/controllers/report_controller.ex:89
 #, elixir-autogen, elixir-format
 msgid "You cannot report your own content."
 msgstr "Eigene Inhalte können Sie nicht melden."
@@ -3544,8 +3539,8 @@ msgstr ""
 "Ihre Meldung ist anonym. Wenn sie plausibel ist, wird der Inhalt sofort "
 "verborgen und der Besitzer gebeten, ihn in Ordnung zu bringen."
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:77
-#: lib/vutuv_web/templates/report/new.html.heex:93
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:85
+#: lib/vutuv_web/templates/report/new.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "community guidelines"
 msgstr "Community-Richtlinien"
@@ -5618,8 +5613,8 @@ msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
 #: lib/vutuv_web/components/post_components.ex:3974
-#: lib/vutuv_web/components/post_components.ex:4029
-#: lib/vutuv_web/components/post_components.ex:4558
+#: lib/vutuv_web/components/post_components.ex:4026
+#: lib/vutuv_web/components/post_components.ex:4560
 #: lib/vutuv_web/live/notification_live/index.ex:1086
 #: lib/vutuv_web/views/user_html.ex:131
 #, elixir-autogen, elixir-format
@@ -7607,7 +7602,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:6143
+#: lib/vutuv_web/components/post_components.ex:6184
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -9174,7 +9169,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:5044
+#: lib/vutuv_web/components/post_components.ex:5046
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -10352,7 +10347,7 @@ msgstr ""
 msgid "Spam"
 msgstr "Spam"
 
-#: lib/vutuv_web/controllers/report_controller.ex:105
+#: lib/vutuv_web/controllers/report_controller.ex:132
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. Our moderators have been notified and will review this account."
 msgstr ""
@@ -10370,7 +10365,7 @@ msgstr "deaktiviert"
 msgid "deleted"
 msgstr "gelöscht"
 
-#: lib/vutuv_web/controllers/report_controller.ex:115
+#: lib/vutuv_web/controllers/report_controller.ex:142
 #, elixir-autogen, elixir-format
 msgid "To protect you, the connection between you and the reported member is paused - no contact in either direction, including messages. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -12532,7 +12527,7 @@ msgstr "Behörde / Öffentlich"
 msgid "%{views} views · %{clicks} apply clicks"
 msgstr "%{views} Aufrufe · %{clicks} Bewerbungsklicks"
 
-#: lib/vutuv_web/views/report_html.ex:25
+#: lib/vutuv_web/views/report_html.ex:31
 #, elixir-autogen, elixir-format
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr "Eine gefälschte, irreführende oder diskriminierende Stellenanzeige."
@@ -12746,7 +12741,7 @@ msgstr "Anbieter:in anschreiben"
 msgid "Mini-job"
 msgstr "Minijob"
 
-#: lib/vutuv_web/views/report_html.ex:14
+#: lib/vutuv_web/views/report_html.ex:16
 #, elixir-autogen, elixir-format
 msgid "Misleading job posting"
 msgstr "Irreführende Stellenanzeige"
@@ -14221,34 +14216,34 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:5720
+#: lib/vutuv_web/components/post_components.ex:5734
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:5677
+#: lib/vutuv_web/components/post_components.ex:5691
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:5721
+#: lib/vutuv_web/components/post_components.ex:5735
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:5723
+#: lib/vutuv_web/components/post_components.ex:5737
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:5719
+#: lib/vutuv_web/components/post_components.ex:5733
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:5676
+#: lib/vutuv_web/components/post_components.ex:5690
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14259,12 +14254,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:5718
+#: lib/vutuv_web/components/post_components.ex:5732
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:5722
+#: lib/vutuv_web/components/post_components.ex:5736
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14284,7 +14279,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:5759
+#: lib/vutuv_web/components/post_components.ex:5773
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14292,27 +14287,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:5789
+#: lib/vutuv_web/components/post_components.ex:5803
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:5790
+#: lib/vutuv_web/components/post_components.ex:5804
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:5788
+#: lib/vutuv_web/components/post_components.ex:5802
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:5748
+#: lib/vutuv_web/components/post_components.ex:5762
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:5795
+#: lib/vutuv_web/components/post_components.ex:5809
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14342,7 +14337,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5562
+#: lib/vutuv_web/components/post_components.ex:5576
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14385,7 +14380,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:5553
+#: lib/vutuv_web/components/post_components.ex:5567
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -14782,7 +14777,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:6242
+#: lib/vutuv_web/components/post_components.ex:6283
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -15943,7 +15938,7 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:6188
+#: lib/vutuv_web/components/post_components.ex:6229
 #: lib/vutuv_web/live/notification_live/index.ex:1690
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -15951,7 +15946,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:6192
+#: lib/vutuv_web/components/post_components.ex:6233
 #: lib/vutuv_web/live/notification_live/index.ex:1684
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15959,7 +15954,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:6196
+#: lib/vutuv_web/components/post_components.ex:6237
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15967,7 +15962,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:6147
+#: lib/vutuv_web/components/post_components.ex:6188
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16882,12 +16877,12 @@ msgstr "Noch keine Bildbeschreibung"
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:4689
+#: lib/vutuv_web/components/post_components.ex:4691
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:4838
+#: lib/vutuv_web/components/post_components.ex:4840
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -16900,7 +16895,7 @@ msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1462
 #: lib/vutuv_web/agent_docs/text.ex:890
-#: lib/vutuv_web/components/post_components.ex:4920
+#: lib/vutuv_web/components/post_components.ex:4922
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
@@ -17061,13 +17056,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1319
-#: lib/vutuv_web/components/post_components.ex:6185
+#: lib/vutuv_web/components/post_components.ex:6226
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1317
-#: lib/vutuv_web/components/post_components.ex:6182
+#: lib/vutuv_web/components/post_components.ex:6223
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17077,7 +17072,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:6072
+#: lib/vutuv_web/components/post_components.ex:6113
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -18711,19 +18706,19 @@ msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:5214
+#: lib/vutuv_web/components/post_components.ex:5216
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5216
+#: lib/vutuv_web/components/post_components.ex:5218
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:5227
+#: lib/vutuv_web/components/post_components.ex:5229
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
@@ -21271,27 +21266,27 @@ msgstr "Sprache"
 msgid "The language this post is written in"
 msgstr "Die Sprache, in der dieser Beitrag geschrieben ist"
 
-#: lib/vutuv_web/components/post_components.ex:5108
+#: lib/vutuv_web/components/post_components.ex:5110
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Original anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:5144
+#: lib/vutuv_web/components/post_components.ex:5146
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Übersetzen"
 
-#: lib/vutuv_web/components/post_components.ex:5153
+#: lib/vutuv_web/components/post_components.ex:5155
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Übersetzt"
 
-#: lib/vutuv_web/components/post_components.ex:5156
+#: lib/vutuv_web/components/post_components.ex:5158
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Übersetzt aus %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:5133
+#: lib/vutuv_web/components/post_components.ex:5135
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Wird übersetzt …"
@@ -21301,7 +21296,7 @@ msgstr "Wird übersetzt …"
 msgid "Feed language settings reset to the site defaults."
 msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
 
-#: lib/vutuv_web/components/post_components.ex:5123
+#: lib/vutuv_web/components/post_components.ex:5125
 #: lib/vutuv_web/components/ui.ex:5167
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -21430,20 +21425,20 @@ msgstr "Wir haben den Link in Ihrem Profil noch nicht gefunden. Bitte versuchen 
 msgid "Your username, or paste the address of your profile page."
 msgstr "Ihr Benutzername – oder fügen Sie die Adresse Ihrer Profilseite ein."
 
-#: lib/vutuv_web/components/post_components.ex:4886
+#: lib/vutuv_web/components/post_components.ex:4888
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] "Unsere KI prüft es gerade. Sobald die Prüfung durch ist, erscheint das Foto von selbst."
 msgstr[1] "Unsere KI prüft sie gerade, %{done} von %{total} sind durch. Sobald die letzte durch ist, erscheinen die Fotos von selbst."
 
-#: lib/vutuv_web/components/post_components.ex:4883
+#: lib/vutuv_web/components/post_components.ex:4885
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Ihr Beitrag ist veröffentlicht, das Foto noch nicht."
 
 #: lib/vutuv_web/components/post_components.ex:2527
-#: lib/vutuv_web/components/post_components.ex:4094
+#: lib/vutuv_web/components/post_components.ex:4096
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -22998,7 +22993,7 @@ msgstr "Nur diese Accounts (leer = alle) …"
 msgid "only %{account}"
 msgstr "nur %{account}"
 
-#: lib/vutuv_web/components/post_components.ex:6528
+#: lib/vutuv_web/components/post_components.ex:6569
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -23504,7 +23499,7 @@ msgstr[1] "%{formatted} neue Follower"
 msgid "Last 30 days: %{parts}"
 msgstr "Letzte 30 Tage: %{parts}"
 
-#: lib/vutuv_web/components/post_components.ex:4446
+#: lib/vutuv_web/components/post_components.ex:4448
 #: lib/vutuv_web/live/notification_live/index.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -24018,13 +24013,13 @@ msgstr "Sie können das auch direkt im Feed ändern, gleich unter „Mehr laden�
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr "feed länge seitengröße beiträge anzahl menge mehr laden scrollen blättern seite umfang page size posts number load more"
 
-#: lib/vutuv_web/components/post_components.ex:6519
-#: lib/vutuv_web/components/post_components.ex:6520
+#: lib/vutuv_web/components/post_components.ex:6560
+#: lib/vutuv_web/components/post_components.ex:6561
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr "Ein Wort oder eine Wortgruppe …"
 
-#: lib/vutuv_web/components/post_components.ex:6547
+#: lib/vutuv_web/components/post_components.ex:6588
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr "Für wen %{thing} ausgeblendet wird"
@@ -24041,7 +24036,7 @@ msgstr "Ausgeblendet"
 msgid "Hide something from your feed"
 msgstr "Etwas aus dem Feed ausblenden"
 
-#: lib/vutuv_web/components/post_components.ex:6467
+#: lib/vutuv_web/components/post_components.ex:6508
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr "Nicht mehr zeigen"
@@ -24056,22 +24051,22 @@ msgstr "Was hiervon getroffen wird, klappt im Feed auf eine Zeile zu."
 msgid "Words & tags"
 msgstr "Wörter & Tags"
 
-#: lib/vutuv_web/components/post_components.ex:6551
+#: lib/vutuv_web/components/post_components.ex:6592
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr "bei allen"
 
-#: lib/vutuv_web/components/post_components.ex:6554
+#: lib/vutuv_web/components/post_components.ex:6595
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr "nur %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:6523
+#: lib/vutuv_web/components/post_components.ex:6564
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr "dieses Wort"
 
-#: lib/vutuv_web/components/post_components.ex:6564
+#: lib/vutuv_web/components/post_components.ex:6605
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "nur %{server}"
@@ -24123,7 +24118,7 @@ msgstr "Diese Website ist gerade offline."
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr "Die Website läuft, nur diese Adresse gibt es hier nicht. Wahrscheinlich ist der Link alt oder enthält einen Tippfehler."
 
-#: lib/vutuv_web/components/post_components.ex:5883
+#: lib/vutuv_web/components/post_components.ex:5918
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr "Screenshot vergrößern"
@@ -24142,3 +24137,38 @@ msgstr "Schalten Sie ihn für Ihr Konto ein, dann können Sie %{app} gleich hier
 #, elixir-autogen, elixir-format
 msgid "Turn on for my account"
 msgstr "Für mein Konto einschalten"
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:47
+#, elixir-autogen, elixir-format
+msgid "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."
+msgstr "Korrigieren. Einer unserer Admins sieht sich die Änderung dann an; bis dahin bleibt der Beitrag verborgen."
+
+#: lib/vutuv_web/templates/report/new.html.heex:135
+#, elixir-autogen, elixir-format
+msgid "I declare in good faith that this use is authorized neither by the rights holder nor by law."
+msgstr "Ich versichere nach bestem Wissen, dass diese Nutzung weder vom Rechteinhaber noch vom Gesetz gedeckt ist."
+
+#: lib/vutuv_web/templates/page/community.html.heex:43
+#, elixir-autogen, elixir-format
+msgid "Publish only what you hold the rights to"
+msgstr "Veröffentlichen Sie nur, wozu Sie die Rechte haben"
+
+#: lib/vutuv_web/views/report_html.ex:34
+#, elixir-autogen, elixir-format
+msgid "Tell us which work it is and where the original can be seen."
+msgstr "Sagen Sie uns, um welches Werk es geht und wo das Original zu sehen ist."
+
+#: lib/vutuv_web/templates/page/community.html.heex:46
+#, elixir-autogen, elixir-format
+msgid "Texts, photos and videos belong to whoever made them. Post your own work, or work you have permission to use. A rights holder can report content here, and such a complaint is decided by one of our admins - an edit does not settle it."
+msgstr "Texte, Fotos und Videos gehören denen, die sie gemacht haben. Veröffentlichen Sie eigene Werke oder solche, für die Sie die Erlaubnis haben. Rechteinhaber können Inhalte hier melden; über eine solche Meldung entscheidet einer unserer Admins - eine Korrektur erledigt sie nicht."
+
+#: lib/vutuv_web/views/report_html.ex:19
+#, elixir-autogen, elixir-format
+msgid "Uses a text, photo or video without the rights holder's permission"
+msgstr "Nutzt einen Text, ein Foto oder ein Video ohne Erlaubnis des Rechteinhabers"
+
+#: lib/vutuv_web/templates/report/new.html.heex:111
+#, elixir-autogen, elixir-format
+msgid "Which work is it, and where can the original be seen? (required)"
+msgstr "Um welches Werk geht es, und wo ist das Original zu sehen? (erforderlich)"

--- a/priv/gettext/de/LC_MESSAGES/errors.po
+++ b/priv/gettext/de/LC_MESSAGES/errors.po
@@ -232,12 +232,12 @@ msgstr "darf nicht nur aus Satzzeichen bestehen"
 msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr "„%{tag}“ besteht nur aus Satzzeichen und ist kein Tag."
 
-#: lib/vutuv_web/views/error_helpers.ex:131
+#: lib/vutuv_web/views/error_helpers.ex:139
 #, elixir-autogen, elixir-format
 msgid "\"%{uri}\" is not a valid https account address."
 msgstr "„%{uri}“ ist keine gültige https-Kontoadresse."
 
-#: lib/vutuv_web/views/error_helpers.ex:130
+#: lib/vutuv_web/views/error_helpers.ex:138
 #, elixir-autogen, elixir-format
 msgid "Please list at most %{max} accounts."
 msgstr "Bitte geben Sie höchstens %{max} Konten an."
@@ -247,74 +247,74 @@ msgstr "Bitte geben Sie höchstens %{max} Konten an."
 msgid "must spell out how the name sounds"
 msgstr "muss beschreiben, wie der Name klingt"
 
-#: lib/vutuv_web/views/error_helpers.ex:123
+#: lib/vutuv_web/views/error_helpers.ex:131
 #, elixir-autogen, elixir-format
 msgid "Please use at most %{max} tags."
 msgstr "Bitte verwenden Sie höchstens %{max} Tags."
 
-#: lib/vutuv_web/views/error_helpers.ex:133
+#: lib/vutuv_web/views/error_helpers.ex:141
 #, elixir-autogen, elixir-format
 msgid "Enter your Signal link, it starts with https://signal.me/#"
 msgstr "Bitte geben Sie Ihren Signal-Link ein, er beginnt mit https://signal.me/#"
 
-#: lib/vutuv_web/views/error_helpers.ex:125
+#: lib/vutuv_web/views/error_helpers.ex:133
 #, elixir-autogen, elixir-format
 msgid "We allow at most %{max} accounts per post. Please remove some mentions."
 msgstr ""
 "Wir erlauben höchstens %{max} Konten pro Beitrag. Bitte entfernen Sie einige "
 "Erwähnungen."
 
-#: lib/vutuv_web/views/error_helpers.ex:136
+#: lib/vutuv_web/views/error_helpers.ex:144
 #, elixir-autogen, elixir-format
 msgid "Enter your Bluesky handle, e.g. name.bsky.social"
 msgstr "Geben Sie Ihr Bluesky-Handle an, z. B. name.bsky.social"
 
-#: lib/vutuv_web/views/error_helpers.ex:149
+#: lib/vutuv_web/views/error_helpers.ex:157
 #, elixir-autogen, elixir-format
 msgid "Enter your Codeberg username, not a full URL with extra path segments"
 msgstr "Geben Sie Ihren Codeberg-Benutzernamen an, keine vollständige URL mit weiteren Pfadangaben"
 
-#: lib/vutuv_web/views/error_helpers.ex:145
+#: lib/vutuv_web/views/error_helpers.ex:153
 #, elixir-autogen, elixir-format
 msgid "Enter your GitHub username, not a full URL with extra path segments"
 msgstr "Geben Sie Ihren GitHub-Benutzernamen an, keine vollständige URL mit weiteren Pfadangaben"
 
-#: lib/vutuv_web/views/error_helpers.ex:141
+#: lib/vutuv_web/views/error_helpers.ex:149
 #, elixir-autogen, elixir-format
 msgid "Enter your GitLab username, e.g. gitlab.com/username (not a /-/u/ ID link)"
 msgstr "Geben Sie Ihren GitLab-Benutzernamen an, z. B. gitlab.com/benutzername (keinen ID-Link mit /-/u/)"
 
-#: lib/vutuv_web/views/error_helpers.ex:135
+#: lib/vutuv_web/views/error_helpers.ex:143
 #, elixir-autogen, elixir-format
 msgid "Enter your full Mastodon handle, e.g. @user@instance.social"
 msgstr "Geben Sie Ihr vollständiges Mastodon-Handle an, z. B. @name@instanz.social"
 
-#: lib/vutuv_web/views/error_helpers.ex:137
+#: lib/vutuv_web/views/error_helpers.ex:145
 #, elixir-autogen, elixir-format
 msgid "Enter your username and your instance, e.g. name@git.example.com"
 msgstr "Geben Sie Ihren Benutzernamen und Ihre Instanz an, z. B. name@git.example.com"
 
-#: lib/vutuv_web/views/error_helpers.ex:153
+#: lib/vutuv_web/views/error_helpers.ex:161
 #, elixir-autogen, elixir-format
 msgid "Invalid account name"
 msgstr "Ungültiger Kontoname"
 
-#: lib/vutuv_web/views/error_helpers.ex:154
+#: lib/vutuv_web/views/error_helpers.ex:162
 #, elixir-autogen, elixir-format
 msgid "Someone has already claimed this account"
 msgstr "Dieses Konto hat bereits jemand für sich beansprucht"
 
-#: lib/vutuv_web/views/error_helpers.ex:161
+#: lib/vutuv_web/views/error_helpers.ex:169
 #, elixir-autogen, elixir-format
 msgid "That instance did not answer. Please try again in a moment."
 msgstr "Diese Instanz hat nicht geantwortet. Bitte versuchen Sie es gleich noch einmal."
 
-#: lib/vutuv_web/views/error_helpers.ex:162
+#: lib/vutuv_web/views/error_helpers.ex:170
 #, elixir-autogen, elixir-format
 msgid "Too many checks for now. Please try again later."
 msgstr "Vorerst zu viele Prüfungen. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/views/error_helpers.ex:157
+#: lib/vutuv_web/views/error_helpers.ex:165
 #, elixir-autogen, elixir-format
 msgid "We could not find this account on that instance. Please check the address."
 msgstr "Wir konnten dieses Konto auf dieser Instanz nicht finden. Bitte prüfen Sie die Adresse."
@@ -323,3 +323,23 @@ msgstr "Wir konnten dieses Konto auf dieser Instanz nicht finden. Bitte prüfen 
 #, elixir-autogen, elixir-format
 msgid "Only one email address can be given at sign-up."
 msgstr "Bei der Anmeldung kann nur eine E-Mail-Adresse angegeben werden."
+
+#: lib/vutuv_web/views/error_helpers.ex:129
+#, elixir-autogen, elixir-format
+msgid "Please confirm that you are making this claim in good faith."
+msgstr "Bitte bestätigen Sie, dass Sie diese Meldung nach bestem Wissen machen."
+
+#: lib/vutuv_web/views/error_helpers.ex:123
+#, elixir-autogen, elixir-format
+msgid "Please pick a category."
+msgstr "Bitte wählen Sie eine Kategorie."
+
+#: lib/vutuv_web/views/error_helpers.ex:125
+#, elixir-autogen, elixir-format
+msgid "Please tell us which work it is and where the original can be seen."
+msgstr "Bitte sagen Sie uns, um welches Werk es geht und wo das Original zu sehen ist."
+
+#: lib/vutuv_web/views/error_helpers.ex:124
+#, elixir-autogen, elixir-format
+msgid "Your note is too long."
+msgstr "Ihre Notiz ist zu lang."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -125,7 +125,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:113
-#: lib/vutuv_web/templates/report/new.html.heex:103
+#: lib/vutuv_web/templates/report/new.html.heex:154
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:255
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
@@ -172,7 +172,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:167
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:28
 #: lib/vutuv_web/templates/dev_app/show.html.heex:135
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:59
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:67
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:70
 #, elixir-autogen
 msgid "Delete"
@@ -224,7 +224,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:6
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:45
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:53
 #: lib/vutuv_web/templates/user/show.html.heex:1124
 #, elixir-autogen
 msgid "Edit"
@@ -1180,7 +1180,7 @@ msgstr ""
 msgid "All tag urls"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4437
+#: lib/vutuv_web/components/post_components.ex:4439
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:619
@@ -2188,13 +2188,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4310
-#: lib/vutuv_web/components/post_components.ex:4314
+#: lib/vutuv_web/components/post_components.ex:4312
+#: lib/vutuv_web/components/post_components.ex:4316
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4311
+#: lib/vutuv_web/components/post_components.ex:4313
 #: lib/vutuv_web/live/fediverse_account_live.ex:387
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2294,22 +2294,22 @@ msgstr ""
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5895
+#: lib/vutuv_web/components/post_components.ex:5936
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5899
+#: lib/vutuv_web/components/post_components.ex:5940
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5897
+#: lib/vutuv_web/components/post_components.ex:5938
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5898
+#: lib/vutuv_web/components/post_components.ex:5939
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2354,7 +2354,7 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2104
-#: lib/vutuv_web/components/post_components.ex:5995
+#: lib/vutuv_web/components/post_components.ex:6036
 #: lib/vutuv_web/components/ui.ex:4131
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
@@ -2373,7 +2373,7 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2055
-#: lib/vutuv_web/components/post_components.ex:6233
+#: lib/vutuv_web/components/post_components.ex:6274
 #: lib/vutuv_web/components/ui.ex:4117
 #: lib/vutuv_web/live/notification_live/index.ex:1512
 #: lib/vutuv_web/views/user_html.ex:481
@@ -2382,7 +2382,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1263
-#: lib/vutuv_web/components/post_components.ex:6243
+#: lib/vutuv_web/components/post_components.ex:6284
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:522
 #: lib/vutuv_web/live/shell_live.ex:1523
@@ -2403,13 +2403,13 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5983
+#: lib/vutuv_web/components/post_components.ex:6024
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2103
-#: lib/vutuv_web/components/post_components.ex:5994
+#: lib/vutuv_web/components/post_components.ex:6035
 #: lib/vutuv_web/live/post_live/saved.ex:818
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
@@ -2417,26 +2417,26 @@ msgid "Remove bookmark"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2084
-#: lib/vutuv_web/components/post_components.ex:5979
+#: lib/vutuv_web/components/post_components.ex:6020
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2372
-#: lib/vutuv_web/components/post_components.ex:5041
+#: lib/vutuv_web/components/post_components.ex:5043
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2083
-#: lib/vutuv_web/components/post_components.ex:5978
+#: lib/vutuv_web/components/post_components.ex:6019
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2054
-#: lib/vutuv_web/components/post_components.ex:6232
+#: lib/vutuv_web/components/post_components.ex:6273
 #: lib/vutuv_web/live/post_live/saved.ex:817
 #: lib/vutuv_web/views/user_html.ex:481
 #, elixir-autogen, elixir-format
@@ -2464,7 +2464,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6287
+#: lib/vutuv_web/components/post_components.ex:6328
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2476,8 +2476,8 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2068
-#: lib/vutuv_web/components/post_components.ex:6270
-#: lib/vutuv_web/components/post_components.ex:6271
+#: lib/vutuv_web/components/post_components.ex:6311
+#: lib/vutuv_web/components/post_components.ex:6312
 #: lib/vutuv_web/live/notification_live/index.ex:1010
 #: lib/vutuv_web/live/notification_live/index.ex:1509
 #: lib/vutuv_web/live/post_live/reply.ex:49
@@ -2820,7 +2820,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5896
+#: lib/vutuv_web/components/post_components.ex:5937
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2907,22 +2907,22 @@ msgstr ""
 msgid "Abusive"
 msgstr ""
 
-#: lib/vutuv_web/views/moderation_case_html.ex:26
+#: lib/vutuv_web/views/moderation_case_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "An admin confirmed the report. The content stays hidden."
 msgstr ""
 
-#: lib/vutuv_web/views/moderation_case_html.ex:29
+#: lib/vutuv_web/views/moderation_case_html.ex:30
 #, elixir-autogen, elixir-format
 msgid "An admin dismissed the report. The content is visible again."
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:80
+#: lib/vutuv_web/templates/report/new.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Anything our admins should know? (optional)"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:12
+#: lib/vutuv_web/views/report_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Bullying or harassment"
 msgstr ""
@@ -2936,7 +2936,7 @@ msgstr ""
 msgid "Community guidelines"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:68
+#: lib/vutuv_web/templates/page/community.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Confirmed violations follow three steps: a warning, then a one-week suspension, then permanent deactivation. Strikes expire after twelve months."
 msgstr ""
@@ -2956,7 +2956,7 @@ msgstr ""
 msgid "Current version (edited since the report)"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:57
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "Delete this content permanently?"
 msgstr ""
@@ -2971,7 +2971,7 @@ msgstr ""
 msgid "Escalated"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:42
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "Fix it. An edited post is visible again immediately."
 msgstr ""
@@ -2981,12 +2981,12 @@ msgstr ""
 msgid "Flagged"
 msgstr ""
 
-#: lib/vutuv_web/views/moderation_case_html.ex:17
+#: lib/vutuv_web/views/moderation_case_html.ex:18
 #, elixir-autogen, elixir-format
 msgid "Hidden until one of our admins has ruled. You do not need to do anything."
 msgstr ""
 
-#: lib/vutuv_web/views/moderation_case_html.ex:11
+#: lib/vutuv_web/views/moderation_case_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Hidden. You can settle this yourself - see below."
 msgstr ""
@@ -3022,7 +3022,7 @@ msgstr ""
 msgid "Moderation queue"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:68
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "My content is fine"
 msgstr ""
@@ -3062,7 +3062,7 @@ msgstr ""
 msgid "Nobody else can see it right now. You have 72 hours to settle this yourself; after that our admins decide. Three ways out:"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:11
+#: lib/vutuv_web/views/report_html.ex:13
 #, elixir-autogen, elixir-format
 msgid "Not family-friendly"
 msgstr ""
@@ -3072,7 +3072,7 @@ msgstr ""
 msgid "Nothing here - none of your content is currently reported."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:19
+#: lib/vutuv_web/views/report_html.ex:25
 #, elixir-autogen, elixir-format
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
@@ -3117,12 +3117,7 @@ msgstr ""
 msgid "Owner"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:88
-#, elixir-autogen, elixir-format
-msgid "Please pick a category."
-msgstr ""
-
-#: lib/vutuv_web/templates/report/new.html.heex:91
+#: lib/vutuv_web/templates/report/new.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Please report honestly. Reporting to harm someone breaks our"
 msgstr ""
@@ -3152,7 +3147,7 @@ msgstr ""
 msgid "Rejected"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:51
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:59
 #, elixir-autogen, elixir-format
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
@@ -3166,12 +3161,12 @@ msgstr ""
 msgid "Report"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:46
+#: lib/vutuv_web/controllers/report_controller.ex:52
 #, elixir-autogen, elixir-format
 msgid "Report content"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:43
+#: lib/vutuv_web/templates/page/community.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Report honestly"
 msgstr ""
@@ -3212,7 +3207,7 @@ msgstr ""
 msgid "Reported content"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:58
+#: lib/vutuv_web/templates/page/community.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Reported content is hidden right away while the report is handled. Nobody is publicly marked."
 msgstr ""
@@ -3237,7 +3232,7 @@ msgstr ""
 msgid "Reports"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:75
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:83
 #, elixir-autogen, elixir-format
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
@@ -3250,37 +3245,37 @@ msgstr ""
 msgid "Review"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:46
+#: lib/vutuv_web/templates/page/community.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "See something that breaks these rules? Report it - every post, message and profile has a report option, and reports are anonymous. But reporting is not a weapon: deliberately false reports count as bullying and earn the reporter the same strikes."
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:105
+#: lib/vutuv_web/templates/report/new.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "Send report"
 msgstr ""
 
-#: lib/vutuv_web/views/moderation_case_html.ex:20
+#: lib/vutuv_web/views/moderation_case_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "Settled: the content was deleted."
 msgstr ""
 
-#: lib/vutuv_web/views/moderation_case_html.ex:23
+#: lib/vutuv_web/views/moderation_case_html.ex:24
 #, elixir-autogen, elixir-format
 msgid "Settled: you revised the content and it is visible again."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:15
+#: lib/vutuv_web/views/report_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "Something else"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:13
+#: lib/vutuv_web/views/report_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "Spam or scam"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:65
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "Stand by it. It stays hidden until one of our admins has ruled."
 msgstr ""
@@ -3304,17 +3299,17 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:21
+#: lib/vutuv_web/views/report_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "Targets, demeans or threatens a person."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:27
+#: lib/vutuv_web/views/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Tell us more in the note below."
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:109
+#: lib/vutuv_web/controllers/report_controller.ex:136
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. We take it from here."
 msgstr ""
@@ -3324,7 +3319,7 @@ msgstr ""
 msgid "The content in question"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:63
+#: lib/vutuv_web/templates/page/community.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "The owner is notified and can delete the content, fix it (it becomes visible again immediately) or stand by it - then our admins decide."
 msgstr ""
@@ -3381,7 +3376,7 @@ msgstr ""
 msgid "Understood. The content stays hidden until one of our admins has ruled."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:22
+#: lib/vutuv_web/views/report_html.ex:28
 #, elixir-autogen, elixir-format
 msgid "Unwanted advertising, fraud or fake activity."
 msgstr ""
@@ -3391,12 +3386,12 @@ msgstr ""
 msgid "Uphold the report"
 msgstr ""
 
-#: lib/vutuv_web/views/moderation_case_html.ex:14
+#: lib/vutuv_web/views/moderation_case_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "Visible. Our admins will take a look."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:54
+#: lib/vutuv_web/templates/page/community.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "What happens after a report"
 msgstr ""
@@ -3406,7 +3401,7 @@ msgstr ""
 msgid "Who reports, and how it holds up"
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:55
+#: lib/vutuv_web/templates/report/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Why are you reporting this?"
 msgstr ""
@@ -3416,12 +3411,12 @@ msgstr ""
 msgid "Worst offenders first. Reporters with abusive reports or three rejections in a year lose the instant freeze; their reports only flag for review."
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:74
+#: lib/vutuv_web/controllers/report_controller.ex:83
 #, elixir-autogen, elixir-format
 msgid "You already reported this. Our team is on it."
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:80
+#: lib/vutuv_web/controllers/report_controller.ex:89
 #, elixir-autogen, elixir-format
 msgid "You cannot report your own content."
 msgstr ""
@@ -3451,8 +3446,8 @@ msgstr ""
 msgid "Your report is anonymous. If it checks out, the content is hidden right away and the owner is asked to fix it."
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:77
-#: lib/vutuv_web/templates/report/new.html.heex:93
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:85
+#: lib/vutuv_web/templates/report/new.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "community guidelines"
 msgstr ""
@@ -5400,8 +5395,8 @@ msgid "Footer navigation"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3974
-#: lib/vutuv_web/components/post_components.ex:4029
-#: lib/vutuv_web/components/post_components.ex:4558
+#: lib/vutuv_web/components/post_components.ex:4026
+#: lib/vutuv_web/components/post_components.ex:4560
 #: lib/vutuv_web/live/notification_live/index.ex:1086
 #: lib/vutuv_web/views/user_html.ex:131
 #, elixir-autogen, elixir-format
@@ -7310,7 +7305,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:6143
+#: lib/vutuv_web/components/post_components.ex:6184
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8751,7 +8746,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5044
+#: lib/vutuv_web/components/post_components.ex:5046
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9875,7 +9870,7 @@ msgstr ""
 msgid "Spam"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:105
+#: lib/vutuv_web/controllers/report_controller.ex:132
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. Our moderators have been notified and will review this account."
 msgstr ""
@@ -9891,7 +9886,7 @@ msgstr ""
 msgid "deleted"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:115
+#: lib/vutuv_web/controllers/report_controller.ex:142
 #, elixir-autogen, elixir-format
 msgid "To protect you, the connection between you and the reported member is paused - no contact in either direction, including messages. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -11894,7 +11889,7 @@ msgstr ""
 msgid "%{views} views · %{clicks} apply clicks"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:25
+#: lib/vutuv_web/views/report_html.ex:31
 #, elixir-autogen, elixir-format
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr ""
@@ -12108,7 +12103,7 @@ msgstr ""
 msgid "Mini-job"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:14
+#: lib/vutuv_web/views/report_html.ex:16
 #, elixir-autogen, elixir-format
 msgid "Misleading job posting"
 msgstr ""
@@ -13562,34 +13557,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5720
+#: lib/vutuv_web/components/post_components.ex:5734
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:5677
+#: lib/vutuv_web/components/post_components.ex:5691
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5721
+#: lib/vutuv_web/components/post_components.ex:5735
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5723
+#: lib/vutuv_web/components/post_components.ex:5737
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5719
+#: lib/vutuv_web/components/post_components.ex:5733
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:5676
+#: lib/vutuv_web/components/post_components.ex:5690
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13600,12 +13595,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5718
+#: lib/vutuv_web/components/post_components.ex:5732
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5722
+#: lib/vutuv_web/components/post_components.ex:5736
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13625,7 +13620,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5759
+#: lib/vutuv_web/components/post_components.ex:5773
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13633,27 +13628,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5789
+#: lib/vutuv_web/components/post_components.ex:5803
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5790
+#: lib/vutuv_web/components/post_components.ex:5804
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5788
+#: lib/vutuv_web/components/post_components.ex:5802
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5748
+#: lib/vutuv_web/components/post_components.ex:5762
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5795
+#: lib/vutuv_web/components/post_components.ex:5809
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13683,7 +13678,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5562
+#: lib/vutuv_web/components/post_components.ex:5576
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13726,7 +13721,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5553
+#: lib/vutuv_web/components/post_components.ex:5567
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14107,7 +14102,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6242
+#: lib/vutuv_web/components/post_components.ex:6283
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -15252,7 +15247,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6188
+#: lib/vutuv_web/components/post_components.ex:6229
 #: lib/vutuv_web/live/notification_live/index.ex:1690
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -15260,7 +15255,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6192
+#: lib/vutuv_web/components/post_components.ex:6233
 #: lib/vutuv_web/live/notification_live/index.ex:1684
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15268,7 +15263,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6196
+#: lib/vutuv_web/components/post_components.ex:6237
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15276,7 +15271,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:6147
+#: lib/vutuv_web/components/post_components.ex:6188
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -16181,12 +16176,12 @@ msgstr ""
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4689
+#: lib/vutuv_web/components/post_components.ex:4691
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4838
+#: lib/vutuv_web/components/post_components.ex:4840
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16199,7 +16194,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1462
 #: lib/vutuv_web/agent_docs/text.ex:890
-#: lib/vutuv_web/components/post_components.ex:4920
+#: lib/vutuv_web/components/post_components.ex:4922
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
@@ -16360,13 +16355,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1319
-#: lib/vutuv_web/components/post_components.ex:6185
+#: lib/vutuv_web/components/post_components.ex:6226
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1317
-#: lib/vutuv_web/components/post_components.ex:6182
+#: lib/vutuv_web/components/post_components.ex:6223
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16376,7 +16371,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6072
+#: lib/vutuv_web/components/post_components.ex:6113
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -17985,19 +17980,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5214
+#: lib/vutuv_web/components/post_components.ex:5216
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5216
+#: lib/vutuv_web/components/post_components.ex:5218
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5227
+#: lib/vutuv_web/components/post_components.ex:5229
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -20510,27 +20505,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5108
+#: lib/vutuv_web/components/post_components.ex:5110
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5144
+#: lib/vutuv_web/components/post_components.ex:5146
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5153
+#: lib/vutuv_web/components/post_components.ex:5155
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5156
+#: lib/vutuv_web/components/post_components.ex:5158
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5133
+#: lib/vutuv_web/components/post_components.ex:5135
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20540,7 +20535,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5123
+#: lib/vutuv_web/components/post_components.ex:5125
 #: lib/vutuv_web/components/ui.ex:5167
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20669,20 +20664,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4886
+#: lib/vutuv_web/components/post_components.ex:4888
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4883
+#: lib/vutuv_web/components/post_components.ex:4885
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2527
-#: lib/vutuv_web/components/post_components.ex:4094
+#: lib/vutuv_web/components/post_components.ex:4096
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -22207,7 +22202,7 @@ msgstr ""
 msgid "only %{account}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6528
+#: lib/vutuv_web/components/post_components.ex:6569
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -22713,7 +22708,7 @@ msgstr[1] ""
 msgid "Last 30 days: %{parts}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4446
+#: lib/vutuv_web/components/post_components.ex:4448
 #: lib/vutuv_web/live/notification_live/index.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -23227,13 +23222,13 @@ msgstr ""
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6519
-#: lib/vutuv_web/components/post_components.ex:6520
+#: lib/vutuv_web/components/post_components.ex:6560
+#: lib/vutuv_web/components/post_components.ex:6561
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6547
+#: lib/vutuv_web/components/post_components.ex:6588
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr ""
@@ -23250,7 +23245,7 @@ msgstr ""
 msgid "Hide something from your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6467
+#: lib/vutuv_web/components/post_components.ex:6508
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr ""
@@ -23265,22 +23260,22 @@ msgstr ""
 msgid "Words & tags"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6551
+#: lib/vutuv_web/components/post_components.ex:6592
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6554
+#: lib/vutuv_web/components/post_components.ex:6595
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6523
+#: lib/vutuv_web/components/post_components.ex:6564
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6564
+#: lib/vutuv_web/components/post_components.ex:6605
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr ""
@@ -23332,7 +23327,7 @@ msgstr ""
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5883
+#: lib/vutuv_web/components/post_components.ex:5918
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr ""
@@ -23350,4 +23345,39 @@ msgstr ""
 #: lib/vutuv_web/templates/oauth/authorize.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Turn on for my account"
+msgstr ""
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:47
+#, elixir-autogen, elixir-format
+msgid "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."
+msgstr ""
+
+#: lib/vutuv_web/templates/report/new.html.heex:135
+#, elixir-autogen, elixir-format
+msgid "I declare in good faith that this use is authorized neither by the rights holder nor by law."
+msgstr ""
+
+#: lib/vutuv_web/templates/page/community.html.heex:43
+#, elixir-autogen, elixir-format
+msgid "Publish only what you hold the rights to"
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:34
+#, elixir-autogen, elixir-format
+msgid "Tell us which work it is and where the original can be seen."
+msgstr ""
+
+#: lib/vutuv_web/templates/page/community.html.heex:46
+#, elixir-autogen, elixir-format
+msgid "Texts, photos and videos belong to whoever made them. Post your own work, or work you have permission to use. A rights holder can report content here, and such a complaint is decided by one of our admins - an edit does not settle it."
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:19
+#, elixir-autogen, elixir-format
+msgid "Uses a text, photo or video without the rights holder's permission"
+msgstr ""
+
+#: lib/vutuv_web/templates/report/new.html.heex:111
+#, elixir-autogen, elixir-format
+msgid "Which work is it, and where can the original be seen? (required)"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -123,7 +123,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:113
-#: lib/vutuv_web/templates/report/new.html.heex:103
+#: lib/vutuv_web/templates/report/new.html.heex:154
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:255
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
@@ -170,7 +170,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:167
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:28
 #: lib/vutuv_web/templates/dev_app/show.html.heex:135
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:59
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:67
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:70
 #, elixir-autogen
 msgid "Delete"
@@ -222,7 +222,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:6
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:45
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:53
 #: lib/vutuv_web/templates/user/show.html.heex:1124
 #, elixir-autogen
 msgid "Edit"
@@ -1178,7 +1178,7 @@ msgstr ""
 msgid "All tag urls"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4437
+#: lib/vutuv_web/components/post_components.ex:4439
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:619
@@ -2186,13 +2186,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4310
-#: lib/vutuv_web/components/post_components.ex:4314
+#: lib/vutuv_web/components/post_components.ex:4312
+#: lib/vutuv_web/components/post_components.ex:4316
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4311
+#: lib/vutuv_web/components/post_components.ex:4313
 #: lib/vutuv_web/live/fediverse_account_live.ex:387
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2292,22 +2292,22 @@ msgstr ""
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5895
+#: lib/vutuv_web/components/post_components.ex:5936
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5899
+#: lib/vutuv_web/components/post_components.ex:5940
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5897
+#: lib/vutuv_web/components/post_components.ex:5938
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5898
+#: lib/vutuv_web/components/post_components.ex:5939
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2352,7 +2352,7 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2104
-#: lib/vutuv_web/components/post_components.ex:5995
+#: lib/vutuv_web/components/post_components.ex:6036
 #: lib/vutuv_web/components/ui.ex:4131
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
@@ -2371,7 +2371,7 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2055
-#: lib/vutuv_web/components/post_components.ex:6233
+#: lib/vutuv_web/components/post_components.ex:6274
 #: lib/vutuv_web/components/ui.ex:4117
 #: lib/vutuv_web/live/notification_live/index.ex:1512
 #: lib/vutuv_web/views/user_html.ex:481
@@ -2380,7 +2380,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1263
-#: lib/vutuv_web/components/post_components.ex:6243
+#: lib/vutuv_web/components/post_components.ex:6284
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:522
 #: lib/vutuv_web/live/shell_live.ex:1523
@@ -2401,13 +2401,13 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5983
+#: lib/vutuv_web/components/post_components.ex:6024
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2103
-#: lib/vutuv_web/components/post_components.ex:5994
+#: lib/vutuv_web/components/post_components.ex:6035
 #: lib/vutuv_web/live/post_live/saved.ex:818
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
@@ -2415,26 +2415,26 @@ msgid "Remove bookmark"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2084
-#: lib/vutuv_web/components/post_components.ex:5979
+#: lib/vutuv_web/components/post_components.ex:6020
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2372
-#: lib/vutuv_web/components/post_components.ex:5041
+#: lib/vutuv_web/components/post_components.ex:5043
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2083
-#: lib/vutuv_web/components/post_components.ex:5978
+#: lib/vutuv_web/components/post_components.ex:6019
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2054
-#: lib/vutuv_web/components/post_components.ex:6232
+#: lib/vutuv_web/components/post_components.ex:6273
 #: lib/vutuv_web/live/post_live/saved.ex:817
 #: lib/vutuv_web/views/user_html.ex:481
 #, elixir-autogen, elixir-format
@@ -2462,7 +2462,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6287
+#: lib/vutuv_web/components/post_components.ex:6328
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2474,8 +2474,8 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2068
-#: lib/vutuv_web/components/post_components.ex:6270
-#: lib/vutuv_web/components/post_components.ex:6271
+#: lib/vutuv_web/components/post_components.ex:6311
+#: lib/vutuv_web/components/post_components.ex:6312
 #: lib/vutuv_web/live/notification_live/index.ex:1010
 #: lib/vutuv_web/live/notification_live/index.ex:1509
 #: lib/vutuv_web/live/post_live/reply.ex:49
@@ -2818,7 +2818,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5896
+#: lib/vutuv_web/components/post_components.ex:5937
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2905,22 +2905,22 @@ msgstr ""
 msgid "Abusive"
 msgstr ""
 
-#: lib/vutuv_web/views/moderation_case_html.ex:26
+#: lib/vutuv_web/views/moderation_case_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "An admin confirmed the report. The content stays hidden."
 msgstr ""
 
-#: lib/vutuv_web/views/moderation_case_html.ex:29
+#: lib/vutuv_web/views/moderation_case_html.ex:30
 #, elixir-autogen, elixir-format
 msgid "An admin dismissed the report. The content is visible again."
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:80
+#: lib/vutuv_web/templates/report/new.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Anything our admins should know? (optional)"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:12
+#: lib/vutuv_web/views/report_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Bullying or harassment"
 msgstr ""
@@ -2934,7 +2934,7 @@ msgstr ""
 msgid "Community guidelines"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:68
+#: lib/vutuv_web/templates/page/community.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Confirmed violations follow three steps: a warning, then a one-week suspension, then permanent deactivation. Strikes expire after twelve months."
 msgstr ""
@@ -2954,7 +2954,7 @@ msgstr ""
 msgid "Current version (edited since the report)"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:57
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "Delete this content permanently?"
 msgstr ""
@@ -2969,7 +2969,7 @@ msgstr ""
 msgid "Escalated"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:42
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "Fix it. An edited post is visible again immediately."
 msgstr ""
@@ -2979,12 +2979,12 @@ msgstr ""
 msgid "Flagged"
 msgstr ""
 
-#: lib/vutuv_web/views/moderation_case_html.ex:17
+#: lib/vutuv_web/views/moderation_case_html.ex:18
 #, elixir-autogen, elixir-format
 msgid "Hidden until one of our admins has ruled. You do not need to do anything."
 msgstr ""
 
-#: lib/vutuv_web/views/moderation_case_html.ex:11
+#: lib/vutuv_web/views/moderation_case_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Hidden. You can settle this yourself - see below."
 msgstr ""
@@ -3020,7 +3020,7 @@ msgstr ""
 msgid "Moderation queue"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:68
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "My content is fine"
 msgstr ""
@@ -3060,7 +3060,7 @@ msgstr ""
 msgid "Nobody else can see it right now. You have 72 hours to settle this yourself; after that our admins decide. Three ways out:"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:11
+#: lib/vutuv_web/views/report_html.ex:13
 #, elixir-autogen, elixir-format
 msgid "Not family-friendly"
 msgstr ""
@@ -3070,7 +3070,7 @@ msgstr ""
 msgid "Nothing here - none of your content is currently reported."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:19
+#: lib/vutuv_web/views/report_html.ex:25
 #, elixir-autogen, elixir-format
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
@@ -3115,12 +3115,7 @@ msgstr ""
 msgid "Owner"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:88
-#, elixir-autogen, elixir-format
-msgid "Please pick a category."
-msgstr ""
-
-#: lib/vutuv_web/templates/report/new.html.heex:91
+#: lib/vutuv_web/templates/report/new.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Please report honestly. Reporting to harm someone breaks our"
 msgstr ""
@@ -3150,7 +3145,7 @@ msgstr ""
 msgid "Rejected"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:51
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:59
 #, elixir-autogen, elixir-format
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
@@ -3164,12 +3159,12 @@ msgstr ""
 msgid "Report"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:46
+#: lib/vutuv_web/controllers/report_controller.ex:52
 #, elixir-autogen, elixir-format
 msgid "Report content"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:43
+#: lib/vutuv_web/templates/page/community.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Report honestly"
 msgstr ""
@@ -3210,7 +3205,7 @@ msgstr ""
 msgid "Reported content"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:58
+#: lib/vutuv_web/templates/page/community.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Reported content is hidden right away while the report is handled. Nobody is publicly marked."
 msgstr ""
@@ -3235,7 +3230,7 @@ msgstr ""
 msgid "Reports"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:75
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:83
 #, elixir-autogen, elixir-format
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
@@ -3248,37 +3243,37 @@ msgstr ""
 msgid "Review"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:46
+#: lib/vutuv_web/templates/page/community.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "See something that breaks these rules? Report it - every post, message and profile has a report option, and reports are anonymous. But reporting is not a weapon: deliberately false reports count as bullying and earn the reporter the same strikes."
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:105
+#: lib/vutuv_web/templates/report/new.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "Send report"
 msgstr ""
 
-#: lib/vutuv_web/views/moderation_case_html.ex:20
+#: lib/vutuv_web/views/moderation_case_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "Settled: the content was deleted."
 msgstr ""
 
-#: lib/vutuv_web/views/moderation_case_html.ex:23
+#: lib/vutuv_web/views/moderation_case_html.ex:24
 #, elixir-autogen, elixir-format
 msgid "Settled: you revised the content and it is visible again."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:15
+#: lib/vutuv_web/views/report_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "Something else"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:13
+#: lib/vutuv_web/views/report_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "Spam or scam"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:65
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "Stand by it. It stays hidden until one of our admins has ruled."
 msgstr ""
@@ -3302,17 +3297,17 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:21
+#: lib/vutuv_web/views/report_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "Targets, demeans or threatens a person."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:27
+#: lib/vutuv_web/views/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Tell us more in the note below."
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:109
+#: lib/vutuv_web/controllers/report_controller.ex:136
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. We take it from here."
 msgstr ""
@@ -3322,7 +3317,7 @@ msgstr ""
 msgid "The content in question"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:63
+#: lib/vutuv_web/templates/page/community.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "The owner is notified and can delete the content, fix it (it becomes visible again immediately) or stand by it - then our admins decide."
 msgstr ""
@@ -3379,7 +3374,7 @@ msgstr ""
 msgid "Understood. The content stays hidden until one of our admins has ruled."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:22
+#: lib/vutuv_web/views/report_html.ex:28
 #, elixir-autogen, elixir-format
 msgid "Unwanted advertising, fraud or fake activity."
 msgstr ""
@@ -3389,12 +3384,12 @@ msgstr ""
 msgid "Uphold the report"
 msgstr ""
 
-#: lib/vutuv_web/views/moderation_case_html.ex:14
+#: lib/vutuv_web/views/moderation_case_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "Visible. Our admins will take a look."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:54
+#: lib/vutuv_web/templates/page/community.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "What happens after a report"
 msgstr ""
@@ -3404,7 +3399,7 @@ msgstr ""
 msgid "Who reports, and how it holds up"
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:55
+#: lib/vutuv_web/templates/report/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Why are you reporting this?"
 msgstr ""
@@ -3414,12 +3409,12 @@ msgstr ""
 msgid "Worst offenders first. Reporters with abusive reports or three rejections in a year lose the instant freeze; their reports only flag for review."
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:74
+#: lib/vutuv_web/controllers/report_controller.ex:83
 #, elixir-autogen, elixir-format
 msgid "You already reported this. Our team is on it."
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:80
+#: lib/vutuv_web/controllers/report_controller.ex:89
 #, elixir-autogen, elixir-format
 msgid "You cannot report your own content."
 msgstr ""
@@ -3449,8 +3444,8 @@ msgstr ""
 msgid "Your report is anonymous. If it checks out, the content is hidden right away and the owner is asked to fix it."
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:77
-#: lib/vutuv_web/templates/report/new.html.heex:93
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:85
+#: lib/vutuv_web/templates/report/new.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "community guidelines"
 msgstr ""
@@ -5398,8 +5393,8 @@ msgid "Footer navigation"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3974
-#: lib/vutuv_web/components/post_components.ex:4029
-#: lib/vutuv_web/components/post_components.ex:4558
+#: lib/vutuv_web/components/post_components.ex:4026
+#: lib/vutuv_web/components/post_components.ex:4560
 #: lib/vutuv_web/live/notification_live/index.ex:1086
 #: lib/vutuv_web/views/user_html.ex:131
 #, elixir-autogen, elixir-format
@@ -7308,7 +7303,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:6143
+#: lib/vutuv_web/components/post_components.ex:6184
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8749,7 +8744,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5044
+#: lib/vutuv_web/components/post_components.ex:5046
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9873,7 +9868,7 @@ msgstr ""
 msgid "Spam"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:105
+#: lib/vutuv_web/controllers/report_controller.ex:132
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. Our moderators have been notified and will review this account."
 msgstr ""
@@ -9889,7 +9884,7 @@ msgstr ""
 msgid "deleted"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:115
+#: lib/vutuv_web/controllers/report_controller.ex:142
 #, elixir-autogen, elixir-format
 msgid "To protect you, the connection between you and the reported member is paused - no contact in either direction, including messages. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -11892,7 +11887,7 @@ msgstr ""
 msgid "%{views} views · %{clicks} apply clicks"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:25
+#: lib/vutuv_web/views/report_html.ex:31
 #, elixir-autogen, elixir-format
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr ""
@@ -12106,7 +12101,7 @@ msgstr ""
 msgid "Mini-job"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:14
+#: lib/vutuv_web/views/report_html.ex:16
 #, elixir-autogen, elixir-format
 msgid "Misleading job posting"
 msgstr ""
@@ -13560,34 +13555,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5720
+#: lib/vutuv_web/components/post_components.ex:5734
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:5677
+#: lib/vutuv_web/components/post_components.ex:5691
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5721
+#: lib/vutuv_web/components/post_components.ex:5735
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5723
+#: lib/vutuv_web/components/post_components.ex:5737
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5719
+#: lib/vutuv_web/components/post_components.ex:5733
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:5676
+#: lib/vutuv_web/components/post_components.ex:5690
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13598,12 +13593,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5718
+#: lib/vutuv_web/components/post_components.ex:5732
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5722
+#: lib/vutuv_web/components/post_components.ex:5736
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13623,7 +13618,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5759
+#: lib/vutuv_web/components/post_components.ex:5773
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13631,27 +13626,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5789
+#: lib/vutuv_web/components/post_components.ex:5803
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5790
+#: lib/vutuv_web/components/post_components.ex:5804
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5788
+#: lib/vutuv_web/components/post_components.ex:5802
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5748
+#: lib/vutuv_web/components/post_components.ex:5762
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5795
+#: lib/vutuv_web/components/post_components.ex:5809
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13681,7 +13676,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5562
+#: lib/vutuv_web/components/post_components.ex:5576
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13724,7 +13719,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5553
+#: lib/vutuv_web/components/post_components.ex:5567
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14105,7 +14100,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6242
+#: lib/vutuv_web/components/post_components.ex:6283
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -15250,7 +15245,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6188
+#: lib/vutuv_web/components/post_components.ex:6229
 #: lib/vutuv_web/live/notification_live/index.ex:1690
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
@@ -15258,7 +15253,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6192
+#: lib/vutuv_web/components/post_components.ex:6233
 #: lib/vutuv_web/live/notification_live/index.ex:1684
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15266,7 +15261,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6196
+#: lib/vutuv_web/components/post_components.ex:6237
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15274,7 +15269,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:6147
+#: lib/vutuv_web/components/post_components.ex:6188
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -16179,12 +16174,12 @@ msgstr ""
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4689
+#: lib/vutuv_web/components/post_components.ex:4691
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4838
+#: lib/vutuv_web/components/post_components.ex:4840
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16197,7 +16192,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1462
 #: lib/vutuv_web/agent_docs/text.ex:890
-#: lib/vutuv_web/components/post_components.ex:4920
+#: lib/vutuv_web/components/post_components.ex:4922
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
@@ -16358,13 +16353,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1319
-#: lib/vutuv_web/components/post_components.ex:6185
+#: lib/vutuv_web/components/post_components.ex:6226
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1317
-#: lib/vutuv_web/components/post_components.ex:6182
+#: lib/vutuv_web/components/post_components.ex:6223
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16374,7 +16369,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6072
+#: lib/vutuv_web/components/post_components.ex:6113
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -17983,19 +17978,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5214
+#: lib/vutuv_web/components/post_components.ex:5216
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5216
+#: lib/vutuv_web/components/post_components.ex:5218
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5227
+#: lib/vutuv_web/components/post_components.ex:5229
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -20508,27 +20503,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5108
+#: lib/vutuv_web/components/post_components.ex:5110
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5144
+#: lib/vutuv_web/components/post_components.ex:5146
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5153
+#: lib/vutuv_web/components/post_components.ex:5155
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5156
+#: lib/vutuv_web/components/post_components.ex:5158
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5133
+#: lib/vutuv_web/components/post_components.ex:5135
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20538,7 +20533,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5123
+#: lib/vutuv_web/components/post_components.ex:5125
 #: lib/vutuv_web/components/ui.ex:5167
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20667,20 +20662,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4886
+#: lib/vutuv_web/components/post_components.ex:4888
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4883
+#: lib/vutuv_web/components/post_components.ex:4885
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2527
-#: lib/vutuv_web/components/post_components.ex:4094
+#: lib/vutuv_web/components/post_components.ex:4096
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -22205,7 +22200,7 @@ msgstr ""
 msgid "only %{account}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6528
+#: lib/vutuv_web/components/post_components.ex:6569
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -22711,7 +22706,7 @@ msgstr[1] ""
 msgid "Last 30 days: %{parts}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4446
+#: lib/vutuv_web/components/post_components.ex:4448
 #: lib/vutuv_web/live/notification_live/index.ex:1020
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Less"
@@ -23225,13 +23220,13 @@ msgstr ""
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6519
-#: lib/vutuv_web/components/post_components.ex:6520
+#: lib/vutuv_web/components/post_components.ex:6560
+#: lib/vutuv_web/components/post_components.ex:6561
 #, elixir-autogen, elixir-format, fuzzy
 msgid "A word or phrase …"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6547
+#: lib/vutuv_web/components/post_components.ex:6588
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr ""
@@ -23248,7 +23243,7 @@ msgstr ""
 msgid "Hide something from your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6467
+#: lib/vutuv_web/components/post_components.ex:6508
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr ""
@@ -23263,22 +23258,22 @@ msgstr ""
 msgid "Words & tags"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6551
+#: lib/vutuv_web/components/post_components.ex:6592
 #, elixir-autogen, elixir-format, fuzzy
 msgid "everyone"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6554
+#: lib/vutuv_web/components/post_components.ex:6595
 #, elixir-autogen, elixir-format, fuzzy
 msgid "only %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6523
+#: lib/vutuv_web/components/post_components.ex:6564
 #, elixir-autogen, elixir-format, fuzzy
 msgid "this word"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6564
+#: lib/vutuv_web/components/post_components.ex:6605
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "only %{server}"
@@ -23330,7 +23325,7 @@ msgstr ""
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5883
+#: lib/vutuv_web/components/post_components.ex:5918
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr ""
@@ -23348,4 +23343,39 @@ msgstr ""
 #: lib/vutuv_web/templates/oauth/authorize.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Turn on for my account"
+msgstr ""
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:47
+#, elixir-autogen, elixir-format
+msgid "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."
+msgstr ""
+
+#: lib/vutuv_web/templates/report/new.html.heex:135
+#, elixir-autogen, elixir-format
+msgid "I declare in good faith that this use is authorized neither by the rights holder nor by law."
+msgstr ""
+
+#: lib/vutuv_web/templates/page/community.html.heex:43
+#, elixir-autogen, elixir-format
+msgid "Publish only what you hold the rights to"
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:34
+#, elixir-autogen, elixir-format
+msgid "Tell us which work it is and where the original can be seen."
+msgstr ""
+
+#: lib/vutuv_web/templates/page/community.html.heex:46
+#, elixir-autogen, elixir-format
+msgid "Texts, photos and videos belong to whoever made them. Post your own work, or work you have permission to use. A rights holder can report content here, and such a complaint is decided by one of our admins - an edit does not settle it."
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:19
+#, elixir-autogen, elixir-format
+msgid "Uses a text, photo or video without the rights holder's permission"
+msgstr ""
+
+#: lib/vutuv_web/templates/report/new.html.heex:111
+#, elixir-autogen, elixir-format
+msgid "Which work is it, and where can the original be seen? (required)"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -230,12 +230,12 @@ msgstr ""
 msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:131
+#: lib/vutuv_web/views/error_helpers.ex:139
 #, elixir-autogen, elixir-format
 msgid "\"%{uri}\" is not a valid https account address."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:130
+#: lib/vutuv_web/views/error_helpers.ex:138
 #, elixir-autogen, elixir-format
 msgid "Please list at most %{max} accounts."
 msgstr ""
@@ -245,72 +245,72 @@ msgstr ""
 msgid "must spell out how the name sounds"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:123
+#: lib/vutuv_web/views/error_helpers.ex:131
 #, elixir-autogen, elixir-format
 msgid "Please use at most %{max} tags."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:133
+#: lib/vutuv_web/views/error_helpers.ex:141
 #, elixir-autogen, elixir-format
 msgid "Enter your Signal link, it starts with https://signal.me/#"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:125
+#: lib/vutuv_web/views/error_helpers.ex:133
 #, elixir-autogen, elixir-format
 msgid "We allow at most %{max} accounts per post. Please remove some mentions."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:136
+#: lib/vutuv_web/views/error_helpers.ex:144
 #, elixir-autogen, elixir-format
 msgid "Enter your Bluesky handle, e.g. name.bsky.social"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:149
+#: lib/vutuv_web/views/error_helpers.ex:157
 #, elixir-autogen, elixir-format
 msgid "Enter your Codeberg username, not a full URL with extra path segments"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:145
+#: lib/vutuv_web/views/error_helpers.ex:153
 #, elixir-autogen, elixir-format
 msgid "Enter your GitHub username, not a full URL with extra path segments"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:141
+#: lib/vutuv_web/views/error_helpers.ex:149
 #, elixir-autogen, elixir-format
 msgid "Enter your GitLab username, e.g. gitlab.com/username (not a /-/u/ ID link)"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:135
+#: lib/vutuv_web/views/error_helpers.ex:143
 #, elixir-autogen, elixir-format
 msgid "Enter your full Mastodon handle, e.g. @user@instance.social"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:137
+#: lib/vutuv_web/views/error_helpers.ex:145
 #, elixir-autogen, elixir-format
 msgid "Enter your username and your instance, e.g. name@git.example.com"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:153
+#: lib/vutuv_web/views/error_helpers.ex:161
 #, elixir-autogen, elixir-format
 msgid "Invalid account name"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:154
+#: lib/vutuv_web/views/error_helpers.ex:162
 #, elixir-autogen, elixir-format
 msgid "Someone has already claimed this account"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:161
+#: lib/vutuv_web/views/error_helpers.ex:169
 #, elixir-autogen, elixir-format
 msgid "That instance did not answer. Please try again in a moment."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:162
+#: lib/vutuv_web/views/error_helpers.ex:170
 #, elixir-autogen, elixir-format
 msgid "Too many checks for now. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:157
+#: lib/vutuv_web/views/error_helpers.ex:165
 #, elixir-autogen, elixir-format
 msgid "We could not find this account on that instance. Please check the address."
 msgstr ""
@@ -319,3 +319,23 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Only one email address can be given at sign-up."
 msgstr "Only one email address can be given at sign-up."
+
+#: lib/vutuv_web/views/error_helpers.ex:129
+#, elixir-autogen, elixir-format
+msgid "Please confirm that you are making this claim in good faith."
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:123
+#, elixir-autogen, elixir-format
+msgid "Please pick a category."
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:125
+#, elixir-autogen, elixir-format
+msgid "Please tell us which work it is and where the original can be seen."
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:124
+#, elixir-autogen, elixir-format
+msgid "Your note is too long."
+msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -233,12 +233,12 @@ msgstr ""
 msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:131
+#: lib/vutuv_web/views/error_helpers.ex:139
 #, elixir-autogen, elixir-format
 msgid "\"%{uri}\" is not a valid https account address."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:130
+#: lib/vutuv_web/views/error_helpers.ex:138
 #, elixir-autogen, elixir-format
 msgid "Please list at most %{max} accounts."
 msgstr ""
@@ -248,72 +248,72 @@ msgstr ""
 msgid "must spell out how the name sounds"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:123
+#: lib/vutuv_web/views/error_helpers.ex:131
 #, elixir-autogen, elixir-format
 msgid "Please use at most %{max} tags."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:133
+#: lib/vutuv_web/views/error_helpers.ex:141
 #, elixir-autogen, elixir-format
 msgid "Enter your Signal link, it starts with https://signal.me/#"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:125
+#: lib/vutuv_web/views/error_helpers.ex:133
 #, elixir-autogen, elixir-format
 msgid "We allow at most %{max} accounts per post. Please remove some mentions."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:136
+#: lib/vutuv_web/views/error_helpers.ex:144
 #, elixir-autogen, elixir-format
 msgid "Enter your Bluesky handle, e.g. name.bsky.social"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:149
+#: lib/vutuv_web/views/error_helpers.ex:157
 #, elixir-autogen, elixir-format
 msgid "Enter your Codeberg username, not a full URL with extra path segments"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:145
+#: lib/vutuv_web/views/error_helpers.ex:153
 #, elixir-autogen, elixir-format
 msgid "Enter your GitHub username, not a full URL with extra path segments"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:141
+#: lib/vutuv_web/views/error_helpers.ex:149
 #, elixir-autogen, elixir-format
 msgid "Enter your GitLab username, e.g. gitlab.com/username (not a /-/u/ ID link)"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:135
+#: lib/vutuv_web/views/error_helpers.ex:143
 #, elixir-autogen, elixir-format
 msgid "Enter your full Mastodon handle, e.g. @user@instance.social"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:137
+#: lib/vutuv_web/views/error_helpers.ex:145
 #, elixir-autogen, elixir-format
 msgid "Enter your username and your instance, e.g. name@git.example.com"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:153
+#: lib/vutuv_web/views/error_helpers.ex:161
 #, elixir-autogen, elixir-format
 msgid "Invalid account name"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:154
+#: lib/vutuv_web/views/error_helpers.ex:162
 #, elixir-autogen, elixir-format
 msgid "Someone has already claimed this account"
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:161
+#: lib/vutuv_web/views/error_helpers.ex:169
 #, elixir-autogen, elixir-format
 msgid "That instance did not answer. Please try again in a moment."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:162
+#: lib/vutuv_web/views/error_helpers.ex:170
 #, elixir-autogen, elixir-format
 msgid "Too many checks for now. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:157
+#: lib/vutuv_web/views/error_helpers.ex:165
 #, elixir-autogen, elixir-format
 msgid "We could not find this account on that instance. Please check the address."
 msgstr ""
@@ -321,4 +321,24 @@ msgstr ""
 #: lib/vutuv_web/views/error_helpers.ex:105
 #, elixir-autogen, elixir-format
 msgid "Only one email address can be given at sign-up."
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:129
+#, elixir-autogen, elixir-format
+msgid "Please confirm that you are making this claim in good faith."
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:123
+#, elixir-autogen, elixir-format
+msgid "Please pick a category."
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:125
+#, elixir-autogen, elixir-format
+msgid "Please tell us which work it is and where the original can be seen."
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:124
+#, elixir-autogen, elixir-format
+msgid "Your note is too long."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -125,7 +125,7 @@ msgstr "Compleanno"
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:113
-#: lib/vutuv_web/templates/report/new.html.heex:103
+#: lib/vutuv_web/templates/report/new.html.heex:154
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:255
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
@@ -172,7 +172,7 @@ msgstr "Non è stato possibile ricambiare il follow a %{name}."
 #: lib/vutuv_web/live/admin/user_delete_live.ex:167
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:28
 #: lib/vutuv_web/templates/dev_app/show.html.heex:135
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:59
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:67
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:70
 #, elixir-autogen
 msgid "Delete"
@@ -224,7 +224,7 @@ msgstr "Scarica"
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:6
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:45
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:53
 #: lib/vutuv_web/templates/user/show.html.heex:1124
 #, elixir-autogen
 msgid "Edit"
@@ -1201,7 +1201,7 @@ msgstr "Tutti i sinonimi dei tag"
 msgid "All tag urls"
 msgstr "Tutti gli URL dei tag"
 
-#: lib/vutuv_web/components/post_components.ex:4437
+#: lib/vutuv_web/components/post_components.ex:4439
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:619
@@ -2230,13 +2230,13 @@ msgstr "Post eliminato."
 msgid "Posts"
 msgstr "Post"
 
-#: lib/vutuv_web/components/post_components.ex:4310
-#: lib/vutuv_web/components/post_components.ex:4314
+#: lib/vutuv_web/components/post_components.ex:4312
+#: lib/vutuv_web/components/post_components.ex:4316
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Leggi tutto"
 
-#: lib/vutuv_web/components/post_components.ex:4311
+#: lib/vutuv_web/components/post_components.ex:4313
 #: lib/vutuv_web/live/fediverse_account_live.ex:387
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2338,22 +2338,22 @@ msgstr "Che c'è di nuovo? Markdown è supportato."
 msgid "edited"
 msgstr "modificato"
 
-#: lib/vutuv_web/components/post_components.ex:5895
+#: lib/vutuv_web/components/post_components.ex:5936
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "tutti gli altri"
 
-#: lib/vutuv_web/components/post_components.ex:5899
+#: lib/vutuv_web/components/post_components.ex:5940
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "visitatori non connessi"
 
-#: lib/vutuv_web/components/post_components.ex:5897
+#: lib/vutuv_web/components/post_components.ex:5938
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "persone che non La seguono"
 
-#: lib/vutuv_web/components/post_components.ex:5898
+#: lib/vutuv_web/components/post_components.ex:5939
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "persone che non segue"
@@ -2398,7 +2398,7 @@ msgid "All posts"
 msgstr "Tutti i post"
 
 #: lib/vutuv_web/components/post_components.ex:2104
-#: lib/vutuv_web/components/post_components.ex:5995
+#: lib/vutuv_web/components/post_components.ex:6036
 #: lib/vutuv_web/components/ui.ex:4131
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
@@ -2417,7 +2417,7 @@ msgid "Bookmarks"
 msgstr "Salvati"
 
 #: lib/vutuv_web/components/post_components.ex:2055
-#: lib/vutuv_web/components/post_components.ex:6233
+#: lib/vutuv_web/components/post_components.ex:6274
 #: lib/vutuv_web/components/ui.ex:4117
 #: lib/vutuv_web/live/notification_live/index.ex:1512
 #: lib/vutuv_web/views/user_html.ex:481
@@ -2426,7 +2426,7 @@ msgid "Like"
 msgstr "Mi piace"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1263
-#: lib/vutuv_web/components/post_components.ex:6243
+#: lib/vutuv_web/components/post_components.ex:6284
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:522
 #: lib/vutuv_web/live/shell_live.ex:1523
@@ -2447,13 +2447,13 @@ msgstr "Qui non c'è ancora nulla. I post che salva compaiono qui."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Qui non c'è ancora nulla. I post a cui mette Mi piace compaiono qui."
 
-#: lib/vutuv_web/components/post_components.ex:5983
+#: lib/vutuv_web/components/post_components.ex:6024
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Solo i post pubblici possono essere ripubblicati."
 
 #: lib/vutuv_web/components/post_components.ex:2103
-#: lib/vutuv_web/components/post_components.ex:5994
+#: lib/vutuv_web/components/post_components.ex:6035
 #: lib/vutuv_web/live/post_live/saved.ex:818
 #: lib/vutuv_web/views/user_html.ex:471
 #, elixir-autogen, elixir-format
@@ -2461,26 +2461,26 @@ msgid "Remove bookmark"
 msgstr "Rimuovi dai salvati"
 
 #: lib/vutuv_web/components/post_components.ex:2084
-#: lib/vutuv_web/components/post_components.ex:5979
+#: lib/vutuv_web/components/post_components.ex:6020
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Ripubblica"
 
 #: lib/vutuv_web/components/post_components.ex:2372
-#: lib/vutuv_web/components/post_components.ex:5041
+#: lib/vutuv_web/components/post_components.ex:5043
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Ripubblicato da %{name}"
 
 #: lib/vutuv_web/components/post_components.ex:2083
-#: lib/vutuv_web/components/post_components.ex:5978
+#: lib/vutuv_web/components/post_components.ex:6019
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Annulla la ripubblicazione"
 
 #: lib/vutuv_web/components/post_components.ex:2054
-#: lib/vutuv_web/components/post_components.ex:6232
+#: lib/vutuv_web/components/post_components.ex:6273
 #: lib/vutuv_web/live/post_live/saved.ex:817
 #: lib/vutuv_web/views/user_html.ex:481
 #, elixir-autogen, elixir-format
@@ -2508,7 +2508,7 @@ msgstr "Non seguire più"
 msgid "Welcome to vutuv!"
 msgstr "Benvenuto su vutuv."
 
-#: lib/vutuv_web/components/post_components.ex:6287
+#: lib/vutuv_web/components/post_components.ex:6328
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Solo ai post pubblici si può rispondere."
@@ -2520,8 +2520,8 @@ msgid "Replies"
 msgstr "Risposte"
 
 #: lib/vutuv_web/components/post_components.ex:2068
-#: lib/vutuv_web/components/post_components.ex:6270
-#: lib/vutuv_web/components/post_components.ex:6271
+#: lib/vutuv_web/components/post_components.ex:6311
+#: lib/vutuv_web/components/post_components.ex:6312
 #: lib/vutuv_web/live/notification_live/index.ex:1010
 #: lib/vutuv_web/live/notification_live/index.ex:1509
 #: lib/vutuv_web/live/post_live/reply.ex:49
@@ -2871,7 +2871,7 @@ msgid_plural "connections"
 msgstr[0] "collegamento"
 msgstr[1] "collegamenti"
 
-#: lib/vutuv_web/components/post_components.ex:5896
+#: lib/vutuv_web/components/post_components.ex:5937
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "persone che non sono Suoi collegamenti"
@@ -2960,26 +2960,26 @@ msgstr ""
 msgid "Abusive"
 msgstr "Offensivo"
 
-#: lib/vutuv_web/views/moderation_case_html.ex:26
+#: lib/vutuv_web/views/moderation_case_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "An admin confirmed the report. The content stays hidden."
 msgstr ""
 "Un amministratore ha confermato la segnalazione. Il contenuto resta "
 "nascosto."
 
-#: lib/vutuv_web/views/moderation_case_html.ex:29
+#: lib/vutuv_web/views/moderation_case_html.ex:30
 #, elixir-autogen, elixir-format
 msgid "An admin dismissed the report. The content is visible again."
 msgstr ""
 "Un amministratore ha respinto la segnalazione. Il contenuto è di nuovo "
 "visibile."
 
-#: lib/vutuv_web/templates/report/new.html.heex:80
+#: lib/vutuv_web/templates/report/new.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Anything our admins should know? (optional)"
 msgstr "Qualcosa che i nostri amministratori dovrebbero sapere? (facoltativo)"
 
-#: lib/vutuv_web/views/report_html.ex:12
+#: lib/vutuv_web/views/report_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Bullying or harassment"
 msgstr "Bullismo o molestie"
@@ -2993,7 +2993,7 @@ msgstr "Bullismo o molestie"
 msgid "Community guidelines"
 msgstr "Regole della community"
 
-#: lib/vutuv_web/templates/page/community.html.heex:68
+#: lib/vutuv_web/templates/page/community.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Confirmed violations follow three steps: a warning, then a one-week suspension, then permanent deactivation. Strikes expire after twelve months."
 msgstr ""
@@ -3019,7 +3019,7 @@ msgstr ""
 msgid "Current version (edited since the report)"
 msgstr "Versione attuale (modificata dopo la segnalazione)"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:57
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "Delete this content permanently?"
 msgstr "Eliminare definitivamente questo contenuto?"
@@ -3034,7 +3034,7 @@ msgstr "Eliminato. La segnalazione è chiusa, non serve altro."
 msgid "Escalated"
 msgstr "Inoltrato"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:42
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "Fix it. An edited post is visible again immediately."
 msgstr "Lo corregga. Un post modificato torna subito visibile."
@@ -3044,14 +3044,14 @@ msgstr "Lo corregga. Un post modificato torna subito visibile."
 msgid "Flagged"
 msgstr "Segnalato"
 
-#: lib/vutuv_web/views/moderation_case_html.ex:17
+#: lib/vutuv_web/views/moderation_case_html.ex:18
 #, elixir-autogen, elixir-format
 msgid "Hidden until one of our admins has ruled. You do not need to do anything."
 msgstr ""
 "Nascosto finché uno dei nostri amministratori non avrà deciso. Non deve fare"
 " nulla."
 
-#: lib/vutuv_web/views/moderation_case_html.ex:11
+#: lib/vutuv_web/views/moderation_case_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Hidden. You can settle this yourself - see below."
 msgstr "Nascosto. Può risolvere da solo: veda qui sotto."
@@ -3087,7 +3087,7 @@ msgstr "Caso di moderazione"
 msgid "Moderation queue"
 msgstr "Coda di moderazione"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:68
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "My content is fine"
 msgstr "Il mio contenuto è a posto"
@@ -3134,7 +3134,7 @@ msgstr ""
 "Al momento nessun altro può vederlo. Ha 72 ore per risolvere da solo; poi "
 "decidono i nostri amministratori. Tre vie d'uscita:"
 
-#: lib/vutuv_web/views/report_html.ex:11
+#: lib/vutuv_web/views/report_html.ex:13
 #, elixir-autogen, elixir-format
 msgid "Not family-friendly"
 msgstr "Non adatto a tutti"
@@ -3144,7 +3144,7 @@ msgstr "Non adatto a tutti"
 msgid "Nothing here - none of your content is currently reported."
 msgstr "Qui non c'è nulla: al momento nessun Suo contenuto è segnalato."
 
-#: lib/vutuv_web/views/report_html.ex:19
+#: lib/vutuv_web/views/report_html.ex:25
 #, elixir-autogen, elixir-format
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nudità, violenza o altri contenuti che non hanno posto su vutuv."
@@ -3191,12 +3191,7 @@ msgstr "Aperto"
 msgid "Owner"
 msgstr "Proprietario"
 
-#: lib/vutuv_web/controllers/report_controller.ex:88
-#, elixir-autogen, elixir-format
-msgid "Please pick a category."
-msgstr "Scelga una categoria."
-
-#: lib/vutuv_web/templates/report/new.html.heex:91
+#: lib/vutuv_web/templates/report/new.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Please report honestly. Reporting to harm someone breaks our"
 msgstr ""
@@ -3227,7 +3222,7 @@ msgstr "Respingi la segnalazione"
 msgid "Rejected"
 msgstr "Respinta"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:51
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:59
 #, elixir-autogen, elixir-format
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Lo rimuova. La segnalazione si chiude, senza altre domande."
@@ -3241,12 +3236,12 @@ msgstr "Lo rimuova. La segnalazione si chiude, senza altre domande."
 msgid "Report"
 msgstr "Segnala"
 
-#: lib/vutuv_web/controllers/report_controller.ex:46
+#: lib/vutuv_web/controllers/report_controller.ex:52
 #, elixir-autogen, elixir-format
 msgid "Report content"
 msgstr "Segnala il contenuto"
 
-#: lib/vutuv_web/templates/page/community.html.heex:43
+#: lib/vutuv_web/templates/page/community.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Report honestly"
 msgstr "Segnali in buona fede"
@@ -3287,7 +3282,7 @@ msgstr "Segnalato come"
 msgid "Reported content"
 msgstr "Contenuto segnalato"
 
-#: lib/vutuv_web/templates/page/community.html.heex:58
+#: lib/vutuv_web/templates/page/community.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Reported content is hidden right away while the report is handled. Nobody is publicly marked."
 msgstr ""
@@ -3314,7 +3309,7 @@ msgstr "Storico dei segnalanti"
 msgid "Reports"
 msgstr "Segnalazioni"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:75
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:83
 #, elixir-autogen, elixir-format
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
@@ -3329,7 +3324,7 @@ msgstr ""
 msgid "Review"
 msgstr "Esamina"
 
-#: lib/vutuv_web/templates/page/community.html.heex:46
+#: lib/vutuv_web/templates/page/community.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "See something that breaks these rules? Report it - every post, message and profile has a report option, and reports are anonymous. But reporting is not a weapon: deliberately false reports count as bullying and earn the reporter the same strikes."
 msgstr ""
@@ -3338,32 +3333,32 @@ msgstr ""
 " segnalazione non è un'arma: le segnalazioni deliberatamente false valgono "
 "come bullismo e portano al segnalante gli stessi richiami."
 
-#: lib/vutuv_web/templates/report/new.html.heex:105
+#: lib/vutuv_web/templates/report/new.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "Send report"
 msgstr "Invia la segnalazione"
 
-#: lib/vutuv_web/views/moderation_case_html.ex:20
+#: lib/vutuv_web/views/moderation_case_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "Settled: the content was deleted."
 msgstr "Chiuso: il contenuto è stato eliminato."
 
-#: lib/vutuv_web/views/moderation_case_html.ex:23
+#: lib/vutuv_web/views/moderation_case_html.ex:24
 #, elixir-autogen, elixir-format
 msgid "Settled: you revised the content and it is visible again."
 msgstr "Chiuso: ha corretto il contenuto ed è di nuovo visibile."
 
-#: lib/vutuv_web/views/report_html.ex:15
+#: lib/vutuv_web/views/report_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "Something else"
 msgstr "Altro"
 
-#: lib/vutuv_web/views/report_html.ex:13
+#: lib/vutuv_web/views/report_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "Spam or scam"
 msgstr "Spam o truffa"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:65
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "Stand by it. It stays hidden until one of our admins has ruled."
 msgstr ""
@@ -3389,17 +3384,17 @@ msgstr ""
 msgid "Status"
 msgstr "Stato"
 
-#: lib/vutuv_web/views/report_html.ex:21
+#: lib/vutuv_web/views/report_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "Targets, demeans or threatens a person."
 msgstr "Prende di mira, umilia o minaccia una persona."
 
-#: lib/vutuv_web/views/report_html.ex:27
+#: lib/vutuv_web/views/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Tell us more in the note below."
 msgstr "Ci dica di più nella nota qui sotto."
 
-#: lib/vutuv_web/controllers/report_controller.ex:109
+#: lib/vutuv_web/controllers/report_controller.ex:136
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. We take it from here."
 msgstr "Grazie per la segnalazione. Ce ne occupiamo noi."
@@ -3409,7 +3404,7 @@ msgstr "Grazie per la segnalazione. Ce ne occupiamo noi."
 msgid "The content in question"
 msgstr "Il contenuto in questione"
 
-#: lib/vutuv_web/templates/page/community.html.heex:63
+#: lib/vutuv_web/templates/page/community.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "The owner is notified and can delete the content, fix it (it becomes visible again immediately) or stand by it - then our admins decide."
 msgstr ""
@@ -3475,7 +3470,7 @@ msgstr ""
 "Inteso. Il contenuto resta nascosto finché uno dei nostri amministratori non"
 " avrà deciso."
 
-#: lib/vutuv_web/views/report_html.ex:22
+#: lib/vutuv_web/views/report_html.ex:28
 #, elixir-autogen, elixir-format
 msgid "Unwanted advertising, fraud or fake activity."
 msgstr "Pubblicità indesiderata, frode o attività falsa."
@@ -3485,12 +3480,12 @@ msgstr "Pubblicità indesiderata, frode o attività falsa."
 msgid "Uphold the report"
 msgstr "Accogli la segnalazione"
 
-#: lib/vutuv_web/views/moderation_case_html.ex:14
+#: lib/vutuv_web/views/moderation_case_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "Visible. Our admins will take a look."
 msgstr "Visibile. I nostri amministratori daranno un'occhiata."
 
-#: lib/vutuv_web/templates/page/community.html.heex:54
+#: lib/vutuv_web/templates/page/community.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "What happens after a report"
 msgstr "Cosa succede dopo una segnalazione"
@@ -3500,7 +3495,7 @@ msgstr "Cosa succede dopo una segnalazione"
 msgid "Who reports, and how it holds up"
 msgstr "Chi segnala, e quanto regge"
 
-#: lib/vutuv_web/templates/report/new.html.heex:55
+#: lib/vutuv_web/templates/report/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Why are you reporting this?"
 msgstr "Perché lo segnala?"
@@ -3513,12 +3508,12 @@ msgstr ""
 "respingimenti in un anno perdono il blocco immediato: le loro segnalazioni "
 "si limitano a mettere il contenuto in esame."
 
-#: lib/vutuv_web/controllers/report_controller.ex:74
+#: lib/vutuv_web/controllers/report_controller.ex:83
 #, elixir-autogen, elixir-format
 msgid "You already reported this. Our team is on it."
 msgstr "Lo ha già segnalato. Ce ne stiamo occupando."
 
-#: lib/vutuv_web/controllers/report_controller.ex:80
+#: lib/vutuv_web/controllers/report_controller.ex:89
 #, elixir-autogen, elixir-format
 msgid "You cannot report your own content."
 msgstr "Non può segnalare i propri contenuti."
@@ -3552,8 +3547,8 @@ msgstr ""
 "La Sua segnalazione è anonima. Se risulta fondata, il contenuto viene "
 "nascosto subito e al proprietario viene chiesto di correggerlo."
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:77
-#: lib/vutuv_web/templates/report/new.html.heex:93
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:85
+#: lib/vutuv_web/templates/report/new.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "community guidelines"
 msgstr "regole della community"
@@ -5615,8 +5610,8 @@ msgid "Footer navigation"
 msgstr "Navigazione a piè di pagina"
 
 #: lib/vutuv_web/components/post_components.ex:3974
-#: lib/vutuv_web/components/post_components.ex:4029
-#: lib/vutuv_web/components/post_components.ex:4558
+#: lib/vutuv_web/components/post_components.ex:4026
+#: lib/vutuv_web/components/post_components.ex:4560
 #: lib/vutuv_web/live/notification_live/index.ex:1086
 #: lib/vutuv_web/views/user_html.ex:131
 #, elixir-autogen, elixir-format
@@ -7598,7 +7593,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "vale per l'intero elenco, non solo per questa pagina"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:6143
+#: lib/vutuv_web/components/post_components.ex:6184
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -9148,7 +9143,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Download del CV"
 
-#: lib/vutuv_web/components/post_components.ex:5044
+#: lib/vutuv_web/components/post_components.ex:5046
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -10320,7 +10315,7 @@ msgstr "Ripristinare questo account perché il membro possa accedere di nuovo?"
 msgid "Spam"
 msgstr "Spam"
 
-#: lib/vutuv_web/controllers/report_controller.ex:105
+#: lib/vutuv_web/controllers/report_controller.ex:132
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. Our moderators have been notified and will review this account."
 msgstr ""
@@ -10338,7 +10333,7 @@ msgstr "disattivato"
 msgid "deleted"
 msgstr "eliminato"
 
-#: lib/vutuv_web/controllers/report_controller.ex:115
+#: lib/vutuv_web/controllers/report_controller.ex:142
 #, elixir-autogen, elixir-format
 msgid "To protect you, the connection between you and the reported member is paused - no contact in either direction, including messages. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -12517,7 +12512,7 @@ msgstr "Ente pubblico"
 msgid "%{views} views · %{clicks} apply clicks"
 msgstr "%{views} visualizzazioni · %{clicks} clic per candidarsi"
 
-#: lib/vutuv_web/views/report_html.ex:25
+#: lib/vutuv_web/views/report_html.ex:31
 #, elixir-autogen, elixir-format
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr "Un annuncio di lavoro falso, ingannevole o discriminatorio."
@@ -12733,7 +12728,7 @@ msgstr "Scriva a chi ha pubblicato"
 msgid "Mini-job"
 msgstr "Mini-job"
 
-#: lib/vutuv_web/views/report_html.ex:14
+#: lib/vutuv_web/views/report_html.ex:16
 #, elixir-autogen, elixir-format
 msgid "Misleading job posting"
 msgstr "Annuncio di lavoro ingannevole"
@@ -14306,34 +14301,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr "ha aggiunto %{count} nuove voci al proprio CV:"
 
-#: lib/vutuv_web/components/post_components.ex:5720
+#: lib/vutuv_web/components/post_components.ex:5734
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Audiolibro"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:5677
+#: lib/vutuv_web/components/post_components.ex:5691
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Recensione di un libro"
 
-#: lib/vutuv_web/components/post_components.ex:5721
+#: lib/vutuv_web/components/post_components.ex:5735
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Cinema"
 
-#: lib/vutuv_web/components/post_components.ex:5723
+#: lib/vutuv_web/components/post_components.ex:5737
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:5719
+#: lib/vutuv_web/components/post_components.ex:5733
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:5676
+#: lib/vutuv_web/components/post_components.ex:5690
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Recensione di un film"
@@ -14344,12 +14339,12 @@ msgstr "Recensione di un film"
 msgid "Look up"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:5718
+#: lib/vutuv_web/components/post_components.ex:5732
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Libro cartaceo"
 
-#: lib/vutuv_web/components/post_components.ex:5722
+#: lib/vutuv_web/components/post_components.ex:5736
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14369,7 +14364,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Anno"
 
-#: lib/vutuv_web/components/post_components.ex:5759
+#: lib/vutuv_web/components/post_components.ex:5773
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14377,27 +14372,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} pagina"
 msgstr[1] "%{formatted} pagine"
 
-#: lib/vutuv_web/components/post_components.ex:5789
+#: lib/vutuv_web/components/post_components.ex:5803
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} h"
 
-#: lib/vutuv_web/components/post_components.ex:5790
+#: lib/vutuv_web/components/post_components.ex:5804
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} h %{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:5788
+#: lib/vutuv_web/components/post_components.ex:5802
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:5748
+#: lib/vutuv_web/components/post_components.ex:5762
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(edizione cartacea)"
 
-#: lib/vutuv_web/components/post_components.ex:5795
+#: lib/vutuv_web/components/post_components.ex:5809
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "circa %{duration}"
@@ -14429,7 +14424,7 @@ msgstr "Con certificazione:"
 msgid "With qualification: %{name}"
 msgstr "Con certificazione: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5562
+#: lib/vutuv_web/components/post_components.ex:5576
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Editore:"
@@ -14472,7 +14467,7 @@ msgstr "ora La seguono."
 msgid "endorsed you for %{tags}."
 msgstr "L'ha confermata per %{tags}."
 
-#: lib/vutuv_web/components/post_components.ex:5553
+#: lib/vutuv_web/components/post_components.ex:5567
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "di:"
@@ -14885,7 +14880,7 @@ msgstr ""
 "Digiti un nome, un @handle o un indirizzo e-mail per trovare un account da "
 "bloccare."
 
-#: lib/vutuv_web/components/post_components.ex:6242
+#: lib/vutuv_web/components/post_components.ex:6283
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Non può mettere Mi piace al Suo stesso post."
@@ -16151,7 +16146,7 @@ msgstr ""
 " vedere dove va a finire. Modificare o eliminare un post su vutuv è solo una"
 " richiesta rivolta a quei server, e non tutti la rispettano."
 
-#: lib/vutuv_web/components/post_components.ex:6188
+#: lib/vutuv_web/components/post_components.ex:6229
 #: lib/vutuv_web/live/notification_live/index.ex:1690
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -16159,7 +16154,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} risposta"
 msgstr[1] "%{formatted} risposte"
 
-#: lib/vutuv_web/components/post_components.ex:6192
+#: lib/vutuv_web/components/post_components.ex:6233
 #: lib/vutuv_web/live/notification_live/index.ex:1684
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -16167,7 +16162,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Mi piace"
 msgstr[1] "%{formatted} Mi piace"
 
-#: lib/vutuv_web/components/post_components.ex:6196
+#: lib/vutuv_web/components/post_components.ex:6237
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16175,7 +16170,7 @@ msgstr[0] "%{formatted} ripubblicazione"
 msgstr[1] "%{formatted} ripubblicazioni"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:6147
+#: lib/vutuv_web/components/post_components.ex:6188
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Già conteggiate nei numeri qui sopra."
@@ -17127,12 +17122,12 @@ msgstr "Ancora nessuna descrizione dell'immagine"
 msgid "Open Fediverse settings"
 msgstr "Apri le impostazioni del Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:4689
+#: lib/vutuv_web/components/post_components.ex:4691
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} di %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:4838
+#: lib/vutuv_web/components/post_components.ex:4840
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "La foto è in fase di controllo"
@@ -17145,7 +17140,7 @@ msgstr "Opzioni della foto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1462
 #: lib/vutuv_web/agent_docs/text.ex:890
-#: lib/vutuv_web/components/post_components.ex:4920
+#: lib/vutuv_web/components/post_components.ex:4922
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Foto:"
@@ -17332,13 +17327,13 @@ msgstr[1] ""
 "il file esatto lo rivela."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1319
-#: lib/vutuv_web/components/post_components.ex:6185
+#: lib/vutuv_web/components/post_components.ex:6226
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "A %{handle} è piaciuto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1317
-#: lib/vutuv_web/components/post_components.ex:6182
+#: lib/vutuv_web/components/post_components.ex:6223
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} lo ha condiviso"
@@ -17348,7 +17343,7 @@ msgstr "%{handle} lo ha condiviso"
 msgid "Fediverse reactions"
 msgstr "Reazioni dal Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:6072
+#: lib/vutuv_web/components/post_components.ex:6113
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Da altre reti"
@@ -19196,19 +19191,19 @@ msgstr ""
 msgid "Liked by"
 msgstr "Piace a"
 
-#: lib/vutuv_web/components/post_components.ex:5214
+#: lib/vutuv_web/components/post_components.ex:5216
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Piace a %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5216
+#: lib/vutuv_web/components/post_components.ex:5218
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Piace a %{name} e a %{formatted} altro"
 msgstr[1] "Piace a %{name} e ad altri %{formatted}"
 
-#: lib/vutuv_web/components/post_components.ex:5227
+#: lib/vutuv_web/components/post_components.ex:5229
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -21987,27 +21982,27 @@ msgstr "Lingua"
 msgid "The language this post is written in"
 msgstr "La lingua in cui è scritto questo post"
 
-#: lib/vutuv_web/components/post_components.ex:5108
+#: lib/vutuv_web/components/post_components.ex:5110
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Mostra l'originale"
 
-#: lib/vutuv_web/components/post_components.ex:5144
+#: lib/vutuv_web/components/post_components.ex:5146
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Traduci"
 
-#: lib/vutuv_web/components/post_components.ex:5153
+#: lib/vutuv_web/components/post_components.ex:5155
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Tradotto"
 
-#: lib/vutuv_web/components/post_components.ex:5156
+#: lib/vutuv_web/components/post_components.ex:5158
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Tradotto da %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:5133
+#: lib/vutuv_web/components/post_components.ex:5135
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Traduzione in corso…"
@@ -22018,7 +22013,7 @@ msgid "Feed language settings reset to the site defaults."
 msgstr ""
 "Impostazioni delle lingue del feed riportate ai valori predefiniti del sito."
 
-#: lib/vutuv_web/components/post_components.ex:5123
+#: lib/vutuv_web/components/post_components.ex:5125
 #: lib/vutuv_web/components/ui.ex:5167
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -22161,7 +22156,7 @@ msgid "Your username, or paste the address of your profile page."
 msgstr ""
 "Il Suo nome utente, oppure incolli l'indirizzo della Sua pagina di profilo."
 
-#: lib/vutuv_web/components/post_components.ex:4886
+#: lib/vutuv_web/components/post_components.ex:4888
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
@@ -22172,13 +22167,13 @@ msgstr[1] ""
 "La nostra IA le sta ancora controllando, %{done} su %{total} fatte. Appena "
 "avrà finito con l'ultima, le foto compariranno da sé."
 
-#: lib/vutuv_web/components/post_components.ex:4883
+#: lib/vutuv_web/components/post_components.ex:4885
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Il Suo post è pubblicato, la foto non c'è ancora."
 
 #: lib/vutuv_web/components/post_components.ex:2527
-#: lib/vutuv_web/components/post_components.ex:4094
+#: lib/vutuv_web/components/post_components.ex:4096
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -23798,7 +23793,7 @@ msgstr "Solo questi account (vuoto = tutti) …"
 msgid "only %{account}"
 msgstr "solo %{account}"
 
-#: lib/vutuv_web/components/post_components.ex:6528
+#: lib/vutuv_web/components/post_components.ex:6569
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -24304,7 +24299,7 @@ msgstr[1] "%{formatted} follower"
 msgid "Last 30 days: %{parts}"
 msgstr "Ultimi 30 giorni"
 
-#: lib/vutuv_web/components/post_components.ex:4446
+#: lib/vutuv_web/components/post_components.ex:4448
 #: lib/vutuv_web/live/notification_live/index.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -24818,13 +24813,13 @@ msgstr ""
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6519
-#: lib/vutuv_web/components/post_components.ex:6520
+#: lib/vutuv_web/components/post_components.ex:6560
+#: lib/vutuv_web/components/post_components.ex:6561
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr "Una parola o un'espressione …"
 
-#: lib/vutuv_web/components/post_components.ex:6547
+#: lib/vutuv_web/components/post_components.ex:6588
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr "Per chi %{thing} viene nascosto"
@@ -24841,7 +24836,7 @@ msgstr "Nascosti"
 msgid "Hide something from your feed"
 msgstr "Nascondi qualcosa dal tuo feed"
 
-#: lib/vutuv_web/components/post_components.ex:6467
+#: lib/vutuv_web/components/post_components.ex:6508
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr "Non mostrare più"
@@ -24856,22 +24851,22 @@ msgstr "Ciò che corrisponde viene ridotto a una riga nel tuo feed."
 msgid "Words & tags"
 msgstr "Parole e tag"
 
-#: lib/vutuv_web/components/post_components.ex:6551
+#: lib/vutuv_web/components/post_components.ex:6592
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr "per tutti"
 
-#: lib/vutuv_web/components/post_components.ex:6554
+#: lib/vutuv_web/components/post_components.ex:6595
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr "solo %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:6523
+#: lib/vutuv_web/components/post_components.ex:6564
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr "questa parola"
 
-#: lib/vutuv_web/components/post_components.ex:6564
+#: lib/vutuv_web/components/post_components.ex:6605
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "solo %{server}"
@@ -24923,7 +24918,7 @@ msgstr "Questo sito è offline in questo momento."
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr "Il sito funziona, è questo indirizzo a non essere uno dei nostri. Probabilmente il link è vecchio oppure contiene un errore di battitura."
 
-#: lib/vutuv_web/components/post_components.ex:5883
+#: lib/vutuv_web/components/post_components.ex:5918
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr "Ingrandisci lo screenshot"
@@ -24942,3 +24937,38 @@ msgstr "Attivalo per il tuo account e potrai collegare %{app} direttamente da qu
 #, elixir-autogen, elixir-format
 msgid "Turn on for my account"
 msgstr "Attiva per il mio account"
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:47
+#, elixir-autogen, elixir-format
+msgid "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."
+msgstr "Correggilo. Uno dei nostri amministratori esaminerà poi la modifica; fino ad allora il contributo resta nascosto."
+
+#: lib/vutuv_web/templates/report/new.html.heex:135
+#, elixir-autogen, elixir-format
+msgid "I declare in good faith that this use is authorized neither by the rights holder nor by law."
+msgstr "Dichiaro in buona fede che questo utilizzo non è autorizzato né dal titolare dei diritti né dalla legge."
+
+#: lib/vutuv_web/templates/page/community.html.heex:43
+#, elixir-autogen, elixir-format
+msgid "Publish only what you hold the rights to"
+msgstr "Pubblica solo ciò di cui detieni i diritti"
+
+#: lib/vutuv_web/views/report_html.ex:34
+#, elixir-autogen, elixir-format
+msgid "Tell us which work it is and where the original can be seen."
+msgstr "Indica di quale opera si tratta e dove si può vedere l'originale."
+
+#: lib/vutuv_web/templates/page/community.html.heex:46
+#, elixir-autogen, elixir-format
+msgid "Texts, photos and videos belong to whoever made them. Post your own work, or work you have permission to use. A rights holder can report content here, and such a complaint is decided by one of our admins - an edit does not settle it."
+msgstr "Testi, foto e video appartengono a chi li ha creati. Pubblica opere tue o per le quali hai il permesso. Il titolare dei diritti può segnalare un contenuto qui, e su una segnalazione del genere decide uno dei nostri amministratori: una modifica non la risolve."
+
+#: lib/vutuv_web/views/report_html.ex:19
+#, elixir-autogen, elixir-format
+msgid "Uses a text, photo or video without the rights holder's permission"
+msgstr "Usa un testo, una foto o un video senza il permesso del titolare dei diritti"
+
+#: lib/vutuv_web/templates/report/new.html.heex:111
+#, elixir-autogen, elixir-format
+msgid "Which work is it, and where can the original be seen? (required)"
+msgstr "Di quale opera si tratta e dove si può vedere l'originale? (obbligatorio)"

--- a/priv/gettext/it/LC_MESSAGES/errors.po
+++ b/priv/gettext/it/LC_MESSAGES/errors.po
@@ -221,12 +221,12 @@ msgstr "Non può essere composto solo da segni di punteggiatura"
 msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr "\"%{tag}\" è solo punteggiatura, non un tag."
 
-#: lib/vutuv_web/views/error_helpers.ex:131
+#: lib/vutuv_web/views/error_helpers.ex:139
 #, elixir-autogen, elixir-format
 msgid "\"%{uri}\" is not a valid https account address."
 msgstr "\"%{uri}\" non è un indirizzo https valido per un account."
 
-#: lib/vutuv_web/views/error_helpers.ex:130
+#: lib/vutuv_web/views/error_helpers.ex:138
 #, elixir-autogen, elixir-format
 msgid "Please list at most %{max} accounts."
 msgstr "Indichi al massimo %{max} account."
@@ -236,82 +236,82 @@ msgstr "Indichi al massimo %{max} account."
 msgid "must spell out how the name sounds"
 msgstr "Deve indicare come si pronuncia il nome"
 
-#: lib/vutuv_web/views/error_helpers.ex:123
+#: lib/vutuv_web/views/error_helpers.ex:131
 #, elixir-autogen, elixir-format
 msgid "Please use at most %{max} tags."
 msgstr "Usi al massimo %{max} tag."
 
-#: lib/vutuv_web/views/error_helpers.ex:133
+#: lib/vutuv_web/views/error_helpers.ex:141
 #, elixir-autogen, elixir-format
 msgid "Enter your Signal link, it starts with https://signal.me/#"
 msgstr "Inserisca il Suo link Signal: inizia con https://signal.me/#"
 
-#: lib/vutuv_web/views/error_helpers.ex:125
+#: lib/vutuv_web/views/error_helpers.ex:133
 #, elixir-autogen, elixir-format
 msgid "We allow at most %{max} accounts per post. Please remove some mentions."
 msgstr ""
 "Sono ammessi al massimo %{max} account per post. Rimuova qualche menzione."
 
-#: lib/vutuv_web/views/error_helpers.ex:136
+#: lib/vutuv_web/views/error_helpers.ex:144
 #, elixir-autogen, elixir-format
 msgid "Enter your Bluesky handle, e.g. name.bsky.social"
 msgstr "Inserisca il Suo handle Bluesky, ad esempio nome.bsky.social"
 
-#: lib/vutuv_web/views/error_helpers.ex:149
+#: lib/vutuv_web/views/error_helpers.ex:157
 #, elixir-autogen, elixir-format
 msgid "Enter your Codeberg username, not a full URL with extra path segments"
 msgstr ""
 "Inserisca il Suo nome utente Codeberg, non un URL completo con altri "
 "segmenti di percorso"
 
-#: lib/vutuv_web/views/error_helpers.ex:145
+#: lib/vutuv_web/views/error_helpers.ex:153
 #, elixir-autogen, elixir-format
 msgid "Enter your GitHub username, not a full URL with extra path segments"
 msgstr ""
 "Inserisca il Suo nome utente GitHub, non un URL completo con altri segmenti "
 "di percorso"
 
-#: lib/vutuv_web/views/error_helpers.ex:141
+#: lib/vutuv_web/views/error_helpers.ex:149
 #, elixir-autogen, elixir-format
 msgid "Enter your GitLab username, e.g. gitlab.com/username (not a /-/u/ ID link)"
 msgstr ""
 "Inserisca il Suo nome utente GitLab, ad esempio gitlab.com/nomeutente (non "
 "un link ID /-/u/)"
 
-#: lib/vutuv_web/views/error_helpers.ex:135
+#: lib/vutuv_web/views/error_helpers.ex:143
 #, elixir-autogen, elixir-format
 msgid "Enter your full Mastodon handle, e.g. @user@instance.social"
 msgstr ""
 "Inserisca l'handle Mastodon completo, ad esempio @utente@istanza.social"
 
-#: lib/vutuv_web/views/error_helpers.ex:137
+#: lib/vutuv_web/views/error_helpers.ex:145
 #, elixir-autogen, elixir-format
 msgid "Enter your username and your instance, e.g. name@git.example.com"
 msgstr ""
 "Inserisca il Suo nome utente e la Sua istanza, ad esempio "
 "nome@git.esempio.com"
 
-#: lib/vutuv_web/views/error_helpers.ex:153
+#: lib/vutuv_web/views/error_helpers.ex:161
 #, elixir-autogen, elixir-format
 msgid "Invalid account name"
 msgstr "Nome account non valido"
 
-#: lib/vutuv_web/views/error_helpers.ex:154
+#: lib/vutuv_web/views/error_helpers.ex:162
 #, elixir-autogen, elixir-format
 msgid "Someone has already claimed this account"
 msgstr "Questo account è già stato rivendicato da qualcun altro"
 
-#: lib/vutuv_web/views/error_helpers.ex:161
+#: lib/vutuv_web/views/error_helpers.ex:169
 #, elixir-autogen, elixir-format
 msgid "That instance did not answer. Please try again in a moment."
 msgstr "L'istanza non ha risposto. Riprovi tra poco."
 
-#: lib/vutuv_web/views/error_helpers.ex:162
+#: lib/vutuv_web/views/error_helpers.ex:170
 #, elixir-autogen, elixir-format
 msgid "Too many checks for now. Please try again later."
 msgstr "Per ora troppi controlli. Riprovi più tardi."
 
-#: lib/vutuv_web/views/error_helpers.ex:157
+#: lib/vutuv_web/views/error_helpers.ex:165
 #, elixir-autogen, elixir-format
 msgid "We could not find this account on that instance. Please check the address."
 msgstr ""
@@ -321,3 +321,23 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Only one email address can be given at sign-up."
 msgstr "Alla registrazione può indicare un solo indirizzo email."
+
+#: lib/vutuv_web/views/error_helpers.ex:129
+#, elixir-autogen, elixir-format
+msgid "Please confirm that you are making this claim in good faith."
+msgstr "Conferma di presentare questa segnalazione in buona fede."
+
+#: lib/vutuv_web/views/error_helpers.ex:123
+#, elixir-autogen, elixir-format
+msgid "Please pick a category."
+msgstr "Scelga una categoria."
+
+#: lib/vutuv_web/views/error_helpers.ex:125
+#, elixir-autogen, elixir-format
+msgid "Please tell us which work it is and where the original can be seen."
+msgstr "Indica di quale opera si tratta e dove si può vedere l'originale."
+
+#: lib/vutuv_web/views/error_helpers.ex:124
+#, elixir-autogen, elixir-format
+msgid "Your note is too long."
+msgstr "La tua nota è troppo lunga."

--- a/test/vutuv/moderation_copyright_test.exs
+++ b/test/vutuv/moderation_copyright_test.exs
@@ -1,0 +1,176 @@
+defmodule Vutuv.ModerationCopyrightTest do
+  @moduledoc """
+  The copyright complaint (issue #2008): the one report category that carries
+  legal weight rather than house-rule weight, so it is only accepted as a
+  complete notice, it reaches the admin queue the moment it is filed, and the
+  owner cannot rewrite their way out of it.
+  """
+
+  use Vutuv.DataCase, async: true
+
+  alias Vutuv.Moderation
+  alias Vutuv.Moderation.{Case, Report}
+
+  setup do
+    owner = insert(:activated_user)
+    insert(:email, user: owner)
+    reporter = insert(:activated_user)
+    insert(:email, user: reporter)
+    {:ok, %{owner: owner, reporter: reporter}}
+  end
+
+  defp complete_notice(attrs \\ %{}) do
+    Map.merge(
+      %{
+        "category" => "copyright",
+        "note" => "The photo is mine, the original is at example.com/photo",
+        "good_faith?" => "true"
+      },
+      attrs
+    )
+  end
+
+  # A reporter with a bad track record: an admin marked one of their past
+  # reports as abusive within the trust window.
+  defp make_untrusted!(reporter) do
+    post = insert(:post, user: insert(:activated_user))
+    {:ok, case_record} = Moderation.report_content(reporter, post, %{"category" => "spam"})
+    admin = insert(:activated_user, admin?: true)
+    report = Repo.get_by!(Report, case_id: case_record.id)
+    {:ok, _} = Moderation.reject_case(case_record, admin, [report.id])
+    reporter
+  end
+
+  describe "categories_for/1" do
+    test "every content type but a private message offers the copyright notice" do
+      for type <- ["post", "user", "organization", "job_posting"] do
+        assert "copyright" in Report.categories_for(type),
+               "#{type} should offer the copyright category"
+      end
+    end
+
+    test "a private message does not offer it" do
+      # Nothing was published, so there is nothing for a rights holder to have
+      # taken down.
+      refute "copyright" in Report.categories_for("message")
+    end
+  end
+
+  describe "a complete notice" do
+    test "needs the explanation", %{owner: owner, reporter: reporter} do
+      post = insert(:post, user: owner)
+
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Moderation.report_content(reporter, post, complete_notice(%{"note" => "  "}))
+
+      assert %{note: _} = errors_on(changeset)
+      refute Repo.get!(Vutuv.Posts.Post, post.id).frozen_at
+    end
+
+    test "needs the good-faith declaration", %{owner: owner, reporter: reporter} do
+      post = insert(:post, user: owner)
+
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Moderation.report_content(
+                 reporter,
+                 post,
+                 Map.delete(complete_notice(), "good_faith?")
+               )
+
+      assert %{good_faith?: _} = errors_on(changeset)
+      refute Repo.get!(Vutuv.Posts.Post, post.id).frozen_at
+    end
+
+    test "neither is demanded of the other categories", %{owner: owner, reporter: reporter} do
+      post = insert(:post, user: owner)
+
+      assert {:ok, %Case{}} =
+               Moderation.report_content(reporter, post, %{"category" => "spam"})
+    end
+  end
+
+  describe "the admin queue" do
+    test "carries a copyright case from the moment it is filed", %{
+      owner: owner,
+      reporter: reporter
+    } do
+      post = insert(:post, user: owner)
+
+      assert {:ok, %Case{status: "pending_owner"} = case_record} =
+               Moderation.report_content(reporter, post, complete_notice())
+
+      # The trust ladder is untouched: a trusted reporter still freezes the
+      # content and still leaves the owner their 72h self-service window ...
+      assert Repo.get!(Vutuv.Posts.Post, post.id).frozen_at
+      assert case_record.owner_deadline_at
+
+      # ... but unlike every other category the case does not wait for that
+      # window to run out before an admin sees it.
+      assert case_record.id in Enum.map(Moderation.list_queue(), & &1.id)
+      assert Moderation.open_queue_count() == 1
+    end
+
+    test "an untrusted reporter's notice is in the queue without a freeze", %{
+      owner: owner,
+      reporter: reporter
+    } do
+      make_untrusted!(reporter)
+      post = insert(:post, user: owner)
+
+      assert {:ok, %Case{status: "flagged"} = case_record} =
+               Moderation.report_content(reporter, post, complete_notice())
+
+      refute Repo.get!(Vutuv.Posts.Post, post.id).frozen_at
+      assert case_record.id in Enum.map(Moderation.list_queue(), & &1.id)
+    end
+
+    test "a settled copyright case leaves the queue", %{owner: owner, reporter: reporter} do
+      post = insert(:post, user: owner)
+      {:ok, _} = Moderation.report_content(reporter, post, complete_notice())
+
+      Moderation.content_deleted(post)
+
+      assert Moderation.list_queue() == []
+      assert Moderation.open_queue_count() == 0
+    end
+
+    test "an ordinary pending_owner case still waits for the owner", %{
+      owner: owner,
+      reporter: reporter
+    } do
+      post = insert(:post, user: owner)
+      {:ok, _} = Moderation.report_content(reporter, post, %{"category" => "spam"})
+
+      assert Moderation.list_queue() == []
+      assert Moderation.open_queue_count() == 0
+    end
+  end
+
+  describe "content_edited/1 on a copyright case" do
+    test "does not lift the freeze but hands the case to an admin", %{
+      owner: owner,
+      reporter: reporter
+    } do
+      post = insert(:post, user: owner)
+      {:ok, case_record} = Moderation.report_content(reporter, post, complete_notice())
+
+      Moderation.content_edited(Repo.get!(Vutuv.Posts.Post, post.id))
+
+      settled = Repo.get!(Case, case_record.id)
+      assert settled.status == "escalated"
+      assert settled.escalated_at
+      # A rewrite is not an answer to "this is not yours to publish".
+      assert Repo.get!(Vutuv.Posts.Post, post.id).frozen_at
+    end
+
+    test "an ordinary case still unfreezes on an edit", %{owner: owner, reporter: reporter} do
+      post = insert(:post, user: owner)
+      {:ok, case_record} = Moderation.report_content(reporter, post, %{"category" => "spam"})
+
+      Moderation.content_edited(Repo.get!(Vutuv.Posts.Post, post.id))
+
+      assert Repo.get!(Case, case_record.id).status == "resolved_edited"
+      refute Repo.get!(Vutuv.Posts.Post, post.id).frozen_at
+    end
+  end
+end

--- a/test/vutuv_web/controllers/moderation_case_controller_test.exs
+++ b/test/vutuv_web/controllers/moderation_case_controller_test.exs
@@ -5,11 +5,11 @@ defmodule VutuvWeb.ModerationCaseControllerTest do
   alias Vutuv.Moderation.Case
 
   # The logged-in member owns a reported (frozen) post with an open case.
-  defp owner_with_case(conn) do
+  defp owner_with_case(conn, attrs \\ %{"category" => "family"}) do
     {conn, owner} = create_and_login_user(conn)
     post = insert(:post, user: owner)
     reporter = insert(:activated_user)
-    {:ok, case_record} = Moderation.report_content(reporter, post, %{"category" => "family"})
+    {:ok, case_record} = Moderation.report_content(reporter, post, attrs)
     {conn, owner, post, case_record}
   end
 
@@ -38,6 +38,24 @@ defmodule VutuvWeb.ModerationCaseControllerTest do
       assert response =~ ~p"/moderation/cases/#{case_record.id}/dispute"
       assert response =~ ~p"/moderation/cases/#{case_record.id}/delete_content"
       assert response =~ ~p"/posts/#{case_record.content_id}/edit"
+    end
+
+    test "a copyright case keeps delete and dispute but drops the edit promise", %{conn: conn} do
+      {conn, _owner, _post, case_record} =
+        owner_with_case(conn, %{
+          "category" => "copyright",
+          "note" => "The photo is mine, the original is at example.com/photo",
+          "good_faith?" => "true"
+        })
+
+      response = conn |> get(~p"/moderation/cases/#{case_record.id}") |> html_response(200)
+
+      assert response =~ ~p"/moderation/cases/#{case_record.id}/dispute"
+      assert response =~ ~p"/moderation/cases/#{case_record.id}/delete_content"
+      # The edit is still offered, but it no longer promises the post back.
+      assert response =~ ~p"/posts/#{case_record.content_id}/edit"
+      refute response =~ "An edited post is visible again immediately."
+      assert response =~ "stays hidden until they have"
     end
 
     test "another member gets a 404", %{conn: conn} do

--- a/test/vutuv_web/controllers/report_controller_test.exs
+++ b/test/vutuv_web/controllers/report_controller_test.exs
@@ -122,6 +122,51 @@ defmodule VutuvWeb.ReportControllerTest do
              |> html_response(200)
     end
 
+    test "offers the copyright notice with its good-faith box", %{conn: conn, post: post} do
+      {conn, _me} = create_and_login_user(conn)
+
+      response =
+        conn |> get(~p"/reports/new?type=post&id=#{post.id}") |> html_response(200)
+
+      assert response =~ ~s(value="copyright")
+      assert response =~ "without the rights holder&#39;s permission"
+      # The declaration and the "which work, where is the original" prompt are
+      # in the markup and revealed by CSS, so the form needs no JavaScript.
+      assert response =~ ~s(name="report[good_faith?]")
+      assert response =~ "report-good-faith"
+      assert response =~ "where can the original be seen"
+    end
+
+    test "a private message report does not offer it", %{conn: conn} do
+      {conn, me} = create_and_login_user(conn)
+      alice = insert_activated_user()
+      me = Repo.get!(Vutuv.Accounts.User, me.id)
+      conversation = insert_conversation_between(alice, me)
+      message = insert(:message, conversation: conversation, sender: alice)
+
+      response =
+        conn |> get(~p"/reports/new?type=message&id=#{message.id}") |> html_response(200)
+
+      # Nothing was published, so there is nothing to have taken down.
+      refute response =~ ~s(value="copyright")
+      refute response =~ "report-good-faith"
+    end
+
+    test "renders the copyright option in German", %{conn: conn, post: post} do
+      {conn, _me} = create_and_login_user(conn)
+
+      response =
+        conn
+        |> recycle()
+        |> put_req_header("accept-language", "de-DE,de;q=0.9")
+        |> get(~p"/reports/new?type=post&id=#{post.id}")
+        |> html_response(200)
+
+      assert response =~ "ohne Erlaubnis"
+      assert response =~ "nach bestem Wissen"
+      assert response =~ "Um welches Werk geht es"
+    end
+
     test "a reporter tied to the open case still reaches the form", %{conn: conn} do
       {conn, reporter} = create_and_login_user(conn)
       author = insert_activated_user()
@@ -202,6 +247,70 @@ defmodule VutuvWeb.ReportControllerTest do
              |> response(404)
 
       assert Repo.aggregate(Case, :count) == cases_before
+    end
+
+    test "an incomplete copyright notice comes back with the note intact", %{
+      conn: conn,
+      post: post
+    } do
+      {conn, _me} = create_and_login_user(conn)
+      note = "The photo is mine, the original is at example.com/photo"
+
+      conn =
+        post(conn, ~p"/reports", %{
+          "report" => %{
+            "type" => "post",
+            "id" => post.id,
+            "category" => "copyright",
+            "note" => note
+          }
+        })
+
+      # A redirect + flash would throw the written explanation away, which is
+      # the one thing a copyright notice cannot afford to lose.
+      response = html_response(conn, 422)
+      assert response =~ "good faith"
+      assert response =~ note
+      assert Repo.aggregate(Case, :count) == 0
+      refute Repo.get!(Vutuv.Posts.Post, post.id).frozen_at
+    end
+
+    test "says in German what is missing", %{conn: conn, post: post} do
+      {conn, _me} = create_and_login_user(conn)
+
+      response =
+        conn
+        |> recycle()
+        |> put_req_header("accept-language", "de-DE,de;q=0.9")
+        |> post(~p"/reports", %{
+          "report" => %{"type" => "post", "id" => post.id, "category" => "copyright"}
+        })
+        |> html_response(422)
+
+      # Both messages live in errors.po, reached through the extraction anchors
+      # in VutuvWeb.ErrorHelpers - an untranslated banner would read English
+      # here while every other line on the page is German.
+      assert response =~ "Bitte sagen Sie uns, um welches Werk es geht"
+      assert response =~ "nach bestem Wissen"
+    end
+
+    test "a complete copyright notice files the case", %{conn: conn, post: post} do
+      {conn, _me} = create_and_login_user(conn)
+
+      conn =
+        post(conn, ~p"/reports", %{
+          "report" => %{
+            "type" => "post",
+            "id" => post.id,
+            "category" => "copyright",
+            "note" => "The photo is mine, the original is at example.com/photo",
+            "good_faith?" => "true"
+          }
+        })
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Thank you"
+      assert %Case{status: "pending_owner"} = Repo.one(Case)
+      assert Repo.get!(Vutuv.Posts.Post, post.id).frozen_at
     end
 
     test "reporting your own content is refused", %{conn: conn} do


### PR DESCRIPTION
A stolen photo or a pasted article had to be filed as "Something else", so admins had to guess. Every report form except the private-message one now offers "Uses a text, photo or video without the rights holder's permission".

- `Vutuv.Moderation.Report` accepts that category only as a complete notice: the note (which work, where the original is) plus a good-faith declaration. The check sits in the changeset, so no route — the form or the Mastodon report API — can file half a notice.
- `Moderation.list_queue/0` and `open_queue_count/0` take an open copyright case in **any** status, so it reaches an admin the moment it is filed. The trust ladder is unchanged: a trusted reporter still freezes and still leaves the owner their 72 hours.
- `Moderation.content_edited/1` no longer settles a copyright case; it keeps the freeze and escalates. Delete and dispute are untouched, and `/moderation/cases/:id` says so.
- `/community` gains one rule; the good-faith declaration is not persisted (a stored copyright report *is* the record it was made).

Left to #2010: the owner's "an edit makes it visible again" email, which that issue rewrites.

Closes #2008

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01UGPe7bHVS11M1W7fNehSku

<!-- closing-note #2008 -->
Shipped. Every report form but the private-message one now offers the copyright category; picking it requires the explanation and a good-faith checkbox, the case is in the admin queue from the moment it is filed, and the owner's edit hands it to an admin instead of lifting the freeze (delete and dispute are unchanged). I kept the trust ladder rather than forcing a status: a trusted reporter's notice still freezes and still leaves the owner their 72 hours, an untrusted one still only flags, and the queue simply widened to include an open copyright case in any status. The good-faith declaration is not stored, because the changeset refuses the category without it, so a stored copyright report is itself the record that it was made; the owner's "an edit makes it visible again" email still reads the old way and belongs to #2010.

*An AI agent wrote this text in my name. I know that is problematic.*
