### PR TITLE
Profile pictures and covers become rows in a shared images table

### DIFF
--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -222,6 +222,55 @@ them); once the scheme is confirmed healthy in production, `mix
 vutuv.images.sweep_legacy` (`Vutuv.Release.sweep_legacy_images()`) deletes the
 legacy files — a deliberate, manual step, never part of the deploy
 
+## The shared `images` table (issue #2013)
+
+A post photo has been a row of its own for a long time — a token, an AI gate
+verdict, a parent a report can take offline. A member's profile picture and
+cover were four columns on the member row each (`avatar` /
+`avatar_fingerprint` / `avatar_crop` / `avatar_moderation`, and the cover
+four), so every moderation answer about a picture had to be written once per
+kind, and a stolen profile picture could only be reported as the whole
+profile.
+
+`Vutuv.Images` is where that ends. One row per picture: `kind`, the owner,
+an unguessable `token`, the three columns describing the stored file
+(`file` / `fingerprint` / `crop`), the gate's `moderation` verdict, and
+`frozen_at` for a copyright case (#2012 writes it; a freeze moves files and
+never deletes them).
+
+This release is the **expand** half and is deliberately additive. An upload
+writes the row *and* keeps filling all four member-row columns, which stay the
+source of truth every URL builder and every display gate reads; the member row
+only gains a pointer (`users.avatar_image_id` / `cover_image_id`). Nothing
+about how a picture is stored or served moved — an avatar URL is byte for byte
+the one it was, which matters because other servers hold it in their copy of
+our ActivityPub actor document, search engines hold it, and sent mail holds
+it. #2014 backfills the pictures uploaded before this and drops the columns a
+deploy later; #2015 moves the remaining kinds in.
+
+Five places write the pair, and they are the only ones that touch the
+member-row columns at all: `Vutuv.Accounts.store_pending_image/6` (upload — it
+mints a fresh token, because a token names the bytes and a re-upload should
+leave a report pointing at nothing rather than quietly at the new picture),
+`ImageSubjects.apply_approved/1`, `apply_rejected/1` and `cleanup_canceled/1`
+(the gate's verdict and its cancel), and `Vutuv.Uploads.regenerate/3` for the
+fingerprint a re-derive produces. That last one keys on the pointer the member
+row already holds, so a picture with no row yet costs no statement and the
+regeneration pass never *creates* one — that is #2014's backfill, not a side
+effect of a deploy.
+
+**How a kind is served is a property of the kind, not a column**
+(`Vutuv.Images.serving/1`). `:static` means the derived files sit in a public
+tree nginx serves straight off disk, nothing asks this application for
+permission, and the only off switch is moving the bytes out of that tree —
+the quarantine tree the AI gate already uses
+(`Vutuv.Uploads.quarantine_dir/1`), which nginx has no location for. `:proxy`
+means every byte goes through a controller that authorizes the reader first,
+so the row is the off switch. Avatars and covers are `:static`; the kinds
+#2015 brings are mostly `:proxy`. It raises for a kind nobody has declared,
+because a picture that inherits a default is one nobody knows how to take
+offline.
+
 ## URL screenshots
 
 URL screenshots are rendered by local headless Chromium, wrapped in a browser

--- a/docs/architecture/moderation.md
+++ b/docs/architecture/moderation.md
@@ -128,6 +128,17 @@ severances, owner self-service, escalations, rulings, strikes, `owner_removed`)
 rendered as the History timeline on the admin case page, and the urgent admin
 email names the profile, category and reporter's note instead of just a link.
 
+**A picture is not yet reportable on its own**, and the groundwork for that is
+in place: since issue #2013 a profile picture and a cover are rows in the
+shared `images` table (`Vutuv.Images`, see `images.md`) carrying a token a
+report form can name and a `frozen_at` a case can set, instead of four columns
+on the member row. Nothing reads either yet — `fetch_content/2` still knows
+only `post`, `message`, `user`, `organization` and `job_posting`, and a frozen
+profile still keeps its pictures online because nginx serves them straight off
+disk. #2012 adds the `image` report type and the freeze, whose off switch is
+moving every size and the original into the quarantine tree nginx has no
+location for.
+
 ## The statement of reasons (issue #2010)
 
 A member whose content goes dark is owed more than "something of yours was

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -26,6 +26,7 @@ defmodule Vutuv.Accounts do
   alias Vutuv.Deliverability
   alias Vutuv.Handles
   alias Vutuv.Identity
+  alias Vutuv.Images
   alias Vutuv.LoginCodes
   alias Vutuv.Mentions
   alias Vutuv.Moderation
@@ -2218,15 +2219,31 @@ defmodule Vutuv.Accounts do
     # The moderation state is set in the same UPDATE: a fresh upload starts in
     # limbo ("pending" — files in quarantine, placeholder for everyone but the
     # owner) until the AI scan releases or deletes it (Vutuv.Moderation.ImageScans).
+    #
+    # Since issue #2013 the same picture is also a row in the shared `images`
+    # table, written first so the member row can point at it in the one UPDATE.
+    # Nothing else moves: the four columns keep serving every URL and every
+    # display gate, and this release writes both (#2014 is the contract half).
+    kind = scan_kind(field)
+    moderation = ImageScans.initial_state()
+
     with {:ok, file_name, fingerprint} <- store.({upload, user}, crop),
-         attrs = %{
+         image_attrs = %{
+           file: file_name,
+           fingerprint: fingerprint,
+           crop: crop,
+           moderation: moderation
+         },
+         {:ok, image} <- Images.put_profile_image(user, kind, image_attrs),
+         user_attrs = %{
            field => file_name,
            fingerprint_field(field) => fingerprint,
            crop_field => crop,
-           moderation_field(field) => ImageScans.initial_state()
+           moderation_field(field) => moderation,
+           Images.pointer_field(kind) => image.id
          },
-         {:ok, saved} <- user |> Ecto.Changeset.change(attrs) |> Repo.update() do
-      ImageScans.enqueue(scan_kind(field), saved.id, saved.id, fingerprint)
+         {:ok, saved} <- user |> Ecto.Changeset.change(user_attrs) |> Repo.update() do
+      ImageScans.enqueue(kind, saved.id, saved.id, fingerprint)
       saved
     else
       _ ->

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -176,6 +176,15 @@ defmodule Vutuv.Accounts.User do
     # Set programmatically with the image columns, never cast from params.
     field(:avatar_moderation, :string)
     field(:cover_moderation, :string)
+
+    # The member's rows in the shared `images` table (issue #2013), where a
+    # picture also carries a token a report can name and a `frozen_at` a
+    # copyright case can set. Written beside the eight columns above, which
+    # stay the source of truth for every URL and every display gate until
+    # #2014 has backfilled the pictures uploaded before this and dropped them.
+    belongs_to(:avatar_image, Vutuv.Images.Image)
+    belongs_to(:cover_image, Vutuv.Images.Image)
+
     field(:username, :string)
     # The member's original legacy handle (the dotted / over-length import),
     # preserved before Accounts.normalize_legacy_usernames/0 rewrote :username

--- a/lib/vutuv/images.ex
+++ b/lib/vutuv/images.ex
@@ -1,0 +1,138 @@
+defmodule Vutuv.Images do
+  @moduledoc """
+  The one table every stored picture ends up in, and the per-kind facts that do
+  not belong on a row. The whole story — why the table exists, what is expand
+  and what is contract, and what a member row still holds meanwhile — is in
+  `docs/architecture/images.md`.
+
+  The invariant this module carries: **this release writes both.** A picture is
+  a row here *and* the four columns it has always lived in on the member row,
+  which stay the source of truth for every URL and every display gate until
+  #2014 has backfilled the older pictures and dropped them.
+
+  `serving/1` is the second thing here that is not a column: how a kind reaches
+  a reader decides what its off switch is, and a kind nobody has declared
+  raises rather than inheriting one.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Images.Image
+  alias Vutuv.Repo
+  alias Vutuv.Uploads
+
+  # The kinds that have a row today. `Vutuv.Moderation.ImageScans` uses the
+  # same two strings for its scan kinds, so a scan row and an image row name
+  # the same thing. #2015 brings the rest.
+  @kinds ~w(avatar cover)
+
+  @doc "The image kinds that live in this table today."
+  def kinds, do: @kinds
+
+  @doc """
+  How this kind reaches a reader.
+
+    * `:static` — the derived files sit in a public tree nginx serves straight
+      off disk, so nothing asks this application for permission and the only
+      off switch is moving the bytes out of that tree (the quarantine tree the
+      AI gate already uses, `Vutuv.Uploads.quarantine_dir/1`).
+    * `:proxy` — every byte goes through a controller that authorizes the
+      reader first, so the row is the off switch.
+
+  Raises for an undeclared kind: a picture that inherits a default is one
+  nobody knows how to take offline.
+  """
+  def serving(kind) when kind in @kinds, do: :static
+
+  def serving(kind),
+    do:
+      raise(ArgumentError, """
+      no serving strategy declared for image kind #{inspect(kind)}. \
+      Declare it in Vutuv.Images.serving/1 — a kind that inherits a default \
+      is a picture nobody knows how to take offline.\
+      """)
+
+  @doc """
+  The member-row column pointing at this kind's row. The one place that name is
+  written; `Vutuv.Accounts`, `Vutuv.Uploads` and
+  `Vutuv.Moderation.ImageSubjects` all read it from here.
+  """
+  def pointer_field("avatar"), do: :avatar_image_id
+  def pointer_field("cover"), do: :cover_image_id
+
+  @doc """
+  Records the picture a member just uploaded, replacing whatever row that
+  member had for this kind.
+
+  Called from `Vutuv.Accounts.store_pending_image/6` once the file is on disk,
+  in the same step that fills the member row's own columns. A **fresh token**
+  is minted every time, because a token names the bytes: after a re-upload, a
+  report that named the old picture should point at nothing rather than quietly
+  at the new one.
+  """
+  def put_profile_image(%User{} = user, kind, attrs) when kind in @kinds do
+    attrs = Map.merge(attrs, %{kind: kind, user_id: user.id, token: Uploads.gen_token()})
+
+    %Image{}
+    |> Image.changeset(attrs)
+    |> Repo.insert(
+      on_conflict: {:replace, [:token, :file, :fingerprint, :crop, :moderation, :updated_at]},
+      conflict_target: {:unsafe_fragment, "(user_id, kind) WHERE kind IN ('avatar', 'cover')"},
+      returning: [:id]
+    )
+  end
+
+  @doc "The member's row for this kind, or nil."
+  def profile_image(user_id, kind) when kind in @kinds,
+    do: Repo.one(profile_query(user_id, kind))
+
+  @doc """
+  Applies the AI gate's verdict to the member's row, guarded on the bytes that
+  were scanned exactly as `Vutuv.Moderation.ImageSubjects` guards the member
+  row. A nil fingerprint would raise rather than match nothing (`where: x ==
+  ^nil` is not a silent no-op in Ecto), so it is answered as "no row".
+  """
+  def mark_moderation(user_id, kind, fingerprint, state)
+      when kind in @kinds and is_binary(fingerprint) do
+    user_id
+    |> profile_query(kind)
+    |> where([i], i.fingerprint == ^fingerprint)
+    |> Repo.update_all(set: [moderation: state, updated_at: now()])
+
+    :ok
+  end
+
+  def mark_moderation(_user_id, _kind, _fingerprint, _state), do: :ok
+
+  @doc """
+  Keeps the row's fingerprint in step when `Vutuv.Uploads.regenerate/3`
+  re-derives a picture and writes a new one onto the member row. Takes the id
+  the member row points at, so a picture that has no row yet — every one
+  uploaded before this release, until #2014's backfill — costs no statement.
+  """
+  def sync_fingerprint(image_id, fingerprint) when is_binary(image_id) do
+    from(i in Image, where: i.id == ^image_id)
+    |> Repo.update_all(set: [fingerprint: fingerprint, updated_at: now()])
+
+    :ok
+  end
+
+  def sync_fingerprint(nil, _fingerprint), do: :ok
+
+  @doc """
+  Drops the member's row for this kind — the picture is gone (the AI gate
+  rejected it, or the scan was canceled because the bytes vanished). Deleting
+  rather than blanking keeps "there is a row" and "there is a picture" the same
+  statement.
+  """
+  def forget_profile_image(user_id, kind) when kind in @kinds do
+    user_id |> profile_query(kind) |> Repo.delete_all()
+    :ok
+  end
+
+  defp profile_query(user_id, kind),
+    do: from(i in Image, where: i.user_id == ^user_id and i.kind == ^kind)
+
+  defp now, do: NaiveDateTime.utc_now(:second)
+end

--- a/lib/vutuv/images/image.ex
+++ b/lib/vutuv/images/image.ex
@@ -1,0 +1,54 @@
+defmodule Vutuv.Images.Image do
+  @moduledoc """
+  One stored picture, whatever kind it is: what it is (`kind`), whose it is,
+  the unguessable handle it can be named by from outside (`token`), the three
+  columns describing the stored file, the AI gate's verdict, and whether a
+  copyright case has taken it offline (`frozen_at`, written by #2012).
+
+  Why this table exists and what the member row still holds beside it is in
+  `docs/architecture/images.md`; `Vutuv.Images` is the context.
+  """
+
+  use VutuvWeb, :model
+
+  schema "images" do
+    field(:kind, :string)
+    belongs_to(:user, Vutuv.Accounts.User)
+
+    field(:token, :string)
+
+    # The upload's own file name, the content fingerprint baked into the
+    # served file name (`<handle>-<version>-<fingerprint>.avif`) and the
+    # member's crop rectangle — the three the member row holds today.
+    field(:file, :string)
+    field(:fingerprint, :string)
+    field(:crop, :string)
+
+    # `Vutuv.Moderation.ImageScans`: nil = grandfathered, "pending" = the
+    # files wait in quarantine, "approved" = released.
+    field(:moderation, :string)
+
+    # Set by a copyright freeze (#2012). A freeze moves files, never deletes.
+    field(:frozen_at, :naive_datetime)
+
+    timestamps()
+  end
+
+  @doc """
+  Every field here is written by the pipeline that stored the file, never by a
+  form, so the only length worth validating is `file`: it is the upload's own
+  name, which a member chooses, and an over-long one would otherwise raise
+  Postgres 22001 on a path no form guards. The rest are minted here and bounded
+  by construction, in varchar(255) columns.
+  """
+  def changeset(image, attrs) do
+    image
+    |> cast(attrs, [:kind, :user_id, :token, :file, :fingerprint, :crop, :moderation, :frozen_at])
+    |> validate_required([:kind, :token])
+    |> validate_length(:file, max: 255)
+    |> unique_constraint(:token)
+    |> unique_constraint(:kind, name: :images_member_profile_kind_index)
+    |> check_constraint(:user_id, name: :images_profile_kind_has_owner)
+    |> foreign_key_constraint(:user_id)
+  end
+end

--- a/lib/vutuv/moderation/image_subjects.ex
+++ b/lib/vutuv/moderation/image_subjects.ex
@@ -19,6 +19,7 @@ defmodule Vutuv.Moderation.ImageSubjects do
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemoteImage
+  alias Vutuv.Images
   alias Vutuv.JobReferenceDocument
   alias Vutuv.Jobs.JobPostingImage
   alias Vutuv.Moderation.ImageScan
@@ -351,6 +352,7 @@ defmodule Vutuv.Moderation.ImageSubjects do
 
     case flipped do
       {1, _} ->
+        Images.mark_moderation(scan.subject_id, scan.kind, scan.fingerprint, "approved")
         config.module.promote_from_quarantine(Repo.get!(User, scan.subject_id))
         broadcast(scan, :approved)
         :ok
@@ -564,10 +566,11 @@ defmodule Vutuv.Moderation.ImageSubjects do
       from(u in User,
         where: u.id == ^scan.subject_id and field(u, ^config.fingerprint) == ^scan.fingerprint
       )
-      |> Repo.update_all(set: clear_profile_columns(config))
+      |> Repo.update_all(set: clear_profile_columns(config, scan.kind))
 
     case cleared do
       {1, _} ->
+        Images.forget_profile_image(scan.subject_id, scan.kind)
         config.module.delete(%User{id: scan.subject_id})
         broadcast(scan, :rejected)
         :ok
@@ -872,13 +875,19 @@ defmodule Vutuv.Moderation.ImageSubjects do
   def cleanup_canceled(%ImageScan{kind: kind} = scan) when is_map_key(@profile_images, kind) do
     config = @profile_images[kind]
 
-    from(u in User,
-      where:
-        u.id == ^scan.subject_id and
-          field(u, ^config.fingerprint) == ^scan.fingerprint and
-          field(u, ^config.moderation) == "pending"
-    )
-    |> Repo.update_all(set: clear_profile_columns(config))
+    cleared =
+      from(u in User,
+        where:
+          u.id == ^scan.subject_id and
+            field(u, ^config.fingerprint) == ^scan.fingerprint and
+            field(u, ^config.moderation) == "pending"
+      )
+      |> Repo.update_all(set: clear_profile_columns(config, scan.kind))
+
+    # Only when this scan's own picture was the one cleared — the common case
+    # here is a stale cancel that matches nothing, and a delete then would take
+    # out the row of a picture uploaded since.
+    if match?({1, _}, cleared), do: Images.forget_profile_image(scan.subject_id, scan.kind)
 
     :ok
   end
@@ -893,14 +902,18 @@ defmodule Vutuv.Moderation.ImageSubjects do
 
   def cleanup_canceled(%ImageScan{}), do: :ok
 
-  # The four profile-image columns (file, fingerprint, crop, moderation) reset to
-  # nil when a scan rejects the image or cancels a pending one.
-  defp clear_profile_columns(config),
+  # The four profile-image columns (file, fingerprint, crop, moderation) and the
+  # pointer at the shared `images` row reset to nil when a scan rejects the
+  # image or cancels a pending one. The row itself is deleted beside this
+  # (`Vutuv.Images.forget_profile_image/2`): "there is a row" and "there is a
+  # picture" stay the same statement.
+  defp clear_profile_columns(config, kind),
     do: [
       {config.file, nil},
       {config.fingerprint, nil},
       {config.crop, nil},
-      {config.moderation, nil}
+      {config.moderation, nil},
+      {Images.pointer_field(kind), nil}
     ]
 
   # Every document column resets when a scan rejects the proof document; the

--- a/lib/vutuv/uploaders/avatar.ex
+++ b/lib/vutuv/uploaders/avatar.ex
@@ -44,6 +44,10 @@ defmodule Vutuv.Avatar do
   @config %{
     spec_key: :avatar,
     prefix: "avatars",
+    # This image's kind in the shared `images` table (`Vutuv.Images`), declared
+    # rather than derived from `spec_key`: the two strings coincide today and
+    # nothing says they must.
+    kind: "avatar",
     default_version: :medium,
     # The user column holding this image's content fingerprint. When set, the
     # served filename embeds the handle + fingerprint (`<username>-<version>-<fp>.avif`)

--- a/lib/vutuv/uploaders/cover.ex
+++ b/lib/vutuv/uploaders/cover.ex
@@ -31,6 +31,8 @@ defmodule Vutuv.Cover do
   @config %{
     spec_key: :cover,
     prefix: "covers",
+    # This image's kind in the shared `images` table (`Vutuv.Images`).
+    kind: "cover",
     default_version: :wide,
     # See Vutuv.Avatar's @config: the user column holding this image's content
     # fingerprint, baked into `<username>-<version>-<fp>.avif` when set.

--- a/lib/vutuv/uploads.ex
+++ b/lib/vutuv/uploads.ex
@@ -14,6 +14,7 @@ defmodule Vutuv.Uploads do
 
   require Logger
 
+  alias Vutuv.Images
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Repo
   alias Vutuv.Uploads.Crop
@@ -41,13 +42,17 @@ defmodule Vutuv.Uploads do
     * `:crop_field` — the scope field holding the persisted crop string that
       `regenerate/3` re-applies (`:avatar_crop` / `:cover_crop`); absent for
       uploaders without a user-chosen crop
+    * `:kind` — this image's kind in the shared `images` table
+      (`Vutuv.Images`), declared beside `:fingerprint_field` because the
+      re-derive has to keep that row naming the same bytes
   """
   @type uploader_config :: %{
           required(:spec_key) => atom(),
           required(:prefix) => String.t(),
           required(:default_version) => atom(),
           optional(:fingerprint_field) => atom(),
-          optional(:crop_field) => atom()
+          optional(:crop_field) => atom(),
+          optional(:kind) => String.t()
         }
 
   @doc """
@@ -424,10 +429,22 @@ defmodule Vutuv.Uploads do
     end
   end
 
+  # A re-derive writes a fresh fingerprint onto the member row, so the picture's
+  # row in the shared `images` table (issue #2013) has to name the same bytes.
+  # Keyed on the pointer the member row already holds, so a picture that has no
+  # row yet — every one uploaded before that table, until #2014's backfill —
+  # costs no statement, and creating one is not a side effect of a deploy.
   defp persist_fingerprint(user, fingerprint, config) do
-    user
-    |> Ecto.Changeset.change(%{config.fingerprint_field => fingerprint})
-    |> Repo.update()
+    with {:ok, saved} <-
+           user
+           |> Ecto.Changeset.change(%{config.fingerprint_field => fingerprint})
+           |> Repo.update() do
+      saved
+      |> Map.get(Images.pointer_field(config.kind))
+      |> Images.sync_fingerprint(fingerprint)
+
+      {:ok, saved}
+    end
   end
 
   defp dry_run_fingerprinted(user, storage_dir, dir, fingerprint, config) do

--- a/priv/repo/migrations/20260906100036_create_images_table.exs
+++ b/priv/repo/migrations/20260906100036_create_images_table.exs
@@ -1,0 +1,97 @@
+defmodule Vutuv.Repo.Migrations.CreateImagesTable do
+  use Ecto.Migration
+
+  # One row per stored picture (issue #2013). The reasoning is in
+  # `docs/architecture/images.md`; what matters here is that this is the expand
+  # half of an expand/contract and takes nothing away — a new table, two
+  # nullable columns on `users`, N-1 safe for the blue/green window. #2014
+  # backfills the pictures uploaded before this and drops the member row's four
+  # columns per kind a deploy later.
+  #
+  # Column types are the ones the values are copied from: `users.avatar`,
+  # `users.avatar_fingerprint`, `users.avatar_crop` and
+  # `users.avatar_moderation` are all varchar(255), `post_images.token` is
+  # varchar(255) with a unique index, and every `frozen_at` here is a
+  # naive_datetime.
+  def change do
+    create table(:images) do
+      # "avatar" and "cover" today — the same vocabulary
+      # `Vutuv.Moderation.ImageScans` uses for its scan kinds. The remaining
+      # kinds (post_image, organization_image, job_posting_image,
+      # review_cover) move in one at a time in #2015.
+      add(:kind, :string, null: false)
+
+      # The owner. Deliberately **nullable** although both kinds here always
+      # have one: the kinds #2015 brings are owned by a post, an organization
+      # or a job posting, not by a member, so they will add a column of their
+      # own beside this one. Widening a NOT NULL column afterwards is the
+      # expensive migration this project has been bitten by repeatedly
+      # (#1334/#1336); a check constraint scoped to the kinds that do have a
+      # member owner costs nothing and is cheap to extend.
+      add(:user_id, references(:users, type: :binary_id, on_delete: :delete_all))
+
+      # An unguessable handle, so a report form (#2012) can name a picture
+      # without exposing a row id. This is also the column `post_images.token`
+      # moves into in #2015 — that token is the lookup key of the post-image
+      # proxy and its on-disk directory name, so it has to be unique across
+      # the whole table from the start.
+      add(:token, :string, null: false)
+
+      # The three columns a profile picture keeps today, copied verbatim: the
+      # upload's own file name, the content fingerprint baked into the served
+      # file name, and the member's crop rectangle.
+      add(:file, :string)
+      add(:fingerprint, :string)
+      add(:crop, :string)
+
+      # The AI image gate's verdict (`Vutuv.Moderation.ImageScans`):
+      # nil = grandfathered, "pending" = in quarantine, "approved" = released.
+      add(:moderation, :string)
+
+      # When a moderation case took this picture offline. Nothing writes it
+      # yet; #2012 does, and a freeze moves files rather than deleting them.
+      add(:frozen_at, :naive_datetime)
+
+      timestamps()
+    end
+
+    create(unique_index(:images, [:token]))
+
+    # The cascade's own lookup. The partial index below cannot serve it: the
+    # planner cannot prove `kind IN (…)` holds for a bare `WHERE user_id = $1`,
+    # so deleting an account would scan the table — and after #2015 this table
+    # holds every picture in the system.
+    create(index(:images, [:user_id]))
+
+    # A member has at most one avatar and one cover. Partial, so the kinds
+    # #2015 brings (a post has many photos) are not caught by it. It is also
+    # the conflict target `Vutuv.Images.put_profile_image/3` upserts on.
+    create(
+      unique_index(:images, [:user_id, :kind],
+        where: "kind IN ('avatar', 'cover')",
+        name: :images_member_profile_kind_index
+      )
+    )
+
+    create(
+      constraint(:images, :images_profile_kind_has_owner,
+        check: "kind NOT IN ('avatar', 'cover') OR user_id IS NOT NULL"
+      )
+    )
+
+    alter table(:users) do
+      # The pointer at the row above. Nullable and unread by the release this
+      # migration runs against; the four per-kind columns stay the source of
+      # truth until #2014 has backfilled every member and dropped them.
+      add(:avatar_image_id, references(:images, type: :binary_id, on_delete: :nilify_all))
+      add(:cover_image_id, references(:images, type: :binary_id, on_delete: :nilify_all))
+    end
+
+    # `nilify_all` looks for referencing rows on every image delete (a rejected
+    # or canceled scan today, #2014's contract pass later), so both sides of
+    # the pointer are indexed — the shape `users_pinned_post_id_index` and the
+    # two profile-section pointers already have.
+    create(index(:users, [:avatar_image_id]))
+    create(index(:users, [:cover_image_id]))
+  end
+end

--- a/test/vutuv/images_test.exs
+++ b/test/vutuv/images_test.exs
@@ -1,0 +1,237 @@
+defmodule Vutuv.ImagesTest do
+  @moduledoc """
+  The shared `images` table, expand half (issue #2013).
+
+  Two things have to be true at once. A profile picture and a cover are rows
+  now — and **nothing has been taken away**: the member row keeps its four
+  columns per kind filled, and no avatar or cover URL moves, because other
+  servers hold those URLs in their copy of our ActivityPub actor document and
+  sent mail holds them too.
+  """
+  # Not async: flips the global :uploads_dir_prefix and :moderate_images.
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.WebPushHelpers, only: [put_config: 2]
+
+  alias Vutuv.Accounts
+  alias Vutuv.Accounts.User
+  alias Vutuv.Images
+  alias Vutuv.Images.Image, as: ImageRow
+  alias Vutuv.Moderation.ImageScans
+  alias Vutuv.Repo
+
+  @safe {:ok, %{safe?: true, category: "safe"}}
+  @unsafe {:ok, %{safe?: false, category: "nudity"}}
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "vutuv_images_test_#{System.unique_integer([:positive])}")
+    put_config(:uploads_dir_prefix, tmp)
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    user = insert(:activated_user)
+    insert(:email, user: user)
+
+    {:ok, user: user}
+  end
+
+  defp jpeg_upload(name \\ "selfie.jpg", color \\ [10, 120, 200]) do
+    src = Path.join(System.tmp_dir!(), "images_src_#{System.unique_integer([:positive])}.jpg")
+    {:ok, img} = Image.new(300, 200, color: color)
+    {:ok, _} = Image.write(img, src)
+    on_exit(fn -> File.rm(src) end)
+    %Plug.Upload{filename: name, path: src, content_type: "image/jpeg"}
+  end
+
+  defp reload(user), do: Repo.get!(User, user.id)
+
+  describe "an upload writes the row beside the member's own columns" do
+    test "avatar", %{user: user} do
+      {:ok, user} = Accounts.update_user(user, %{avatar: jpeg_upload()})
+
+      # Nothing was taken away.
+      assert user.avatar == "selfie.jpg"
+      assert user.avatar_fingerprint
+      assert user.avatar_moderation == "approved"
+
+      image = Images.profile_image(user.id, "avatar")
+      assert image.kind == "avatar"
+      assert image.user_id == user.id
+      assert image.file == user.avatar
+      assert image.fingerprint == user.avatar_fingerprint
+      assert image.moderation == user.avatar_moderation
+      assert image.crop == user.avatar_crop
+      assert is_binary(image.token) and image.token != ""
+      assert image.frozen_at == nil
+
+      assert reload(user).avatar_image_id == image.id
+    end
+
+    test "cover, with the member's crop", %{user: user} do
+      {:ok, user} =
+        Accounts.update_user(user, %{
+          "cover_photo" => jpeg_upload("wide.jpg"),
+          "cover_crop" => "0,0,0.5,0.5"
+        })
+
+      assert user.cover_photo == "wide.jpg"
+      # Normalised on the way in (Vutuv.Uploads.Crop), so read it back rather
+      # than repeating the literal the form sent.
+      assert user.cover_crop == "0.0000,0.0000,0.5000,0.5000"
+
+      image = Images.profile_image(user.id, "cover")
+      assert image.kind == "cover"
+      assert image.file == user.cover_photo
+      assert image.crop == user.cover_crop
+      assert image.fingerprint == user.cover_fingerprint
+      assert reload(user).cover_image_id == image.id
+    end
+
+    test "the two kinds get one row each and two different tokens", %{user: user} do
+      {:ok, user} =
+        Accounts.update_user(user, %{
+          avatar: jpeg_upload("a.jpg"),
+          cover_photo: jpeg_upload("c.jpg", [200, 30, 30])
+        })
+
+      avatar = Images.profile_image(user.id, "avatar")
+      cover = Images.profile_image(user.id, "cover")
+
+      assert avatar.token != cover.token
+      assert Repo.aggregate(ImageRow, :count) == 2
+    end
+
+    test "a re-upload replaces the one row and mints a fresh token", %{user: user} do
+      {:ok, user} = Accounts.update_user(user, %{avatar: jpeg_upload("first.jpg")})
+      first = Images.profile_image(user.id, "avatar")
+
+      {:ok, user} = Accounts.update_user(user, %{avatar: jpeg_upload("second.jpg", [9, 9, 9])})
+      second = Images.profile_image(user.id, "avatar")
+
+      assert Repo.aggregate(from(i in ImageRow, where: i.user_id == ^user.id), :count) == 1
+      assert second.id == first.id
+      assert second.file == "second.jpg"
+      assert second.fingerprint == user.avatar_fingerprint
+      assert second.token != first.token
+      assert reload(user).avatar_image_id == second.id
+    end
+  end
+
+  describe "no URL moves" do
+    test "the avatar and cover URLs are exactly the ones the member row builds", %{user: user} do
+      {:ok, user} =
+        Accounts.update_user(user, %{
+          avatar: jpeg_upload("a.jpg"),
+          cover_photo: jpeg_upload("c.jpg", [200, 30, 30])
+        })
+
+      # The one shape other servers, Google and sent mail already hold:
+      # /avatars/<user id>/<handle>-<version>-<fingerprint>.avif — built from
+      # the member row's own columns, with the images row playing no part.
+      assert Vutuv.Avatar.url({user.avatar, user}, :medium) ==
+               "/avatars/#{user.id}/#{user.username}-medium-#{user.avatar_fingerprint}.avif"
+
+      assert Vutuv.Avatar.display_url(user, :thumb) ==
+               "/avatars/#{user.id}/#{user.username}-thumb-#{user.avatar_fingerprint}.avif"
+
+      assert Vutuv.Cover.url({user.cover_photo, user}, :wide) ==
+               "/covers/#{user.id}/#{user.username}-wide-#{user.cover_fingerprint}.avif"
+    end
+  end
+
+  describe "the AI gate's verdict reaches the row too" do
+    setup do
+      put_config(:moderate_images, true)
+      :ok
+    end
+
+    test "a fresh upload is pending on both, and released on both", %{user: user} do
+      {:ok, user} = Accounts.update_user(user, %{avatar: jpeg_upload()})
+
+      assert user.avatar_moderation == "pending"
+      assert Images.profile_image(user.id, "avatar").moderation == "pending"
+
+      ImageScans.deliver_due(judge: fn _path -> @safe end)
+
+      assert reload(user).avatar_moderation == "approved"
+      assert Images.profile_image(user.id, "avatar").moderation == "approved"
+    end
+
+    test "a rejection clears the member's columns and drops the row", %{user: user} do
+      {:ok, user} = Accounts.update_user(user, %{avatar: jpeg_upload()})
+      assert Images.profile_image(user.id, "avatar")
+
+      ImageScans.deliver_due(judge: fn _path -> @unsafe end)
+
+      user = reload(user)
+      assert user.avatar == nil
+      assert user.avatar_moderation == nil
+      assert user.avatar_image_id == nil
+      assert Images.profile_image(user.id, "avatar") == nil
+    end
+  end
+
+  describe "a re-derive keeps the row's fingerprint in step" do
+    test "regenerating under a new handle leaves both sides naming the same bytes", %{user: user} do
+      {:ok, user} = Accounts.update_user(user, %{avatar: jpeg_upload()})
+
+      # Force a re-derive the way the deploy's regeneration pass does.
+      assert :ok = Vutuv.Avatar.regenerate(user, force: true)
+
+      user = reload(user)
+      assert Images.profile_image(user.id, "avatar").fingerprint == user.avatar_fingerprint
+    end
+  end
+
+  describe "how a kind is served is a property of the kind" do
+    test "avatars and covers are served straight off disk" do
+      assert Images.serving("avatar") == :static
+      assert Images.serving("cover") == :static
+      assert Images.kinds() == ~w(avatar cover)
+    end
+
+    test "an undeclared kind raises rather than inheriting a default" do
+      assert_raise ArgumentError, ~r/no serving strategy declared/, fn ->
+        Images.serving("post_image")
+      end
+    end
+  end
+
+  describe "the row's own guards" do
+    test "a token is unique across the table", %{user: user} do
+      other = insert(:activated_user)
+      {:ok, user} = Accounts.update_user(user, %{avatar: jpeg_upload()})
+      taken = Images.profile_image(user.id, "avatar").token
+
+      assert {:error, changeset} =
+               %ImageRow{}
+               |> ImageRow.changeset(%{
+                 "kind" => "avatar",
+                 "user_id" => other.id,
+                 "token" => taken
+               })
+               |> Repo.insert()
+
+      assert "has already been taken" in errors_on(changeset).token
+    end
+
+    test "a profile kind without an owner is refused by the database" do
+      assert {:error, changeset} =
+               %ImageRow{}
+               |> ImageRow.changeset(%{"kind" => "avatar", "token" => Vutuv.Uploads.gen_token()})
+               |> Repo.insert()
+
+      assert errors_on(changeset)[:user_id]
+    end
+
+    test "an over-long file name is refused rather than raising 22001" do
+      changeset =
+        ImageRow.changeset(%ImageRow{}, %{
+          "kind" => "avatar",
+          "token" => "t",
+          "file" => String.duplicate("a", 256)
+        })
+
+      assert errors_on(changeset)[:file]
+    end
+  end
+end


### PR DESCRIPTION
A post photo is a row with a token and a scan verdict. A profile picture and a cover were four columns on the member row each, so every moderation answer about a picture was written once per kind, and a stolen profile picture could only be reported as the whole profile.

This is the expand half and takes nothing away. New `images` table behind `Vutuv.Images`: kind, owner, token, scan state, `frozen_at`. `Vutuv.Accounts.store_pending_image/6` writes the row *and* keeps all four member-row columns filled, plus a pointer. Those columns stay the source of truth for every URL, so no avatar or cover URL moves; other servers hold them in their copy of our actor document. `Vutuv.Images.serving/1` keeps "how a kind is served" a property of the kind, not a column.

Left out: the backfill (#2014) and the `image` report type (#2012). Details in `docs/architecture/images.md`.

Closes #2013

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01UGPe7bHVS11M1W7fNehSku

<!-- closing-note #2013 -->
Profile pictures and covers are rows in the `images` table from this release on, carrying a kind, an owner, a token and a `frozen_at`, so a picture can be named and taken offline on its own rather than only as the whole profile. Nothing was taken away: the four member-row columns per kind stay filled and stay the source of truth for every URL builder and every display gate, which is why no avatar or cover URL moved for anybody, on this installation or any other. The backfill of the pictures uploaded before this (#2014) and the `image` report type (#2012) are deliberately not here, and #2014 drops the columns a deploy after this one proves healthy.

*An AI agent wrote this text in my name. I know that is problematic.*
