### PR TITLE
Tell a member what was claimed, who decided, and how long they have

### DIFF
--- a/docs/architecture/email.md
+++ b/docs/architecture/email.md
@@ -83,6 +83,28 @@ blank line inside the quote gets the bare `">"` — a quote block ends at the
 first line without a marker, and mail clients that strip trailing whitespace
 would turn `"> "` into exactly that.
 
+**Both halves ask `UserHelpers.split_lines/1` where a line ends, and it is
+written as the effect rather than as a list of spellings.** `Regex.split(~r/\R/u,
+text)` is PCRE's closed set of mandatory line breaks, which is the set UAX #14
+gives a mail client. Enumerating `\r\n`, `\r` and `\n` — the obvious spelling,
+and what shipped first — leaves VT, FF, NEL (U+0085), LINE SEPARATOR (U+2028)
+and PARAGRAPH SEPARATOR (U+2029) inside one "line": invisible in a form, a real
+break in Gmail, Apple Mail and Thunderbird, so everything after one arrives
+**without** the `"> "` that is the whole safeguard. Nothing strips control
+characters from a report note on the way in, so this split is the only thing
+standing between a member in good standing and a forged vutuv signature with a
+sign-in link inside a DKIM-signed vutuv mail — on a site where signing in means
+clicking a mailed PIN. The `u` modifier is load-bearing: without it `\R` stops
+short of NEL and the two separators.
+
+**A digest subject is capped** (`Emailer.shorten_subject/1`, 78 characters, cut
+back to a word boundary). A digest of exactly one notification uses that
+notification's own line as the subject, and a line is written for a list row
+where it may wrap: the moderation line runs to 163 German characters once it
+names the reported category. The cap sits on the subject, which is the surface
+with the hard limit, rather than every kind's sentence being kept short enough
+to double as one.
+
 ## Opt-out and unsubscribe
 
 **Notification mail is opt-out**: the unread-message nudge respects

--- a/docs/architecture/email.md
+++ b/docs/architecture/email.md
@@ -70,6 +70,19 @@ layout, dark mode, and blocks like the PIN box, CTA button and key/value panel).
 The two formats are paired by a drift test, so an email added with only one
 fails the build.
 
+**Quoting somebody else's text.** A mail that carries what another person wrote
+has two blocks, and they are not interchangeable. `email_markdown/1` renders a
+member's own Markdown (an invitation note, a DM) with its links live.
+`email_quote/1` renders a *stranger's* plain text — today only a moderation
+report's note, shown to the member it accuses — escaped, unlinked and behind a
+left rule. The `text/plain` half of the latter goes through
+`VutuvWeb.UserHelpers.email_quoted_text/1`, which wraps at 72 characters and
+prefixes every line with `"> "`: a text template escapes nothing, so an unmarked
+block can be shaped to read as our own signature plus a second, fake link. A
+blank line inside the quote gets the bare `">"` — a quote block ends at the
+first line without a marker, and mail clients that strip trailing whitespace
+would turn `"> "` into exactly that.
+
 ## Opt-out and unsubscribe
 
 **Notification mail is opt-out**: the unread-message nudge respects

--- a/docs/architecture/moderation.md
+++ b/docs/architecture/moderation.md
@@ -173,9 +173,13 @@ The reporter's note is a stranger's text shown to the accused member. The HTML
 half renders it through `EmailComponents.email_quote/1`, which escapes it and
 does **not** turn it into Markdown or links — a clickable link out of an
 accusation is a phishing seat. The `text/plain` half has no escaping at all, so
-`UserHelpers.email_quoted_text/1` wraps it at 72 columns and prefixes every line
-with `"> "`: without that, a crafted note can be shaped to read as our own
-signature followed by a second, fake link.
+`UserHelpers.email_quoted_text/1` wraps it at 72 characters and prefixes every
+line with `"> "`: without that, a crafted note can be shaped to read as our own
+signature followed by a second, fake link. **Both halves decide where a line
+ends in one place** (`UserHelpers.split_lines/1`, PCRE's `\R` with the `u`
+modifier), because a break the reader's client honours but our split does not
+puts the rest of the note outside the marker — see `email.md` for why the rule
+is written as the effect rather than as a list of `\r\n`, `\r` and `\n`.
 
 ## Admin-initiated freeze (`/admin/accounts`, issue #812)
 

--- a/docs/architecture/moderation.md
+++ b/docs/architecture/moderation.md
@@ -57,9 +57,8 @@ on the reports (`queue_query/0`).
 unfreezes the content and closes the case; for a copyright case
 `Moderation.content_edited/1` keeps the freeze, logs the edit and escalates, so
 a human decides whether the revision removed the work. Delete and dispute are
-unchanged. The owner's case page says so (`ModerationCaseHTML.copyright?/1`
-picks the wording); the *email* still describes the generic edit, which issue
-#2010 rewrites.
+unchanged. The case page and the owner's email both say so, because both read
+`Moderation.owner_notice/1` (see below).
 
 Admin rulings are one click: **uphold** (owner gets a strike: warning → one-week
 suspension → permanent deactivation; strikes expire after 12 months) or
@@ -128,6 +127,55 @@ Every case carries an **audit log** (`moderation_events`: reports, freezes,
 severances, owner self-service, escalations, rulings, strikes, `owner_removed`)
 rendered as the History timeline on the admin case page, and the urgent admin
 email names the profile, category and reporter's note instead of just a link.
+
+## The statement of reasons (issue #2010)
+
+A member whose content goes dark is owed more than "something of yours was
+reported". Three surfaces carry the same five facts — the category, the
+reporter's explanation **quoted** (never who wrote it), that the hiding was
+**automatic** rather than a person's decision, the ground (the house rules, or
+the law), and the options that case really has, with the 72-hour deadline where
+there is one. This is what the Digital Services Act calls a statement of reasons
+(Art. 17); the member-facing text never says so.
+
+`Moderation.owner_notice/1` is the one place all three read: it returns the
+deduplicated `categories` (most recent report first), the `category` to name
+where there is room for only one, the reporters' `notes`, and `copyright?`.
+The reporter is deliberately not in the map — a surface cannot leak what it
+was never handed. The three surfaces are
+
+- the case page `/moderation/cases/:id`, which the controller hands the notice
+  as `@notice`;
+- the owner's email (`moderation_frozen_*` and `moderation_review_*`, three
+  locales × two formats), built by `Emailer.statement_of_reasons/2`;
+- the in-app line, which names the category and the automatic freeze and links
+  to the case page (`NotificationLine.notification_text/1`; the category is
+  read back per page by `Moderation.notice_category_by_case/1`, one query, not
+  one per row — and only for a case that is still hidden, since a settled one's
+  line names the ruling). The **digest mail** delegates this one kind to that
+  same function, so a member who reads the mail instead of opening the app is
+  told the same thing.
+
+Two things the mail must not get wrong. **The options are the options that case
+actually has**, and `Moderation.owner_edit_offer/2` answers that as one value
+(`:immediate` / `:reviewed` / `:none`) rather than as two booleans each of the
+seven rendering places recombines: only a post has an editor behind the case
+page's button, so a reported message or job posting gets delete and dispute,
+and a **copyright** case is never promised that an edit makes the content
+visible again — an admin looks at the revision first. (`owner_edit_offer/1` is
+the same answer for the email, which does not already hold the content and
+reads the database only when the type could have an editor at all.) And the
+**review** mail (an escalated case: a re-report after a self-service round, or
+a frozen profile) promises no 72-hour window and no self-service, because there
+is none.
+
+The reporter's note is a stranger's text shown to the accused member. The HTML
+half renders it through `EmailComponents.email_quote/1`, which escapes it and
+does **not** turn it into Markdown or links — a clickable link out of an
+accusation is a phishing seat. The `text/plain` half has no escaping at all, so
+`UserHelpers.email_quoted_text/1` wraps it at 72 columns and prefixes every line
+with `"> "`: without that, a crafted note can be shaped to read as our own
+signature followed by a second, fake link.
 
 ## Admin-initiated freeze (`/admin/accounts`, issue #812)
 

--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -1746,18 +1746,31 @@ defmodule Vutuv.Activity do
   # actually told about is Moderation's rule, not ours — the query comes from
   # there so this feed cannot drift from the notify behavior.
   defp moderation_items(user_id, limit, cursor) do
-    Vutuv.Moderation.owner_notified_cases_query(user_id)
-    |> order_by([c], desc: c.inserted_at, desc: c.id)
-    |> limit(^limit)
-    |> select([c], {c.id, c.inserted_at, c.status})
-    |> at_or_before(cursor)
-    |> Repo.all()
-    |> Enum.map(fn {id, at, status} ->
+    rows =
+      Vutuv.Moderation.owner_notified_cases_query(user_id)
+      |> order_by([c], desc: c.inserted_at, desc: c.id)
+      |> limit(^limit)
+      |> select([c], {c.id, c.inserted_at, c.status})
+      |> at_or_before(cursor)
+      |> Repo.all()
+
+    # What was claimed, so the line can name it instead of saying only that
+    # something was reported. One query for the whole page, never one per row —
+    # and only for the still-hidden cases, since a settled case's line names
+    # the ruling instead and a member's feed keeps those forever.
+    categories =
+      rows
+      |> Enum.filter(fn {_id, _at, status} -> status in ~w(pending_owner flagged escalated) end)
+      |> Enum.map(&elem(&1, 0))
+      |> Vutuv.Moderation.notice_category_by_case()
+
+    Enum.map(rows, fn {id, at, status} ->
       %{
         id: event_id("moderation", id),
         kind: "moderation",
         at: at,
         case_id: id,
+        category: Map.get(categories, id),
         status: status
       }
     end)

--- a/lib/vutuv/moderation.ex
+++ b/lib/vutuv/moderation.ex
@@ -690,6 +690,86 @@ defmodule Vutuv.Moderation do
     do: Repo.exists?(where(copyright_reports(), [r], r.case_id == ^case_id))
 
   @doc """
+  The statement of reasons the owner of hidden content is owed (issue #2010):
+  what was claimed, in the words the reporters typed, and on what ground.
+
+  `categories` are the wire strings, deduplicated, most recent report first;
+  `notes` are the explanations, blanks dropped; `copyright?` says whether the
+  ground is the law rather than the house rules. The reporter is deliberately
+  not in the map — reports are anonymous, and a surface cannot leak what it
+  was never handed.
+
+  All three surfaces that carry the notice (the case page, the owner's email
+  and the in-app line) read it here, so they cannot drift apart.
+  """
+  def owner_notice(%Case{reports: reports}) when is_list(reports) do
+    ordered = Enum.sort_by(reports, & &1.inserted_at, {:desc, NaiveDateTime})
+    categories = ordered |> Enum.map(& &1.category) |> Enum.uniq()
+
+    %{
+      categories: categories,
+      category: leading_category(categories),
+      notes: ordered |> Enum.map(& &1.note) |> Enum.reject(&(&1 in [nil, ""])),
+      copyright?: Enum.any?(categories, &Report.copyright?/1)
+    }
+  end
+
+  def owner_notice(%Case{} = case_record),
+    do: case_record |> Repo.preload(:reports) |> owner_notice()
+
+  @doc """
+  What the owner's self-service round offers as an *edit*, as one value the
+  surfaces render instead of deriving: `:immediate` (an edit brings the content
+  straight back), `:reviewed` (a copyright claim, so an admin looks at the
+  revision and the content stays hidden until they have) or `:none`.
+
+  Only a post has an editor behind the case page's button, so a reported
+  message or job posting is offered delete and dispute alone. Answered here
+  rather than recombined from two booleans in each of the seven places that
+  render the options, so no locale can promise a copyright case its content
+  back.
+  """
+  def owner_edit_offer(%Case{content_type: "post"} = case_record, %Post{}),
+    do: if(copyright_case?(case_record), do: :reviewed, else: :immediate)
+
+  def owner_edit_offer(%Case{}, _content), do: :none
+
+  @doc """
+  The same answer for a caller that does not already hold the content — the
+  email path. Looks the post up only when the type could have an editor at all.
+  """
+  def owner_edit_offer(%Case{content_type: "post"} = case_record),
+    do: owner_edit_offer(case_record, case_content(case_record))
+
+  def owner_edit_offer(%Case{}), do: :none
+
+  @doc """
+  The one category to name per case id — what the in-app notification line, the
+  one place with room for a single word, says was claimed. Returns a
+  `case_id => category` map; a case whose reports are gone is absent.
+  """
+  def notice_category_by_case([]), do: %{}
+
+  def notice_category_by_case(case_ids) when is_list(case_ids) do
+    # Ordered in SQL, and `Enum.group_by/3` keeps that order inside each group,
+    # so `leading_category/1` sees the same "most recent first" list the
+    # single-case `owner_notice/1` builds.
+    from(r in Report,
+      where: r.case_id in ^case_ids,
+      order_by: [desc: r.inserted_at],
+      select: {r.case_id, r.category}
+    )
+    |> Repo.all()
+    |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+    |> Map.new(fn {case_id, categories} -> {case_id, leading_category(categories)} end)
+  end
+
+  # A copyright notice wins over anything else on the same case — it is the one
+  # with legal weight — otherwise the most recent report speaks.
+  defp leading_category(categories),
+    do: Enum.find(categories, &Report.copyright?/1) || List.first(categories)
+
+  @doc """
   How many open cases (any open status: frozen-pending-owner, flagged or
   escalated) exist for a content type — the per-area tile figure (e.g. the
   `/admin/jobs` "open job-related moderation cases" count for `"job_posting"`).

--- a/lib/vutuv/moderation/notifier.ex
+++ b/lib/vutuv/moderation/notifier.ex
@@ -16,20 +16,28 @@ defmodule Vutuv.Moderation.Notifier do
 
   import Ecto.Query
 
-  alias Vutuv.{Accounts, Activity, Repo}
+  alias Vutuv.{Accounts, Activity, Moderation, Repo}
   alias Vutuv.Accounts.User
   alias Vutuv.Moderation.Case
   alias Vutuv.Notifications.Emailer
 
-  @doc "The owner's content was frozen; they can delete, edit or dispute."
+  @doc """
+  The owner's content was frozen; they can delete, edit or dispute.
+
+  Both owner notices carry the statement of reasons (issue #2010), so the
+  reports come along — `:reports` alone, never `reports: :reporter`: a report
+  is anonymous, and a surface cannot leak what it was never handed.
+  """
   def owner_content_frozen(%Case{} = case_record) do
-    push_owner(case_record, "One of your contributions was reported and is hidden for now.")
+    case_record = Repo.preload(case_record, :reports)
+    push_owner(case_record)
     mail_owner(case_record, &Emailer.moderation_frozen_email/3)
   end
 
   @doc "The owner's content was frozen and is with the admins (no self-service)."
   def owner_under_review(%Case{} = case_record) do
-    push_owner(case_record, "One of your contributions is hidden while our admins review it.")
+    case_record = Repo.preload(case_record, :reports)
+    push_owner(case_record)
     mail_owner(case_record, &Emailer.moderation_review_email/3)
   end
 
@@ -113,10 +121,15 @@ defmodule Vutuv.Moderation.Notifier do
 
   def admins_digest(_), do: :ok
 
-  defp push_owner(%Case{} = case_record, text) do
+  # The live push carries the same category the persisted row will
+  # (`Vutuv.Activity.moderation_items/3` reads it back from the reports), so
+  # the popup and the row under the bell say the same thing. No `:text` — the
+  # moderation branch of `VutuvWeb.NotificationLine.notification_text/1` writes
+  # the sentence from the category and the status, in the reader's language.
+  defp push_owner(%Case{} = case_record) do
     Activity.notify(case_record.owner_id, %{
       kind: "moderation",
-      text: text,
+      category: Moderation.owner_notice(case_record).category,
       case_id: case_record.id,
       source_id: case_record.id,
       at: DateTime.utc_now()

--- a/lib/vutuv/notifications/emailer.ex
+++ b/lib/vutuv/notifications/emailer.ex
@@ -455,11 +455,32 @@ defmodule Vutuv.Notifications.Emailer do
   # Named in the subject when there is one thing to say, counted when there are
   # several: "3 neue Mitteilungen" tells a member nothing they cannot see in
   # the app's badge, while the single line often saves them the trip.
-  defp digest_subject([line], 0), do: line
+  defp digest_subject([line], 0), do: shorten_subject(line)
 
   defp digest_subject(lines, more) do
     count = length(lines) + more
     ngettext("%{count} new notification on vutuv", "%{count} new notifications on vutuv", count)
+  end
+
+  # A line is written for a list row, where it may wrap over two lines and lose
+  # nothing; a subject is cut by the reader's client at around seventy
+  # characters, and one that runs past that reads as spam. So the cap lives
+  # here, on the surface that has it, rather than every kind's sentence being
+  # kept short enough to double as a subject — the moderation line grew to
+  # ~160 German characters the moment it started naming the reported category
+  # (issue #2010), and any other kind can grow the same way. Cut back to a word
+  # boundary so the subject never ends mid-word.
+  @subject_max 78
+
+  defp shorten_subject(line) do
+    if String.length(line) <= @subject_max do
+      line
+    else
+      line
+      |> String.slice(0, @subject_max)
+      |> String.replace(~r/\s+\S*$/u, "")
+      |> Kernel.<>("…")
+    end
   end
 
   @doc """

--- a/lib/vutuv/notifications/emailer.ex
+++ b/lib/vutuv/notifications/emailer.ex
@@ -33,6 +33,7 @@ defmodule Vutuv.Notifications.Emailer do
   alias Vutuv.Accounts.User
   alias Vutuv.Identity
   alias Vutuv.Mailto
+  alias Vutuv.Moderation
   alias Vutuv.Notifications.Bounces
   alias Vutuv.Operator
   alias Vutuv.Organizations.Organization
@@ -42,6 +43,7 @@ defmodule Vutuv.Notifications.Emailer do
   alias VutuvWeb.EmailText
   alias VutuvWeb.NotificationDigestText, as: DigestText
   alias VutuvWeb.Plug.Locale
+  alias VutuvWeb.ReportHTML
   alias VutuvWeb.SavedSearchToken
 
   # The visible From ({name, address}) on every message. Per-installation:
@@ -960,16 +962,45 @@ defmodule Vutuv.Notifications.Emailer do
 
   @doc "Owner notice: content frozen, please delete / edit / dispute within 72h."
   def moderation_frozen_email(user, email, case_record) do
-    build_email(user, email, "moderation_frozen", %{case_id: case_record.id}, fn ->
+    # The edit option is the one fact the review mail has no use for, so it is
+    # added here — and `owner_edit_offer/1` only reads the database when the
+    # content type could have an editor at all.
+    assigns =
+      user
+      |> statement_of_reasons(case_record)
+      |> Map.put(:edit_offer, Moderation.owner_edit_offer(case_record))
+
+    build_email(user, email, "moderation_frozen", assigns, fn ->
       gettext("Your content on vutuv was reported and is hidden")
     end)
   end
 
   @doc "Owner notice: content frozen and with the admins (no self-service round)."
   def moderation_review_email(user, email, case_record) do
-    build_email(user, email, "moderation_review", %{case_id: case_record.id}, fn ->
+    build_email(user, email, "moderation_review", statement_of_reasons(user, case_record), fn ->
       gettext("Your content on vutuv is under review")
     end)
+  end
+
+  # What the owner of hidden content is owed (issue #2010): what was claimed,
+  # in the reporters' own words, and on what ground. `Vutuv.Moderation` owns
+  # every answer, so the mail cannot claim something the case page does not.
+  # The labels are joined here, in the *recipient's* language — the body
+  # template is picked by their locale, and the ambient one is the sender's.
+  defp statement_of_reasons(user, case_record) do
+    notice = Moderation.owner_notice(case_record)
+
+    labels =
+      in_locale(get_locale(user.locale), fn ->
+        Enum.map_join(notice.categories, ", ", &ReportHTML.category_label/1)
+      end)
+
+    %{
+      case_id: case_record.id,
+      category_labels: labels,
+      notes: notice.notes,
+      copyright_case: notice.copyright?
+    }
   end
 
   @doc "Reporter notice: the content they reported was revised by its owner."
@@ -1072,9 +1103,7 @@ defmodule Vutuv.Notifications.Emailer do
   defp localized_category_label(nil, _user), do: nil
 
   defp localized_category_label(report, user) do
-    in_locale(get_locale(user.locale), fn ->
-      VutuvWeb.ReportHTML.category_label(report.category)
-    end)
+    in_locale(get_locale(user.locale), fn -> ReportHTML.category_label(report.category) end)
   end
 
   defp presence(nil), do: nil

--- a/lib/vutuv_web/controllers/moderation_case_controller.ex
+++ b/lib/vutuv_web/controllers/moderation_case_controller.ex
@@ -26,10 +26,16 @@ defmodule VutuvWeb.ModerationCaseController do
   def show(conn, %{"id" => id}) do
     with %Case{} = case_record <- Moderation.get_case_with_details(id),
          :ok <- authorize(conn, case_record) do
+      content = Moderation.case_content(case_record)
+
       render(conn, "show.html",
         page_title: gettext("Reported content"),
         case: case_record,
-        content: Moderation.case_content(case_record)
+        # What was claimed, in the reporters' words, and on what ground — the
+        # same statement of reasons the owner's email carries (issue #2010).
+        notice: Moderation.owner_notice(case_record),
+        edit_offer: Moderation.owner_edit_offer(case_record, content),
+        content: content
       )
     else
       _ -> ControllerHelpers.render_error(conn, 404)

--- a/lib/vutuv_web/notification_line.ex
+++ b/lib/vutuv_web/notification_line.ex
@@ -119,7 +119,7 @@ defmodule VutuvWeb.NotificationLine do
       "rejected" -> gettext("A report about your content was dismissed; it is visible again.")
       "resolved_edited" -> gettext("You revised reported content; the case is closed.")
       "resolved_deleted" -> gettext("You deleted reported content; the case is closed.")
-      _ -> gettext("Your content was reported and is hidden while the report is handled.")
+      _ -> content_hidden_text(n[:category])
     end
   end
 
@@ -193,6 +193,23 @@ defmodule VutuvWeb.NotificationLine do
   # the generic line is the honest floor. `VutuvWeb.NotificationDigestText`
   # makes the same promise for the digest mail.
   def notification_text(n), do: n[:text] || gettext("Something new happened on your account.")
+
+  # The line the owner reads the moment their content goes dark. It names what
+  # was claimed and says outright that no person decided it, because "your
+  # content was reported" leaves both open; the rest of the statement of
+  # reasons (the reporter's own words, the ground, the options) is on the case
+  # page the line links to.
+  defp content_hidden_text(category) when is_binary(category) do
+    gettext("Hidden automatically after a report: %{reason}. The case page says what you can do.",
+      reason: VutuvWeb.ReportHTML.category_label(category)
+    )
+  end
+
+  defp content_hidden_text(_missing) do
+    gettext(
+      "Your content was hidden automatically after a report. The case page says what you can do."
+    )
+  end
 
   @doc """
   The popup's two halves: an actor's name over their verb phrase.

--- a/lib/vutuv_web/templates/email/moderation_frozen_de.text.eex
+++ b/lib/vutuv_web/templates/email/moderation_frozen_de.text.eex
@@ -1,16 +1,45 @@
 <%= email_greeting(@user) %>,
 
-einer Ihrer Beiträge auf vutuv wurde gemeldet. Sicherheitshalber ist er
-vorerst verborgen; niemand sonst kann ihn sehen.
+einer Ihrer Beiträge auf vutuv wurde gemeldet. Kein Mensch hat ihn vorher
+angesehen: Die Meldung eines Mitglieds mit guter Bilanz verbirgt den
+gemeldeten Inhalt automatisch, sobald sie eintrifft. Genau das ist hier
+passiert; sehen können ihn jetzt nur noch Sie und unsere Admins.
 
-Sie können das innerhalb von 72 Stunden selbst klären:
+  Gemeldet als: <%= @category_labels %>
+<%= if @notes != [] do %>
+Das steht in der Meldung, mit den Worten der meldenden Person. Wer das war,
+sagen wir Ihnen nie:
+
+<%= email_quoted_text(@notes) %>
+<% else %>
+Die Meldung nannte diese Kategorie und sonst nichts.
+<% end %><%= if @copyright_case do %>
+Das ist eine rechtliche Beschwerde, keine Hausregel: Sie besagt, dass das
+Werk nicht Ihres ist, um es zu veröffentlichen. Darüber entscheidet das
+Urheberrecht, also muss eine Admin sich das ansehen.
+<% else %>
+Grundlage sind unsere Verhaltensregeln, an die sich alles auf vutuv halten
+muss:
+
+<%= @url %>community
+<% end %>
+Sie haben 72 Stunden, das selbst zu klären; danach entscheiden unsere
+Admins:
 
 <%= @url %>moderation/cases/<%= @case_id %>
 
-Dort können Sie den Inhalt löschen, ihn bearbeiten (nach einer
-Bearbeitung ist er sofort wieder sichtbar) oder uns mitteilen, dass Ihr
-Inhalt in Ordnung ist. Hören wir nichts von Ihnen, schauen sich unsere
-Admins den Fall an.
+Auf dieser Seite können Sie:
+<%= if @edit_offer == :immediate do %>
+  * Den Inhalt bearbeiten. Nach einer Bearbeitung ist er sofort wieder
+    sichtbar.
+<% end %><%= if @edit_offer == :reviewed do %>
+  * Den Inhalt bearbeiten. Unsere Admins sehen sich die Überarbeitung dann
+    an; bis dahin bleibt er verborgen.
+<% end %>
+  * Ihn löschen. Damit ist die Meldung erledigt, ohne Rückfragen.
+
+  * Uns mitteilen, dass Ihr Inhalt in Ordnung ist. Er bleibt dann
+    verborgen, bis eine unserer Admins entschieden hat.
 
 <%= render "_signature_de.text" %>
 

--- a/lib/vutuv_web/templates/email/moderation_frozen_en.text.eex
+++ b/lib/vutuv_web/templates/email/moderation_frozen_en.text.eex
@@ -1,15 +1,43 @@
 <%= email_greeting(@user) %>,
 
-someone reported one of your contributions on vutuv. To be on the safe
-side it is hidden for now; nobody else can see it.
+someone reported one of your contributions on vutuv. No person looked at it
+first: a report from a member in good standing hides the reported content
+automatically, the moment it arrives. That is what happened here, and only
+you and our admins can see it now.
 
-You can settle this yourself within 72 hours:
+  Reported as: <%= @category_labels %>
+<%= if @notes != [] do %>
+What the report says, in the reporter's own words. We never tell you who
+reported:
+
+<%= email_quoted_text(@notes) %>
+<% else %>
+The report named that category and gave no further explanation.
+<% end %><%= if @copyright_case do %>
+This is a legal complaint, not a house-rule one: it says the work is not
+yours to publish. Copyright law decides that question, so an admin has to
+look at it.
+<% else %>
+The ground is our community guidelines, which everything on vutuv has to
+keep to:
+
+<%= @url %>community
+<% end %>
+You have 72 hours to settle this yourself; after that our admins decide:
 
 <%= @url %>moderation/cases/<%= @case_id %>
 
-On that page you can delete the content, edit it (an edit makes it
-visible again right away), or tell us that your content is fine. If we
-do not hear from you, our admins will take a look.
+On that page you can:
+<%= if @edit_offer == :immediate do %>
+  * Edit the content. An edit makes it visible again right away.
+<% end %><%= if @edit_offer == :reviewed do %>
+  * Edit the content. One of our admins then looks at the revision, and it
+    stays hidden until they have.
+<% end %>
+  * Delete it. That settles the report, no questions asked.
+
+  * Tell us your content is fine. It stays hidden until one of our admins
+    has ruled.
 
 <%= render "_signature_en.text" %>
 

--- a/lib/vutuv_web/templates/email/moderation_frozen_it.text.eex
+++ b/lib/vutuv_web/templates/email/moderation_frozen_it.text.eex
@@ -1,15 +1,43 @@
 <%= email_greeting(@user) %>,
 
-qualcuno ha segnalato un Suo contributo su vutuv. Per prudenza per ora è
-nascosto; nessun altro può vederlo.
+qualcuno ha segnalato un Suo contributo su vutuv. Nessuna persona lo ha
+esaminato prima: la segnalazione di un membro affidabile nasconde il
+contenuto segnalato automaticamente, nel momento in cui arriva. È quello che
+è successo qui; ora possono vederlo solo Lei e i nostri amministratori.
 
-Può risolvere da solo entro 72 ore:
+  Segnalato come: <%= @category_labels %>
+<%= if @notes != [] do %>
+Ecco cosa dice la segnalazione, con le parole di chi l'ha scritta. Chi sia
+stato non glielo diciamo mai:
+
+<%= email_quoted_text(@notes) %>
+<% else %>
+La segnalazione ha indicato quella categoria e nient'altro.
+<% end %><%= if @copyright_case do %>
+Questa è una contestazione legale, non una regola della casa: sostiene che
+l'opera non è Sua da pubblicare. A deciderlo è il diritto d'autore, quindi
+deve esaminarla un amministratore.
+<% else %>
+Il fondamento sono le nostre regole della comunità, a cui tutto su vutuv
+deve attenersi:
+
+<%= @url %>community
+<% end %>
+Ha 72 ore per risolvere da solo; dopo decidono i nostri amministratori:
 
 <%= @url %>moderation/cases/<%= @case_id %>
 
-Su quella pagina può eliminare il contenuto, modificarlo (una modifica lo rende
-subito di nuovo visibile) oppure dirci che il Suo contenuto è a posto. Se non
-avremo Sue notizie, ci daranno un'occhiata i nostri amministratori.
+Su quella pagina può:
+<%= if @edit_offer == :immediate do %>
+  * Modificare il contenuto. Dopo una modifica torna subito visibile.
+<% end %><%= if @edit_offer == :reviewed do %>
+  * Modificare il contenuto. I nostri amministratori esaminano poi la
+    revisione; fino ad allora resta nascosto.
+<% end %>
+  * Eliminarlo. Così la segnalazione è chiusa, senza altre domande.
+
+  * Dirci che il Suo contenuto è a posto. Resta nascosto finché un
+    amministratore non avrà deciso.
 
 <%= render "_signature_it.text" %>
 

--- a/lib/vutuv_web/templates/email/moderation_review_de.text.eex
+++ b/lib/vutuv_web/templates/email/moderation_review_de.text.eex
@@ -1,8 +1,32 @@
 <%= email_greeting(@user) %>,
 
-einer Ihrer Beiträge auf vutuv wurde gemeldet und ist verborgen,
-während unsere Admins den Fall prüfen. Sie müssen nichts weiter tun;
-wir melden uns mit dem Ergebnis.
+einer Ihrer Beiträge auf vutuv wurde gemeldet und ist verborgen, während
+unsere Admins den Fall prüfen. Kein Mensch hat ihn vorher angesehen: Die
+Meldung eines Mitglieds mit guter Bilanz verbirgt den gemeldeten Inhalt
+automatisch, sobald sie eintrifft.
+
+  Gemeldet als: <%= @category_labels %>
+<%= if @notes != [] do %>
+Das steht in der Meldung, mit den Worten der meldenden Person. Wer das war,
+sagen wir Ihnen nie:
+
+<%= email_quoted_text(@notes) %>
+<% else %>
+Die Meldung nannte diese Kategorie und sonst nichts.
+<% end %><%= if @copyright_case do %>
+Das ist eine rechtliche Beschwerde, keine Hausregel: Sie besagt, dass das
+Werk nicht Ihres ist, um es zu veröffentlichen. Darüber entscheidet das
+Urheberrecht.
+<% else %>
+Grundlage sind unsere Verhaltensregeln, an die sich alles auf vutuv halten
+muss:
+
+<%= @url %>community
+<% end %>
+Dieser Fall liegt bereits bei unseren Admins, eine Runde zum Selbstklären
+gibt es hier also nicht. Sie müssen nichts weiter tun: Wir melden uns mit
+dem Ergebnis, und wenn die Meldung unbegründet war, ist Ihr Inhalt wieder
+da.
 
 Den Fall finden Sie hier:
 

--- a/lib/vutuv_web/templates/email/moderation_review_en.text.eex
+++ b/lib/vutuv_web/templates/email/moderation_review_en.text.eex
@@ -1,10 +1,32 @@
 <%= email_greeting(@user) %>,
 
 one of your contributions on vutuv was reported and is hidden while our
-admins review it. You do not need to do anything; we will let you know
-the outcome.
+admins review it. No person looked at it first: a report from a member in
+good standing hides the reported content automatically, the moment it
+arrives.
 
-You can see the case here:
+  Reported as: <%= @category_labels %>
+<%= if @notes != [] do %>
+What the report says, in the reporter's own words. We never tell you who
+reported:
+
+<%= email_quoted_text(@notes) %>
+<% else %>
+The report named that category and gave no further explanation.
+<% end %><%= if @copyright_case do %>
+This is a legal complaint, not a house-rule one: it says the work is not
+yours to publish. Copyright law decides that question.
+<% else %>
+The ground is our community guidelines, which everything on vutuv has to
+keep to:
+
+<%= @url %>community
+<% end %>
+This one is with our admins already, so there is no round in which you could
+settle it yourself. You do not need to do anything: we will tell you the
+outcome, and if they find the report unfounded your content comes back.
+
+You can follow the case here:
 
 <%= @url %>moderation/cases/<%= @case_id %>
 

--- a/lib/vutuv_web/templates/email/moderation_review_it.text.eex
+++ b/lib/vutuv_web/templates/email/moderation_review_it.text.eex
@@ -1,7 +1,31 @@
 <%= email_greeting(@user) %>,
 
 un Suo contributo su vutuv è stato segnalato ed è nascosto mentre i nostri
-amministratori lo esaminano. Non deve fare nulla; Le comunicheremo l'esito.
+amministratori lo esaminano. Nessuna persona lo ha esaminato prima: la
+segnalazione di un membro affidabile nasconde il contenuto segnalato
+automaticamente, nel momento in cui arriva.
+
+  Segnalato come: <%= @category_labels %>
+<%= if @notes != [] do %>
+Ecco cosa dice la segnalazione, con le parole di chi l'ha scritta. Chi sia
+stato non glielo diciamo mai:
+
+<%= email_quoted_text(@notes) %>
+<% else %>
+La segnalazione ha indicato quella categoria e nient'altro.
+<% end %><%= if @copyright_case do %>
+Questa è una contestazione legale, non una regola della casa: sostiene che
+l'opera non è Sua da pubblicare. A deciderlo è il diritto d'autore.
+<% else %>
+Il fondamento sono le nostre regole della comunità, a cui tutto su vutuv
+deve attenersi:
+
+<%= @url %>community
+<% end %>
+Questo caso è già in mano ai nostri amministratori, quindi non c'è un giro
+in cui possa risolverlo da solo. Non deve fare nulla: Le comunicheremo
+l'esito e, se la segnalazione risulterà infondata, il Suo contenuto tornerà
+visibile.
 
 Può vedere il caso qui:
 

--- a/lib/vutuv_web/templates/email_body/moderation_frozen_de.html.heex
+++ b/lib/vutuv_web/templates/email_body/moderation_frozen_de.html.heex
@@ -1,15 +1,45 @@
 <.email_layout preheader="Ihr Inhalt auf vutuv wurde gemeldet und ist verborgen" locale={@locale}>
   <.email_p>{email_greeting(@user)},</.email_p>
   <.email_p>
-    einer Ihrer Beiträge auf vutuv wurde gemeldet. Sicherheitshalber ist er vorerst verborgen;
-    niemand sonst kann ihn sehen.
+    einer Ihrer Beiträge auf vutuv wurde gemeldet. Kein Mensch hat ihn vorher angesehen: Die
+    Meldung eines Mitglieds mit guter Bilanz verbirgt den gemeldeten Inhalt automatisch, sobald
+    sie eintrifft. Genau das ist hier passiert; sehen können ihn jetzt nur noch Sie und unsere
+    Admins.
   </.email_p>
-  <.email_p>Sie können das innerhalb von 72 Stunden selbst klären:</.email_p>
-  <.email_button href={"#{@url}moderation/cases/#{@case_id}"}>Meldung ansehen</.email_button>
+  <.email_panel>
+    <.email_row label="Gemeldet als">{@category_labels}</.email_row>
+  </.email_panel>
+  <.email_p :if={@notes != []}>
+    Das steht in der Meldung, mit den Worten der meldenden Person. Wer das war, sagen wir Ihnen
+    nie:
+  </.email_p>
+  <.email_quote :for={note <- @notes} text={note} />
+  <.email_p :if={@notes == []}>Die Meldung nannte diese Kategorie und sonst nichts.</.email_p>
+  <.email_p :if={@copyright_case}>
+    Das ist eine rechtliche Beschwerde, keine Hausregel: Sie besagt, dass das Werk nicht Ihres
+    ist, um es zu veröffentlichen. Darüber entscheidet das Urheberrecht, also muss eine Admin sich
+    das ansehen.
+  </.email_p>
+  <.email_p :if={!@copyright_case}>
+    Grundlage sind
+    <.email_link href={"#{@url}community"}>unsere Verhaltensregeln</.email_link>, an die sich
+    alles auf vutuv halten muss.
+  </.email_p>
   <.email_p>
-    Dort können Sie den Inhalt löschen, ihn bearbeiten (nach einer Bearbeitung ist er sofort wieder
-    sichtbar) oder uns mitteilen, dass Ihr Inhalt in Ordnung ist. Hören wir nichts von Ihnen,
-    schauen sich unsere Admins den Fall an.
+    Sie haben 72 Stunden, das selbst zu klären; danach entscheiden unsere Admins:
   </.email_p>
+  <.email_button href={"#{@url}moderation/cases/#{@case_id}"}>Meldung ansehen</.email_button>
+  <.email_p>Auf dieser Seite können Sie:</.email_p>
+  <.email_list items={[
+    if(@edit_offer == :immediate,
+      do: "Den Inhalt bearbeiten. Nach einer Bearbeitung ist er sofort wieder sichtbar."
+    ),
+    if(@edit_offer == :reviewed,
+      do:
+        "Den Inhalt bearbeiten. Unsere Admins sehen sich die Überarbeitung dann an; bis dahin bleibt er verborgen."
+    ),
+    "Ihn löschen. Damit ist die Meldung erledigt, ohne Rückfragen.",
+    "Uns mitteilen, dass Ihr Inhalt in Ordnung ist. Er bleibt dann verborgen, bis eine unserer Admins entschieden hat."
+  ]} />
   <.email_signature locale={@locale} />
 </.email_layout>

--- a/lib/vutuv_web/templates/email_body/moderation_frozen_en.html.heex
+++ b/lib/vutuv_web/templates/email_body/moderation_frozen_en.html.heex
@@ -1,14 +1,42 @@
 <.email_layout preheader="Your content on vutuv was reported and is hidden" locale={@locale}>
   <.email_p>{email_greeting(@user)},</.email_p>
   <.email_p>
-    someone reported one of your contributions on vutuv. To be on the safe side it is hidden for
-    now; nobody else can see it.
+    someone reported one of your contributions on vutuv. No person looked at it first: a report
+    from a member in good standing hides the reported content automatically, the moment it
+    arrives. That is what happened here, and only you and our admins can see it now.
   </.email_p>
-  <.email_p>You can settle this yourself within 72 hours:</.email_p>
+  <.email_panel>
+    <.email_row label="Reported as">{@category_labels}</.email_row>
+  </.email_panel>
+  <.email_p :if={@notes != []}>
+    What the report says, in the reporter's own words. We never tell you who reported:
+  </.email_p>
+  <.email_quote :for={note <- @notes} text={note} />
+  <.email_p :if={@notes == []}>
+    The report named that category and gave no further explanation.
+  </.email_p>
+  <.email_p :if={@copyright_case}>
+    This is a legal complaint, not a house-rule one: it says the work is not yours to publish.
+    Copyright law decides that question, so an admin has to look at it.
+  </.email_p>
+  <.email_p :if={!@copyright_case}>
+    The ground is
+    <.email_link href={"#{@url}community"}>our community guidelines</.email_link>, which
+    everything on vutuv has to keep to.
+  </.email_p>
+  <.email_p>You have 72 hours to settle this yourself; after that our admins decide:</.email_p>
   <.email_button href={"#{@url}moderation/cases/#{@case_id}"}>Review the report</.email_button>
-  <.email_p>
-    On that page you can delete the content, edit it (an edit makes it visible again right away),
-    or tell us that your content is fine. If we do not hear from you, our admins will take a look.
-  </.email_p>
+  <.email_p>On that page you can:</.email_p>
+  <.email_list items={[
+    if(@edit_offer == :immediate,
+      do: "Edit the content. An edit makes it visible again right away."
+    ),
+    if(@edit_offer == :reviewed,
+      do:
+        "Edit the content. One of our admins then looks at the revision, and it stays hidden until they have."
+    ),
+    "Delete it. That settles the report, no questions asked.",
+    "Tell us your content is fine. It stays hidden until one of our admins has ruled."
+  ]} />
   <.email_signature locale={@locale} />
 </.email_layout>

--- a/lib/vutuv_web/templates/email_body/moderation_frozen_it.html.heex
+++ b/lib/vutuv_web/templates/email_body/moderation_frozen_it.html.heex
@@ -1,15 +1,46 @@
 <.email_layout preheader="Un Suo contenuto su vutuv è stato segnalato ed è nascosto" locale={@locale}>
   <.email_p>{email_greeting(@user)},</.email_p>
   <.email_p>
-    qualcuno ha segnalato un Suo contributo su vutuv. Per prudenza per ora è nascosto; nessun
-    altro può vederlo.
+    qualcuno ha segnalato un Suo contributo su vutuv. Nessuna persona lo ha esaminato prima: la
+    segnalazione di un membro affidabile nasconde il contenuto segnalato automaticamente, nel
+    momento in cui arriva. È quello che è successo qui; ora possono vederlo solo Lei e i nostri
+    amministratori.
   </.email_p>
-  <.email_p>Può risolvere da solo entro 72 ore:</.email_p>
-  <.email_button href={"#{@url}moderation/cases/#{@case_id}"}>Esamini la segnalazione</.email_button>
-  <.email_p>
-    Su quella pagina può eliminare il contenuto, modificarlo (una modifica lo rende subito di
-    nuovo visibile) oppure dirci che il Suo contenuto è a posto. Se non avremo Sue notizie, ci
-    daranno un'occhiata i nostri amministratori.
+  <.email_panel>
+    <.email_row label="Segnalato come">{@category_labels}</.email_row>
+  </.email_panel>
+  <.email_p :if={@notes != []}>
+    Ecco cosa dice la segnalazione, con le parole di chi l'ha scritta. Chi sia stato non glielo
+    diciamo mai:
   </.email_p>
+  <.email_quote :for={note <- @notes} text={note} />
+  <.email_p :if={@notes == []}>
+    La segnalazione ha indicato quella categoria e nient'altro.
+  </.email_p>
+  <.email_p :if={@copyright_case}>
+    Questa è una contestazione legale, non una regola della casa: sostiene che l'opera non è Sua
+    da pubblicare. A deciderlo è il diritto d'autore, quindi deve esaminarla un amministratore.
+  </.email_p>
+  <.email_p :if={!@copyright_case}>
+    Il fondamento sono
+    <.email_link href={"#{@url}community"}>le nostre regole della comunità</.email_link>, a cui
+    tutto su vutuv deve attenersi.
+  </.email_p>
+  <.email_p>Ha 72 ore per risolvere da solo; dopo decidono i nostri amministratori:</.email_p>
+  <.email_button href={"#{@url}moderation/cases/#{@case_id}"}>
+    Esamini la segnalazione
+  </.email_button>
+  <.email_p>Su quella pagina può:</.email_p>
+  <.email_list items={[
+    if(@edit_offer == :immediate,
+      do: "Modificare il contenuto. Dopo una modifica torna subito visibile."
+    ),
+    if(@edit_offer == :reviewed,
+      do:
+        "Modificare il contenuto. I nostri amministratori esaminano poi la revisione; fino ad allora resta nascosto."
+    ),
+    "Eliminarlo. Così la segnalazione è chiusa, senza altre domande.",
+    "Dirci che il Suo contenuto è a posto. Resta nascosto finché un amministratore non avrà deciso."
+  ]} />
   <.email_signature locale={@locale} />
 </.email_layout>

--- a/lib/vutuv_web/templates/email_body/moderation_review_de.html.heex
+++ b/lib/vutuv_web/templates/email_body/moderation_review_de.html.heex
@@ -1,10 +1,33 @@
 <.email_layout preheader="Ihr Inhalt auf vutuv wird geprüft" locale={@locale}>
   <.email_p>{email_greeting(@user)},</.email_p>
   <.email_p>
-    einer Ihrer Beiträge auf vutuv wurde gemeldet und ist verborgen, während unsere Admins den Fall
-    prüfen. Sie müssen nichts weiter tun; wir melden uns mit dem Ergebnis.
+    einer Ihrer Beiträge auf vutuv wurde gemeldet und ist verborgen, während unsere Admins den
+    Fall prüfen. Kein Mensch hat ihn vorher angesehen: Die Meldung eines Mitglieds mit guter
+    Bilanz verbirgt den gemeldeten Inhalt automatisch, sobald sie eintrifft.
   </.email_p>
-  <.email_p>Den Fall finden Sie hier:</.email_p>
+  <.email_panel>
+    <.email_row label="Gemeldet als">{@category_labels}</.email_row>
+  </.email_panel>
+  <.email_p :if={@notes != []}>
+    Das steht in der Meldung, mit den Worten der meldenden Person. Wer das war, sagen wir Ihnen
+    nie:
+  </.email_p>
+  <.email_quote :for={note <- @notes} text={note} />
+  <.email_p :if={@notes == []}>Die Meldung nannte diese Kategorie und sonst nichts.</.email_p>
+  <.email_p :if={@copyright_case}>
+    Das ist eine rechtliche Beschwerde, keine Hausregel: Sie besagt, dass das Werk nicht Ihres
+    ist, um es zu veröffentlichen. Darüber entscheidet das Urheberrecht.
+  </.email_p>
+  <.email_p :if={!@copyright_case}>
+    Grundlage sind
+    <.email_link href={"#{@url}community"}>unsere Verhaltensregeln</.email_link>, an die sich
+    alles auf vutuv halten muss.
+  </.email_p>
+  <.email_p>
+    Dieser Fall liegt bereits bei unseren Admins, eine Runde zum Selbstklären gibt es hier also
+    nicht. Sie müssen nichts weiter tun: Wir melden uns mit dem Ergebnis, und wenn die Meldung
+    unbegründet war, ist Ihr Inhalt wieder da.
+  </.email_p>
   <.email_button href={"#{@url}moderation/cases/#{@case_id}"}>Fall ansehen</.email_button>
   <.email_signature locale={@locale} />
 </.email_layout>

--- a/lib/vutuv_web/templates/email_body/moderation_review_en.html.heex
+++ b/lib/vutuv_web/templates/email_body/moderation_review_en.html.heex
@@ -1,10 +1,34 @@
 <.email_layout preheader="Your content on vutuv is under review" locale={@locale}>
   <.email_p>{email_greeting(@user)},</.email_p>
   <.email_p>
-    one of your contributions on vutuv was reported and is hidden while our admins review it. You
-    do not need to do anything; we will let you know the outcome.
+    one of your contributions on vutuv was reported and is hidden while our admins review it. No
+    person looked at it first: a report from a member in good standing hides the reported content
+    automatically, the moment it arrives.
   </.email_p>
-  <.email_p>You can see the case here:</.email_p>
+  <.email_panel>
+    <.email_row label="Reported as">{@category_labels}</.email_row>
+  </.email_panel>
+  <.email_p :if={@notes != []}>
+    What the report says, in the reporter's own words. We never tell you who reported:
+  </.email_p>
+  <.email_quote :for={note <- @notes} text={note} />
+  <.email_p :if={@notes == []}>
+    The report named that category and gave no further explanation.
+  </.email_p>
+  <.email_p :if={@copyright_case}>
+    This is a legal complaint, not a house-rule one: it says the work is not yours to publish.
+    Copyright law decides that question.
+  </.email_p>
+  <.email_p :if={!@copyright_case}>
+    The ground is
+    <.email_link href={"#{@url}community"}>our community guidelines</.email_link>, which
+    everything on vutuv has to keep to.
+  </.email_p>
+  <.email_p>
+    This one is with our admins already, so there is no round in which you could settle it
+    yourself. You do not need to do anything: we will tell you the outcome, and if they find the
+    report unfounded your content comes back.
+  </.email_p>
   <.email_button href={"#{@url}moderation/cases/#{@case_id}"}>See the case</.email_button>
   <.email_signature locale={@locale} />
 </.email_layout>

--- a/lib/vutuv_web/templates/email_body/moderation_review_it.html.heex
+++ b/lib/vutuv_web/templates/email_body/moderation_review_it.html.heex
@@ -2,9 +2,34 @@
   <.email_p>{email_greeting(@user)},</.email_p>
   <.email_p>
     un Suo contributo su vutuv è stato segnalato ed è nascosto mentre i nostri amministratori lo
-    esaminano. Non deve fare nulla; Le comunicheremo l'esito.
+    esaminano. Nessuna persona lo ha esaminato prima: la segnalazione di un membro affidabile
+    nasconde il contenuto segnalato automaticamente, nel momento in cui arriva.
   </.email_p>
-  <.email_p>Può vedere il caso qui:</.email_p>
+  <.email_panel>
+    <.email_row label="Segnalato come">{@category_labels}</.email_row>
+  </.email_panel>
+  <.email_p :if={@notes != []}>
+    Ecco cosa dice la segnalazione, con le parole di chi l'ha scritta. Chi sia stato non glielo
+    diciamo mai:
+  </.email_p>
+  <.email_quote :for={note <- @notes} text={note} />
+  <.email_p :if={@notes == []}>
+    La segnalazione ha indicato quella categoria e nient'altro.
+  </.email_p>
+  <.email_p :if={@copyright_case}>
+    Questa è una contestazione legale, non una regola della casa: sostiene che l'opera non è Sua
+    da pubblicare. A deciderlo è il diritto d'autore.
+  </.email_p>
+  <.email_p :if={!@copyright_case}>
+    Il fondamento sono
+    <.email_link href={"#{@url}community"}>le nostre regole della comunità</.email_link>, a cui
+    tutto su vutuv deve attenersi.
+  </.email_p>
+  <.email_p>
+    Questo caso è già in mano ai nostri amministratori, quindi non c'è un giro in cui possa
+    risolverlo da solo. Non deve fare nulla: Le comunicheremo l'esito e, se la segnalazione
+    risulterà infondata, il Suo contenuto tornerà visibile.
+  </.email_p>
   <.email_button href={"#{@url}moderation/cases/#{@case_id}"}>Veda il caso</.email_button>
   <.email_signature locale={@locale} />
 </.email_layout>

--- a/lib/vutuv_web/templates/moderation_case/show.html.heex
+++ b/lib/vutuv_web/templates/moderation_case/show.html.heex
@@ -9,10 +9,44 @@
       {status_line(@case)}
     </p>
 
+    <%!-- Nobody weighed this up: the freeze is what a report from a member in
+          good standing does on arrival, and a member owed a statement of
+          reasons is owed that fact first. --%>
+    <p :if={@case.status in ~w(pending_owner escalated)} class="mt-3 text-sm text-slate-600 dark:text-slate-400">
+      {gettext(
+        "No person made this decision: a report from a member in good standing hides the reported content automatically, the moment it arrives."
+      )}
+    </p>
+
     <dl class="mt-4 space-y-3 text-sm">
       <div>
         <dt class="font-semibold text-slate-700 dark:text-slate-300">{gettext("Reported as")}</dt>
-        <dd class="text-slate-600 dark:text-slate-400">{category_names(@case)}</dd>
+        <dd class="text-slate-600 dark:text-slate-400">{category_names(@notice)}</dd>
+      </div>
+      <div :if={@notice.notes != []}>
+        <dt class="font-semibold text-slate-700 dark:text-slate-300">
+          {gettext("What the report says")}
+        </dt>
+        <dd>
+          <%!-- A stranger's words. `{...}` escapes; never raw/1 here. --%>
+          <blockquote
+            :for={note <- @notice.notes}
+            class="mt-1 whitespace-pre-line rounded-lg bg-slate-50 p-3 text-slate-600 ring-1 ring-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700"
+          >
+            {note}
+          </blockquote>
+        </dd>
+      </div>
+      <div>
+        <dt class="font-semibold text-slate-700 dark:text-slate-300">{gettext("The ground")}</dt>
+        <dd class="text-slate-600 dark:text-slate-400">
+          {if @notice.copyright?,
+            do:
+              gettext(
+                "Copyright law. This complaint says the work is not yours to publish, which is a legal question rather than a house rule."
+              ),
+            else: gettext("Our community guidelines, which everything on vutuv has to keep to.")}
+        </dd>
       </div>
       <div :if={@case.content_snapshot not in [nil, ""]}>
         <dt class="font-semibold text-slate-700 dark:text-slate-300">
@@ -28,21 +62,25 @@
 
     <%= if @case.status == "pending_owner" do %>
       <p class="mt-5 text-sm text-slate-600 dark:text-slate-400">
+        <%!-- Not "three ways out": a reported message or job posting has no
+              edit button, so the count would be wrong for them. --%>
         {gettext(
-          "Nobody else can see it right now. You have 72 hours to settle this yourself; after that our admins decide. Three ways out:"
+          "Nobody else can see it right now. You have 72 hours to settle this yourself; after that our admins decide. Here is what you can do:"
         )}
       </p>
 
       <div class="mt-4 space-y-3">
+        <%!-- A rewrite does not answer "this work is not yours to publish", so
+              a copyright case must not promise the post comes straight back —
+              an admin checks the revision first. Which of the two it is (and
+              whether an edit is offered at all) is `owner_edit_offer/2`'s
+              answer, the same one the email renders. --%>
         <div
-          :if={@case.content_type == "post" and @content}
+          :if={@edit_offer != :none}
           class="flex items-center justify-between gap-4 rounded-lg border border-slate-200 p-3 dark:border-slate-700"
         >
-          <%!-- A rewrite does not answer "this work is not yours to publish",
-                so a copyright case must not promise the post comes straight
-                back — an admin checks the revision first. --%>
           <p class="text-sm text-slate-600 dark:text-slate-400">
-            {if Moderation.copyright_case?(@case),
+            {if @edit_offer == :reviewed,
               do:
                 gettext(
                   "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."

--- a/lib/vutuv_web/views/email_components.ex
+++ b/lib/vutuv_web/views/email_components.ex
@@ -2,8 +2,8 @@ defmodule VutuvWeb.EmailComponents do
   @moduledoc """
   The shared HTML-email framework: one `email_layout/1` chrome plus a small set
   of inline-styled building blocks (`email_p`, `email_pin`, `email_button`,
-  `email_panel`/`email_row`, `email_markdown`, `email_list`, `email_divider`,
-  `email_muted`, `email_signature`). Every HTML email body
+  `email_panel`/`email_row`, `email_markdown`, `email_quote`, `email_list`,
+  `email_divider`, `email_muted`, `email_signature`). Every HTML email body
   (`lib/vutuv_web/templates/email_body/`) composes these, so the look and feel
   is defined in exactly one place.
 
@@ -239,11 +239,48 @@ defmodule VutuvWeb.EmailComponents do
     assigns = assign(assigns, :html, EmailMarkdown.render(assigns.body))
 
     ~H"""
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="email-panel" style="margin:0 0 20px;background:#f8fafc;border:1px solid #e2e8f0;border-left:4px solid #1d4ed8;border-radius:8px;">
+    <.quote_box rule="#1d4ed8">
+      <div class="email-msg">{@html}</div>
+    </.quote_box>
+    """
+  end
+
+  @doc """
+  A stranger's plain text, quoted behind a left rule.
+
+  Unlike `email_markdown/1` this renders the characters as they were typed: no
+  Markdown, no links. The one text quoted this way is a moderation report's
+  note (issue #2010) — written by somebody the reader has never met and shown
+  to them at the worst possible moment, so a clickable link out of it would be
+  a phishing seat. HEEx escapes the text and the rule marks where the
+  stranger's words start and stop; the `text/plain` half of the same mail gets
+  `VutuvWeb.UserHelpers.email_quoted_text/1`.
+  """
+  attr(:text, :string, required: true)
+
+  def email_quote(assigns) do
+    assigns = assign(assigns, :lines, String.split(assigns.text, ["\r\n", "\r", "\n"]))
+
+    ~H"""
+    <.quote_box rule="#94a3b8">
+      <%!-- A <br> per line rather than `white-space: pre-wrap`, which Outlook's
+            Word engine ignores — the one place a member reads an accusation is
+            the wrong place to lose the writer's line breaks. --%>
+      <span :for={line <- @lines}>{line}<br /></span>
+    </.quote_box>
+    """
+  end
+
+  # The panel both quote blocks sit in: same chrome, different left rule. One
+  # copy, so the two never disagree inside a single mail.
+  attr(:rule, :string, required: true)
+  slot(:inner_block, required: true)
+
+  defp quote_box(assigns) do
+    ~H"""
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="email-panel" style={"margin:0 0 20px;background:#f8fafc;border:1px solid #e2e8f0;border-left:4px solid #{@rule};border-radius:8px;"}>
       <tr>
-        <td class="email-text" style={markdown_quote_style()}>
-          <div class="email-msg">{@html}</div>
-        </td>
+        <td class="email-text" style={markdown_quote_style()}>{render_slot(@inner_block)}</td>
       </tr>
     </table>
     """
@@ -266,6 +303,11 @@ defmodule VutuvWeb.EmailComponents do
   attr(:items, :list, required: true)
 
   def email_list(assigns) do
+    # Nils are dropped here rather than by each caller: a list whose entries are
+    # conditional (the moderation notice's options) is otherwise wrapped in an
+    # `Enum.reject` in every locale file that renders it.
+    assigns = assign(assigns, :items, Enum.reject(assigns.items, &is_nil/1))
+
     ~H"""
     <ul class="email-text" style={list_style()}>
       <li :for={item <- @items} style="margin:0 0 6px;">{item}</li>

--- a/lib/vutuv_web/views/email_components.ex
+++ b/lib/vutuv_web/views/email_components.ex
@@ -254,12 +254,14 @@ defmodule VutuvWeb.EmailComponents do
   to them at the worst possible moment, so a clickable link out of it would be
   a phishing seat. HEEx escapes the text and the rule marks where the
   stranger's words start and stop; the `text/plain` half of the same mail gets
-  `VutuvWeb.UserHelpers.email_quoted_text/1`.
+  `VutuvWeb.UserHelpers.email_quoted_text/1`. Both halves ask
+  `UserHelpers.split_lines/1` where a line ends, so a break the reader's client
+  honours is one this markup drew rather than one it let through.
   """
   attr(:text, :string, required: true)
 
   def email_quote(assigns) do
-    assigns = assign(assigns, :lines, String.split(assigns.text, ["\r\n", "\r", "\n"]))
+    assigns = assign(assigns, :lines, split_lines(assigns.text))
 
     ~H"""
     <.quote_box rule="#94a3b8">

--- a/lib/vutuv_web/views/moderation_case_html.ex
+++ b/lib/vutuv_web/views/moderation_case_html.ex
@@ -2,7 +2,6 @@ defmodule VutuvWeb.ModerationCaseHTML do
   @moduledoc false
   use VutuvWeb, :html
 
-  alias Vutuv.Moderation
   alias Vutuv.Moderation.Case
 
   embed_templates("../templates/moderation_case/*")
@@ -29,11 +28,11 @@ defmodule VutuvWeb.ModerationCaseHTML do
   def status_line(%Case{status: "rejected"}),
     do: gettext("An admin dismissed the report. The content is visible again.")
 
-  @doc "The reported categories of a case, deduplicated, human-readable."
-  def category_names(%Case{reports: reports}) when is_list(reports) do
-    reports
-    |> Enum.map(&VutuvWeb.ReportHTML.category_label(&1.category))
-    |> Enum.uniq()
-    |> Enum.join(", ")
-  end
+  @doc """
+  The reported categories, human-readable. Takes the statement of reasons
+  (`Vutuv.Moderation.owner_notice/1`) rather than the case, so the page and
+  the owner's email name the same categories in the same order.
+  """
+  def category_names(%{categories: categories}),
+    do: Enum.map_join(categories, ", ", &VutuvWeb.ReportHTML.category_label/1)
 end

--- a/lib/vutuv_web/views/notification_digest_text.ex
+++ b/lib/vutuv_web/views/notification_digest_text.ex
@@ -68,8 +68,12 @@ defmodule VutuvWeb.NotificationDigestText do
       when is_binary(old) and is_binary(new),
       do: gettext("@%{old} is now @%{new}.", old: old, new: new)
 
-  def line(%{kind: "moderation"}),
-    do: gettext("A moderation case on your account was updated.")
+  # The one kind that has no actor and is already a whole sentence, so the
+  # digest and the notifications page say the same thing (issue #2010): a
+  # member who reads the mail instead of opening the app is owed the category
+  # and the fact that the freeze was automatic, not "something was updated".
+  def line(%{kind: "moderation"} = item),
+    do: VutuvWeb.NotificationLine.notification_text(item)
 
   def line(%{kind: "image_rejected"}),
     do: gettext("One of your images was removed by the image review.")

--- a/lib/vutuv_web/views/user_helpers.ex
+++ b/lib/vutuv_web/views/user_helpers.ex
@@ -1037,6 +1037,64 @@ defmodule VutuvWeb.UserHelpers do
 
   def email_greeting(_), do: "Hi"
 
+  @doc """
+  A stranger's text quoted into a `text/plain` email: hard-wrapped at 72
+  columns and every line prefixed with `"> "`.
+
+  The prefix is not decoration. A `text/plain` template does no escaping at
+  all, so an unmarked block of somebody else's writing can be shaped to read
+  as our own — a fake signature, a second link, a sentence that looks like it
+  came from vutuv. Prefixing every line means the reader can see where the
+  stranger's words start and stop. The only text quoted this way today is a
+  moderation report's note (issue #2010), which the changeset caps at
+  `Vutuv.Moderation.Report.max_note_length/0`.
+
+  Takes one note or a list of them; returns "" for nothing to quote.
+  """
+  @quote_width 72
+
+  def email_quoted_text(notes) when is_list(notes),
+    do: Enum.map_join(notes, "\n>\n", &email_quoted_text/1)
+
+  def email_quoted_text(nil), do: ""
+
+  def email_quoted_text(text) when is_binary(text) do
+    text
+    |> String.split(["\r\n", "\r", "\n"])
+    |> Enum.flat_map(&wrap_line/1)
+    |> Enum.map_join("\n", &quote_line/1)
+  end
+
+  # A blank line gets the bare marker, never `"> "`: a quote block ends at the
+  # first line without one, and mail clients that strip trailing whitespace
+  # would turn the space into exactly that.
+  defp quote_line(""), do: ">"
+  defp quote_line(line), do: "> " <> line
+
+  # Greedy wrap, counting characters rather than bytes — a note full of
+  # umlauts would otherwise wrap several columns short. A word longer than the
+  # width (a pasted URL) keeps its own line rather than being cut in half,
+  # which would break the link it names.
+  defp wrap_line(line) do
+    line
+    |> String.split(" ", trim: true)
+    |> Enum.reduce([], fn
+      word, [current | rest]
+      when is_binary(current) and is_binary(word) ->
+        if String.length(current) + 1 + String.length(word) <= @quote_width,
+          do: [current <> " " <> word | rest],
+          else: [word, current | rest]
+
+      word, [] ->
+        [word]
+    end)
+    |> Enum.reverse()
+    |> case do
+      [] -> [""]
+      lines -> lines
+    end
+  end
+
   # The name the neutral salutation greets: given name and surname, no
   # honorifics. "Hallo Max Meier" rather than "Hallo Max", because the German
   # UI addresses members as "Sie" throughout and a bare given name undercuts

--- a/lib/vutuv_web/views/user_helpers.ex
+++ b/lib/vutuv_web/views/user_helpers.ex
@@ -1047,7 +1047,9 @@ defmodule VutuvWeb.UserHelpers do
   came from vutuv. Prefixing every line means the reader can see where the
   stranger's words start and stop. The only text quoted this way today is a
   moderation report's note (issue #2010), which the changeset caps at
-  `Vutuv.Moderation.Report.max_note_length/0`.
+  `Vutuv.Moderation.Report.max_note_length/0` and otherwise passes through
+  untouched — no control character is stripped on the way in, so "what counts
+  as a line" is decided here and nowhere else (`split_lines/1`).
 
   Takes one note or a list of them; returns "" for nothing to quote.
   """
@@ -1060,10 +1062,28 @@ defmodule VutuvWeb.UserHelpers do
 
   def email_quoted_text(text) when is_binary(text) do
     text
-    |> String.split(["\r\n", "\r", "\n"])
+    |> split_lines()
     |> Enum.flat_map(&wrap_line/1)
     |> Enum.map_join("\n", &quote_line/1)
   end
+
+  @doc """
+  Splits a stranger's text wherever a *renderer* will start a new line.
+
+  The rule is the effect, not a list of the spellings anyone happens to think
+  of: `\\R` is PCRE's closed set of mandatory line breaks, which is the set
+  UAX #14 gives a mail client. Enumerating `\\r\\n`, `\\r` and `\\n` instead
+  leaves VT, FF, NEL (U+0085), LINE SEPARATOR (U+2028) and PARAGRAPH SEPARATOR
+  (U+2029) inside what this code calls one line — invisible in a form, a real
+  break in Gmail, Apple Mail and Thunderbird — so everything after one arrives
+  without whatever marker the caller puts on each line. The `u` modifier is
+  load-bearing rather than decorative: without it `\\R` stops at NEL and the two
+  separators pass straight through.
+
+  Both halves of a quoted mail split here, so the `text/plain` prefix and the
+  HTML `<br>` can never disagree about where a line ends.
+  """
+  def split_lines(text) when is_binary(text), do: Regex.split(~r/\R/u, text)
 
   # A blank line gets the bare marker, never `"> "`: a quote block ends at the
   # first line without one, and mail clients that strip trailing whitespace

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -172,7 +172,7 @@ msgstr "%{name} konnte nicht zurückgefolgt werden."
 #: lib/vutuv_web/live/admin/user_delete_live.ex:167
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:28
 #: lib/vutuv_web/templates/dev_app/show.html.heex:135
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:67
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:103
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:70
 #, elixir-autogen
 msgid "Delete"
@@ -224,7 +224,7 @@ msgstr "Download"
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:6
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:53
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:89
 #: lib/vutuv_web/templates/user/show.html.heex:1124
 #, elixir-autogen
 msgid "Edit"
@@ -1068,22 +1068,22 @@ msgstr "Allgemeines"
 msgid "Verify"
 msgstr "Verifizieren"
 
-#: lib/vutuv/notifications/emailer.ex:282
+#: lib/vutuv/notifications/emailer.ex:283
 #, elixir-autogen
 msgid "Confirm your account deletion"
 msgstr "PIN zum Löschen eines vutuv-Kontos"
 
-#: lib/vutuv/notifications/emailer.ex:276
+#: lib/vutuv/notifications/emailer.ex:277
 #, elixir-autogen
 msgid "Confirm your email"
 msgstr "Weitere E-Mail-Adresse für ein vutuv-Konto bestätigen"
 
-#: lib/vutuv/notifications/emailer.ex:264
+#: lib/vutuv/notifications/emailer.ex:265
 #, elixir-autogen
 msgid "Confirm your vutuv account"
 msgstr "vutuv-Konto einrichten"
 
-#: lib/vutuv/notifications/emailer.ex:270
+#: lib/vutuv/notifications/emailer.ex:271
 #, elixir-autogen
 msgid "Login to vutuv"
 msgstr "vutuv Login-PIN"
@@ -1553,7 +1553,7 @@ msgstr "Verwandte Tags anzeigen"
 msgid "tag name"
 msgstr "Tag-Name"
 
-#: lib/vutuv/notifications/emailer.ex:322
+#: lib/vutuv/notifications/emailer.ex:323
 #, elixir-autogen
 msgid "vutuv Account verified"
 msgstr "verifizierter Account"
@@ -3006,12 +3006,12 @@ msgstr ""
 msgid "Current version (edited since the report)"
 msgstr "Aktuelle Version (seit der Meldung bearbeitet)"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:65
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Delete this content permanently?"
 msgstr "Diesen Inhalt endgültig löschen?"
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:68
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:71
 #, elixir-autogen, elixir-format
 msgid "Deleted. The report is settled, no further steps needed."
 msgstr ""
@@ -3022,7 +3022,7 @@ msgstr ""
 msgid "Escalated"
 msgstr "Eskaliert"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:50
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Fix it. An edited post is visible again immediately."
 msgstr "Korrigieren. Ein bearbeiteter Beitrag ist sofort wieder sichtbar."
@@ -3075,7 +3075,7 @@ msgstr "Moderationsfall"
 msgid "Moderation queue"
 msgstr "Moderations-Warteschlange"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:76
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "My content is fine"
 msgstr "Mein Inhalt ist in Ordnung"
@@ -3116,13 +3116,6 @@ msgid "No unwanted advertising, fake profiles, fraud or link bait."
 msgstr ""
 "Keine unerwünschte Werbung, keine Fake-Profile, kein Betrug, keine "
 "Klickköder."
-
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:31
-#, elixir-autogen, elixir-format
-msgid "Nobody else can see it right now. You have 72 hours to settle this yourself; after that our admins decide. Three ways out:"
-msgstr ""
-"Niemand sonst kann ihn gerade sehen. Sie haben 72 Stunden, um das selbst zu "
-"klären; danach entscheiden unsere Admins. Drei Wege:"
 
 #: lib/vutuv_web/views/report_html.ex:13
 #, elixir-autogen, elixir-format
@@ -3213,7 +3206,7 @@ msgstr "Meldung ablehnen"
 msgid "Rejected"
 msgstr "Abgelehnt"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:59
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
@@ -3261,7 +3254,7 @@ msgid "Report upheld; the owner got a strike."
 msgstr "Meldung bestätigt; der Besitzer hat einen Verwarnungspunkt erhalten."
 
 #: lib/vutuv_web/live/admin/moderation_live.ex:55
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:14
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:23
 #, elixir-autogen, elixir-format
 msgid "Reported as"
 msgstr "Gemeldet als"
@@ -3300,7 +3293,7 @@ msgstr "Melder-Bilanz"
 msgid "Reports"
 msgstr "Meldungen"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:83
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
@@ -3349,7 +3342,7 @@ msgstr "Etwas anderes"
 msgid "Spam or scam"
 msgstr "Spam oder Betrug"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:73
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "Stand by it. It stays hidden until one of our admins has ruled."
 msgstr ""
@@ -3390,7 +3383,7 @@ msgstr "Beschreiben Sie es in der Notiz unten genauer."
 msgid "Thank you for your report. We take it from here."
 msgstr "Danke für Ihre Meldung. Wir übernehmen ab hier."
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:19
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "The content in question"
 msgstr "Der betreffende Inhalt"
@@ -3435,7 +3428,7 @@ msgstr "Dieses Konto wurde deaktiviert."
 msgid "This account is suspended until %{date}."
 msgstr "Dieses Konto ist bis zum %{date} gesperrt."
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:83
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:86
 #, elixir-autogen, elixir-format
 msgid "This case is already settled."
 msgstr "Dieser Fall ist bereits erledigt."
@@ -3455,7 +3448,7 @@ msgstr "Vertrauenswürdig"
 msgid "Type"
 msgstr "Typ"
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:45
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:48
 #, elixir-autogen, elixir-format
 msgid "Understood. The content stays hidden until one of our admins has ruled."
 msgstr ""
@@ -3525,13 +3518,6 @@ msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
 msgid "Your content was reported"
 msgstr "Ihr Inhalt wurde gemeldet"
 
-#: lib/vutuv_web/notification_line.ex:122
-#, elixir-autogen, elixir-format
-msgid "Your content was reported and is hidden while the report is handled."
-msgstr ""
-"Ihr Inhalt wurde gemeldet und ist verborgen, solange die Meldung bearbeitet "
-"wird."
-
 #: lib/vutuv_web/templates/report/new.html.heex:7
 #, elixir-autogen, elixir-format
 msgid "Your report is anonymous. If it checks out, the content is hidden right away and the owner is asked to fix it."
@@ -3539,7 +3525,7 @@ msgstr ""
 "Ihre Meldung ist anonym. Wenn sie plausibel ist, wird der Inhalt sofort "
 "verborgen und der Besitzer gebeten, ihn in Ordnung zu bringen."
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:85
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:121
 #: lib/vutuv_web/templates/report/new.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "community guidelines"
@@ -3563,42 +3549,42 @@ msgstr ""
 msgid "yes"
 msgstr "ja"
 
-#: lib/vutuv/notifications/emailer.ex:1004
+#: lib/vutuv/notifications/emailer.ex:1026
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr "Eine Verwarnung für Ihr vutuv-Konto"
 
-#: lib/vutuv/notifications/emailer.ex:1088
+#: lib/vutuv/notifications/emailer.ex:1110
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr "Moderation: %{count} Fälle warten"
 
-#: lib/vutuv/notifications/emailer.ex:1066
+#: lib/vutuv/notifications/emailer.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr "Moderation: Ein Profil wurde gemeldet"
 
-#: lib/vutuv/notifications/emailer.ex:978
+#: lib/vutuv/notifications/emailer.ex:1000
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr "Der von Ihnen gemeldete Inhalt wurde überarbeitet"
 
-#: lib/vutuv/notifications/emailer.ex:971
+#: lib/vutuv/notifications/emailer.ex:972
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr "Ihr Inhalt auf vutuv wird geprüft"
 
-#: lib/vutuv/notifications/emailer.ex:964
+#: lib/vutuv/notifications/emailer.ex:965
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr "Ihr Inhalt auf vutuv wurde gemeldet und ist verborgen"
 
-#: lib/vutuv/notifications/emailer.ex:1018
+#: lib/vutuv/notifications/emailer.ex:1040
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr "Ihr vutuv-Konto wurde deaktiviert"
 
-#: lib/vutuv/notifications/emailer.ex:1011
+#: lib/vutuv/notifications/emailer.ex:1033
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr "Ihr vutuv-Konto ist gesperrt"
@@ -5621,7 +5607,7 @@ msgstr "Fußzeilen-Navigation"
 msgid "View post"
 msgstr "Beitrag ansehen"
 
-#: lib/vutuv/notifications/emailer.ex:314
+#: lib/vutuv/notifications/emailer.ex:315
 #, elixir-autogen, elixir-format
 msgid "Someone tried to register with your email address"
 msgstr "Registrierungsversuch mit Ihrer E-Mail-Adresse"
@@ -5814,12 +5800,12 @@ msgstr "z. B. Dr. oder Prof."
 msgid "e.g. Jr. or PhD"
 msgstr "z. B. jun. oder B.Sc."
 
-#: lib/vutuv/notifications/emailer.ex:416
+#: lib/vutuv/notifications/emailer.ex:417
 #, elixir-autogen, elixir-format
 msgid "@%{slug} endorsed you on vutuv"
 msgstr "@%{slug} hat Sie auf vutuv empfohlen"
 
-#: lib/vutuv/notifications/emailer.ex:402
+#: lib/vutuv/notifications/emailer.ex:403
 #, elixir-autogen, elixir-format
 msgid "@%{slug} started following you on vutuv"
 msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
@@ -6065,7 +6051,7 @@ msgstr[1] "vor %{count} Minuten"
 msgid "All other devices have been logged out."
 msgstr "Alle anderen Geräte wurden abgemeldet."
 
-#: lib/vutuv/notifications/emailer.ex:718
+#: lib/vutuv/notifications/emailer.ex:719
 #, elixir-autogen, elixir-format
 msgid "Another session was already active on your account."
 msgstr "Auf Ihrem Konto war bereits eine andere Sitzung aktiv."
@@ -6090,7 +6076,7 @@ msgstr "Von allen Geräten außer diesem abmelden?"
 msgid "Log this device out of your account?"
 msgstr "Dieses Gerät von Ihrem Konto abmelden?"
 
-#: lib/vutuv/notifications/emailer.ex:692
+#: lib/vutuv/notifications/emailer.ex:693
 #, elixir-autogen, elixir-format
 msgid "New sign-in to your vutuv account"
 msgstr "Neue Anmeldung bei Ihrem vutuv-Konto"
@@ -6105,7 +6091,7 @@ msgstr "Angemeldete Geräte"
 msgid "That device has been logged out."
 msgstr "Dieses Gerät wurde abgemeldet."
 
-#: lib/vutuv/notifications/emailer.ex:721
+#: lib/vutuv/notifications/emailer.ex:722
 #, elixir-autogen, elixir-format
 msgid "The location looks different from where you usually sign in."
 msgstr "Der Ort weicht von dem ab, von dem Sie sich üblicherweise anmelden."
@@ -6115,7 +6101,7 @@ msgstr "Der Ort weicht von dem ab, von dem Sie sich üblicherweise anmelden."
 msgid "This device"
 msgstr "Dieses Gerät"
 
-#: lib/vutuv/notifications/emailer.ex:715
+#: lib/vutuv/notifications/emailer.ex:716
 #, elixir-autogen, elixir-format
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
@@ -12876,7 +12862,7 @@ msgstr "Veröffentlichen"
 
 #: lib/vutuv/accounts/user.ex:1275
 #: lib/vutuv/jobs/job_posting.ex:166
-#: lib/vutuv/notifications/emailer.ex:566
+#: lib/vutuv/notifications/emailer.ex:567
 #: lib/vutuv_web/agent_docs/markdown.ex:532
 #: lib/vutuv_web/agent_docs/markdown.ex:534
 #: lib/vutuv_web/agent_docs/text.ex:547
@@ -13011,12 +12997,12 @@ msgstr "Arbeitsort"
 msgid "You already have the maximum number of published postings."
 msgstr "Sie haben bereits die maximale Anzahl veröffentlichter Anzeigen."
 
-#: lib/vutuv/notifications/emailer.ex:1034
+#: lib/vutuv/notifications/emailer.ex:1056
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr "Ihre Stellenanzeige auf vutuv läuft bald ab"
 
-#: lib/vutuv/notifications/emailer.ex:912
+#: lib/vutuv/notifications/emailer.ex:913
 #, elixir-autogen, elixir-format
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr "Eine Domain Ihrer Organisationsseite auf vutuv entfällt bald"
@@ -13036,12 +13022,12 @@ msgstr "Nachweis fehlt"
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr "Der Nachweis dieser Domain war bei der letzten Prüfung nicht abrufbar. Stellen Sie ihn wieder her und prüfen Sie erneut, sonst verliert die Domain ihre Verifizierung."
 
-#: lib/vutuv/notifications/emailer.ex:909
+#: lib/vutuv/notifications/emailer.ex:910
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is about to lose its verification"
 msgstr "Ihre Organisationsseite auf vutuv verliert bald ihre Verifizierung"
 
-#: lib/vutuv/notifications/emailer.ex:955
+#: lib/vutuv/notifications/emailer.ex:956
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is no longer public"
 msgstr "Ihre Organisationsseite auf vutuv ist nicht mehr öffentlich"
@@ -13491,7 +13477,7 @@ msgstr "verifizierte Organisationsseite"
 msgid "—"
 msgstr "—"
 
-#: lib/vutuv/notifications/emailer.ex:515
+#: lib/vutuv/notifications/emailer.ex:516
 #, elixir-autogen, elixir-format
 msgid "%{count} new match for your saved searches"
 msgid_plural "%{count} new matches for your saved searches"
@@ -14590,7 +14576,7 @@ msgstr "Bevorzugte Arbeitsform"
 msgid "Availability"
 msgstr "Verfügbarkeit"
 
-#: lib/vutuv/notifications/emailer.ex:996
+#: lib/vutuv/notifications/emailer.ex:1018
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Eine automatische Prüfung hat ein Bild aus Ihrem vutuv-Konto entfernt"
@@ -14608,7 +14594,7 @@ msgstr ""
 msgid "Thread reply"
 msgstr "Thread-Antwort"
 
-#: lib/vutuv_web/notification_line.ex:246
+#: lib/vutuv_web/notification_line.ex:263
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -16160,7 +16146,7 @@ msgstr "Bitte bestätigen Sie die Änderung, bevor wir Ihr Konto umbenennen."
 msgid "This confirmation expired. Please start again."
 msgstr "Diese Bestätigung ist abgelaufen. Bitte beginnen Sie von vorn."
 
-#: lib/vutuv/notifications/emailer.ex:296
+#: lib/vutuv/notifications/emailer.ex:297
 #, elixir-autogen, elixir-format
 msgid "Confirm your new username"
 msgstr "Bestätigen Sie Ihren neuen Benutzernamen"
@@ -17098,21 +17084,21 @@ msgstr ""
 "Mehr speichern wir über diese Menschen nicht: keinen Namen, kein Bild, "
 "keinen Text. Ausschalten löscht, was dafür gespeichert ist."
 
-#: lib/vutuv_web/notification_line.ex:227
+#: lib/vutuv_web/notification_line.ex:244
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] "gefällt Ihr Beitrag in einem anderen Netzwerk."
 msgstr[1] "gefällt Ihr Beitrag in einem anderen Netzwerk."
 
-#: lib/vutuv_web/notification_line.ex:235
+#: lib/vutuv_web/notification_line.ex:252
 #, elixir-autogen, elixir-format
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] "hat aus einem anderen Netzwerk auf Ihren Beitrag reagiert."
 msgstr[1] "haben aus einem anderen Netzwerk auf Ihren Beitrag reagiert."
 
-#: lib/vutuv_web/notification_line.ex:219
+#: lib/vutuv_web/notification_line.ex:236
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -19293,7 +19279,7 @@ msgstr "Wenn die Prüfung eines Ihrer Arbeitszeugnisse fertig ist. Das dauert ei
 msgid "Your employment reference has been reviewed."
 msgstr "Ihr Arbeitszeugnis wurde geprüft."
 
-#: lib/vutuv/notifications/emailer.ex:479
+#: lib/vutuv/notifications/emailer.ex:480
 #, elixir-autogen, elixir-format
 msgid "Your reference “%{title}” has been reviewed"
 msgstr "Ihr Zeugnis „%{title}“ wurde geprüft"
@@ -19369,7 +19355,7 @@ msgstr "Nur nötig, wenn Sie keine Datei zum Hochladen haben."
 msgid "Upload the PDF or the scan. We read the text out of it, and the review always reads that text, never the file itself."
 msgstr "Laden Sie das PDF oder den Scan hoch. Wir lesen den Text daraus aus, und die Prüfung liest immer diesen Text, nie die Datei selbst."
 
-#: lib/vutuv/notifications/emailer.ex:460
+#: lib/vutuv/notifications/emailer.ex:461
 #, elixir-autogen, elixir-format
 msgid "%{count} new notification on vutuv"
 msgid_plural "%{count} new notifications on vutuv"
@@ -20652,7 +20638,7 @@ msgstr "Diese Seite folgt noch niemandem auf einem anderen Netzwerk."
 msgid "Too many attempts for now. Try again later."
 msgstr "Zu viele Versuche. Bitte versuchen Sie es später erneut."
 
-#: lib/vutuv/notifications/emailer.ex:352
+#: lib/vutuv/notifications/emailer.ex:353
 #, elixir-autogen, elixir-format
 msgid "New message from %{sender} on vutuv"
 msgstr "Neue Nachricht von %{sender} auf vutuv"
@@ -21017,7 +21003,7 @@ msgstr "Wir haben diese Adresse abgerufen:"
 msgid "What is published there right now:"
 msgstr "Was dort im Moment veröffentlicht ist:"
 
-#: lib/vutuv/notifications/emailer.ex:935
+#: lib/vutuv/notifications/emailer.ex:936
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is verified"
 msgstr "Ihre Organisationsseite auf vutuv ist verifiziert"
@@ -24138,7 +24124,7 @@ msgstr "Schalten Sie ihn für Ihr Konto ein, dann können Sie %{app} gleich hier
 msgid "Turn on for my account"
 msgstr "Für mein Konto einschalten"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:47
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:83
 #, elixir-autogen, elixir-format
 msgid "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."
 msgstr "Korrigieren. Einer unserer Admins sieht sich die Änderung dann an; bis dahin bleibt der Beitrag verborgen."
@@ -24172,3 +24158,43 @@ msgstr "Nutzt einen Text, ein Foto oder ein Video ohne Erlaubnis des Rechteinhab
 #, elixir-autogen, elixir-format
 msgid "Which work is it, and where can the original be seen? (required)"
 msgstr "Um welches Werk geht es, und wo ist das Original zu sehen? (erforderlich)"
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:45
+#, elixir-autogen, elixir-format
+msgid "Copyright law. This complaint says the work is not yours to publish, which is a legal question rather than a house rule."
+msgstr "Das Urheberrecht. Diese Beschwerde besagt, dass das Werk nicht Ihres ist, um es zu veröffentlichen, und das ist eine Rechtsfrage, keine Hausregel."
+
+#: lib/vutuv_web/notification_line.ex:203
+#, elixir-autogen, elixir-format
+msgid "Hidden automatically after a report: %{reason}. The case page says what you can do."
+msgstr "Nach einer Meldung automatisch verborgen: %{reason}. Auf der Fallseite steht, was Sie tun können."
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:16
+#, elixir-autogen, elixir-format
+msgid "No person made this decision: a report from a member in good standing hides the reported content automatically, the moment it arrives."
+msgstr "Diese Entscheidung hat kein Mensch getroffen: Die Meldung eines Mitglieds mit guter Bilanz verbirgt den gemeldeten Inhalt automatisch, sobald sie eintrifft."
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:67
+#, elixir-autogen, elixir-format
+msgid "Nobody else can see it right now. You have 72 hours to settle this yourself; after that our admins decide. Here is what you can do:"
+msgstr "Niemand sonst kann ihn gerade sehen. Sie haben 72 Stunden, um das selbst zu klären; danach entscheiden unsere Admins. Das können Sie tun:"
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:48
+#, elixir-autogen, elixir-format
+msgid "Our community guidelines, which everything on vutuv has to keep to."
+msgstr "Unsere Verhaltensregeln, an die sich alles auf vutuv halten muss."
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:41
+#, elixir-autogen, elixir-format
+msgid "The ground"
+msgstr "Grundlage"
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:28
+#, elixir-autogen, elixir-format
+msgid "What the report says"
+msgstr "Was in der Meldung steht"
+
+#: lib/vutuv_web/notification_line.ex:209
+#, elixir-autogen, elixir-format
+msgid "Your content was hidden automatically after a report. The case page says what you can do."
+msgstr "Ihr Inhalt wurde nach einer Meldung automatisch verborgen. Auf der Fallseite steht, was Sie tun können."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -172,7 +172,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:167
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:28
 #: lib/vutuv_web/templates/dev_app/show.html.heex:135
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:67
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:103
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:70
 #, elixir-autogen
 msgid "Delete"
@@ -224,7 +224,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:6
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:53
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:89
 #: lib/vutuv_web/templates/user/show.html.heex:1124
 #, elixir-autogen
 msgid "Edit"
@@ -1049,22 +1049,22 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:282
+#: lib/vutuv/notifications/emailer.ex:283
 #, elixir-autogen
 msgid "Confirm your account deletion"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:276
+#: lib/vutuv/notifications/emailer.ex:277
 #, elixir-autogen
 msgid "Confirm your email"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:264
+#: lib/vutuv/notifications/emailer.ex:265
 #, elixir-autogen
 msgid "Confirm your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:270
+#: lib/vutuv/notifications/emailer.ex:271
 #, elixir-autogen
 msgid "Login to vutuv"
 msgstr ""
@@ -1528,7 +1528,7 @@ msgstr ""
 msgid "tag name"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:322
+#: lib/vutuv/notifications/emailer.ex:323
 #, elixir-autogen
 msgid "vutuv Account verified"
 msgstr ""
@@ -2956,12 +2956,12 @@ msgstr ""
 msgid "Current version (edited since the report)"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:65
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Delete this content permanently?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:68
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:71
 #, elixir-autogen, elixir-format
 msgid "Deleted. The report is settled, no further steps needed."
 msgstr ""
@@ -2971,7 +2971,7 @@ msgstr ""
 msgid "Escalated"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:50
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Fix it. An edited post is visible again immediately."
 msgstr ""
@@ -3022,7 +3022,7 @@ msgstr ""
 msgid "Moderation queue"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:76
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "My content is fine"
 msgstr ""
@@ -3055,11 +3055,6 @@ msgstr ""
 #: lib/vutuv_web/templates/page/community.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "No unwanted advertising, fake profiles, fraud or link bait."
-msgstr ""
-
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:31
-#, elixir-autogen, elixir-format
-msgid "Nobody else can see it right now. You have 72 hours to settle this yourself; after that our admins decide. Three ways out:"
 msgstr ""
 
 #: lib/vutuv_web/views/report_html.ex:13
@@ -3147,7 +3142,7 @@ msgstr ""
 msgid "Rejected"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:59
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
@@ -3195,7 +3190,7 @@ msgid "Report upheld; the owner got a strike."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_live.ex:55
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:14
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:23
 #, elixir-autogen, elixir-format
 msgid "Reported as"
 msgstr ""
@@ -3232,7 +3227,7 @@ msgstr ""
 msgid "Reports"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:83
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
@@ -3275,7 +3270,7 @@ msgstr ""
 msgid "Spam or scam"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:73
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "Stand by it. It stays hidden until one of our admins has ruled."
 msgstr ""
@@ -3314,7 +3309,7 @@ msgstr ""
 msgid "Thank you for your report. We take it from here."
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:19
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "The content in question"
 msgstr ""
@@ -3351,7 +3346,7 @@ msgstr ""
 msgid "This account is suspended until %{date}."
 msgstr ""
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:83
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:86
 #, elixir-autogen, elixir-format
 msgid "This case is already settled."
 msgstr ""
@@ -3371,7 +3366,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:45
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:48
 #, elixir-autogen, elixir-format
 msgid "Understood. The content stays hidden until one of our admins has ruled."
 msgstr ""
@@ -3436,17 +3431,12 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:122
-#, elixir-autogen, elixir-format
-msgid "Your content was reported and is hidden while the report is handled."
-msgstr ""
-
 #: lib/vutuv_web/templates/report/new.html.heex:7
 #, elixir-autogen, elixir-format
 msgid "Your report is anonymous. If it checks out, the content is hidden right away and the owner is asked to fix it."
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:85
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:121
 #: lib/vutuv_web/templates/report/new.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "community guidelines"
@@ -3467,42 +3457,42 @@ msgstr ""
 msgid "yes"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1004
+#: lib/vutuv/notifications/emailer.ex:1026
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1088
+#: lib/vutuv/notifications/emailer.ex:1110
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1066
+#: lib/vutuv/notifications/emailer.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:978
+#: lib/vutuv/notifications/emailer.ex:1000
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:971
+#: lib/vutuv/notifications/emailer.ex:972
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:964
+#: lib/vutuv/notifications/emailer.ex:965
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1018
+#: lib/vutuv/notifications/emailer.ex:1040
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1011
+#: lib/vutuv/notifications/emailer.ex:1033
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr ""
@@ -5403,7 +5393,7 @@ msgstr ""
 msgid "View post"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:314
+#: lib/vutuv/notifications/emailer.ex:315
 #, elixir-autogen, elixir-format
 msgid "Someone tried to register with your email address"
 msgstr ""
@@ -5593,12 +5583,12 @@ msgstr ""
 msgid "e.g. Jr. or PhD"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:416
+#: lib/vutuv/notifications/emailer.ex:417
 #, elixir-autogen, elixir-format
 msgid "@%{slug} endorsed you on vutuv"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:402
+#: lib/vutuv/notifications/emailer.ex:403
 #, elixir-autogen, elixir-format
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
@@ -5840,7 +5830,7 @@ msgstr[1] ""
 msgid "All other devices have been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:718
+#: lib/vutuv/notifications/emailer.ex:719
 #, elixir-autogen, elixir-format
 msgid "Another session was already active on your account."
 msgstr ""
@@ -5865,7 +5855,7 @@ msgstr ""
 msgid "Log this device out of your account?"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:692
+#: lib/vutuv/notifications/emailer.ex:693
 #, elixir-autogen, elixir-format
 msgid "New sign-in to your vutuv account"
 msgstr ""
@@ -5880,7 +5870,7 @@ msgstr ""
 msgid "That device has been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:721
+#: lib/vutuv/notifications/emailer.ex:722
 #, elixir-autogen, elixir-format
 msgid "The location looks different from where you usually sign in."
 msgstr ""
@@ -5890,7 +5880,7 @@ msgstr ""
 msgid "This device"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:715
+#: lib/vutuv/notifications/emailer.ex:716
 #, elixir-autogen, elixir-format
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
@@ -12238,7 +12228,7 @@ msgstr ""
 
 #: lib/vutuv/accounts/user.ex:1275
 #: lib/vutuv/jobs/job_posting.ex:166
-#: lib/vutuv/notifications/emailer.ex:566
+#: lib/vutuv/notifications/emailer.ex:567
 #: lib/vutuv_web/agent_docs/markdown.ex:532
 #: lib/vutuv_web/agent_docs/markdown.ex:534
 #: lib/vutuv_web/agent_docs/text.ex:547
@@ -12373,12 +12363,12 @@ msgstr ""
 msgid "You already have the maximum number of published postings."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1034
+#: lib/vutuv/notifications/emailer.ex:1056
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:912
+#: lib/vutuv/notifications/emailer.ex:913
 #, elixir-autogen, elixir-format
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr ""
@@ -12398,12 +12388,12 @@ msgstr ""
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:909
+#: lib/vutuv/notifications/emailer.ex:910
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is about to lose its verification"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:955
+#: lib/vutuv/notifications/emailer.ex:956
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is no longer public"
 msgstr ""
@@ -12853,7 +12843,7 @@ msgstr ""
 msgid "—"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:515
+#: lib/vutuv/notifications/emailer.ex:516
 #, elixir-autogen, elixir-format
 msgid "%{count} new match for your saved searches"
 msgid_plural "%{count} new matches for your saved searches"
@@ -13925,7 +13915,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:996
+#: lib/vutuv/notifications/emailer.ex:1018
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
@@ -13940,7 +13930,7 @@ msgstr ""
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:246
+#: lib/vutuv_web/notification_line.ex:263
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -15469,7 +15459,7 @@ msgstr ""
 msgid "This confirmation expired. Please start again."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:296
+#: lib/vutuv/notifications/emailer.ex:297
 #, elixir-autogen, elixir-format
 msgid "Confirm your new username"
 msgstr ""
@@ -16392,21 +16382,21 @@ msgstr ""
 msgid "Show under each of your posts who out there liked or shared it, by their account address on their own server, linked to that account. Visible to everyone who sees the post. We keep nothing else about these people: no name, no picture, no text. Switching it off deletes what is stored for it."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:227
+#: lib/vutuv_web/notification_line.ex:244
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/notification_line.ex:235
+#: lib/vutuv_web/notification_line.ex:252
 #, elixir-autogen, elixir-format
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/notification_line.ex:219
+#: lib/vutuv_web/notification_line.ex:236
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -18565,7 +18555,7 @@ msgstr ""
 msgid "Your employment reference has been reviewed."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:479
+#: lib/vutuv/notifications/emailer.ex:480
 #, elixir-autogen, elixir-format
 msgid "Your reference “%{title}” has been reviewed"
 msgstr ""
@@ -18641,7 +18631,7 @@ msgstr ""
 msgid "Upload the PDF or the scan. We read the text out of it, and the review always reads that text, never the file itself."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:460
+#: lib/vutuv/notifications/emailer.ex:461
 #, elixir-autogen, elixir-format
 msgid "%{count} new notification on vutuv"
 msgid_plural "%{count} new notifications on vutuv"
@@ -19910,7 +19900,7 @@ msgstr ""
 msgid "Too many attempts for now. Try again later."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:352
+#: lib/vutuv/notifications/emailer.ex:353
 #, elixir-autogen, elixir-format
 msgid "New message from %{sender} on vutuv"
 msgstr ""
@@ -20273,7 +20263,7 @@ msgstr ""
 msgid "What is published there right now:"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:935
+#: lib/vutuv/notifications/emailer.ex:936
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is verified"
 msgstr ""
@@ -23347,7 +23337,7 @@ msgstr ""
 msgid "Turn on for my account"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:47
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:83
 #, elixir-autogen, elixir-format
 msgid "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."
 msgstr ""
@@ -23380,4 +23370,44 @@ msgstr ""
 #: lib/vutuv_web/templates/report/new.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "Which work is it, and where can the original be seen? (required)"
+msgstr ""
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:45
+#, elixir-autogen, elixir-format
+msgid "Copyright law. This complaint says the work is not yours to publish, which is a legal question rather than a house rule."
+msgstr ""
+
+#: lib/vutuv_web/notification_line.ex:203
+#, elixir-autogen, elixir-format
+msgid "Hidden automatically after a report: %{reason}. The case page says what you can do."
+msgstr ""
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:16
+#, elixir-autogen, elixir-format
+msgid "No person made this decision: a report from a member in good standing hides the reported content automatically, the moment it arrives."
+msgstr ""
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:67
+#, elixir-autogen, elixir-format
+msgid "Nobody else can see it right now. You have 72 hours to settle this yourself; after that our admins decide. Here is what you can do:"
+msgstr ""
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:48
+#, elixir-autogen, elixir-format
+msgid "Our community guidelines, which everything on vutuv has to keep to."
+msgstr ""
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:41
+#, elixir-autogen, elixir-format
+msgid "The ground"
+msgstr ""
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:28
+#, elixir-autogen, elixir-format
+msgid "What the report says"
+msgstr ""
+
+#: lib/vutuv_web/notification_line.ex:209
+#, elixir-autogen, elixir-format
+msgid "Your content was hidden automatically after a report. The case page says what you can do."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -170,7 +170,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:167
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:28
 #: lib/vutuv_web/templates/dev_app/show.html.heex:135
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:67
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:103
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:70
 #, elixir-autogen
 msgid "Delete"
@@ -222,7 +222,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:6
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:53
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:89
 #: lib/vutuv_web/templates/user/show.html.heex:1124
 #, elixir-autogen
 msgid "Edit"
@@ -1047,22 +1047,22 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:282
+#: lib/vutuv/notifications/emailer.ex:283
 #, elixir-autogen
 msgid "Confirm your account deletion"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:276
+#: lib/vutuv/notifications/emailer.ex:277
 #, elixir-autogen
 msgid "Confirm your email"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:264
+#: lib/vutuv/notifications/emailer.ex:265
 #, elixir-autogen
 msgid "Confirm your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:270
+#: lib/vutuv/notifications/emailer.ex:271
 #, elixir-autogen
 msgid "Login to vutuv"
 msgstr ""
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "tag name"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:322
+#: lib/vutuv/notifications/emailer.ex:323
 #, elixir-autogen
 msgid "vutuv Account verified"
 msgstr ""
@@ -2954,12 +2954,12 @@ msgstr ""
 msgid "Current version (edited since the report)"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:65
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Delete this content permanently?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:68
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:71
 #, elixir-autogen, elixir-format
 msgid "Deleted. The report is settled, no further steps needed."
 msgstr ""
@@ -2969,7 +2969,7 @@ msgstr ""
 msgid "Escalated"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:50
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Fix it. An edited post is visible again immediately."
 msgstr ""
@@ -3020,7 +3020,7 @@ msgstr ""
 msgid "Moderation queue"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:76
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "My content is fine"
 msgstr ""
@@ -3053,11 +3053,6 @@ msgstr ""
 #: lib/vutuv_web/templates/page/community.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "No unwanted advertising, fake profiles, fraud or link bait."
-msgstr ""
-
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:31
-#, elixir-autogen, elixir-format
-msgid "Nobody else can see it right now. You have 72 hours to settle this yourself; after that our admins decide. Three ways out:"
 msgstr ""
 
 #: lib/vutuv_web/views/report_html.ex:13
@@ -3145,7 +3140,7 @@ msgstr ""
 msgid "Rejected"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:59
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
@@ -3193,7 +3188,7 @@ msgid "Report upheld; the owner got a strike."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_live.ex:55
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:14
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:23
 #, elixir-autogen, elixir-format
 msgid "Reported as"
 msgstr ""
@@ -3230,7 +3225,7 @@ msgstr ""
 msgid "Reports"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:83
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
@@ -3273,7 +3268,7 @@ msgstr ""
 msgid "Spam or scam"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:73
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "Stand by it. It stays hidden until one of our admins has ruled."
 msgstr ""
@@ -3312,7 +3307,7 @@ msgstr ""
 msgid "Thank you for your report. We take it from here."
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:19
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "The content in question"
 msgstr ""
@@ -3349,7 +3344,7 @@ msgstr ""
 msgid "This account is suspended until %{date}."
 msgstr ""
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:83
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:86
 #, elixir-autogen, elixir-format
 msgid "This case is already settled."
 msgstr ""
@@ -3369,7 +3364,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:45
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:48
 #, elixir-autogen, elixir-format
 msgid "Understood. The content stays hidden until one of our admins has ruled."
 msgstr ""
@@ -3434,17 +3429,12 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:122
-#, elixir-autogen, elixir-format
-msgid "Your content was reported and is hidden while the report is handled."
-msgstr ""
-
 #: lib/vutuv_web/templates/report/new.html.heex:7
 #, elixir-autogen, elixir-format
 msgid "Your report is anonymous. If it checks out, the content is hidden right away and the owner is asked to fix it."
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:85
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:121
 #: lib/vutuv_web/templates/report/new.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "community guidelines"
@@ -3465,42 +3455,42 @@ msgstr ""
 msgid "yes"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1004
+#: lib/vutuv/notifications/emailer.ex:1026
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1088
+#: lib/vutuv/notifications/emailer.ex:1110
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1066
+#: lib/vutuv/notifications/emailer.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:978
+#: lib/vutuv/notifications/emailer.ex:1000
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:971
+#: lib/vutuv/notifications/emailer.ex:972
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:964
+#: lib/vutuv/notifications/emailer.ex:965
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1018
+#: lib/vutuv/notifications/emailer.ex:1040
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1011
+#: lib/vutuv/notifications/emailer.ex:1033
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr ""
@@ -5401,7 +5391,7 @@ msgstr ""
 msgid "View post"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:314
+#: lib/vutuv/notifications/emailer.ex:315
 #, elixir-autogen, elixir-format
 msgid "Someone tried to register with your email address"
 msgstr ""
@@ -5591,12 +5581,12 @@ msgstr ""
 msgid "e.g. Jr. or PhD"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:416
+#: lib/vutuv/notifications/emailer.ex:417
 #, elixir-autogen, elixir-format
 msgid "@%{slug} endorsed you on vutuv"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:402
+#: lib/vutuv/notifications/emailer.ex:403
 #, elixir-autogen, elixir-format
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
@@ -5838,7 +5828,7 @@ msgstr[1] ""
 msgid "All other devices have been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:718
+#: lib/vutuv/notifications/emailer.ex:719
 #, elixir-autogen, elixir-format
 msgid "Another session was already active on your account."
 msgstr ""
@@ -5863,7 +5853,7 @@ msgstr ""
 msgid "Log this device out of your account?"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:692
+#: lib/vutuv/notifications/emailer.ex:693
 #, elixir-autogen, elixir-format
 msgid "New sign-in to your vutuv account"
 msgstr ""
@@ -5878,7 +5868,7 @@ msgstr ""
 msgid "That device has been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:721
+#: lib/vutuv/notifications/emailer.ex:722
 #, elixir-autogen, elixir-format
 msgid "The location looks different from where you usually sign in."
 msgstr ""
@@ -5888,7 +5878,7 @@ msgstr ""
 msgid "This device"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:715
+#: lib/vutuv/notifications/emailer.ex:716
 #, elixir-autogen, elixir-format
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
@@ -12236,7 +12226,7 @@ msgstr ""
 
 #: lib/vutuv/accounts/user.ex:1275
 #: lib/vutuv/jobs/job_posting.ex:166
-#: lib/vutuv/notifications/emailer.ex:566
+#: lib/vutuv/notifications/emailer.ex:567
 #: lib/vutuv_web/agent_docs/markdown.ex:532
 #: lib/vutuv_web/agent_docs/markdown.ex:534
 #: lib/vutuv_web/agent_docs/text.ex:547
@@ -12371,12 +12361,12 @@ msgstr ""
 msgid "You already have the maximum number of published postings."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1034
+#: lib/vutuv/notifications/emailer.ex:1056
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:912
+#: lib/vutuv/notifications/emailer.ex:913
 #, elixir-autogen, elixir-format
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr ""
@@ -12396,12 +12386,12 @@ msgstr ""
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:909
+#: lib/vutuv/notifications/emailer.ex:910
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is about to lose its verification"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:955
+#: lib/vutuv/notifications/emailer.ex:956
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is no longer public"
 msgstr ""
@@ -12851,7 +12841,7 @@ msgstr ""
 msgid "—"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:515
+#: lib/vutuv/notifications/emailer.ex:516
 #, elixir-autogen, elixir-format
 msgid "%{count} new match for your saved searches"
 msgid_plural "%{count} new matches for your saved searches"
@@ -13923,7 +13913,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:996
+#: lib/vutuv/notifications/emailer.ex:1018
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
@@ -13938,7 +13928,7 @@ msgstr ""
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:246
+#: lib/vutuv_web/notification_line.ex:263
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -15467,7 +15457,7 @@ msgstr ""
 msgid "This confirmation expired. Please start again."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:296
+#: lib/vutuv/notifications/emailer.ex:297
 #, elixir-autogen, elixir-format
 msgid "Confirm your new username"
 msgstr ""
@@ -16390,21 +16380,21 @@ msgstr ""
 msgid "Show under each of your posts who out there liked or shared it, by their account address on their own server, linked to that account. Visible to everyone who sees the post. We keep nothing else about these people: no name, no picture, no text. Switching it off deletes what is stored for it."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:227
+#: lib/vutuv_web/notification_line.ex:244
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/notification_line.ex:235
+#: lib/vutuv_web/notification_line.ex:252
 #, elixir-autogen, elixir-format, fuzzy
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/notification_line.ex:219
+#: lib/vutuv_web/notification_line.ex:236
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -18563,7 +18553,7 @@ msgstr ""
 msgid "Your employment reference has been reviewed."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:479
+#: lib/vutuv/notifications/emailer.ex:480
 #, elixir-autogen, elixir-format
 msgid "Your reference “%{title}” has been reviewed"
 msgstr ""
@@ -18639,7 +18629,7 @@ msgstr ""
 msgid "Upload the PDF or the scan. We read the text out of it, and the review always reads that text, never the file itself."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:460
+#: lib/vutuv/notifications/emailer.ex:461
 #, elixir-autogen, elixir-format
 msgid "%{count} new notification on vutuv"
 msgid_plural "%{count} new notifications on vutuv"
@@ -19908,7 +19898,7 @@ msgstr ""
 msgid "Too many attempts for now. Try again later."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:352
+#: lib/vutuv/notifications/emailer.ex:353
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New message from %{sender} on vutuv"
 msgstr ""
@@ -20271,7 +20261,7 @@ msgstr ""
 msgid "What is published there right now:"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:935
+#: lib/vutuv/notifications/emailer.ex:936
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is verified"
 msgstr ""
@@ -23345,7 +23335,7 @@ msgstr ""
 msgid "Turn on for my account"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:47
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:83
 #, elixir-autogen, elixir-format
 msgid "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."
 msgstr ""
@@ -23378,4 +23368,44 @@ msgstr ""
 #: lib/vutuv_web/templates/report/new.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "Which work is it, and where can the original be seen? (required)"
+msgstr ""
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:45
+#, elixir-autogen, elixir-format
+msgid "Copyright law. This complaint says the work is not yours to publish, which is a legal question rather than a house rule."
+msgstr ""
+
+#: lib/vutuv_web/notification_line.ex:203
+#, elixir-autogen, elixir-format
+msgid "Hidden automatically after a report: %{reason}. The case page says what you can do."
+msgstr ""
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:16
+#, elixir-autogen, elixir-format
+msgid "No person made this decision: a report from a member in good standing hides the reported content automatically, the moment it arrives."
+msgstr ""
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:67
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Nobody else can see it right now. You have 72 hours to settle this yourself; after that our admins decide. Here is what you can do:"
+msgstr ""
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:48
+#, elixir-autogen, elixir-format
+msgid "Our community guidelines, which everything on vutuv has to keep to."
+msgstr ""
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:41
+#, elixir-autogen, elixir-format, fuzzy
+msgid "The ground"
+msgstr ""
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:28
+#, elixir-autogen, elixir-format
+msgid "What the report says"
+msgstr ""
+
+#: lib/vutuv_web/notification_line.ex:209
+#, elixir-autogen, elixir-format
+msgid "Your content was hidden automatically after a report. The case page says what you can do."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -23386,7 +23386,7 @@ msgid "No person made this decision: a report from a member in good standing hid
 msgstr ""
 
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:67
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Nobody else can see it right now. You have 72 hours to settle this yourself; after that our admins decide. Here is what you can do:"
 msgstr ""
 
@@ -23396,7 +23396,7 @@ msgid "Our community guidelines, which everything on vutuv has to keep to."
 msgstr ""
 
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:41
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "The ground"
 msgstr ""
 

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -172,7 +172,7 @@ msgstr "Non è stato possibile ricambiare il follow a %{name}."
 #: lib/vutuv_web/live/admin/user_delete_live.ex:167
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:28
 #: lib/vutuv_web/templates/dev_app/show.html.heex:135
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:67
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:103
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:70
 #, elixir-autogen
 msgid "Delete"
@@ -224,7 +224,7 @@ msgstr "Scarica"
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:6
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:53
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:89
 #: lib/vutuv_web/templates/user/show.html.heex:1124
 #, elixir-autogen
 msgid "Edit"
@@ -1069,22 +1069,22 @@ msgstr "Informazioni generali"
 msgid "Verify"
 msgstr "Verifica"
 
-#: lib/vutuv/notifications/emailer.ex:282
+#: lib/vutuv/notifications/emailer.ex:283
 #, elixir-autogen
 msgid "Confirm your account deletion"
 msgstr "Confermi l'eliminazione del Suo account"
 
-#: lib/vutuv/notifications/emailer.ex:276
+#: lib/vutuv/notifications/emailer.ex:277
 #, elixir-autogen
 msgid "Confirm your email"
 msgstr "Confermi il Suo indirizzo e-mail"
 
-#: lib/vutuv/notifications/emailer.ex:264
+#: lib/vutuv/notifications/emailer.ex:265
 #, elixir-autogen
 msgid "Confirm your vutuv account"
 msgstr "Confermi il Suo account vutuv"
 
-#: lib/vutuv/notifications/emailer.ex:270
+#: lib/vutuv/notifications/emailer.ex:271
 #, elixir-autogen
 msgid "Login to vutuv"
 msgstr "Accedi a vutuv"
@@ -1556,7 +1556,7 @@ msgstr "Vedi tag correlati"
 msgid "tag name"
 msgstr "nome del tag"
 
-#: lib/vutuv/notifications/emailer.ex:322
+#: lib/vutuv/notifications/emailer.ex:323
 #, elixir-autogen
 msgid "vutuv Account verified"
 msgstr "Account vutuv verificato"
@@ -3019,12 +3019,12 @@ msgstr ""
 msgid "Current version (edited since the report)"
 msgstr "Versione attuale (modificata dopo la segnalazione)"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:65
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Delete this content permanently?"
 msgstr "Eliminare definitivamente questo contenuto?"
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:68
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:71
 #, elixir-autogen, elixir-format
 msgid "Deleted. The report is settled, no further steps needed."
 msgstr "Eliminato. La segnalazione è chiusa, non serve altro."
@@ -3034,7 +3034,7 @@ msgstr "Eliminato. La segnalazione è chiusa, non serve altro."
 msgid "Escalated"
 msgstr "Inoltrato"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:50
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Fix it. An edited post is visible again immediately."
 msgstr "Lo corregga. Un post modificato torna subito visibile."
@@ -3087,7 +3087,7 @@ msgstr "Caso di moderazione"
 msgid "Moderation queue"
 msgstr "Coda di moderazione"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:76
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "My content is fine"
 msgstr "Il mio contenuto è a posto"
@@ -3126,13 +3126,6 @@ msgstr "Niente spam né truffe"
 msgid "No unwanted advertising, fake profiles, fraud or link bait."
 msgstr ""
 "Niente pubblicità indesiderata, profili falsi, frodi o link acchiappaclic."
-
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:31
-#, elixir-autogen, elixir-format
-msgid "Nobody else can see it right now. You have 72 hours to settle this yourself; after that our admins decide. Three ways out:"
-msgstr ""
-"Al momento nessun altro può vederlo. Ha 72 ore per risolvere da solo; poi "
-"decidono i nostri amministratori. Tre vie d'uscita:"
 
 #: lib/vutuv_web/views/report_html.ex:13
 #, elixir-autogen, elixir-format
@@ -3222,7 +3215,7 @@ msgstr "Respingi la segnalazione"
 msgid "Rejected"
 msgstr "Respinta"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:59
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Lo rimuova. La segnalazione si chiude, senza altre domande."
@@ -3270,7 +3263,7 @@ msgid "Report upheld; the owner got a strike."
 msgstr "Segnalazione accolta; il proprietario ha ricevuto un richiamo."
 
 #: lib/vutuv_web/live/admin/moderation_live.ex:55
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:14
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:23
 #, elixir-autogen, elixir-format
 msgid "Reported as"
 msgstr "Segnalato come"
@@ -3309,7 +3302,7 @@ msgstr "Storico dei segnalanti"
 msgid "Reports"
 msgstr "Segnalazioni"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:83
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
@@ -3358,7 +3351,7 @@ msgstr "Altro"
 msgid "Spam or scam"
 msgstr "Spam o truffa"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:73
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "Stand by it. It stays hidden until one of our admins has ruled."
 msgstr ""
@@ -3399,7 +3392,7 @@ msgstr "Ci dica di più nella nota qui sotto."
 msgid "Thank you for your report. We take it from here."
 msgstr "Grazie per la segnalazione. Ce ne occupiamo noi."
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:19
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "The content in question"
 msgstr "Il contenuto in questione"
@@ -3443,7 +3436,7 @@ msgstr "Questo account è stato disattivato."
 msgid "This account is suspended until %{date}."
 msgstr "Questo account è sospeso fino al %{date}."
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:83
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:86
 #, elixir-autogen, elixir-format
 msgid "This case is already settled."
 msgstr "Questo caso è già chiuso."
@@ -3463,7 +3456,7 @@ msgstr "Affidabile"
 msgid "Type"
 msgstr "Tipo"
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:45
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:48
 #, elixir-autogen, elixir-format
 msgid "Understood. The content stays hidden until one of our admins has ruled."
 msgstr ""
@@ -3533,13 +3526,6 @@ msgstr "Ha corretto un contenuto segnalato; il caso è chiuso."
 msgid "Your content was reported"
 msgstr "Un Suo contenuto è stato segnalato"
 
-#: lib/vutuv_web/notification_line.ex:122
-#, elixir-autogen, elixir-format
-msgid "Your content was reported and is hidden while the report is handled."
-msgstr ""
-"Un Suo contenuto è stato segnalato ed è nascosto finché la segnalazione è in"
-" corso."
-
 #: lib/vutuv_web/templates/report/new.html.heex:7
 #, elixir-autogen, elixir-format
 msgid "Your report is anonymous. If it checks out, the content is hidden right away and the owner is asked to fix it."
@@ -3547,7 +3533,7 @@ msgstr ""
 "La Sua segnalazione è anonima. Se risulta fondata, il contenuto viene "
 "nascosto subito e al proprietario viene chiesto di correggerlo."
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:85
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:121
 #: lib/vutuv_web/templates/report/new.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "community guidelines"
@@ -3571,42 +3557,42 @@ msgstr ""
 msgid "yes"
 msgstr "sì"
 
-#: lib/vutuv/notifications/emailer.ex:1004
+#: lib/vutuv/notifications/emailer.ex:1026
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr "Un avvertimento per il Suo account vutuv"
 
-#: lib/vutuv/notifications/emailer.ex:1088
+#: lib/vutuv/notifications/emailer.ex:1110
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr "Moderazione: %{count} casi in attesa"
 
-#: lib/vutuv/notifications/emailer.ex:1066
+#: lib/vutuv/notifications/emailer.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr "Moderazione: un profilo è stato segnalato"
 
-#: lib/vutuv/notifications/emailer.ex:978
+#: lib/vutuv/notifications/emailer.ex:1000
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr "Il contenuto che ha segnalato è stato corretto"
 
-#: lib/vutuv/notifications/emailer.ex:971
+#: lib/vutuv/notifications/emailer.ex:972
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr "Un Suo contenuto su vutuv è in esame"
 
-#: lib/vutuv/notifications/emailer.ex:964
+#: lib/vutuv/notifications/emailer.ex:965
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr "Un Suo contenuto su vutuv è stato segnalato ed è nascosto"
 
-#: lib/vutuv/notifications/emailer.ex:1018
+#: lib/vutuv/notifications/emailer.ex:1040
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr "Il Suo account vutuv è stato disattivato"
 
-#: lib/vutuv/notifications/emailer.ex:1011
+#: lib/vutuv/notifications/emailer.ex:1033
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr "Il Suo account vutuv è sospeso"
@@ -5618,7 +5604,7 @@ msgstr "Navigazione a piè di pagina"
 msgid "View post"
 msgstr "Vedi il post"
 
-#: lib/vutuv/notifications/emailer.ex:314
+#: lib/vutuv/notifications/emailer.ex:315
 #, elixir-autogen, elixir-format
 msgid "Someone tried to register with your email address"
 msgstr "Qualcuno ha provato a registrarsi con il Suo indirizzo e-mail"
@@ -5810,12 +5796,12 @@ msgstr "ad esempio Dott. o Prof."
 msgid "e.g. Jr. or PhD"
 msgstr "ad esempio Jr. o PhD"
 
-#: lib/vutuv/notifications/emailer.ex:416
+#: lib/vutuv/notifications/emailer.ex:417
 #, elixir-autogen, elixir-format
 msgid "@%{slug} endorsed you on vutuv"
 msgstr "@%{slug} L'ha confermata su vutuv"
 
-#: lib/vutuv/notifications/emailer.ex:402
+#: lib/vutuv/notifications/emailer.ex:403
 #, elixir-autogen, elixir-format
 msgid "@%{slug} started following you on vutuv"
 msgstr "@%{slug} ha iniziato a seguirla su vutuv"
@@ -6060,7 +6046,7 @@ msgstr[1] "%{count} minuti fa"
 msgid "All other devices have been logged out."
 msgstr "Tutti gli altri dispositivi sono stati disconnessi."
 
-#: lib/vutuv/notifications/emailer.ex:718
+#: lib/vutuv/notifications/emailer.ex:719
 #, elixir-autogen, elixir-format
 msgid "Another session was already active on your account."
 msgstr "Sul Suo account era già attiva un'altra sessione."
@@ -6085,7 +6071,7 @@ msgstr "Disconnettere ogni dispositivo tranne questo?"
 msgid "Log this device out of your account?"
 msgstr "Disconnettere questo dispositivo dal Suo account?"
 
-#: lib/vutuv/notifications/emailer.ex:692
+#: lib/vutuv/notifications/emailer.ex:693
 #, elixir-autogen, elixir-format
 msgid "New sign-in to your vutuv account"
 msgstr "Nuovo accesso al Suo account vutuv"
@@ -6100,7 +6086,7 @@ msgstr "Dispositivi connessi"
 msgid "That device has been logged out."
 msgstr "Quel dispositivo è stato disconnesso."
 
-#: lib/vutuv/notifications/emailer.ex:721
+#: lib/vutuv/notifications/emailer.ex:722
 #, elixir-autogen, elixir-format
 msgid "The location looks different from where you usually sign in."
 msgstr "La posizione è diversa da quella da cui accede di solito."
@@ -6110,7 +6096,7 @@ msgstr "La posizione è diversa da quella da cui accede di solito."
 msgid "This device"
 msgstr "Questo dispositivo"
 
-#: lib/vutuv/notifications/emailer.ex:715
+#: lib/vutuv/notifications/emailer.ex:716
 #, elixir-autogen, elixir-format
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr "È il primo accesso che vediamo da questo dispositivo o browser."
@@ -12868,7 +12854,7 @@ msgstr "Pubblica"
 
 #: lib/vutuv/accounts/user.ex:1275
 #: lib/vutuv/jobs/job_posting.ex:166
-#: lib/vutuv/notifications/emailer.ex:566
+#: lib/vutuv/notifications/emailer.ex:567
 #: lib/vutuv_web/agent_docs/markdown.ex:532
 #: lib/vutuv_web/agent_docs/markdown.ex:534
 #: lib/vutuv_web/agent_docs/text.ex:547
@@ -13008,12 +12994,12 @@ msgstr "Modalità di lavoro"
 msgid "You already have the maximum number of published postings."
 msgstr "Ha già raggiunto il numero massimo di annunci pubblicati."
 
-#: lib/vutuv/notifications/emailer.ex:1034
+#: lib/vutuv/notifications/emailer.ex:1056
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr "Il Suo annuncio di lavoro su vutuv scade a breve"
 
-#: lib/vutuv/notifications/emailer.ex:912
+#: lib/vutuv/notifications/emailer.ex:913
 #, elixir-autogen, elixir-format
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr ""
@@ -13038,12 +13024,12 @@ msgstr ""
 "dominio. La ripristini e controlli di nuovo, altrimenti il dominio perde la "
 "verifica."
 
-#: lib/vutuv/notifications/emailer.ex:909
+#: lib/vutuv/notifications/emailer.ex:910
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is about to lose its verification"
 msgstr "La Sua pagina di organizzazione su vutuv sta per perdere la verifica"
 
-#: lib/vutuv/notifications/emailer.ex:955
+#: lib/vutuv/notifications/emailer.ex:956
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is no longer public"
 msgstr "La Sua pagina di organizzazione su vutuv non è più pubblica"
@@ -13526,7 +13512,7 @@ msgstr "pagina di organizzazione verificata"
 msgid "—"
 msgstr "—"
 
-#: lib/vutuv/notifications/emailer.ex:515
+#: lib/vutuv/notifications/emailer.ex:516
 #, elixir-autogen, elixir-format
 msgid "%{count} new match for your saved searches"
 msgid_plural "%{count} new matches for your saved searches"
@@ -14680,7 +14666,7 @@ msgstr "Modalità di lavoro preferita"
 msgid "Availability"
 msgstr "Disponibilità"
 
-#: lib/vutuv/notifications/emailer.ex:996
+#: lib/vutuv/notifications/emailer.ex:1018
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Un controllo automatico ha rimosso un'immagine dal Suo account vutuv"
@@ -14698,7 +14684,7 @@ msgstr ""
 msgid "Thread reply"
 msgstr "Risposta in una discussione"
 
-#: lib/vutuv_web/notification_line.ex:246
+#: lib/vutuv_web/notification_line.ex:263
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -16382,7 +16368,7 @@ msgstr "Confermi la modifica prima che rinominiamo il Suo account."
 msgid "This confirmation expired. Please start again."
 msgstr "Questa conferma è scaduta. Ricominci da capo."
 
-#: lib/vutuv/notifications/emailer.ex:296
+#: lib/vutuv/notifications/emailer.ex:297
 #, elixir-autogen, elixir-format
 msgid "Confirm your new username"
 msgstr "Confermi il Suo nuovo nome utente"
@@ -17369,21 +17355,21 @@ msgstr ""
 "conserviamo altro: nessun nome, nessuna immagine, nessun testo. Disattivando"
 " l'opzione, ciò che è stato memorizzato viene eliminato."
 
-#: lib/vutuv_web/notification_line.ex:227
+#: lib/vutuv_web/notification_line.ex:244
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] "ha messo Mi piace al Suo post su un'altra rete."
 msgstr[1] "ha messo Mi piace al Suo post su un'altra rete."
 
-#: lib/vutuv_web/notification_line.ex:235
+#: lib/vutuv_web/notification_line.ex:252
 #, elixir-autogen, elixir-format
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] "ha reagito al Suo post da un'altra rete."
 msgstr[1] "ha reagito al Suo post da un'altra rete."
 
-#: lib/vutuv_web/notification_line.ex:219
+#: lib/vutuv_web/notification_line.ex:236
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -19815,7 +19801,7 @@ msgstr ""
 msgid "Your employment reference has been reviewed."
 msgstr "Il Suo attestato di lavoro è stato analizzato."
 
-#: lib/vutuv/notifications/emailer.ex:479
+#: lib/vutuv/notifications/emailer.ex:480
 #, elixir-autogen, elixir-format
 msgid "Your reference “%{title}” has been reviewed"
 msgstr "Il Suo attestato “%{title}” è stato analizzato"
@@ -19906,7 +19892,7 @@ msgstr ""
 "Carichi il PDF o la scansione. Ne estraiamo il testo, e l'analisi legge "
 "sempre quel testo, mai il file stesso."
 
-#: lib/vutuv/notifications/emailer.ex:460
+#: lib/vutuv/notifications/emailer.ex:461
 #, elixir-autogen, elixir-format
 msgid "%{count} new notification on vutuv"
 msgid_plural "%{count} new notifications on vutuv"
@@ -21313,7 +21299,7 @@ msgstr "Questa pagina non segue ancora nessuno su un'altra rete."
 msgid "Too many attempts for now. Try again later."
 msgstr "Per ora troppi tentativi. Riprovi più tardi."
 
-#: lib/vutuv/notifications/emailer.ex:352
+#: lib/vutuv/notifications/emailer.ex:353
 #, elixir-autogen, elixir-format
 msgid "New message from %{sender} on vutuv"
 msgstr "Nuovo messaggio da %{sender} su vutuv"
@@ -21731,7 +21717,7 @@ msgstr "Abbiamo scaricato questo indirizzo:"
 msgid "What is published there right now:"
 msgstr "Cosa è pubblicato lì in questo momento:"
 
-#: lib/vutuv/notifications/emailer.ex:935
+#: lib/vutuv/notifications/emailer.ex:936
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is verified"
 msgstr "La Sua pagina di organizzazione su vutuv è verificata"
@@ -24938,7 +24924,7 @@ msgstr "Attivalo per il tuo account e potrai collegare %{app} direttamente da qu
 msgid "Turn on for my account"
 msgstr "Attiva per il mio account"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:47
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:83
 #, elixir-autogen, elixir-format
 msgid "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."
 msgstr "Correggilo. Uno dei nostri amministratori esaminerà poi la modifica; fino ad allora il contributo resta nascosto."
@@ -24972,3 +24958,43 @@ msgstr "Usa un testo, una foto o un video senza il permesso del titolare dei dir
 #, elixir-autogen, elixir-format
 msgid "Which work is it, and where can the original be seen? (required)"
 msgstr "Di quale opera si tratta e dove si può vedere l'originale? (obbligatorio)"
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:45
+#, elixir-autogen, elixir-format
+msgid "Copyright law. This complaint says the work is not yours to publish, which is a legal question rather than a house rule."
+msgstr "Il diritto d'autore. Questa contestazione sostiene che l'opera non è Sua da pubblicare, e questa è una questione giuridica, non una regola della casa."
+
+#: lib/vutuv_web/notification_line.ex:203
+#, elixir-autogen, elixir-format
+msgid "Hidden automatically after a report: %{reason}. The case page says what you can do."
+msgstr "Nascosto automaticamente dopo una segnalazione: %{reason}. Nella pagina del caso trova cosa può fare."
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:16
+#, elixir-autogen, elixir-format
+msgid "No person made this decision: a report from a member in good standing hides the reported content automatically, the moment it arrives."
+msgstr "Questa decisione non l'ha presa nessuna persona: la segnalazione di un membro affidabile nasconde il contenuto segnalato automaticamente, nel momento in cui arriva."
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:67
+#, elixir-autogen, elixir-format
+msgid "Nobody else can see it right now. You have 72 hours to settle this yourself; after that our admins decide. Here is what you can do:"
+msgstr "Nessun altro può vederlo in questo momento. Ha 72 ore per risolvere da solo; dopo decidono i nostri amministratori. Ecco cosa può fare:"
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:48
+#, elixir-autogen, elixir-format
+msgid "Our community guidelines, which everything on vutuv has to keep to."
+msgstr "Le nostre regole della comunità, a cui tutto su vutuv deve attenersi."
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:41
+#, elixir-autogen, elixir-format
+msgid "The ground"
+msgstr "Il fondamento"
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:28
+#, elixir-autogen, elixir-format
+msgid "What the report says"
+msgstr "Cosa dice la segnalazione"
+
+#: lib/vutuv_web/notification_line.ex:209
+#, elixir-autogen, elixir-format
+msgid "Your content was hidden automatically after a report. The case page says what you can do."
+msgstr "Il Suo contenuto è stato nascosto automaticamente dopo una segnalazione. Nella pagina del caso trova cosa può fare."

--- a/test/vutuv/moderation_statement_of_reasons_test.exs
+++ b/test/vutuv/moderation_statement_of_reasons_test.exs
@@ -12,11 +12,33 @@ defmodule Vutuv.ModerationStatementOfReasonsTest do
 
   use Vutuv.DataCase, async: false
 
+  import Phoenix.LiveViewTest, only: [render_component: 2]
+
   alias Vutuv.Moderation
+  alias Vutuv.Notifications.Emailer
+  alias VutuvWeb.EmailComponents
   alias VutuvWeb.NotificationDigestText, as: DigestText
   alias VutuvWeb.NotificationLine
+  alias VutuvWeb.UserHelpers
 
   @note "The photo is mine. The original is at example.com/hafen.jpg, shot 2019."
+
+  # Every character a line-breaking renderer treats as a mandatory break. Named
+  # here rather than inline so the two quoting halves are held to the same set.
+  @line_breaks [
+    {"LF", "\n"},
+    {"CR", "\r"},
+    {"CRLF", "\r\n"},
+    {"VT", <<0x0B>>},
+    {"FF", <<0x0C>>},
+    {"NEL", <<0xC2, 0x85>>},
+    {"LS", <<0xE2, 0x80, 0xA8>>},
+    {"PS", <<0xE2, 0x80, 0xA9>>}
+  ]
+
+  # U+2028 LINE SEPARATOR: invisible in a report form, a mandatory break in
+  # Gmail, Apple Mail and Thunderbird.
+  @line_separator <<0xE2, 0x80, 0xA8>>
 
   setup do
     owner = insert(:activated_user)
@@ -154,6 +176,29 @@ defmodule Vutuv.ModerationStatementOfReasonsTest do
       refute email.html_body =~ "<a href=\"http://evil.example/login\""
     end
 
+    test "a break the mail client honours cannot smuggle an unquoted line", %{
+      owner: owner,
+      reporter: reporter
+    } do
+      post = insert(:post, user: owner)
+
+      # Nothing strips control characters from a note on the way in
+      # (`Report.changeset/3` trims and length-caps, no more), so the quoter is
+      # the only thing standing between a member in good standing and a forged
+      # vutuv signature inside a DKIM-signed vutuv mail — on a site where
+      # signing in means clicking a mailed PIN.
+      crafted =
+        "The photo is mine." <>
+          @line_separator <> "Regards, the vutuv team. Sign in: http://evil.example/login"
+
+      report!(reporter, post, %{"category" => "spam", "note" => crafted})
+
+      email = owner_email("reported")
+
+      assert email.text_body =~ "> Regards, the vutuv team."
+      refute email.text_body =~ @line_separator
+    end
+
     test "an ordinary case still promises the edit brings the post back", %{
       owner: owner,
       reporter: reporter
@@ -200,6 +245,43 @@ defmodule Vutuv.ModerationStatementOfReasonsTest do
       assert squish(email.text_body) =~ "Leave me alone."
       refute squish(email.text_body) =~ "Edit the content"
       assert squish(email.text_body) =~ "Delete it"
+    end
+  end
+
+  describe "quoting a stranger's text" do
+    test "every mandatory line break starts a fresh quoted line" do
+      for {name, break} <- @line_breaks do
+        quoted = UserHelpers.email_quoted_text("before" <> break <> "after")
+
+        assert quoted == "> before\n> after",
+               "#{name} did not start a new quoted line; got #{inspect(quoted)}"
+      end
+    end
+
+    test "a character that only looks like whitespace does not break the line" do
+      # U+00A0 NO-BREAK SPACE is the near miss: a renderer keeps it on the line,
+      # so splitting on it would put a "> " where the reader sees none.
+      assert UserHelpers.email_quoted_text("before" <> <<0xC2, 0xA0>> <> "after") ==
+               "> before" <> <<0xC2, 0xA0>> <> "after"
+    end
+
+    test "a blank line keeps the bare marker" do
+      assert UserHelpers.email_quoted_text("one\n\ntwo") == "> one\n>\n> two"
+    end
+
+    test "the HTML half breaks on the same set" do
+      for {name, break} <- @line_breaks do
+        html =
+          render_component(&EmailComponents.email_quote/1, text: "before" <> break <> "after")
+
+        # What follows "before" must be our own break, not the stranger's
+        # character: the template's own markup carries newlines, so asking
+        # whether the break survived anywhere in the output proves nothing.
+        [_head, tail] = String.split(html, "before", parts: 2)
+
+        assert String.starts_with?(tail, "<br"),
+               "#{name} did not become a line break in the HTML quote; got #{inspect(String.slice(tail, 0, 20))}"
+      end
     end
   end
 
@@ -269,6 +351,19 @@ defmodule Vutuv.ModerationStatementOfReasonsTest do
       item = %{kind: "moderation", category: "spam", case_id: "x"}
 
       assert DigestText.line(item) == NotificationLine.notification_text(item)
+    end
+
+    test "and its subject is cut to a subject's length" do
+      # Naming the category made this line long enough to be a bad subject:
+      # a digest of exactly one notification uses the line itself.
+      user = insert(:activated_user, locale: "de")
+      item = %{kind: "moderation", category: "copyright", case_id: "x"}
+
+      email = Emailer.notification_digest_email("owner@example.com", user, [item], 0)
+
+      assert String.length(email.subject) <= 80
+      refute String.ends_with?(email.subject, " ")
+      assert email.subject =~ "Nach einer Meldung automatisch verborgen"
     end
   end
 end

--- a/test/vutuv/moderation_statement_of_reasons_test.exs
+++ b/test/vutuv/moderation_statement_of_reasons_test.exs
@@ -1,0 +1,274 @@
+defmodule Vutuv.ModerationStatementOfReasonsTest do
+  @moduledoc """
+  What a member is told when a report hides their content (issue #2010): the
+  category, the reporter's explanation in their own words, that no person
+  decided it, the ground it rests on, and the options that are really open —
+  with the deadline where there is one.
+
+  The three surfaces (the in-app line, the email, the case page) read the same
+  facts from `Moderation.owner_notice/1`, so these tests assert on the email
+  and on the notice map; the case page has its own controller test.
+  """
+
+  use Vutuv.DataCase, async: false
+
+  alias Vutuv.Moderation
+  alias VutuvWeb.NotificationDigestText, as: DigestText
+  alias VutuvWeb.NotificationLine
+
+  @note "The photo is mine. The original is at example.com/hafen.jpg, shot 2019."
+
+  setup do
+    owner = insert(:activated_user)
+    insert(:email, user: owner, value: "owner@example.com")
+    reporter = insert(:activated_user, first_name: "Cordula", last_name: "Melder")
+    insert(:email, user: reporter, value: "cordula@example.com")
+    {:ok, %{owner: owner, reporter: reporter}}
+  end
+
+  defp copyright_notice(attrs \\ %{}) do
+    Map.merge(
+      %{"category" => "copyright", "note" => @note, "good_faith?" => "true"},
+      attrs
+    )
+  end
+
+  # The one email the owner was sent, by subject fragment.
+  defp owner_email(fragment) do
+    Enum.find(flush_emails(), &(&1.subject =~ fragment)) ||
+      flunk("no owner email with #{inspect(fragment)} in the subject")
+  end
+
+  defp report!(reporter, content, attrs) do
+    {:ok, case_record} = Moderation.report_content(reporter, content, attrs)
+    case_record
+  end
+
+  # Both bodies hard-wrap (the text templates at ~72 columns, the HEEx ones
+  # wherever the formatter put them), so a sentence is asserted against the
+  # collapsed text rather than against one rendered line.
+  defp squish(body), do: body |> String.replace(~r/\s+/, " ") |> String.trim()
+
+  defp bodies(email), do: [squish(email.text_body), squish(email.html_body)]
+
+  describe "owner_notice/1" do
+    test "carries the categories and the notes, never the reporter", %{
+      owner: owner,
+      reporter: reporter
+    } do
+      post = insert(:post, user: owner)
+      case_record = report!(reporter, post, copyright_notice())
+
+      notice = Moderation.owner_notice(case_record)
+
+      assert notice.categories == ["copyright"]
+      assert notice.notes == [@note]
+      assert notice.copyright?
+      refute Map.has_key?(notice, :reporter)
+    end
+
+    test "drops an empty note instead of quoting a blank line", %{
+      owner: owner,
+      reporter: reporter
+    } do
+      post = insert(:post, user: owner)
+      case_record = report!(reporter, post, %{"category" => "spam"})
+
+      assert Moderation.owner_notice(case_record).notes == []
+      refute Moderation.owner_notice(case_record).copyright?
+    end
+  end
+
+  describe "owner_edit_offer/1,2" do
+    test "a post is editable, a message is not", %{owner: owner, reporter: reporter} do
+      post = insert(:post, user: owner)
+      post_case = report!(reporter, post, %{"category" => "spam"})
+
+      conversation = insert_conversation_between(owner, reporter)
+      message = insert(:message, conversation: conversation, sender: owner)
+      message_case = report!(reporter, message, %{"category" => "bullying"})
+
+      assert Moderation.owner_edit_offer(post_case, Moderation.case_content(post_case)) ==
+               :immediate
+
+      assert Moderation.owner_edit_offer(message_case) == :none
+    end
+
+    test "a copyright case is edited under review, not straight back", %{
+      owner: owner,
+      reporter: reporter
+    } do
+      post = insert(:post, user: owner)
+      case_record = report!(reporter, post, copyright_notice())
+
+      assert Moderation.owner_edit_offer(case_record) == :reviewed
+    end
+  end
+
+  describe "the frozen email" do
+    test "names the category, quotes the report and says nobody decided it", %{
+      owner: owner,
+      reporter: reporter
+    } do
+      post = insert(:post, user: owner)
+      report!(reporter, post, %{"category" => "bullying", "note" => "This targets my colleague."})
+
+      email = owner_email("reported")
+
+      for body <- bodies(email) do
+        assert body =~ "Bullying or harassment"
+        assert body =~ "This targets my colleague."
+        assert body =~ "hides the reported content automatically"
+        assert body =~ "72 hours"
+        assert body =~ "community"
+      end
+
+      # The reporter is never named, on either half.
+      for body <- [email.text_body, email.html_body] do
+        refute body =~ "Cordula"
+        refute body =~ "Melder"
+        refute body =~ "cordula@example.com"
+        refute body =~ reporter.username
+      end
+    end
+
+    test "quotes the reporter's text so it cannot pose as our own lines", %{
+      owner: owner,
+      reporter: reporter
+    } do
+      post = insert(:post, user: owner)
+
+      crafted = "Regards\nThe vutuv team\nConfirm at http://evil.example/login"
+      report!(reporter, post, %{"category" => "spam", "note" => crafted})
+
+      email = owner_email("reported")
+
+      # Every line of a stranger's text is prefixed, so a crafted signature
+      # cannot read as ours.
+      assert email.text_body =~ "> Regards"
+      assert email.text_body =~ "> The vutuv team"
+      assert email.text_body =~ "> Confirm at http://evil.example/login"
+      refute email.text_body =~ "\nThe vutuv team\nConfirm"
+
+      # And the HTML half escapes rather than linking it.
+      refute email.html_body =~ "<a href=\"http://evil.example/login\""
+    end
+
+    test "an ordinary case still promises the edit brings the post back", %{
+      owner: owner,
+      reporter: reporter
+    } do
+      post = insert(:post, user: owner)
+      report!(reporter, post, %{"category" => "spam"})
+
+      email = owner_email("reported")
+
+      assert squish(email.text_body) =~ "visible again right away"
+      assert squish(email.text_body) =~ "our community guidelines"
+    end
+
+    test "a copyright case names the law and drops the edit promise", %{
+      owner: owner,
+      reporter: reporter
+    } do
+      post = insert(:post, user: owner)
+      report!(reporter, post, copyright_notice())
+
+      email = owner_email("reported")
+
+      # The apostrophe in the category label is an entity in the HTML half, so
+      # the shared fragment stops before it.
+      for body <- bodies(email) do
+        assert body =~ "Uses a text, photo or video without the rights"
+        assert body =~ @note
+        assert body =~ "Copyright law decides"
+        refute body =~ "visible again right away"
+        assert body =~ "stays hidden until they have"
+      end
+    end
+
+    test "a reported message is not offered an edit it does not have", %{
+      owner: owner,
+      reporter: reporter
+    } do
+      conversation = insert_conversation_between(owner, reporter)
+      message = insert(:message, conversation: conversation, sender: owner)
+      report!(reporter, message, %{"category" => "bullying", "note" => "Leave me alone."})
+
+      email = owner_email("reported")
+
+      assert squish(email.text_body) =~ "Leave me alone."
+      refute squish(email.text_body) =~ "Edit the content"
+      assert squish(email.text_body) =~ "Delete it"
+    end
+  end
+
+  describe "the under-review email" do
+    test "carries the reasons but promises no self-service round", %{
+      owner: owner,
+      reporter: reporter
+    } do
+      post = insert(:post, user: owner)
+      first = report!(reporter, post, %{"category" => "spam", "note" => "Sold me a fake watch."})
+      # The owner already used their one self-service round on this content, so
+      # a fresh report freezes it and goes straight to the admins.
+      Moderation.content_edited(Repo.get!(Vutuv.Posts.Post, post.id))
+      assert Repo.get!(Moderation.Case, first.id).status == "resolved_edited"
+      _ = flush_emails()
+
+      other = insert(:activated_user)
+      insert(:email, user: other)
+      report!(other, Repo.get!(Vutuv.Posts.Post, post.id), %{"category" => "spam"})
+
+      email = owner_email("under review")
+
+      body = squish(email.text_body)
+
+      assert body =~ "hides the reported content automatically"
+      assert body =~ "Spam or scam"
+      refute body =~ "72 hours"
+      assert body =~ "You do not need to do anything"
+    end
+  end
+
+  describe "the German mail" do
+    test "says in German that no person decided and what the ground is", %{reporter: reporter} do
+      owner = insert(:activated_user, locale: "de")
+      insert(:email, user: owner, value: "de-owner@example.com")
+      post = insert(:post, user: owner)
+      report!(reporter, post, copyright_notice())
+
+      email = owner_email("verborgen")
+
+      for body <- bodies(email) do
+        assert body =~ "verbirgt den gemeldeten Inhalt automatisch"
+        assert body =~ "Darüber entscheidet das Urheberrecht"
+        assert body =~ @note
+        refute body =~ "sofort wieder sichtbar"
+      end
+    end
+  end
+
+  describe "the in-app line" do
+    test "names the category instead of a bare 'was reported'" do
+      line = %{kind: "moderation", category: "copyright", case_id: "x"}
+
+      text = NotificationLine.notification_text(line)
+
+      assert text =~ "Uses a text, photo or video without the rights holder's permission"
+      assert text =~ "automatically"
+    end
+
+    test "falls back to a category-less sentence" do
+      text = NotificationLine.notification_text(%{kind: "moderation", case_id: "x"})
+
+      assert text =~ "automatically"
+    end
+
+    test "the digest mail says the same thing" do
+      item = %{kind: "moderation", category: "spam", case_id: "x"}
+
+      assert DigestText.line(item) == NotificationLine.notification_text(item)
+    end
+  end
+end

--- a/test/vutuv_web/controllers/moderation_case_controller_test.exs
+++ b/test/vutuv_web/controllers/moderation_case_controller_test.exs
@@ -58,6 +58,67 @@ defmodule VutuvWeb.ModerationCaseControllerTest do
       assert response =~ "stays hidden until they have"
     end
 
+    test "carries the statement of reasons: the words, the ground, the deadline", %{conn: conn} do
+      {conn, _owner, _post, case_record} =
+        owner_with_case(conn, %{
+          "category" => "bullying",
+          "note" => "This names my colleague and calls her a liar."
+        })
+
+      response = conn |> get(~p"/moderation/cases/#{case_record.id}") |> html_response(200)
+
+      assert response =~ "This names my colleague and calls her a liar."
+      assert response =~ "No person made this decision"
+      assert response =~ "Our community guidelines"
+      assert response =~ "72 hours"
+    end
+
+    test "a copyright case names the law as the ground", %{conn: conn} do
+      {conn, _owner, _post, case_record} =
+        owner_with_case(conn, %{
+          "category" => "copyright",
+          "note" => "The photo is mine, the original is at example.com/photo",
+          "good_faith?" => "true"
+        })
+
+      response = conn |> get(~p"/moderation/cases/#{case_record.id}") |> html_response(200)
+
+      assert response =~ "Copyright law."
+      refute response =~ "Our community guidelines, which everything"
+    end
+
+    test "a reported message is not offered an edit it does not have", %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+      other = insert(:activated_user)
+      conversation = insert_conversation_between(owner, other)
+      message = insert(:message, conversation: conversation, sender: owner)
+
+      {:ok, case_record} =
+        Moderation.report_content(other, message, %{"category" => "bullying", "note" => "Stop."})
+
+      response = conn |> get(~p"/moderation/cases/#{case_record.id}") |> html_response(200)
+
+      assert response =~ "Stop."
+      assert response =~ ~p"/moderation/cases/#{case_record.id}/delete_content"
+      refute response =~ "/edit"
+    end
+
+    test "reads in German for a German member", %{conn: conn} do
+      {conn, owner, _post, case_record} = owner_with_case(conn, %{"category" => "spam"})
+      owner |> Ecto.Changeset.change(locale: "de") |> Repo.update!()
+
+      response =
+        conn
+        |> recycle()
+        |> put_req_header("accept-language", "de-DE,de")
+        |> get(~p"/moderation/cases/#{case_record.id}")
+        |> html_response(200)
+
+      assert response =~ "Diese Entscheidung hat kein Mensch getroffen"
+      assert response =~ "Grundlage"
+      assert response =~ "Unsere Verhaltensregeln"
+    end
+
     test "another member gets a 404", %{conn: conn} do
       {_conn, _owner, _post, case_record} = owner_with_case(conn)
 


### PR DESCRIPTION
A member whose post is hidden by a report was told the category and shown their own text, and nothing else: not what the reporter claimed, not that no person decided it, not the ground, not how long they have. Worse since #2018, the mail still promised everyone that an edit brings the content straight back, which is wrong for a copyright case.

All three surfaces now carry the same statement of reasons from one source, `Vutuv.Moderation.owner_notice/1`: the category, the reporter's explanation quoted and never their name, the automatic freeze, the ground (house rules or copyright law), and the options that case really has. `owner_edit_offer/2` answers the edit question once instead of seven templates recombining two booleans, so a message or job posting is not offered an editor it has no button for, and the review mail promises no 72-hour round it does not have.

Entry points: `/moderation/cases/:id`, `Vutuv.Moderation.Notifier`, `moderation_frozen_*` / `moderation_review_*` (three locales, both formats). Also corrects a wrong function name in `docs/architecture/moderation.md`.

Closes #2010

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01UGPe7bHVS11M1W7fNehSku

<!-- closing-note #2010 -->
Shipped. The notice, the mail and the case page now all say what was claimed, quote the reporter's words without naming them, state that the freeze happened automatically the moment the report arrived, name the ground as the house rules or copyright law, and list only the options that case actually has, with the 72-hour deadline where there is one. The options are answered once by `Moderation.owner_edit_offer/2` rather than recombined per template, because the copyright case from #2018 had already made the old "an edit makes it visible again" promise false and no locale should be able to get that wrong on its own. I left the wording of the moderation *digest* untouched beyond delegating its one moderation line to the same sentence, and did not widen the case page's edit button to job postings, which is a separate decision.

*An AI agent wrote this text in my name. I know that is problematic.*
