### PR TITLE
Show what the bell's number stands for on hover

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -19,6 +19,7 @@ import { openPhotoCropper } from "./photo_crop"
 import {
   b64urlToBuf,
   bindEscape,
+  canHover,
   cancelIdle,
   copyText,
   csrfToken,
@@ -1380,6 +1381,64 @@ const Hooks = {
       window.removeEventListener("vutuv:tab-teaser", this.onPreview)
       if (this.teaserTimer) clearTimeout(this.teaserTimer)
       if (this.observer) this.observer.disconnect()
+    },
+  },
+  // The bell's hover preview (docs/architecture/realtime.md, which has the why
+  // for all three rules below). The panel is ShellLive's; this hook owns only
+  // when it opens and closes, because a hover is not something a LiveView
+  // binding can see — and each rule exists because the close MARKS THOSE EVENTS
+  // READ. This is not a tooltip that costs nothing to raise.
+  //
+  //   (1) a hovering pointer or nothing — a tap is not a hover, and on a touch
+  //       screen `mouseenter` fires on the way to the link;
+  //   (2) a dwell, so crossing the bar on the way to the avatar is not resting;
+  //   (3) a grace period, for a pointer landing on a row.
+  //
+  // Reading `data-unread` keeps a bell with nothing behind it silent: no round
+  // trip, no query, and no empty box under an empty badge.
+  BellPreview: {
+    mounted() {
+      if (!canHover()) return
+
+      this.open = false
+      this.arm = () => this.armOpen()
+      this.disarm = () => this.armClose()
+
+      // Focus and blur alongside the pointer, so a keyboard reaches the same
+      // panel by tabbing to the bell. `focusin`/`focusout` rather than
+      // focus/blur: they bubble, so focus moving into a row inside the panel
+      // is the subtree keeping focus, not leaving it.
+      this.el.addEventListener("mouseenter", this.arm)
+      this.el.addEventListener("mouseleave", this.disarm)
+      this.el.addEventListener("focusin", this.arm)
+      this.el.addEventListener("focusout", this.disarm)
+    },
+    armOpen() {
+      clearTimeout(this.closeTimer)
+      if (this.open) return
+
+      this.openTimer = setTimeout(() => {
+        if (this.open || !(Number(this.el.dataset.unread) > 0)) return
+        this.open = true
+        this.pushEvent("bell:preview")
+      }, 200)
+    },
+    armClose() {
+      clearTimeout(this.openTimer)
+      if (!this.open) return
+
+      this.closeTimer = setTimeout(() => {
+        this.open = false
+        this.pushEvent("bell:preview_close")
+      }, 150)
+    },
+    destroyed() {
+      clearTimeout(this.openTimer)
+      clearTimeout(this.closeTimer)
+      this.el.removeEventListener("mouseenter", this.arm)
+      this.el.removeEventListener("mouseleave", this.disarm)
+      this.el.removeEventListener("focusin", this.arm)
+      this.el.removeEventListener("focusout", this.disarm)
     },
   },
   // Browser notifications (issue #1249): a popup for activity that arrives while

--- a/assets/js/mention_card.js
+++ b/assets/js/mention_card.js
@@ -28,7 +28,7 @@
 // LiveView root: a patch of the page underneath must not be able to take the
 // open card with it. That is also why the fragment carries no `phx-` link and
 // no fixed id (see the template).
-import { copyText, request, revealPreviewClamp } from "./util"
+import { canHover, copyText, request, revealPreviewClamp } from "./util"
 
 const CARD_URL = "/system/fediverse/actor_card"
 
@@ -329,17 +329,15 @@ async function act(button) {
 // come back. The wording is the server's (`data-actor-confirm`) — this file
 // writes no sentences.
 //
-// `matchMedia("(hover: hover)")` and not `SHEET`: the question is whether this
-// input device can hover, which is not the same as how wide the window is. A
-// touch laptop asked to open the card in a narrow window gets a sheet and can
-// still hover; a stylus tablet at 900px gets a popover and cannot. The same
-// query gates the CSS half, so the two cannot disagree about which device this
-// is.
-const CAN_HOVER = window.matchMedia("(hover: hover)")
+// `canHover()` and not `SHEET`: the question is whether this input device can
+// hover, which is not the same as how wide the window is. A touch laptop asked
+// to open the card in a narrow window gets a sheet and can still hover; a
+// stylus tablet at 900px gets a popover and cannot. The same query gates the
+// CSS half, so the two cannot disagree about which device this is.
 
 function armed(button) {
   const asks = button.querySelector("[data-actor-state-confirm]")
-  if (!asks || CAN_HOVER.matches || button.classList.contains("is-confirming")) return false
+  if (!asks || canHover() || button.classList.contains("is-confirming")) return false
 
   button.classList.add("is-confirming")
   return true

--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -114,6 +114,15 @@ export function postJSON(url, body) {
 export const reducedMotion = () =>
   window.matchMedia("(prefers-reduced-motion: reduce)").matches
 
+// Whether this device's pointer can hover at all — which is a question about the
+// input, not about how wide the window is: a touch laptop in a narrow window can
+// hover, a stylus tablet at 900px cannot. Gates every affordance that only
+// exists under a resting pointer (the remote-actor card's confirm step, the
+// bell's hover preview, whose close marks notifications read and must therefore
+// never fire from a tap). Deliberately NOT the `(pointer: fine)` pair
+// `keyboard_shortcuts.js` asks for — that one is about typing, not hovering.
+export const canHover = () => window.matchMedia("(hover: hover)").matches
+
 // A click that means "this link, here, now": nobody else has handled it and
 // no modifier turned it into "open elsewhere". The one test for every
 // document-level press interceptor (the nav press paint, the Feed tab's

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -483,6 +483,53 @@ item name the same row. Opening /notifications deletes the member's dismissals:
 the marker now covers them, so the table only ever holds the exceptions that
 still matter.
 
+### The bell's hover preview
+
+Most of what the bell counts is worth knowing and not worth a trip: two people
+liked a post, somebody followed you. Reading that on /notifications costs a page
+load there and a page load back, so the number sat there being ignored. Resting
+the pointer on the bell drops a small panel under it instead — one round kind
+badge, who did what, how long ago, six of them at most and a "+N more" footer
+into the page — and **looking away marks them read**. The gesture says "I have
+seen this" as plainly as opening the page does, so it carries the same weight.
+
+The panel is `ShellLive`'s; only the gesture is the client's, because a hover is
+not something a LiveView binding can see. The `BellPreview` hook pushes
+`bell:preview` and `bell:preview_close` under three rules, each of which exists
+because the close *writes* something:
+
+* **A hovering pointer or nothing** (`matchMedia("(hover: hover)")`). On a touch
+  screen `mouseenter` fires on the tap that follows the link, so a member
+  walking to /notifications would empty the badge on the way and arrive at a page
+  with nothing marked new. The viewport width the bell is hidden below is a
+  different question, and a touch tablet answers it wrong.
+* **A dwell of 200 ms before opening.** The bell sits between four other icons,
+  and a pointer travelling to the avatar crosses it; until the dwell passes
+  nothing is asked of the server. The hook also reads `data-unread` off the
+  wrapper, so a bell with nothing behind it costs no round trip and no query.
+* **A grace period of 150 ms before closing**, for a pointer landing on a row.
+  The hook listens on the *wrapper*, not the link, so the panel hanging out of
+  it is a descendant and travelling into the list never leaves the subtree.
+
+**What arrives while the panel is open must survive it**, and that is the one
+thing `mark_notifications_read/1` cannot do: it sweeps the marker up to whatever
+the newest event is *at that moment*, so a like landing during the read would be
+marked read without ever having been shown. So `Activity.unread_notifications/2`
+hands the open the instant it is showing (`read_up_to`, the newest event there
+is — not the newest *unread* one, or a marker already past it would go back) and
+the close hands that same instant to `Activity.mark_notifications_read_up_to/2`.
+Everything after it is still new, and the badge says 1 the moment the pointer
+leaves. That marker only ever moves forward, so a second tab that opened
+/notifications in the meantime cannot be undone by a preview that started
+before it, and a marker that does not move broadcasts nothing.
+
+`unread_notifications/2` reads the feed where the badge counts with SQL, so it
+repeats the same three exclusions by hand — the read marker, `seen_post_ids/2`
+and `dismissed_event_ids/1` — or the panel and the number would disagree.
+Nothing is marked read by the close alone: the marker's own
+`:notifications_changed` broadcast is what recounts the badge, like every other
+change.
+
 ### The notifications page (2026-09 cards)
 
 `VutuvWeb.NotificationLive.Index` renders the derived feed as **cards under

--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -100,6 +100,145 @@ defmodule Vutuv.Activity do
     broadcast(user_id, :notifications_read)
   end
 
+  @doc """
+  Move the read marker forward to `at` and no further — everything up to that
+  instant has been seen, whatever arrived afterwards has not.
+
+  The bell's hover preview (`VutuvWeb.ShellLive`) is what needs the "and no
+  further": it shows the member the events behind the number and empties the
+  badge when they look away, but a like that lands *while* they are reading the
+  panel was never in it and has to come back as a fresh 1. So the caller pins
+  the instant when it opens the panel and hands it back here on close, rather
+  than letting `mark_notifications_read/1` sweep the marker up to whatever the
+  newest event is by then.
+
+  This writer only ever moves the marker **forward** (the `where` refuses an
+  older stamp), so a second tab that opened /notifications in the meantime
+  cannot be undone by a preview that started before it. That is a promise about
+  this function, not about the column — `mark_notifications_read/1` still sets
+  it outright. Per-event dismissals are left alone,
+  unlike the full read above: this marker covers only part of what they hold
+  out of the tally, and one that is now redundant costs a row, not a wrong
+  count. A marker that does not move broadcasts nothing.
+  """
+  def mark_notifications_read_up_to(nil, _at), do: :ok
+  def mark_notifications_read_up_to(_user_id, nil), do: :ok
+
+  def mark_notifications_read_up_to(user_id, at) do
+    at = naive_second(at)
+
+    {moved, _} =
+      Repo.update_all(
+        from(u in User,
+          where: u.id == ^user_id,
+          where: is_nil(u.notifications_read_at) or u.notifications_read_at < ^at
+        ),
+        set: [notifications_read_at: at]
+      )
+
+    if moved > 0, do: broadcast(user_id, :notifications_changed), else: :ok
+  end
+
+  # The column is a naive_datetime and the event tables keep whole seconds, so a
+  # finer stamp would be rounded on the way in and never compare equal again.
+  defp naive_second(%DateTime{} = at), do: at |> DateTime.to_naive() |> naive_second()
+  defp naive_second(%NaiveDateTime{} = at), do: NaiveDateTime.truncate(at, :second)
+
+  @doc """
+  The events the bell's number stands for: the unread ones, newest first, at
+  most `limit` of them — plus `read_up_to`, the instant that marks exactly
+  these read.
+
+  The badge counts with SQL and this reads the feed, so the two can only agree
+  if the same exclusions apply here: an event older than the read marker, one
+  about a post the member has already engaged with (`mark_post_seen/2`), one
+  they dismissed from a browser notification (`mark_notification_seen/3`) and a
+  vernetzt pair they closed themselves are all read. The marker is re-read
+  rather than taken from a `%User{}` a caller is holding, for the reason
+  `unread_notification_count/1`'s id clause gives: the shell's copy is as old
+  as its mount and the marker moves in the member's other tabs.
+
+  `read_up_to` is a stamp off an entry the panel actually looked at, so it can
+  never mark read something nobody was shown; a member with nothing unread gets
+  `nil` and no marker is written at all.
+  """
+  def unread_notifications(nil, _limit), do: %{items: [], read_up_to: nil}
+
+  def unread_notifications(user_id, limit) do
+    read_at = notifications_read_at(user_id)
+
+    case unread_kinds(user_id, read_at) do
+      [] -> %{items: [], read_up_to: nil}
+      kinds -> unread_notifications(user_id, limit, read_at, kinds)
+    end
+  end
+
+  defp unread_notifications(user_id, limit, read_at, kinds) do
+    %{entries: entries} = notifications_page(user_id, limit: limit, kinds: kinds)
+    flagged = with_seen_flags(user_id, entries, dismissed_event_ids(user_id))
+
+    %{
+      items: Enum.filter(flagged, &unread_item?(&1, read_at)),
+      # An item the panel really could have shown, deliberately rather than
+      # `latest_event_at/1`: the two agree, and where they ever stopped
+      # agreeing this is the one that cannot mark read something nobody saw.
+      read_up_to: entries |> List.first(%{}) |> Map.get(:at)
+    }
+  end
+
+  # Which kinds have anything unread, from the badge's own one-query tally. The
+  # feed is read for those alone, because the full fan-out is a source query per
+  # registry kind — eighteen of them, four connections at a time — and a hover
+  # that turns out to be one like has no business paying it. This handler hangs
+  # off a shell mounted on every page, so connections held is the budget here,
+  # not milliseconds (`Vutuv.Concurrent` makes the same argument).
+  defp unread_kinds(user_id, read_at) do
+    kinds()
+    |> Map.new(&{&1, [&1]})
+    |> then(&unread_counts_by(user_id, read_at, &1))
+    |> Enum.filter(fn {_kind, count} -> count > 0 end)
+    |> Enum.map(fn {kind, _count} -> kind end)
+  end
+
+  # The three exclusions `total_count/4` expresses in SQL, over an item: older
+  # than the marker, one of the per-post/per-event exceptions (`:seen?`), or a
+  # vernetzt pair the member closed themselves — which is news to everybody
+  # except them, so `count_connections/3` leaves it out of the tally too.
+  defp unread_item?(item, read_at) do
+    after?(item[:at], read_at) and item[:seen?] != true and item[:self_triggered?] != true
+  end
+
+  @doc """
+  Flag each entry `:seen?` — the per-post (`mark_post_seen/2`) and per-event
+  (`mark_notification_seen/3`) exceptions that make an event read although the
+  read marker still sits behind it. `dismissed` is `dismissed_event_ids/1`,
+  passed in because a page loads it once and holds it. One query for the batch.
+
+  Shared so the notifications page and the bell's preview cannot answer "has
+  this been dealt with" differently — the page renders such a row as read while
+  the preview leaves it out, and both readings come from here.
+  """
+  def with_seen_flags(user_id, entries, dismissed) do
+    seen =
+      entries
+      |> Enum.map(&subject_post_id/1)
+      |> Enum.reject(&is_nil/1)
+      |> then(&seen_post_ids(user_id, &1))
+
+    Enum.map(entries, fn entry ->
+      read? =
+        MapSet.member?(seen, subject_post_id(entry)) or MapSet.member?(dismissed, entry[:id])
+
+      Map.put(entry, :seen?, read?)
+    end)
+  end
+
+  # The member's read marker. Re-read rather than taken off a `%User{}` a caller
+  # is holding, for the reason `unread_notification_count/1`'s id clause gives:
+  # a socket's copy is as old as its mount and the marker moves in other tabs.
+  defp notifications_read_at(user_id),
+    do: Repo.one(from(u in User, where: u.id == ^user_id, select: u.notifications_read_at))
+
   # The read marker is the timestamp of the newest feed event the user has seen,
   # not the wall clock. The event tables only keep second precision, and unread
   # counting uses a strict `>`, so a wall-clock marker would swallow any event
@@ -1178,10 +1317,8 @@ defmodule Vutuv.Activity do
   def unread_notification_count(%User{id: user_id, notifications_read_at: read_at}),
     do: total_count(user_id, read_at, nil, true)
 
-  def unread_notification_count(user_id) do
-    read_at = Repo.one(from(u in User, where: u.id == ^user_id, select: u.notifications_read_at))
-    total_count(user_id, read_at, nil, true)
-  end
+  def unread_notification_count(user_id),
+    do: total_count(user_id, notifications_read_at(user_id), nil, true)
 
   @doc """
   `unread_notification_count/1` split by named kind groups — `groups` is
@@ -1192,7 +1329,13 @@ defmodule Vutuv.Activity do
   whole feed. A group whose kinds count nothing answers 0.
   """
   def unread_notification_counts(%User{id: user_id, notifications_read_at: read_at}, groups)
-      when is_map(groups) do
+      when is_map(groups),
+      do: unread_counts_by(user_id, read_at, groups)
+
+  # By id and marker rather than the struct, so a caller that has just read the
+  # marker itself (the bell's preview) can ask the same question without
+  # loading a `%User{}` it has no other use for.
+  defp unread_counts_by(user_id, read_at, groups) do
     arms =
       for spec <- kind_specs(user_id, read_at, true),
           {count, dismiss} <- Enum.zip(spec.counts, spec.dismiss),

--- a/lib/vutuv_web/components/ui.ex
+++ b/lib/vutuv_web/components/ui.ex
@@ -3632,6 +3632,13 @@ defmodule VutuvWeb.UI do
   """
   def relative_time(nil), do: gettext("unknown")
 
+  # A derived feed item's stamp comes off a `naive_datetime` column and is UTC
+  # by construction, the same reading `local_time/1` and `post_time/1` document.
+  # Here rather than at each call site, so a caller holding one does not write
+  # the conversion out again (the bell's preview did).
+  def relative_time(%NaiveDateTime{} = at),
+    do: at |> DateTime.from_naive!("Etc/UTC") |> relative_time()
+
   def relative_time(%DateTime{} = at) do
     seconds = DateTime.diff(DateTime.utc_now(), at, :second)
 

--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -67,6 +67,9 @@ defmodule VutuvWeb.NotificationLive.Index do
     only: [
       cv_entry_label: 1,
       cv_entry_path: 2,
+      kind_classes: 1,
+      kind_glyph: 1,
+      kind_label: 1,
       notification_target: 2,
       notification_text: 1
     ]
@@ -321,9 +324,12 @@ defmodule VutuvWeb.NotificationLive.Index do
 
     feed = Activity.notifications_page(user.id, limit: @page_size, kinds: kinds, page: page)
 
+    # Rows the reader already dealt with out in the feed stay listed — the page
+    # is the log of what happened — they just stop rendering as new, so the
+    # list and the badge tell one story.
     {items, posts} =
       feed.entries
-      |> with_seen_flags(user, socket.assigns.dismissed)
+      |> then(&Activity.with_seen_flags(user.id, &1, socket.assigns.dismissed))
       |> with_post_previews(user)
 
     %{page: page, total: total, items: items, post_cards: post_cards(items, posts)}
@@ -333,28 +339,6 @@ defmodule VutuvWeb.NotificationLive.Index do
     socket
     |> assign(payload)
     |> assign_sections()
-  end
-
-  # Rows the reader has already dealt with out in the feed: they answered,
-  # liked, bookmarked or reposted the post the row is about, so
-  # `Vutuv.Activity.mark_post_seen/2` recorded it and the shell's badge stopped
-  # counting it. They stay listed — the page is the log of what happened — they
-  # just no longer render as new, so the list and the badge tell one story. One
-  # query per page.
-  defp with_seen_flags(entries, viewer, dismissed) do
-    seen =
-      entries
-      |> Enum.map(&Activity.subject_post_id/1)
-      |> Enum.reject(&is_nil/1)
-      |> then(&Activity.seen_post_ids(viewer.id, &1))
-
-    Enum.map(entries, fn entry ->
-      read? =
-        MapSet.member?(seen, Activity.subject_post_id(entry)) or
-          MapSet.member?(dismissed, entry[:id])
-
-      Map.put(entry, :seen?, read?)
-    end)
   end
 
   defp assign_sections(socket) do
@@ -1442,87 +1426,6 @@ defmodule VutuvWeb.NotificationLive.Index do
 
     gettext("Last 30 days: %{parts}", parts: Enum.join(parts, " · "))
   end
-
-  # ── Kind styling (badge colour + glyph + accessible label) ──
-
-  # Event kinds that share the brand badge colour, so the class string lives
-  # in one place.
-  @brand_kind_classes "bg-brand-50 text-brand-700 dark:bg-brand-900/40 dark:text-brand-100"
-  @brand_kinds ~w(follower reply thread mention connection report_protection organization_role handle_change cv_update fediverse_reply fediverse_reaction share)
-
-  defp kind_classes("endorsement"),
-    do: "bg-emerald-50 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-300"
-
-  defp kind_classes("like"), do: "bg-accent/10 text-accent dark:bg-accent/20"
-
-  defp kind_classes("moderation"),
-    do: "bg-amber-50 text-amber-600 dark:bg-amber-900/30 dark:text-amber-200"
-
-  # The AI image scan removed an image — amber, like every moderation notice.
-  defp kind_classes("image_rejected"),
-    do: "bg-amber-50 text-amber-600 dark:bg-amber-900/30 dark:text-amber-200"
-
-  defp kind_classes(kind) when kind in @brand_kinds, do: @brand_kind_classes
-
-  defp kind_classes(_), do: "bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-300"
-
-  defp kind_glyph("follower"), do: "+"
-  defp kind_glyph("endorsement"), do: "★"
-  defp kind_glyph("reply"), do: "↩"
-  # A reply elsewhere in a thread the recipient writes in.
-  defp kind_glyph("thread"), do: "⤷"
-  # Being named by @handle. Shares the glyph with the (rare, "More"-chip)
-  # handle-change kind: both are about a handle, and the badge's title/sr-only
-  # label tells them apart where the glyph alone would not.
-  defp kind_glyph("mention"), do: "@"
-  defp kind_glyph("like"), do: "♥"
-  # A re-share from another network (issue #1068): the arrows, since the line
-  # beside it names the verb and the globe already sits on the sharer's name.
-  defp kind_glyph("share"), do: "↻"
-  # A reply written on another network (issue #1069) — the same globe the
-  # post card's "from other networks" line uses, so one glyph means one thing.
-  defp kind_glyph("fediverse_reply"), do: "🌐"
-  # A reaction from out there of a kind that is neither a favourite nor a
-  # re-share — the globe, since "this came from another network" is the one
-  # thing the glyph has to say; the sentence beside it names the verb.
-  defp kind_glyph("fediverse_reaction"), do: "🌐"
-  # "connection" is the vernetzt (mutual-follow) event; the handshake glyph.
-  defp kind_glyph("connection"), do: "🤝"
-  defp kind_glyph("moderation"), do: "⚑"
-  defp kind_glyph("image_rejected"), do: "🖼"
-  defp kind_glyph("report_protection"), do: "🛡"
-  defp kind_glyph("organization_role"), do: "🏢"
-  defp kind_glyph("handle_change"), do: "@"
-  defp kind_glyph("cv_update"), do: "📄"
-  # The welcome note naming the member's own handle.
-  defp kind_glyph("username"), do: "👋"
-  # The finished AI reading of an Arbeitszeugnis. The magnifier, not a robot:
-  # what arrived is a close reading of wording, and the member is being told to
-  # go and read it.
-  defp kind_glyph("reference_check"), do: "🔍"
-  defp kind_glyph(_), do: "•"
-
-  # The accessible kind name (the badge's title + sr-only text). Translated
-  # like the row text; raw kind strings ("cv_update") must not leak to users.
-  defp kind_label("follower"), do: gettext("Follower")
-  defp kind_label("endorsement"), do: gettext("Endorsement")
-  defp kind_label("reply"), do: gettext("Reply")
-  defp kind_label("thread"), do: gettext("Thread reply")
-  defp kind_label("mention"), do: gettext("Mention")
-  defp kind_label("like"), do: gettext("Like")
-  defp kind_label("fediverse_reply"), do: gettext("Reply from another network")
-  defp kind_label("share"), do: gettext("Reaction from another network")
-  defp kind_label("fediverse_reaction"), do: gettext("Reaction from another network")
-  defp kind_label("connection"), do: gettext("Connection")
-  defp kind_label("moderation"), do: gettext("Moderation")
-  defp kind_label("image_rejected"), do: gettext("Image review")
-  defp kind_label("report_protection"), do: gettext("Report protection")
-  defp kind_label("organization_role"), do: gettext("Organization role")
-  defp kind_label("handle_change"), do: gettext("Handle change")
-  defp kind_label("cv_update"), do: gettext("CV update")
-  defp kind_label("username"), do: gettext("Username")
-  defp kind_label("reference_check"), do: gettext("Employment reference review")
-  defp kind_label(_), do: gettext("Activity")
 
   # ── A card line's vocabulary ──
 

--- a/lib/vutuv_web/live/shell_live.ex
+++ b/lib/vutuv_web/live/shell_live.ex
@@ -39,7 +39,8 @@ defmodule VutuvWeb.ShellLive do
       icon_bookmark: 1,
       icon_pencil: 1,
       name_initials: 1,
-      presence_dot: 1
+      presence_dot: 1,
+      relative_time: 1
     ]
 
   import VutuvWeb.UserHelpers, only: [full_name: 1]
@@ -78,6 +79,11 @@ defmodule VutuvWeb.ShellLive do
   # 4.0 s and the title handed back at 6.0. Sizing the window at the requested
   # second instead closed it at 3 s, while the browser was still on frame two.
   @frame_ms 2_000
+
+  # How many events the bell's hover preview lists before it says "and N more"
+  # (see the handlers below). Enough for a day's likes on one post, short enough
+  # that the panel stays a glance rather than a second notifications page.
+  @preview_limit 6
 
   @impl true
   def mount(_params, session, socket) do
@@ -269,6 +275,10 @@ defmodule VutuvWeb.ShellLive do
     |> assign(:presence_hidden_ids, MapSet.new())
     |> assign(:messages_count, 0)
     |> assign(:notifications_count, 0)
+    # What the bell's number stands for, while the pointer rests on it (see the
+    # panel in render/1). Nil is closed, and closed is where every render that
+    # is not a hover starts — nothing asks the feed until somebody looks.
+    |> assign(:bell_preview, nil)
     # How many posts reached the feed while the member was elsewhere, and the
     # ceiling its query counts to (`Vutuv.Posts.unread_feed_count/1`), which the
     # badge needs in order to draw "50+" instead of a bare floor. Zero on the
@@ -870,6 +880,43 @@ defmodule VutuvWeb.ShellLive do
 
   def handle_event("notify:seen", _params, socket), do: {:noreply, socket}
 
+  ## ── The bell's hover preview (docs/architecture/realtime.md) ──
+  #
+  # Looking away is what marks these read, so the close *writes*: the gesture
+  # says "I have seen this" as plainly as opening /notifications does. What the
+  # doc explains and the code cannot show is why the instant is pinned at the
+  # **open** — `mark_notifications_read/1` would sweep the marker to whatever is
+  # newest by the time the pointer leaves, marking an arrival read that was
+  # never in the panel.
+  #
+  # An old document that predates the hook simply never asks (the capability
+  # handshake `tab:visibility` above describes), so no member meets a panel
+  # their bundle cannot draw.
+  def handle_event("bell:preview", _params, socket) do
+    preview = Activity.unread_notifications(socket.assigns.user_id, @preview_limit)
+
+    # Nothing unread by the time the query ran (the member read it in another
+    # tab, or engaged with the post out in the feed): no panel, and no marker
+    # either — closing a panel that never opened must not move anything.
+    {:noreply, assign(socket, :bell_preview, if(preview.items != [], do: preview))}
+  end
+
+  def handle_event("bell:preview_close", _params, %{assigns: %{bell_preview: nil}} = socket),
+    do: {:noreply, socket}
+
+  def handle_event("bell:preview_close", _params, socket) do
+    Activity.mark_notifications_read_up_to(
+      socket.assigns.user_id,
+      socket.assigns.bell_preview.read_up_to
+    )
+
+    # No recount here: the marker's own `:notifications_changed` broadcast comes
+    # back to this socket like every other change, so the badge is never set by
+    # hand and cannot drift from the feed (the same reasoning `notify:seen`
+    # above gives).
+    {:noreply, assign(socket, :bell_preview, nil)}
+  end
+
   # The TabBadge hook reports whether this browser tab is in the background, on
   # connect and on every change. The server needs the answer because the teaser
   # below costs a query: a member sitting in front of the page would pay it for
@@ -1466,18 +1513,38 @@ defmodule VutuvWeb.ShellLive do
                   class={count_badge_class(:glyph)}
                 />
               </.link>
-              <.link
-                href={~p"/notifications"}
-                data-nav-item
-                title={gettext("Notifications")}
-                class="relative hidden h-10 w-10 items-center justify-center rounded-full text-slate-500 hover:bg-slate-100 md:flex dark:text-slate-400 dark:hover:bg-slate-800"
+              <%!-- The bell, and under it the preview the pointer resting on it
+              opens. The wrapper is what the hook listens on — not the link —
+              so the panel hanging out of it is a descendant: the pointer
+              travelling from the glyph down into the list never leaves the
+              subtree, and there is nothing to close. It also carries the
+              breakpoint the link used to carry, and `data-unread` so the hook
+              can stay quiet while there is nothing to show. --%>
+              <div
+                id="bell-preview-host"
+                phx-hook="BellPreview"
+                data-unread={@notifications_count}
+                class="relative hidden md:block"
               >
-                <.icon_bell />
-                <.count_badge
+                <.link
+                  href={~p"/notifications"}
+                  data-nav-item
+                  title={gettext("Notifications")}
+                  class="relative flex h-10 w-10 items-center justify-center rounded-full text-slate-500 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800"
+                >
+                  <.icon_bell />
+                  <.count_badge
+                    count={@notifications_count}
+                    class={count_badge_class(:glyph)}
+                  />
+                </.link>
+                <.bell_preview
+                  :if={@bell_preview}
+                  preview={@bell_preview}
                   count={@notifications_count}
-                  class={count_badge_class(:glyph)}
+                  user_param={@user_param}
                 />
-              </.link>
+              </div>
               <%!-- The avatar opens the account menu (a native <details data-menu>,
               light-dismissed by app.js): the single, conventional home for every
               account/settings destination, so the whole surface is one click from
@@ -1502,7 +1569,7 @@ defmodule VutuvWeb.ShellLive do
                   <span class="sr-only">{gettext("Account menu")}</span>
                 </summary>
 
-                <div class="absolute right-0 z-20 mt-2 w-60 rounded-xl bg-white py-1 shadow-lg ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-700">
+                <div class={["absolute right-0 z-20 mt-2 w-60", menu_surface_class()]}>
                   <.link
                     href={~p"/#{@user_param}"}
                     data-self-profile
@@ -1669,6 +1736,102 @@ defmodule VutuvWeb.ShellLive do
     if is_integer(percent), do: "#{base} · #{percent} %", else: base
   end
 
+  attr(:preview, :map, required: true)
+  attr(:count, :integer, required: true)
+  attr(:user_param, :string, required: true)
+
+  # What the bell's number stands for, in the smallest form that still answers
+  # it: one round kind badge, who did what, and how long ago. No teasers and no
+  # unfolding — a second notifications page hanging off the bar would move the
+  # trip rather than save it. Every row is still a link, so the one item that IS
+  # worth opening stays one click away.
+  #
+  # The gap under the bell is `pt-2` on the positioned wrapper rather than a
+  # margin on the card: padding belongs to the hover area, a margin does not,
+  # and an 8px dead strip that closes the panel mid-reach is the classic way a
+  # menu like this becomes unusable.
+  defp bell_preview(assigns) do
+    assigns =
+      assigns
+      |> Map.put(:more, max(assigns.count - length(assigns.preview.items), 0))
+      |> Map.put(:rows, Enum.map(assigns.preview.items, &preview_row(&1, assigns.user_param)))
+
+    ~H"""
+    <div id="bell-preview" class="absolute right-0 top-full z-20 w-80 pt-2">
+      <div class={menu_surface_class()}>
+        <ul
+          class="divide-y divide-slate-100 dark:divide-slate-800"
+          aria-label={gettext("New notifications")}
+        >
+          <li :for={row <- @rows} data-bell-preview-item>
+            <.link
+              href={row.href}
+              class="flex items-start gap-2.5 px-4 py-2.5 hover:bg-slate-50 dark:hover:bg-slate-800"
+            >
+              <span
+                class={[
+                  "mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-bold",
+                  NotificationLine.kind_classes(row.kind)
+                ]}
+                aria-hidden="true"
+              >
+                {NotificationLine.kind_glyph(row.kind)}
+              </span>
+              <span class="min-w-0 flex-1">
+                <%!-- Name and verb phrase read as one sentence, so they share
+                one clamp; `line-clamp-2` brings its own `display`, which is
+                why no block utility sits beside it. A kind with no actor is a
+                whole sentence and gets no bold half. --%>
+                <span class="line-clamp-2 text-sm leading-snug text-slate-800 dark:text-slate-100">
+                  <span class="sr-only">{NotificationLine.kind_label(row.kind)}:</span>
+                  <span class={row.body && "font-semibold"}>{row.title}</span>
+                  {row.body}
+                </span>
+                <span class="mt-0.5 block text-xs text-slate-500 dark:text-slate-400">
+                  {relative_time(row.at)}
+                </span>
+              </span>
+            </.link>
+          </li>
+        </ul>
+
+        <%!-- The panel is a glance, not the page, so it says outright when it
+        is holding some back — the same "+N more" line, msgid and formatter the
+        post card and the job list already use for the same sentence. --%>
+        <.link
+          href={~p"/notifications"}
+          data-bell-preview-all
+          class="flex items-center justify-between gap-2 border-t border-slate-100 px-4 py-2.5 text-sm font-semibold text-brand-700 hover:bg-slate-50 dark:border-slate-800 dark:text-brand-400 dark:hover:bg-slate-800"
+        >
+          <span>{gettext("All notifications")} ›</span>
+          <span
+            :if={@more > 0}
+            data-bell-preview-more
+            class="font-medium text-slate-500 dark:text-slate-400"
+          >
+            {gettext("+%{count} more", count: compact_count(@more))}
+          </span>
+        </.link>
+      </div>
+    </div>
+    """
+  end
+
+  # One row's presentation, so the markup above carries no lookups: the same
+  # name-over-verb-phrase split the browser notification uses, and the same
+  # `notification_url/2` destination that a popup lands on.
+  defp preview_row(item, viewer) do
+    {title, body} = NotificationLine.title_and_body(item)
+
+    %{
+      kind: item.kind,
+      title: title,
+      body: body,
+      at: item[:at],
+      href: NotificationLine.notification_url(item, viewer)
+    }
+  end
+
   attr(:href, :string, required: true)
   attr(:label, :string, required: true)
   attr(:count, :integer, default: 0)
@@ -1735,6 +1898,13 @@ defmodule VutuvWeb.ShellLive do
       <span class="text-[10px]">{@label}</span>
     </.link>
     """
+  end
+
+  # The card a dropdown in this bar is drawn on, shared by the account menu and
+  # the bell's preview. Positioning and width stay at the call site; what is
+  # here is the surface, so a radius or dark-mode tweak lands on both.
+  defp menu_surface_class do
+    "rounded-xl bg-white py-1 shadow-lg ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-700"
   end
 
   # Shared classes for an avatar account-menu item — mirrors the card_menu

--- a/lib/vutuv_web/notification_line.ex
+++ b/lib/vutuv_web/notification_line.ex
@@ -8,12 +8,17 @@ defmodule VutuvWeb.NotificationLine do
   ("replied to your post."); the few with no actor - moderation, a rejected
   image, a finished reference check - are whole sentences.
 
-  Two surfaces share it, which is why it lives here rather than in either:
-  `VutuvWeb.NotificationLive.Index` (the page under the bell) and
-  `VutuvWeb.ShellLive`, which puts the same line into a **browser**
-  notification (issue #1249). A second copy would drift the moment a kind is
-  added, and the popup would quietly go back to the untranslated English
-  `:text` fallback.
+  Three surfaces share it, which is why it lives here rather than in any of
+  them: `VutuvWeb.NotificationLive.Index` (the page under the bell) and
+  `VutuvWeb.ShellLive` twice over — the **browser** notification it raises
+  (issue #1249) and the **hover preview** under the bell itself, which shows
+  the member what the badge's number stands for. A second copy would drift the
+  moment a kind is added, and the popup would quietly go back to the
+  untranslated English `:text` fallback.
+
+  `kind_glyph/1`, `kind_classes/1` and `kind_label/1` are here for the same
+  reason one step further: the preview draws the same little round badge the
+  page draws, so the vocabulary of what a kind looks like is one table too.
 
   `notification_target/2` lives here for the same reason and is the half that
   is easiest to leave behind: a popup is raised precisely when the member is
@@ -210,6 +215,95 @@ defmodule VutuvWeb.NotificationLine do
       "Your content was hidden automatically after a report. The case page says what you can do."
     )
   end
+
+  # Event kinds that share the brand badge colour, so the class string lives
+  # in one place.
+  @brand_kind_classes "bg-brand-50 text-brand-700 dark:bg-brand-900/40 dark:text-brand-100"
+  @brand_kinds ~w(follower reply thread mention connection report_protection organization_role handle_change cv_update fediverse_reply fediverse_reaction share)
+
+  @doc """
+  How one notification kind is *drawn*: the badge colour, the glyph inside it
+  and the accessible name that says in words what the glyph means.
+
+  Beside the wording above, because a surface that renders a notification needs
+  both halves and there is now a third of them (the bell's hover preview in
+  `VutuvWeb.ShellLive`, next to the notifications page and the browser popup).
+  A raw kind string ("cv_update") must never reach a reader, which is what
+  `kind_label/1` is for — it is the badge's `title` and its screen-reader text.
+  """
+  def kind_classes("endorsement"),
+    do: "bg-emerald-50 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-300"
+
+  def kind_classes("like"), do: "bg-accent/10 text-accent dark:bg-accent/20"
+
+  def kind_classes("moderation"),
+    do: "bg-amber-50 text-amber-600 dark:bg-amber-900/30 dark:text-amber-200"
+
+  # The AI image scan removed an image — amber, like every moderation notice.
+  def kind_classes("image_rejected"),
+    do: "bg-amber-50 text-amber-600 dark:bg-amber-900/30 dark:text-amber-200"
+
+  def kind_classes(kind) when kind in @brand_kinds, do: @brand_kind_classes
+
+  def kind_classes(_), do: "bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-300"
+
+  def kind_glyph("follower"), do: "+"
+  def kind_glyph("endorsement"), do: "★"
+  def kind_glyph("reply"), do: "↩"
+  # A reply elsewhere in a thread the recipient writes in.
+  def kind_glyph("thread"), do: "⤷"
+  # Being named by @handle. Shares the glyph with the (rare, "More"-chip)
+  # handle-change kind: both are about a handle, and the badge's title/sr-only
+  # label tells them apart where the glyph alone would not.
+  def kind_glyph("mention"), do: "@"
+  def kind_glyph("like"), do: "♥"
+  # A re-share from another network (issue #1068): the arrows, since the line
+  # beside it names the verb and the globe already sits on the sharer's name.
+  def kind_glyph("share"), do: "↻"
+  # A reply written on another network (issue #1069) — the same globe the
+  # post card's "from other networks" line uses, so one glyph means one thing.
+  def kind_glyph("fediverse_reply"), do: "🌐"
+  # A reaction from out there of a kind that is neither a favourite nor a
+  # re-share — the globe, since "this came from another network" is the one
+  # thing the glyph has to say; the sentence beside it names the verb.
+  def kind_glyph("fediverse_reaction"), do: "🌐"
+  # "connection" is the vernetzt (mutual-follow) event; the handshake glyph.
+  def kind_glyph("connection"), do: "🤝"
+  def kind_glyph("moderation"), do: "⚑"
+  def kind_glyph("image_rejected"), do: "🖼"
+  def kind_glyph("report_protection"), do: "🛡"
+  def kind_glyph("organization_role"), do: "🏢"
+  def kind_glyph("handle_change"), do: "@"
+  def kind_glyph("cv_update"), do: "📄"
+  # The welcome note naming the member's own handle.
+  def kind_glyph("username"), do: "👋"
+  # The finished AI reading of an Arbeitszeugnis. The magnifier, not a robot:
+  # what arrived is a close reading of wording, and the member is being told to
+  # go and read it.
+  def kind_glyph("reference_check"), do: "🔍"
+  def kind_glyph(_), do: "•"
+
+  # The accessible kind name (the badge's title + sr-only text). Translated
+  # like the row text; raw kind strings ("cv_update") must not leak to users.
+  def kind_label("follower"), do: gettext("Follower")
+  def kind_label("endorsement"), do: gettext("Endorsement")
+  def kind_label("reply"), do: gettext("Reply")
+  def kind_label("thread"), do: gettext("Thread reply")
+  def kind_label("mention"), do: gettext("Mention")
+  def kind_label("like"), do: gettext("Like")
+  def kind_label("fediverse_reply"), do: gettext("Reply from another network")
+  def kind_label("share"), do: gettext("Reaction from another network")
+  def kind_label("fediverse_reaction"), do: gettext("Reaction from another network")
+  def kind_label("connection"), do: gettext("Connection")
+  def kind_label("moderation"), do: gettext("Moderation")
+  def kind_label("image_rejected"), do: gettext("Image review")
+  def kind_label("report_protection"), do: gettext("Report protection")
+  def kind_label("organization_role"), do: gettext("Organization role")
+  def kind_label("handle_change"), do: gettext("Handle change")
+  def kind_label("cv_update"), do: gettext("CV update")
+  def kind_label("username"), do: gettext("Username")
+  def kind_label("reference_check"), do: gettext("Employment reference review")
+  def kind_label(_), do: gettext("Activity")
 
   @doc """
   The popup's two halves: an actor's name over their verb phrase.

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -442,8 +442,8 @@ msgstr "Einloggen"
 msgid "Log Out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/live/shell_live.ex:1573
-#: lib/vutuv_web/live/shell_live.ex:1649
+#: lib/vutuv_web/live/shell_live.ex:1653
+#: lib/vutuv_web/live/shell_live.ex:1729
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -456,7 +456,7 @@ msgstr "Einloggen"
 msgid "Middle Name"
 msgstr "Zweiter Vorname"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1351
+#: lib/vutuv_web/live/notification_live/index.ex:1354
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:298
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:306
 #, elixir-autogen
@@ -476,7 +476,7 @@ msgid "Name"
 msgstr "Name"
 
 #: lib/vutuv_web/components/post_components.ex:793
-#: lib/vutuv_web/live/notification_live/index.ex:793
+#: lib/vutuv_web/live/notification_live/index.ex:796
 #: lib/vutuv_web/live/organization_live/activity.ex:136
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
@@ -648,8 +648,8 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
-#: lib/vutuv_web/live/shell_live.ex:1442
-#: lib/vutuv_web/live/shell_live.ex:1629
+#: lib/vutuv_web/live/shell_live.ex:1502
+#: lib/vutuv_web/live/shell_live.ex:1709
 #: lib/vutuv_web/live/tag_live/timeline.ex:337
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
@@ -798,7 +798,7 @@ msgstr "User wurde verifiziert."
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
 #: lib/vutuv_web/live/directory_search_live.ex:134
-#: lib/vutuv_web/live/notification_live/index.ex:1523
+#: lib/vutuv_web/notification_line.ex:304
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:51
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -1158,7 +1158,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:63
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1549
+#: lib/vutuv_web/live/shell_live.ex:1629
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1601,7 +1601,7 @@ msgstr "Adressen von %{name}"
 msgid "Admin control panel"
 msgstr "Admin-Bereich"
 
-#: lib/vutuv_web/live/shell_live.ex:1647
+#: lib/vutuv_web/live/shell_live.ex:1727
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Mitteilungen"
@@ -1718,7 +1718,7 @@ msgstr ""
 " von jemandem, den Sie kennen oder interessant finden, und klicken Sie auf "
 "Folgen!"
 
-#: lib/vutuv_web/live/shell_live.ex:1568
+#: lib/vutuv_web/live/shell_live.ex:1648
 #: lib/vutuv_web/views/settings_html.ex:340
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1750,8 +1750,8 @@ msgstr "Nachricht"
 #: lib/vutuv_web/controllers/page_controller.ex:218
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1460
-#: lib/vutuv_web/live/shell_live.ex:1646
+#: lib/vutuv_web/live/shell_live.ex:1520
+#: lib/vutuv_web/live/shell_live.ex:1726
 #: lib/vutuv_web/templates/layout/app.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1773,7 +1773,7 @@ msgstr "Netzwerk"
 msgid "Nothing here yet."
 msgstr "Hier gibt es noch nichts."
 
-#: lib/vutuv_web/live/notification_live/index.ex:539
+#: lib/vutuv_web/live/notification_live/index.ex:542
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr "Noch nichts Neues."
@@ -1781,9 +1781,9 @@ msgstr "Noch nichts Neues."
 #: lib/vutuv/api_auth/scopes.ex:85
 #: lib/vutuv_web/components/ui.ex:5138
 #: lib/vutuv_web/controllers/page_controller.ex:219
-#: lib/vutuv_web/live/notification_live/index.ex:152
-#: lib/vutuv_web/live/notification_live/index.ex:457
-#: lib/vutuv_web/live/shell_live.ex:1472
+#: lib/vutuv_web/live/notification_live/index.ex:155
+#: lib/vutuv_web/live/notification_live/index.ex:460
+#: lib/vutuv_web/live/shell_live.ex:1545
 #: lib/vutuv_web/templates/layout/app.html.heex:160
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -1909,17 +1909,17 @@ msgstr[1] "Follower"
 msgid "following"
 msgstr "folgt"
 
-#: lib/vutuv_web/notification_line.ex:82
+#: lib/vutuv_web/notification_line.ex:87
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr "hat Sie für %{tag} empfohlen."
 
-#: lib/vutuv_web/notification_line.ex:77
+#: lib/vutuv_web/notification_line.ex:82
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr "ist jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/notification_line.ex:75
+#: lib/vutuv_web/notification_line.ex:80
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr "folgt Ihnen jetzt."
@@ -2133,8 +2133,8 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/live/post_live/feed.ex:331
 #: lib/vutuv_web/live/post_live/feed.ex:3254
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1294
-#: lib/vutuv_web/live/shell_live.ex:1619
+#: lib/vutuv_web/live/shell_live.ex:1354
+#: lib/vutuv_web/live/shell_live.ex:1699
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2313,7 +2313,7 @@ msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
 #: lib/vutuv_web/components/ui.ex:5483
-#: lib/vutuv_web/live/shell_live.ex:1515
+#: lib/vutuv_web/live/shell_live.ex:1595
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:287
@@ -2406,8 +2406,8 @@ msgstr "Lesezeichen setzen"
 #: lib/vutuv_web/agent_docs/markdown.ex:1264
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1452
-#: lib/vutuv_web/live/shell_live.ex:1520
+#: lib/vutuv_web/live/shell_live.ex:1512
+#: lib/vutuv_web/live/shell_live.ex:1600
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2417,7 +2417,7 @@ msgstr "Lesezeichen"
 #: lib/vutuv_web/components/post_components.ex:2055
 #: lib/vutuv_web/components/post_components.ex:6322
 #: lib/vutuv_web/components/ui.ex:4117
-#: lib/vutuv_web/live/notification_live/index.ex:1512
+#: lib/vutuv_web/notification_line.ex:293
 #: lib/vutuv_web/views/user_html.ex:481
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2427,7 +2427,7 @@ msgstr "Gefällt mir"
 #: lib/vutuv_web/components/post_components.ex:6332
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1523
+#: lib/vutuv_web/live/shell_live.ex:1603
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2512,7 +2512,7 @@ msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
 #: lib/vutuv_web/components/post_components.ex:430
-#: lib/vutuv_web/live/notification_live/index.ex:1348
+#: lib/vutuv_web/live/notification_live/index.ex:1351
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
@@ -2520,9 +2520,9 @@ msgstr "Antworten"
 #: lib/vutuv_web/components/post_components.ex:2068
 #: lib/vutuv_web/components/post_components.ex:6359
 #: lib/vutuv_web/components/post_components.ex:6360
-#: lib/vutuv_web/live/notification_live/index.ex:1010
-#: lib/vutuv_web/live/notification_live/index.ex:1509
+#: lib/vutuv_web/live/notification_live/index.ex:1013
 #: lib/vutuv_web/live/post_live/reply.ex:49
+#: lib/vutuv_web/notification_line.ex:290
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
@@ -2543,7 +2543,7 @@ msgstr "Solange es geteilte Beiträge oder Antworten gibt, lässt sich der Empf�
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beiträge oder Antworten gibt, bleibt er öffentlich; löschen können Sie ihn weiterhin."
 
-#: lib/vutuv_web/notification_line.ex:64
+#: lib/vutuv_web/notification_line.ex:69
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
@@ -2875,23 +2875,23 @@ msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
 
 #: lib/vutuv_web/components/organization_components.ex:259
-#: lib/vutuv_web/live/notification_live/index.ex:1525
 #: lib/vutuv_web/live/organization_live/activity.ex:112
+#: lib/vutuv_web/notification_line.ex:306
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr "Aktivität"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1516
+#: lib/vutuv_web/notification_line.ex:297
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr "Vernetzung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1508
+#: lib/vutuv_web/notification_line.ex:289
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr "Empfehlung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1507
+#: lib/vutuv_web/notification_line.ex:288
 #: lib/vutuv_web/templates/user/show.html.heex:947
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2904,7 +2904,7 @@ msgstr[1] "Follower"
 msgid "Welcome to vutuv, %{name}!"
 msgstr "Willkommen bei vutuv, %{name}!"
 
-#: lib/vutuv_web/notification_line.ex:73
+#: lib/vutuv_web/notification_line.ex:78
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr "gefällt Ihr Beitrag."
@@ -2936,12 +2936,12 @@ msgstr "(gelöschtes Konto)"
 msgid "(no text)"
 msgstr "(kein Text)"
 
-#: lib/vutuv_web/notification_line.ex:118
+#: lib/vutuv_web/notification_line.ex:123
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde bestätigt."
 
-#: lib/vutuv_web/notification_line.ex:119
+#: lib/vutuv_web/notification_line.ex:124
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde verworfen; er ist wieder sichtbar."
@@ -3057,7 +3057,7 @@ msgstr "Familienfreundlich bleiben"
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1517
+#: lib/vutuv_web/notification_line.ex:298
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3188,7 +3188,7 @@ msgid "Private message"
 msgstr "Private Nachricht"
 
 #: lib/vutuv_web/components/ui.ex:5070
-#: lib/vutuv_web/live/shell_live.ex:1326
+#: lib/vutuv_web/live/shell_live.ex:1386
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3504,12 +3504,12 @@ msgstr "Sie haben das bereits gemeldet. Unser Team kümmert sich darum."
 msgid "You cannot report your own content."
 msgstr "Eigene Inhalte können Sie nicht melden."
 
-#: lib/vutuv_web/notification_line.ex:121
+#: lib/vutuv_web/notification_line.ex:126
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt gelöscht; der Fall ist abgeschlossen."
 
-#: lib/vutuv_web/notification_line.ex:120
+#: lib/vutuv_web/notification_line.ex:125
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
@@ -3707,7 +3707,7 @@ msgstr "Verlauf"
 msgid "Open the profile"
 msgstr "Profil öffnen"
 
-#: lib/vutuv_web/notification_line.ex:146
+#: lib/vutuv_web/notification_line.ex:151
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3734,7 +3734,7 @@ msgstr "Besitzer hat den Inhalt bearbeitet"
 msgid "Report filed"
 msgstr "Meldung eingegangen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1519
+#: lib/vutuv_web/notification_line.ex:300
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr "Schutz nach Meldung"
@@ -3816,7 +3816,7 @@ msgstr "Bestätigt"
 msgid "Waiting for the owner"
 msgstr "Wartet auf den Besitzer"
 
-#: lib/vutuv_web/notification_line.ex:151
+#: lib/vutuv_web/notification_line.ex:156
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4003,7 +4003,7 @@ msgstr "Beitragsarchiv von %{name}"
 #: lib/vutuv_web/agent_docs/text.ex:138
 #: lib/vutuv_web/live/admin/screenshot_live.ex:380
 #: lib/vutuv_web/live/admin/screenshot_live.ex:389
-#: lib/vutuv_web/live/notification_live/index.ex:1635
+#: lib/vutuv_web/live/notification_live/index.ex:1557
 #: lib/vutuv_web/templates/post/show.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "Post by %{name}"
@@ -4727,8 +4727,8 @@ msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 #: lib/vutuv_web/agent_docs/markdown.ex:510
 #: lib/vutuv_web/agent_docs/text.ex:525
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/live/notification_live/index.ex:657
-#: lib/vutuv_web/live/notification_live/index.ex:1350
+#: lib/vutuv_web/live/notification_live/index.ex:660
+#: lib/vutuv_web/live/notification_live/index.ex:1353
 #: lib/vutuv_web/live/organization_live/show.ex:797
 #: lib/vutuv_web/live/post_live/saved.ex:539
 #: lib/vutuv_web/live/search_live.ex:346
@@ -4754,7 +4754,7 @@ msgstr "Ähnliche Namen"
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
-#: lib/vutuv_web/live/notification_live/index.ex:1347
+#: lib/vutuv_web/live/notification_live/index.ex:1350
 #: lib/vutuv_web/live/search_live.ex:345
 #: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
@@ -5492,7 +5492,7 @@ msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
 msgid "Content under review"
 msgstr "Inhalte in Prüfung"
 
-#: lib/vutuv_web/live/shell_live.ex:1502
+#: lib/vutuv_web/live/shell_live.ex:1582
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Kontomenü"
@@ -5514,7 +5514,7 @@ msgstr "Menüs und Dialoge schließen"
 msgid "General"
 msgstr "Allgemeines"
 
-#: lib/vutuv_web/live/shell_live.ex:1559
+#: lib/vutuv_web/live/shell_live.ex:1639
 #: lib/vutuv_web/templates/layout/app.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5533,7 +5533,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:276
-#: lib/vutuv_web/live/shell_live.ex:1539
+#: lib/vutuv_web/live/shell_live.ex:1619
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5587,8 +5587,8 @@ msgstr "Nächster Beitrag im Feed"
 msgid "Previous post in the feed"
 msgstr "Vorheriger Beitrag im Feed"
 
-#: lib/vutuv_web/live/shell_live.ex:1282
-#: lib/vutuv_web/live/shell_live.ex:1600
+#: lib/vutuv_web/live/shell_live.ex:1342
+#: lib/vutuv_web/live/shell_live.ex:1680
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Hauptnavigation"
@@ -5601,7 +5601,7 @@ msgstr "Fußzeilen-Navigation"
 #: lib/vutuv_web/components/post_components.ex:4022
 #: lib/vutuv_web/components/post_components.ex:4074
 #: lib/vutuv_web/components/post_components.ex:4608
-#: lib/vutuv_web/live/notification_live/index.ex:1086
+#: lib/vutuv_web/live/notification_live/index.ex:1089
 #: lib/vutuv_web/views/user_html.ex:131
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5729,7 +5729,7 @@ msgstr "Ansehen"
 msgid "Your name"
 msgstr "Ihr Name"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1629
+#: lib/vutuv_web/live/notification_live/index.ex:1551
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr "Ihr Beitrag"
@@ -6521,10 +6521,10 @@ msgid "No endorsements yet."
 msgstr "Noch keine Empfehlungen."
 
 #: lib/vutuv_web/components/ui.ex:2712
-#: lib/vutuv_web/live/notification_live/index.ex:724
-#: lib/vutuv_web/live/notification_live/index.ex:739
-#: lib/vutuv_web/live/notification_live/index.ex:1239
-#: lib/vutuv_web/live/notification_live/index.ex:1241
+#: lib/vutuv_web/live/notification_live/index.ex:727
+#: lib/vutuv_web/live/notification_live/index.ex:742
+#: lib/vutuv_web/live/notification_live/index.ex:1242
+#: lib/vutuv_web/live/notification_live/index.ex:1244
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
@@ -7590,6 +7590,7 @@ msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 #: lib/vutuv_web/components/job_components.ex:190
 #: lib/vutuv_web/components/post_components.ex:6232
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
+#: lib/vutuv_web/live/shell_live.ex:1822
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
 msgstr "+%{count} weitere"
@@ -8005,13 +8006,13 @@ msgstr "Neue Mitglieder"
 #: lib/vutuv_web/components/job_components.ex:219
 #: lib/vutuv_web/live/admin/dashboard_live.ex:304
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:468
-#: lib/vutuv_web/live/notification_live/index.ex:1385
+#: lib/vutuv_web/live/notification_live/index.ex:1388
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Heute"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:308
-#: lib/vutuv_web/live/notification_live/index.ex:1388
+#: lib/vutuv_web/live/notification_live/index.ex:1391
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr "Gestern"
@@ -8257,8 +8258,8 @@ msgstr "Identität verifiziert. Das Mitglied wurde per E-Mail benachrichtigt."
 msgid "Identity-verified"
 msgstr "Identität verifiziert"
 
-#: lib/vutuv/accounts.ex:1451
-#: lib/vutuv/accounts.ex:1500
+#: lib/vutuv/accounts.ex:1452
+#: lib/vutuv/accounts.ex:1501
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8299,7 +8300,7 @@ msgstr "Nicht bestätigt"
 msgid "Open the member browser"
 msgstr "Mitgliederübersicht öffnen"
 
-#: lib/vutuv/accounts.ex:1468
+#: lib/vutuv/accounts.ex:1469
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -9041,7 +9042,7 @@ msgstr "Social-Media-Konten verwalten"
 msgid "Your Fediverse handle"
 msgstr "Ihr Fediverse-Handle"
 
-#: lib/vutuv/accounts.ex:1463
+#: lib/vutuv/accounts.ex:1464
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -9845,7 +9846,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
-#: lib/vutuv/accounts/user.ex:1262
+#: lib/vutuv/accounts/user.ex:1271
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9856,7 +9857,7 @@ msgstr "Auf Jobsuche"
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
-#: lib/vutuv/accounts/user.ex:1259
+#: lib/vutuv/accounts/user.ex:1268
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10633,7 +10634,7 @@ msgid_plural "%{count} stars"
 msgstr[0] "%{count} Stern"
 msgstr[1] "%{count} Sterne"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1433
+#: lib/vutuv_web/live/notification_live/index.ex:1436
 #: lib/vutuv_web/live/organization_live/show.ex:648
 #: lib/vutuv_web/views/user_html.ex:960
 #: lib/vutuv_web/views/user_html.ex:1136
@@ -11295,19 +11296,19 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
-#: lib/vutuv/accounts/user.ex:1300
+#: lib/vutuv/accounts/user.ex:1309
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
-#: lib/vutuv/accounts/user.ex:1305
+#: lib/vutuv/accounts/user.ex:1314
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
-#: lib/vutuv/accounts/user.ex:1303
+#: lib/vutuv/accounts/user.ex:1312
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -12324,7 +12325,7 @@ msgstr "Organisationsseite"
 msgid "Organization pages"
 msgstr "Organisationsseiten"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1520
+#: lib/vutuv_web/notification_line.ex:301
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr "Organisationsrolle"
@@ -12342,7 +12343,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:542
-#: lib/vutuv_web/live/shell_live.ex:1530
+#: lib/vutuv_web/live/shell_live.ex:1610
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:80
@@ -12442,22 +12443,22 @@ msgstr "Ihre Organisationsseite ist verifiziert und jetzt live."
 msgid "Your organization page was updated."
 msgstr "Ihre Organisationsseite wurde aktualisiert."
 
-#: lib/vutuv_web/notification_line.ex:110
+#: lib/vutuv_web/notification_line.ex:115
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr "hat Ihnen eine Rolle bei %{organization} gegeben."
 
-#: lib/vutuv_web/notification_line.ex:107
+#: lib/vutuv_web/notification_line.ex:112
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr "hat Sie zum Recruiter für %{organization} gemacht."
 
-#: lib/vutuv_web/notification_line.ex:104
+#: lib/vutuv_web/notification_line.ex:109
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr "hat Sie zum Administrator von %{organization} gemacht."
 
-#: lib/vutuv_web/notification_line.ex:101
+#: lib/vutuv_web/notification_line.ex:106
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr "hat Sie zum Besitzer von %{organization} gemacht."
@@ -12659,7 +12660,7 @@ msgstr "Hervorgehobene Tags passen zu Ihrem Profil."
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
 
-#: lib/vutuv/accounts/user.ex:1274
+#: lib/vutuv/accounts/user.ex:1283
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12685,7 +12686,7 @@ msgstr "Stellenbezeichnung"
 #: lib/vutuv_web/live/job_board_live.ex:47
 #: lib/vutuv_web/live/job_board_live.ex:265
 #: lib/vutuv_web/live/post_live/saved.ex:545
-#: lib/vutuv_web/live/shell_live.ex:1334
+#: lib/vutuv_web/live/shell_live.ex:1394
 #: lib/vutuv_web/templates/layout/app.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -12778,7 +12779,7 @@ msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
 
-#: lib/vutuv/accounts/user.ex:1273
+#: lib/vutuv/accounts/user.ex:1282
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12860,7 +12861,7 @@ msgstr "Anzeige nicht gefunden."
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: lib/vutuv/accounts/user.ex:1275
+#: lib/vutuv/accounts/user.ex:1284
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:589
 #: lib/vutuv_web/agent_docs/markdown.ex:532
@@ -13849,7 +13850,7 @@ msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 T
 msgid "Image awaiting review, visible only to you"
 msgstr "Bild wird geprüft, nur für Sie sichtbar"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1518
+#: lib/vutuv_web/notification_line.ex:299
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13890,7 +13891,7 @@ msgstr "Screenshot entfernt."
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
-#: lib/vutuv/accounts/user.ex:1318
+#: lib/vutuv/accounts/user.ex:1327
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13901,19 +13902,19 @@ msgstr "Nur das Alter, ohne das Datum"
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
-#: lib/vutuv/accounts/user.ex:1321
+#: lib/vutuv/accounts/user.ex:1330
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
-#: lib/vutuv/accounts/user.ex:1324
+#: lib/vutuv/accounts/user.ex:1333
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
-#: lib/vutuv/accounts/user.ex:1315
+#: lib/vutuv/accounts/user.ex:1324
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13936,7 +13937,7 @@ msgstr[1] "%{formatted} Beiträge erwähnen aktuell %{handle} und werden beim Um
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr "Beim Ändern werden alle Erwähnungen Ihres alten Handles in Beiträgen automatisch auf den neuen umgeschrieben und die Verfasser dieser Beiträge benachrichtigt. Ihre alte Profiladresse funktioniert dann nicht mehr."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1521
+#: lib/vutuv_web/notification_line.ex:302
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr "Handle-Änderung"
@@ -13948,7 +13949,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] "Wir haben %{formatted} Beitrag aktualisiert, der Ihren alten Handle erwähnt hat, und dessen Verfasser benachrichtigt."
 msgstr[1] "Wir haben %{formatted} Beiträge aktualisiert, die Ihren alten Handle erwähnt haben, und deren Verfasser benachrichtigt."
 
-#: lib/vutuv_web/notification_line.ex:160
+#: lib/vutuv_web/notification_line.ex:165
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "hat den Handle von @%{old} auf @%{new} geändert."
@@ -14157,22 +14158,22 @@ msgstr[1] "Meine %{formatted} Follower darüber informieren"
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1522
+#: lib/vutuv_web/notification_line.ex:303
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr "Lebenslauf-Update"
 
-#: lib/vutuv_web/notification_line.ex:180
+#: lib/vutuv_web/notification_line.ex:185
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr "hat eine neue Station im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/notification_line.ex:172
+#: lib/vutuv_web/notification_line.ex:177
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr "hat eine neue Ausbildung im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/notification_line.ex:177
+#: lib/vutuv_web/notification_line.ex:182
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr "hat ein neues Zertifikat im Lebenslauf: %{entry}"
@@ -14197,7 +14198,7 @@ msgstr "Über neue Lebenslauf-Einträge von Personen informieren, denen ich folg
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch immer."
 
-#: lib/vutuv_web/notification_line.ex:185
+#: lib/vutuv_web/notification_line.ex:190
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
@@ -14328,40 +14329,40 @@ msgstr "Mit Qualifikation: %{name}"
 msgid "Publisher:"
 msgstr "Verlag:"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1377
+#: lib/vutuv_web/live/notification_live/index.ex:1380
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] "%{formatted} neue Mitteilung"
 msgstr[1] "%{formatted} neue Mitteilungen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1391
+#: lib/vutuv_web/live/notification_live/index.ex:1394
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr "%{day}. %{month} %{year}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:556
+#: lib/vutuv_web/live/notification_live/index.ex:559
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr "Zurückfolgen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1334
-#: lib/vutuv_web/live/notification_live/index.ex:1701
+#: lib/vutuv_web/live/notification_live/index.ex:1337
+#: lib/vutuv_web/live/notification_live/index.ex:1623
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "und"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1608
+#: lib/vutuv_web/live/notification_live/index.ex:1530
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr "sind jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1605
+#: lib/vutuv_web/live/notification_live/index.ex:1527
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr "folgen Ihnen jetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1614
+#: lib/vutuv_web/live/notification_live/index.ex:1536
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
@@ -14383,7 +14384,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] "Empfohlen von %{name} und %{formatted} weiteren"
 msgstr[1] "Empfohlen von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/live/shell_live.ex:711
+#: lib/vutuv_web/live/shell_live.ex:721
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -14581,7 +14582,7 @@ msgstr "Verfügbarkeit"
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Eine automatische Prüfung hat ein Bild aus Ihrem vutuv-Konto entfernt"
 
-#: lib/vutuv_web/notification_line.ex:134
+#: lib/vutuv_web/notification_line.ex:139
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
@@ -14589,12 +14590,12 @@ msgstr ""
 "familienfreundlich genug für ein Arbeitsumfeld. Sie kann sich irren, "
 "antworten Sie in dem Fall einfach auf unsere E-Mail."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1510
+#: lib/vutuv_web/notification_line.ex:291
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr "Thread-Antwort"
 
-#: lib/vutuv_web/notification_line.ex:263
+#: lib/vutuv_web/notification_line.ex:358
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14617,12 +14618,12 @@ msgstr "Unterhaltung"
 msgid "Only part of this long conversation is shown."
 msgstr "Von dieser langen Unterhaltung wird nur ein Teil angezeigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1511
+#: lib/vutuv_web/notification_line.ex:292
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr "Erwähnung"
 
-#: lib/vutuv_web/notification_line.ex:84
+#: lib/vutuv_web/notification_line.ex:89
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr "hat Sie in einem Beitrag erwähnt."
@@ -14883,7 +14884,7 @@ msgstr "Sie können nur alle %{days} Tage umziehen."
 msgid "as an account alias."
 msgstr "als Konto-Alias hinzu."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1693
+#: lib/vutuv_web/live/notification_live/index.ex:1615
 #: lib/vutuv_web/templates/user_tag/show.html.heex:24
 #, elixir-autogen, elixir-format
 msgid "%{formatted} endorsement"
@@ -14972,7 +14973,7 @@ msgstr "Diese Ausbildung wird jetzt oben in Ihrem Profil angezeigt."
 msgid "Thread replies"
 msgstr "Thread-Antworten"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1039
+#: lib/vutuv_web/live/notification_live/index.ex:1042
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr "Thread-Benachrichtigungen abschalten"
@@ -15023,7 +15024,7 @@ msgstr "Sie haben noch nichts stummgeschaltet."
 msgid "You have reached the maximum of %{count} filters."
 msgstr "Sie haben das Maximum von %{count} Filtern erreicht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1034
+#: lib/vutuv_web/live/notification_live/index.ex:1037
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr "Sie haben in diesem Thread geschrieben."
@@ -15925,7 +15926,7 @@ msgstr ""
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
 #: lib/vutuv_web/components/post_components.ex:6277
-#: lib/vutuv_web/live/notification_live/index.ex:1690
+#: lib/vutuv_web/live/notification_live/index.ex:1612
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
@@ -15933,7 +15934,7 @@ msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
 #: lib/vutuv_web/components/post_components.ex:6281
-#: lib/vutuv_web/live/notification_live/index.ex:1684
+#: lib/vutuv_web/live/notification_live/index.ex:1606
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
@@ -15992,7 +15993,7 @@ msgstr "Vom Mitglied entfernt"
 msgid "Replies from other networks"
 msgstr "Antworten aus anderen Netzwerken"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1513
+#: lib/vutuv_web/notification_line.ex:294
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr "Antwort aus einem anderen Netzwerk"
@@ -16013,7 +16014,7 @@ msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
 #: lib/vutuv_web/components/post_components.ex:1445
-#: lib/vutuv_web/live/notification_live/index.ex:1134
+#: lib/vutuv_web/live/notification_live/index.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr "Nur an Sie gesendet, für niemanden sonst sichtbar"
@@ -16065,7 +16066,7 @@ msgstr "Was"
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr "Sie haben heute schon viel gemeldet. Bitte versuchen Sie es morgen wieder."
 
-#: lib/vutuv_web/notification_line.ex:87
+#: lib/vutuv_web/notification_line.ex:92
 #, elixir-autogen, elixir-format
 msgid "replied to your post from another network."
 msgstr "hat aus einem anderen Netzwerk auf Ihren Beitrag geantwortet."
@@ -17063,8 +17064,8 @@ msgstr "Fediverse-Reaktionen"
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1514
-#: lib/vutuv_web/live/notification_live/index.ex:1515
+#: lib/vutuv_web/notification_line.ex:295
+#: lib/vutuv_web/notification_line.ex:296
 #, elixir-autogen, elixir-format
 msgid "Reaction from another network"
 msgstr "Reaktion aus einem anderen Netzwerk"
@@ -17084,21 +17085,21 @@ msgstr ""
 "Mehr speichern wir über diese Menschen nicht: keinen Namen, kein Bild, "
 "keinen Text. Ausschalten löscht, was dafür gespeichert ist."
 
-#: lib/vutuv_web/notification_line.ex:244
+#: lib/vutuv_web/notification_line.ex:339
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] "gefällt Ihr Beitrag in einem anderen Netzwerk."
 msgstr[1] "gefällt Ihr Beitrag in einem anderen Netzwerk."
 
-#: lib/vutuv_web/notification_line.ex:252
+#: lib/vutuv_web/notification_line.ex:347
 #, elixir-autogen, elixir-format
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] "hat aus einem anderen Netzwerk auf Ihren Beitrag reagiert."
 msgstr[1] "haben aus einem anderen Netzwerk auf Ihren Beitrag reagiert."
 
-#: lib/vutuv_web/notification_line.ex:236
+#: lib/vutuv_web/notification_line.ex:331
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -18351,7 +18352,7 @@ msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
 "Noch nichts von vutuv. Folgen Sie Menschen hier, um diesen Tab zu füllen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1148
+#: lib/vutuv_web/live/notification_live/index.ex:1151
 #, elixir-autogen, elixir-format
 msgid "View the conversation"
 msgstr "Unterhaltung ansehen"
@@ -18996,7 +18997,7 @@ msgstr "Arbeitszeugnis geändert"
 msgid "Employment reference deleted"
 msgstr "Arbeitszeugnis gelöscht"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1524
+#: lib/vutuv_web/notification_line.ex:305
 #, elixir-autogen, elixir-format
 msgid "Employment reference review"
 msgstr "Zeugnisprüfung"
@@ -19021,13 +19022,13 @@ msgstr "Ausstellungsdatum"
 msgid "Reviewing your reference. This usually takes about %{duration}."
 msgstr "Ihr Zeugnis wird geprüft. Das dauert erfahrungsgemäß etwa %{duration}."
 
-#: lib/vutuv_web/notification_line.ex:57
+#: lib/vutuv_web/notification_line.ex:62
 #: lib/vutuv_web/views/notification_digest_text.ex:94
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready."
 msgstr "Die Prüfung von „%{title}“ ist fertig."
 
-#: lib/vutuv_web/notification_line.ex:54
+#: lib/vutuv_web/notification_line.ex:59
 #: lib/vutuv_web/views/notification_digest_text.ex:91
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready: %{grade}."
@@ -19043,7 +19044,7 @@ msgstr "Erfahrungsgemäß etwa %{duration}."
 msgid "When the review of one of your employment references is finished. It takes minutes, so you can close the page and wait for the email."
 msgstr "Wenn die Prüfung eines Ihrer Arbeitszeugnisse fertig ist. Das dauert einige Minuten, Sie können die Seite also schließen und auf die E-Mail warten."
 
-#: lib/vutuv_web/notification_line.ex:60
+#: lib/vutuv_web/notification_line.ex:65
 #, elixir-autogen, elixir-format
 msgid "Your employment reference has been reviewed."
 msgstr "Ihr Arbeitszeugnis wurde geprüft."
@@ -19212,7 +19213,7 @@ msgstr "Eines Ihrer Bilder wurde von der Bildprüfung entfernt."
 msgid "Somebody"
 msgstr "Jemand"
 
-#: lib/vutuv_web/notification_line.ex:195
+#: lib/vutuv_web/notification_line.ex:200
 #: lib/vutuv_web/views/notification_digest_text.ex:100
 #, elixir-autogen, elixir-format
 msgid "Something new happened on your account."
@@ -19356,7 +19357,7 @@ msgstr ""
 msgid "Cancel registration"
 msgstr "Registrierung abbrechen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1301
+#: lib/vutuv_web/live/notification_live/index.ex:1304
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -19371,17 +19372,17 @@ msgstr ""
 "Kommt keine PIN an? Ist die E-Mail-Adresse {email} korrekt? Haben Sie einmal "
 "in Ihren Spam-Ordner geschaut?"
 
-#: lib/vutuv/accounts/user.ex:1421
+#: lib/vutuv/accounts/user.ex:1430
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/vutuv/accounts/user.ex:1419
+#: lib/vutuv/accounts/user.ex:1428
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Weiblich"
 
-#: lib/vutuv/accounts/user.ex:1420
+#: lib/vutuv/accounts/user.ex:1429
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
@@ -20144,7 +20145,7 @@ msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."
 msgid "A post in an organization's name is always public."
 msgstr "Ein Beitrag im Namen einer Organisation ist immer öffentlich."
 
-#: lib/vutuv_web/live/shell_live.ex:1240
+#: lib/vutuv_web/live/shell_live.ex:1300
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr "Seite öffnen"
@@ -20164,7 +20165,7 @@ msgstr "Beendet, im Namen einer Organisation zu schreiben"
 msgid "Write as %{name} for now"
 msgstr "Vorerst als %{name} schreiben"
 
-#: lib/vutuv_web/live/shell_live.ex:1250
+#: lib/vutuv_web/live/shell_live.ex:1310
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr "Wieder als ich selbst schreiben"
@@ -20174,7 +20175,7 @@ msgstr "Wieder als ich selbst schreiben"
 msgid "You are writing as %{name} now."
 msgstr "Sie schreiben jetzt als %{name}."
 
-#: lib/vutuv_web/live/shell_live.ex:1226
+#: lib/vutuv_web/live/shell_live.ex:1286
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr "Sie schreiben als %{name}."
@@ -20538,21 +20539,21 @@ msgstr "Sie folgen #%{tag} hier bereits."
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr "Sie sind selbst auf diesem vutuv. Sie folgen #%{tag} jetzt direkt hier."
 
-#: lib/vutuv_web/live/shell_live.ex:755
+#: lib/vutuv_web/live/shell_live.ex:765
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] "%{formatted} Person"
 msgstr[1] "%{formatted} Personen"
 
-#: lib/vutuv_web/live/shell_live.ex:742
+#: lib/vutuv_web/live/shell_live.ex:752
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] "Person"
 msgstr[1] "Personen"
 
-#: lib/vutuv_web/live/shell_live.ex:777
+#: lib/vutuv_web/live/shell_live.ex:787
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -21651,7 +21652,7 @@ msgstr "%{handle} nicht mehr folgen? Die Beiträge verschwinden aus Ihrem Feed."
 msgid "Unfollowed. Their posts leave your feed."
 msgstr "Nicht mehr gefolgt. Die Beiträge verschwinden aus Ihrem Feed."
 
-#: lib/vutuv_web/live/shell_live.ex:1200
+#: lib/vutuv_web/live/shell_live.ex:1260
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr "Erlauben"
@@ -21666,12 +21667,12 @@ msgstr "Jetzt fragen"
 msgid "Browser notifications"
 msgstr "Browser-Benachrichtigungen"
 
-#: lib/vutuv_web/live/shell_live.ex:1058
+#: lib/vutuv_web/live/shell_live.ex:1118
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr "Neue Nachricht"
 
-#: lib/vutuv_web/live/shell_live.ex:1203
+#: lib/vutuv_web/live/shell_live.ex:1263
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Jetzt nicht"
@@ -21711,7 +21712,7 @@ msgstr "Dieser Browser zeigt sie an."
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr "Wenn etwas eintrifft, während vutuv in einem Tab offen ist, den Sie gerade nicht ansehen, kann Ihr Browser es als Benachrichtigung anzeigen. Aus, solange Sie es nicht einschalten."
 
-#: lib/vutuv_web/live/shell_live.ex:1197
+#: lib/vutuv_web/live/shell_live.ex:1257
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr "Sie haben Browser-Benachrichtigungen eingeschaltet. Dieser Browser wurde noch nicht um Erlaubnis gebeten."
@@ -21751,12 +21752,12 @@ msgstr "Test-Benachrichtigung senden"
 msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
 msgstr "Gesendet. Wenn nichts erschienen ist, hält Ihr System sie zurück. Prüfen Sie „Nicht stören“ und Ihre Benachrichtigungseinstellungen."
 
-#: lib/vutuv_web/live/shell_live.ex:850
+#: lib/vutuv_web/live/shell_live.ex:860
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr "Test-Benachrichtigung"
 
-#: lib/vutuv_web/live/shell_live.ex:851
+#: lib/vutuv_web/live/shell_live.ex:861
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr "So sieht es aus, wenn auf vutuv etwas für Sie eintrifft."
@@ -21996,7 +21997,7 @@ msgstr "In %{language} übersetzen"
 msgid "Translated into %{language}."
 msgstr "Wird in %{language} übersetzt."
 
-#: lib/vutuv_web/live/shell_live.ex:991
+#: lib/vutuv_web/live/shell_live.ex:1051
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -22122,7 +22123,7 @@ msgstr "Neue Nachricht auf vutuv"
 msgid "No connection"
 msgstr "Keine Verbindung"
 
-#: lib/vutuv_web/live/shell_live.ex:1130
+#: lib/vutuv_web/live/shell_live.ex:1190
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr "Neu laden"
@@ -22610,7 +22611,7 @@ msgstr "Passwortmanager wie Bitwarden übernehmen daraus den ganzen Eintrag: Nam
 msgid "Scan it with the device that has the app"
 msgstr "Mit dem Gerät scannen, auf dem die App läuft"
 
-#: lib/vutuv_web/live/shell_live.ex:1112
+#: lib/vutuv_web/live/shell_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "A new version is ready."
 msgstr "Neue Version bereit."
@@ -22691,7 +22692,7 @@ msgctxt "filter rule"
 msgid "Hide"
 msgstr "Ausblenden"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1687
+#: lib/vutuv_web/live/notification_live/index.ex:1609
 #, elixir-autogen, elixir-format
 msgid "%{formatted} share"
 msgid_plural "%{formatted} shares"
@@ -22699,31 +22700,31 @@ msgstr[0] "%{formatted} Mal geteilt"
 msgstr[1] "%{formatted} Mal geteilt"
 
 #: lib/vutuv_web/controllers/post_calendar_controller.ex:136
-#: lib/vutuv_web/live/notification_live/index.ex:838
+#: lib/vutuv_web/live/notification_live/index.ex:841
 #, elixir-autogen, elixir-format
 msgid "Post without text"
 msgstr "Beitrag ohne Text"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1563
+#: lib/vutuv_web/live/notification_live/index.ex:1485
 #, elixir-autogen, elixir-format
 msgid "likes this."
 msgid_plural "like this."
 msgstr[0] "gefällt das."
 msgstr[1] "gefällt das."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1569
+#: lib/vutuv_web/live/notification_live/index.ex:1491
 #, elixir-autogen, elixir-format
 msgid "reacted to this."
 msgid_plural "reacted to this."
 msgstr[0] "hat darauf reagiert."
 msgstr[1] "haben darauf reagiert."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1571
+#: lib/vutuv_web/live/notification_live/index.ex:1493
 #, elixir-autogen, elixir-format
 msgid "replied."
 msgstr "hat geantwortet."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1566
+#: lib/vutuv_web/live/notification_live/index.ex:1488
 #, elixir-autogen, elixir-format
 msgid "shared this."
 msgid_plural "shared this."
@@ -22860,7 +22861,7 @@ msgstr "Wenn Ihre Verbindung langsam ist oder Ihr Datenvolumen begrenzt, kann vu
 msgid "Low-bandwidth mode"
 msgstr "Datensparmodus"
 
-#: lib/vutuv_web/live/shell_live.ex:1641
+#: lib/vutuv_web/live/shell_live.ex:1721
 #, elixir-autogen, elixir-format
 msgctxt "phone tab bar"
 msgid "Write"
@@ -23018,7 +23019,7 @@ msgstr "bandbreite langsam internet mobil daten sparen datensparmodus volumen sc
 msgid "Appearance"
 msgstr "Darstellung"
 
-#: lib/vutuv_web/live/shell_live.ex:1667
+#: lib/vutuv_web/live/shell_live.ex:1747
 #, elixir-autogen, elixir-format
 msgid "%{count} video in progress"
 msgid_plural "%{count} videos in progress"
@@ -23163,69 +23164,69 @@ msgstr "Sie können jetzt veröffentlichen: Der Beitrag erscheint, sobald das Vi
 msgid "Your post appears as soon as the video is ready"
 msgstr "Ihr Beitrag erscheint, sobald das Video fertig ist"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1437
+#: lib/vutuv_web/live/notification_live/index.ex:1440
 #, elixir-autogen, elixir-format
 msgid "%{formatted} connection"
 msgid_plural "%{formatted} connections"
 msgstr[0] "%{formatted} Vernetzung"
 msgstr[1] "%{formatted} Vernetzungen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1664
+#: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new connection"
 msgid_plural "%{formatted} new connections"
 msgstr[0] "%{formatted} neue Vernetzung"
 msgstr[1] "%{formatted} neue Vernetzungen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1668
+#: lib/vutuv_web/live/notification_live/index.ex:1590
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new follower"
 msgid_plural "%{formatted} new followers"
 msgstr[0] "%{formatted} neuer Follower"
 msgstr[1] "%{formatted} neue Follower"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1443
+#: lib/vutuv_web/live/notification_live/index.ex:1446
 #, elixir-autogen, elixir-format
 msgid "Last 30 days: %{parts}"
 msgstr "Letzte 30 Tage: %{parts}"
 
 #: lib/vutuv_web/components/post_components.ex:4496
-#: lib/vutuv_web/live/notification_live/index.ex:1020
+#: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format
 msgid "Less"
 msgstr "Weniger"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1349
+#: lib/vutuv_web/live/notification_live/index.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Reactions"
 msgstr "Reaktionen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:522
+#: lib/vutuv_web/live/notification_live/index.ex:525
 #, elixir-autogen, elixir-format
 msgid "Seen before"
 msgstr "Bereits gesehen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:634
+#: lib/vutuv_web/live/notification_live/index.ex:637
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more"
 msgstr "%{formatted} weitere anzeigen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:845
+#: lib/vutuv_web/live/notification_live/index.ex:848
 #, elixir-autogen, elixir-format
 msgid "The post is no longer available."
 msgstr "Der Beitrag ist nicht mehr verfügbar."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1632
+#: lib/vutuv_web/live/notification_live/index.ex:1554
 #, elixir-autogen, elixir-format
 msgid "Thread by %{name}"
 msgstr "Thread von %{name}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1573
+#: lib/vutuv_web/live/notification_live/index.ex:1495
 #, elixir-autogen, elixir-format
 msgid "mentioned you."
 msgstr "hat Sie erwähnt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1572
+#: lib/vutuv_web/live/notification_live/index.ex:1494
 #, elixir-autogen, elixir-format
 msgid "replied in the thread."
 msgstr "hat im Thread geantwortet."
@@ -23273,7 +23274,7 @@ msgid_plural "%{formatted} random vutuv accounts that are open to offers."
 msgstr[0] "Ein zufälliger vutuv Account, der offen für Angebote ist."
 msgstr[1] "%{formatted} zufällige vutuv Accounts, die offen für Angebote sind."
 
-#: lib/vutuv_web/live/shell_live.ex:725
+#: lib/vutuv_web/live/shell_live.ex:735
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post in your feed"
 msgid_plural "%{formatted} new posts in your feed"
@@ -23866,7 +23867,7 @@ msgstr "Um welches Werk geht es, und wo ist das Original zu sehen? (erforderlich
 msgid "Copyright law. This complaint says the work is not yours to publish, which is a legal question rather than a house rule."
 msgstr "Das Urheberrecht. Diese Beschwerde besagt, dass das Werk nicht Ihres ist, um es zu veröffentlichen, und das ist eine Rechtsfrage, keine Hausregel."
 
-#: lib/vutuv_web/notification_line.ex:203
+#: lib/vutuv_web/notification_line.ex:208
 #, elixir-autogen, elixir-format
 msgid "Hidden automatically after a report: %{reason}. The case page says what you can do."
 msgstr "Nach einer Meldung automatisch verborgen: %{reason}. Auf der Fallseite steht, was Sie tun können."
@@ -23896,7 +23897,7 @@ msgstr "Grundlage"
 msgid "What the report says"
 msgstr "Was in der Meldung steht"
 
-#: lib/vutuv_web/notification_line.ex:209
+#: lib/vutuv_web/notification_line.ex:214
 #, elixir-autogen, elixir-format
 msgid "Your content was hidden automatically after a report. The case page says what you can do."
 msgstr "Ihr Inhalt wurde nach einer Meldung automatisch verborgen. Auf der Fallseite steht, was Sie tun können."
@@ -24114,3 +24115,13 @@ msgstr ""
 "Mastodon zählt. Ob Ihre Beiträge daran teilnehmen, entscheiden Sie bei der "
 "Anmeldung und später mit einem Schalter in den Einstellungen. Wir sind da "
 "nicht dogmatisch: jeder, wie er will."
+
+#: lib/vutuv_web/live/shell_live.ex:1816
+#, elixir-autogen, elixir-format
+msgid "All notifications"
+msgstr "Alle Mitteilungen"
+
+#: lib/vutuv_web/live/shell_live.ex:1775
+#, elixir-autogen, elixir-format
+msgid "New notifications"
+msgstr "Neue Mitteilungen"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -442,8 +442,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1573
-#: lib/vutuv_web/live/shell_live.ex:1649
+#: lib/vutuv_web/live/shell_live.ex:1653
+#: lib/vutuv_web/live/shell_live.ex:1729
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -456,7 +456,7 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1351
+#: lib/vutuv_web/live/notification_live/index.ex:1354
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:298
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:306
 #, elixir-autogen
@@ -476,7 +476,7 @@ msgid "Name"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:793
-#: lib/vutuv_web/live/notification_live/index.ex:793
+#: lib/vutuv_web/live/notification_live/index.ex:796
 #: lib/vutuv_web/live/organization_live/activity.ex:136
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
@@ -648,8 +648,8 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
-#: lib/vutuv_web/live/shell_live.ex:1442
-#: lib/vutuv_web/live/shell_live.ex:1629
+#: lib/vutuv_web/live/shell_live.ex:1502
+#: lib/vutuv_web/live/shell_live.ex:1709
 #: lib/vutuv_web/live/tag_live/timeline.ex:337
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
@@ -796,7 +796,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
 #: lib/vutuv_web/live/directory_search_live.ex:134
-#: lib/vutuv_web/live/notification_live/index.ex:1523
+#: lib/vutuv_web/notification_line.ex:304
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:51
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -1139,7 +1139,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:63
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1549
+#: lib/vutuv_web/live/shell_live.ex:1629
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1647
+#: lib/vutuv_web/live/shell_live.ex:1727
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1688,7 +1688,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1568
+#: lib/vutuv_web/live/shell_live.ex:1648
 #: lib/vutuv_web/views/settings_html.ex:340
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1720,8 +1720,8 @@ msgstr ""
 #: lib/vutuv_web/controllers/page_controller.ex:218
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1460
-#: lib/vutuv_web/live/shell_live.ex:1646
+#: lib/vutuv_web/live/shell_live.ex:1520
+#: lib/vutuv_web/live/shell_live.ex:1726
 #: lib/vutuv_web/templates/layout/app.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1743,7 +1743,7 @@ msgstr ""
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:539
+#: lib/vutuv_web/live/notification_live/index.ex:542
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr ""
@@ -1751,9 +1751,9 @@ msgstr ""
 #: lib/vutuv/api_auth/scopes.ex:85
 #: lib/vutuv_web/components/ui.ex:5138
 #: lib/vutuv_web/controllers/page_controller.ex:219
-#: lib/vutuv_web/live/notification_live/index.ex:152
-#: lib/vutuv_web/live/notification_live/index.ex:457
-#: lib/vutuv_web/live/shell_live.ex:1472
+#: lib/vutuv_web/live/notification_live/index.ex:155
+#: lib/vutuv_web/live/notification_live/index.ex:460
+#: lib/vutuv_web/live/shell_live.ex:1545
 #: lib/vutuv_web/templates/layout/app.html.heex:160
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -1873,17 +1873,17 @@ msgstr[1] ""
 msgid "following"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:82
+#: lib/vutuv_web/notification_line.ex:87
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:77
+#: lib/vutuv_web/notification_line.ex:82
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:75
+#: lib/vutuv_web/notification_line.ex:80
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
@@ -2095,8 +2095,8 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/feed.ex:331
 #: lib/vutuv_web/live/post_live/feed.ex:3254
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1294
-#: lib/vutuv_web/live/shell_live.ex:1619
+#: lib/vutuv_web/live/shell_live.ex:1354
+#: lib/vutuv_web/live/shell_live.ex:1699
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2271,7 +2271,7 @@ msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5483
-#: lib/vutuv_web/live/shell_live.ex:1515
+#: lib/vutuv_web/live/shell_live.ex:1595
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:287
@@ -2364,8 +2364,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1264
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1452
-#: lib/vutuv_web/live/shell_live.ex:1520
+#: lib/vutuv_web/live/shell_live.ex:1512
+#: lib/vutuv_web/live/shell_live.ex:1600
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2375,7 +2375,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:2055
 #: lib/vutuv_web/components/post_components.ex:6322
 #: lib/vutuv_web/components/ui.ex:4117
-#: lib/vutuv_web/live/notification_live/index.ex:1512
+#: lib/vutuv_web/notification_line.ex:293
 #: lib/vutuv_web/views/user_html.ex:481
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2385,7 +2385,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:6332
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1523
+#: lib/vutuv_web/live/shell_live.ex:1603
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2470,7 +2470,7 @@ msgid "Only public posts can be answered."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:430
-#: lib/vutuv_web/live/notification_live/index.ex:1348
+#: lib/vutuv_web/live/notification_live/index.ex:1351
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
@@ -2478,9 +2478,9 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:2068
 #: lib/vutuv_web/components/post_components.ex:6359
 #: lib/vutuv_web/components/post_components.ex:6360
-#: lib/vutuv_web/live/notification_live/index.ex:1010
-#: lib/vutuv_web/live/notification_live/index.ex:1509
+#: lib/vutuv_web/live/notification_live/index.ex:1013
 #: lib/vutuv_web/live/post_live/reply.ex:49
+#: lib/vutuv_web/notification_line.ex:290
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
@@ -2501,7 +2501,7 @@ msgstr ""
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:64
+#: lib/vutuv_web/notification_line.ex:69
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
@@ -2831,23 +2831,23 @@ msgid "Open someone's profile to message them."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:259
-#: lib/vutuv_web/live/notification_live/index.ex:1525
 #: lib/vutuv_web/live/organization_live/activity.ex:112
+#: lib/vutuv_web/notification_line.ex:306
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1516
+#: lib/vutuv_web/notification_line.ex:297
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1508
+#: lib/vutuv_web/notification_line.ex:289
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1507
+#: lib/vutuv_web/notification_line.ex:288
 #: lib/vutuv_web/templates/user/show.html.heex:947
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2860,7 +2860,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:73
+#: lib/vutuv_web/notification_line.ex:78
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2892,12 +2892,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:118
+#: lib/vutuv_web/notification_line.ex:123
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:119
+#: lib/vutuv_web/notification_line.ex:124
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -3004,7 +3004,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1517
+#: lib/vutuv_web/notification_line.ex:298
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3124,7 +3124,7 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5070
-#: lib/vutuv_web/live/shell_live.ex:1326
+#: lib/vutuv_web/live/shell_live.ex:1386
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3417,12 +3417,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:121
+#: lib/vutuv_web/notification_line.ex:126
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:120
+#: lib/vutuv_web/notification_line.ex:125
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3611,7 +3611,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:146
+#: lib/vutuv_web/notification_line.ex:151
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3636,7 +3636,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1519
+#: lib/vutuv_web/notification_line.ex:300
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3711,7 +3711,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:151
+#: lib/vutuv_web/notification_line.ex:156
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -3886,7 +3886,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:138
 #: lib/vutuv_web/live/admin/screenshot_live.ex:380
 #: lib/vutuv_web/live/admin/screenshot_live.ex:389
-#: lib/vutuv_web/live/notification_live/index.ex:1635
+#: lib/vutuv_web/live/notification_live/index.ex:1557
 #: lib/vutuv_web/templates/post/show.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "Post by %{name}"
@@ -4565,8 +4565,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:510
 #: lib/vutuv_web/agent_docs/text.ex:525
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/live/notification_live/index.ex:657
-#: lib/vutuv_web/live/notification_live/index.ex:1350
+#: lib/vutuv_web/live/notification_live/index.ex:660
+#: lib/vutuv_web/live/notification_live/index.ex:1353
 #: lib/vutuv_web/live/organization_live/show.ex:797
 #: lib/vutuv_web/live/post_live/saved.ex:539
 #: lib/vutuv_web/live/search_live.ex:346
@@ -4590,7 +4590,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
-#: lib/vutuv_web/live/notification_live/index.ex:1347
+#: lib/vutuv_web/live/notification_live/index.ex:1350
 #: lib/vutuv_web/live/search_live.ex:345
 #: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
@@ -5278,7 +5278,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1502
+#: lib/vutuv_web/live/shell_live.ex:1582
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5300,7 +5300,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1559
+#: lib/vutuv_web/live/shell_live.ex:1639
 #: lib/vutuv_web/templates/layout/app.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5319,7 +5319,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:276
-#: lib/vutuv_web/live/shell_live.ex:1539
+#: lib/vutuv_web/live/shell_live.ex:1619
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5373,8 +5373,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1282
-#: lib/vutuv_web/live/shell_live.ex:1600
+#: lib/vutuv_web/live/shell_live.ex:1342
+#: lib/vutuv_web/live/shell_live.ex:1680
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5387,7 +5387,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:4022
 #: lib/vutuv_web/components/post_components.ex:4074
 #: lib/vutuv_web/components/post_components.ex:4608
-#: lib/vutuv_web/live/notification_live/index.ex:1086
+#: lib/vutuv_web/live/notification_live/index.ex:1089
 #: lib/vutuv_web/views/user_html.ex:131
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5514,7 +5514,7 @@ msgstr ""
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1629
+#: lib/vutuv_web/live/notification_live/index.ex:1551
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
@@ -6278,10 +6278,10 @@ msgid "No endorsements yet."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2712
-#: lib/vutuv_web/live/notification_live/index.ex:724
-#: lib/vutuv_web/live/notification_live/index.ex:739
-#: lib/vutuv_web/live/notification_live/index.ex:1239
-#: lib/vutuv_web/live/notification_live/index.ex:1241
+#: lib/vutuv_web/live/notification_live/index.ex:727
+#: lib/vutuv_web/live/notification_live/index.ex:742
+#: lib/vutuv_web/live/notification_live/index.ex:1242
+#: lib/vutuv_web/live/notification_live/index.ex:1244
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
@@ -7297,6 +7297,7 @@ msgstr ""
 #: lib/vutuv_web/components/job_components.ex:190
 #: lib/vutuv_web/components/post_components.ex:6232
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
+#: lib/vutuv_web/live/shell_live.ex:1822
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
 msgstr ""
@@ -7682,13 +7683,13 @@ msgstr ""
 #: lib/vutuv_web/components/job_components.ex:219
 #: lib/vutuv_web/live/admin/dashboard_live.ex:304
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:468
-#: lib/vutuv_web/live/notification_live/index.ex:1385
+#: lib/vutuv_web/live/notification_live/index.ex:1388
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:308
-#: lib/vutuv_web/live/notification_live/index.ex:1388
+#: lib/vutuv_web/live/notification_live/index.ex:1391
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -7913,8 +7914,8 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1451
-#: lib/vutuv/accounts.ex:1500
+#: lib/vutuv/accounts.ex:1452
+#: lib/vutuv/accounts.ex:1501
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -7953,7 +7954,7 @@ msgstr ""
 msgid "Open the member browser"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1468
+#: lib/vutuv/accounts.ex:1469
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8629,7 +8630,7 @@ msgstr ""
 msgid "Your Fediverse handle"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1463
+#: lib/vutuv/accounts.ex:1464
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -9399,7 +9400,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1262
+#: lib/vutuv/accounts/user.ex:1271
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9410,7 +9411,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1259
+#: lib/vutuv/accounts/user.ex:1268
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10128,7 +10129,7 @@ msgid_plural "%{count} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1433
+#: lib/vutuv_web/live/notification_live/index.ex:1436
 #: lib/vutuv_web/live/organization_live/show.ex:648
 #: lib/vutuv_web/views/user_html.ex:960
 #: lib/vutuv_web/views/user_html.ex:1136
@@ -10729,19 +10730,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1300
+#: lib/vutuv/accounts/user.ex:1309
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1305
+#: lib/vutuv/accounts/user.ex:1314
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1303
+#: lib/vutuv/accounts/user.ex:1312
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -11703,7 +11704,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1520
+#: lib/vutuv_web/notification_line.ex:301
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -11721,7 +11722,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:542
-#: lib/vutuv_web/live/shell_live.ex:1530
+#: lib/vutuv_web/live/shell_live.ex:1610
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:80
@@ -11813,22 +11814,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:110
+#: lib/vutuv_web/notification_line.ex:115
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:107
+#: lib/vutuv_web/notification_line.ex:112
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:104
+#: lib/vutuv_web/notification_line.ex:109
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:101
+#: lib/vutuv_web/notification_line.ex:106
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -12025,7 +12026,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1274
+#: lib/vutuv/accounts/user.ex:1283
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12051,7 +12052,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:47
 #: lib/vutuv_web/live/job_board_live.ex:265
 #: lib/vutuv_web/live/post_live/saved.ex:545
-#: lib/vutuv_web/live/shell_live.ex:1334
+#: lib/vutuv_web/live/shell_live.ex:1394
 #: lib/vutuv_web/templates/layout/app.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -12144,7 +12145,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1273
+#: lib/vutuv/accounts/user.ex:1282
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12226,7 +12227,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1275
+#: lib/vutuv/accounts/user.ex:1284
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:589
 #: lib/vutuv_web/agent_docs/markdown.ex:532
@@ -13201,7 +13202,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1518
+#: lib/vutuv_web/notification_line.ex:299
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13242,7 +13243,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1318
+#: lib/vutuv/accounts/user.ex:1327
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13253,19 +13254,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1321
+#: lib/vutuv/accounts/user.ex:1330
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1324
+#: lib/vutuv/accounts/user.ex:1333
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1315
+#: lib/vutuv/accounts/user.ex:1324
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13288,7 +13289,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1521
+#: lib/vutuv_web/notification_line.ex:302
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13300,7 +13301,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/notification_line.ex:160
+#: lib/vutuv_web/notification_line.ex:165
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
@@ -13502,22 +13503,22 @@ msgstr[1] ""
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1522
+#: lib/vutuv_web/notification_line.ex:303
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:180
+#: lib/vutuv_web/notification_line.ex:185
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:172
+#: lib/vutuv_web/notification_line.ex:177
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:177
+#: lib/vutuv_web/notification_line.ex:182
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13542,7 +13543,7 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:185
+#: lib/vutuv_web/notification_line.ex:190
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
@@ -13673,40 +13674,40 @@ msgstr ""
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1377
+#: lib/vutuv_web/live/notification_live/index.ex:1380
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1391
+#: lib/vutuv_web/live/notification_live/index.ex:1394
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:556
+#: lib/vutuv_web/live/notification_live/index.ex:559
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1334
-#: lib/vutuv_web/live/notification_live/index.ex:1701
+#: lib/vutuv_web/live/notification_live/index.ex:1337
+#: lib/vutuv_web/live/notification_live/index.ex:1623
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1608
+#: lib/vutuv_web/live/notification_live/index.ex:1530
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1605
+#: lib/vutuv_web/live/notification_live/index.ex:1527
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1614
+#: lib/vutuv_web/live/notification_live/index.ex:1536
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
@@ -13728,7 +13729,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:711
+#: lib/vutuv_web/live/shell_live.ex:721
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -13920,17 +13921,17 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:134
+#: lib/vutuv_web/notification_line.ex:139
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1510
+#: lib/vutuv_web/notification_line.ex:291
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:263
+#: lib/vutuv_web/notification_line.ex:358
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -13953,12 +13954,12 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1511
+#: lib/vutuv_web/notification_line.ex:292
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:84
+#: lib/vutuv_web/notification_line.ex:89
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr ""
@@ -14212,7 +14213,7 @@ msgstr ""
 msgid "as an account alias."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1693
+#: lib/vutuv_web/live/notification_live/index.ex:1615
 #: lib/vutuv_web/templates/user_tag/show.html.heex:24
 #, elixir-autogen, elixir-format
 msgid "%{formatted} endorsement"
@@ -14299,7 +14300,7 @@ msgstr ""
 msgid "Thread replies"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1039
+#: lib/vutuv_web/live/notification_live/index.ex:1042
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr ""
@@ -14350,7 +14351,7 @@ msgstr ""
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1034
+#: lib/vutuv_web/live/notification_live/index.ex:1037
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr ""
@@ -15238,7 +15239,7 @@ msgid "Your public posts are copied to other servers. Once a copy is there we ca
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:6277
-#: lib/vutuv_web/live/notification_live/index.ex:1690
+#: lib/vutuv_web/live/notification_live/index.ex:1612
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
@@ -15246,7 +15247,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/components/post_components.ex:6281
-#: lib/vutuv_web/live/notification_live/index.ex:1684
+#: lib/vutuv_web/live/notification_live/index.ex:1606
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
@@ -15305,7 +15306,7 @@ msgstr ""
 msgid "Replies from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1513
+#: lib/vutuv_web/notification_line.ex:294
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr ""
@@ -15326,7 +15327,7 @@ msgid "Reported as not appropriate"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1445
-#: lib/vutuv_web/live/notification_live/index.ex:1134
+#: lib/vutuv_web/live/notification_live/index.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr ""
@@ -15378,7 +15379,7 @@ msgstr ""
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:87
+#: lib/vutuv_web/notification_line.ex:92
 #, elixir-autogen, elixir-format
 msgid "replied to your post from another network."
 msgstr ""
@@ -16366,8 +16367,8 @@ msgstr ""
 msgid "From other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1514
-#: lib/vutuv_web/live/notification_live/index.ex:1515
+#: lib/vutuv_web/notification_line.ex:295
+#: lib/vutuv_web/notification_line.ex:296
 #, elixir-autogen, elixir-format
 msgid "Reaction from another network"
 msgstr ""
@@ -16382,21 +16383,21 @@ msgstr ""
 msgid "Show under each of your posts who out there liked or shared it, by their account address on their own server, linked to that account. Visible to everyone who sees the post. We keep nothing else about these people: no name, no picture, no text. Switching it off deletes what is stored for it."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:244
+#: lib/vutuv_web/notification_line.ex:339
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/notification_line.ex:252
+#: lib/vutuv_web/notification_line.ex:347
 #, elixir-autogen, elixir-format
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/notification_line.ex:236
+#: lib/vutuv_web/notification_line.ex:331
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -17629,7 +17630,7 @@ msgstr ""
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1148
+#: lib/vutuv_web/live/notification_live/index.ex:1151
 #, elixir-autogen, elixir-format
 msgid "View the conversation"
 msgstr ""
@@ -18272,7 +18273,7 @@ msgstr ""
 msgid "Employment reference deleted"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1524
+#: lib/vutuv_web/notification_line.ex:305
 #, elixir-autogen, elixir-format
 msgid "Employment reference review"
 msgstr ""
@@ -18297,13 +18298,13 @@ msgstr ""
 msgid "Reviewing your reference. This usually takes about %{duration}."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:57
+#: lib/vutuv_web/notification_line.ex:62
 #: lib/vutuv_web/views/notification_digest_text.ex:94
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:54
+#: lib/vutuv_web/notification_line.ex:59
 #: lib/vutuv_web/views/notification_digest_text.ex:91
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready: %{grade}."
@@ -18319,7 +18320,7 @@ msgstr ""
 msgid "When the review of one of your employment references is finished. It takes minutes, so you can close the page and wait for the email."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:60
+#: lib/vutuv_web/notification_line.ex:65
 #, elixir-autogen, elixir-format
 msgid "Your employment reference has been reviewed."
 msgstr ""
@@ -18488,7 +18489,7 @@ msgstr ""
 msgid "Somebody"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:195
+#: lib/vutuv_web/notification_line.ex:200
 #: lib/vutuv_web/views/notification_digest_text.ex:100
 #, elixir-autogen, elixir-format
 msgid "Something new happened on your account."
@@ -18625,7 +18626,7 @@ msgstr ""
 msgid "Cancel registration"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1301
+#: lib/vutuv_web/live/notification_live/index.ex:1304
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -18635,17 +18636,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1421
+#: lib/vutuv/accounts/user.ex:1430
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1419
+#: lib/vutuv/accounts/user.ex:1428
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1420
+#: lib/vutuv/accounts/user.ex:1429
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19406,7 +19407,7 @@ msgstr ""
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1240
+#: lib/vutuv_web/live/shell_live.ex:1300
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr ""
@@ -19426,7 +19427,7 @@ msgstr ""
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1250
+#: lib/vutuv_web/live/shell_live.ex:1310
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -19436,7 +19437,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1226
+#: lib/vutuv_web/live/shell_live.ex:1286
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -19800,21 +19801,21 @@ msgstr ""
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:755
+#: lib/vutuv_web/live/shell_live.ex:765
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:742
+#: lib/vutuv_web/live/shell_live.ex:752
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:777
+#: lib/vutuv_web/live/shell_live.ex:787
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -20894,7 +20895,7 @@ msgstr ""
 msgid "Unfollowed. Their posts leave your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1200
+#: lib/vutuv_web/live/shell_live.ex:1260
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr ""
@@ -20909,12 +20910,12 @@ msgstr ""
 msgid "Browser notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1058
+#: lib/vutuv_web/live/shell_live.ex:1118
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1203
+#: lib/vutuv_web/live/shell_live.ex:1263
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
@@ -20954,7 +20955,7 @@ msgstr ""
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1197
+#: lib/vutuv_web/live/shell_live.ex:1257
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -20994,12 +20995,12 @@ msgstr ""
 msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:850
+#: lib/vutuv_web/live/shell_live.ex:860
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:851
+#: lib/vutuv_web/live/shell_live.ex:861
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr ""
@@ -21220,7 +21221,7 @@ msgstr ""
 msgid "Translated into %{language}."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:991
+#: lib/vutuv_web/live/shell_live.ex:1051
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -21339,7 +21340,7 @@ msgstr ""
 msgid "No connection"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1130
+#: lib/vutuv_web/live/shell_live.ex:1190
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr ""
@@ -21823,7 +21824,7 @@ msgstr ""
 msgid "Scan it with the device that has the app"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1112
+#: lib/vutuv_web/live/shell_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "A new version is ready."
 msgstr ""
@@ -21904,7 +21905,7 @@ msgctxt "filter rule"
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1687
+#: lib/vutuv_web/live/notification_live/index.ex:1609
 #, elixir-autogen, elixir-format
 msgid "%{formatted} share"
 msgid_plural "%{formatted} shares"
@@ -21912,31 +21913,31 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/controllers/post_calendar_controller.ex:136
-#: lib/vutuv_web/live/notification_live/index.ex:838
+#: lib/vutuv_web/live/notification_live/index.ex:841
 #, elixir-autogen, elixir-format
 msgid "Post without text"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1563
+#: lib/vutuv_web/live/notification_live/index.ex:1485
 #, elixir-autogen, elixir-format
 msgid "likes this."
 msgid_plural "like this."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1569
+#: lib/vutuv_web/live/notification_live/index.ex:1491
 #, elixir-autogen, elixir-format
 msgid "reacted to this."
 msgid_plural "reacted to this."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1571
+#: lib/vutuv_web/live/notification_live/index.ex:1493
 #, elixir-autogen, elixir-format
 msgid "replied."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1566
+#: lib/vutuv_web/live/notification_live/index.ex:1488
 #, elixir-autogen, elixir-format
 msgid "shared this."
 msgid_plural "shared this."
@@ -22073,7 +22074,7 @@ msgstr ""
 msgid "Low-bandwidth mode"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1641
+#: lib/vutuv_web/live/shell_live.ex:1721
 #, elixir-autogen, elixir-format
 msgctxt "phone tab bar"
 msgid "Write"
@@ -22231,7 +22232,7 @@ msgstr ""
 msgid "Appearance"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1667
+#: lib/vutuv_web/live/shell_live.ex:1747
 #, elixir-autogen, elixir-format
 msgid "%{count} video in progress"
 msgid_plural "%{count} videos in progress"
@@ -22376,69 +22377,69 @@ msgstr ""
 msgid "Your post appears as soon as the video is ready"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1437
+#: lib/vutuv_web/live/notification_live/index.ex:1440
 #, elixir-autogen, elixir-format
 msgid "%{formatted} connection"
 msgid_plural "%{formatted} connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1664
+#: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new connection"
 msgid_plural "%{formatted} new connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1668
+#: lib/vutuv_web/live/notification_live/index.ex:1590
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new follower"
 msgid_plural "%{formatted} new followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1443
+#: lib/vutuv_web/live/notification_live/index.ex:1446
 #, elixir-autogen, elixir-format
 msgid "Last 30 days: %{parts}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:4496
-#: lib/vutuv_web/live/notification_live/index.ex:1020
+#: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format
 msgid "Less"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1349
+#: lib/vutuv_web/live/notification_live/index.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Reactions"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:522
+#: lib/vutuv_web/live/notification_live/index.ex:525
 #, elixir-autogen, elixir-format
 msgid "Seen before"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:634
+#: lib/vutuv_web/live/notification_live/index.ex:637
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:845
+#: lib/vutuv_web/live/notification_live/index.ex:848
 #, elixir-autogen, elixir-format
 msgid "The post is no longer available."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1632
+#: lib/vutuv_web/live/notification_live/index.ex:1554
 #, elixir-autogen, elixir-format
 msgid "Thread by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1573
+#: lib/vutuv_web/live/notification_live/index.ex:1495
 #, elixir-autogen, elixir-format
 msgid "mentioned you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1572
+#: lib/vutuv_web/live/notification_live/index.ex:1494
 #, elixir-autogen, elixir-format
 msgid "replied in the thread."
 msgstr ""
@@ -22486,7 +22487,7 @@ msgid_plural "%{formatted} random vutuv accounts that are open to offers."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:725
+#: lib/vutuv_web/live/shell_live.ex:735
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post in your feed"
 msgid_plural "%{formatted} new posts in your feed"
@@ -23079,7 +23080,7 @@ msgstr ""
 msgid "Copyright law. This complaint says the work is not yours to publish, which is a legal question rather than a house rule."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:203
+#: lib/vutuv_web/notification_line.ex:208
 #, elixir-autogen, elixir-format
 msgid "Hidden automatically after a report: %{reason}. The case page says what you can do."
 msgstr ""
@@ -23109,7 +23110,7 @@ msgstr ""
 msgid "What the report says"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:209
+#: lib/vutuv_web/notification_line.ex:214
 #, elixir-autogen, elixir-format
 msgid "Your content was hidden automatically after a report. The case page says what you can do."
 msgstr ""
@@ -23288,4 +23289,14 @@ msgstr ""
 #: lib/vutuv_web/templates/page/index.html.heex:558
 #, elixir-autogen, elixir-format
 msgid "vutuv is part of the Fediverse, the union of independent networks that Mastodon belongs to as well. Whether your posts take part is your choice at sign-up, and one switch in the settings later. We are not religious about it: each to their own."
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:1816
+#, elixir-autogen, elixir-format
+msgid "All notifications"
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:1775
+#, elixir-autogen, elixir-format
+msgid "New notifications"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -440,8 +440,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1573
-#: lib/vutuv_web/live/shell_live.ex:1649
+#: lib/vutuv_web/live/shell_live.ex:1653
+#: lib/vutuv_web/live/shell_live.ex:1729
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -454,7 +454,7 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1351
+#: lib/vutuv_web/live/notification_live/index.ex:1354
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:298
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:306
 #, elixir-autogen
@@ -474,7 +474,7 @@ msgid "Name"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:793
-#: lib/vutuv_web/live/notification_live/index.ex:793
+#: lib/vutuv_web/live/notification_live/index.ex:796
 #: lib/vutuv_web/live/organization_live/activity.ex:136
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
@@ -646,8 +646,8 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
-#: lib/vutuv_web/live/shell_live.ex:1442
-#: lib/vutuv_web/live/shell_live.ex:1629
+#: lib/vutuv_web/live/shell_live.ex:1502
+#: lib/vutuv_web/live/shell_live.ex:1709
 #: lib/vutuv_web/live/tag_live/timeline.ex:337
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
@@ -794,7 +794,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
 #: lib/vutuv_web/live/directory_search_live.ex:134
-#: lib/vutuv_web/live/notification_live/index.ex:1523
+#: lib/vutuv_web/notification_line.ex:304
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:51
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -1137,7 +1137,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:63
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1549
+#: lib/vutuv_web/live/shell_live.ex:1629
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1647
+#: lib/vutuv_web/live/shell_live.ex:1727
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1686,7 +1686,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1568
+#: lib/vutuv_web/live/shell_live.ex:1648
 #: lib/vutuv_web/views/settings_html.ex:340
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1718,8 +1718,8 @@ msgstr ""
 #: lib/vutuv_web/controllers/page_controller.ex:218
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1460
-#: lib/vutuv_web/live/shell_live.ex:1646
+#: lib/vutuv_web/live/shell_live.ex:1520
+#: lib/vutuv_web/live/shell_live.ex:1726
 #: lib/vutuv_web/templates/layout/app.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1741,7 +1741,7 @@ msgstr ""
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:539
+#: lib/vutuv_web/live/notification_live/index.ex:542
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr ""
@@ -1749,9 +1749,9 @@ msgstr ""
 #: lib/vutuv/api_auth/scopes.ex:85
 #: lib/vutuv_web/components/ui.ex:5138
 #: lib/vutuv_web/controllers/page_controller.ex:219
-#: lib/vutuv_web/live/notification_live/index.ex:152
-#: lib/vutuv_web/live/notification_live/index.ex:457
-#: lib/vutuv_web/live/shell_live.ex:1472
+#: lib/vutuv_web/live/notification_live/index.ex:155
+#: lib/vutuv_web/live/notification_live/index.ex:460
+#: lib/vutuv_web/live/shell_live.ex:1545
 #: lib/vutuv_web/templates/layout/app.html.heex:160
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -1871,17 +1871,17 @@ msgstr[1] ""
 msgid "following"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:82
+#: lib/vutuv_web/notification_line.ex:87
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:77
+#: lib/vutuv_web/notification_line.ex:82
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:75
+#: lib/vutuv_web/notification_line.ex:80
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
@@ -2093,8 +2093,8 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/feed.ex:331
 #: lib/vutuv_web/live/post_live/feed.ex:3254
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1294
-#: lib/vutuv_web/live/shell_live.ex:1619
+#: lib/vutuv_web/live/shell_live.ex:1354
+#: lib/vutuv_web/live/shell_live.ex:1699
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2269,7 +2269,7 @@ msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5483
-#: lib/vutuv_web/live/shell_live.ex:1515
+#: lib/vutuv_web/live/shell_live.ex:1595
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:287
@@ -2362,8 +2362,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1264
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1452
-#: lib/vutuv_web/live/shell_live.ex:1520
+#: lib/vutuv_web/live/shell_live.ex:1512
+#: lib/vutuv_web/live/shell_live.ex:1600
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2373,7 +2373,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:2055
 #: lib/vutuv_web/components/post_components.ex:6322
 #: lib/vutuv_web/components/ui.ex:4117
-#: lib/vutuv_web/live/notification_live/index.ex:1512
+#: lib/vutuv_web/notification_line.ex:293
 #: lib/vutuv_web/views/user_html.ex:481
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2383,7 +2383,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:6332
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1523
+#: lib/vutuv_web/live/shell_live.ex:1603
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2468,7 +2468,7 @@ msgid "Only public posts can be answered."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:430
-#: lib/vutuv_web/live/notification_live/index.ex:1348
+#: lib/vutuv_web/live/notification_live/index.ex:1351
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
@@ -2476,9 +2476,9 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:2068
 #: lib/vutuv_web/components/post_components.ex:6359
 #: lib/vutuv_web/components/post_components.ex:6360
-#: lib/vutuv_web/live/notification_live/index.ex:1010
-#: lib/vutuv_web/live/notification_live/index.ex:1509
+#: lib/vutuv_web/live/notification_live/index.ex:1013
 #: lib/vutuv_web/live/post_live/reply.ex:49
+#: lib/vutuv_web/notification_line.ex:290
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
@@ -2499,7 +2499,7 @@ msgstr ""
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:64
+#: lib/vutuv_web/notification_line.ex:69
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
@@ -2829,23 +2829,23 @@ msgid "Open someone's profile to message them."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:259
-#: lib/vutuv_web/live/notification_live/index.ex:1525
 #: lib/vutuv_web/live/organization_live/activity.ex:112
+#: lib/vutuv_web/notification_line.ex:306
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1516
+#: lib/vutuv_web/notification_line.ex:297
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1508
+#: lib/vutuv_web/notification_line.ex:289
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1507
+#: lib/vutuv_web/notification_line.ex:288
 #: lib/vutuv_web/templates/user/show.html.heex:947
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2858,7 +2858,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:73
+#: lib/vutuv_web/notification_line.ex:78
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2890,12 +2890,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:118
+#: lib/vutuv_web/notification_line.ex:123
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:119
+#: lib/vutuv_web/notification_line.ex:124
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -3002,7 +3002,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1517
+#: lib/vutuv_web/notification_line.ex:298
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3122,7 +3122,7 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5070
-#: lib/vutuv_web/live/shell_live.ex:1326
+#: lib/vutuv_web/live/shell_live.ex:1386
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3415,12 +3415,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:121
+#: lib/vutuv_web/notification_line.ex:126
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:120
+#: lib/vutuv_web/notification_line.ex:125
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3609,7 +3609,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:146
+#: lib/vutuv_web/notification_line.ex:151
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3634,7 +3634,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1519
+#: lib/vutuv_web/notification_line.ex:300
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3709,7 +3709,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:151
+#: lib/vutuv_web/notification_line.ex:156
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -3884,7 +3884,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:138
 #: lib/vutuv_web/live/admin/screenshot_live.ex:380
 #: lib/vutuv_web/live/admin/screenshot_live.ex:389
-#: lib/vutuv_web/live/notification_live/index.ex:1635
+#: lib/vutuv_web/live/notification_live/index.ex:1557
 #: lib/vutuv_web/templates/post/show.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "Post by %{name}"
@@ -4563,8 +4563,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:510
 #: lib/vutuv_web/agent_docs/text.ex:525
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/live/notification_live/index.ex:657
-#: lib/vutuv_web/live/notification_live/index.ex:1350
+#: lib/vutuv_web/live/notification_live/index.ex:660
+#: lib/vutuv_web/live/notification_live/index.ex:1353
 #: lib/vutuv_web/live/organization_live/show.ex:797
 #: lib/vutuv_web/live/post_live/saved.ex:539
 #: lib/vutuv_web/live/search_live.ex:346
@@ -4588,7 +4588,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
-#: lib/vutuv_web/live/notification_live/index.ex:1347
+#: lib/vutuv_web/live/notification_live/index.ex:1350
 #: lib/vutuv_web/live/search_live.ex:345
 #: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
@@ -5276,7 +5276,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1502
+#: lib/vutuv_web/live/shell_live.ex:1582
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5298,7 +5298,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1559
+#: lib/vutuv_web/live/shell_live.ex:1639
 #: lib/vutuv_web/templates/layout/app.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5317,7 +5317,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:276
-#: lib/vutuv_web/live/shell_live.ex:1539
+#: lib/vutuv_web/live/shell_live.ex:1619
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5371,8 +5371,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1282
-#: lib/vutuv_web/live/shell_live.ex:1600
+#: lib/vutuv_web/live/shell_live.ex:1342
+#: lib/vutuv_web/live/shell_live.ex:1680
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5385,7 +5385,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:4022
 #: lib/vutuv_web/components/post_components.ex:4074
 #: lib/vutuv_web/components/post_components.ex:4608
-#: lib/vutuv_web/live/notification_live/index.ex:1086
+#: lib/vutuv_web/live/notification_live/index.ex:1089
 #: lib/vutuv_web/views/user_html.ex:131
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5512,7 +5512,7 @@ msgstr ""
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1629
+#: lib/vutuv_web/live/notification_live/index.ex:1551
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
@@ -6276,10 +6276,10 @@ msgid "No endorsements yet."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2712
-#: lib/vutuv_web/live/notification_live/index.ex:724
-#: lib/vutuv_web/live/notification_live/index.ex:739
-#: lib/vutuv_web/live/notification_live/index.ex:1239
-#: lib/vutuv_web/live/notification_live/index.ex:1241
+#: lib/vutuv_web/live/notification_live/index.ex:727
+#: lib/vutuv_web/live/notification_live/index.ex:742
+#: lib/vutuv_web/live/notification_live/index.ex:1242
+#: lib/vutuv_web/live/notification_live/index.ex:1244
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
@@ -7295,6 +7295,7 @@ msgstr ""
 #: lib/vutuv_web/components/job_components.ex:190
 #: lib/vutuv_web/components/post_components.ex:6232
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
+#: lib/vutuv_web/live/shell_live.ex:1822
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
 msgstr ""
@@ -7680,13 +7681,13 @@ msgstr ""
 #: lib/vutuv_web/components/job_components.ex:219
 #: lib/vutuv_web/live/admin/dashboard_live.ex:304
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:468
-#: lib/vutuv_web/live/notification_live/index.ex:1385
+#: lib/vutuv_web/live/notification_live/index.ex:1388
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:308
-#: lib/vutuv_web/live/notification_live/index.ex:1388
+#: lib/vutuv_web/live/notification_live/index.ex:1391
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -7911,8 +7912,8 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1451
-#: lib/vutuv/accounts.ex:1500
+#: lib/vutuv/accounts.ex:1452
+#: lib/vutuv/accounts.ex:1501
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -7951,7 +7952,7 @@ msgstr ""
 msgid "Open the member browser"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1468
+#: lib/vutuv/accounts.ex:1469
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8627,7 +8628,7 @@ msgstr ""
 msgid "Your Fediverse handle"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1463
+#: lib/vutuv/accounts.ex:1464
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -9397,7 +9398,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1262
+#: lib/vutuv/accounts/user.ex:1271
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9408,7 +9409,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1259
+#: lib/vutuv/accounts/user.ex:1268
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10126,7 +10127,7 @@ msgid_plural "%{count} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1433
+#: lib/vutuv_web/live/notification_live/index.ex:1436
 #: lib/vutuv_web/live/organization_live/show.ex:648
 #: lib/vutuv_web/views/user_html.ex:960
 #: lib/vutuv_web/views/user_html.ex:1136
@@ -10727,19 +10728,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1300
+#: lib/vutuv/accounts/user.ex:1309
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1305
+#: lib/vutuv/accounts/user.ex:1314
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1303
+#: lib/vutuv/accounts/user.ex:1312
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -11701,7 +11702,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1520
+#: lib/vutuv_web/notification_line.ex:301
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -11719,7 +11720,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:542
-#: lib/vutuv_web/live/shell_live.ex:1530
+#: lib/vutuv_web/live/shell_live.ex:1610
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:80
@@ -11811,22 +11812,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:110
+#: lib/vutuv_web/notification_line.ex:115
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:107
+#: lib/vutuv_web/notification_line.ex:112
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:104
+#: lib/vutuv_web/notification_line.ex:109
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:101
+#: lib/vutuv_web/notification_line.ex:106
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -12023,7 +12024,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1274
+#: lib/vutuv/accounts/user.ex:1283
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12049,7 +12050,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:47
 #: lib/vutuv_web/live/job_board_live.ex:265
 #: lib/vutuv_web/live/post_live/saved.ex:545
-#: lib/vutuv_web/live/shell_live.ex:1334
+#: lib/vutuv_web/live/shell_live.ex:1394
 #: lib/vutuv_web/templates/layout/app.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -12142,7 +12143,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1273
+#: lib/vutuv/accounts/user.ex:1282
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12224,7 +12225,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1275
+#: lib/vutuv/accounts/user.ex:1284
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:589
 #: lib/vutuv_web/agent_docs/markdown.ex:532
@@ -13199,7 +13200,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1518
+#: lib/vutuv_web/notification_line.ex:299
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13240,7 +13241,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1318
+#: lib/vutuv/accounts/user.ex:1327
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13251,19 +13252,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1321
+#: lib/vutuv/accounts/user.ex:1330
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1324
+#: lib/vutuv/accounts/user.ex:1333
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1315
+#: lib/vutuv/accounts/user.ex:1324
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13286,7 +13287,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1521
+#: lib/vutuv_web/notification_line.ex:302
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13298,7 +13299,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/notification_line.ex:160
+#: lib/vutuv_web/notification_line.ex:165
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
@@ -13500,22 +13501,22 @@ msgstr[1] ""
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1522
+#: lib/vutuv_web/notification_line.ex:303
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:180
+#: lib/vutuv_web/notification_line.ex:185
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:172
+#: lib/vutuv_web/notification_line.ex:177
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:177
+#: lib/vutuv_web/notification_line.ex:182
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13540,7 +13541,7 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:185
+#: lib/vutuv_web/notification_line.ex:190
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
@@ -13671,40 +13672,40 @@ msgstr ""
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1377
+#: lib/vutuv_web/live/notification_live/index.ex:1380
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1391
+#: lib/vutuv_web/live/notification_live/index.ex:1394
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:556
+#: lib/vutuv_web/live/notification_live/index.ex:559
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1334
-#: lib/vutuv_web/live/notification_live/index.ex:1701
+#: lib/vutuv_web/live/notification_live/index.ex:1337
+#: lib/vutuv_web/live/notification_live/index.ex:1623
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1608
+#: lib/vutuv_web/live/notification_live/index.ex:1530
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1605
+#: lib/vutuv_web/live/notification_live/index.ex:1527
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1614
+#: lib/vutuv_web/live/notification_live/index.ex:1536
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
@@ -13726,7 +13727,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:711
+#: lib/vutuv_web/live/shell_live.ex:721
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -13918,17 +13919,17 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:134
+#: lib/vutuv_web/notification_line.ex:139
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1510
+#: lib/vutuv_web/notification_line.ex:291
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:263
+#: lib/vutuv_web/notification_line.ex:358
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -13951,12 +13952,12 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1511
+#: lib/vutuv_web/notification_line.ex:292
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:84
+#: lib/vutuv_web/notification_line.ex:89
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr ""
@@ -14210,7 +14211,7 @@ msgstr ""
 msgid "as an account alias."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1693
+#: lib/vutuv_web/live/notification_live/index.ex:1615
 #: lib/vutuv_web/templates/user_tag/show.html.heex:24
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} endorsement"
@@ -14297,7 +14298,7 @@ msgstr ""
 msgid "Thread replies"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1039
+#: lib/vutuv_web/live/notification_live/index.ex:1042
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr ""
@@ -14348,7 +14349,7 @@ msgstr ""
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1034
+#: lib/vutuv_web/live/notification_live/index.ex:1037
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr ""
@@ -15236,7 +15237,7 @@ msgid "Your public posts are copied to other servers. Once a copy is there we ca
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:6277
-#: lib/vutuv_web/live/notification_live/index.ex:1690
+#: lib/vutuv_web/live/notification_live/index.ex:1612
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
@@ -15244,7 +15245,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/components/post_components.ex:6281
-#: lib/vutuv_web/live/notification_live/index.ex:1684
+#: lib/vutuv_web/live/notification_live/index.ex:1606
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
@@ -15303,7 +15304,7 @@ msgstr ""
 msgid "Replies from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1513
+#: lib/vutuv_web/notification_line.ex:294
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr ""
@@ -15324,7 +15325,7 @@ msgid "Reported as not appropriate"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1445
-#: lib/vutuv_web/live/notification_live/index.ex:1134
+#: lib/vutuv_web/live/notification_live/index.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr ""
@@ -15376,7 +15377,7 @@ msgstr ""
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:87
+#: lib/vutuv_web/notification_line.ex:92
 #, elixir-autogen, elixir-format, fuzzy
 msgid "replied to your post from another network."
 msgstr ""
@@ -16364,8 +16365,8 @@ msgstr ""
 msgid "From other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1514
-#: lib/vutuv_web/live/notification_live/index.ex:1515
+#: lib/vutuv_web/notification_line.ex:295
+#: lib/vutuv_web/notification_line.ex:296
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reaction from another network"
 msgstr ""
@@ -16380,21 +16381,21 @@ msgstr ""
 msgid "Show under each of your posts who out there liked or shared it, by their account address on their own server, linked to that account. Visible to everyone who sees the post. We keep nothing else about these people: no name, no picture, no text. Switching it off deletes what is stored for it."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:244
+#: lib/vutuv_web/notification_line.ex:339
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/notification_line.ex:252
+#: lib/vutuv_web/notification_line.ex:347
 #, elixir-autogen, elixir-format, fuzzy
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/notification_line.ex:236
+#: lib/vutuv_web/notification_line.ex:331
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -17627,7 +17628,7 @@ msgstr ""
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1148
+#: lib/vutuv_web/live/notification_live/index.ex:1151
 #, elixir-autogen, elixir-format
 msgid "View the conversation"
 msgstr ""
@@ -18270,7 +18271,7 @@ msgstr ""
 msgid "Employment reference deleted"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1524
+#: lib/vutuv_web/notification_line.ex:305
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employment reference review"
 msgstr ""
@@ -18295,13 +18296,13 @@ msgstr ""
 msgid "Reviewing your reference. This usually takes about %{duration}."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:57
+#: lib/vutuv_web/notification_line.ex:62
 #: lib/vutuv_web/views/notification_digest_text.ex:94
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:54
+#: lib/vutuv_web/notification_line.ex:59
 #: lib/vutuv_web/views/notification_digest_text.ex:91
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready: %{grade}."
@@ -18317,7 +18318,7 @@ msgstr ""
 msgid "When the review of one of your employment references is finished. It takes minutes, so you can close the page and wait for the email."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:60
+#: lib/vutuv_web/notification_line.ex:65
 #, elixir-autogen, elixir-format
 msgid "Your employment reference has been reviewed."
 msgstr ""
@@ -18486,7 +18487,7 @@ msgstr ""
 msgid "Somebody"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:195
+#: lib/vutuv_web/notification_line.ex:200
 #: lib/vutuv_web/views/notification_digest_text.ex:100
 #, elixir-autogen, elixir-format
 msgid "Something new happened on your account."
@@ -18623,7 +18624,7 @@ msgstr ""
 msgid "Cancel registration"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1301
+#: lib/vutuv_web/live/notification_live/index.ex:1304
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -18633,17 +18634,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1421
+#: lib/vutuv/accounts/user.ex:1430
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1419
+#: lib/vutuv/accounts/user.ex:1428
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1420
+#: lib/vutuv/accounts/user.ex:1429
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19404,7 +19405,7 @@ msgstr ""
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1240
+#: lib/vutuv_web/live/shell_live.ex:1300
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Open the page"
 msgstr ""
@@ -19424,7 +19425,7 @@ msgstr ""
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1250
+#: lib/vutuv_web/live/shell_live.ex:1310
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -19434,7 +19435,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1226
+#: lib/vutuv_web/live/shell_live.ex:1286
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -19798,21 +19799,21 @@ msgstr ""
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:755
+#: lib/vutuv_web/live/shell_live.ex:765
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:742
+#: lib/vutuv_web/live/shell_live.ex:752
 #, elixir-autogen, elixir-format, fuzzy
 msgid "person"
 msgid_plural "people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:777
+#: lib/vutuv_web/live/shell_live.ex:787
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -20892,7 +20893,7 @@ msgstr ""
 msgid "Unfollowed. Their posts leave your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1200
+#: lib/vutuv_web/live/shell_live.ex:1260
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr ""
@@ -20907,12 +20908,12 @@ msgstr ""
 msgid "Browser notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1058
+#: lib/vutuv_web/live/shell_live.ex:1118
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1203
+#: lib/vutuv_web/live/shell_live.ex:1263
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
@@ -20952,7 +20953,7 @@ msgstr ""
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1197
+#: lib/vutuv_web/live/shell_live.ex:1257
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -20992,12 +20993,12 @@ msgstr ""
 msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:850
+#: lib/vutuv_web/live/shell_live.ex:860
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:851
+#: lib/vutuv_web/live/shell_live.ex:861
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr ""
@@ -21218,7 +21219,7 @@ msgstr ""
 msgid "Translated into %{language}."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:991
+#: lib/vutuv_web/live/shell_live.ex:1051
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -21337,7 +21338,7 @@ msgstr ""
 msgid "No connection"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1130
+#: lib/vutuv_web/live/shell_live.ex:1190
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr ""
@@ -21821,7 +21822,7 @@ msgstr ""
 msgid "Scan it with the device that has the app"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1112
+#: lib/vutuv_web/live/shell_live.ex:1172
 #, elixir-autogen, elixir-format, fuzzy
 msgid "A new version is ready."
 msgstr ""
@@ -21902,7 +21903,7 @@ msgctxt "filter rule"
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1687
+#: lib/vutuv_web/live/notification_live/index.ex:1609
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} share"
 msgid_plural "%{formatted} shares"
@@ -21910,31 +21911,31 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/controllers/post_calendar_controller.ex:136
-#: lib/vutuv_web/live/notification_live/index.ex:838
+#: lib/vutuv_web/live/notification_live/index.ex:841
 #, elixir-autogen, elixir-format
 msgid "Post without text"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1563
+#: lib/vutuv_web/live/notification_live/index.ex:1485
 #, elixir-autogen, elixir-format
 msgid "likes this."
 msgid_plural "like this."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1569
+#: lib/vutuv_web/live/notification_live/index.ex:1491
 #, elixir-autogen, elixir-format
 msgid "reacted to this."
 msgid_plural "reacted to this."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1571
+#: lib/vutuv_web/live/notification_live/index.ex:1493
 #, elixir-autogen, elixir-format
 msgid "replied."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1566
+#: lib/vutuv_web/live/notification_live/index.ex:1488
 #, elixir-autogen, elixir-format
 msgid "shared this."
 msgid_plural "shared this."
@@ -22071,7 +22072,7 @@ msgstr ""
 msgid "Low-bandwidth mode"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1641
+#: lib/vutuv_web/live/shell_live.ex:1721
 #, elixir-autogen, elixir-format
 msgctxt "phone tab bar"
 msgid "Write"
@@ -22229,7 +22230,7 @@ msgstr ""
 msgid "Appearance"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1667
+#: lib/vutuv_web/live/shell_live.ex:1747
 #, elixir-autogen, elixir-format
 msgid "%{count} video in progress"
 msgid_plural "%{count} videos in progress"
@@ -22374,69 +22375,69 @@ msgstr ""
 msgid "Your post appears as soon as the video is ready"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1437
+#: lib/vutuv_web/live/notification_live/index.ex:1440
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} connection"
 msgid_plural "%{formatted} connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1664
+#: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} new connection"
 msgid_plural "%{formatted} new connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1668
+#: lib/vutuv_web/live/notification_live/index.ex:1590
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} new follower"
 msgid_plural "%{formatted} new followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1443
+#: lib/vutuv_web/live/notification_live/index.ex:1446
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Last 30 days: %{parts}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:4496
-#: lib/vutuv_web/live/notification_live/index.ex:1020
+#: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Less"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1349
+#: lib/vutuv_web/live/notification_live/index.ex:1352
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reactions"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:522
+#: lib/vutuv_web/live/notification_live/index.ex:525
 #, elixir-autogen, elixir-format
 msgid "Seen before"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:634
+#: lib/vutuv_web/live/notification_live/index.ex:637
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Show %{formatted} more"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:845
+#: lib/vutuv_web/live/notification_live/index.ex:848
 #, elixir-autogen, elixir-format, fuzzy
 msgid "The post is no longer available."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1632
+#: lib/vutuv_web/live/notification_live/index.ex:1554
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Thread by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1573
+#: lib/vutuv_web/live/notification_live/index.ex:1495
 #, elixir-autogen, elixir-format, fuzzy
 msgid "mentioned you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1572
+#: lib/vutuv_web/live/notification_live/index.ex:1494
 #, elixir-autogen, elixir-format
 msgid "replied in the thread."
 msgstr ""
@@ -22484,7 +22485,7 @@ msgid_plural "%{formatted} random vutuv accounts that are open to offers."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:725
+#: lib/vutuv_web/live/shell_live.ex:735
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post in your feed"
 msgid_plural "%{formatted} new posts in your feed"
@@ -23077,7 +23078,7 @@ msgstr ""
 msgid "Copyright law. This complaint says the work is not yours to publish, which is a legal question rather than a house rule."
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:203
+#: lib/vutuv_web/notification_line.ex:208
 #, elixir-autogen, elixir-format
 msgid "Hidden automatically after a report: %{reason}. The case page says what you can do."
 msgstr ""
@@ -23107,7 +23108,7 @@ msgstr ""
 msgid "What the report says"
 msgstr ""
 
-#: lib/vutuv_web/notification_line.ex:209
+#: lib/vutuv_web/notification_line.ex:214
 #, elixir-autogen, elixir-format
 msgid "Your content was hidden automatically after a report. The case page says what you can do."
 msgstr ""
@@ -23286,4 +23287,14 @@ msgstr ""
 #: lib/vutuv_web/templates/page/index.html.heex:558
 #, elixir-autogen, elixir-format
 msgid "vutuv is part of the Fediverse, the union of independent networks that Mastodon belongs to as well. Whether your posts take part is your choice at sign-up, and one switch in the settings later. We are not religious about it: each to their own."
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:1816
+#, elixir-autogen, elixir-format
+msgid "All notifications"
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:1775
+#, elixir-autogen, elixir-format
+msgid "New notifications"
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -444,8 +444,8 @@ msgstr "Accedi"
 msgid "Log Out"
 msgstr "Esci"
 
-#: lib/vutuv_web/live/shell_live.ex:1573
-#: lib/vutuv_web/live/shell_live.ex:1649
+#: lib/vutuv_web/live/shell_live.ex:1653
+#: lib/vutuv_web/live/shell_live.ex:1729
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -458,7 +458,7 @@ msgstr "Accedi"
 msgid "Middle Name"
 msgstr "Secondo nome"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1351
+#: lib/vutuv_web/live/notification_live/index.ex:1354
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:298
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:306
 #, elixir-autogen
@@ -478,7 +478,7 @@ msgid "Name"
 msgstr "Nome"
 
 #: lib/vutuv_web/components/post_components.ex:793
-#: lib/vutuv_web/live/notification_live/index.ex:793
+#: lib/vutuv_web/live/notification_live/index.ex:796
 #: lib/vutuv_web/live/organization_live/activity.ex:136
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
@@ -650,8 +650,8 @@ msgstr "Salva"
 #: lib/vutuv_web/live/search_live.ex:61
 #: lib/vutuv_web/live/search_live.ex:654
 #: lib/vutuv_web/live/search_live.ex:680
-#: lib/vutuv_web/live/shell_live.ex:1442
-#: lib/vutuv_web/live/shell_live.ex:1629
+#: lib/vutuv_web/live/shell_live.ex:1502
+#: lib/vutuv_web/live/shell_live.ex:1709
 #: lib/vutuv_web/live/tag_live/timeline.ex:337
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:35
@@ -798,7 +798,7 @@ msgstr "Utente verificato."
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
 #: lib/vutuv_web/live/directory_search_live.ex:134
-#: lib/vutuv_web/live/notification_live/index.ex:1523
+#: lib/vutuv_web/notification_line.ex:304
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:51
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -1160,7 +1160,7 @@ msgstr "Aggiungi localizzazione"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:63
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:1549
+#: lib/vutuv_web/live/shell_live.ex:1629
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1602,7 +1602,7 @@ msgstr "Indirizzi di %{name}"
 msgid "Admin control panel"
 msgstr "Pannello di amministrazione"
 
-#: lib/vutuv_web/live/shell_live.ex:1647
+#: lib/vutuv_web/live/shell_live.ex:1727
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Avvisi"
@@ -1718,7 +1718,7 @@ msgstr ""
 "Sembra che non segua ancora nessuno. Apra il profilo di una persona che "
 "conosce o che La incuriosisce e prema il pulsante «Segui»."
 
-#: lib/vutuv_web/live/shell_live.ex:1568
+#: lib/vutuv_web/live/shell_live.ex:1648
 #: lib/vutuv_web/views/settings_html.ex:340
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1750,8 +1750,8 @@ msgstr "Messaggio"
 #: lib/vutuv_web/controllers/page_controller.ex:218
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:1460
-#: lib/vutuv_web/live/shell_live.ex:1646
+#: lib/vutuv_web/live/shell_live.ex:1520
+#: lib/vutuv_web/live/shell_live.ex:1726
 #: lib/vutuv_web/templates/layout/app.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1773,7 +1773,7 @@ msgstr "Rete"
 msgid "Nothing here yet."
 msgstr "Qui non c'è ancora nulla."
 
-#: lib/vutuv_web/live/notification_live/index.ex:539
+#: lib/vutuv_web/live/notification_live/index.ex:542
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr "Ancora nessuna novità."
@@ -1781,9 +1781,9 @@ msgstr "Ancora nessuna novità."
 #: lib/vutuv/api_auth/scopes.ex:85
 #: lib/vutuv_web/components/ui.ex:5138
 #: lib/vutuv_web/controllers/page_controller.ex:219
-#: lib/vutuv_web/live/notification_live/index.ex:152
-#: lib/vutuv_web/live/notification_live/index.ex:457
-#: lib/vutuv_web/live/shell_live.ex:1472
+#: lib/vutuv_web/live/notification_live/index.ex:155
+#: lib/vutuv_web/live/notification_live/index.ex:460
+#: lib/vutuv_web/live/shell_live.ex:1545
 #: lib/vutuv_web/templates/layout/app.html.heex:160
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -1909,17 +1909,17 @@ msgstr[1] "follower"
 msgid "following"
 msgstr "seguiti"
 
-#: lib/vutuv_web/notification_line.ex:82
+#: lib/vutuv_web/notification_line.ex:87
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr "L'ha confermata per %{tag}."
 
-#: lib/vutuv_web/notification_line.ex:77
+#: lib/vutuv_web/notification_line.ex:82
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr "ora è collegato con Lei."
 
-#: lib/vutuv_web/notification_line.ex:75
+#: lib/vutuv_web/notification_line.ex:80
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr "ha iniziato a seguirla."
@@ -2135,8 +2135,8 @@ msgstr "Modifica il post"
 #: lib/vutuv_web/live/post_live/feed.ex:331
 #: lib/vutuv_web/live/post_live/feed.ex:3254
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
-#: lib/vutuv_web/live/shell_live.ex:1294
-#: lib/vutuv_web/live/shell_live.ex:1619
+#: lib/vutuv_web/live/shell_live.ex:1354
+#: lib/vutuv_web/live/shell_live.ex:1699
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2315,7 +2315,7 @@ msgid "Upload failed."
 msgstr "Caricamento non riuscito."
 
 #: lib/vutuv_web/components/ui.ex:5483
-#: lib/vutuv_web/live/shell_live.ex:1515
+#: lib/vutuv_web/live/shell_live.ex:1595
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:287
@@ -2408,8 +2408,8 @@ msgstr "Salva"
 #: lib/vutuv_web/agent_docs/markdown.ex:1264
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:1452
-#: lib/vutuv_web/live/shell_live.ex:1520
+#: lib/vutuv_web/live/shell_live.ex:1512
+#: lib/vutuv_web/live/shell_live.ex:1600
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2419,7 +2419,7 @@ msgstr "Salvati"
 #: lib/vutuv_web/components/post_components.ex:2055
 #: lib/vutuv_web/components/post_components.ex:6322
 #: lib/vutuv_web/components/ui.ex:4117
-#: lib/vutuv_web/live/notification_live/index.ex:1512
+#: lib/vutuv_web/notification_line.ex:293
 #: lib/vutuv_web/views/user_html.ex:481
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2429,7 +2429,7 @@ msgstr "Mi piace"
 #: lib/vutuv_web/components/post_components.ex:6332
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:1523
+#: lib/vutuv_web/live/shell_live.ex:1603
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2514,7 +2514,7 @@ msgid "Only public posts can be answered."
 msgstr "Solo ai post pubblici si può rispondere."
 
 #: lib/vutuv_web/components/post_components.ex:430
-#: lib/vutuv_web/live/notification_live/index.ex:1348
+#: lib/vutuv_web/live/notification_live/index.ex:1351
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Risposte"
@@ -2522,9 +2522,9 @@ msgstr "Risposte"
 #: lib/vutuv_web/components/post_components.ex:2068
 #: lib/vutuv_web/components/post_components.ex:6359
 #: lib/vutuv_web/components/post_components.ex:6360
-#: lib/vutuv_web/live/notification_live/index.ex:1010
-#: lib/vutuv_web/live/notification_live/index.ex:1509
+#: lib/vutuv_web/live/notification_live/index.ex:1013
 #: lib/vutuv_web/live/post_live/reply.ex:49
+#: lib/vutuv_web/notification_line.ex:290
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Rispondi"
@@ -2550,7 +2550,7 @@ msgstr ""
 "resta pubblico finché esistono ripubblicazioni o risposte; può comunque "
 "eliminare il post."
 
-#: lib/vutuv_web/notification_line.ex:64
+#: lib/vutuv_web/notification_line.ex:69
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr "ha risposto al Suo post."
@@ -2882,23 +2882,23 @@ msgid "Open someone's profile to message them."
 msgstr "Apra il profilo di una persona per scriverle."
 
 #: lib/vutuv_web/components/organization_components.ex:259
-#: lib/vutuv_web/live/notification_live/index.ex:1525
 #: lib/vutuv_web/live/organization_live/activity.ex:112
+#: lib/vutuv_web/notification_line.ex:306
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr "Attività"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1516
+#: lib/vutuv_web/notification_line.ex:297
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr "Collegamento"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1508
+#: lib/vutuv_web/notification_line.ex:289
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr "Conferma"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1507
+#: lib/vutuv_web/notification_line.ex:288
 #: lib/vutuv_web/templates/user/show.html.heex:947
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2911,7 +2911,7 @@ msgstr[1] "Follower"
 msgid "Welcome to vutuv, %{name}!"
 msgstr "Benvenuto su vutuv, %{name}."
 
-#: lib/vutuv_web/notification_line.ex:73
+#: lib/vutuv_web/notification_line.ex:78
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr "ha messo Mi piace al Suo post."
@@ -2943,12 +2943,12 @@ msgstr "(account eliminato)"
 msgid "(no text)"
 msgstr "(nessun testo)"
 
-#: lib/vutuv_web/notification_line.ex:118
+#: lib/vutuv_web/notification_line.ex:123
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr "Una segnalazione sui Suoi contenuti è stata confermata."
 
-#: lib/vutuv_web/notification_line.ex:119
+#: lib/vutuv_web/notification_line.ex:124
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -3069,7 +3069,7 @@ msgstr "Contenuti adatti a tutti"
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1517
+#: lib/vutuv_web/notification_line.ex:298
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3197,7 +3197,7 @@ msgid "Private message"
 msgstr "Messaggio privato"
 
 #: lib/vutuv_web/components/ui.ex:5070
-#: lib/vutuv_web/live/shell_live.ex:1326
+#: lib/vutuv_web/live/shell_live.ex:1386
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3512,12 +3512,12 @@ msgstr "Lo ha già segnalato. Ce ne stiamo occupando."
 msgid "You cannot report your own content."
 msgstr "Non può segnalare i propri contenuti."
 
-#: lib/vutuv_web/notification_line.ex:121
+#: lib/vutuv_web/notification_line.ex:126
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr "Ha eliminato un contenuto segnalato; il caso è chiuso."
 
-#: lib/vutuv_web/notification_line.ex:120
+#: lib/vutuv_web/notification_line.ex:125
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr "Ha corretto un contenuto segnalato; il caso è chiuso."
@@ -3714,7 +3714,7 @@ msgstr "Cronologia"
 msgid "Open the profile"
 msgstr "Apri il profilo"
 
-#: lib/vutuv_web/notification_line.ex:146
+#: lib/vutuv_web/notification_line.ex:151
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3741,7 +3741,7 @@ msgstr "Il proprietario ha modificato il contenuto"
 msgid "Report filed"
 msgstr "Segnalazione inviata"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1519
+#: lib/vutuv_web/notification_line.ex:300
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr "Protezione dopo la segnalazione"
@@ -3824,7 +3824,7 @@ msgstr "Accolta"
 msgid "Waiting for the owner"
 msgstr "In attesa del proprietario"
 
-#: lib/vutuv_web/notification_line.ex:151
+#: lib/vutuv_web/notification_line.ex:156
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4013,7 +4013,7 @@ msgstr "Archivio dei post di %{name}"
 #: lib/vutuv_web/agent_docs/text.ex:138
 #: lib/vutuv_web/live/admin/screenshot_live.ex:380
 #: lib/vutuv_web/live/admin/screenshot_live.ex:389
-#: lib/vutuv_web/live/notification_live/index.ex:1635
+#: lib/vutuv_web/live/notification_live/index.ex:1557
 #: lib/vutuv_web/templates/post/show.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "Post by %{name}"
@@ -4736,8 +4736,8 @@ msgstr "Non è una corrispondenza esatta, ma somiglia alla Sua ricerca."
 #: lib/vutuv_web/agent_docs/markdown.ex:510
 #: lib/vutuv_web/agent_docs/text.ex:525
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/live/notification_live/index.ex:657
-#: lib/vutuv_web/live/notification_live/index.ex:1350
+#: lib/vutuv_web/live/notification_live/index.ex:660
+#: lib/vutuv_web/live/notification_live/index.ex:1353
 #: lib/vutuv_web/live/organization_live/show.ex:797
 #: lib/vutuv_web/live/post_live/saved.ex:539
 #: lib/vutuv_web/live/search_live.ex:346
@@ -4761,7 +4761,7 @@ msgstr "Nomi simili"
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
-#: lib/vutuv_web/live/notification_live/index.ex:1347
+#: lib/vutuv_web/live/notification_live/index.ex:1350
 #: lib/vutuv_web/live/search_live.ex:345
 #: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
@@ -5489,7 +5489,7 @@ msgstr "Non può più rispondere a questo post."
 msgid "Content under review"
 msgstr "Contenuto in esame"
 
-#: lib/vutuv_web/live/shell_live.ex:1502
+#: lib/vutuv_web/live/shell_live.ex:1582
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Menu dell'account"
@@ -5511,7 +5511,7 @@ msgstr "Chiudi menu e finestre"
 msgid "General"
 msgstr "Generale"
 
-#: lib/vutuv_web/live/shell_live.ex:1559
+#: lib/vutuv_web/live/shell_live.ex:1639
 #: lib/vutuv_web/templates/layout/app.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5530,7 +5530,7 @@ msgstr "Navigazione"
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:276
-#: lib/vutuv_web/live/shell_live.ex:1539
+#: lib/vutuv_web/live/shell_live.ex:1619
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5584,8 +5584,8 @@ msgstr "Post successivo nel feed"
 msgid "Previous post in the feed"
 msgstr "Post precedente nel feed"
 
-#: lib/vutuv_web/live/shell_live.ex:1282
-#: lib/vutuv_web/live/shell_live.ex:1600
+#: lib/vutuv_web/live/shell_live.ex:1342
+#: lib/vutuv_web/live/shell_live.ex:1680
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Navigazione principale"
@@ -5598,7 +5598,7 @@ msgstr "Navigazione a piè di pagina"
 #: lib/vutuv_web/components/post_components.ex:4022
 #: lib/vutuv_web/components/post_components.ex:4074
 #: lib/vutuv_web/components/post_components.ex:4608
-#: lib/vutuv_web/live/notification_live/index.ex:1086
+#: lib/vutuv_web/live/notification_live/index.ex:1089
 #: lib/vutuv_web/views/user_html.ex:131
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5725,7 +5725,7 @@ msgstr "Vedi"
 msgid "Your name"
 msgstr "Il Suo nome"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1629
+#: lib/vutuv_web/live/notification_live/index.ex:1551
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr "Il Suo post"
@@ -6511,10 +6511,10 @@ msgid "No endorsements yet."
 msgstr "Ancora nessuna conferma."
 
 #: lib/vutuv_web/components/ui.ex:2712
-#: lib/vutuv_web/live/notification_live/index.ex:724
-#: lib/vutuv_web/live/notification_live/index.ex:739
-#: lib/vutuv_web/live/notification_live/index.ex:1239
-#: lib/vutuv_web/live/notification_live/index.ex:1241
+#: lib/vutuv_web/live/notification_live/index.ex:727
+#: lib/vutuv_web/live/notification_live/index.ex:742
+#: lib/vutuv_web/live/notification_live/index.ex:1242
+#: lib/vutuv_web/live/notification_live/index.ex:1244
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr "e altri %{count}"
@@ -7581,6 +7581,7 @@ msgstr "vale per l'intero elenco, non solo per questa pagina"
 #: lib/vutuv_web/components/job_components.ex:190
 #: lib/vutuv_web/components/post_components.ex:6232
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
+#: lib/vutuv_web/live/shell_live.ex:1822
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
 msgstr "+%{count} altri"
@@ -7993,13 +7994,13 @@ msgstr "Nuovi membri"
 #: lib/vutuv_web/components/job_components.ex:219
 #: lib/vutuv_web/live/admin/dashboard_live.ex:304
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:468
-#: lib/vutuv_web/live/notification_live/index.ex:1385
+#: lib/vutuv_web/live/notification_live/index.ex:1388
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Oggi"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:308
-#: lib/vutuv_web/live/notification_live/index.ex:1388
+#: lib/vutuv_web/live/notification_live/index.ex:1391
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr "Ieri"
@@ -8246,8 +8247,8 @@ msgstr "Identità verificata. Il membro è stato avvisato per e-mail."
 msgid "Identity-verified"
 msgstr "Identità verificata"
 
-#: lib/vutuv/accounts.ex:1451
-#: lib/vutuv/accounts.ex:1500
+#: lib/vutuv/accounts.ex:1452
+#: lib/vutuv/accounts.ex:1501
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8288,7 +8289,7 @@ msgstr "Non confermato"
 msgid "Open the member browser"
 msgstr "Apri l'elenco dei membri"
 
-#: lib/vutuv/accounts.ex:1468
+#: lib/vutuv/accounts.ex:1469
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -9017,7 +9018,7 @@ msgstr "Gestisci gli account social"
 msgid "Your Fediverse handle"
 msgstr "Il Suo handle nel Fediverso"
 
-#: lib/vutuv/accounts.ex:1463
+#: lib/vutuv/accounts.ex:1464
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -9816,7 +9817,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Situazione lavorativa"
 
-#: lib/vutuv/accounts/user.ex:1262
+#: lib/vutuv/accounts/user.ex:1271
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9827,7 +9828,7 @@ msgstr "In cerca di lavoro"
 msgid "Not open to work"
 msgstr "Non in cerca di lavoro"
 
-#: lib/vutuv/accounts/user.ex:1259
+#: lib/vutuv/accounts/user.ex:1268
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10601,7 +10602,7 @@ msgid_plural "%{count} stars"
 msgstr[0] "%{count} stella"
 msgstr[1] "%{count} stelle"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1433
+#: lib/vutuv_web/live/notification_live/index.ex:1436
 #: lib/vutuv_web/live/organization_live/show.ex:648
 #: lib/vutuv_web/views/user_html.ex:960
 #: lib/vutuv_web/views/user_html.ex:1136
@@ -11263,19 +11264,19 @@ msgstr ""
 "Sua disponibilità ma non può garantirla, perché chiunque può creare un "
 "account. Scelga \"Nessuno\" per conservare lo stato senza mostrarlo."
 
-#: lib/vutuv/accounts/user.ex:1300
+#: lib/vutuv/accounts/user.ex:1309
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Tutti, compresi i visitatori non connessi"
 
-#: lib/vutuv/accounts/user.ex:1305
+#: lib/vutuv/accounts/user.ex:1314
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Nessuno"
 
-#: lib/vutuv/accounts/user.ex:1303
+#: lib/vutuv/accounts/user.ex:1312
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -12308,7 +12309,7 @@ msgstr "Pagina dell'organizzazione"
 msgid "Organization pages"
 msgstr "Pagine delle organizzazioni"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1520
+#: lib/vutuv_web/notification_line.ex:301
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr "Ruolo nell'organizzazione"
@@ -12326,7 +12327,7 @@ msgstr "Organizzazione sbloccata."
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
 #: lib/vutuv_web/live/post_live/saved.ex:542
-#: lib/vutuv_web/live/shell_live.ex:1530
+#: lib/vutuv_web/live/shell_live.ex:1610
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:80
@@ -12426,22 +12427,22 @@ msgstr "La pagina della Sua organizzazione è verificata e ora è online."
 msgid "Your organization page was updated."
 msgstr "La pagina della Sua organizzazione è stata aggiornata."
 
-#: lib/vutuv_web/notification_line.ex:110
+#: lib/vutuv_web/notification_line.ex:115
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr "Le ha assegnato un ruolo in %{organization}."
 
-#: lib/vutuv_web/notification_line.ex:107
+#: lib/vutuv_web/notification_line.ex:112
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr "L'ha nominata selezionatore per %{organization}."
 
-#: lib/vutuv_web/notification_line.ex:104
+#: lib/vutuv_web/notification_line.ex:109
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr "L'ha nominata amministratore di %{organization}."
 
-#: lib/vutuv_web/notification_line.ex:101
+#: lib/vutuv_web/notification_line.ex:106
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr "L'ha nominata proprietario di %{organization}."
@@ -12646,7 +12647,7 @@ msgstr "I tag evidenziati corrispondono al Suo profilo."
 msgid "How to apply"
 msgstr "Come candidarsi"
 
-#: lib/vutuv/accounts/user.ex:1274
+#: lib/vutuv/accounts/user.ex:1283
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12672,7 +12673,7 @@ msgstr "Titolo della posizione"
 #: lib/vutuv_web/live/job_board_live.ex:47
 #: lib/vutuv_web/live/job_board_live.ex:265
 #: lib/vutuv_web/live/post_live/saved.ex:545
-#: lib/vutuv_web/live/shell_live.ex:1334
+#: lib/vutuv_web/live/shell_live.ex:1394
 #: lib/vutuv_web/templates/layout/app.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -12768,7 +12769,7 @@ msgstr ""
 "Offri i formati leggibili dalle macchine (.md/.txt/.json/.xml) agli agenti "
 "IA."
 
-#: lib/vutuv/accounts/user.ex:1273
+#: lib/vutuv/accounts/user.ex:1282
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12852,7 +12853,7 @@ msgstr "Annuncio non trovato."
 msgid "Publish"
 msgstr "Pubblica"
 
-#: lib/vutuv/accounts/user.ex:1275
+#: lib/vutuv/accounts/user.ex:1284
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:589
 #: lib/vutuv_web/agent_docs/markdown.ex:532
@@ -13907,7 +13908,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr "Immagine in attesa di esame, visibile solo a Lei"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1518
+#: lib/vutuv_web/notification_line.ex:299
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13953,7 +13954,7 @@ msgstr ""
 "Se è venuto male (ad esempio con un avviso sui cookie che copre la pagina), "
 "può rimuoverlo."
 
-#: lib/vutuv/accounts/user.ex:1318
+#: lib/vutuv/accounts/user.ex:1327
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13967,19 +13968,19 @@ msgstr ""
 "la data esatta, \"Giorno e mese\" nasconde l'anno (e la Sua età) e \"Non "
 "mostrare\" lo conserva ma lo tiene fuori dal profilo."
 
-#: lib/vutuv/accounts/user.ex:1321
+#: lib/vutuv/accounts/user.ex:1330
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Giorno e mese, senza l'anno"
 
-#: lib/vutuv/accounts/user.ex:1324
+#: lib/vutuv/accounts/user.ex:1333
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Non mostrare il mio compleanno"
 
-#: lib/vutuv/accounts/user.ex:1315
+#: lib/vutuv/accounts/user.ex:1324
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14009,7 +14010,7 @@ msgstr ""
 "con quello nuovo e gli autori di quei post vengono avvisati. Il Suo vecchio "
 "indirizzo di profilo smette di funzionare."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1521
+#: lib/vutuv_web/notification_line.ex:302
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr "Cambio di handle"
@@ -14025,7 +14026,7 @@ msgstr[1] ""
 "Abbiamo aggiornato %{formatted} post che menzionavano il Suo vecchio handle "
 "e ne abbiamo avvisato gli autori."
 
-#: lib/vutuv_web/notification_line.ex:160
+#: lib/vutuv_web/notification_line.ex:165
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "ha cambiato il proprio handle da @%{old} a @%{new}."
@@ -14239,22 +14240,22 @@ msgstr ""
 "Vedono una notifica che rimanda a questa voce. Non viene inviata alcuna "
 "e-mail, e accade solo per una voce nuova."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1522
+#: lib/vutuv_web/notification_line.ex:303
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr "Aggiornamento del CV"
 
-#: lib/vutuv_web/notification_line.ex:180
+#: lib/vutuv_web/notification_line.ex:185
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr "ha aggiunto una nuova posizione al proprio CV: %{entry}"
 
-#: lib/vutuv_web/notification_line.ex:172
+#: lib/vutuv_web/notification_line.ex:177
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr "ha aggiunto una nuova voce di formazione al proprio CV: %{entry}"
 
-#: lib/vutuv_web/notification_line.ex:177
+#: lib/vutuv_web/notification_line.ex:182
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr "ha aggiunto un nuovo certificato al proprio CV: %{entry}"
@@ -14282,7 +14283,7 @@ msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 "Se disattivo, non vede mai questo tipo di notifica, da chiunque arrivi."
 
-#: lib/vutuv_web/notification_line.ex:185
+#: lib/vutuv_web/notification_line.ex:190
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr "ha aggiunto %{count} nuove voci al proprio CV:"
@@ -14415,40 +14416,40 @@ msgstr "Con certificazione: %{name}"
 msgid "Publisher:"
 msgstr "Editore:"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1377
+#: lib/vutuv_web/live/notification_live/index.ex:1380
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] "%{formatted} nuova notifica"
 msgstr[1] "%{formatted} nuove notifiche"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1391
+#: lib/vutuv_web/live/notification_live/index.ex:1394
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr "%{day} %{month} %{year}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:556
+#: lib/vutuv_web/live/notification_live/index.ex:559
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr "Segui anche tu"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1334
-#: lib/vutuv_web/live/notification_live/index.ex:1701
+#: lib/vutuv_web/live/notification_live/index.ex:1337
+#: lib/vutuv_web/live/notification_live/index.ex:1623
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "e"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1608
+#: lib/vutuv_web/live/notification_live/index.ex:1530
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr "ora sono collegati con Lei."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1605
+#: lib/vutuv_web/live/notification_live/index.ex:1527
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr "ora La seguono."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1614
+#: lib/vutuv_web/live/notification_live/index.ex:1536
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr "L'ha confermata per %{tags}."
@@ -14470,7 +14471,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] "Confermato da %{name} e da %{formatted} altro"
 msgstr[1] "Confermato da %{name} e da altri %{formatted}"
 
-#: lib/vutuv_web/live/shell_live.ex:711
+#: lib/vutuv_web/live/shell_live.ex:721
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -14671,7 +14672,7 @@ msgstr "Disponibilità"
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Un controllo automatico ha rimosso un'immagine dal Suo account vutuv"
 
-#: lib/vutuv_web/notification_line.ex:134
+#: lib/vutuv_web/notification_line.ex:139
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
@@ -14679,12 +14680,12 @@ msgstr ""
 "non abbastanza adatta a un ambiente di lavoro. Può sbagliare, quindi "
 "risponda alla nostra e-mail se non è d'accordo."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1510
+#: lib/vutuv_web/notification_line.ex:291
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr "Risposta in una discussione"
 
-#: lib/vutuv_web/notification_line.ex:263
+#: lib/vutuv_web/notification_line.ex:358
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14707,12 +14708,12 @@ msgstr "Conversazione"
 msgid "Only part of this long conversation is shown."
 msgstr "Di questa lunga conversazione è mostrata solo una parte."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1511
+#: lib/vutuv_web/notification_line.ex:292
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr "Menzione"
 
-#: lib/vutuv_web/notification_line.ex:84
+#: lib/vutuv_web/notification_line.ex:89
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr "L'ha menzionata in un post."
@@ -15002,7 +15003,7 @@ msgstr "Può spostarsi solo una volta ogni %{days} giorni."
 msgid "as an account alias."
 msgstr "come alias dell'account."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1693
+#: lib/vutuv_web/live/notification_live/index.ex:1615
 #: lib/vutuv_web/templates/user_tag/show.html.heex:24
 #, elixir-autogen, elixir-format
 msgid "%{formatted} endorsement"
@@ -15096,7 +15097,7 @@ msgstr "Questa formazione ora compare in cima al Suo profilo."
 msgid "Thread replies"
 msgstr "Risposte nelle discussioni"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1039
+#: lib/vutuv_web/live/notification_live/index.ex:1042
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr "Disattiva le notifiche delle discussioni"
@@ -15154,7 +15155,7 @@ msgstr "Non ha ancora silenziato nulla."
 msgid "You have reached the maximum of %{count} filters."
 msgstr "Ha raggiunto il massimo di %{count} filtri."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1034
+#: lib/vutuv_web/live/notification_live/index.ex:1037
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr "Ha scritto in questa discussione."
@@ -16133,7 +16134,7 @@ msgstr ""
 " richiesta rivolta a quei server, e non tutti la rispettano."
 
 #: lib/vutuv_web/components/post_components.ex:6277
-#: lib/vutuv_web/live/notification_live/index.ex:1690
+#: lib/vutuv_web/live/notification_live/index.ex:1612
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
@@ -16141,7 +16142,7 @@ msgstr[0] "%{formatted} risposta"
 msgstr[1] "%{formatted} risposte"
 
 #: lib/vutuv_web/components/post_components.ex:6281
-#: lib/vutuv_web/live/notification_live/index.ex:1684
+#: lib/vutuv_web/live/notification_live/index.ex:1606
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
@@ -16205,7 +16206,7 @@ msgstr "Rimossa dal membro"
 msgid "Replies from other networks"
 msgstr "Risposte da altre reti"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1513
+#: lib/vutuv_web/notification_line.ex:294
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr "Risposta da un'altra rete"
@@ -16227,7 +16228,7 @@ msgid "Reported as not appropriate"
 msgstr "Segnalata come non appropriata"
 
 #: lib/vutuv_web/components/post_components.ex:1445
-#: lib/vutuv_web/live/notification_live/index.ex:1134
+#: lib/vutuv_web/live/notification_live/index.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr "Inviata solo a Lei, non visibile a nessun altro"
@@ -16279,7 +16280,7 @@ msgstr "Cosa"
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr "Oggi ha fatto molte segnalazioni. Riprovi domani."
 
-#: lib/vutuv_web/notification_line.ex:87
+#: lib/vutuv_web/notification_line.ex:92
 #, elixir-autogen, elixir-format
 msgid "replied to your post from another network."
 msgstr "ha risposto al Suo post da un'altra rete."
@@ -17334,8 +17335,8 @@ msgstr "Reazioni dal Fediverso"
 msgid "From other networks"
 msgstr "Da altre reti"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1514
-#: lib/vutuv_web/live/notification_live/index.ex:1515
+#: lib/vutuv_web/notification_line.ex:295
+#: lib/vutuv_web/notification_line.ex:296
 #, elixir-autogen, elixir-format
 msgid "Reaction from another network"
 msgstr "Reazione da un'altra rete"
@@ -17355,21 +17356,21 @@ msgstr ""
 "conserviamo altro: nessun nome, nessuna immagine, nessun testo. Disattivando"
 " l'opzione, ciò che è stato memorizzato viene eliminato."
 
-#: lib/vutuv_web/notification_line.ex:244
+#: lib/vutuv_web/notification_line.ex:339
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] "ha messo Mi piace al Suo post su un'altra rete."
 msgstr[1] "ha messo Mi piace al Suo post su un'altra rete."
 
-#: lib/vutuv_web/notification_line.ex:252
+#: lib/vutuv_web/notification_line.ex:347
 #, elixir-autogen, elixir-format
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] "ha reagito al Suo post da un'altra rete."
 msgstr[1] "ha reagito al Suo post da un'altra rete."
 
-#: lib/vutuv_web/notification_line.ex:236
+#: lib/vutuv_web/notification_line.ex:331
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -18760,7 +18761,7 @@ msgstr ""
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr "Ancora nulla da vutuv. Segua persone qui per riempire questa scheda."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1148
+#: lib/vutuv_web/live/notification_live/index.ex:1151
 #, elixir-autogen, elixir-format
 msgid "View the conversation"
 msgstr "Vedi la conversazione"
@@ -19445,7 +19446,7 @@ msgstr "Attestato di lavoro modificato"
 msgid "Employment reference deleted"
 msgstr "Attestato di lavoro eliminato"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1524
+#: lib/vutuv_web/notification_line.ex:305
 #, elixir-autogen, elixir-format
 msgid "Employment reference review"
 msgstr "Analisi dell'attestato di lavoro"
@@ -19471,13 +19472,13 @@ msgid "Reviewing your reference. This usually takes about %{duration}."
 msgstr ""
 "Analisi del Suo attestato in corso. Di solito ci vogliono circa %{duration}."
 
-#: lib/vutuv_web/notification_line.ex:57
+#: lib/vutuv_web/notification_line.ex:62
 #: lib/vutuv_web/views/notification_digest_text.ex:94
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready."
 msgstr "L'analisi di “%{title}” è pronta."
 
-#: lib/vutuv_web/notification_line.ex:54
+#: lib/vutuv_web/notification_line.ex:59
 #: lib/vutuv_web/views/notification_digest_text.ex:91
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready: %{grade}."
@@ -19495,7 +19496,7 @@ msgstr ""
 "Quando l'analisi di uno dei Suoi attestati di lavoro è terminata. Ci "
 "vogliono alcuni minuti, quindi può chiudere la pagina e aspettare l'e-mail."
 
-#: lib/vutuv_web/notification_line.ex:60
+#: lib/vutuv_web/notification_line.ex:65
 #, elixir-autogen, elixir-format
 msgid "Your employment reference has been reviewed."
 msgstr "Il Suo attestato di lavoro è stato analizzato."
@@ -19680,7 +19681,7 @@ msgstr "Una Sua immagine è stata rimossa dall'esame delle immagini."
 msgid "Somebody"
 msgstr "Qualcuno"
 
-#: lib/vutuv_web/notification_line.ex:195
+#: lib/vutuv_web/notification_line.ex:200
 #: lib/vutuv_web/views/notification_digest_text.ex:100
 #, elixir-autogen, elixir-format
 msgid "Something new happened on your account."
@@ -19833,7 +19834,7 @@ msgstr ""
 msgid "Cancel registration"
 msgstr "Annulla la registrazione"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1301
+#: lib/vutuv_web/live/notification_live/index.ex:1304
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -19847,17 +19848,17 @@ msgstr ""
 "Il PIN non arriva? L'indirizzo e-mail {email} è corretto? Ha controllato la "
 "cartella dello spam?"
 
-#: lib/vutuv/accounts/user.ex:1421
+#: lib/vutuv/accounts/user.ex:1430
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Non binario"
 
-#: lib/vutuv/accounts/user.ex:1419
+#: lib/vutuv/accounts/user.ex:1428
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Femminile"
 
-#: lib/vutuv/accounts/user.ex:1420
+#: lib/vutuv/accounts/user.ex:1429
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Maschile"
@@ -20701,7 +20702,7 @@ msgstr "Non può più scrivere a nome di questa organizzazione."
 msgid "A post in an organization's name is always public."
 msgstr "Un post a nome di un'organizzazione è sempre pubblico."
 
-#: lib/vutuv_web/live/shell_live.ex:1240
+#: lib/vutuv_web/live/shell_live.ex:1300
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr "Apri la pagina"
@@ -20721,7 +20722,7 @@ msgstr "Ha smesso di scrivere come organizzazione"
 msgid "Write as %{name} for now"
 msgstr "Scrivi come %{name} per ora"
 
-#: lib/vutuv_web/live/shell_live.ex:1250
+#: lib/vutuv_web/live/shell_live.ex:1310
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr "Torna a scrivere come me stesso"
@@ -20731,7 +20732,7 @@ msgstr "Torna a scrivere come me stesso"
 msgid "You are writing as %{name} now."
 msgstr "Ora sta scrivendo come %{name}."
 
-#: lib/vutuv_web/live/shell_live.ex:1226
+#: lib/vutuv_web/live/shell_live.ex:1286
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr "Sta scrivendo come %{name}."
@@ -21142,21 +21143,21 @@ msgstr "Segue già #%{tag} qui."
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr "Anche Lei è su questo vutuv, quindi ora segue #%{tag} proprio qui."
 
-#: lib/vutuv_web/live/shell_live.ex:755
+#: lib/vutuv_web/live/shell_live.ex:765
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] "%{formatted} persona"
 msgstr[1] "%{formatted} persone"
 
-#: lib/vutuv_web/live/shell_live.ex:742
+#: lib/vutuv_web/live/shell_live.ex:752
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] "persona"
 msgstr[1] "persone"
 
-#: lib/vutuv_web/live/shell_live.ex:777
+#: lib/vutuv_web/live/shell_live.ex:787
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -22353,7 +22354,7 @@ msgstr "Smettere di seguire %{handle}? I suoi post spariscono dal Suo feed."
 msgid "Unfollowed. Their posts leave your feed."
 msgstr "Non lo segue più. I suoi post spariscono dal Suo feed."
 
-#: lib/vutuv_web/live/shell_live.ex:1200
+#: lib/vutuv_web/live/shell_live.ex:1260
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr "Consenti"
@@ -22368,12 +22369,12 @@ msgstr "Chiedi ora"
 msgid "Browser notifications"
 msgstr "Notifiche del browser"
 
-#: lib/vutuv_web/live/shell_live.ex:1058
+#: lib/vutuv_web/live/shell_live.ex:1118
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr "Nuovo messaggio"
 
-#: lib/vutuv_web/live/shell_live.ex:1203
+#: lib/vutuv_web/live/shell_live.ex:1263
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Non ora"
@@ -22423,7 +22424,7 @@ msgstr ""
 "guardando, il Suo browser può mostrarlo come notifica. Disattivate finché "
 "non le attiva."
 
-#: lib/vutuv_web/live/shell_live.ex:1197
+#: lib/vutuv_web/live/shell_live.ex:1257
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -22469,12 +22470,12 @@ msgstr ""
 "Inviata. Se non è comparso nulla, è il Suo sistema a trattenerla. Controlli "
 "la modalità Non disturbare e le impostazioni delle notifiche."
 
-#: lib/vutuv_web/live/shell_live.ex:850
+#: lib/vutuv_web/live/shell_live.ex:860
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr "Notifica di prova"
 
-#: lib/vutuv_web/live/shell_live.ex:851
+#: lib/vutuv_web/live/shell_live.ex:861
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr "Ecco come si presenta vutuv quando arriva qualcosa."
@@ -22704,7 +22705,7 @@ msgstr "Traducili in %{language}"
 msgid "Translated into %{language}."
 msgstr "Vengono tradotti in %{language}."
 
-#: lib/vutuv_web/live/shell_live.ex:991
+#: lib/vutuv_web/live/shell_live.ex:1051
 #, elixir-autogen, elixir-format
 msgid "+%{formatted} more post"
 msgid_plural "+%{formatted} more posts"
@@ -22829,7 +22830,7 @@ msgstr "Nuovo messaggio su vutuv"
 msgid "No connection"
 msgstr "Nessuna connessione"
 
-#: lib/vutuv_web/live/shell_live.ex:1130
+#: lib/vutuv_web/live/shell_live.ex:1190
 #, elixir-autogen, elixir-format
 msgid "Reload"
 msgstr "Ricarica"
@@ -23317,7 +23318,7 @@ msgstr "I gestori di password come Bitwarden ne ricavano l'intera voce: nome, ac
 msgid "Scan it with the device that has the app"
 msgstr "Da scansionare con il dispositivo su cui è installata l'app"
 
-#: lib/vutuv_web/live/shell_live.ex:1112
+#: lib/vutuv_web/live/shell_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "A new version is ready."
 msgstr "È pronta una nuova versione."
@@ -23398,7 +23399,7 @@ msgctxt "filter rule"
 msgid "Hide"
 msgstr "Nascondi"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1687
+#: lib/vutuv_web/live/notification_live/index.ex:1609
 #, elixir-autogen, elixir-format
 msgid "%{formatted} share"
 msgid_plural "%{formatted} shares"
@@ -23406,31 +23407,31 @@ msgstr[0] "%{formatted} condivisione"
 msgstr[1] "%{formatted} condivisioni"
 
 #: lib/vutuv_web/controllers/post_calendar_controller.ex:136
-#: lib/vutuv_web/live/notification_live/index.ex:838
+#: lib/vutuv_web/live/notification_live/index.ex:841
 #, elixir-autogen, elixir-format
 msgid "Post without text"
 msgstr "Post senza testo"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1563
+#: lib/vutuv_web/live/notification_live/index.ex:1485
 #, elixir-autogen, elixir-format
 msgid "likes this."
 msgid_plural "like this."
 msgstr[0] "ha messo Mi piace."
 msgstr[1] "hanno messo Mi piace."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1569
+#: lib/vutuv_web/live/notification_live/index.ex:1491
 #, elixir-autogen, elixir-format
 msgid "reacted to this."
 msgid_plural "reacted to this."
 msgstr[0] "ha reagito."
 msgstr[1] "hanno reagito."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1571
+#: lib/vutuv_web/live/notification_live/index.ex:1493
 #, elixir-autogen, elixir-format
 msgid "replied."
 msgstr "ha risposto."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1566
+#: lib/vutuv_web/live/notification_live/index.ex:1488
 #, elixir-autogen, elixir-format
 msgid "shared this."
 msgid_plural "shared this."
@@ -23567,7 +23568,7 @@ msgstr "Se la Sua connessione è lenta o a consumo, vutuv può tralasciare le pa
 msgid "Low-bandwidth mode"
 msgstr "Modalità risparmio dati"
 
-#: lib/vutuv_web/live/shell_live.ex:1641
+#: lib/vutuv_web/live/shell_live.ex:1721
 #, elixir-autogen, elixir-format
 msgctxt "phone tab bar"
 msgid "Write"
@@ -23725,7 +23726,7 @@ msgstr "banda lento internet mobile risparmio dati volume compressione immagini 
 msgid "Appearance"
 msgstr "Aspetto"
 
-#: lib/vutuv_web/live/shell_live.ex:1667
+#: lib/vutuv_web/live/shell_live.ex:1747
 #, elixir-autogen, elixir-format
 msgid "%{count} video in progress"
 msgid_plural "%{count} videos in progress"
@@ -23870,69 +23871,69 @@ msgstr "Può pubblicare subito: il post apparirà appena il video sarà pronto."
 msgid "Your post appears as soon as the video is ready"
 msgstr "Il Suo post apparirà appena il video sarà pronto"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1437
+#: lib/vutuv_web/live/notification_live/index.ex:1440
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} connection"
 msgid_plural "%{formatted} connections"
 msgstr[0] "%{formatted} nuovo"
 msgstr[1] "%{formatted} nuovi"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1664
+#: lib/vutuv_web/live/notification_live/index.ex:1586
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} new connection"
 msgid_plural "%{formatted} new connections"
 msgstr[0] "%{formatted} nuovo"
 msgstr[1] "%{formatted} nuovi"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1668
+#: lib/vutuv_web/live/notification_live/index.ex:1590
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} new follower"
 msgid_plural "%{formatted} new followers"
 msgstr[0] "%{formatted} follower"
 msgstr[1] "%{formatted} follower"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1443
+#: lib/vutuv_web/live/notification_live/index.ex:1446
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Last 30 days: %{parts}"
 msgstr "Ultimi 30 giorni"
 
 #: lib/vutuv_web/components/post_components.ex:4496
-#: lib/vutuv_web/live/notification_live/index.ex:1020
+#: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format
 msgid "Less"
 msgstr "Meno"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1349
+#: lib/vutuv_web/live/notification_live/index.ex:1352
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reactions"
 msgstr "Sezione"
 
-#: lib/vutuv_web/live/notification_live/index.ex:522
+#: lib/vutuv_web/live/notification_live/index.ex:525
 #, elixir-autogen, elixir-format
 msgid "Seen before"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:634
+#: lib/vutuv_web/live/notification_live/index.ex:637
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Show %{formatted} more"
 msgstr "Mostra %{formatted} altra risposta"
 
-#: lib/vutuv_web/live/notification_live/index.ex:845
+#: lib/vutuv_web/live/notification_live/index.ex:848
 #, elixir-autogen, elixir-format, fuzzy
 msgid "The post is no longer available."
 msgstr "Questa posizione non è più disponibile."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1632
+#: lib/vutuv_web/live/notification_live/index.ex:1554
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Thread by %{name}"
 msgstr "Piace a %{name}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1573
+#: lib/vutuv_web/live/notification_live/index.ex:1495
 #, elixir-autogen, elixir-format, fuzzy
 msgid "mentioned you."
 msgstr "L'ha menzionata in un post."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1572
+#: lib/vutuv_web/live/notification_live/index.ex:1494
 #, elixir-autogen, elixir-format
 msgid "replied in the thread."
 msgstr ""
@@ -23980,7 +23981,7 @@ msgid_plural "%{formatted} random vutuv accounts that are open to offers."
 msgstr[0] "Un account vutuv scelto a caso, aperto a proposte."
 msgstr[1] "%{formatted} account vutuv scelti a caso, aperti a proposte."
 
-#: lib/vutuv_web/live/shell_live.ex:725
+#: lib/vutuv_web/live/shell_live.ex:735
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post in your feed"
 msgid_plural "%{formatted} new posts in your feed"
@@ -24573,7 +24574,7 @@ msgstr "Di quale opera si tratta e dove si può vedere l'originale? (obbligatori
 msgid "Copyright law. This complaint says the work is not yours to publish, which is a legal question rather than a house rule."
 msgstr "Il diritto d'autore. Questa contestazione sostiene che l'opera non è Sua da pubblicare, e questa è una questione giuridica, non una regola della casa."
 
-#: lib/vutuv_web/notification_line.ex:203
+#: lib/vutuv_web/notification_line.ex:208
 #, elixir-autogen, elixir-format
 msgid "Hidden automatically after a report: %{reason}. The case page says what you can do."
 msgstr "Nascosto automaticamente dopo una segnalazione: %{reason}. Nella pagina del caso trova cosa può fare."
@@ -24603,7 +24604,7 @@ msgstr "Il fondamento"
 msgid "What the report says"
 msgstr "Cosa dice la segnalazione"
 
-#: lib/vutuv_web/notification_line.ex:209
+#: lib/vutuv_web/notification_line.ex:214
 #, elixir-autogen, elixir-format
 msgid "Your content was hidden automatically after a report. The case page says what you can do."
 msgstr "Il Suo contenuto è stato nascosto automaticamente dopo una segnalazione. Nella pagina del caso trova cosa può fare."
@@ -24819,3 +24820,13 @@ msgstr ""
 "anche Mastodon. Se i Suoi post vi partecipano lo decide Lei all'iscrizione, e"
 " più tardi con un interruttore nelle impostazioni. Non ne facciamo una "
 "religione: ognuno come vuole."
+
+#: lib/vutuv_web/live/shell_live.ex:1816
+#, elixir-autogen, elixir-format
+msgid "All notifications"
+msgstr "Tutte le notifiche"
+
+#: lib/vutuv_web/live/shell_live.ex:1775
+#, elixir-autogen, elixir-format
+msgid "New notifications"
+msgstr "Nuove notifiche"

--- a/test/vutuv/activity_test.exs
+++ b/test/vutuv/activity_test.exs
@@ -1094,6 +1094,125 @@ defmodule Vutuv.ActivityTest do
     end
   end
 
+  describe "unread_notifications/2 and mark_notifications_read_up_to/2" do
+    test "lists what the badge counts, newest first and capped at the limit" do
+      me = insert(:user)
+
+      for day <- 1..4 do
+        follow = insert(:follow, follower: insert(:user), followee: me)
+        backdate_connection(follow, %{~N[2024-03-01 12:00:00] | day: day})
+      end
+
+      preview = Activity.unread_notifications(me.id, 3)
+      stamps = Enum.map(preview.items, & &1.at)
+
+      assert length(preview.items) == 3
+      assert stamps == Enum.sort(stamps, {:desc, NaiveDateTime})
+      assert preview.read_up_to == ~N[2024-03-04 12:00:00]
+      assert Activity.unread_notification_count(me.id) == 4
+    end
+
+    test "leaves out what the member has already read" do
+      me = insert(:user)
+
+      old = insert(:follow, follower: insert(:user), followee: me)
+      backdate_connection(old, ~N[2024-03-01 12:00:00])
+      Activity.mark_notifications_read(me.id)
+
+      new = insert(:follow, follower: insert(:user), followee: me)
+      backdate_connection(new, ~N[2024-03-02 12:00:00])
+
+      preview = Activity.unread_notifications(me.id, 6)
+
+      assert [%{kind: "follower", at: ~N[2024-03-02 12:00:00]}] = preview.items
+      # The stamp that marks them read is the newest event there IS, not the
+      # newest unread one — otherwise a marker already past it would go back.
+      assert preview.read_up_to == ~N[2024-03-02 12:00:00]
+    end
+
+    test "what arrives while the panel is open is still unread when it closes" do
+      me = insert(:user)
+
+      shown = insert(:follow, follower: insert(:user), followee: me)
+      backdate_connection(shown, ~N[2024-03-01 12:00:00])
+
+      # The pointer comes to rest: the panel pins the instant it is showing.
+      preview = Activity.unread_notifications(me.id, 6)
+      assert length(preview.items) == 1
+
+      # …and a like lands while the member is reading it.
+      during = insert(:follow, follower: insert(:user), followee: me)
+      backdate_connection(during, ~N[2024-03-02 12:00:00])
+
+      # The pointer leaves. Only what was in the panel is read.
+      Activity.mark_notifications_read_up_to(me.id, preview.read_up_to)
+      assert Activity.unread_notification_count(me.id) == 1
+
+      # The calibration: the ordinary full read is what this must NOT do — it
+      # sweeps the marker to whatever is newest by then, arrival included.
+      Activity.mark_notifications_read(me.id)
+      assert Activity.unread_notification_count(me.id) == 0
+    end
+
+    test "leaves out a vernetzt pair the member closed themselves, exactly as the badge does" do
+      me = insert(:user)
+      mine = insert(:user)
+      theirs = insert(:user)
+
+      # Two vernetzt pairs, one closed from each side. `count_connections/3`
+      # counts only the one the OTHER person closed — a circle the member shut
+      # themselves is news to everybody except them. Both pairs are needed for
+      # this to bite: with only the self-closed one, the kind's count is zero
+      # and the preview never reads that source at all.
+      {:ok, _} = Vutuv.Social.follow(mine, me.id)
+      {:ok, _} = Vutuv.Social.follow(me, mine.id)
+      {:ok, _} = Vutuv.Social.follow(me, theirs.id)
+      {:ok, _} = Vutuv.Social.follow(theirs, me.id)
+
+      preview = Activity.unread_notifications(me.id, 20)
+      connections = Enum.filter(preview.items, &(&1.kind == "connection"))
+
+      assert length(connections) == 1
+      # The invariant worth pinning: under the cap, the panel lists exactly what
+      # the number counts. A row the badge left out makes the two disagree.
+      assert length(preview.items) == Activity.unread_notification_count(me.id)
+    end
+
+    test "the marker only ever moves forward" do
+      me = insert(:user)
+
+      follow = insert(:follow, follower: insert(:user), followee: me)
+      backdate_connection(follow, ~N[2024-03-05 12:00:00])
+
+      # Another tab read everything in the meantime; a preview that opened
+      # before it must not undo that.
+      Activity.mark_notifications_read(me.id)
+      Activity.mark_notifications_read_up_to(me.id, ~N[2024-01-01 12:00:00])
+
+      assert Activity.unread_notification_count(me.id) == 0
+    end
+
+    test "a marker that moves tells the member's other sessions, and one that does not stays quiet" do
+      me = insert(:user)
+      Activity.subscribe(me.id)
+
+      follow = insert(:follow, follower: insert(:user), followee: me)
+      backdate_connection(follow, ~N[2024-03-05 12:00:00])
+
+      Activity.mark_notifications_read_up_to(me.id, ~N[2024-03-05 12:00:00])
+      assert_receive :notifications_changed
+
+      Activity.mark_notifications_read_up_to(me.id, ~N[2024-03-05 12:00:00])
+      refute_receive :notifications_changed, 50
+    end
+
+    test "answers empty for a logged-out visitor and writes no marker for nil" do
+      assert Activity.unread_notifications(nil, 6) == %{items: [], read_up_to: nil}
+      assert Activity.mark_notifications_read_up_to(nil, ~N[2024-03-05 12:00:00]) == :ok
+      assert Activity.mark_notifications_read_up_to(Vutuv.UUIDv7.generate(), nil) == :ok
+    end
+  end
+
   # Test shorthand for the first page's entries.
   defp recent_notifications(user_id, limit \\ 50) do
     Activity.notifications_page(user_id, limit: limit).entries

--- a/test/vutuv_web/live/shell_bell_preview_test.exs
+++ b/test/vutuv_web/live/shell_bell_preview_test.exs
@@ -1,0 +1,158 @@
+defmodule VutuvWeb.ShellBellPreviewTest do
+  @moduledoc """
+  The bell's hover preview: what the badge's number stands for, shown under the
+  bell while the pointer rests on it, and marked read when it leaves.
+
+  The gesture itself is the `BellPreview` hook's (a hover is not a LiveView
+  binding), so these drive the two events it pushes. What they are really about
+  is the promise the hook cannot keep on its own: **an event that arrives while
+  the panel is open was never in it**, so the badge has to say so the moment the
+  pointer leaves.
+  """
+  use VutuvWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Activity
+
+  @bell_badge ~s(a[title="Notifications"] span.bg-accent)
+  @panel "#bell-preview"
+  @row_marker "data-bell-preview-item"
+
+  defp shell(conn, user) do
+    live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
+  end
+
+  # One follower event, backdated so its stamp is deterministic and distinct.
+  defp follower_event(user, at) do
+    follow = insert(:follow, follower: insert(:user), followee: user)
+
+    Vutuv.Repo.update_all(
+      from(f in Vutuv.Social.Follow, where: f.id == ^follow.id),
+      set: [inserted_at: at]
+    )
+
+    follow
+  end
+
+  test "the bell carries the unread count for the hook to read", %{conn: conn} do
+    user = insert(:user)
+    follower_event(user, ~N[2024-03-01 12:00:00])
+
+    {:ok, view, _html} = shell(conn, user)
+
+    assert has_element?(view, ~s(#bell-preview-host[data-unread="1"]))
+    refute has_element?(view, @panel)
+  end
+
+  test "resting on the bell lists the events behind the number", %{conn: conn} do
+    user = insert(:user)
+    liker = insert(:user, first_name: "Ada", last_name: "Lovelace")
+    insert(:follow, follower: liker, followee: user)
+
+    {:ok, view, _html} = shell(conn, user)
+    html = render_hook(view, "bell:preview", %{})
+
+    assert html =~ "Ada Lovelace"
+    assert html =~ "started following you."
+    # Looking is not reading: the number stands until the pointer leaves.
+    assert has_element?(view, @bell_badge, "1")
+  end
+
+  test "moving the pointer away marks exactly what was shown as read", %{conn: conn} do
+    user = insert(:user)
+    follower_event(user, ~N[2024-03-01 12:00:00])
+
+    {:ok, view, _html} = shell(conn, user)
+    render_hook(view, "bell:preview", %{})
+    render_hook(view, "bell:preview_close", %{})
+
+    refute has_element?(view, @panel)
+    refute has_element?(view, @bell_badge)
+    assert Activity.unread_notification_count(user.id) == 0
+  end
+
+  test "an event arriving while the panel is open is back in the badge on close", %{conn: conn} do
+    user = insert(:user)
+    follower_event(user, ~N[2024-03-01 12:00:00])
+
+    {:ok, view, _html} = shell(conn, user)
+    assert render_hook(view, "bell:preview", %{}) =~ "started following you."
+
+    # The member is reading the panel; somebody follows them right now.
+    follower_event(user, ~N[2024-03-02 12:00:00])
+    Activity.broadcast(user.id, :notifications_changed)
+
+    render_hook(view, "bell:preview_close", %{})
+
+    assert has_element?(view, @bell_badge, "1")
+    assert Activity.unread_notification_count(user.id) == 1
+  end
+
+  test "a bell with nothing behind it opens no panel and reads nothing", %{conn: conn} do
+    user = insert(:user)
+
+    {:ok, view, _html} = shell(conn, user)
+    render_hook(view, "bell:preview", %{})
+
+    refute has_element?(view, @panel)
+
+    # And a close without an open panel must not move the marker: the member
+    # never saw anything, so a later event has to still be new.
+    render_hook(view, "bell:preview_close", %{})
+    follower_event(user, ~N[2024-03-01 12:00:00])
+
+    assert Activity.unread_notification_count(user.id) == 1
+  end
+
+  test "the panel caps its list and says how many it is holding back", %{conn: conn} do
+    user = insert(:user)
+
+    for day <- 1..8 do
+      follower_event(user, %{~N[2024-03-01 12:00:00] | day: day})
+    end
+
+    {:ok, view, _html} = shell(conn, user)
+    render_hook(view, "bell:preview", %{})
+
+    # Six rows of eight events, and the footer names the two it left out.
+    assert has_element?(view, "[data-bell-preview-all]", "All notifications")
+    assert row_count(view) == 6
+    assert has_element?(view, "[data-bell-preview-more]", "2")
+
+    # Leaving still empties the whole badge: the number was what the member
+    # looked at, and the page keeps every one of the eight.
+    render_hook(view, "bell:preview_close", %{})
+    refute has_element?(view, @bell_badge)
+  end
+
+  test "the panel's German is written, not fuzzy-filled from something else", %{conn: conn} do
+    # `gettext.extract --merge` fills a brand-new msgid with the translation of
+    # whatever looked similar to it and nothing fails the build — "+%{count}
+    # more" came back as "+%{formatted} weiterer Beitrag" the first time. So the
+    # German of every string on this panel is asserted by name.
+    user = insert(:user, locale: "de")
+
+    insert(:follow,
+      follower: insert(:user, first_name: "Ada", last_name: "Lovelace"),
+      followee: user
+    )
+
+    for day <- 2..8, do: follower_event(user, %{~N[2024-03-01 12:00:00] | day: day})
+
+    {:ok, view, _html} = shell(conn, user)
+    html = render_hook(view, "bell:preview", %{})
+
+    assert html =~ "Alle Mitteilungen"
+    assert html =~ ~s(aria-label="Neue Mitteilungen")
+    assert html =~ "weitere"
+    assert html =~ "folgt Ihnen jetzt."
+    refute html =~ "All notifications"
+  end
+
+  # Counted out of the markup rather than with a selector: `has_element?/2`
+  # answers yes or no, and the number of rows is the assertion here.
+  defp row_count(view) do
+    view |> render() |> String.split(@row_marker) |> length() |> Kernel.-(1)
+  end
+end


### PR DESCRIPTION
Two likes and a new follower were never worth the trip to `/notifications` and back, so the bell's number sat there being ignored. Resting the pointer on it now drops a small panel under the bell — six rows at most, then "All notifications ›" and a "+N more" — and moving the pointer away marks those read.

The part that needed care: an event arriving *while* the panel is open was never in it. `Activity.unread_notifications/2` pins the instant it is showing and the close hands that same instant to `mark_notifications_read_up_to/2`, so the badge says 1 the moment the pointer leaves. `mark_notifications_read/1` would have swept it up.

The gesture is a JS hook (`BellPreview` in `app.js`) because a hover is not a LiveView binding; it never fires without a hovering pointer, which is what keeps a tap on a phone from emptying the badge on the way to the page.

Entry point: the bell in `VutuvWeb.ShellLive`. Full account in `docs/architecture/realtime.md`.

An AI agent wrote this text in my name. I know that is problematic.

https://claude.ai/code/session_01KUfnbW85Mx154nr7QsrEgD
