### PR TITLE
Bring every existing profile picture and cover into the shared images table

### DIFF
--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -690,12 +690,25 @@ Run on the server, against the release:
   cannot re-derive them; this is their equivalent after an upgrade that
   changes the cover size. Needs outbound network and `FETCH_BOOK_METADATA=true`,
   and paces itself (3s per cover) to stay inside Open Library's rate limit.
+- `bin/vutuv eval "Vutuv.Release.backfill_image_rows()"` — brings every profile
+  picture and cover uploaded before the shared `images` table into it, and
+  corrects any row that disagrees with the member's own columns. Moves no file
+  and changes no URL, so it is safe while the app serves traffic; safe to run
+  again if it is interrupted (a deploy stopping the slot mid-run leaves every
+  member it reached already correct).
+- `bin/vutuv eval "Vutuv.Release.check_image_rows()"` — counts every member
+  picture against its row and against its file on disk, writing nothing. Run it
+  after the backfill and read `ok?`: a `false` names the members behind each
+  mismatch, and a picture whose file is missing is the one the backfill cannot
+  repair. This is the gate on the later upgrade that removes the member row's
+  own image columns — do not take that upgrade with a mismatch outstanding.
 - `bin/vutuv eval 'Vutuv.Release.promote_admin("handle-or-email")'` — grants
   admin rights.
 
 (In a source checkout the same exist as `mix vutuv.images.regenerate` /
-`mix vutuv.review_covers.refresh` / `mix vutuv.admin.promote`; URL screenshots
-can be re-rendered with `mix urls.create_screenshots`.)
+`mix vutuv.images.backfill` / `mix vutuv.review_covers.refresh` /
+`mix vutuv.admin.promote`; URL screenshots can be re-rendered with
+`mix urls.create_screenshots`.)
 
 ### Watch the tables for bloat after a mass rewrite
 

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -697,11 +697,14 @@ Run on the server, against the release:
   again if it is interrupted (a deploy stopping the slot mid-run leaves every
   member it reached already correct).
 - `bin/vutuv eval "Vutuv.Release.check_image_rows()"` — counts every member
-  picture against its row and against its file on disk, writing nothing. Run it
-  after the backfill and read `ok?`: a `false` names the members behind each
-  mismatch, and a picture whose file is missing is the one the backfill cannot
-  repair. This is the gate on the later upgrade that removes the member row's
-  own image columns — do not take that upgrade with a mismatch outstanding.
+  picture against its row and against its file on disk, writing nothing. It
+  prints one line per kind, names the members behind each mismatch, and
+  **fails the command** when anything is outstanding, so a deploy script can
+  stand on its exit status. A picture whose file is missing is the one class
+  the backfill cannot repair. This is the gate on the later upgrade that
+  removes the member row's own image columns — do not take that upgrade with a
+  mismatch outstanding. `mix vutuv.images.backfill --check` is the same check
+  in a source checkout, and a plain `mix vutuv.images.backfill` ends with it.
 - `bin/vutuv eval 'Vutuv.Release.promote_admin("handle-or-email")'` — grants
   admin rights.
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -29,7 +29,7 @@ installing and operating vutuv in [Running your own vutuv](../ADMINS.md).
 | [moderation.md](moderation.md) | reports, freezes, the strike ladder, reporter trust, evidence screenshots |
 | [agents-and-seo.md](agents-and-seo.md) | agent formats (`.md`/`.txt`/`.json`/`.xml`/`.vcf`), the member directory, sitemap/RSS/JSON-LD, Open Graph, how to read the Search Console reports |
 | [email.md](email.md) | the Emailer chokepoint, multipart bodies, opt-outs, bounces & deliverability |
-| [images.md](images.md) | the AVIF pipeline, kept originals, fingerprinted filenames, URL screenshots, AI image moderation (Ollama) |
+| [images.md](images.md) | the AVIF pipeline, kept originals, fingerprinted filenames, the shared `images` table and its backfill, URL screenshots, AI image moderation (Ollama) |
 | [video.md](video.md) | video on posts: the ffmpeg pipeline and its resumable job, the AI check over the stills, the post that waits for its clip, the player and the range-answering proxy, what federates and what the Mastodon API says |
 | [admin.md](admin.md) | the admin panel: live dashboard, member browser, account deletion, newsletter & audiences, daily report |
 | [ads.md](ads.md) | the daily text ad: booking, review, serving |

--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -296,12 +296,19 @@ no half-pair, and the second run created the other 1,438 and corrected none).
 `from: "<user id>"` resumes from a progress line instead of re-reading the
 table.
 
-`Backfill.check/1` (`mix vutuv.images.backfill --check`) is the gate before the
+`Backfill.check/1` (`mix vutuv.images.backfill --check`, or
+`bin/vutuv eval "Vutuv.Release.check_image_rows()"`) is the gate before the
 cut: it counts every member picture against its row *and* against its file on
 disk — the quarantine tree while the picture is `"pending"`, the served tree
-otherwise — and answers `ok?: false` with the member ids behind each class of
-mismatch. A missing file is the one class the backfill cannot repair; it
-predates the table and wants a human before the columns go.
+otherwise — prints one line per kind plus the members behind each class of
+mismatch, and **fails the command** when anything is outstanding. Both of
+those come from `check/1` itself rather than from either entry point, because
+the first version put the printing in the mix task alone: it fell out of step
+with the shape `check/1` returns and crashed on every invocation, while the
+release path printed nothing and exited 0 with 1,678 mismatches — which reads
+exactly like a clean bill of health. A missing file is the one class the
+backfill cannot repair; it predates the table and wants a human before the
+columns go.
 
 **The columns go two deploys later, not one.** The order is: this deploy ships
 the backfill (the columns still serve everything), the operator runs it and

--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -238,15 +238,19 @@ an unguessable `token`, the three columns describing the stored file
 `frozen_at` for a copyright case (#2012 writes it; a freeze moves files and
 never deletes them).
 
-This release is the **expand** half and is deliberately additive. An upload
-writes the row *and* keeps filling all four member-row columns, which stay the
-source of truth every URL builder and every display gate reads; the member row
-only gains a pointer (`users.avatar_image_id` / `cover_image_id`). Nothing
-about how a picture is stored or served moved — an avatar URL is byte for byte
-the one it was, which matters because other servers hold it in their copy of
-our ActivityPub actor document, search engines hold it, and sent mail holds
-it. #2014 backfills the pictures uploaded before this and drops the columns a
-deploy later; #2015 moves the remaining kinds in.
+The table arrived **additively**. An upload writes the row *and* keeps filling
+all four member-row columns, which stay the source of truth every URL builder
+and every display gate reads; the member row only gains a pointer
+(`users.avatar_image_id` / `cover_image_id`). Nothing about how a picture is
+stored or served moved — an avatar URL is byte for byte the one it was, which
+matters because other servers hold it in their copy of our ActivityPub actor
+document, search engines hold it, and sent mail holds it. #2015 moves the
+remaining kinds in.
+
+Which member-row column holds what is written **once**, in
+`Vutuv.Images.member_columns/0`; `Vutuv.Moderation.ImageSubjects` and
+`Vutuv.Images.Backfill` read it from there, so the deploy that drops those
+columns has one list to delete rather than four copies to find.
 
 Five places write the pair, and they are the only ones that touch the
 member-row columns at all: `Vutuv.Accounts.store_pending_image/6` (upload — it
@@ -256,8 +260,56 @@ leave a report pointing at nothing rather than quietly at the new picture),
 (the gate's verdict and its cancel), and `Vutuv.Uploads.regenerate/3` for the
 fingerprint a re-derive produces. That last one keys on the pointer the member
 row already holds, so a picture with no row yet costs no statement and the
-regeneration pass never *creates* one — that is #2014's backfill, not a side
+regeneration pass never *creates* one — that is the backfill's job, not a side
 effect of a deploy.
+
+The upload writes its pair in **one transaction**. Apart they could
+half-commit: `Uploads.store/4` has already replaced the served files by then,
+so a failure between the two writes (a pool timeout, a slot dying in the
+blue/green switch, a `StaleEntryError`) left the row naming the new picture,
+the member row still naming the old file whose bytes were gone, and no scan
+queued to take the row out of `"pending"` — with a success flash on the way
+back. For the same reason `:moderate_images` is read once per upload and handed
+to `Uploads.store/4`, so the state the row records and the tree the bytes land
+in cannot disagree.
+
+### Bringing the older pictures in (issue #2014)
+
+`Vutuv.Images.Backfill` is the contract half — `mix vutuv.images.backfill`, or
+`bin/vutuv eval "Vutuv.Release.backfill_image_rows()"` on a release. It moves
+no file and changes no URL, so the previous release keeps serving unchanged
+while it runs.
+
+It **reconciles**, it does not insert-where-missing: for every member it
+compares `file`, `fingerprint`, `crop` and `moderation` against the row and
+corrects the row where they differ (with a fresh token when the picture itself
+changed), creates one where there is none, and deletes a row whose member has
+no picture of that kind any more. Insert-where-missing would skip exactly the
+members a half-committed upload had already given a wrong row — the ones whose
+truth the column drop is about to destroy.
+
+Work is a keyset scan over `users.id` with one transaction per member and no
+state in memory, so a run a deploy kills mid-flight is simply run again: every
+member it reached is already right and reports `unchanged` (rehearsed on the
+production copy: `kill -9` at 309 of 1,747 pictures left 309 complete pairs and
+no half-pair, and the second run created the other 1,438 and corrected none).
+`from: "<user id>"` resumes from a progress line instead of re-reading the
+table.
+
+`Backfill.check/1` (`mix vutuv.images.backfill --check`) is the gate before the
+cut: it counts every member picture against its row *and* against its file on
+disk — the quarantine tree while the picture is `"pending"`, the served tree
+otherwise — and answers `ok?: false` with the member ids behind each class of
+mismatch. A missing file is the one class the backfill cannot repair; it
+predates the table and wants a human before the columns go.
+
+**The columns go two deploys later, not one.** The order is: this deploy ships
+the backfill (the columns still serve everything), the operator runs it and
+reads the check; a later deploy moves every URL builder and display gate onto
+the row; and only the deploy after *that* carries the migration dropping
+`avatar` / `avatar_fingerprint` / `avatar_crop` / `avatar_moderation` and the
+cover four. Each step is N-1 safe on its own, and no two can be merged: a
+migration may only drop what the *currently deployed* release no longer reads.
 
 **How a kind is served is a property of the kind, not a column**
 (`Vutuv.Images.serving/1`). `:static` means the derived files sit in a public

--- a/lib/mix/tasks/vutuv.images.backfill.ex
+++ b/lib/mix/tasks/vutuv.images.backfill.ex
@@ -17,9 +17,14 @@ defmodule Mix.Tasks.Vutuv.Images.Backfill do
   is interrupted (a deploy stopping the slot) is simply run again, and every
   member it already reached reports `unchanged`.
 
-  Every run ends with the check, and **a mismatch raises**: that is the gate on
-  the later deploy that drops the columns. In production (a release, no Mix)
-  use `bin/vutuv eval "Vutuv.Release.backfill_image_rows()"` /
+  Every run ends with the check, which prints what it found and **fails the
+  command only when something is outstanding** — that non-zero exit is the gate
+  on the later deploy that drops the columns. The printing lives in
+  `Vutuv.Images.Backfill.check/1`, not here, so this task and the release path
+  cannot say different things.
+
+  In production (a release, no Mix) use
+  `bin/vutuv eval "Vutuv.Release.backfill_image_rows()"` /
   `bin/vutuv eval "Vutuv.Release.check_image_rows()"`.
   """
 
@@ -44,43 +49,12 @@ defmodule Mix.Tasks.Vutuv.Images.Backfill do
 
     unless opts[:check], do: opts |> Keyword.delete(:check) |> Backfill.run()
 
-    opts |> Keyword.take([:only]) |> Backfill.check() |> report!()
-  end
+    summary = opts |> Keyword.take([:only]) |> Backfill.check()
 
-  defp report!(%{kinds: kinds, ok?: ok?}) do
-    for {kind, result} <- kinds do
-      Mix.shell().info(
-        "#{kind}: #{result.pictures} picture(s), #{result.rows} row(s) — " <>
-          Enum.map_join(classes(), ", ", fn {key, label} ->
-            "#{length(Map.fetch!(result, key))} #{label}"
-          end)
-      )
+    unless summary.ok?,
+      do: Mix.raise("images backfill check failed — see the mismatches above")
 
-      for {key, label} <- classes(), Map.fetch!(result, key) != [] do
-        Mix.shell().info("  #{label}: #{sample(Map.fetch!(result, key))}")
-      end
-    end
-
-    unless ok?, do: Mix.raise("images backfill check failed — see the mismatches above")
-
-    Mix.shell().info("Every member picture has its row and its file. Safe to cut.")
-  end
-
-  # Ten ids is enough to go and look at one; the count above is the number that
-  # matters, and printing 1,700 uuids buries it.
-  defp sample(ids) do
-    shown = Enum.take(ids, 10)
-    Enum.join(shown, " ") <> if(length(ids) > 10, do: " … (#{length(ids)} total)", else: "")
-  end
-
-  defp classes do
-    [
-      missing_row: "without a row",
-      mismatched_row: "disagreeing with the member row",
-      missing_pointer: "not pointed at",
-      missing_file: "with no file on disk",
-      orphan_row: "orphan row(s)"
-    ]
+    summary
   end
 
   defp parse_kind!(kind) do

--- a/lib/mix/tasks/vutuv.images.backfill.ex
+++ b/lib/mix/tasks/vutuv.images.backfill.ex
@@ -1,0 +1,96 @@
+defmodule Mix.Tasks.Vutuv.Images.Backfill do
+  @shortdoc "Brings every existing profile picture and cover into the images table"
+
+  @moduledoc """
+  Reconciles every member's profile picture and cover with its row in the
+  shared `images` table — the **contract** half of issue #2013. See
+  `Vutuv.Images.Backfill`.
+
+      mix vutuv.images.backfill              # reconcile, then check
+      mix vutuv.images.backfill --dry-run    # report what would change
+      mix vutuv.images.backfill --check      # check only, write nothing
+      mix vutuv.images.backfill --only cover
+      mix vutuv.images.backfill --from 019f0000-0000-7000-8000-000000000000
+
+  Moves no file and changes no URL: the four member-row columns stay the source
+  of truth, and this copies what they say into a row. Idempotent — a run that
+  is interrupted (a deploy stopping the slot) is simply run again, and every
+  member it already reached reports `unchanged`.
+
+  Every run ends with the check, and **a mismatch raises**: that is the gate on
+  the later deploy that drops the columns. In production (a release, no Mix)
+  use `bin/vutuv eval "Vutuv.Release.backfill_image_rows()"` /
+  `bin/vutuv eval "Vutuv.Release.check_image_rows()"`.
+  """
+
+  use Mix.Task
+
+  alias Vutuv.Images.Backfill
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _argv, _errors} =
+      OptionParser.parse(args,
+        strict: [only: :string, dry_run: :boolean, check: :boolean, from: :string]
+      )
+
+    Mix.Task.run("app.start")
+
+    opts =
+      Enum.map(opts, fn
+        {:only, kind} -> {:only, parse_kind!(kind)}
+        other -> other
+      end)
+
+    unless opts[:check], do: opts |> Keyword.delete(:check) |> Backfill.run()
+
+    opts |> Keyword.take([:only]) |> Backfill.check() |> report!()
+  end
+
+  defp report!(%{kinds: kinds, ok?: ok?}) do
+    for {kind, result} <- kinds do
+      Mix.shell().info(
+        "#{kind}: #{result.pictures} picture(s), #{result.rows} row(s) — " <>
+          Enum.map_join(classes(), ", ", fn {key, label} ->
+            "#{length(Map.fetch!(result, key))} #{label}"
+          end)
+      )
+
+      for {key, label} <- classes(), Map.fetch!(result, key) != [] do
+        Mix.shell().info("  #{label}: #{sample(Map.fetch!(result, key))}")
+      end
+    end
+
+    unless ok?, do: Mix.raise("images backfill check failed — see the mismatches above")
+
+    Mix.shell().info("Every member picture has its row and its file. Safe to cut.")
+  end
+
+  # Ten ids is enough to go and look at one; the count above is the number that
+  # matters, and printing 1,700 uuids buries it.
+  defp sample(ids) do
+    shown = Enum.take(ids, 10)
+    Enum.join(shown, " ") <> if(length(ids) > 10, do: " … (#{length(ids)} total)", else: "")
+  end
+
+  defp classes do
+    [
+      missing_row: "without a row",
+      mismatched_row: "disagreeing with the member row",
+      missing_pointer: "not pointed at",
+      missing_file: "with no file on disk",
+      orphan_row: "orphan row(s)"
+    ]
+  end
+
+  defp parse_kind!(kind) do
+    if kind in Backfill.kinds() do
+      kind
+    else
+      Mix.raise(
+        "unknown --only kind #{inspect(kind)}; expected one of: " <>
+          Enum.join(Backfill.kinds(), ", ")
+      )
+    end
+  end
+end

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -2221,28 +2221,33 @@ defmodule Vutuv.Accounts do
     # owner) until the AI scan releases or deletes it (Vutuv.Moderation.ImageScans).
     #
     # Since issue #2013 the same picture is also a row in the shared `images`
-    # table, written first so the member row can point at it in the one UPDATE.
-    # Nothing else moves: the four columns keep serving every URL and every
-    # display gate, and this release writes both (#2014 is the contract half).
+    # table, and since #2014 the two writes are **one transaction**. Apart they
+    # could half-commit: the row named the new picture, the member row still
+    # named the old file whose bytes the store had just replaced, no scan was
+    # ever queued to take the row out of "pending", and the member got a success
+    # flash. Nothing else moves: the four columns keep serving every URL and
+    # every display gate, and this release writes both (#2014's backfill brings
+    # the older pictures in; the columns go a deploy later).
+    #
+    # The moderation state comes back from the store rather than being read a
+    # second time here: the store is where `:moderate_images` decided which tree
+    # the bytes went into, so the row records the state that actually happened.
     kind = scan_kind(field)
-    moderation = ImageScans.initial_state()
 
-    with {:ok, file_name, fingerprint} <- store.({upload, user}, crop),
+    with {:ok, file_name, fingerprint, moderation} <- store.({upload, user}, crop),
          image_attrs = %{
            file: file_name,
            fingerprint: fingerprint,
            crop: crop,
            moderation: moderation
          },
-         {:ok, image} <- Images.put_profile_image(user, kind, image_attrs),
          user_attrs = %{
            field => file_name,
            fingerprint_field(field) => fingerprint,
            crop_field => crop,
-           moderation_field(field) => moderation,
-           Images.pointer_field(kind) => image.id
+           moderation_field(field) => moderation
          },
-         {:ok, saved} <- user |> Ecto.Changeset.change(user_attrs) |> Repo.update() do
+         {:ok, saved} <- store_image_pair(user, kind, image_attrs, user_attrs) do
       ImageScans.enqueue(kind, saved.id, saved.id, fingerprint)
       saved
     else
@@ -2250,6 +2255,21 @@ defmodule Vutuv.Accounts do
         Logger.warning("#{field} store failed for user ##{user.id}")
         user
     end
+  end
+
+  # The image row and the member row, or neither. The row goes first so the
+  # member row can point at it in the one UPDATE; the transaction is what makes
+  # that order safe.
+  defp store_image_pair(user, kind, image_attrs, user_attrs) do
+    Repo.transaction(fn ->
+      with {:ok, image} <- Images.put_profile_image(user, kind, image_attrs),
+           attrs = Map.put(user_attrs, Images.pointer_field(kind), image.id),
+           {:ok, saved} <- user |> Ecto.Changeset.change(attrs) |> Repo.update() do
+        saved
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
   end
 
   defp fingerprint_field(:avatar), do: :avatar_fingerprint

--- a/lib/vutuv/images.ex
+++ b/lib/vutuv/images.ex
@@ -53,13 +53,67 @@ defmodule Vutuv.Images do
       is a picture nobody knows how to take offline.\
       """)
 
+  # Which member-row column holds what for a profile picture, plus the uploader
+  # that owns its files. The one place these names are written: the backfill
+  # (`Vutuv.Images.Backfill`), `Vutuv.Moderation.ImageSubjects` and
+  # `Vutuv.Accounts` all read them from here, so the contract deploy that drops
+  # the four columns per kind has one list to delete rather than four copies to
+  # find.
+  @profile_columns %{
+    "avatar" => %{
+      file: :avatar,
+      fingerprint: :avatar_fingerprint,
+      crop: :avatar_crop,
+      moderation: :avatar_moderation,
+      pointer: :avatar_image_id,
+      module: Vutuv.Avatar,
+      prefix: "avatars"
+    },
+    "cover" => %{
+      file: :cover_photo,
+      fingerprint: :cover_fingerprint,
+      crop: :cover_crop,
+      moderation: :cover_moderation,
+      pointer: :cover_image_id,
+      module: Vutuv.Cover,
+      prefix: "covers"
+    }
+  }
+
+  @doc """
+  The member-row columns this kind still lives in, keyed by what each holds
+  (`:file`, `:fingerprint`, `:crop`, `:moderation`, `:pointer`), plus the
+  `:module` that owns the files and its on-disk `:prefix`.
+  """
+  def member_columns, do: @profile_columns
+  def member_columns(kind) when is_map_key(@profile_columns, kind), do: @profile_columns[kind]
+
   @doc """
   The member-row column pointing at this kind's row. The one place that name is
   written; `Vutuv.Accounts`, `Vutuv.Uploads` and
   `Vutuv.Moderation.ImageSubjects` all read it from here.
   """
-  def pointer_field("avatar"), do: :avatar_image_id
-  def pointer_field("cover"), do: :cover_image_id
+  def pointer_field(kind) when is_map_key(@profile_columns, kind),
+    do: @profile_columns[kind].pointer
+
+  @doc """
+  Where this member's picture of that kind actually is on disk right now, or
+  `nil` when the row names a file that is not there.
+
+  Asks the uploader rather than rebuilding a path: an unmoderated picture sits
+  in the served tree under whichever of the three naming schemes its row is on
+  (fingerprinted, stable-legacy, name-derived), and one still `"pending"` sits
+  in the quarantine tree instead. `Vutuv.Images.Backfill.check/1` is what needs
+  the distinction — "the row is right" and "the bytes are there" are two
+  different questions and the cut before #2012 needs both answered.
+  """
+  def stored_path(%User{} = user, kind) when is_map_key(@profile_columns, kind) do
+    config = @profile_columns[kind]
+
+    if Map.get(user, config.moderation) == "pending",
+      do: config.module.pending_preview_path(user),
+      else: config.module.stored_path(user)
+  end
 
   @doc """
   Records the picture a member just uploaded, replacing whatever row that

--- a/lib/vutuv/images/backfill.ex
+++ b/lib/vutuv/images/backfill.ex
@@ -114,10 +114,57 @@ defmodule Vutuv.Images.Backfill do
       otherwise). The backfill cannot repair this one — it predates the table
       and the bytes are simply gone — but the cut must not happen with it
       unread.
+
+  It **prints what it found** on the way out, through the same log as `run/1`.
+  Both operator paths (`mix vutuv.images.backfill --check` and `bin/vutuv eval
+  "Vutuv.Release.check_image_rows()"`) then say the same thing without either
+  of them owning a copy of the formatting — the first version put that half in
+  the mix task alone, where it went out of step with this map's shape and
+  crashed on every call while the release path printed nothing at all.
   """
   def check(opts \\ []) do
     kinds = for kind <- selected_kinds(opts), into: %{}, do: {kind, check_kind(kind)}
+
     %{kinds: kinds, ok?: Enum.all?(kinds, fn {_kind, result} -> result.ok? end)}
+    |> tap(&report/1)
+  end
+
+  # The classes in the order an operator wants to read them, with the words
+  # that say what each one means.
+  @labels [
+    missing_row: "without a row",
+    mismatched_row: "disagreeing with the member row",
+    missing_pointer: "not pointed at",
+    missing_file: "with no file on disk",
+    orphan_row: "orphan row(s)"
+  ]
+
+  defp report(%{kinds: kinds, ok?: ok?}) do
+    for {kind, result} <- kinds do
+      log(
+        "#{kind}: #{result.pictures} picture(s), #{result.rows} row(s) — " <>
+          Enum.map_join(@labels, ", ", fn {class, label} ->
+            "#{Map.fetch!(result, class).count} #{label}"
+          end)
+      )
+
+      for {class, label} <- @labels, Map.fetch!(result, class).count > 0 do
+        log("  #{label}: #{sample_line(Map.fetch!(result, class))}")
+      end
+    end
+
+    log(
+      if ok?,
+        do: "Every member picture has its row and its file. Safe to cut.",
+        else: "MISMATCH — do not drop the member row's image columns yet."
+    )
+  end
+
+  # The count above is the number that matters; a handful of ids is what makes
+  # it actionable, and printing 1,700 of them buries the count.
+  defp sample_line(%{count: count, sample: sample}) do
+    shown = Enum.take(sample, 10)
+    Enum.join(shown, " ") <> if(count > length(shown), do: " … (#{count} total)", else: "")
   end
 
   defp selected_kinds(opts) do

--- a/lib/vutuv/images/backfill.ex
+++ b/lib/vutuv/images/backfill.ex
@@ -1,0 +1,371 @@
+defmodule Vutuv.Images.Backfill do
+  @moduledoc """
+  Brings every profile picture and cover that existed before the shared
+  `images` table into it — the **contract** half of issue #2013, in the same
+  expand/contract shape the fingerprint migration used
+  (`Vutuv.Uploads.Regenerator` expand, `Vutuv.Uploads.LegacySweeper` contract).
+
+  It **moves no file and changes no URL.** The four member-row columns stay the
+  source of truth every URL builder and every display gate reads; this only
+  copies what they say into a row and points the member row at it, so the
+  previous release keeps serving unchanged through the whole deploy window.
+
+  ## Reconcile, not insert-where-missing
+
+  A row can already exist *and disagree* with the member columns. Until the
+  transaction in `Vutuv.Accounts.store_pending_image/6` was added, an upload
+  wrote the image row first and the member row second, so a failure in between
+  (a pool timeout, a slot dying in the blue/green switch, a `StaleEntryError`)
+  left the row naming the new picture and the member row still naming the old
+  one. A backfill that only creates rows where none exists skips exactly those
+  members, and the contract deploy that drops the columns then destroys the
+  only record of which file is really current. So every member is compared
+  field by field and a row that disagrees is corrected — `run/1` reports the
+  rows it created and the rows it corrected apart.
+
+  A row whose member has no picture of that kind any more is deleted: "there is
+  a row" and "there is a picture" are the same statement (the same reason
+  `Vutuv.Images.forget_profile_image/2` deletes rather than blanks).
+
+  `classify/3` is what decides which of those a member is, and `run/1` and
+  `check/1` both go through it — otherwise the gate would be answering a
+  slightly different question from the repair it gates.
+
+  ## Interrupted halfway
+
+  Nothing here is a queue and nothing holds state in memory. Work is a keyset
+  scan over `users.id` with **one transaction per member**, and each member's
+  outcome depends only on that member's own columns — so a run killed
+  mid-flight (a deploy stopping the slot, `Ctrl-C`) leaves every member it
+  reached already correct and every member it did not reach exactly as before.
+  **Simply run it again**: the members already done cost no write and report
+  `unchanged`. `from: "<user id>"` picks up where a log line left off when
+  re-reading the whole table is not wanted, and `check/1` — which reads no
+  state the run holds — is what says whether anything is still outstanding.
+
+  Per member rather than per batch on purpose: one bad row then fails alone and
+  the run carries on. It is a one-shot job over the pictures an installation
+  has (1,747 on vutuv.de), so the writes are not batched and no index is added
+  for it; the reads are `@batch` members at a time.
+
+  ## The check before the cut
+
+  `check/1` counts every member picture against its row *and* against its file
+  on disk, and answers `ok?: false` with a bounded sample of the member ids
+  behind each class of mismatch. That is the gate on the deploy that drops the
+  columns: run it, read it, and only cut when it is green.
+  """
+
+  import Ecto.Query
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Images
+  alias Vutuv.Images.Image
+  alias Vutuv.Repo
+  alias Vutuv.Uploads
+
+  # Members per SELECT. Small enough that an interrupted run has wasted little,
+  # large enough that 1,700 avatars are four reads rather than 1,700.
+  @batch 500
+
+  # Ids kept per mismatch class. Before the backfill has run, `missing_row` is
+  # every picture on the installation by construction, and `check_image_rows/1`
+  # returns its answer straight to a `bin/vutuv eval` console — the count is
+  # what the operator needs, a sample is what makes it actionable.
+  @sample 100
+
+  # The four the member row holds and the row copies. `:crop` and `:moderation`
+  # are legitimately nil on old rows, so a comparison has to be on equality,
+  # never on presence.
+  @copied [:file, :fingerprint, :crop, :moderation]
+
+  @classes [:missing_row, :mismatched_row, :missing_pointer, :missing_file, :orphan_row]
+
+  @doc "The profile-image kinds this backfill covers."
+  def kinds, do: Images.member_columns() |> Map.keys() |> Enum.sort()
+
+  @doc """
+  Reconciles every member's picture with its row.
+
+  Options: `only: "avatar" | "cover"`, `dry_run: true` (report, write nothing),
+  `from: "<user id>"` (resume the keyset scan above that id).
+
+  Returns `%{"avatar" => %{pictures: n, created: n, corrected: n, unchanged: n,
+  dropped: n, failed: n}, "cover" => …}`.
+  """
+  def run(opts \\ []) do
+    for kind <- selected_kinds(opts), into: %{}, do: {kind, run_kind(kind, opts)}
+  end
+
+  @doc """
+  Counts every member picture against its row and its file on disk, without
+  writing anything. Same `only:` option as `run/1`.
+
+  Returns `%{kinds: %{"avatar" => …}, ok?: boolean}`, where each kind carries a
+  `%{count: n, sample: [user id]}` per class of mismatch:
+
+    * `missing_row` — a picture with no row at all (the backfill has not run)
+    * `mismatched_row` — a row that disagrees with the member's own columns
+    * `missing_pointer` — a row the member row does not point at
+    * `orphan_row` — a row whose member has no picture of that kind any more
+      (sampled by row id, not member id)
+    * `missing_file` — the file the member row names is not on disk (in the
+      quarantine tree while the picture is `"pending"`, in the served tree
+      otherwise). The backfill cannot repair this one — it predates the table
+      and the bytes are simply gone — but the cut must not happen with it
+      unread.
+  """
+  def check(opts \\ []) do
+    kinds = for kind <- selected_kinds(opts), into: %{}, do: {kind, check_kind(kind)}
+    %{kinds: kinds, ok?: Enum.all?(kinds, fn {_kind, result} -> result.ok? end)}
+  end
+
+  defp selected_kinds(opts) do
+    case Keyword.get(opts, :only) do
+      nil -> kinds()
+      kind -> [kind]
+    end
+  end
+
+  ## What is wrong with this member, if anything
+
+  # The one place that decides. `run/1` repairs what this names and `check/1`
+  # reports it, so a class added here can never be invisible to the gate.
+  defp classify(user, row, cols) do
+    cond do
+      is_nil(row) -> :missing_row
+      drifted?(row, desired(user, cols)) -> :mismatched_row
+      Map.get(user, cols.pointer) != row.id -> :missing_pointer
+      true -> :ok
+    end
+  end
+
+  defp desired(user, cols),
+    do: Map.new(@copied, fn field -> {field, Map.get(user, cols[field])} end)
+
+  defp drifted?(row, desired), do: Enum.any?(desired, fn {f, v} -> Map.get(row, f) != v end)
+
+  ## Reconcile
+
+  defp run_kind(kind, opts) do
+    cols = Images.member_columns(kind)
+    tally = %{pictures: 0, created: 0, corrected: 0, unchanged: 0, dropped: 0, failed: 0}
+
+    log("#{kind}: reconciling#{if opts[:dry_run], do: " — dry run", else: ""}")
+
+    # One line per batch, so an interrupted run leaves the operator an id to
+    # resume from. Per batch, not per member: 1,700 lines is not progress.
+    on_batch = fn id -> log("  #{kind}: through #{id} (--from to resume here)") end
+
+    tally
+    |> each_batch(
+      kind,
+      cols,
+      Keyword.get(opts, :from),
+      fn {user, row}, acc ->
+        acc
+        |> bump(:pictures)
+        |> bump(repair(classify(user, row, cols), user, row, kind, cols, opts))
+      end,
+      on_batch
+    )
+    |> drop_orphans(kind, cols, opts)
+    |> tap(fn t ->
+      log(
+        "#{kind}: #{t.pictures} picture(s) — #{t.created} row(s) created, " <>
+          "#{t.corrected} corrected, #{t.unchanged} already right, " <>
+          "#{t.dropped} orphan row(s) dropped, #{t.failed} failed"
+      )
+    end)
+  end
+
+  # The keyset walk both halves share. One SELECT per batch carries the member
+  # and its row together, so a member that is already right costs no second
+  # statement.
+  defp each_batch(acc, kind, cols, cursor, fun, on_batch \\ fn _id -> :ok end) do
+    case Repo.all(batch_query(kind, cols, cursor)) do
+      [] ->
+        acc
+
+      rows ->
+        acc = Enum.reduce(rows, acc, fun)
+        {last_user, _row} = List.last(rows)
+        on_batch.(last_user.id)
+        each_batch(acc, kind, cols, last_user.id, fun, on_batch)
+    end
+  end
+
+  defp batch_query(kind, cols, cursor) do
+    query =
+      from(u in User,
+        left_join: i in Image,
+        on: i.user_id == u.id and i.kind == ^kind,
+        where: not is_nil(field(u, ^cols.file)),
+        order_by: [asc: u.id],
+        limit: @batch,
+        select: {u, i}
+      )
+
+    if cursor, do: where(query, [u], u.id > ^cursor), else: query
+  end
+
+  defp repair(:ok, _user, _row, _kind, _cols, _opts), do: :unchanged
+
+  defp repair(verdict, user, row, kind, cols, opts) do
+    outcome = if verdict == :missing_row, do: :created, else: :corrected
+
+    if opts[:dry_run],
+      do: outcome,
+      else: write(user, cols, outcome, fn -> mend(verdict, user, row, kind, cols) end)
+  end
+
+  # A create goes through `Images.put_profile_image/3`, the same function the
+  # upload path uses: it mints the fresh token and carries the upsert against
+  # the partial unique index, so a row an upload writes between this batch's
+  # SELECT and this write converges instead of failing.
+  defp mend(:missing_row, user, _row, kind, cols) do
+    with {:ok, image} <- Images.put_profile_image(user, kind, desired(user, cols)),
+         do: point_at(user, cols, image.id)
+  end
+
+  # The row is overwritten from the member columns, never the other way round:
+  # they are what every URL and every display gate reads today, so they are the
+  # truth this table has to agree with. Not `put_profile_image/3`, which always
+  # mints a fresh token — here a **fresh token goes with a changed picture**
+  # only, because a token names the bytes: a row corrected back to a different
+  # file must not keep a handle that named the other one, and a row whose
+  # moderation state alone drifted must not lose the handle it has.
+  defp mend(:mismatched_row, user, row, _kind, cols) do
+    desired = desired(user, cols)
+
+    attrs =
+      if row.fingerprint == desired.fingerprint and row.file == desired.file,
+        do: desired,
+        else: Map.put(desired, :token, Uploads.gen_token())
+
+    with {:ok, image} <- row |> Image.changeset(attrs) |> Repo.update(),
+         do: point_at(user, cols, image.id)
+  end
+
+  # The row is right and only the member row's pointer is not — the shape a
+  # half-committed upload leaves behind.
+  defp mend(:missing_pointer, user, row, _kind, cols), do: point_at(user, cols, row.id)
+
+  defp point_at(user, cols, image_id) do
+    from(u in User, where: u.id == ^user.id)
+    |> Repo.update_all(set: [{cols.pointer, image_id}])
+
+    :ok
+  end
+
+  # Row and pointer move together or not at all, so an interrupted run can
+  # never leave the pair the upload path used to be able to leave. A member the
+  # database refuses is logged and counted, never fatal to the run.
+  defp write(user, cols, outcome, fun) do
+    result =
+      Repo.transaction(fn ->
+        case fun.() do
+          :ok -> :ok
+          {:error, reason} -> Repo.rollback(reason)
+        end
+      end)
+
+    case result do
+      {:ok, :ok} ->
+        outcome
+
+      {:error, reason} ->
+        log("  FAIL #{cols.file} #{user.id}: #{inspect(reason)}")
+        :failed
+    end
+  rescue
+    exception ->
+      log("  FAIL #{cols.file} #{user.id}: #{inspect(exception)}")
+      :failed
+  end
+
+  # A row whose member has no picture of that kind any more, deleted in one
+  # statement (`Vutuv.Images.forget_profile_image/2` is its single-row twin on
+  # the moderation path). The member row's pointer follows by itself
+  # (`on_delete: :nilify_all`).
+  defp drop_orphans(tally, kind, cols, opts) do
+    dropped =
+      if opts[:dry_run] do
+        Repo.aggregate(orphan_query(kind, cols), :count)
+      else
+        {count, _} = Repo.delete_all(orphan_query(kind, cols))
+        count
+      end
+
+    %{tally | dropped: tally.dropped + dropped}
+  end
+
+  # Deletable as it stands: `delete_all` takes a join-free query, so the "has
+  # this member still got a picture" half is a correlated subquery.
+  defp orphan_query(kind, cols) do
+    ownerless =
+      from(u in User,
+        where: u.id == parent_as(:image).user_id and is_nil(field(u, ^cols.file))
+      )
+
+    from(i in Image, as: :image, where: i.kind == ^kind and exists(subquery(ownerless)))
+  end
+
+  ## Check
+
+  defp check_kind(kind) do
+    cols = Images.member_columns(kind)
+
+    empty = %{
+      pictures: 0,
+      rows: Repo.aggregate(from(i in Image, where: i.kind == ^kind), :count),
+      missing_row: blank(),
+      mismatched_row: blank(),
+      missing_pointer: blank(),
+      missing_file: blank(),
+      orphan_row: orphan_class(kind, cols)
+    }
+
+    empty
+    |> each_batch(kind, cols, nil, fn {user, row}, acc ->
+      acc
+      |> Map.update!(:pictures, &(&1 + 1))
+      |> flag(classify(user, row, cols), user.id)
+      |> flag(file_verdict(user, kind), user.id)
+    end)
+    |> finish_check()
+  end
+
+  defp file_verdict(user, kind) do
+    if is_nil(Images.stored_path(user, kind)), do: :missing_file, else: :ok
+  end
+
+  defp blank, do: %{count: 0, sample: []}
+
+  defp orphan_class(kind, cols) do
+    query = orphan_query(kind, cols)
+
+    %{
+      count: Repo.aggregate(query, :count),
+      sample: Repo.all(from(i in query, order_by: [asc: i.id], limit: @sample, select: i.id))
+    }
+  end
+
+  defp flag(result, :ok, _id), do: result
+
+  defp flag(result, class, id) do
+    Map.update!(result, class, fn %{count: count, sample: sample} ->
+      %{count: count + 1, sample: if(count < @sample, do: sample ++ [id], else: sample)}
+    end)
+  end
+
+  defp finish_check(result),
+    do: Map.put(result, :ok?, Enum.all?(@classes, &(Map.fetch!(result, &1).count == 0)))
+
+  ## Shared
+
+  defp bump(tally, key), do: Map.update!(tally, key, &(&1 + 1))
+
+  # The quiet-flag logic lives once in Vutuv.Uploads.log/1.
+  defp log(message), do: Uploads.log(message)
+end

--- a/lib/vutuv/moderation/image_subjects.ex
+++ b/lib/vutuv/moderation/image_subjects.ex
@@ -46,24 +46,11 @@ defmodule Vutuv.Moderation.ImageSubjects do
   alias Vutuv.Videos
 
   # The avatar/cover twins differ only in their column names + uploader module.
-  @profile_images %{
-    "avatar" => %{
-      file: :avatar,
-      fingerprint: :avatar_fingerprint,
-      crop: :avatar_crop,
-      moderation: :avatar_moderation,
-      module: Vutuv.Avatar,
-      prefix: "avatars"
-    },
-    "cover" => %{
-      file: :cover_photo,
-      fingerprint: :cover_fingerprint,
-      crop: :cover_crop,
-      moderation: :cover_moderation,
-      module: Vutuv.Cover,
-      prefix: "covers"
-    }
-  }
+  # Which member-row column holds what, read from the one module that owns
+  # those names (`Vutuv.Images.member_columns/0`) rather than spelled a second
+  # time here: the contract half of #2013 drops all four per kind, and a second
+  # copy is a second place to remember.
+  @profile_images Vutuv.Images.member_columns()
 
   @gallery_images %{
     # `pixelated: true` marks the one gallery kind a stranger meets while the
@@ -566,7 +553,7 @@ defmodule Vutuv.Moderation.ImageSubjects do
       from(u in User,
         where: u.id == ^scan.subject_id and field(u, ^config.fingerprint) == ^scan.fingerprint
       )
-      |> Repo.update_all(set: clear_profile_columns(config, scan.kind))
+      |> Repo.update_all(set: clear_profile_columns(config))
 
     case cleared do
       {1, _} ->
@@ -882,7 +869,7 @@ defmodule Vutuv.Moderation.ImageSubjects do
             field(u, ^config.fingerprint) == ^scan.fingerprint and
             field(u, ^config.moderation) == "pending"
       )
-      |> Repo.update_all(set: clear_profile_columns(config, scan.kind))
+      |> Repo.update_all(set: clear_profile_columns(config))
 
     # Only when this scan's own picture was the one cleared — the common case
     # here is a stale cancel that matches nothing, and a delete then would take
@@ -907,13 +894,13 @@ defmodule Vutuv.Moderation.ImageSubjects do
   # image or cancels a pending one. The row itself is deleted beside this
   # (`Vutuv.Images.forget_profile_image/2`): "there is a row" and "there is a
   # picture" stay the same statement.
-  defp clear_profile_columns(config, kind),
+  defp clear_profile_columns(config),
     do: [
       {config.file, nil},
       {config.fingerprint, nil},
       {config.crop, nil},
       {config.moderation, nil},
-      {Images.pointer_field(kind), nil}
+      {config.pointer, nil}
     ]
 
   # Every document column resets when a scan rejects the proof document; the

--- a/lib/vutuv/release.ex
+++ b/lib/vutuv/release.ex
@@ -6,6 +6,7 @@ defmodule Vutuv.Release do
 
       bin/vutuv eval "Vutuv.Release.migrate()"
   """
+  alias Vutuv.Images.Backfill
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Organizations.Screenshots, as: OrganizationScreenshots
   alias Vutuv.PageScreenshot
@@ -125,6 +126,46 @@ defmodule Vutuv.Release do
 
     {:ok, summary, _apps} =
       Ecto.Migrator.with_repo(repo, fn _repo -> LegacySweeper.run(opts) end)
+
+    summary
+  end
+
+  @doc """
+  Brings every profile picture and cover uploaded before the shared `images`
+  table into it, and corrects any row that disagrees with the member's own
+  columns (see `Vutuv.Images.Backfill`). Moves no file and changes no URL, so
+  it is safe while the app serves traffic and safe to run again after an
+  interruption:
+
+      bin/vutuv eval "Vutuv.Release.backfill_image_rows()"
+      bin/vutuv eval "Vutuv.Release.backfill_image_rows(dry_run: true)"
+      bin/vutuv eval "Vutuv.Release.backfill_image_rows(only: \\"cover\\")"
+  """
+  def backfill_image_rows(opts \\ []) do
+    load_app()
+
+    [repo] = repos()
+
+    {:ok, summary, _apps} =
+      Ecto.Migrator.with_repo(repo, fn _repo -> Backfill.run(opts) end)
+
+    summary
+  end
+
+  @doc """
+  Counts every member picture against its row and its file on disk, writing
+  nothing. The gate on the deploy that drops the member row's four columns per
+  kind: read it, and cut only when `ok?` is true.
+
+      bin/vutuv eval "Vutuv.Release.check_image_rows()"
+  """
+  def check_image_rows(opts \\ []) do
+    load_app()
+
+    [repo] = repos()
+
+    {:ok, summary, _apps} =
+      Ecto.Migrator.with_repo(repo, fn _repo -> Backfill.check(opts) end)
 
     summary
   end

--- a/lib/vutuv/release.ex
+++ b/lib/vutuv/release.ex
@@ -154,10 +154,15 @@ defmodule Vutuv.Release do
 
   @doc """
   Counts every member picture against its row and its file on disk, writing
-  nothing. The gate on the deploy that drops the member row's four columns per
-  kind: read it, and cut only when `ok?` is true.
+  nothing, and prints what it found. The gate on the deploy that drops the
+  member row's four columns per kind:
 
       bin/vutuv eval "Vutuv.Release.check_image_rows()"
+
+  **Raises when anything is outstanding**, so the command's exit status is the
+  gate and a deploy script can stand on it. A silent success is the one answer
+  this must never give by accident: a check that says nothing reads exactly
+  like a clean bill of health.
   """
   def check_image_rows(opts \\ []) do
     load_app()
@@ -166,6 +171,10 @@ defmodule Vutuv.Release do
 
     {:ok, summary, _apps} =
       Ecto.Migrator.with_repo(repo, fn _repo -> Backfill.check(opts) end)
+
+    unless summary.ok? do
+      raise "images backfill check failed — see the mismatches above"
+    end
 
     summary
   end

--- a/lib/vutuv/uploaders/avatar.ex
+++ b/lib/vutuv/uploaders/avatar.ex
@@ -66,9 +66,10 @@ defmodule Vutuv.Avatar do
   @doc """
   Stores every avatar version for `{upload, user}`, cropping the served
   versions to `crop` (a `"x,y,w,h"` string or `nil` for the centered default;
-  see `Vutuv.Uploads.Crop`) and returns `{:ok, original_file_name, fingerprint}`
-  (kept in the `:avatar` / `:avatar_fingerprint` columns; the crop is folded
-  into the fingerprint), or `{:error, :invalid_file}` when the
+  see `Vutuv.Uploads.Crop`) and returns
+  `{:ok, original_file_name, fingerprint, moderation}` (kept in the `:avatar` /
+  `:avatar_fingerprint` / `:avatar_moderation` columns; the crop is folded into
+  the fingerprint), or `{:error, :invalid_file}` when the
   extension is not whitelisted **or the file cannot be decoded as an image**
   (corrupt/truncated uploads used to crash the request with a `MatchError`).
   """
@@ -104,8 +105,18 @@ defmodule Vutuv.Avatar do
   The quarantined version's on-disk path while the avatar waits in moderation
   limbo — the owner-only preview (`VutuvWeb.PendingImageController`).
   """
-  def pending_preview_path(user, version) do
+  def pending_preview_path(user, version \\ @config.default_version) do
     Uploads.quarantine_version_path(user, version, @config)
+  end
+
+  @doc """
+  The served version's on-disk path, or `nil` when the file the row names is
+  not there. Whichever of the three naming schemes the row is on
+  (`Vutuv.Uploads.version_path/3` resolves them). What
+  `Vutuv.Images.Backfill.check/1` asks before the contract cut.
+  """
+  def stored_path(user, version \\ @config.default_version) do
+    Uploads.version_path({user.avatar, user}, version, @config)
   end
 
   @doc """

--- a/lib/vutuv/uploaders/cover.ex
+++ b/lib/vutuv/uploaders/cover.ex
@@ -47,9 +47,10 @@ defmodule Vutuv.Cover do
   @doc """
   Stores every cover version for `{upload, user}`, cropping the served banner
   to `crop` (a `"x,y,w,h"` string or `nil` for the full-width default; see
-  `Vutuv.Uploads.Crop`) and returns `{:ok, original_file_name, fingerprint}`
-  (kept in the `:cover_photo` / `:cover_fingerprint` columns; the crop is folded
-  into the fingerprint), or `{:error, :invalid_file}` when the
+  `Vutuv.Uploads.Crop`) and returns
+  `{:ok, original_file_name, fingerprint, moderation}` (kept in the
+  `:cover_photo` / `:cover_fingerprint` / `:cover_moderation` columns; the crop
+  is folded into the fingerprint), or `{:error, :invalid_file}` when the
   extension is not whitelisted or the file cannot be decoded as an image.
   """
   def store({%Plug.Upload{}, _scope} = upload_and_scope, crop \\ nil) do
@@ -77,8 +78,17 @@ defmodule Vutuv.Cover do
   The quarantined version's on-disk path while the cover waits in moderation
   limbo — the owner-only preview (`VutuvWeb.PendingImageController`).
   """
-  def pending_preview_path(user, version) do
+  def pending_preview_path(user, version \\ @config.default_version) do
     Uploads.quarantine_version_path(user, version, @config)
+  end
+
+  @doc """
+  The served version's on-disk path, or `nil` when the file the row names is
+  not there — the cover's half of `Vutuv.Images.Backfill.check/1`. See
+  `Vutuv.Avatar.stored_path/2`.
+  """
+  def stored_path(user, version \\ @config.default_version) do
+    Uploads.version_path({user.cover_photo, user}, version, @config)
   end
 
   @doc """

--- a/lib/vutuv/uploads.ex
+++ b/lib/vutuv/uploads.ex
@@ -103,11 +103,18 @@ defmodule Vutuv.Uploads do
 
   @doc """
   Stores every derived version for `{upload, scope}` per `config` and returns
-  `{:ok, original_file_name, fingerprint}` — the verbatim upload name and the
-  content fingerprint (`sha256(original)[0..#{@hash_length - 1}]`) the caller
-  keeps in its columns — or `{:error, :invalid_file}` when the extension is not
+  `{:ok, original_file_name, fingerprint, moderation}` — the verbatim upload
+  name, the content fingerprint (`sha256(original)[0..#{@hash_length - 1}]`)
+  and the moderation state the bytes were actually stored under, all three for
+  the caller's columns — or `{:error, :invalid_file}` when the extension is not
   whitelisted **or the file cannot be decoded as an image** (corrupt/truncated
   uploads used to crash the request with a `MatchError`).
+
+  The moderation state comes back rather than being read a second time by the
+  caller: this function is where `:moderate_images` decides which tree the
+  bytes land in, so it is also where the state the row records is decided —
+  one read, and the two can never disagree. `nil` for an uploader with no
+  moderation column.
 
   The served files are written under the fingerprinted scheme-B name
   `<handle>-<version>-<fingerprint>.avif`, so a fresh upload is immediately on
@@ -118,6 +125,7 @@ defmodule Vutuv.Uploads do
   prior versions cleared, the new ones written, and the original copied
   (privately). Clearing prior versions keeps exactly one image set per dir, so a
   re-upload never accumulates stale fingerprinted/legacy files.
+
   """
   def store({%Plug.Upload{} = upload, scope}, config, crop \\ nil) do
     if valid_extension?(upload.filename) do
@@ -134,7 +142,8 @@ defmodule Vutuv.Uploads do
       # moves the files into the served dir (approve) or removes everything
       # (reject). The old public image is cleared only after the new derive
       # succeeded, so a corrupt upload never costs the current image.
-      target_dir = if quarantined?(config), do: quarantine_dir(storage_dir), else: dir
+      moderation = initial_moderation(config)
+      target_dir = if moderation == "pending", do: quarantine_dir(storage_dir), else: dir
       File.mkdir_p!(target_dir)
 
       with {:ok, rotated} <- Spec.open_rotated(upload.path),
@@ -143,7 +152,7 @@ defmodule Vutuv.Uploads do
            :ok <- write_derived_versions(cropped, target_dir, scope, fingerprint, config),
            :ok <- clear_displaced_versions(target_dir, dir),
            :ok <- Originals.store(storage_dir, upload.path, ext) do
-        {:ok, upload.filename, fingerprint}
+        {:ok, upload.filename, fingerprint, moderation}
       else
         {:error, _reason} -> {:error, :invalid_file}
       end
@@ -158,10 +167,12 @@ defmodule Vutuv.Uploads do
   defp clear_displaced_versions(dir, dir), do: :ok
   defp clear_displaced_versions(_target_dir, dir), do: clear_public_versions(dir)
 
-  # Whether this uploader's fresh files belong in the quarantine tree: it has
-  # a moderation state column and AI image moderation is on.
-  defp quarantined?(config) do
-    Map.has_key?(config, :moderation_field) and ImageScans.enabled?()
+  # The state this uploader's fresh files start in — the **single** read of
+  # `:moderate_images` per store. "pending" puts the bytes in the quarantine
+  # tree and is what the caller writes onto its row; nil is an uploader with no
+  # moderation column, which has neither.
+  defp initial_moderation(config) do
+    if Map.has_key?(config, :moderation_field), do: ImageScans.initial_state()
   end
 
   @doc """

--- a/test/vutuv/images/backfill_test.exs
+++ b/test/vutuv/images/backfill_test.exs
@@ -6,10 +6,12 @@ defmodule Vutuv.Images.BackfillTest do
 
   Not async: `check/1` reads the disk, so the module holds the global
   `:uploads_dir_prefix` down for its lifetime (`Vutuv.Uploads.disk_dir/1` and
-  every uploader read it).
+  every uploader read it), and the operator-output tests below un-silence the
+  equally global `:regenerator_quiet` that the three uploads mix tasks read.
   """
   use Vutuv.DataCase, async: false
 
+  import ExUnit.CaptureIO
   import Vutuv.WebPushHelpers, only: [put_config: 2]
 
   alias Vutuv.Accounts
@@ -306,6 +308,80 @@ defmodule Vutuv.Images.BackfillTest do
       %{kinds: %{"avatar" => result}, ok?: ok?} = Backfill.check(only: "avatar")
       assert ok?, "a pending picture lives in the quarantine tree, not the served one"
       assert result.missing_file.count == 0
+    end
+  end
+
+  # The half that a rehearsal driving `Backfill.run/1` and `check/1` directly
+  # never touches, and the half the operator actually meets. The first version
+  # of it lived in the mix task, went out of step with what `check/1` returns,
+  # and crashed on every single invocation — while the release path printed
+  # nothing at all and exited 0 with 1,678 mismatches outstanding.
+  describe "what the operator sees" do
+    setup do
+      put_config(:regenerator_quiet, false)
+      :ok
+    end
+
+    test "the check names what is wrong, with the member behind it" do
+      user = legacy_avatar()
+
+      output = capture_io(fn -> assert %{ok?: false} = Backfill.check(only: "avatar") end)
+
+      assert output =~ "avatar: 1 picture(s), 0 row(s)"
+      assert output =~ "1 without a row"
+      assert output =~ "without a row: #{user.id}"
+      assert output =~ "MISMATCH"
+      refute output =~ "Safe to cut"
+    end
+
+    test "and says it is safe to cut once everything is in order" do
+      user = insert(:activated_user)
+      insert(:email, user: user)
+      {:ok, _user} = Accounts.update_user(user, %{avatar: jpeg_upload()})
+      capture_io(fn -> Backfill.run(only: "avatar") end)
+
+      output = capture_io(fn -> assert %{ok?: true} = Backfill.check(only: "avatar") end)
+
+      assert output =~ "avatar: 1 picture(s), 1 row(s)"
+      assert output =~ "0 without a row"
+      assert output =~ "0 with no file on disk"
+      assert output =~ "Safe to cut"
+      refute output =~ "MISMATCH"
+    end
+
+    test "a long list of ids is capped and says how many there really are" do
+      for _ <- 1..12, do: legacy_avatar()
+
+      output = capture_io(fn -> Backfill.check(only: "avatar") end)
+
+      assert output =~ "12 without a row"
+      assert output =~ "… (12 total)"
+
+      assert length(String.split(Regex.run(~r/without a row: (.+) …/, output) |> Enum.at(1))) ==
+               10
+    end
+
+    test "the mix task reconciles and succeeds when everything is in order" do
+      user = insert(:activated_user)
+      insert(:email, user: user)
+      {:ok, user} = Accounts.update_user(user, %{avatar: jpeg_upload()})
+      Repo.delete_all(from(i in ImageRow, where: i.user_id == ^user.id))
+
+      capture_io(fn ->
+        assert %{ok?: true} = Mix.Tasks.Vutuv.Images.Backfill.run([])
+      end)
+
+      assert Images.profile_image(user.id, "avatar")
+    end
+
+    test "the mix task fails the command when something is outstanding" do
+      legacy_avatar()
+
+      capture_io(fn ->
+        assert_raise Mix.Error, ~r/check failed/, fn ->
+          Mix.Tasks.Vutuv.Images.Backfill.run(["--check"])
+        end
+      end)
     end
   end
 end

--- a/test/vutuv/images/backfill_test.exs
+++ b/test/vutuv/images/backfill_test.exs
@@ -1,0 +1,311 @@
+defmodule Vutuv.Images.BackfillTest do
+  @moduledoc """
+  The contract half of the shared `images` table (issue #2014): every picture
+  that existed before the table arrives in it, nothing on disk moves, and the
+  check that gates the later column drop is loud about anything it cannot fix.
+
+  Not async: `check/1` reads the disk, so the module holds the global
+  `:uploads_dir_prefix` down for its lifetime (`Vutuv.Uploads.disk_dir/1` and
+  every uploader read it).
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.WebPushHelpers, only: [put_config: 2]
+
+  alias Vutuv.Accounts
+  alias Vutuv.Accounts.User
+  alias Vutuv.Images
+  alias Vutuv.Images.Backfill
+  alias Vutuv.Images.Image, as: ImageRow
+  alias Vutuv.Repo
+
+  setup do
+    tmp =
+      Path.join(System.tmp_dir!(), "vutuv_backfill_test_#{System.unique_integer([:positive])}")
+
+    put_config(:uploads_dir_prefix, tmp)
+    on_exit(fn -> File.rm_rf(tmp) end)
+    :ok
+  end
+
+  # A picture from before the table: the member row's four columns filled, no
+  # row, no pointer — exactly what 1,679 avatars on vutuv.de look like.
+  defp legacy_avatar(attrs \\ %{}) do
+    attrs =
+      Map.merge(
+        %{
+          avatar: "old.jpg",
+          avatar_fingerprint: "1a2b3c4d5e6f",
+          avatar_crop: nil,
+          avatar_moderation: "approved"
+        },
+        attrs
+      )
+
+    insert(:activated_user) |> Ecto.Changeset.change(attrs) |> Repo.update!()
+  end
+
+  defp reload(user), do: Repo.get!(User, user.id)
+
+  defp jpeg_upload(name \\ "selfie.jpg") do
+    src = Path.join(System.tmp_dir!(), "backfill_src_#{System.unique_integer([:positive])}.jpg")
+    {:ok, img} = Image.new(300, 200, color: [10, 120, 200])
+    {:ok, _} = Image.write(img, src)
+    on_exit(fn -> File.rm(src) end)
+    %Plug.Upload{filename: name, path: src, content_type: "image/jpeg"}
+  end
+
+  describe "creating the rows that were never written" do
+    test "an old avatar arrives with its four values, a token and a pointer" do
+      user = legacy_avatar(%{avatar_crop: "0.0000,0.0000,0.5000,0.5000"})
+
+      assert %{"avatar" => tally} = Backfill.run(only: "avatar")
+      assert tally.pictures == 1
+      assert tally.created == 1
+      assert tally.corrected == 0
+
+      image = Images.profile_image(user.id, "avatar")
+      assert image.kind == "avatar"
+      assert image.file == "old.jpg"
+      assert image.fingerprint == "1a2b3c4d5e6f"
+      assert image.crop == "0.0000,0.0000,0.5000,0.5000"
+      assert image.moderation == "approved"
+      assert is_binary(image.token) and image.token != ""
+      assert image.frozen_at == nil
+      assert reload(user).avatar_image_id == image.id
+    end
+
+    test "a picture still on the pre-fingerprint scheme keeps its nil fingerprint" do
+      user = legacy_avatar(%{avatar_fingerprint: nil, avatar_moderation: nil})
+
+      Backfill.run(only: "avatar")
+
+      image = Images.profile_image(user.id, "avatar")
+      assert image.fingerprint == nil
+      assert image.moderation == nil
+      assert image.file == "old.jpg"
+    end
+
+    test "a member with no picture gets no row" do
+      user = insert(:activated_user)
+
+      assert %{"avatar" => %{pictures: 0, created: 0}} = Backfill.run(only: "avatar")
+      assert Images.profile_image(user.id, "avatar") == nil
+    end
+
+    test "running it again changes nothing" do
+      legacy_avatar()
+
+      Backfill.run(only: "avatar")
+      assert %{"avatar" => tally} = Backfill.run(only: "avatar")
+
+      assert tally == %{
+               pictures: 1,
+               created: 0,
+               corrected: 0,
+               unchanged: 1,
+               dropped: 0,
+               failed: 0
+             }
+
+      assert Repo.aggregate(ImageRow, :count) == 1
+    end
+
+    test "a dry run reports without writing" do
+      user = legacy_avatar()
+
+      assert %{"avatar" => %{created: 1}} = Backfill.run(only: "avatar", dry_run: true)
+      assert Images.profile_image(user.id, "avatar") == nil
+    end
+  end
+
+  describe "reconciling a row that disagrees" do
+    # The shape a half-committed upload left behind before
+    # `Accounts.store_pending_image/6` became one transaction: the image row
+    # names the new picture, the member row still names the old one. An
+    # insert-where-missing backfill skips this member entirely, and the contract
+    # deploy then drops the only record of which file is really current.
+    test "the member's own columns win, and a changed picture gets a fresh token" do
+      user = legacy_avatar()
+
+      {:ok, stale} =
+        %ImageRow{}
+        |> ImageRow.changeset(%{
+          kind: "avatar",
+          user_id: user.id,
+          token: "token-of-the-lost-upload",
+          file: "never-landed.jpg",
+          fingerprint: "ffffffffffff",
+          moderation: "pending"
+        })
+        |> Repo.insert()
+
+      assert %{"avatar" => tally} = Backfill.run(only: "avatar")
+      assert tally.created == 0
+      assert tally.corrected == 1
+
+      image = Images.profile_image(user.id, "avatar")
+      assert image.id == stale.id
+      assert image.file == "old.jpg"
+      assert image.fingerprint == "1a2b3c4d5e6f"
+      assert image.moderation == "approved"
+      assert image.token != "token-of-the-lost-upload"
+      assert reload(user).avatar_image_id == image.id
+    end
+
+    test "a row that only lost its pointer keeps its token" do
+      user = legacy_avatar()
+      Backfill.run(only: "avatar")
+      image = Images.profile_image(user.id, "avatar")
+
+      Repo.update_all(from(u in User, where: u.id == ^user.id), set: [avatar_image_id: nil])
+
+      assert %{"avatar" => %{corrected: 1, created: 0}} = Backfill.run(only: "avatar")
+      assert reload(user).avatar_image_id == image.id
+      assert Images.profile_image(user.id, "avatar").token == image.token
+    end
+
+    test "a row whose member has no picture any more is dropped" do
+      user = legacy_avatar()
+      Backfill.run(only: "avatar")
+
+      Repo.update_all(from(u in User, where: u.id == ^user.id), set: [avatar: nil])
+
+      assert %{"avatar" => %{dropped: 1}} = Backfill.run(only: "avatar")
+      assert Images.profile_image(user.id, "avatar") == nil
+      assert reload(user).avatar_image_id == nil
+    end
+  end
+
+  describe "interrupted halfway" do
+    # A deploy stops the slot mid-run and logs nothing. The proof is not that
+    # the first pass finished — it is that the second one finishes exactly the
+    # rest and touches nothing it already did.
+    test "a second run finishes the rest and leaves the first half alone" do
+      [first, second] = Enum.sort_by([legacy_avatar(), legacy_avatar()], & &1.id)
+
+      # Kill it after the first member: resuming from that id is what the run's
+      # own progress line tells the operator to do.
+      assert %{"avatar" => %{created: 1}} = Backfill.run(only: "avatar", from: first.id)
+      assert Images.profile_image(first.id, "avatar") == nil
+      assert Images.profile_image(second.id, "avatar")
+
+      assert %{"avatar" => tally} = Backfill.run(only: "avatar")
+      assert tally.created == 1
+      assert tally.unchanged == 1
+      assert tally.corrected == 0
+
+      assert Images.profile_image(first.id, "avatar")
+      assert Repo.aggregate(ImageRow, :count) == 2
+    end
+  end
+
+  describe "both kinds" do
+    test "avatars and covers are counted apart" do
+      user =
+        legacy_avatar()
+        |> Ecto.Changeset.change(%{
+          cover_photo: "banner.jpg",
+          cover_fingerprint: "aabbccddeeff",
+          cover_moderation: "approved"
+        })
+        |> Repo.update!()
+
+      assert %{"avatar" => avatars, "cover" => covers} = Backfill.run()
+      assert avatars.created == 1
+      assert covers.created == 1
+
+      assert Images.profile_image(user.id, "avatar").file == "old.jpg"
+      assert Images.profile_image(user.id, "cover").file == "banner.jpg"
+      assert reload(user).cover_image_id == Images.profile_image(user.id, "cover").id
+    end
+  end
+
+  describe "the check before the cut" do
+    test "it names the members with no row, and goes quiet once they have one" do
+      user = legacy_avatar()
+
+      %{kinds: %{"avatar" => before}, ok?: ok_before?} = Backfill.check(only: "avatar")
+      refute ok_before?
+      assert before.pictures == 1
+      assert before.rows == 0
+      assert before.missing_row == %{count: 1, sample: [user.id]}
+
+      Backfill.run(only: "avatar")
+
+      %{kinds: %{"avatar" => after_run}} = Backfill.check(only: "avatar")
+      assert after_run.missing_row.count == 0
+      assert after_run.mismatched_row.count == 0
+      assert after_run.missing_pointer.count == 0
+      assert after_run.orphan_row.count == 0
+      assert after_run.rows == 1
+    end
+
+    test "it names a row that disagrees with the member row" do
+      user = legacy_avatar()
+      Backfill.run(only: "avatar")
+
+      Repo.update_all(
+        from(i in ImageRow, where: i.user_id == ^user.id),
+        set: [file: "something-else.jpg"]
+      )
+
+      %{kinds: %{"avatar" => result}, ok?: ok?} = Backfill.check(only: "avatar")
+      refute ok?
+      assert result.mismatched_row == %{count: 1, sample: [user.id]}
+      assert result.missing_row.count == 0
+    end
+
+    test "it names an orphan row" do
+      user = legacy_avatar()
+      Backfill.run(only: "avatar")
+      Repo.update_all(from(u in User, where: u.id == ^user.id), set: [avatar: nil])
+
+      %{kinds: %{"avatar" => result}, ok?: ok?} = Backfill.check(only: "avatar")
+      refute ok?
+
+      assert result.orphan_row == %{
+               count: 1,
+               sample: [Images.profile_image(user.id, "avatar").id]
+             }
+    end
+
+    # Calibration: the same check, one member whose bytes are on disk and one
+    # whose are not. A file check that cannot tell them apart reads "all clear"
+    # for a whole tree that is gone.
+    test "it tells a picture whose file is there from one whose file is not" do
+      user = insert(:activated_user)
+      insert(:email, user: user)
+      {:ok, user} = Accounts.update_user(user, %{avatar: jpeg_upload()})
+      Backfill.run(only: "avatar")
+
+      %{kinds: %{"avatar" => present}, ok?: ok?} = Backfill.check(only: "avatar")
+      assert ok?
+      assert present.missing_file.count == 0
+
+      File.rm_rf!(Vutuv.Uploads.disk_dir("avatars/#{user.id}"))
+
+      %{kinds: %{"avatar" => gone}, ok?: still_ok?} = Backfill.check(only: "avatar")
+      refute still_ok?
+      assert gone.missing_file == %{count: 1, sample: [user.id]}
+      # The row is still right — the bytes are what went missing, and the
+      # backfill cannot bring those back.
+      assert gone.missing_row.count == 0
+      assert gone.mismatched_row.count == 0
+    end
+
+    test "a picture waiting in quarantine counts its quarantined file" do
+      put_config(:moderate_images, true)
+      user = insert(:activated_user)
+      insert(:email, user: user)
+      {:ok, user} = Accounts.update_user(user, %{avatar: jpeg_upload()})
+
+      assert user.avatar_moderation == "pending"
+      Backfill.run(only: "avatar")
+
+      %{kinds: %{"avatar" => result}, ok?: ok?} = Backfill.check(only: "avatar")
+      assert ok?, "a pending picture lives in the quarantine tree, not the served one"
+      assert result.missing_file.count == 0
+    end
+  end
+end

--- a/test/vutuv/images_test.exs
+++ b/test/vutuv/images_test.exs
@@ -16,8 +16,11 @@ defmodule Vutuv.ImagesTest do
   alias Vutuv.Accounts
   alias Vutuv.Accounts.User
   alias Vutuv.Images
+  alias Vutuv.Images.Backfill
   alias Vutuv.Images.Image, as: ImageRow
+  alias Vutuv.Moderation.ImageScan
   alias Vutuv.Moderation.ImageScans
+  alias Vutuv.Moderation.ImageSubjects
   alias Vutuv.Repo
 
   @safe {:ok, %{safe?: true, category: "safe"}}
@@ -168,6 +171,46 @@ defmodule Vutuv.ImagesTest do
       assert user.avatar_image_id == nil
       assert Images.profile_image(user.id, "avatar") == nil
     end
+
+    # A cancel arrives when the scanned bytes are gone. The two cases have to be
+    # told apart by whether this scan's own picture was the one cleared: a
+    # cancel for a picture that has since been replaced matches nothing, and
+    # deleting the row then would take out the *replacement's* row — a live
+    # picture with no row at all, which the backfill would then have to repair.
+    test "a cancel for the picture that is still current drops the row", %{user: user} do
+      {:ok, user} = Accounts.update_user(user, %{avatar: jpeg_upload()})
+      assert Images.profile_image(user.id, "avatar")
+
+      ImageSubjects.cleanup_canceled(%ImageScan{
+        kind: "avatar",
+        subject_id: user.id,
+        fingerprint: user.avatar_fingerprint
+      })
+
+      assert reload(user).avatar == nil
+      assert Images.profile_image(user.id, "avatar") == nil
+    end
+
+    test "a stale cancel leaves the picture uploaded since alone", %{user: user} do
+      {:ok, first} = Accounts.update_user(user, %{avatar: jpeg_upload("first.jpg")})
+      stale_fingerprint = first.avatar_fingerprint
+
+      {:ok, second} =
+        Accounts.update_user(reload(first), %{avatar: jpeg_upload("second.jpg", [9, 9, 9])})
+
+      refute second.avatar_fingerprint == stale_fingerprint
+
+      ImageSubjects.cleanup_canceled(%ImageScan{
+        kind: "avatar",
+        subject_id: user.id,
+        fingerprint: stale_fingerprint
+      })
+
+      assert reload(user).avatar == "second.jpg"
+      image = Images.profile_image(user.id, "avatar")
+      assert image.file == "second.jpg"
+      assert image.fingerprint == second.avatar_fingerprint
+    end
   end
 
   describe "a re-derive keeps the row's fingerprint in step" do
@@ -179,6 +222,56 @@ defmodule Vutuv.ImagesTest do
 
       user = reload(user)
       assert Images.profile_image(user.id, "avatar").fingerprint == user.avatar_fingerprint
+    end
+
+    # The case that actually needs `Images.sync_fingerprint/2`: a picture still
+    # on the pre-fingerprint scheme, whose row #2014's backfill created with a
+    # nil fingerprint. The deploy's regeneration pass computes one for the first
+    # time and writes it onto the member row — and the row has to follow, or the
+    # contract deploy drops the only column that named those bytes.
+    #
+    # Re-deriving an *already* fingerprinted picture cannot show this: the hash
+    # is over the original plus the crop, so it comes back identical and the row
+    # already agrees with or without the sync.
+    test "a picture that gets its first fingerprint carries the row along", %{user: user} do
+      {:ok, user} = Accounts.update_user(user, %{avatar: jpeg_upload()})
+
+      # Put it back on the legacy scheme, the way every pre-#2013 row looks.
+      Repo.update_all(from(u in User, where: u.id == ^user.id),
+        set: [avatar_fingerprint: nil, avatar_image_id: nil]
+      )
+
+      Repo.delete_all(from(i in ImageRow, where: i.user_id == ^user.id))
+      Backfill.run(only: "avatar")
+
+      assert Images.profile_image(user.id, "avatar").fingerprint == nil
+
+      assert :ok = Vutuv.Avatar.regenerate(reload(user))
+
+      user = reload(user)
+      assert is_binary(user.avatar_fingerprint)
+      assert Images.profile_image(user.id, "avatar").fingerprint == user.avatar_fingerprint
+    end
+  end
+
+  describe "the upload writes both rows or neither" do
+    # The half-commit this transaction exists to prevent: the row named the new
+    # picture, the member row still named the old file whose bytes the store had
+    # just replaced, and no scan was ever queued to take the row out of
+    # "pending". A check constraint stands in for the production causes (a pool
+    # timeout, a slot dying in the blue/green switch, a `StaleEntryError`) —
+    # they all reach `Repo.update` as a raise, not as `{:error, changeset}`.
+    test "a member-row failure takes the image row with it", %{user: user} do
+      Repo.query!(
+        "ALTER TABLE users ADD CONSTRAINT test_avatar_boom CHECK (avatar <> 'boom.jpg')"
+      )
+
+      assert_raise Ecto.ConstraintError, fn ->
+        Accounts.update_user(user, %{avatar: jpeg_upload("boom.jpg")})
+      end
+
+      assert Images.profile_image(user.id, "avatar") == nil
+      assert Repo.aggregate(ImageRow, :count) == 0
     end
   end
 

--- a/test/vutuv/uploaders/avatar_test.exs
+++ b/test/vutuv/uploaders/avatar_test.exs
@@ -336,7 +336,7 @@ defmodule Vutuv.AvatarTest do
     test "writes fingerprinted AVIF versions publicly and the original privately",
          %{tmp: tmp, src: src} do
       upload = %Plug.Upload{filename: "selfie.jpg", path: src, content_type: "image/jpeg"}
-      assert {:ok, "selfie.jpg", fp} = Vutuv.Avatar.store({upload, @user})
+      assert {:ok, "selfie.jpg", fp, _} = Vutuv.Avatar.store({upload, @user})
       assert fp =~ ~r/\A[0-9a-f]{12}\z/
 
       dir = Path.join(tmp, "avatars/7")
@@ -350,7 +350,7 @@ defmodule Vutuv.AvatarTest do
 
     test "the returned fingerprint is what url/2 then serves (write == URL)", %{src: src} do
       upload = %Plug.Upload{filename: "selfie.jpg", path: src, content_type: "image/jpeg"}
-      assert {:ok, file_name, fp} = Vutuv.Avatar.store({upload, @user})
+      assert {:ok, file_name, fp, _} = Vutuv.Avatar.store({upload, @user})
       stored = %{@user | avatar: file_name, avatar_fingerprint: fp}
 
       assert Vutuv.Avatar.url({file_name, stored}, :medium) ==
@@ -360,14 +360,14 @@ defmodule Vutuv.AvatarTest do
     test "a re-upload clears the prior fingerprinted versions (no accumulation)",
          %{tmp: tmp, src: src} do
       upload = %Plug.Upload{filename: "selfie.jpg", path: src, content_type: "image/jpeg"}
-      assert {:ok, _, _fp1} = Vutuv.Avatar.store({upload, @user})
+      assert {:ok, _, _fp1, _} = Vutuv.Avatar.store({upload, @user})
 
       png = Path.join(System.tmp_dir!(), "src_#{System.unique_integer([:positive])}.png")
       {:ok, img} = Image.new(400, 400, color: [9, 9, 9])
       {:ok, _} = Image.write(img, png)
       on_exit(fn -> File.rm(png) end)
       upload2 = %Plug.Upload{filename: "new.png", path: png, content_type: "image/png"}
-      assert {:ok, _, fp2} = Vutuv.Avatar.store({upload2, @user})
+      assert {:ok, _, fp2, _} = Vutuv.Avatar.store({upload2, @user})
 
       # Exactly the versions of the latest upload remain — read from the spec,
       # so adding one (the `:large` of issue #1528) does not read as accumulation.
@@ -382,21 +382,21 @@ defmodule Vutuv.AvatarTest do
       src: src
     } do
       upload = %Plug.Upload{filename: "selfie.jpg", path: src, content_type: "image/jpeg"}
-      assert {:ok, _, _} = Vutuv.Avatar.store({upload, @user})
+      assert {:ok, _, _, _} = Vutuv.Avatar.store({upload, @user})
 
       png = Path.join(System.tmp_dir!(), "src_#{System.unique_integer([:positive])}.png")
       {:ok, img} = Image.new(300, 300, color: [1, 2, 3])
       {:ok, _} = Image.write(img, png)
       on_exit(fn -> File.rm(png) end)
       upload2 = %Plug.Upload{filename: "new.png", path: png, content_type: "image/png"}
-      assert {:ok, _, _} = Vutuv.Avatar.store({upload2, @user})
+      assert {:ok, _, _, _} = Vutuv.Avatar.store({upload2, @user})
 
       assert File.ls!(Path.join(tmp, "originals/avatars/7")) == ["original.png"]
     end
 
     test "thumb/medium are cropped to the Spec dimensions", %{tmp: tmp, src: src} do
       upload = %Plug.Upload{filename: "selfie.jpg", path: src, content_type: "image/jpeg"}
-      assert {:ok, _, fp} = Vutuv.Avatar.store({upload, @user})
+      assert {:ok, _, fp, _} = Vutuv.Avatar.store({upload, @user})
 
       dir = Path.join(tmp, "avatars/7")
       assert dimensions(Path.join(dir, "john.doe-thumb-#{fp}.avif")) == {96, 96}
@@ -416,7 +416,7 @@ defmodule Vutuv.AvatarTest do
       on_exit(fn -> File.rm(src) end)
 
       upload = %Plug.Upload{filename: "selfie.jpg", path: src, content_type: "image/jpeg"}
-      assert {:ok, _, fp} = Vutuv.Avatar.store({upload, @user})
+      assert {:ok, _, fp, _} = Vutuv.Avatar.store({upload, @user})
 
       {:ok, stored} = Image.open(Path.join(tmp, "avatars/7/john.doe-thumb-#{fp}.avif"))
       {:ok, fields} = VipsImage.header_field_names(stored)

--- a/test/vutuv/uploaders/cover_test.exs
+++ b/test/vutuv/uploaders/cover_test.exs
@@ -199,7 +199,7 @@ defmodule Vutuv.CoverTest do
       src: src
     } do
       upload = %Plug.Upload{filename: "banner.jpg", path: src, content_type: "image/jpeg"}
-      assert {:ok, "banner.jpg", fp} = Vutuv.Cover.store({upload, @user})
+      assert {:ok, "banner.jpg", fp, _} = Vutuv.Cover.store({upload, @user})
       assert fp =~ ~r/\A[0-9a-f]{12}\z/
 
       dir = Path.join(tmp, "covers/7")
@@ -215,7 +215,7 @@ defmodule Vutuv.CoverTest do
       src: src
     } do
       upload = %Plug.Upload{filename: "banner.jpg", path: src, content_type: "image/jpeg"}
-      assert {:ok, _, fp} = Vutuv.Cover.store({upload, @user})
+      assert {:ok, _, fp, _} = Vutuv.Cover.store({upload, @user})
 
       # Source is 1200 wide (< 1600), so it is not upscaled; aspect ratio holds.
       {w, h} = dimensions(Path.join(tmp, "covers/7/john.doe-wide-#{fp}.avif"))
@@ -236,7 +236,7 @@ defmodule Vutuv.CoverTest do
       on_exit(fn -> File.rm(src) end)
 
       upload = %Plug.Upload{filename: "banner.jpg", path: src, content_type: "image/jpeg"}
-      assert {:ok, _, fp} = Vutuv.Cover.store({upload, @user})
+      assert {:ok, _, fp, _} = Vutuv.Cover.store({upload, @user})
 
       {:ok, stored} = Image.open(Path.join(tmp, "covers/7/john.doe-wide-#{fp}.avif"))
       {:ok, fields} = VipsImage.header_field_names(stored)

--- a/test/vutuv/uploads/regenerator_test.exs
+++ b/test/vutuv/uploads/regenerator_test.exs
@@ -378,7 +378,7 @@ defmodule Vutuv.Uploads.RegeneratorTest do
     user = insert(:user, first_name: "Ada", last_name: "King", avatar: "fresh.jpg")
     src = jpeg!(Path.join(tmp, "fresh.jpg"))
     upload = %Plug.Upload{filename: "fresh.jpg", path: src, content_type: "image/jpeg"}
-    {:ok, "fresh.jpg", fp} = Vutuv.Avatar.store({upload, user})
+    {:ok, "fresh.jpg", fp, _} = Vutuv.Avatar.store({upload, user})
     # Mirror what Accounts.store_pending_image persists after the store.
     {:ok, _user} = user |> Ecto.Changeset.change(%{avatar_fingerprint: fp}) |> Repo.update()
 

--- a/test/vutuv_web/controllers/avatar_controller_test.exs
+++ b/test/vutuv_web/controllers/avatar_controller_test.exs
@@ -43,7 +43,7 @@ defmodule VutuvWeb.AvatarControllerTest do
     on_exit(fn -> File.rm(src) end)
 
     upload = %Plug.Upload{filename: "selfie.jpg", path: src, content_type: "image/jpeg"}
-    {:ok, stored, fingerprint} = Vutuv.Avatar.store({upload, user})
+    {:ok, stored, fingerprint, _moderation} = Vutuv.Avatar.store({upload, user})
 
     user
     |> Ecto.Changeset.change(avatar: stored, avatar_fingerprint: fingerprint)


### PR DESCRIPTION
Every profile picture and cover uploaded before the shared `images` table (#2013) has no row in it, so the table describes only what has been uploaded since — on the production copy that is 1,679 avatars and 68 covers invisible to the copyright report #2012 is being built on.

`mix vutuv.images.backfill` (`Vutuv.Release.backfill_image_rows/1` on a release) brings them in. It moves no file and changes no URL, so the previous release keeps serving through the deploy. It **reconciles** rather than inserting where missing: a row that disagrees with the member's own columns is corrected, because a half-committed upload is exactly the case an insert-where-missing pass would skip.

`--check` (and `Vutuv.Release.check_image_rows/1`) counts every picture against its row and its file on disk, prints what it found, and fails the command only when something is outstanding. Both paths print through `Backfill.check/1` itself: putting that half in the mix task alone is what let it go out of step and crash on every call while the release path stayed silent.

Rehearsed through those commands against a clean and a damaged copy of production, and by `kill -9` at 309 of 1,747 pictures — the second run finished the other 1,438 and corrected none.

Beside it, the upload's two writes are now one transaction, and `:moderate_images` is read once per upload.

**The columns are not dropped here** — that needs the readers moved onto the row first, one deploy more than the issue assumed. `docs/architecture/images.md` has the order.

Closes #2014

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01UGPe7bHVS11M1W7fNehSku

<!-- closing-note #2014 -->
Every profile picture and cover that predates the shared `images` table now has a row in it, and `mix vutuv.images.backfill` is safe to run again after a deploy kills it halfway — rehearsed on a copy of production by killing it at 309 of 1,747 pictures. It reconciles rather than only inserting, so a row that disagrees with the member's own columns is corrected instead of skipped, and the check that gates the later column drop prints what it found and fails the command when anything is outstanding, on both the mix and the release path. What I left out is the cut itself: dropping the four columns per kind needs every URL builder and display gate moved onto the row first, which is one deploy more than this issue assumed.

*An AI agent wrote this text in my name. I know that is problematic.*
