### PR TITLE
Count and show the answers a remote post got

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -477,6 +477,41 @@ config :vutuv, :fediverse_counts_ladder, [
 config :vutuv, :fediverse_counts_batch, 60
 config :vutuv, :fediverse_counts_per_host, 10
 
+# The same ladder for the **answer** count, and it is deliberately much flatter.
+#
+# A like tally is a field in a document the ask above already fetched, so it
+# costs nothing extra. An answer tally is not served as a figure by anybody —
+# forty objects from our own cache were asked and not one of their servers put a
+# `totalItems` on `replies` — so it has to be counted by walking the collection,
+# and every walk is a request of its own. Riding the fine-grained ladder above
+# would therefore roughly double the traffic of a queue that is already behind.
+#
+# Four tiers, then never again: a quarter-hourly ask through the first hour,
+# hourly to six, six-hourly to two days. An answer arriving on a three-day-old
+# post is rare enough that the figure may stand.
+config :vutuv, :fediverse_replies_ladder, [
+  {60, 15},
+  {6 * 60, 60},
+  {48 * 60, 360}
+]
+
+# How many pages of 60 one count may walk before it gives up and says "at
+# least this many". Three is 180 answers, past which the exact figure is not
+# what anybody is reading.
+config :vutuv, :fediverse_replies_max_pages, 3
+
+# How many answers one "show the answers" click fetches, and the ceiling across
+# all the clicks on one card. Each answer is an object on some other server —
+# ten of them, four at a time, took a second against real hosts — so the first
+# number is a page and the second is where the page stops asking for more.
+config :vutuv, :fediverse_thread_page, 10
+config :vutuv, :fediverse_thread_max, 50
+
+# How many answers one member may pull in per hour, across every card. The
+# outbound budget the reply and follow paths have, for the one act here that
+# spends somebody else's bandwidth on a click.
+config :vutuv, :fediverse_thread_fetch_limit, 200
+
 # How long a post whose picture the AI image scan has not judged yet waits before
 # it federates anyway (issue #1070). The scan normally settles within seconds and
 # releases the post at once, so this is the CEILING, not the usual wait: it is

--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -2029,6 +2029,86 @@ The tag page's "most liked" order reads these figures too
 (`Vutuv.Tags.Timeline`), which is why the note that used to apologise for
 parking every fediverse post at the bottom of that order is gone.
 
+**An origin that serves none of the three collections leaves the ladder after
+one ask** (`counts_absent`), without a strike: the server answered, and answered
+correctly, with a document that carries no figures — a property of its software,
+not of its health. The column earns its place by what it costs not to have.
+Measured on a copy of production: flipboard.com held **1.026 of the 2.627**
+objects on the ladder (39 %) and had answered **0 of its 1.478** stored posts
+with a figure of any kind, while **2.511 of those 2.627** objects were overdue,
+the median asked at 1,9 times its own interval and the p90 at ten times. A batch
+of 60 every two minutes against 2.627 objects is one full round every 87
+minutes, so the five-minute tier at the head of the ladder was arithmetic and
+nothing else.
+
+### How many answered it, and reading those answers
+
+The third figure on that bar, and it is not like the other two.
+
+`likes` and `shares` arrive as a `totalItems` in a document the ask already
+fetched, so they are free. `replies` is not: forty objects from this
+installation's own cache were asked before this was built and **not one** of
+their servers put a `totalItems` on that collection. Mastodon serialises
+`replies` as a Collection whose **first page is embedded in the object** and
+carries the author's own follow-ups, and whose `next`
+(`?only_other_accounts=true`) carries everybody else's, 60 ids to a page. So the
+figure is **counted**, and counting costs a request.
+
+Counted that way it is exactly the figure the origin shows its own readers.
+Against Mastodon's `replies_count` for five real threads: 121/121, 51/51, 6/6,
+2/2, and 21 against 22 (one answer deleted between the two reads).
+
+- **Its own, much flatter ladder** (`:fediverse_replies_ladder`): quarter hourly
+  through the first hour, hourly to six, six-hourly to two days, then never. It
+  rides the like ask rather than running a sweep of its own, so a count costs one
+  page fetch and no second object fetch — and a `304` on the object cannot carry
+  it, because the answer figure is not in that body.
+- **Three pages and no further** (`:fediverse_replies_max_pages`): 180 answers,
+  past which the exact figure is not what anybody is reading.
+- **Every failure is a failure, the `404` included.** A page the collection
+  itself named and the server will not serve is not the end of the list, and
+  reading it as one would write a confident `0` over a figure that was right.
+- **The clock is stamped on every outcome**, including "this origin serves no
+  `replies` at all" — the issue #1316 rule, and here it matters twice over,
+  since an object that stayed due would walk a collection that does not exist on
+  every single ask for the rest of its week.
+
+Pressing the figure unfolds the answers under the card
+(`VutuvWeb.PostComponents.thread_replies/1`, handled by the action bar itself so
+all seven hosts get it at once). The control is **two targets in one slot**: the
+glyph leads to the answering page, the number beside it opens the thread, and
+they keep their own padding plus a `gap-2` so a thumb lands on the one it aimed
+at.
+
+What we already hold is painted at once from one indexed query
+(`stored_thread_replies/3`); the fetch behind it runs in `start_async` and gets
+`:fediverse_thread_page` answers at a time, four at a time, to a ceiling of
+`:fediverse_thread_max` per card and `:fediverse_thread_fetch_limit` per member
+per hour. Ten answers from ten different servers took **one second** against
+real hosts, and six of those ten refused an unsigned request — which is why the
+fetch signs, with the reader's own key where they have one and otherwise with
+whoever the background count would have signed as.
+
+**An answer is stored as an ordinary cached post** (`fetch_and_store_object/4`,
+the same fence a boost passes), which is what gives it a card, an action bar, a
+report path and the six-month ceiling for nothing. Two things follow from that:
+
+- It carries **`thread_context`**, and `RemotePost.timeline_scope/1` is what the
+  feed and the account page narrow by. Without it the feature would quietly
+  rewrite people's feeds: a delivered reply is only ever stored when it
+  continues a thread of the **same** account (`own_thread?/2`), so an answer by
+  somebody a member follows has never been feed material here, and fetching one
+  as thread context would drop it into that member's feed at its own old
+  timestamp, days back. Its hashtags are not filed either, which is what keeps
+  it off the tag pages. A later ordinary arrival (a delivery, a boost, a lookup)
+  **promotes** the row; nothing demotes one, or a card would vanish from a feed
+  because somebody else opened a thread.
+- It is **held for as long as the post it answers** (the sixth hold in
+  `spare_held/1`). Nobody follows the author of a thread answer — that is what
+  makes it an answer rather than feed material — so the purge would otherwise
+  delete it out from under the reader who pressed for it, usually within the
+  hour. It buys no extra time: the ceiling still applies.
+
 ### Answering one of their posts (issue #1165)
 
 The `Vutuv.Posts.PostRemoteReply` sidecar generalized rather than a second table

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -2942,6 +2942,7 @@ defmodule Vutuv.Fediverse do
         limit: ^fetch_n,
         preload: [:screenshot, remote_account: a]
       )
+      |> RemotePost.timeline_scope()
       |> time_window(cursor, :published_at, {:utc, :received_at})
       |> Repo.all()
       |> Enum.map(&remote_feed_entry/1)
@@ -2975,6 +2976,7 @@ defmodule Vutuv.Fediverse do
         where: p.expires_at > ^DateTime.utc_now(:second),
         preload: [:screenshot, remote_account: a]
       )
+      |> RemotePost.timeline_scope()
       |> Keyset.scope(opts)
       |> Repo.all()
       |> Keyset.restore(opts)
@@ -3248,6 +3250,9 @@ defmodule Vutuv.Fediverse do
       order_by: [desc: p.published_at, desc: p.id],
       limit: ^fetch_n
     )
+    # An answer pulled in to read a thread is not this account's contribution to
+    # anybody's feed, however faithfully it is stored as one of its posts.
+    |> RemotePost.timeline_scope()
     |> reject_muted_hosts(viewer)
     |> Vutuv.Posts.language_scope(Vutuv.Posts.feed_language_filter(viewer))
     |> time_window(cursor, :published_at, {:utc, :received_at})
@@ -4244,6 +4249,24 @@ defmodule Vutuv.Fediverse do
     |> where([p], not exists(looked_up))
     |> where([p], not exists(quoted))
     |> where([p], not exists(spanned))
+    |> where([p], not exists(answering_a_held_post()))
+  end
+
+  # A sixth hold: this row answers a post that is still cached here, so somebody
+  # is reading the thread it belongs to. Nobody follows the author of a thread
+  # answer — that is what makes it an answer rather than feed material — so
+  # without this the purge would delete it out from under the reader who pressed
+  # for it, usually within the hour.
+  #
+  # Tied to the parent rather than to a row of its own (the shape a lookup uses)
+  # because the parent already is that row: the answer exists for it, and when
+  # it goes there is nothing left to hang the answer under. It buys no extra
+  # time either, the ceiling still applies.
+  defp answering_a_held_post do
+    from(parent in RemotePost,
+      where: parent.object_uri == parent_as(:post).in_reply_to_uri,
+      where: parent.id != parent_as(:post).id
+    )
   end
 
   @doc """
@@ -4402,6 +4425,9 @@ defmodule Vutuv.Fediverse do
       # fourth audience value cannot open here and close there.
       where: p.audience in ^RemotePost.open_audiences() or exists(accepted)
     )
+    # Same reason as the feed's: an answer somebody pulled in is not one of this
+    # account's posts, even though the row is shaped exactly like one.
+    |> RemotePost.timeline_scope()
   end
 
   # Nobody in particular follows nothing: the card is behind a login, but a nil
@@ -4529,7 +4555,7 @@ defmodule Vutuv.Fediverse do
 
   defp own_thread?(_object, _account), do: true
 
-  defp insert_remote_post(%RemoteAccount{} = account, object, audience) do
+  defp insert_remote_post(%RemoteAccount{} = account, object, audience, thread_context? \\ false) do
     received = DateTime.utc_now(:second)
 
     with uri when is_binary(uri) <- SearchText.normalize_search(object["id"]),
@@ -4553,23 +4579,49 @@ defmodule Vutuv.Fediverse do
         })
       )
       |> put_object_counts(object)
+      |> Ecto.Changeset.put_change(:thread_context, thread_context?)
       |> Repo.insert(on_conflict: :nothing, conflict_target: [:object_uri])
       |> stored_post(uri)
-      |> file_hashtags(object)
+      |> promote_thread_context(thread_context?)
+      |> file_hashtags(object, thread_context?)
     else
       _ -> :error
     end
   end
+
+  # A row first written as thread context, now arriving on a path that puts
+  # posts in front of people who did not ask for this one: a delivery from a
+  # followed account, a boost, a member's own URL lookup. It stops being context
+  # and becomes an ordinary cached post.
+  #
+  # The insert above cannot do this itself (`on_conflict: :nothing` writes
+  # nothing at all on a second arrival), and the direction matters: context is
+  # only ever *promoted*. Nothing demotes a post that reached a feed, or a
+  # member would watch a card disappear because somebody else opened a thread.
+  defp promote_thread_context({:exists, %RemotePost{thread_context: true} = post}, false) do
+    Repo.update_all(from(p in RemotePost, where: p.id == ^post.id),
+      set: [thread_context: false]
+    )
+
+    {:exists, %{post | thread_context: false}}
+  end
+
+  defp promote_thread_context(result, _thread_context?), do: result
 
   # File the post under the tags its hashtags name, so it reaches `/tags/:slug`
   # (`Vutuv.Fediverse.Hashtags`). Done here rather than at the three call sites,
   # so a fourth ingestion path cannot forget it — and only for the row **this**
   # delivery wrote: a redelivery (`{:exists, _}`) is the same post arriving once
   # per follower, already filed.
-  defp file_hashtags({:ok, %RemotePost{} = post}, object),
+  defp file_hashtags({:ok, %RemotePost{} = post}, object, false),
     do: {:ok, Hashtags.sync(post, object)}
 
-  defp file_hashtags(result, _object), do: result
+  # Thread context is filed under nothing. A tag page is a listing surface like
+  # the feed and the account page (`RemotePost.timeline_scope/1`), and the
+  # cheapest way to keep an answer off it is to never file the answer's
+  # hashtags in the first place — a `#Linux` in the third reply of a thread
+  # somebody read once is not what `/tags/linux` is for.
+  defp file_hashtags(result, _object, _thread_context?), do: result
 
   # Which row this delivery actually left behind, and whether it was *this*
   # delivery that wrote it.
@@ -7122,8 +7174,11 @@ defmodule Vutuv.Fediverse do
   stay distinguishable from "nobody liked it". The bar renders nothing for a
   `nil`; a `0` would be a claim we cannot make.
   """
-  def counts(%RemotePost{} = post), do: %{likes: post.likes_count, shares: post.shares_count}
-  def counts(%Note{} = note), do: %{likes: note.likes_count, shares: note.shares_count}
+  def counts(%RemotePost{} = post),
+    do: %{likes: post.likes_count, shares: post.shares_count, replies: post.replies_count}
+
+  def counts(%Note{} = note),
+    do: %{likes: note.likes_count, shares: note.shares_count, replies: note.replies_count}
 
   @doc """
   Asks the origins of every due object for their own figures, bounded per run
@@ -7225,7 +7280,11 @@ defmodule Vutuv.Fediverse do
   defp ask_counts(subject) do
     with true <- counts_askable?(subject),
          signer when not is_nil(signer) <- counts_signer(subject) do
-      apply_counts(subject, fetch_object(subject.object_uri, signer, subject.counts_etag))
+      apply_counts(
+        subject,
+        fetch_object(subject.object_uri, signer, subject.counts_etag),
+        signer
+      )
     else
       _ ->
         stamp_counts(subject, [])
@@ -7233,7 +7292,9 @@ defmodule Vutuv.Fediverse do
     end
   end
 
-  # Public and unlisted only — see `refresh_counts/1`.
+  # Public and unlisted only — see `refresh_counts/1`. An origin that serves no
+  # figures at all is filtered out one level up, in the due query, which is
+  # where it has to happen: skipping it here would leave it in the queue.
   defp counts_askable?(%RemotePost{} = post), do: RemotePost.open?(post)
   defp counts_askable?(%Note{} = note), do: Note.public?(note)
 
@@ -7310,25 +7371,399 @@ defmodule Vutuv.Fediverse do
     )
   end
 
-  defp apply_counts(subject, {:ok, doc, etag}) do
-    store_counts(subject, %{
-      likes_count: collection_total(doc["likes"]),
-      shares_count: collection_total(doc["shares"]),
-      counts_etag: truncate_etag(etag)
-    })
+  defp apply_counts(subject, {:ok, doc, etag}, signer) do
+    likes = collection_total(doc["likes"])
+    shares = collection_total(doc["shares"])
+
+    store_counts(
+      subject,
+      %{
+        likes_count: likes,
+        shares_count: shares,
+        counts_etag: truncate_etag(etag)
+      }
+      |> Map.merge(reply_count_attrs(subject, doc, signer))
+      |> Map.merge(absent_attrs(doc, likes, shares))
+    )
   end
 
   # The figures live in the body, so a `304` really does mean "nothing changed"
-  # — which is the whole reason the conditional GET is worth sending.
-  defp apply_counts(subject, {:not_modified, etag}),
+  # — which is the whole reason the conditional GET is worth sending. The answer
+  # count cannot ride a `304`: its figure is not in the body, it is counted by
+  # walking a collection, and that collection moves while the object does not.
+  defp apply_counts(subject, {:not_modified, etag}, _signer),
     do: store_counts(subject, %{counts_etag: truncate_etag(etag)})
 
   # Unreachable, a 429, a 5xx, a 404, a body we cannot read: a strike, and the
   # next ask is twice as far away. Nothing about the stored figures changes.
-  defp apply_counts(subject, _other) do
+  defp apply_counts(subject, _other, _signer) do
     stamp_counts(subject, counts_failures: subject.counts_failures + 1)
     :failed
   end
+
+  # A document that answered `200` and carries none of the three collections is
+  # a statement about the software on the other side, not about its health, so
+  # the object leaves the ladder without a strike. `flipboard.com` serves
+  # `likes`, `shares` and `replies` as `null` on every post, and 0 of the 1.478
+  # of them we hold has ever carried a figure.
+  #
+  # Only ever set, never cleared: an object we stop asking about cannot tell us
+  # it changed its mind. That costs nothing — the ladder ends after a week
+  # anyway — and it keeps this from oscillating on a server that omits the
+  # collections while a post is brand new.
+  defp absent_attrs(doc, likes, shares) do
+    if is_nil(likes) and is_nil(shares) and is_nil(doc["replies"]),
+      do: %{counts_absent: true},
+      else: %{}
+  end
+
+  ## The origin's own answer count (issue #1102's sibling for `replies`)
+  ##
+  ## Everything above reads a figure out of a document we already hold. This
+  ## one has to be counted, and that is the whole difference: forty objects
+  ## from this installation's own cache were asked before this was written and
+  ## **not one** of their servers put a `totalItems` on `replies`. Mastodon
+  ## serialises the collection as a first page of the author's own follow-ups
+  ## (embedded in the object, so free) and a second page of everybody else's
+  ## (`only_other_accounts=true`, 60 ids at a time, one request each).
+  ##
+  ## Counted that way the figure is exactly the one the origin shows its own
+  ## readers: against Mastodon's `replies_count` for five real threads it came
+  ## back 121/121, 51/51, 6/6, 2/2 and 21 against 22 (one answer deleted in
+  ## between).
+
+  # Consecutive failed walks after which the answer count is left as it stands.
+  @replies_max_strikes 4
+
+  @doc "The ladder for the answer count. See `counts_ladder/0` for the shape."
+  def replies_ladder, do: Application.get_env(:vutuv, :fediverse_replies_ladder, [])
+
+  @doc "How many pages of a `replies` collection one count may walk."
+  def replies_max_pages, do: Application.get_env(:vutuv, :fediverse_replies_max_pages, 3)
+
+  # Whether this ask should also count the answers, and the result of doing so.
+  # Empty when it is not due, which is the common case: the ladder above asks
+  # about a young post every five minutes, this one every fifteen at its
+  # busiest.
+  defp reply_count_attrs(subject, doc, signer) do
+    if replies_due?(subject, DateTime.utc_now(:second)),
+      do: walk_replies(subject, doc["replies"], signer),
+      else: %{}
+  end
+
+  # The clock is stamped on **every** outcome, the ones where there was nothing
+  # to count included (issue #1316): an object whose origin serves no `replies`
+  # collection would otherwise be due on every single ask for the rest of its
+  # week, and since this rides the ask above, that means walking a collection
+  # that does not exist over and over.
+  defp walk_replies(_subject, nil, _signer),
+    do: %{replies_checked_at: DateTime.utc_now(:second), replies_failures: 0}
+
+  defp walk_replies(subject, replies, signer) do
+    case collect_reply_pages(replies, signer, replies_max_pages()) do
+      {:ok, %{total: total, uris: uris}} ->
+        %{
+          replies_count: total || length(uris),
+          replies_checked_at: DateTime.utc_now(:second),
+          replies_failures: 0
+        }
+
+      :error ->
+        %{
+          replies_checked_at: DateTime.utc_now(:second),
+          replies_failures: (subject.replies_failures || 0) + 1
+        }
+    end
+  end
+
+  @doc """
+  Walks a `replies` collection and returns `%{total: n | nil, uris: [uri]}`.
+
+  One walk for both readers of it: the background count (which wants the
+  number) and a member's press (which wants the ids). They have to agree, or a
+  card would offer to show eleven answers and then find nine.
+
+  Mastodon's shape is the one to hold in mind: the collection's **first** page
+  is embedded in the object and lists the author's own follow-ups, and its
+  `next` is `?only_other_accounts=true`, which is where everybody else's answers
+  are, 60 ids to a page. So a typical count costs exactly one request beyond
+  the ask it rides on, and a typical thread is one page.
+
+  A `totalItems` is believed the moment one appears — no server we cache serves
+  it today, but the spec allows it, and counting past a figure the origin states
+  itself would be work for a worse answer.
+  """
+  def collect_reply_pages(collection, signer, pages, acc \\ [])
+
+  def collect_reply_pages(_collection, _signer, 0, acc),
+    do: {:ok, %{total: nil, uris: Enum.reverse(acc)}}
+
+  def collect_reply_pages(%{} = collection, signer, pages, acc) do
+    # `collection_total/1` is the same guarded read the like and repost figures
+    # go through, cap included — a `nil` here simply means the walk decides.
+    total = collection_total(collection)
+
+    case collection["first"] || collection["items"] || collection["orderedItems"] do
+      nil ->
+        {:ok, %{total: total, uris: Enum.reverse(acc)}}
+
+      _some ->
+        # The ids are walked for even when the origin states a total: a member
+        # pressing "show them" needs them either way, and the stated figure
+        # wins over the walk's own length.
+        case collect_reply_page(page_of(collection), signer, pages, acc) do
+          {:ok, walked} -> {:ok, %{walked | total: total || walked.total}}
+          :error when not is_nil(total) -> {:ok, %{total: total, uris: Enum.reverse(acc)}}
+          :error -> :error
+        end
+    end
+  end
+
+  # A collection given as a bare URI: one fetch, then the same walk.
+  #
+  # Every failure here is a failure, the `404` included. A page the collection
+  # itself named and the server will not serve is not the end of the list, and
+  # reading it as one is how a walk that reached nothing would store a
+  # confident `0` over a figure that was right — the collection is empty and
+  # the collection is unreachable have to stay different answers.
+  def collect_reply_pages(uri, signer, pages, acc) when is_binary(uri) do
+    case fetch_object(uri, signer, nil) do
+      {:ok, doc, _etag} -> collect_reply_pages(doc, signer, pages - 1, acc)
+      _other -> :error
+    end
+  end
+
+  def collect_reply_pages(_other, _signer, _pages, _acc), do: :error
+
+  # The first page of a collection, embedded (Mastodon) or named by URI.
+  defp page_of(%{"first" => first}) when not is_nil(first), do: first
+  defp page_of(%{} = collection), do: collection
+
+  defp collect_reply_page(page, signer, pages, acc) when is_binary(page) do
+    case fetch_object(page, signer, nil) do
+      {:ok, doc, _etag} -> collect_reply_page(doc, signer, pages, acc)
+      _other -> :error
+    end
+  end
+
+  defp collect_reply_page(%{} = page, signer, pages, acc) do
+    acc = Enum.reduce(page_items(page), acc, &[&1 | &2])
+
+    case page["next"] do
+      next when is_binary(next) and pages > 1 -> collect_reply_page(next, signer, pages - 1, acc)
+      _last_or_capped -> {:ok, %{total: nil, uris: Enum.reverse(acc)}}
+    end
+  end
+
+  defp collect_reply_page(_other, _signer, _pages, acc),
+    do: {:ok, %{total: nil, uris: Enum.reverse(acc)}}
+
+  # What a collection page lists, whichever of the two names it uses. Only the
+  # entries usable as an id: a page may list bare URIs or embed whole objects —
+  # Mastodon does both in one page, the remote answers as ids and its own as
+  # documents — and `activity_object_id/1` is this codebase's answer to that
+  # pair already.
+  defp page_items(%{} = page) do
+    (page["items"] || page["orderedItems"] || [])
+    |> List.wrap()
+    |> Enum.map(&activity_object_id/1)
+    |> Enum.filter(&is_binary/1)
+  end
+
+  # The ladder, in Elixir rather than SQL: this rides an ask that already
+  # selected its object, so there is nothing to query for.
+  defp replies_due?(subject, now) do
+    checked = subject.replies_checked_at
+
+    cond do
+      (subject.replies_failures || 0) >= @replies_max_strikes -> false
+      # Never counted, so counted once whatever its age — the same one-off the
+      # figures above get, and safe for the same reason: the clock is stamped
+      # on every outcome, so nothing can stay permanently due.
+      is_nil(checked) -> true
+      true -> reply_tier_due?(subject, checked, now)
+    end
+  end
+
+  defp reply_tier_due?(subject, checked, now) do
+    age = DateTime.diff(now, counts_age(subject), :second) / 60
+    waited = DateTime.diff(now, checked, :second) / 60
+    backoff = Integer.pow(2, subject.replies_failures || 0)
+
+    case Enum.find(replies_ladder(), fn {age_minutes, _interval} -> age <= age_minutes end) do
+      {_age_minutes, interval} -> waited >= interval * backoff
+      nil -> false
+    end
+  end
+
+  ## Reading the answers themselves
+  ##
+  ## The count above says how many people answered; this is what a member gets
+  ## when they press it. Two halves, and which one runs decides how the card
+  ## behaves: what we already hold is free and instant, what we do not costs one
+  ## request per answer to a server that is usually neither ours nor the
+  ## origin's (a thread of 60 answers on mastodon.social listed authors on nine
+  ## other hosts). So the stored half paints first and the fetch fills in behind
+  ## it.
+  ##
+  ## An answer is stored as an ordinary cached post, which is what gives it a
+  ## card, an action bar, a report path and the six-month ceiling for free. It
+  ## carries `thread_context` so the surfaces that list an **account's** posts
+  ## skip it (`RemotePost.timeline_scope/1`), and it is held for as long as the
+  ## post it answers is here (`spare_held/1`).
+
+  @doc "How many answers one press fetches."
+  def thread_page, do: Application.get_env(:vutuv, :fediverse_thread_page, 10)
+
+  @doc "How many answers one card will fetch across every press."
+  def thread_max, do: Application.get_env(:vutuv, :fediverse_thread_max, 50)
+
+  @doc "How many answers one member may pull in per hour, across every card."
+  def thread_fetch_limit, do: Application.get_env(:vutuv, :fediverse_thread_fetch_limit, 200)
+
+  @doc """
+  The answers to this object we already hold, oldest first.
+
+  Costs one indexed query and no network at all, so it is what a press paints
+  with before anything is fetched. Public audiences only — an answer stored
+  from somebody's followers-only stream is not ours to show a stranger — and
+  the reader's own muted hosts are dropped, the same gate their feed applies.
+  """
+  def stored_thread_replies(subject, viewer, opts \\ [])
+
+  def stored_thread_replies(%{object_uri: uri}, viewer, opts) when is_binary(uri) do
+    limit = Keyword.get(opts, :limit, thread_max())
+
+    from(p in RemotePost,
+      as: :post,
+      join: a in RemoteAccount,
+      as: :remote_account,
+      on: a.id == p.remote_account_id,
+      where: p.in_reply_to_uri == ^uri,
+      where: p.audience in ^RemotePost.open_audiences(),
+      order_by: [asc: p.published_at, asc: p.id],
+      limit: ^limit,
+      preload: [remote_account: a],
+      select: p
+    )
+    |> reject_muted_hosts(viewer)
+    |> Repo.all()
+  end
+
+  def stored_thread_replies(_subject, _viewer, _opts), do: []
+
+  @doc """
+  Fetches the next page of answers to `subject` from the servers that hold them.
+
+  Returns `{:ok, %{replies: [%RemotePost{}], pending: [uri], fetched: n}}`,
+  where `pending` is what is left for the next press — the caller keeps it, so
+  a second press walks no collection again. Or `{:error, reason}`:
+
+    * `:capped` — this member has pulled in their hour's worth of answers.
+    * `:unavailable` — the origin serves no `replies` collection, or would not
+      answer. Both are the same sentence to a reader: we cannot get them.
+
+  Nothing here is speculative. It runs on a member's press, never on a render,
+  and it is the one place in this subsystem that spends other people's
+  bandwidth on somebody's curiosity — hence the hourly budget, the page size,
+  and the ceiling on how far one card may go.
+  """
+  def fetch_thread_replies(viewer, subject, opts \\ [])
+
+  def fetch_thread_replies(%User{} = viewer, subject, opts) do
+    if enabled?(), do: do_fetch_thread_replies(viewer, subject, opts), else: {:error, :disabled}
+  end
+
+  def fetch_thread_replies(_viewer, _subject, _opts), do: {:error, :unavailable}
+
+  defp do_fetch_thread_replies(viewer, subject, opts) do
+    with :ok <- claim_thread_fetch(viewer),
+         signer when not is_nil(signer) <- thread_signer(viewer, subject),
+         {:ok, uris} <- thread_reply_uris(subject, signer, opts) do
+      {take, rest} = Enum.split(uris, thread_page())
+
+      replies =
+        take |> resolve_thread_replies(signer) |> Enum.filter(&readable_reply?(&1, viewer))
+
+      {:ok, %{replies: replies, pending: rest, fetched: length(take)}}
+    else
+      {:error, reason} -> {:error, reason}
+      nil -> {:error, :unavailable}
+    end
+  end
+
+  # What is left to fetch: the caller's leftovers from a previous press, or a
+  # fresh walk of the collection. The walk is capped at `thread_max/0` ids and
+  # at the same page count the background count uses — a thread with two
+  # thousand answers is read at its origin, not here.
+  defp thread_reply_uris(subject, signer, opts) do
+    case Keyword.get(opts, :pending) do
+      [_ | _] = pending -> {:ok, pending}
+      _none -> walk_thread_reply_uris(subject, signer)
+    end
+  end
+
+  defp walk_thread_reply_uris(subject, signer) do
+    with {:ok, doc, _etag} <- fetch_object(subject.object_uri, signer, nil),
+         replies when not is_nil(replies) <- doc["replies"],
+         {:ok, %{uris: uris}} <- collect_reply_pages(replies, signer, replies_max_pages()) do
+      {:ok, uris |> Enum.uniq() |> Enum.take(thread_max())}
+    else
+      _unavailable -> {:error, :unavailable}
+    end
+  end
+
+  defp claim_thread_fetch(%User{id: id}),
+    do: claim_outbound_budget(id, :fediverse_thread_fetch, thread_fetch_limit(), :capped)
+
+  # The member's own key where they have one, so the request says who is asking
+  # on an authorized-fetch server (six of ten hosts in one real thread answered
+  # `401` unsigned). A member who does not federate has none, and then this
+  # falls back to whoever the background count would have signed as — the same
+  # claim, made by the same installation, for the same object.
+  defp thread_signer(%User{} = viewer, subject), do: signer(viewer) || counts_signer(subject)
+
+  # Every id turned into a row: the ones already here for nothing, the rest
+  # fetched through the same fence a boost passes (`fetch_and_store_object/4`),
+  # four at a time.
+  defp resolve_thread_replies(uris, signer) do
+    stored = uris |> stored_by_uri() |> Map.new(&{&1.object_uri, &1})
+    missing = Enum.reject(uris, &Map.has_key?(stored, &1))
+
+    fetched =
+      missing
+      |> Task.async_stream(
+        fn uri ->
+          case fetch_and_store_object(uri, signer, false, true) do
+            {:ok, %RemotePost{} = post} -> post
+            _other -> nil
+          end
+        end,
+        max_concurrency: 4,
+        timeout: 20_000,
+        on_timeout: :kill_task
+      )
+      |> Enum.flat_map(fn
+        {:ok, %RemotePost{} = post} -> [post]
+        _other -> []
+      end)
+      # One preload for the whole page rather than one inside each task: the
+      # cards name their authors, and ten answers are ten accounts.
+      |> Repo.preload(:remote_account)
+      |> Map.new(&{&1.object_uri, &1})
+
+    # In the origin's own order, which is the order the thread was written in.
+    uris |> Enum.map(&(Map.get(stored, &1) || Map.get(fetched, &1))) |> Enum.reject(&is_nil/1)
+  end
+
+  defp stored_by_uri(uris) do
+    from(p in RemotePost, where: p.object_uri in ^uris, preload: [:remote_account]) |> Repo.all()
+  end
+
+  # The same gate every other read-side surface asks, plus the audience: an
+  # answer is shown only where its author addressed everybody.
+  defp readable_reply?(%RemotePost{} = post, viewer),
+    do: RemotePost.open?(post) and remote_post_readable?(post, viewer)
 
   # A `nil` is never written over a figure we already hold: it means the server
   # did not tell us this time, not that the number dropped to zero.
@@ -7509,6 +7944,15 @@ defmodule Vutuv.Fediverse do
   defp due_counts_query(schema, age_field, now, ladder, limit) do
     from(r in schema,
       where: r.counts_failures < @counts_max_strikes,
+      # The origins that serve no collection at all are not asked again, and
+      # this is the line that pays for the reply count below. On a copy of
+      # production one such host (flipboard.com) held 1.026 of the 2.627 objects
+      # on the ladder and had never answered with a figure of any kind, while
+      # 2.511 of those 2.627 were overdue — the median asked at 1,9 times its
+      # own interval, the p90 at ten. A batch of 60 every two minutes against
+      # 2.627 objects is one round every 87 minutes, so the five-minute tier at
+      # the head of the ladder was never anything but arithmetic.
+      where: not r.counts_absent,
       order_by: [
         asc_nulls_first: r.counts_checked_at,
         desc: field(r, ^age_field),
@@ -9328,7 +9772,7 @@ defmodule Vutuv.Fediverse do
   # `Event` with a `content` field is not a post. `own_object?/3` is what stops
   # a server speaking for anybody but itself, and the audience gate keeps a
   # followers-only post out entirely.
-  defp fetch_and_store_object(uri, key, quotes?) do
+  defp fetch_and_store_object(uri, key, quotes?, thread_context? \\ false) do
     with :ok <- claim_announce_fetch(uri),
          {:ok, doc} <- fetch_remote_note(uri, key),
          %{} = doc <- remote_post_object(doc),
@@ -9337,7 +9781,7 @@ defmodule Vutuv.Fediverse do
          false <- instance_blocked?(author_uri),
          audience when is_binary(audience) <- announced_audience(doc),
          %RemoteAccount{} = author <- announced_author_account(author_uri, key),
-         {:ok, post} <- insert_remote_post(author, doc, audience) do
+         {:ok, post} <- insert_remote_post(author, doc, audience, thread_context?) do
       {:ok, finish_stored_post(post, doc, quotes?)}
     else
       # Another delivery stored it while this one was fetching; the row is what

--- a/lib/vutuv/fediverse/note.ex
+++ b/lib/vutuv/fediverse/note.ex
@@ -93,6 +93,13 @@ defmodule Vutuv.Fediverse.Note do
     field(:counts_checked_at, :utc_datetime)
     field(:counts_etag, :string)
     field(:counts_failures, :integer, default: 0)
+    field(:counts_absent, :boolean, default: false)
+
+    # And how many answered *this reply* out there — same columns, same clock,
+    # same reason for each of them as on `Vutuv.Fediverse.RemotePost`.
+    field(:replies_count, :integer)
+    field(:replies_checked_at, :utc_datetime)
+    field(:replies_failures, :integer, default: 0)
 
     # The stored account behind `actor_uri`, when we have one (issue #1162).
     # Virtual because a note is keyed to its author by URI, not by a foreign

--- a/lib/vutuv/fediverse/remote_post.ex
+++ b/lib/vutuv/fediverse/remote_post.ex
@@ -109,6 +109,31 @@ defmodule Vutuv.Fediverse.RemotePost do
     field(:counts_etag, :string)
     field(:counts_failures, :integer, default: 0)
 
+    # The origin serves none of the three collections, so it is off the ladder
+    # for good. Set once from a document that answered `200` and carried no
+    # figures at all, which is a fact about that server's software rather than
+    # about its health — hence a flag and not a strike.
+    field(:counts_absent, :boolean, default: false)
+
+    # How many answered it out there, on its own flatter clock beside the two
+    # above (`Vutuv.Fediverse.refresh_counts/1`). Its own columns because the
+    # figure is **counted**, not read: no server we cache serves a `totalItems`
+    # on `replies`, so where a like tally is a field in a document we already
+    # hold, an answer tally is a page fetch of its own — one per 60 answers,
+    # capped, on a ladder that asks a handful of times rather than ninety.
+    #
+    # Null is not zero here either: `replies` is MAY in the spec and some
+    # software (flipboard.com, 19 % of what we cache) serves none of it.
+    field(:replies_count, :integer)
+    field(:replies_checked_at, :utc_datetime)
+    field(:replies_failures, :integer, default: 0)
+
+    # This row exists because a member opened a thread, not because anybody
+    # follows its author. Everything else about it is an ordinary cached post;
+    # what the flag buys is that the surfaces which list **an account's** posts
+    # (the feed, the account page) skip it. See `timeline_scope/1`.
+    field(:thread_context, :boolean, default: false)
+
     # What this post quotes (issue #1609), and whether we may draw it as a card.
     #
     # `quote_uri` is what the author's server said they quoted — the canonical
@@ -192,6 +217,21 @@ defmodule Vutuv.Fediverse.RemotePost do
   audience.
   """
   def open?(%__MODULE__{audience: audience}), do: audience in @open_audiences
+
+  @doc """
+  Narrows a query to the rows that belong on a surface listing **an account's**
+  posts: the feed and the account page, and not an answer somebody pulled in to
+  read a thread.
+
+  One function rather than a `where` at each call site, because the two sides of
+  this have to agree exactly. A thread answer is stored as an ordinary cached
+  post so it can carry a card, an action bar and a report path; the price is
+  that it is now indistinguishable in the tables from a post that arrived
+  because its author is followed. This is where the difference is spelled out,
+  and `fediverse_thread_replies_test.exs` walks every listing surface through
+  it.
+  """
+  def timeline_scope(query), do: Ecto.Query.where(query, [p], not p.thread_context)
 
   @doc """
   Whether the author addressed it to the public collection outright — stricter

--- a/lib/vutuv/feed_band.ex
+++ b/lib/vutuv/feed_band.ex
@@ -101,8 +101,17 @@ defmodule Vutuv.FeedBand do
     from(f in Fediverse.Follow,
       join: a in RemoteAccount,
       on: a.id == f.remote_account_id,
+      # The thread-context condition rides the join rather than going through
+      # `RemotePost.timeline_scope/1`: a `where` on the outer side of a
+      # `left_join` turns it into an inner join, and an account with nothing
+      # recent would drop off the bar entirely. What it keeps out is the same
+      # thing — an answer somebody fetched is not one of this account's posts,
+      # and counting it would move the account up an order the reader reads as
+      # "who has been busy".
       left_join: p in RemotePost,
-      on: p.remote_account_id == a.id and p.published_at > ^utc_since(),
+      on:
+        p.remote_account_id == a.id and p.published_at > ^utc_since() and
+          p.thread_context == false,
       where: f.user_id == ^viewer.id,
       group_by: [a.id, f.muted],
       select: %{account: a, muted: f.muted, posts: count(p.id), last_at: max(p.published_at)}

--- a/lib/vutuv/tags/timeline.ex
+++ b/lib/vutuv/tags/timeline.ex
@@ -301,6 +301,11 @@ defmodule Vutuv.Tags.Timeline do
         where: rp.audience == "public",
         where: rp.expires_at > ^DateTime.utc_now(:second)
       )
+      # Belt and braces on a public page: an answer fetched as thread context
+      # files no hashtags, so it should not be reachable through this join at
+      # all — but this page and the Mastodon hashtag timeline behind it are
+      # public, and "should not be reachable" is a weaker claim than a `where`.
+      |> RemotePost.timeline_scope()
     else
       from(rp in RemotePost, where: false)
     end

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -2061,6 +2061,20 @@ defmodule VutuvWeb.PostComponents do
   attr(:reply_to, :any, default: nil, doc: "the answering page's path, or nil/false for none")
   attr(:repost?, :boolean, default: false)
 
+  attr(:replies, :integer,
+    default: nil,
+    doc:
+      "how many answered it out there; nil where the origin serves no `replies` collection, and then the bar shows no figure rather than a `0` it would be inventing"
+  )
+
+  attr(:replies_open?, :boolean, default: false, doc: "the answers are unfolded under this card")
+
+  attr(:replies_expandable?, :boolean,
+    default: true,
+    doc:
+      "whether the figure is a button. False on a card that is itself inside an unfolded thread, so answers do not nest, and on a dead page where the press would do nothing"
+  )
+
   def remote_actions(assigns) do
     ~H"""
     <%!-- The local action bar's own geometry, deliberately to the pixel
@@ -2100,16 +2114,23 @@ defmodule VutuvWeb.PostComponents do
         <.icon_heart filled?={@liked?} />
       </.remote_action>
 
-      <%!-- A link, not a toggle: answering opens its own page, which is where a
-      member who does not federate yet is told so before they type. --%>
-      <.remote_action_link
+      <%!-- Two targets in one slot, and the gap between them is the design.
+      The glyph is a link — answering opens its own page, which is where a
+      member who does not federate yet is told so before they type — and the
+      figure beside it is a button that unfolds the answers under the card. The
+      alternative was a "show 7 answers" line of its own under the bar, which
+      reads as a second bar; putting the act on the number is what a reader
+      already expects from every other figure up here. What it costs is the
+      chance of hitting the wrong one, so the two keep their own padding and
+      sit a further `gap-2` apart. --%>
+      <.remote_reply_control
         href={@reply_to}
         subject_id={@subject_id}
-        label={gettext("Reply")}
-        shown={@reply_to}
-      >
-        <.icon_reply />
-      </.remote_action_link>
+        target={@target}
+        count={@replies}
+        open?={@replies_open?}
+        expandable?={@replies_expandable?}
+      />
 
       <%!-- `tinted?` for the reason the local bar's repost carries it. --%>
       <.remote_action
@@ -2297,6 +2318,222 @@ defmodule VutuvWeb.PostComponents do
   # appears after something was actually refused.
   def control_id(base, kind, 0), do: "#{base}-#{kind}"
   def control_id(base, kind, reset), do: "#{base}-#{kind}-r#{reset}"
+
+  # The answering slot: a glyph that leads to the answering page, and beside it
+  # the origin's own answer figure, which unfolds the answers where the reader
+  # is standing.
+  #
+  # Two separate targets, which is the one thing to keep about this control. A
+  # single button doing both would have to guess, and the two acts are not
+  # neighbours in meaning: one is "I want to say something", the other is "I
+  # want to read what was said". They keep their own padding and a `gap-2`
+  # between them so a thumb lands on the one it aimed at.
+  attr(:href, :any, required: true)
+  attr(:subject_id, :string, required: true)
+  attr(:target, :any, required: true)
+  attr(:count, :integer, default: nil)
+  attr(:open?, :boolean, default: false)
+  attr(:expandable?, :boolean, default: true)
+
+  # A post whose author narrowed its audience: nothing to answer and nothing to
+  # unfold, so the slot is held open and gives up both its glyph and its figure.
+  defp remote_reply_control(%{href: href} = assigns) when href in [nil, false] do
+    ~H"""
+    <span aria-hidden="true" class="inline-flex px-2 py-1"><span class="h-5 w-5"></span></span>
+    """
+  end
+
+  defp remote_reply_control(assigns) do
+    assigns =
+      assigns
+      |> assign(:figure?, is_integer(assigns.count) and assigns.count > 0)
+      |> assign(:idle_class, @idle_action_class)
+
+    ~H"""
+    <div class="inline-flex items-center gap-2">
+      <.remote_action_link href={@href} subject_id={@subject_id} label={gettext("Reply")}>
+        <.icon_reply />
+      </.remote_action_link>
+
+      <%!-- No figure at all where the origin serves none, and none for a post
+      nobody answered: an empty thread has nothing to unfold, and a `0` that
+      opens onto nothing is a promise the card cannot keep. Inside an unfolded
+      thread the same figure renders as plain text — a reader still wants to
+      know that seven people answered this one, it just does not open a thread
+      within a thread. --%>
+      <button
+        :if={@figure? && @expandable?}
+        type="button"
+        phx-click="replies"
+        phx-target={@target}
+        aria-expanded={to_string(@open?)}
+        aria-label={
+          ngettext("Show the one answer", "Show the %{count} answers", @count, count: @count)
+        }
+        title={ngettext("Show the one answer", "Show the %{count} answers", @count, count: @count)}
+        data-remote-replies={@subject_id}
+        class={[
+          "inline-flex items-center rounded-lg px-2 py-1 text-sm font-medium tabular-nums",
+          "hover:bg-slate-100 dark:hover:bg-slate-800",
+          if(@open?, do: "text-brand-600 dark:text-brand-300", else: @idle_class)
+        ]}
+      >
+        {compact_count(@count)}
+      </button>
+
+      <span
+        :if={@figure? && !@expandable?}
+        class={["px-1 text-sm font-medium tabular-nums", @idle_class]}
+      >{compact_count(@count)}</span>
+    </div>
+    """
+  end
+
+  @doc """
+  What the reader gets when they press that figure: the answers, under the card
+  they belong to.
+
+  Rendered by the action bar itself rather than by each of the seven hosts that
+  draw these cards — the bar already owns the press, and a thread that only
+  unfolded on some of those pages is the copy-per-host problem that bar exists
+  to end.
+
+  Three states in one component, because they are one thing to a reader: what
+  we already hold (painted at once, no network), what is still arriving (the
+  line at the bottom), and what could not be got at all.
+  """
+  attr(:replies, :list, required: true)
+  attr(:viewer, :any, default: nil)
+  attr(:loading?, :boolean, default: false)
+  attr(:more?, :boolean, default: false, doc: "there are further answers to fetch")
+  attr(:notice, :any, default: nil, doc: "why there is nothing (or nothing more) to show")
+  attr(:target, :any, required: true)
+
+  def thread_replies(assigns) do
+    assigns =
+      assigns
+      # The reader's own marks for the whole thread in three queries, not three
+      # per card: each answer's bar would otherwise load its own, in the socket
+      # process, ten cards deep. The same batching every host that draws many
+      # of these cards already does.
+      |> assign(:marks, thread_marks(assigns.viewer, assigns.replies))
+      # And their line budget once rather than per card per render.
+      |> assign(:body_style, post_body_style(User.post_prefs(assigns.viewer)))
+
+    ~H"""
+    <%!-- The left rule is the thread: it says these cards hang under the one
+    above, which is the same thing the conversation view says with an indent. --%>
+    <div
+      class="mt-3 space-y-4 border-l-2 border-slate-200 pl-3 dark:border-slate-700"
+      data-thread-replies
+    >
+      <.thread_reply_card
+        :for={reply <- @replies}
+        reply={reply}
+        viewer={@viewer}
+        body_style={@body_style}
+        marks={Map.get(@marks, reply.id)}
+      />
+
+      <p :if={@loading?} class="text-sm text-slate-500 dark:text-slate-400" role="status">
+        {gettext("Fetching the answers from the servers that hold them…")}
+      </p>
+
+      <p :if={@notice} class="text-sm text-slate-600 dark:text-slate-400" role="status">
+        {@notice}
+      </p>
+
+      <button
+        :if={@more? && !@loading?}
+        type="button"
+        phx-click="more-replies"
+        phx-target={@target}
+        data-thread-more
+        class="text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+      >
+        {gettext("Show more answers")}
+      </button>
+    </div>
+    """
+  end
+
+  # The three marks for a whole unfolded thread, keyed by answer id — the shape
+  # the action bar takes as `marks`.
+  defp thread_marks(nil, _replies), do: %{}
+  defp thread_marks(_viewer, []), do: %{}
+
+  defp thread_marks(viewer, replies) do
+    liked = Fediverse.liked_ids(viewer, replies)
+    reposted = Fediverse.reposted_ids(viewer, replies)
+    bookmarked = Fediverse.bookmarked_ids(viewer, replies)
+
+    Map.new(replies, fn reply ->
+      {reply.id,
+       %{
+         liked?: MapSet.member?(liked, reply.id),
+         reposted?: MapSet.member?(reposted, reply.id),
+         bookmarked?: MapSet.member?(bookmarked, reply.id)
+       }}
+    end)
+  end
+
+  # One answer inside an unfolded thread. The remote skin's own four pieces, in
+  # the order every card from another network wears them, with two things left
+  # out on purpose: the ⋯ menu (this card is not in anybody's feed, and the
+  # report path belongs where the copy is kept) and the reply figure's press,
+  # so a thread cannot unfold inside a thread.
+  attr(:reply, :any, required: true)
+  attr(:viewer, :any, default: nil)
+  attr(:body_style, :any, default: nil)
+  attr(:marks, :any, default: nil, doc: "this answer's like/repost/bookmark flags, batched above")
+
+  defp thread_reply_card(assigns) do
+    account = assigns.reply.remote_account
+
+    assigns =
+      assigns
+      |> assign(:account, account)
+      |> assign(:initials, remote_initials(account))
+
+    ~H"""
+    <article data-thread-reply={@reply.id}>
+      <div class="flex items-start gap-3">
+        <.remote_avatar initials={@initials} src={RemoteAccount.avatar_url(@account)} />
+
+        <div class="min-w-0 flex-1">
+          <.remote_header
+            author={RemoteAccount.label(@account)}
+            handle={RemoteAccount.display_handle(@account)}
+            actor_uri={@account.actor_uri}
+            at={@reply.published_at}
+            network={@account.host}
+            account_id={@account.id}
+            origin={RemotePost.origin(@reply)}
+          />
+
+          <.remote_body
+            warning={RemotePost.warned?(@reply) && @reply.summary}
+            text={@reply.content_text}
+            lang={@reply.language}
+            mode={:preview}
+            body_id={"thread-reply-body-#{@reply.id}"}
+            body_style={@body_style}
+          />
+
+          <.live_component
+            :if={@viewer}
+            module={RemoteActionsComponent}
+            id={RemoteActionsComponent.dom_id(@reply)}
+            subject={@reply}
+            viewer={@viewer}
+            marks={@marks}
+            nested?={true}
+          />
+        </div>
+      </div>
+    </article>
+    """
+  end
 
   # The answering control: the same slot and the same look, but a link.
   attr(:href, :any, required: true)

--- a/lib/vutuv_web/live/post_live/remote_actions_component.ex
+++ b/lib/vutuv_web/live/post_live/remote_actions_component.ex
@@ -41,7 +41,8 @@ defmodule VutuvWeb.PostLive.RemoteActionsComponent do
   """
   use VutuvWeb, :live_component
 
-  import VutuvWeb.PostComponents, only: [remote_actions: 1, like_refusal_message: 2]
+  import VutuvWeb.PostComponents,
+    only: [remote_actions: 1, like_refusal_message: 2, thread_replies: 1]
 
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Note
@@ -99,6 +100,13 @@ defmodule VutuvWeb.PostLive.RemoteActionsComponent do
      # `assign_new` like the marks below: a host re-render must not undo the
      # figure this bar has already nudged for the reader's own press.
      |> assign_new(:counts, fn -> Fediverse.counts(assigns.subject) end)
+     # A card inside an unfolded thread does not unfold a thread of its own.
+     |> assign(:nested?, assigns[:nested?] == true)
+     |> assign_new(:replies_open?, fn -> false end)
+     |> assign_new(:replies, fn -> [] end)
+     |> assign_new(:replies_pending, fn -> [] end)
+     |> assign_new(:replies_loading?, fn -> false end)
+     |> assign_new(:replies_notice, fn -> nil end)
      # `assign_new`, like the local bar: the first pass takes what the host
      # batched (or loads its own), and later host re-renders keep the copy this
      # bar may have toggled since — re-applying a stale preload would undo the
@@ -120,7 +128,38 @@ defmodule VutuvWeb.PostLive.RemoteActionsComponent do
 
   defp marked?(ids, subject), do: MapSet.member?(ids, subject.id)
 
+  # The reader pressed the answer figure. What we already hold is painted at
+  # once — it costs one indexed query and no network — and the fetch that fills
+  # in the rest runs behind it, because it is a request per answer to servers
+  # that are usually neither ours nor the origin's. A press while the thread is
+  # open folds it again.
   @impl true
+  def handle_event("replies", _params, %{assigns: %{replies_open?: true}} = socket),
+    do: {:noreply, assign(socket, :replies_open?, false)}
+
+  def handle_event("replies", _params, socket) do
+    %{subject: subject, viewer: viewer, counts: counts} = socket.assigns
+    stored = Fediverse.stored_thread_replies(subject, viewer, limit: Fediverse.thread_page())
+
+    socket =
+      socket
+      |> assign(:replies_open?, true)
+      |> assign(:replies, stored)
+      |> assign(:replies_notice, nil)
+
+    # A second press on a card whose answers are all here already asks nobody
+    # anything. The figure is the origin's own, so "as many as it said" is the
+    # honest test for having them all — a page reopened while reading is the
+    # commonest press there is, and it must not spend somebody's server time.
+    if complete?(stored, counts.replies),
+      do: {:noreply, assign(socket, :replies_pending, [])},
+      else: {:noreply, load_replies(socket, [])}
+  end
+
+  def handle_event("more-replies", _params, socket) do
+    {:noreply, load_replies(socket, socket.assigns.replies_pending)}
+  end
+
   def handle_event("toggle", %{"act" => act}, socket) do
     %{subject: subject, viewer: viewer, marks: marks} = socket.assigns
     on? = Map.fetch!(marks, flag(act))
@@ -142,6 +181,88 @@ defmodule VutuvWeb.PostLive.RemoteActionsComponent do
         {:noreply, socket |> refusal(reason, subject) |> ActionBar.take_paint_back(true)}
     end
   end
+
+  defp complete?(stored, count) when is_integer(count), do: length(stored) >= count
+  defp complete?(_stored, _count), do: false
+
+  # The fetch itself, off the socket's own process: a card in a feed of twenty
+  # must not hold up the page while a stranger's server thinks about it, and
+  # `Fediverse.fetch_thread_replies/3` talks to one server per answer.
+  defp load_replies(socket, pending) do
+    %{subject: subject, viewer: viewer} = socket.assigns
+
+    socket
+    |> assign(:replies_loading?, true)
+    |> start_async(:thread_replies, fn ->
+      Fediverse.fetch_thread_replies(viewer, subject, pending: pending)
+    end)
+  end
+
+  @impl true
+  def handle_async(:thread_replies, {:ok, {:ok, page}}, socket) do
+    # In the origin's own order and without repeats: the stored half painted
+    # first, and the fetch answers with the same rows plus what it went to get.
+    replies =
+      (socket.assigns.replies ++ page.replies)
+      |> Enum.uniq_by(& &1.id)
+
+    {:noreply,
+     socket
+     |> assign(:replies, replies)
+     |> assign(:replies_pending, page.pending)
+     |> assign(:replies_loading?, false)
+     |> assign(
+       :replies_notice,
+       thread_notice(replies, page.pending, socket.assigns.counts.replies)
+     )}
+  end
+
+  def handle_async(:thread_replies, {:ok, {:error, reason}}, socket) do
+    {:noreply,
+     socket
+     |> assign(:replies_loading?, false)
+     |> assign(:replies_notice, thread_refusal(reason, socket.assigns.replies))}
+  end
+
+  # The task itself died (a timeout, a crash). The same sentence as a refusal:
+  # what a reader can do about it is identical, which is come back later.
+  def handle_async(:thread_replies, {:exit, _reason}, socket) do
+    {:noreply,
+     socket
+     |> assign(:replies_loading?, false)
+     |> assign(:replies_notice, thread_refusal(:unavailable, socket.assigns.replies))}
+  end
+
+  # A thread whose answers we could reach and which turned out to hold none the
+  # reader may see: everything in it was addressed to followers, or came from an
+  # instance this installation blocks. Silence would read as a broken button.
+  defp thread_notice([], _pending, _count),
+    do: gettext("Nothing here we are allowed to show you.")
+
+  # Fewer cards than the figure promised, and nothing left to press for. The
+  # gap is ordinary and it is not ours: an answer may have been deleted since
+  # the count, or its server may not answer us at all — one of six in the first
+  # real thread this was tried on came from an instance that refused the
+  # request. The figure is the origin's own and stays as it is; what would be
+  # wrong is letting the reader count the cards and wonder.
+  defp thread_notice(replies, [], count) when is_integer(count) do
+    if length(replies) < count,
+      do: gettext("Not every answer could be fetched. The rest are on the origin server."),
+      else: nil
+  end
+
+  defp thread_notice(_replies, _pending, _count), do: nil
+
+  defp thread_refusal(:capped, _replies),
+    do: gettext("That is enough answers fetched for one hour. Try again later.")
+
+  # With something on screen already, the sentence is about the rest; with
+  # nothing, it is about the whole thread.
+  defp thread_refusal(_reason, []),
+    do: gettext("The answers could not be fetched from the servers that hold them.")
+
+  defp thread_refusal(_reason, _replies),
+    do: gettext("The rest could not be fetched right now.")
 
   # A refusal, and for the one a member can do something about, the way there
   # (issue #1349). A sentence that names a setting and then leaves them to find
@@ -241,6 +362,10 @@ defmodule VutuvWeb.PostLive.RemoteActionsComponent do
 
     ~H"""
     <div>
+      <%!-- `replies_expandable?` says only whether this card may unfold a
+      thread of its own: false inside one, so answers do not nest. Whether the
+      figure is there at all, and whether there is an answering path beside it,
+      the control works out from the post itself. --%>
       <.remote_actions
         id={@id}
         target={@myself}
@@ -253,9 +378,22 @@ defmodule VutuvWeb.PostLive.RemoteActionsComponent do
         bookmarked?={@marks.bookmarked?}
         likes={@counts.likes}
         shares={@counts.shares}
+        replies={@counts.replies}
+        replies_open?={@replies_open?}
+        replies_expandable?={!@nested?}
         like?={@offer.like?}
         reply_to={@offer.reply_to}
         repost?={@offer.repost?}
+      />
+
+      <.thread_replies
+        :if={@replies_open?}
+        replies={@replies}
+        viewer={@viewer}
+        loading?={@replies_loading?}
+        more?={@replies_pending != []}
+        notice={@replies_notice}
+        target={@myself}
       />
       <%!-- Beside the control that refused, in the reader's own words. The one
       refusal a member can act on says what to do about it; the rest say only

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -15,8 +15,8 @@ msgstr "Language: de\n"
 msgid "About us"
 msgstr "Impressum"
 
-#: lib/vutuv_web/components/ui.ex:4811
-#: lib/vutuv_web/components/ui.ex:4816
+#: lib/vutuv_web/components/ui.ex:4845
+#: lib/vutuv_web/components/ui.ex:4850
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
 #: lib/vutuv_web/live/organization_live/domains.ex:287
@@ -62,7 +62,7 @@ msgstr "Eine Adresse wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/text.ex:71
-#: lib/vutuv_web/components/ui.ex:5148
+#: lib/vutuv_web/components/ui.ex:5182
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -75,14 +75,14 @@ msgstr "Eine Adresse wurde geändert."
 msgid "Addresses"
 msgstr "Adressen"
 
-#: lib/vutuv_web/components/ui.ex:1732
+#: lib/vutuv_web/components/ui.ex:1766
 #: lib/vutuv_web/templates/page/index.html.heex:325
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr "Schon ein Mitglied? Einloggen."
 
-#: lib/vutuv_web/components/ui.ex:4602
-#: lib/vutuv_web/components/ui.ex:4701
+#: lib/vutuv_web/components/ui.ex:4636
+#: lib/vutuv_web/components/ui.ex:4735
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -110,8 +110,8 @@ msgid "Birthday"
 msgstr "Geburtstag"
 
 #: lib/vutuv_web/components/saved_search_components.ex:104
-#: lib/vutuv_web/components/ui.ex:4596
-#: lib/vutuv_web/components/video_components.ex:280
+#: lib/vutuv_web/components/ui.ex:4630
+#: lib/vutuv_web/components/video_components.ex:281
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
 #: lib/vutuv_web/live/admin/user_delete_live.ex:202
@@ -163,8 +163,8 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:3880
-#: lib/vutuv_web/components/ui.ex:4703
+#: lib/vutuv_web/components/post_components.ex:4164
+#: lib/vutuv_web/components/ui.ex:4737
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:657
@@ -211,8 +211,8 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:3845
-#: lib/vutuv_web/components/ui.ex:4694
+#: lib/vutuv_web/components/post_components.ex:4129
+#: lib/vutuv_web/components/ui.ex:4728
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
@@ -286,7 +286,7 @@ msgstr "E-Mail-Adresse eingeben"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:5112
+#: lib/vutuv_web/components/ui.ex:5146
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -326,8 +326,8 @@ msgstr "Follower"
 #: lib/vutuv_web/agent_docs/markdown.ex:698
 #: lib/vutuv_web/agent_docs/text.ex:658
 #: lib/vutuv_web/components/fediverse_components.ex:468
-#: lib/vutuv_web/components/ui.ex:3029
-#: lib/vutuv_web/components/ui.ex:3064
+#: lib/vutuv_web/components/ui.ex:3063
+#: lib/vutuv_web/components/ui.ex:3098
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:618
@@ -475,7 +475,7 @@ msgstr "Mehr"
 msgid "Name"
 msgstr "Name"
 
-#: lib/vutuv_web/components/post_components.ex:793
+#: lib/vutuv_web/components/post_components.ex:806
 #: lib/vutuv_web/live/notification_live/index.ex:777
 #: lib/vutuv_web/live/organization_live/activity.ex:136
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -615,7 +615,7 @@ msgstr "Provider"
 msgid "Public"
 msgstr "Öffentlich"
 
-#: lib/vutuv_web/components/ui.ex:4595
+#: lib/vutuv_web/components/ui.ex:4629
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2201
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -659,7 +659,7 @@ msgstr "Speichern"
 msgid "Search"
 msgstr "Suche"
 
-#: lib/vutuv_web/components/post_components.ex:1812
+#: lib/vutuv_web/components/post_components.ex:1852
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -792,7 +792,7 @@ msgstr "Profil aktualisiert."
 msgid "User verified successfully."
 msgstr "User wurde verifiziert."
 
-#: lib/vutuv_web/components/ui.ex:5108
+#: lib/vutuv_web/components/ui.ex:5142
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:832
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -844,7 +844,7 @@ msgstr "Benutzername"
 msgid "Users"
 msgstr "Benutzer"
 
-#: lib/vutuv_web/components/ui.ex:1539
+#: lib/vutuv_web/components/ui.ex:1573
 #: lib/vutuv_web/views/user_html.ex:582
 #: lib/vutuv_web/views/user_html.ex:583
 #: lib/vutuv_web/views/user_html.ex:597
@@ -852,14 +852,14 @@ msgstr "Benutzer"
 msgid "vCard"
 msgstr "vCard"
 
-#: lib/vutuv_web/components/ui.ex:4764
+#: lib/vutuv_web/components/ui.ex:4798
 #: lib/vutuv_web/templates/user/show.html.heex:982
 #: lib/vutuv_web/templates/user/show.html.heex:1005
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
 
-#: lib/vutuv_web/components/ui.ex:5271
+#: lib/vutuv_web/components/ui.ex:5305
 #: lib/vutuv_web/controllers/settings_controller.ex:175
 #: lib/vutuv_web/live/job_posting_live/form.ex:818
 #: lib/vutuv_web/live/organization_live/edit.ex:339
@@ -1199,7 +1199,7 @@ msgstr "Alle Tag-Synonyme"
 msgid "All tag urls"
 msgstr "Alle Tag-URLs"
 
-#: lib/vutuv_web/components/post_components.ex:4487
+#: lib/vutuv_web/components/post_components.ex:4779
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:638
@@ -1374,7 +1374,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:584
 #: lib/vutuv_web/agent_docs/text.ex:850
-#: lib/vutuv_web/components/ui.ex:5133
+#: lib/vutuv_web/components/ui.ex:5167
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1622,7 +1622,7 @@ msgstr "Zur Startseite"
 msgid "Check your inbox"
 msgstr "Schauen Sie in Ihr Postfach"
 
-#: lib/vutuv_web/components/ui.ex:3188
+#: lib/vutuv_web/components/ui.ex:3222
 #: lib/vutuv_web/components/welcome_components.ex:125
 #: lib/vutuv_web/components/welcome_components.ex:131
 #: lib/vutuv_web/live/admin/job_live.ex:321
@@ -1681,20 +1681,20 @@ msgstr "Mein Konto löschen"
 msgid "Edit profile"
 msgstr "Profil bearbeiten"
 
-#: lib/vutuv_web/components/ui.ex:2271
-#: lib/vutuv_web/components/ui.ex:2280
-#: lib/vutuv_web/components/ui.ex:2758
+#: lib/vutuv_web/components/ui.ex:2305
+#: lib/vutuv_web/components/ui.ex:2314
+#: lib/vutuv_web/components/ui.ex:2792
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr "Empfehlen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:244
-#: lib/vutuv_web/components/ui.ex:2994
-#: lib/vutuv_web/components/ui.ex:2994
-#: lib/vutuv_web/components/ui.ex:3011
-#: lib/vutuv_web/components/ui.ex:3020
-#: lib/vutuv_web/components/ui.ex:3036
-#: lib/vutuv_web/components/ui.ex:3098
+#: lib/vutuv_web/components/ui.ex:3028
+#: lib/vutuv_web/components/ui.ex:3028
+#: lib/vutuv_web/components/ui.ex:3045
+#: lib/vutuv_web/components/ui.ex:3054
+#: lib/vutuv_web/components/ui.ex:3070
+#: lib/vutuv_web/components/ui.ex:3132
 #: lib/vutuv_web/live/fediverse_account_live.ex:422
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:320
@@ -1762,8 +1762,8 @@ msgstr "Nachrichten"
 msgid "Network"
 msgstr "Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:472
-#: lib/vutuv_web/components/ui.ex:4813
+#: lib/vutuv_web/components/post_components.ex:485
+#: lib/vutuv_web/components/ui.ex:4847
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
@@ -1779,7 +1779,7 @@ msgid "Nothing new yet."
 msgstr "Noch nichts Neues."
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:5170
+#: lib/vutuv_web/components/ui.ex:5204
 #: lib/vutuv_web/controllers/page_controller.ex:219
 #: lib/vutuv_web/live/notification_live/index.ex:155
 #: lib/vutuv_web/live/notification_live/index.ex:441
@@ -1924,14 +1924,14 @@ msgstr "ist jetzt mit Ihnen vernetzt."
 msgid "started following you."
 msgstr "folgt Ihnen jetzt."
 
-#: lib/vutuv_web/components/ui.ex:4096
-#: lib/vutuv_web/components/ui.ex:4241
+#: lib/vutuv_web/components/ui.ex:4130
+#: lib/vutuv_web/components/ui.ex:4275
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr "Seitennavigation"
 
-#: lib/vutuv_web/components/ui.ex:4838
+#: lib/vutuv_web/components/ui.ex:4872
 #: lib/vutuv_web/live/organization_live/activity.ex:159
 #: lib/vutuv_web/live/organization_live/feed.ex:258
 #: lib/vutuv_web/live/organization_live/show.ex:787
@@ -1946,13 +1946,13 @@ msgstr ""
 "Die Adresse selbst kann nicht geändert werden. Um eine andere zu verwenden, "
 "legen Sie sie als neue E-Mail-Adresse an und löschen Sie diese hier."
 
-#: lib/vutuv_web/components/ui.ex:4605
+#: lib/vutuv_web/components/ui.ex:4639
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Eintrag löschen"
 
-#: lib/vutuv_web/components/ui.ex:1934
-#: lib/vutuv_web/components/ui.ex:1944
+#: lib/vutuv_web/components/ui.ex:1968
+#: lib/vutuv_web/components/ui.ex:1978
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr "Optionen"
@@ -1991,12 +1991,12 @@ msgstr "Titelbild hinzufügen"
 msgid "Add cover photo"
 msgstr "Titelbild hinzufügen"
 
-#: lib/vutuv_web/components/ui.ex:3555
+#: lib/vutuv_web/components/ui.ex:3589
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr "April"
 
-#: lib/vutuv_web/components/ui.ex:3559
+#: lib/vutuv_web/components/ui.ex:3593
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr "August"
@@ -2022,37 +2022,37 @@ msgstr "Titelbild"
 msgid "Cover photo of %{name}"
 msgstr "Titelbild von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:3563
+#: lib/vutuv_web/components/ui.ex:3597
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr "Dezember"
 
-#: lib/vutuv_web/components/ui.ex:3553
+#: lib/vutuv_web/components/ui.ex:3587
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr "Februar"
 
-#: lib/vutuv_web/components/ui.ex:3552
+#: lib/vutuv_web/components/ui.ex:3586
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr "Januar"
 
-#: lib/vutuv_web/components/ui.ex:3558
+#: lib/vutuv_web/components/ui.ex:3592
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr "Juli"
 
-#: lib/vutuv_web/components/ui.ex:3557
+#: lib/vutuv_web/components/ui.ex:3591
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr "Juni"
 
-#: lib/vutuv_web/components/ui.ex:3554
+#: lib/vutuv_web/components/ui.ex:3588
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr "März"
 
-#: lib/vutuv_web/components/ui.ex:3556
+#: lib/vutuv_web/components/ui.ex:3590
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr "Mai"
@@ -2067,17 +2067,17 @@ msgstr "Mitglied seit %{month} %{year}"
 msgid "Member since %{year}"
 msgstr "Mitglied seit %{year}"
 
-#: lib/vutuv_web/components/ui.ex:3562
+#: lib/vutuv_web/components/ui.ex:3596
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr "November"
 
-#: lib/vutuv_web/components/ui.ex:3561
+#: lib/vutuv_web/components/ui.ex:3595
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr "Oktober"
 
-#: lib/vutuv_web/components/ui.ex:3560
+#: lib/vutuv_web/components/ui.ex:3594
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr "September"
@@ -2116,7 +2116,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:3877
+#: lib/vutuv_web/components/post_components.ex:4161
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2161,8 +2161,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:3831
-#: lib/vutuv_web/components/post_components.ex:3833
+#: lib/vutuv_web/components/post_components.ex:4115
+#: lib/vutuv_web/components/post_components.ex:4117
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2178,7 +2178,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3576
+#: lib/vutuv_web/live/post_live/feed.ex:3583
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2229,13 +2229,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:4360
-#: lib/vutuv_web/components/post_components.ex:4364
+#: lib/vutuv_web/components/post_components.ex:4652
+#: lib/vutuv_web/components/post_components.ex:4656
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:4361
+#: lib/vutuv_web/components/post_components.ex:4653
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2245,7 +2245,7 @@ msgstr "Weniger anzeigen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:497
 #: lib/vutuv_web/components/job_exclusion_components.ex:189
-#: lib/vutuv_web/components/post_components.ex:1421
+#: lib/vutuv_web/components/post_components.ex:1461
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:229
@@ -2313,7 +2313,7 @@ msgstr "Zu viele Dateien."
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
-#: lib/vutuv_web/components/ui.ex:5515
+#: lib/vutuv_web/components/ui.ex:5549
 #: lib/vutuv_web/live/shell_live.ex:1582
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2332,32 +2332,32 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:3828
+#: lib/vutuv_web/components/post_components.ex:4112
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:5984
+#: lib/vutuv_web/components/post_components.ex:6278
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:5988
+#: lib/vutuv_web/components/post_components.ex:6282
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:5986
+#: lib/vutuv_web/components/post_components.ex:6280
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:5987
+#: lib/vutuv_web/components/post_components.ex:6281
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
 
-#: lib/vutuv_web/components/ui.ex:3633
+#: lib/vutuv_web/components/ui.ex:3667
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
@@ -2396,9 +2396,9 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:2104
-#: lib/vutuv_web/components/post_components.ex:6084
-#: lib/vutuv_web/components/ui.ex:4163
+#: lib/vutuv_web/components/post_components.ex:2165
+#: lib/vutuv_web/components/post_components.ex:6378
+#: lib/vutuv_web/components/ui.ex:4197
 #: lib/vutuv_web/views/user_html.ex:481
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2415,9 +2415,9 @@ msgstr "Lesezeichen setzen"
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:2055
-#: lib/vutuv_web/components/post_components.ex:6322
-#: lib/vutuv_web/components/ui.ex:4149
+#: lib/vutuv_web/components/post_components.ex:2109
+#: lib/vutuv_web/components/post_components.ex:6616
+#: lib/vutuv_web/components/ui.ex:4183
 #: lib/vutuv_web/notification_line.ex:293
 #: lib/vutuv_web/views/user_html.ex:491
 #, elixir-autogen, elixir-format
@@ -2425,7 +2425,7 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1263
-#: lib/vutuv_web/components/post_components.ex:6332
+#: lib/vutuv_web/components/post_components.ex:6626
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1590
@@ -2446,40 +2446,40 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:6072
+#: lib/vutuv_web/components/post_components.ex:6366
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:2103
-#: lib/vutuv_web/components/post_components.ex:6083
+#: lib/vutuv_web/components/post_components.ex:2164
+#: lib/vutuv_web/components/post_components.ex:6377
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:481
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:2084
-#: lib/vutuv_web/components/post_components.ex:6068
+#: lib/vutuv_web/components/post_components.ex:2145
+#: lib/vutuv_web/components/post_components.ex:6362
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:2372
-#: lib/vutuv_web/components/post_components.ex:5091
+#: lib/vutuv_web/components/post_components.ex:2649
+#: lib/vutuv_web/components/post_components.ex:5384
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:2083
-#: lib/vutuv_web/components/post_components.ex:6067
+#: lib/vutuv_web/components/post_components.ex:2144
+#: lib/vutuv_web/components/post_components.ex:6361
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:2054
-#: lib/vutuv_web/components/post_components.ex:6321
+#: lib/vutuv_web/components/post_components.ex:2108
+#: lib/vutuv_web/components/post_components.ex:6615
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:491
 #, elixir-autogen, elixir-format
@@ -2487,10 +2487,10 @@ msgid "Unlike"
 msgstr "Gefällt mir entfernen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:498
-#: lib/vutuv_web/components/post_components.ex:2855
-#: lib/vutuv_web/components/ui.ex:2989
-#: lib/vutuv_web/components/ui.ex:2989
-#: lib/vutuv_web/components/ui.ex:3065
+#: lib/vutuv_web/components/post_components.ex:3135
+#: lib/vutuv_web/components/ui.ex:3023
+#: lib/vutuv_web/components/ui.ex:3023
+#: lib/vutuv_web/components/ui.ex:3099
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
 #: lib/vutuv_web/live/organization_live/show.ex:621
@@ -2507,20 +2507,20 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:6376
+#: lib/vutuv_web/components/post_components.ex:6670
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
-#: lib/vutuv_web/components/post_components.ex:430
+#: lib/vutuv_web/components/post_components.ex:443
 #: lib/vutuv_web/live/notification_live/index.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2068
-#: lib/vutuv_web/components/post_components.ex:6359
-#: lib/vutuv_web/components/post_components.ex:6360
+#: lib/vutuv_web/components/post_components.ex:2354
+#: lib/vutuv_web/components/post_components.ex:6653
+#: lib/vutuv_web/components/post_components.ex:6654
 #: lib/vutuv_web/live/notification_live/index.ex:994
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:290
@@ -2528,7 +2528,7 @@ msgstr "Antworten"
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:3795
+#: lib/vutuv_web/components/post_components.ex:4075
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2549,7 +2549,7 @@ msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beitr
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/components/post_components.ex:3321
+#: lib/vutuv_web/components/post_components.ex:3601
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2557,14 +2557,14 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:3767
+#: lib/vutuv_web/components/post_components.ex:4047
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:3758
-#: lib/vutuv_web/components/post_components.ex:3787
-#: lib/vutuv_web/components/post_components.ex:3790
+#: lib/vutuv_web/components/post_components.ex:4038
+#: lib/vutuv_web/components/post_components.ex:4067
+#: lib/vutuv_web/components/post_components.ex:4070
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2625,7 +2625,7 @@ msgstr "Mitglied nicht gefunden."
 msgid "No conversations yet."
 msgstr "Noch keine Unterhaltungen."
 
-#: lib/vutuv_web/components/ui.ex:3312
+#: lib/vutuv_web/components/ui.ex:3346
 #: lib/vutuv_web/live/message_live/index.ex:760
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2714,7 +2714,7 @@ msgstr "Eine neue PIN ist unterwegs zu Ihrer E-Mail-Adresse."
 msgid "Okay, let's start over."
 msgstr "Alles klar, fangen wir neu an."
 
-#: lib/vutuv_web/components/ui.ex:862
+#: lib/vutuv_web/components/ui.ex:869
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr "PIN erneut senden"
@@ -2725,7 +2725,7 @@ msgstr "PIN erneut senden"
 msgid "Too many PIN requests. Please try again later."
 msgstr "Zu viele PIN-Anfragen. Bitte versuchen Sie es später erneut."
 
-#: lib/vutuv_web/components/ui.ex:883
+#: lib/vutuv_web/components/ui.ex:890
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr "Andere E-Mail-Adresse verwenden"
@@ -2775,8 +2775,8 @@ msgstr "Berufserfahrung hinzufügen"
 msgid "Write your first post"
 msgstr "Ersten Beitrag schreiben"
 
-#: lib/vutuv_web/components/ui.ex:4329
-#: lib/vutuv_web/components/ui.ex:4766
+#: lib/vutuv_web/components/ui.ex:4363
+#: lib/vutuv_web/components/ui.ex:4800
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:109
@@ -2789,7 +2789,7 @@ msgstr "Ersten Beitrag schreiben"
 msgid "Manage"
 msgstr "Verwalten"
 
-#: lib/vutuv_web/components/post_components.ex:870
+#: lib/vutuv_web/components/post_components.ex:883
 #: lib/vutuv_web/controllers/page_controller.ex:216
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2827,7 +2827,7 @@ msgstr[1] "+%{formatted} weitere Tags"
 msgid "Connections"
 msgstr "Vernetzungen"
 
-#: lib/vutuv_web/components/ui.ex:1530
+#: lib/vutuv_web/components/ui.ex:1564
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr "Markdown"
@@ -2837,7 +2837,7 @@ msgstr "Markdown"
 msgid "No connections yet."
 msgstr "Noch keine Vernetzungen."
 
-#: lib/vutuv_web/components/ui.ex:1546
+#: lib/vutuv_web/components/ui.ex:1580
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr "Andere Formate"
@@ -2847,7 +2847,7 @@ msgstr "Andere Formate"
 msgid "People who aren't my connections"
 msgstr "Personen, mit denen ich nicht vernetzt bin"
 
-#: lib/vutuv_web/components/ui.ex:1531
+#: lib/vutuv_web/components/ui.ex:1565
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr "Nur Text"
@@ -2865,7 +2865,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:5985
+#: lib/vutuv_web/components/post_components.ex:6279
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -3140,7 +3140,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:3734
+#: lib/vutuv_web/components/post_components.ex:4014
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3188,7 +3188,7 @@ msgstr ""
 msgid "Private message"
 msgstr "Private Nachricht"
 
-#: lib/vutuv_web/components/ui.ex:5102
+#: lib/vutuv_web/components/ui.ex:5136
 #: lib/vutuv_web/live/shell_live.ex:1373
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3213,9 +3213,9 @@ msgstr "Abgelehnt"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
-#: lib/vutuv_web/components/post_components.ex:1434
-#: lib/vutuv_web/components/post_components.ex:2875
-#: lib/vutuv_web/components/post_components.ex:3944
+#: lib/vutuv_web/components/post_components.ex:1474
+#: lib/vutuv_web/components/post_components.ex:3155
+#: lib/vutuv_web/components/post_components.ex:4228
 #: lib/vutuv_web/live/organization_live/show.ex:661
 #: lib/vutuv_web/templates/user/show.html.heex:242
 #, elixir-autogen, elixir-format
@@ -3301,7 +3301,7 @@ msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 "Meldungen sind anonym; wir verraten nie, wer gemeldet hat. Unsere Regeln:"
 
-#: lib/vutuv_web/components/ui.ex:4011
+#: lib/vutuv_web/components/ui.ex:4045
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -4438,12 +4438,12 @@ msgstr "Buchbar bis einschließlich %{last}."
 msgid "Bookings are open through %{last}. Next available day: %{day}"
 msgstr "Buchbar bis einschließlich %{last}. Nächster freier Tag: %{day}"
 
-#: lib/vutuv_web/components/ui.ex:3585
+#: lib/vutuv_web/components/ui.ex:3619
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr "Fr"
 
-#: lib/vutuv_web/components/ui.ex:3581
+#: lib/vutuv_web/components/ui.ex:3615
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr "Mo"
@@ -4455,27 +4455,27 @@ msgstr ""
 "Eine Anzeige pro Kalendertag: Wählen Sie einen freien Tag im Kalender; "
 "durchgestrichene Tage sind bereits vergeben."
 
-#: lib/vutuv_web/components/ui.ex:3586
+#: lib/vutuv_web/components/ui.ex:3620
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr "Sa"
 
-#: lib/vutuv_web/components/ui.ex:3587
+#: lib/vutuv_web/components/ui.ex:3621
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr "So"
 
-#: lib/vutuv_web/components/ui.ex:3584
+#: lib/vutuv_web/components/ui.ex:3618
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr "Do"
 
-#: lib/vutuv_web/components/ui.ex:3582
+#: lib/vutuv_web/components/ui.ex:3616
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr "Di"
 
-#: lib/vutuv_web/components/ui.ex:3583
+#: lib/vutuv_web/components/ui.ex:3617
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr "Mi"
@@ -4619,7 +4619,7 @@ msgstr ""
 "beide Richtungen unterbunden. Eine Aufhebung der Blockierung stellt das "
 "Entfernte nicht wieder her."
 
-#: lib/vutuv_web/components/ui.ex:5275
+#: lib/vutuv_web/components/ui.ex:5309
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4668,7 +4668,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3581
+#: lib/vutuv_web/live/post_live/feed.ex:3588
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -4750,8 +4750,8 @@ msgstr ""
 msgid "Similar names"
 msgstr "Ähnliche Namen"
 
-#: lib/vutuv_web/components/post_components.ex:427
-#: lib/vutuv_web/components/post_components.ex:446
+#: lib/vutuv_web/components/post_components.ex:440
+#: lib/vutuv_web/components/post_components.ex:459
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -5442,7 +5442,7 @@ msgstr "API-Token (%{date})"
 msgid "API documentation"
 msgstr "API-Dokumentation"
 
-#: lib/vutuv_web/components/ui.ex:5325
+#: lib/vutuv_web/components/ui.ex:5359
 #: lib/vutuv_web/controllers/settings_controller.ex:161
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:439
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5526,10 +5526,10 @@ msgstr "Tastaturkürzel"
 msgid "Navigation"
 msgstr "Navigation"
 
-#: lib/vutuv_web/components/ui.ex:5422
-#: lib/vutuv_web/components/ui.ex:5427
-#: lib/vutuv_web/components/ui.ex:5506
-#: lib/vutuv_web/components/ui.ex:5570
+#: lib/vutuv_web/components/ui.ex:5456
+#: lib/vutuv_web/components/ui.ex:5461
+#: lib/vutuv_web/components/ui.ex:5540
+#: lib/vutuv_web/components/ui.ex:5604
 #: lib/vutuv_web/controllers/settings_controller.ex:68
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5599,9 +5599,9 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:4022
-#: lib/vutuv_web/components/post_components.ex:4074
-#: lib/vutuv_web/components/post_components.ex:4608
+#: lib/vutuv_web/components/post_components.ex:4306
+#: lib/vutuv_web/components/post_components.ex:4358
+#: lib/vutuv_web/components/post_components.ex:4900
 #: lib/vutuv_web/live/notification_live/index.ex:1070
 #: lib/vutuv_web/views/user_html.ex:131
 #, elixir-autogen, elixir-format
@@ -5647,7 +5647,7 @@ msgstr "Art der E-Mail-Adresse"
 msgid "About you"
 msgstr "Über Sie"
 
-#: lib/vutuv_web/components/ui.ex:5295
+#: lib/vutuv_web/components/ui.ex:5329
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5669,7 +5669,7 @@ msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 "Laden Sie alles herunter, was vutuv über Sie speichert, als eine Datei."
 
-#: lib/vutuv_web/components/ui.ex:5140
+#: lib/vutuv_web/components/ui.ex:5174
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5704,7 +5704,7 @@ msgstr "Persönliche Tokens für die vutuv-API."
 msgid "Photos"
 msgstr "Fotos"
 
-#: lib/vutuv_web/components/ui.ex:5269
+#: lib/vutuv_web/components/ui.ex:5303
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -5818,7 +5818,7 @@ msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/vutuv_web/components/ui.ex:5318
+#: lib/vutuv_web/components/ui.ex:5352
 #: lib/vutuv_web/controllers/settings_controller.ex:185
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -6026,21 +6026,21 @@ msgid "Sort"
 msgstr "Sortieren"
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3649
+#: lib/vutuv_web/components/ui.ex:3683
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "vor %{count} Tag"
 msgstr[1] "vor %{count} Tagen"
 
-#: lib/vutuv_web/components/ui.ex:3648
+#: lib/vutuv_web/components/ui.ex:3682
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "vor %{count} Stunde"
 msgstr[1] "vor %{count} Stunden"
 
-#: lib/vutuv_web/components/ui.ex:3647
+#: lib/vutuv_web/components/ui.ex:3681
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -6109,7 +6109,7 @@ msgstr ""
 "Das ist die erste Anmeldung, die wir von diesem Gerät oder Browser gesehen "
 "haben."
 
-#: lib/vutuv_web/components/ui.ex:3646
+#: lib/vutuv_web/components/ui.ex:3680
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "gerade eben"
@@ -6261,7 +6261,7 @@ msgstr "Kurzbeschreibung hinzufügen"
 msgid "Tagline"
 msgstr "Kurzbeschreibung"
 
-#: lib/vutuv_web/components/ui.ex:480
+#: lib/vutuv_web/components/ui.ex:487
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:916
@@ -6415,7 +6415,7 @@ msgid "Previous day"
 msgstr "Vorheriger Tag"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1263
-#: lib/vutuv_web/components/post_components.ex:429
+#: lib/vutuv_web/components/post_components.ex:442
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6454,9 +6454,9 @@ msgstr "Nach unten"
 msgid "Move up"
 msgstr "Nach oben"
 
-#: lib/vutuv_web/components/ui.ex:2271
-#: lib/vutuv_web/components/ui.ex:2280
-#: lib/vutuv_web/components/ui.ex:2759
+#: lib/vutuv_web/components/ui.ex:2305
+#: lib/vutuv_web/components/ui.ex:2314
+#: lib/vutuv_web/components/ui.ex:2793
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr "Empfehlung zurücknehmen"
@@ -6521,7 +6521,7 @@ msgstr "Mitglieder, die %{name} für %{tag} empfohlen haben"
 msgid "No endorsements yet."
 msgstr "Noch keine Empfehlungen."
 
-#: lib/vutuv_web/components/ui.ex:2712
+#: lib/vutuv_web/components/ui.ex:2746
 #: lib/vutuv_web/live/notification_live/index.ex:708
 #: lib/vutuv_web/live/notification_live/index.ex:723
 #: lib/vutuv_web/live/notification_live/index.ex:1223
@@ -6841,10 +6841,10 @@ msgstr ""
 "Schalten Sie einen Schalter aus, geht der passende Opt-out auf den Seiten "
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
-#: lib/vutuv_web/components/post_components.ex:2802
-#: lib/vutuv_web/components/post_components.ex:3897
-#: lib/vutuv_web/components/post_components.ex:3911
-#: lib/vutuv_web/components/ui.ex:3137
+#: lib/vutuv_web/components/post_components.ex:3082
+#: lib/vutuv_web/components/post_components.ex:4181
+#: lib/vutuv_web/components/post_components.ex:4195
+#: lib/vutuv_web/components/ui.ex:3171
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
@@ -6871,8 +6871,8 @@ msgstr "Neue Nachrichten und neue Vernetzungen"
 msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
-#: lib/vutuv_web/components/post_components.ex:3897
-#: lib/vutuv_web/components/ui.ex:3136
+#: lib/vutuv_web/components/post_components.ex:4181
+#: lib/vutuv_web/components/ui.ex:3170
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
@@ -7499,13 +7499,13 @@ msgstr "Ihre Mitglieder werden zu dieser hinzugefügt (Vereinigung)."
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr "Seite %{page} von %{pages}, %{total} gesamt"
 
-#: lib/vutuv_web/components/ui.ex:4105
+#: lib/vutuv_web/components/ui.ex:4139
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Zurück"
 
-#: lib/vutuv_web/components/ui.ex:4117
+#: lib/vutuv_web/components/ui.ex:4151
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7589,7 +7589,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:6232
+#: lib/vutuv_web/components/post_components.ex:6526
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #: lib/vutuv_web/live/shell_live.ex:1812
 #, elixir-autogen, elixir-format
@@ -7701,7 +7701,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3870
+#: lib/vutuv_web/live/post_live/feed.ex:3877
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #, elixir-autogen
 msgid "Done"
@@ -8312,7 +8312,7 @@ msgstr "PIN abgelaufen"
 msgid "PIN registered"
 msgstr "PIN-registriert"
 
-#: lib/vutuv_web/components/ui.ex:4108
+#: lib/vutuv_web/components/ui.ex:4142
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr "Seite %{page} von %{pages}"
@@ -8451,7 +8451,7 @@ msgstr "Abschluss"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:5116
+#: lib/vutuv_web/components/ui.ex:5150
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8511,7 +8511,7 @@ msgstr ""
 " was Sie nicht übernehmen möchten. Einträge, die bereits in Ihrem Profil "
 "stehen, sind für Sie abgewählt."
 
-#: lib/vutuv_web/components/ui.ex:5306
+#: lib/vutuv_web/components/ui.ex:5340
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
@@ -8540,7 +8540,7 @@ msgstr "%{items} importiert."
 msgid "Nothing new to import."
 msgstr "Nichts Neues zu importieren."
 
-#: lib/vutuv_web/components/ui.ex:5144
+#: lib/vutuv_web/components/ui.ex:5178
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8637,7 +8637,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 
-#: lib/vutuv_web/components/ui.ex:4381
+#: lib/vutuv_web/components/ui.ex:4415
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8731,13 +8731,13 @@ msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 "Ziehen Sie Ihre ZIP-Datei hierher oder klicken Sie, um eine auszuwählen."
 
-#: lib/vutuv_web/components/ui.ex:5104
+#: lib/vutuv_web/components/ui.ex:5138
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr "Basisdaten & Fotos"
 
-#: lib/vutuv_web/components/ui.ex:5238
+#: lib/vutuv_web/components/ui.ex:5272
 #: lib/vutuv_web/controllers/settings_controller.ex:129
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8749,7 +8749,7 @@ msgstr "Sprache & Anzeige"
 msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
 
-#: lib/vutuv_web/components/ui.ex:5297
+#: lib/vutuv_web/components/ui.ex:5331
 #: lib/vutuv_web/controllers/settings_controller.ex:112
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8759,7 +8759,7 @@ msgstr "Weitere Profil-Bereiche"
 msgid "Sign-in & security"
 msgstr "Anmeldung & Sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:5310
+#: lib/vutuv_web/components/ui.ex:5344
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8881,7 +8881,7 @@ msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 "Die Seite %{letter} des Mitgliederverzeichnisses, sortiert nach Nachnamen."
 
-#: lib/vutuv_web/components/ui.ex:1548
+#: lib/vutuv_web/components/ui.ex:1582
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -8989,8 +8989,8 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/agent_docs/text.ex:648
 #: lib/vutuv_web/agent_docs/text.ex:652
 #: lib/vutuv_web/components/organization_components.ex:276
-#: lib/vutuv_web/components/ui.ex:1749
-#: lib/vutuv_web/components/ui.ex:5287
+#: lib/vutuv_web/components/ui.ex:1783
+#: lib/vutuv_web/components/ui.ex:5321
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:366
 #: lib/vutuv_web/controllers/settings_controller.ex:433
@@ -9152,12 +9152,12 @@ msgstr ""
 "Ihres Browsers (Strg+P oder Cmd+P) und wählen Sie \"Als PDF speichern\", um "
 "eine PDF-Datei zu erhalten."
 
-#: lib/vutuv_web/components/ui.ex:1838
+#: lib/vutuv_web/components/ui.ex:1872
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:5094
+#: lib/vutuv_web/components/post_components.ex:5387
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9190,7 +9190,7 @@ msgstr "Jeder Download enthält genau die ausgewählten Teile."
 msgid "Header"
 msgstr "Kopfzeile"
 
-#: lib/vutuv_web/components/ui.ex:1848
+#: lib/vutuv_web/components/ui.ex:1882
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -9228,7 +9228,7 @@ msgstr ""
 "Besuchers enthält nur, was er dort ohnehin sehen kann, und private E-Mail-"
 "Adressen erscheinen nur in Ihrem eigenen."
 
-#: lib/vutuv_web/components/ui.ex:1840
+#: lib/vutuv_web/components/ui.ex:1874
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -9403,8 +9403,8 @@ msgstr "Dieses Tag kann nur von einem Admin entfernt werden."
 msgid "Yes"
 msgstr "Ja"
 
-#: lib/vutuv_web/components/ui.ex:2315
-#: lib/vutuv_web/components/ui.ex:2316
+#: lib/vutuv_web/components/ui.ex:2349
+#: lib/vutuv_web/components/ui.ex:2350
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9984,7 +9984,7 @@ msgstr "Zertifikate"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:5120
+#: lib/vutuv_web/components/ui.ex:5154
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -10187,13 +10187,13 @@ msgstr "Dauerhafter Profillink"
 msgid "Dismiss"
 msgstr "Schließen"
 
-#: lib/vutuv_web/components/ui.ex:3762
+#: lib/vutuv_web/components/ui.ex:3796
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Kopiert"
 
-#: lib/vutuv_web/components/ui.ex:3761
-#: lib/vutuv_web/components/ui.ex:3769
+#: lib/vutuv_web/components/ui.ex:3795
+#: lib/vutuv_web/components/ui.ex:3803
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Kopieren"
@@ -10387,17 +10387,17 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr "Authenticator-App ausgeschaltet."
 
-#: lib/vutuv_web/components/ui.ex:468
+#: lib/vutuv_web/components/ui.ex:475
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr "Fett"
 
-#: lib/vutuv_web/components/ui.ex:520
+#: lib/vutuv_web/components/ui.ex:527
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr "Aufzählung"
 
-#: lib/vutuv_web/components/ui.ex:523
+#: lib/vutuv_web/components/ui.ex:530
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr "Codeblock"
@@ -10413,13 +10413,13 @@ msgid "Delete your code list? All its codes stop working immediately."
 msgstr ""
 "Kennwortliste löschen? Alle Codes darauf funktionieren sofort nicht mehr."
 
-#: lib/vutuv_web/components/ui.ex:452
+#: lib/vutuv_web/components/ui.ex:459
 #, elixir-autogen, elixir-format
 msgid "Formatting"
 msgstr "Formatierung"
 
-#: lib/vutuv_web/components/ui.ex:587
-#: lib/vutuv_web/components/ui.ex:588
+#: lib/vutuv_web/components/ui.ex:594
+#: lib/vutuv_web/components/ui.ex:595
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr "Vollbild"
@@ -10434,29 +10434,29 @@ msgstr "Neue Liste erstellen"
 msgid "Generate code list"
 msgstr "Kennwortliste erstellen"
 
-#: lib/vutuv_web/components/ui.ex:461
-#: lib/vutuv_web/components/ui.ex:518
+#: lib/vutuv_web/components/ui.ex:468
+#: lib/vutuv_web/components/ui.ex:525
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr "Überschrift 1"
 
-#: lib/vutuv_web/components/ui.ex:464
-#: lib/vutuv_web/components/ui.ex:519
+#: lib/vutuv_web/components/ui.ex:471
+#: lib/vutuv_web/components/ui.ex:526
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr "Überschrift 2"
 
-#: lib/vutuv_web/components/ui.ex:477
+#: lib/vutuv_web/components/ui.ex:484
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr "Inline-Code"
 
-#: lib/vutuv_web/components/ui.ex:471
+#: lib/vutuv_web/components/ui.ex:478
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr "Kursiv"
 
-#: lib/vutuv_web/components/ui.ex:408
+#: lib/vutuv_web/components/ui.ex:415
 #, elixir-autogen, elixir-format
 msgid "Link URL"
 msgstr "Link-URL"
@@ -10472,7 +10472,7 @@ msgstr "Anmelde-Codes"
 msgid "Not set up."
 msgstr "Nicht eingerichtet."
 
-#: lib/vutuv_web/components/ui.ex:521
+#: lib/vutuv_web/components/ui.ex:528
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr "Nummerierte Liste"
@@ -10489,7 +10489,7 @@ msgstr ""
 "Drucken Sie diese Seite aus oder schreiben Sie die Codes ab. "
 "Durchgestrichene Codes wurden bereits verwendet."
 
-#: lib/vutuv_web/components/ui.ex:522
+#: lib/vutuv_web/components/ui.ex:529
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr "Zitat"
@@ -10514,7 +10514,7 @@ msgstr ""
 msgid "Set up"
 msgstr "Einrichten"
 
-#: lib/vutuv_web/components/ui.ex:474
+#: lib/vutuv_web/components/ui.ex:481
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr "Durchgestrichen"
@@ -11245,7 +11245,7 @@ msgstr "Warteschlange"
 msgid "Queued"
 msgstr "Eingereiht"
 
-#: lib/vutuv_web/components/video_components.ex:213
+#: lib/vutuv_web/components/video_components.ex:214
 #: lib/vutuv_web/live/admin/screenshot_live.ex:525
 #, elixir-autogen, elixir-format
 msgid "Ready"
@@ -11609,12 +11609,12 @@ msgstr "Stellen Sie diese Datei bereit unter:"
 msgid "State / region (optional)"
 msgstr "Bundesland / Region (optional)"
 
-#: lib/vutuv_web/components/ui.ex:4435
+#: lib/vutuv_web/components/ui.ex:4469
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr "Dieser Dateityp ist nicht erlaubt."
 
-#: lib/vutuv_web/components/ui.ex:4437
+#: lib/vutuv_web/components/ui.ex:4471
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr "Der Upload ist fehlgeschlagen."
@@ -12048,7 +12048,7 @@ msgstr ""
 "Der Linktext ist beliebig. Ein verstecktes <link rel=\"me\"> im Seitenkopf "
 "funktioniert ebenfalls."
 
-#: lib/vutuv_web/components/ui.ex:1085
+#: lib/vutuv_web/components/ui.ex:1119
 #: lib/vutuv_web/live/section_reorder_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -12339,7 +12339,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:462
-#: lib/vutuv_web/components/ui.ex:5314
+#: lib/vutuv_web/components/ui.ex:5348
 #: lib/vutuv_web/controllers/settings_controller.ex:222
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
@@ -13570,7 +13570,7 @@ msgstr "Suche speichern"
 msgid "Saved search deleted."
 msgstr "Gespeicherte Suche gelöscht."
 
-#: lib/vutuv_web/components/ui.ex:5223
+#: lib/vutuv_web/components/ui.ex:5257
 #: lib/vutuv_web/controllers/settings_controller.ex:629
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13590,7 +13590,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/components/post_components.ex:3280
+#: lib/vutuv_web/components/post_components.ex:3560
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -13955,27 +13955,27 @@ msgstr[1] "Wir haben %{formatted} Beiträge aktualisiert, die Ihren alten Handle
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "hat den Handle von @%{old} auf @%{new} geändert."
 
-#: lib/vutuv_web/components/ui.ex:497
+#: lib/vutuv_web/components/ui.ex:504
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr "Zentriert"
 
-#: lib/vutuv_web/components/ui.ex:494
+#: lib/vutuv_web/components/ui.ex:501
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr "Linksbündig (Text umfließt)"
 
-#: lib/vutuv_web/components/ui.ex:500
+#: lib/vutuv_web/components/ui.ex:507
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr "Rechtsbündig (Text umfließt)"
 
-#: lib/vutuv_web/components/ui.ex:491
+#: lib/vutuv_web/components/ui.ex:498
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr "Volle Breite"
 
-#: lib/vutuv_web/components/ui.ex:524
+#: lib/vutuv_web/components/ui.ex:531
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr "Bild einfügen"
@@ -14014,22 +14014,22 @@ msgstr "Mobil (privat)"
 msgid "Work mobile"
 msgstr "Mobil (Arbeit)"
 
-#: lib/vutuv_web/components/post_components.ex:469
+#: lib/vutuv_web/components/post_components.ex:482
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr "Noch keine Beiträge."
 
-#: lib/vutuv_web/components/post_components.ex:471
+#: lib/vutuv_web/components/post_components.ex:484
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr "Noch keine Antworten."
 
-#: lib/vutuv_web/components/post_components.ex:470
+#: lib/vutuv_web/components/post_components.ex:483
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr "Noch keine Reposts."
 
-#: lib/vutuv_web/components/post_components.ex:428
+#: lib/vutuv_web/components/post_components.ex:441
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr "Eigene Beiträge"
@@ -14042,7 +14042,7 @@ msgstr ""
 "Personen tauchen in Ihren Vorschlägen auf. Einem Tag folgen Sie auf seiner "
 "Seite."
 
-#: lib/vutuv_web/components/ui.ex:5206
+#: lib/vutuv_web/components/ui.ex:5240
 #: lib/vutuv_web/controllers/settings_controller.ex:643
 #: lib/vutuv_web/live/post_live/feed.ex:710
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -14119,7 +14119,7 @@ msgstr "Messenger wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:63
-#: lib/vutuv_web/components/ui.ex:5163
+#: lib/vutuv_web/components/ui.ex:5197
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -14147,14 +14147,14 @@ msgstr "Messenger von %{name}"
 msgid "Select a messenger"
 msgstr "Messenger auswählen"
 
-#: lib/vutuv_web/components/ui.ex:4520
+#: lib/vutuv_web/components/ui.ex:4554
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] "Meinen Follower darüber informieren"
 msgstr[1] "Meine %{formatted} Follower darüber informieren"
 
-#: lib/vutuv_web/components/ui.ex:4530
+#: lib/vutuv_web/components/ui.ex:4564
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
@@ -14204,34 +14204,34 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:5782
+#: lib/vutuv_web/components/post_components.ex:6075
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:5739
+#: lib/vutuv_web/components/post_components.ex:6032
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:5783
+#: lib/vutuv_web/components/post_components.ex:6076
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:5785
+#: lib/vutuv_web/components/post_components.ex:6078
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:5781
+#: lib/vutuv_web/components/post_components.ex:6074
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:5738
+#: lib/vutuv_web/components/post_components.ex:6031
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14242,12 +14242,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:5780
+#: lib/vutuv_web/components/post_components.ex:6073
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:5784
+#: lib/vutuv_web/components/post_components.ex:6077
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14267,7 +14267,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:5821
+#: lib/vutuv_web/components/post_components.ex:6114
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14275,27 +14275,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:5851
+#: lib/vutuv_web/components/post_components.ex:6144
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:5852
+#: lib/vutuv_web/components/post_components.ex:6145
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:5850
+#: lib/vutuv_web/components/post_components.ex:6143
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:5810
+#: lib/vutuv_web/components/post_components.ex:6103
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:5857
+#: lib/vutuv_web/components/post_components.ex:6150
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14325,7 +14325,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5624
+#: lib/vutuv_web/components/post_components.ex:5917
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14368,17 +14368,17 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:5615
+#: lib/vutuv_web/components/post_components.ex:5908
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
 
-#: lib/vutuv_web/components/ui.ex:2449
+#: lib/vutuv_web/components/ui.ex:2483
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr "Empfohlen von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:2453
+#: lib/vutuv_web/components/ui.ex:2487
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -14731,14 +14731,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:3561
+#: lib/vutuv_web/components/post_components.ex:3841
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:3584
+#: lib/vutuv_web/components/post_components.ex:3864
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14765,7 +14765,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:6331
+#: lib/vutuv_web/components/post_components.ex:6625
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -14923,7 +14923,7 @@ msgstr "Blenden Sie Beiträge aus Ihrem Feed aus, die ein Tag tragen oder ein Wo
 msgid "Match whole words only (word/phrase)"
 msgstr "Nur ganze Wörter treffen (Wort/Phrase)"
 
-#: lib/vutuv_web/components/ui.ex:5177
+#: lib/vutuv_web/components/ui.ex:5211
 #: lib/vutuv_web/controllers/settings_controller.ex:773
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -15559,252 +15559,252 @@ msgstr "Ihr Server"
 msgid "moved to %{address}"
 msgstr "umgezogen nach %{address}"
 
-#: lib/vutuv_web/components/ui.ex:5105
+#: lib/vutuv_web/components/ui.ex:5139
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr "Name, Foto, Titelbild, Kurzbeschreibung"
 
-#: lib/vutuv_web/components/ui.ex:5110
+#: lib/vutuv_web/components/ui.ex:5144
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr "handle spitzname nutzername umbenennen slug profiladresse url erwähnung"
 
-#: lib/vutuv_web/components/ui.ex:5113
+#: lib/vutuv_web/components/ui.ex:5147
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr "Die Stationen in Ihrem Lebenslauf"
 
-#: lib/vutuv_web/components/ui.ex:5114
+#: lib/vutuv_web/components/ui.ex:5148
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr "lebenslauf cv karriere beruf arbeitgeber position stelle job firma"
 
-#: lib/vutuv_web/components/ui.ex:5117
+#: lib/vutuv_web/components/ui.ex:5151
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr "Schulen, Hochschulen, Abschlüsse"
 
-#: lib/vutuv_web/components/ui.ex:5118
+#: lib/vutuv_web/components/ui.ex:5152
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr "lebenslauf studium schule universität hochschule abschluss ausbildung"
 
-#: lib/vutuv_web/components/ui.ex:5121
+#: lib/vutuv_web/components/ui.ex:5155
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr "Nachweise, mit Belegdokumenten"
 
-#: lib/vutuv_web/components/ui.ex:5122
+#: lib/vutuv_web/components/ui.ex:5156
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr "zertifikat lizenz urkunde diplom nachweis beleg auszeichnung dokument"
 
-#: lib/vutuv_web/components/ui.ex:5129
+#: lib/vutuv_web/components/ui.ex:5163
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr "Sprachkenntnisse"
 
-#: lib/vutuv_web/components/ui.ex:5130
+#: lib/vutuv_web/components/ui.ex:5164
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr "Die Sprachen, die Sie sprechen"
 
-#: lib/vutuv_web/components/ui.ex:5131
+#: lib/vutuv_web/components/ui.ex:5165
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr "sprache sprachen sprechen fließend muttersprache verhandlungssicher"
 
-#: lib/vutuv_web/components/ui.ex:5134
+#: lib/vutuv_web/components/ui.ex:5168
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr "Die Themen, für die Sie bekannt sind"
 
-#: lib/vutuv_web/components/ui.ex:5135
+#: lib/vutuv_web/components/ui.ex:5169
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr "fähigkeit kenntnis thema stichwort schlagwort expertise empfehlung"
 
-#: lib/vutuv_web/components/ui.ex:5315
+#: lib/vutuv_web/components/ui.ex:5349
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr "Organisationsseiten, die Sie verwalten"
 
-#: lib/vutuv_web/components/ui.ex:5316
+#: lib/vutuv_web/components/ui.ex:5350
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr "firma unternehmen arbeitgeber betrieb organisation seite"
 
-#: lib/vutuv_web/components/ui.ex:5138
+#: lib/vutuv_web/components/ui.ex:5172
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr "Kontaktdaten"
 
-#: lib/vutuv_web/components/ui.ex:5141
+#: lib/vutuv_web/components/ui.ex:5175
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr "Wo wir Sie erreichen, und welche Adresse öffentlich ist"
 
-#: lib/vutuv_web/components/ui.ex:5142
+#: lib/vutuv_web/components/ui.ex:5176
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr "mail e-mail email adresse hauptadresse primär"
 
-#: lib/vutuv_web/components/ui.ex:5145
+#: lib/vutuv_web/components/ui.ex:5179
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr "Festnetz, Mobil, Fax"
 
-#: lib/vutuv_web/components/ui.ex:5146
+#: lib/vutuv_web/components/ui.ex:5180
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr "telefon handy mobil festnetz fax nummer rufnummer"
 
-#: lib/vutuv_web/components/ui.ex:5149
+#: lib/vutuv_web/components/ui.ex:5183
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr "Postanschriften auf Ihrem Profil"
 
-#: lib/vutuv_web/components/ui.ex:5150
+#: lib/vutuv_web/components/ui.ex:5184
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr "straße stadt ort postleitzahl plz land anschrift karte"
 
-#: lib/vutuv_web/components/ui.ex:5152
+#: lib/vutuv_web/components/ui.ex:5186
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr "Webseiten & Links"
 
-#: lib/vutuv_web/components/ui.ex:5153
+#: lib/vutuv_web/components/ui.ex:5187
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr "Ihre Homepage und weitere Links"
 
-#: lib/vutuv_web/components/ui.ex:5154
+#: lib/vutuv_web/components/ui.ex:5188
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr "url webseite website homepage blog link verifizieren bestätigen rel=me"
 
-#: lib/vutuv_web/components/ui.ex:5156
+#: lib/vutuv_web/components/ui.ex:5190
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr "Social-Media-Profile"
 
-#: lib/vutuv_web/components/ui.ex:5157
+#: lib/vutuv_web/components/ui.ex:5191
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr "Mastodon, Bluesky, GitHub und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:5159
+#: lib/vutuv_web/components/ui.ex:5193
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr "mastodon bluesky github gitlab codeberg linkedin x twitter instagram soziale netzwerke"
 
-#: lib/vutuv_web/components/ui.ex:5164
+#: lib/vutuv_web/components/ui.ex:5198
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr "Signal, Threema, Matrix und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:5165
+#: lib/vutuv_web/components/ui.ex:5199
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr "signal threema matrix xmpp telegram whatsapp chat messenger nachrichten"
 
-#: lib/vutuv_web/components/ui.ex:5168
+#: lib/vutuv_web/components/ui.ex:5202
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr "Mitteilungen & Feed"
 
-#: lib/vutuv_web/components/ui.ex:5171
+#: lib/vutuv_web/components/ui.ex:5205
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr "Welche E-Mails wir schicken, und was die Glocke meldet"
 
-#: lib/vutuv_web/components/ui.ex:5178
+#: lib/vutuv_web/components/ui.ex:5212
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr "Beiträge aus Ihrem Feed heraushalten"
 
-#: lib/vutuv_web/components/ui.ex:5179
+#: lib/vutuv_web/components/ui.ex:5213
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr "stummschalten ausblenden verbergen filter wort begriff tag feed blockieren"
 
-#: lib/vutuv_web/components/ui.ex:5207
+#: lib/vutuv_web/components/ui.ex:5241
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr "Themen, deren Beiträge in Ihrem Feed landen"
 
-#: lib/vutuv_web/components/ui.ex:5208
+#: lib/vutuv_web/components/ui.ex:5242
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr "tag thema abonnieren folgen feed"
 
-#: lib/vutuv_web/components/ui.ex:5224
+#: lib/vutuv_web/components/ui.ex:5258
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr "Job- und Personensuchen, die Ihnen neue Treffer mailen"
 
-#: lib/vutuv_web/components/ui.ex:5225
+#: lib/vutuv_web/components/ui.ex:5259
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr "job stelle stellenangebot suchauftrag suche alarm benachrichtigung merkliste"
 
-#: lib/vutuv_web/components/ui.ex:5272
+#: lib/vutuv_web/components/ui.ex:5306
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr "Suchmaschinen, KI, Online-Status"
 
-#: lib/vutuv_web/components/ui.ex:5273
+#: lib/vutuv_web/components/ui.ex:5307
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr "privatsphäre datenschutz google suchmaschine ki ai llm crawler noindex online punkt öffentlich sichtbar"
 
-#: lib/vutuv_web/components/ui.ex:5276
+#: lib/vutuv_web/components/ui.ex:5310
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr "Personen, die nicht mit Ihnen interagieren können"
 
-#: lib/vutuv_web/components/ui.ex:5277
+#: lib/vutuv_web/components/ui.ex:5311
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr "blockieren sperren bannen stummschalten melden missbrauch belästigung"
 
-#: lib/vutuv_web/components/ui.ex:5298
+#: lib/vutuv_web/components/ui.ex:5332
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr "Passkeys, angemeldete Geräte, Anmeldecodes"
 
-#: lib/vutuv_web/components/ui.ex:5299
+#: lib/vutuv_web/components/ui.ex:5333
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr "passwort kennwort anmelden abmelden login logout sitzung gerät passkey totp 2fa pin sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:5307
+#: lib/vutuv_web/components/ui.ex:5341
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr "Ihre Daten von LinkedIn übernehmen"
 
-#: lib/vutuv_web/components/ui.ex:5308
+#: lib/vutuv_web/components/ui.ex:5342
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr "linkedin hochladen zip übernehmen importieren umzug"
 
-#: lib/vutuv_web/components/ui.ex:5311
+#: lib/vutuv_web/components/ui.ex:5345
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr "Alles herunterladen, was wir über Sie speichern"
 
-#: lib/vutuv_web/components/ui.ex:5312
+#: lib/vutuv_web/components/ui.ex:5346
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr "herunterladen download dsgvo gdpr daten sicherung json lebenslauf auskunft"
 
-#: lib/vutuv_web/components/ui.ex:5326
+#: lib/vutuv_web/components/ui.ex:5360
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr "Ihr Konto und alles darauf entfernen"
 
-#: lib/vutuv_web/components/ui.ex:5327
+#: lib/vutuv_web/components/ui.ex:5361
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr "löschen entfernen schließen kündigen beenden verlassen"
@@ -15926,7 +15926,7 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:6277
+#: lib/vutuv_web/components/post_components.ex:6571
 #: lib/vutuv_web/live/notification_live/index.ex:1593
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -15934,7 +15934,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:6281
+#: lib/vutuv_web/components/post_components.ex:6575
 #: lib/vutuv_web/live/notification_live/index.ex:1587
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15942,7 +15942,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:6285
+#: lib/vutuv_web/components/post_components.ex:6579
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15950,7 +15950,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:6236
+#: lib/vutuv_web/components/post_components.ex:6530
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -15968,14 +15968,14 @@ msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem 
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
-#: lib/vutuv_web/components/post_components.ex:1549
-#: lib/vutuv_web/components/post_components.ex:2301
+#: lib/vutuv_web/components/post_components.ex:1589
+#: lib/vutuv_web/components/post_components.ex:2578
 #: lib/vutuv_web/live/fediverse_account_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:1419
+#: lib/vutuv_web/components/post_components.ex:1459
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Diese Antwort aus Ihrem Beitrag entfernen?"
@@ -16004,7 +16004,7 @@ msgstr "Antwort aus einem anderen Netzwerk"
 msgid "Reply removed."
 msgstr "Antwort entfernt."
 
-#: lib/vutuv_web/components/post_components.ex:1431
+#: lib/vutuv_web/components/post_components.ex:1471
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
@@ -16014,7 +16014,7 @@ msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
 msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
-#: lib/vutuv_web/components/post_components.ex:1445
+#: lib/vutuv_web/components/post_components.ex:1485
 #: lib/vutuv_web/live/notification_live/index.ex:1118
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -16046,9 +16046,9 @@ msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1501
-#: lib/vutuv_web/components/post_components.ex:1480
-#: lib/vutuv_web/components/post_components.ex:1680
-#: lib/vutuv_web/components/post_components.ex:3138
+#: lib/vutuv_web/components/post_components.ex:1520
+#: lib/vutuv_web/components/post_components.ex:1720
+#: lib/vutuv_web/components/post_components.ex:3418
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -16281,7 +16281,7 @@ msgstr "API-Token erstellt"
 msgid "Access token revoked"
 msgstr "API-Token widerrufen"
 
-#: lib/vutuv_web/components/ui.ex:5301
+#: lib/vutuv_web/components/ui.ex:5335
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16628,7 +16628,7 @@ msgstr "Was sich an einem Konto geändert hat, wann, von wo und wie es bestätig
 msgid "What changed on your account, and exactly when."
 msgstr "Was sich an Ihrem Konto geändert hat, und wann genau."
 
-#: lib/vutuv_web/components/ui.ex:5302
+#: lib/vutuv_web/components/ui.ex:5336
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr "Was sich an Ihrem Konto geändert hat, und wann"
@@ -16664,7 +16664,7 @@ msgstr "durch den Betreiber"
 msgid "from a signed-in session"
 msgstr "aus einer angemeldeten Sitzung"
 
-#: lib/vutuv_web/components/ui.ex:5304
+#: lib/vutuv_web/components/ui.ex:5338
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr "protokoll verlauf historie chronik audit sicherheit war ich das wer hat wann geaendert geändert log"
@@ -16716,22 +16716,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:3746
+#: lib/vutuv_web/components/post_components.ex:4026
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:3864
+#: lib/vutuv_web/components/post_components.ex:4148
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:3872
+#: lib/vutuv_web/components/post_components.ex:4156
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:3858
+#: lib/vutuv_web/components/post_components.ex:4142
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -16825,7 +16825,7 @@ msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1429
 #: lib/vutuv_web/agent_docs/text.ex:915
-#: lib/vutuv_web/components/ui.ex:3191
+#: lib/vutuv_web/components/ui.ex:3225
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Original herunterladen"
@@ -16850,7 +16850,7 @@ msgstr "Volle Auflösung, direkt aus dem Beitrag."
 msgid "Just the picture"
 msgstr "Nur das Bild"
 
-#: lib/vutuv_web/components/ui.ex:3190
+#: lib/vutuv_web/components/ui.ex:3224
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Nächstes Foto"
@@ -16860,17 +16860,17 @@ msgstr "Nächstes Foto"
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:3333
+#: lib/vutuv_web/components/post_components.ex:3613
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:4739
+#: lib/vutuv_web/components/post_components.ex:5032
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:4888
+#: lib/vutuv_web/components/post_components.ex:5181
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -16883,12 +16883,12 @@ msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1462
 #: lib/vutuv_web/agent_docs/text.ex:890
-#: lib/vutuv_web/components/post_components.ex:4970
+#: lib/vutuv_web/components/post_components.ex:5263
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
 
-#: lib/vutuv_web/components/ui.ex:3189
+#: lib/vutuv_web/components/ui.ex:3223
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
@@ -16909,7 +16909,7 @@ msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qual
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:3386
+#: lib/vutuv_web/components/post_components.ex:3666
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
@@ -16929,7 +16929,7 @@ msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen S
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/components/post_components.ex:3377
+#: lib/vutuv_web/components/post_components.ex:3657
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
@@ -16939,12 +16939,12 @@ msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht �
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/components/post_components.ex:3395
+#: lib/vutuv_web/components/post_components.ex:3675
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Diese Seite nimmt nicht am Fediverse teil."
 
-#: lib/vutuv_web/components/post_components.ex:3329
+#: lib/vutuv_web/components/post_components.ex:3609
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
@@ -16959,7 +16959,7 @@ msgstr "Wer diese Fotos weiterverwenden darf"
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:3390
+#: lib/vutuv_web/components/post_components.ex:3670
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
@@ -16969,7 +16969,7 @@ msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshal
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
 
-#: lib/vutuv_web/components/post_components.ex:3343
+#: lib/vutuv_web/components/post_components.ex:3623
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fediverse-Follower. Auf vutuv ist sie ebenfalls ein öffentlicher Beitrag."
@@ -17044,13 +17044,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1319
-#: lib/vutuv_web/components/post_components.ex:6274
+#: lib/vutuv_web/components/post_components.ex:6568
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1317
-#: lib/vutuv_web/components/post_components.ex:6271
+#: lib/vutuv_web/components/post_components.ex:6565
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17060,7 +17060,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:6161
+#: lib/vutuv_web/components/post_components.ex:6455
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17187,7 +17187,7 @@ msgstr "Ein Konto in einem anderen Netzwerk"
 msgid "Cancel request"
 msgstr "Anfrage zurückziehen"
 
-#: lib/vutuv_web/components/ui.ex:5288
+#: lib/vutuv_web/components/ui.ex:5322
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Konten auf Mastodon folgen, und von dort gefolgt werden"
@@ -17390,7 +17390,7 @@ msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, desh
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr "Ihr Konto ist derzeit gesperrt, deshalb geht nichts von Ihnen an andere Netzwerke und Sie können dort niemandem folgen. Das endet von selbst, sobald die Sperre abläuft."
 
-#: lib/vutuv_web/components/ui.ex:5290
+#: lib/vutuv_web/components/ui.ex:5324
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr "mastodon activitypub foederation federation follower folgen folge umzug migration entferntes konto"
@@ -17410,7 +17410,7 @@ msgstr "Von hier aus wird %{follows} Konten in anderen Netzwerken gefolgt, davon
 msgid "Cached posts"
 msgstr "Zwischengespeicherte Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:2897
+#: lib/vutuv_web/components/post_components.ex:3177
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Nur für die Follower dieses Kontos"
@@ -17420,7 +17420,7 @@ msgstr "Nur für die Follower dieses Kontos"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:3137
+#: lib/vutuv_web/components/post_components.ex:3417
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -17440,12 +17440,12 @@ msgstr "Zwischengespeicherter Beitrag gemeldet, hier für alle entfernt"
 msgid "Content from other networks taken down by members"
 msgstr "Von Mitgliedern entfernte Inhalte aus anderen Netzwerken"
 
-#: lib/vutuv_web/components/post_components.ex:1815
+#: lib/vutuv_web/components/post_components.ex:1855
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Verbergen"
 
-#: lib/vutuv_web/components/post_components.ex:3078
+#: lib/vutuv_web/components/post_components.ex:3358
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Von der verfassenden Person als sensibel markiert"
@@ -17460,7 +17460,7 @@ msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwin
 msgid "Nobody has removed or reported anything yet."
 msgstr "Bisher hat niemand etwas entfernt oder gemeldet."
 
-#: lib/vutuv_web/components/post_components.ex:2870
+#: lib/vutuv_web/components/post_components.ex:3150
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr "Diesen Beitrag als unangemessen melden? Unsere Kopie wird sofort für alle auf diesem vutuv gelöscht."
@@ -17684,27 +17684,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(ein Bild)"
 msgstr[1] "(%{count} Bilder)"
 
-#: lib/vutuv_web/components/post_components.ex:2473
+#: lib/vutuv_web/components/post_components.ex:2751
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr "Bild wird geprüft"
 
-#: lib/vutuv_web/components/post_components.ex:2506
+#: lib/vutuv_web/components/post_components.ex:2784
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Wieder verdecken"
 
-#: lib/vutuv_web/components/post_components.ex:2501
+#: lib/vutuv_web/components/post_components.ex:2779
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Heikles Motiv. Bild anzeigen."
 
-#: lib/vutuv_web/components/post_components.ex:3236
+#: lib/vutuv_web/components/post_components.ex:3516
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:3242
+#: lib/vutuv_web/components/post_components.ex:3522
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
@@ -17714,7 +17714,7 @@ msgstr "Diesen Beitrag gibt es hier nicht mehr."
 msgid "Back to the feed"
 msgstr "Zurück zum Feed"
 
-#: lib/vutuv_web/components/post_components.ex:3381
+#: lib/vutuv_web/components/post_components.ex:3661
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17729,7 +17729,7 @@ msgstr ""
 "beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv "
 "nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/live/post_live/remote_actions_component.ex:181
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:302
 #, elixir-autogen, elixir-format
 msgid "Reposted. Your followers see it now."
 msgstr "Repostet. Ihre Follower sehen es jetzt."
@@ -17772,12 +17772,12 @@ msgstr ""
 "Ihr Feed zeigt die Beiträge der Mitglieder, denen Sie folgen. Folgen Sie ein "
 "paar Mitgliedern, um ihn zu füllen."
 
-#: lib/vutuv_web/components/ui.ex:239
+#: lib/vutuv_web/components/ui.ex:246
 #, elixir-autogen, elixir-format
 msgid "Add another tag"
 msgstr "Weiteren Tag hinzufügen"
 
-#: lib/vutuv_web/components/ui.ex:262
+#: lib/vutuv_web/components/ui.ex:269
 #, elixir-autogen, elixir-format
 msgid "Remove the tag %{name}"
 msgstr "Tag %{name} entfernen"
@@ -17903,7 +17903,7 @@ msgstr "Ihr Benutzername ist hier Ihre öffentliche Identität. Er ändert sich 
 msgid "Your username is your public identity here. It changes only once you confirm with your passkey or a valid code below."
 msgstr "Ihr Benutzername ist hier Ihre öffentliche Identität. Er ändert sich erst, wenn Sie unten mit Ihrem Passkey oder einem gültigen Code bestätigen."
 
-#: lib/vutuv_web/components/ui.ex:622
+#: lib/vutuv_web/components/ui.ex:629
 #, elixir-autogen, elixir-format
 msgid "Markdown help"
 msgstr "Markdown-Hilfe"
@@ -17924,7 +17924,7 @@ msgid "Address of the post"
 msgstr "Adresse des Beitrags"
 
 #: lib/vutuv_web/components/fediverse_components.ex:688
-#: lib/vutuv_web/live/post_live/remote_actions_component.ex:276
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:414
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings"
 msgstr "Fediverse-Einstellungen"
@@ -18340,14 +18340,14 @@ msgstr "Seiten, von denen nie ein Screenshot entsteht, weil ein Browser ohne Anz
 msgid "Screenshot blocklist"
 msgstr "Screenshot-Blockliste"
 
-#: lib/vutuv_web/components/post_components.ex:461
+#: lib/vutuv_web/components/post_components.ex:474
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 "Noch nichts aus dem Fediverse. Folgen Sie Konten dort draußen, um diesen Tab "
 "zu füllen."
 
-#: lib/vutuv_web/components/post_components.ex:458
+#: lib/vutuv_web/components/post_components.ex:471
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
@@ -18391,7 +18391,7 @@ msgstr "Auf vutuv gibt es zu diesem Tag noch keine Beiträge."
 msgid "word in a post"
 msgstr "Wort in einem Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:3239
+#: lib/vutuv_web/components/post_components.ex:3519
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Diese Antwort gibt es hier nicht mehr."
@@ -18432,8 +18432,8 @@ msgstr "Mehr von %{name}"
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr "Das ist die Kopie, die vutuv von einem auf %{host} veröffentlichten Beitrag hat. Sie bleibt erhalten, solange hier jemand diesem Konto folgt."
 
-#: lib/vutuv_web/components/ui.ex:1600
-#: lib/vutuv_web/components/ui.ex:1601
+#: lib/vutuv_web/components/ui.ex:1634
+#: lib/vutuv_web/components/ui.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr "Diesen Feed in Ihrem RSS-Reader abonnieren"
@@ -18448,7 +18448,7 @@ msgstr "Entwicklerdokumentation"
 msgid "Source code"
 msgstr "Quellcode"
 
-#: lib/vutuv_web/components/ui.ex:268
+#: lib/vutuv_web/components/ui.ex:275
 #, elixir-autogen, elixir-format
 msgid "At most %{max} tags. Remove one to add another."
 msgstr "Höchstens %{max} Tags. Entfernen Sie eines, um ein anderes hinzuzufügen."
@@ -18463,19 +18463,19 @@ msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:5264
+#: lib/vutuv_web/components/post_components.ex:5557
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5266
+#: lib/vutuv_web/components/post_components.ex:5559
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:5277
+#: lib/vutuv_web/components/post_components.ex:5570
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
@@ -18604,7 +18604,7 @@ msgstr "Arbeitszeugnis aktualisiert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:5124
+#: lib/vutuv_web/components/ui.ex:5158
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -18649,7 +18649,7 @@ msgstr "Ausstellungsdatum"
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3599
+#: lib/vutuv_web/live/post_live/feed.ex:3606
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -18799,7 +18799,7 @@ msgstr "In der Warteschlange, Ihres ist als Nächstes dran."
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr "Sie haben den Text nach dieser Prüfung geändert. Sie beschreibt die frühere Fassung."
 
-#: lib/vutuv_web/components/ui.ex:5125
+#: lib/vutuv_web/components/ui.ex:5159
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr "Ihre Arbeitszeugnisse, privat bis Sie sie veröffentlichen"
@@ -18810,7 +18810,7 @@ msgstr "Ihre Arbeitszeugnisse, privat bis Sie sie veröffentlichen"
 msgid "Zwischenzeugnis"
 msgstr "Zwischenzeugnis"
 
-#: lib/vutuv_web/components/ui.ex:5127
+#: lib/vutuv_web/components/ui.ex:5161
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr "arbeitszeugnis zeugnis referenz beurteilung arbeitgeber bewertung prüfung"
@@ -19065,7 +19065,7 @@ msgstr "Datei hierher ziehen oder eine auswählen"
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr "PDF, JPG, PNG oder WebP, bis %{limit}"
 
-#: lib/vutuv_web/components/ui.ex:4421
+#: lib/vutuv_web/components/ui.ex:4455
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -19346,14 +19346,14 @@ msgstr "6-stellige PIN"
 msgid "Enter the PIN from the email"
 msgstr "PIN aus der E-Mail eingeben"
 
-#: lib/vutuv_web/components/ui.ex:854
+#: lib/vutuv_web/components/ui.ex:861
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 "Wenn Sie Ihrem vutuv-Konto weitere Adressen hinzugefügt haben, melden Sie "
 "sich stattdessen mit einer davon an."
 
-#: lib/vutuv_web/components/ui.ex:882
+#: lib/vutuv_web/components/ui.ex:889
 #, elixir-autogen, elixir-format
 msgid "Cancel registration"
 msgstr "Registrierung abbrechen"
@@ -19366,7 +19366,7 @@ msgstr ""
 "ändern, und unter {import_url} importieren Sie ein bestehendes "
 "LinkedIn-Profil."
 
-#: lib/vutuv_web/components/ui.ex:837
+#: lib/vutuv_web/components/ui.ex:844
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
@@ -19395,7 +19395,7 @@ msgstr ""
 "Anteile bezogen auf die %{answered} Mitglieder mit Angabe. %{unanswered} ohne "
 "Angabe."
 
-#: lib/vutuv_web/components/ui.ex:5106
+#: lib/vutuv_web/components/ui.ex:5140
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr "avatar profilbild portrait foto bild geburtstag geburtsdatum geschlecht über mich"
@@ -19491,7 +19491,7 @@ msgstr "Ebenfalls löschen"
 msgid "Always keep"
 msgstr "Immer behalten"
 
-#: lib/vutuv_web/components/ui.ex:5281
+#: lib/vutuv_web/components/ui.ex:5315
 #: lib/vutuv_web/controllers/settings_controller.ex:256
 #: lib/vutuv_web/controllers/settings_controller.ex:335
 #: lib/vutuv_web/controllers/settings_controller.ex:347
@@ -19588,7 +19588,7 @@ msgstr "Fotobeiträge behalten"
 msgid "Keep posts that did well"
 msgstr "Beiträge behalten, die gut liefen"
 
-#: lib/vutuv_web/components/ui.ex:5283
+#: lib/vutuv_web/components/ui.ex:5317
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr "Ihre Beiträge nach einer selbst gewählten Zeit auslaufen lassen"
@@ -19697,7 +19697,7 @@ msgstr "Sie können vorher alles herunterladen, was Sie hier haben:"
 msgid "Your rule"
 msgstr "Ihre Regel"
 
-#: lib/vutuv_web/components/ui.ex:5285
+#: lib/vutuv_web/components/ui.ex:5319
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr "löschen entfernen beiträge alter alt ablaufen verfallen automatisch aufräumen aufbewahrung"
@@ -20071,7 +20071,7 @@ msgstr "Suchen Sie so oft Sie möchten und nehmen Sie dazu, was gehört. Abkürz
 msgid "Start over"
 msgstr "Von vorn beginnen"
 
-#: lib/vutuv_web/components/post_components.ex:3269
+#: lib/vutuv_web/components/post_components.ex:3549
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr "Ein Herz oder ein Repost geht zurück in das Netzwerk, aus dem dieser Beitrag stammt. Ihr Konto nimmt derzeit nicht am Fediverse teil. Einschalten können Sie das in den {settings}."
@@ -20488,22 +20488,22 @@ msgstr "Neu registrieren"
 msgid "The PIN has expired."
 msgstr "Die PIN ist abgelaufen."
 
-#: lib/vutuv_web/components/ui.ex:958
+#: lib/vutuv_web/components/ui.ex:965
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr "Die PIN ist noch eine Minute gültig."
 
-#: lib/vutuv_web/components/ui.ex:960
+#: lib/vutuv_web/components/ui.ex:967
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr "Die PIN ist noch eine Sekunde gültig."
 
-#: lib/vutuv_web/components/ui.ex:959
+#: lib/vutuv_web/components/ui.ex:966
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr "Die PIN ist noch {n} Minuten gültig."
 
-#: lib/vutuv_web/components/ui.ex:961
+#: lib/vutuv_web/components/ui.ex:968
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr "Die PIN ist noch {n} Sekunden gültig."
@@ -20958,27 +20958,27 @@ msgstr "Sprache"
 msgid "The language this post is written in"
 msgstr "Die Sprache, in der dieser Beitrag geschrieben ist"
 
-#: lib/vutuv_web/components/post_components.ex:5158
+#: lib/vutuv_web/components/post_components.ex:5451
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Original anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:5194
+#: lib/vutuv_web/components/post_components.ex:5487
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Übersetzen"
 
-#: lib/vutuv_web/components/post_components.ex:5203
+#: lib/vutuv_web/components/post_components.ex:5496
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Übersetzt"
 
-#: lib/vutuv_web/components/post_components.ex:5206
+#: lib/vutuv_web/components/post_components.ex:5499
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Übersetzt aus %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:5183
+#: lib/vutuv_web/components/post_components.ex:5476
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Wird übersetzt …"
@@ -20988,8 +20988,8 @@ msgstr "Wird übersetzt …"
 msgid "Feed language settings reset to the site defaults."
 msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
 
-#: lib/vutuv_web/components/post_components.ex:5173
-#: lib/vutuv_web/components/ui.ex:5199
+#: lib/vutuv_web/components/post_components.ex:5466
+#: lib/vutuv_web/components/ui.ex:5233
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -21117,20 +21117,20 @@ msgstr "Wir haben den Link in Ihrem Profil noch nicht gefunden. Bitte versuchen 
 msgid "Your username, or paste the address of your profile page."
 msgstr "Ihr Benutzername – oder fügen Sie die Adresse Ihrer Profilseite ein."
 
-#: lib/vutuv_web/components/post_components.ex:4936
+#: lib/vutuv_web/components/post_components.ex:5229
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] "Unsere KI prüft es gerade. Sobald die Prüfung durch ist, erscheint das Foto von selbst."
 msgstr[1] "Unsere KI prüft sie gerade, %{done} von %{total} sind durch. Sobald die letzte durch ist, erscheinen die Fotos von selbst."
 
-#: lib/vutuv_web/components/post_components.ex:4933
+#: lib/vutuv_web/components/post_components.ex:5226
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Ihr Beitrag ist veröffentlicht, das Foto noch nicht."
 
-#: lib/vutuv_web/components/post_components.ex:2527
-#: lib/vutuv_web/components/post_components.ex:4144
+#: lib/vutuv_web/components/post_components.ex:2805
+#: lib/vutuv_web/components/post_components.ex:4436
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -21200,7 +21200,7 @@ msgstr "Damit können Sie sich von einer Mastodon-kompatiblen App aus bei diesem
 msgid "Mastodon app access changed"
 msgstr "Mastodon-App-Zugriff geändert"
 
-#: lib/vutuv_web/components/ui.ex:5319
+#: lib/vutuv_web/components/ui.ex:5353
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr "Mastodon-Apps, verbundene Apps und Zugriffstoken"
@@ -21246,7 +21246,7 @@ msgstr "Wer etwas geschrieben hat, wird weiter festgehalten, das Team kann also 
 msgid "Your account is then %{handle}."
 msgstr "Dein Konto heißt dann %{handle}."
 
-#: lib/vutuv_web/components/ui.ex:5321
+#: lib/vutuv_web/components/ui.ex:5355
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr "api token oauth entwickler verbunden drittanbieter schnittstelle mastodon app handy telefon client ivory tusky ice cubes anmelden"
@@ -21281,7 +21281,7 @@ msgstr "Bekannte aus LinkedIn finden"
 msgid "Find your LinkedIn contacts"
 msgstr "Ihre LinkedIn-Kontakte finden"
 
-#: lib/vutuv_web/components/ui.ex:5215
+#: lib/vutuv_web/components/ui.ex:5249
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format
@@ -21389,7 +21389,7 @@ msgstr "Nach Namen suchen"
 msgid "See which of them are already on vutuv"
 msgstr "Sehen Sie, wer davon schon auf vutuv ist"
 
-#: lib/vutuv_web/components/ui.ex:5217
+#: lib/vutuv_web/components/ui.ex:5251
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr "Sehen, wer aus Ihren LinkedIn-Kontakten schon auf vutuv ist"
@@ -21461,7 +21461,7 @@ msgstr "Ihre Kontakte auf vutuv"
 msgid "Your export also lists your LinkedIn contacts."
 msgstr "Ihr Export enthält auch Ihre LinkedIn-Kontakte."
 
-#: lib/vutuv_web/components/ui.ex:5219
+#: lib/vutuv_web/components/ui.ex:5253
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr "linkedin kontakte verbindungen adressbuch bekannte kollegen finden folgen zip import netzwerk"
@@ -21643,7 +21643,7 @@ msgstr "Land suchen"
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr "Diese Seite folgt bereits so vielen Konten, wie hier erlaubt sind (%{max})."
 
-#: lib/vutuv_web/components/post_components.ex:2850
+#: lib/vutuv_web/components/post_components.ex:3130
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr "%{handle} nicht mehr folgen? Die Beiträge verschwinden aus Ihrem Feed."
@@ -21718,7 +21718,7 @@ msgstr "Wenn etwas eintrifft, während vutuv in einem Tab offen ist, den Sie ger
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr "Sie haben Browser-Benachrichtigungen eingeschaltet. Dieser Browser wurde noch nicht um Erlaubnis gebeten."
 
-#: lib/vutuv_web/components/ui.ex:5173
+#: lib/vutuv_web/components/ui.ex:5207
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr "e-mail email mail abbestellen abmelden newsletter glocke benachrichtigung weniger ruhe browser desktop popup push hinweis mitteilung"
@@ -21769,7 +21769,7 @@ msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public po
 msgstr ""
 "Folgen Sie #%{tag} von Mastodon oder einer anderen Fediverse-App aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3764
+#: lib/vutuv_web/live/post_live/feed.ex:3771
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Andere Mitglieder begrüßen"
@@ -21779,43 +21779,43 @@ msgstr "Andere Mitglieder begrüßen"
 msgid "New here"
 msgstr "Neu dabei"
 
-#: lib/vutuv_web/components/ui.ex:1769
+#: lib/vutuv_web/components/ui.ex:1803
 #, elixir-autogen, elixir-format
 msgid "New public posts arrive in any feed reader. No account needed either."
 msgstr "Neue öffentliche Beiträge landen in jedem Feed-Reader. Auch dafür brauchen Sie kein Konto."
 
-#: lib/vutuv_web/components/ui.ex:1765
+#: lib/vutuv_web/components/ui.ex:1799
 #, elixir-autogen, elixir-format
 msgid "Or with an RSS reader"
 msgstr "Oder mit einem RSS-Reader"
 
-#: lib/vutuv_web/components/ui.ex:1645
-#: lib/vutuv_web/components/ui.ex:1714
+#: lib/vutuv_web/components/ui.ex:1679
+#: lib/vutuv_web/components/ui.ex:1748
 #, elixir-autogen, elixir-format
 msgid "Subscribe"
 msgstr "Abonnieren"
 
-#: lib/vutuv_web/components/ui.ex:1766
+#: lib/vutuv_web/components/ui.ex:1800
 #, elixir-autogen, elixir-format
 msgid "With an RSS reader"
 msgstr "Mit einem RSS-Reader"
 
-#: lib/vutuv_web/components/ui.ex:1726
+#: lib/vutuv_web/components/ui.ex:1760
 #, elixir-autogen, elixir-format
 msgid "Create a free account"
 msgstr "Kostenloses Konto erstellen"
 
-#: lib/vutuv_web/components/ui.ex:1741
+#: lib/vutuv_web/components/ui.ex:1775
 #, elixir-autogen, elixir-format
 msgid "No vutuv account? These ways work too:"
 msgstr "Kein vutuv-Konto? Das geht auch:"
 
-#: lib/vutuv_web/components/ui.ex:1719
+#: lib/vutuv_web/components/ui.ex:1753
 #, elixir-autogen, elixir-format
 msgid "The best way: follow %{name} here. New posts land in your feed, and you can reply and join in."
 msgstr "Der beste Weg: Folgen Sie %{name} hier. Neue Beiträge landen in Ihrem Feed, und Sie können antworten und mitreden."
 
-#: lib/vutuv_web/components/ui.ex:1717
+#: lib/vutuv_web/components/ui.ex:1751
 #, elixir-autogen, elixir-format
 msgid "With a vutuv account"
 msgstr "Mit einem vutuv-Konto"
@@ -21950,26 +21950,26 @@ msgstr "Wird in Ihrem Feed ausgeblendet."
 msgid "Shown in the language it was written in."
 msgstr "Wird in der Sprache gezeigt, in der es geschrieben wurde."
 
-#: lib/vutuv_web/components/ui.ex:5200
+#: lib/vutuv_web/components/ui.ex:5234
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr "Welche Sprachen Sie erreichen und was mit dem Rest geschieht"
 
-#: lib/vutuv_web/components/ui.ex:5202
+#: lib/vutuv_web/components/ui.ex:5236
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr ""
 "sprache übersetzen übersetzung deutsch englisch original ausblenden "
 "fremdsprache reihenfolge rang feed language translate"
 
-#: lib/vutuv_web/components/ui.ex:5240
+#: lib/vutuv_web/components/ui.ex:5274
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr ""
 "Anzeigesprache, Datumsformat und Zeitzone, Karten, wie Beiträge gekürzt "
 "werden"
 
-#: lib/vutuv_web/components/ui.ex:5244
+#: lib/vutuv_web/components/ui.ex:5278
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -22093,7 +22093,7 @@ msgstr "Keine bezahlten Premium-Accounts."
 msgid "Your LinkedIn profile can come along."
 msgstr "Ihr LinkedIn-Profil kann mitkommen."
 
-#: lib/vutuv_web/components/ui.ex:1155
+#: lib/vutuv_web/components/ui.ex:1189
 #, elixir-autogen, elixir-format
 msgid "Being checked"
 msgstr "Wird geprüft"
@@ -22282,13 +22282,13 @@ msgid "Hide a word or a whole phrase …"
 msgstr "Wort oder ganzen Satz ausblenden …"
 
 #: lib/vutuv_web/live/post_live/feed.ex:709
-#: lib/vutuv_web/live/post_live/feed.ex:3927
+#: lib/vutuv_web/live/post_live/feed.ex:3934
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Tags ausblenden"
 
 #: lib/vutuv_web/live/post_live/feed.ex:708
-#: lib/vutuv_web/live/post_live/feed.ex:3916
+#: lib/vutuv_web/live/post_live/feed.ex:3923
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Wörter ausblenden"
@@ -22314,7 +22314,7 @@ msgstr "Mehr Ihrer %{formatted} Konten"
 msgid "Move %{card}"
 msgstr "%{card} verschieben"
 
-#: lib/vutuv_web/components/ui.ex:412
+#: lib/vutuv_web/components/ui.ex:419
 #: lib/vutuv_web/live/post_live/filter_band.ex:584
 #, elixir-autogen, elixir-format
 msgid "No account found."
@@ -22355,7 +22355,7 @@ msgstr "Beiträge mit einem dieser Tags werden genauso zugeklappt."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Beiträge mit einem dieser Wörter werden auf eine Zeile zugeklappt — nicht gelöscht, und mit einem Weg, sie doch zu lesen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3790
+#: lib/vutuv_web/live/post_live/feed.ex:3797
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Weggelegt:"
@@ -22394,7 +22394,7 @@ msgid "Show posts by %{name}"
 msgstr "Beiträge von %{name} anzeigen"
 
 #: lib/vutuv_web/live/post_live/feed.ex:707
-#: lib/vutuv_web/live/post_live/feed.ex:3882
+#: lib/vutuv_web/live/post_live/feed.ex:3889
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr "Quellen"
@@ -22453,7 +22453,7 @@ msgid_plural "Show %{formatted} posts in the feed"
 msgstr[0] "%{formatted} Beitrag im Feed anzeigen"
 msgstr[1] "%{formatted} Beiträge im Feed anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2444
+#: lib/vutuv_web/components/post_components.ex:2722
 #, elixir-autogen, elixir-format
 msgid "Picture unavailable"
 msgstr "Bild nicht verfügbar"
@@ -22482,7 +22482,7 @@ msgstr ""
 "Ihre Organisationsseite wurde aktualisiert, aber dieses Bild konnte nicht als "
 "Logo verwendet werden. Bitte wählen Sie ein anderes."
 
-#: lib/vutuv_web/components/ui.ex:4427
+#: lib/vutuv_web/components/ui.ex:4461
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -22503,7 +22503,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} Beitrag am %{day}"
 msgstr[1] "%{count} Beiträge am %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3556
+#: lib/vutuv_web/live/post_live/feed.ex:3563
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Zurück zu jetzt"
@@ -22513,7 +22513,7 @@ msgstr "Zurück zu jetzt"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Voller Monat: die Färbung zählt mindestens so viel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3602
+#: lib/vutuv_web/live/post_live/feed.ex:3609
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22535,7 +22535,7 @@ msgstr "Nächster Monat"
 msgid "Next year"
 msgstr "Nächstes Jahr"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3552
+#: lib/vutuv_web/live/post_live/feed.ex:3559
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Am %{day} ist nichts in Ihrem Feed angekommen."
@@ -22629,7 +22629,7 @@ msgid_plural "New (%{formatted}):"
 msgstr[0] "Neu:"
 msgstr[1] "Neu (%{formatted}):"
 
-#: lib/vutuv_web/components/post_components.ex:3005
+#: lib/vutuv_web/components/post_components.ex:3285
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr "Zitierter Beitrag"
@@ -22644,12 +22644,12 @@ msgstr "Zitiert %{name}: %{url}"
 msgid "Quotes %{url}"
 msgstr "Zitiert %{url}"
 
-#: lib/vutuv_web/components/ui.ex:411
+#: lib/vutuv_web/components/ui.ex:418
 #, elixir-autogen, elixir-format
 msgid "Mention an account"
 msgstr "Ein Konto erwähnen"
 
-#: lib/vutuv_web/components/ui.ex:415
+#: lib/vutuv_web/components/ui.ex:422
 #, elixir-autogen, elixir-format
 msgid "{used} of {max} mentions"
 msgstr "{used} von {max} Erwähnungen"
@@ -22680,12 +22680,12 @@ msgstr "Bleibt das Account-Feld leer, gilt die Regel für alle; %{example} grenz
 msgid "Only these accounts (empty = all) …"
 msgstr "Nur diese Accounts (leer = alle) …"
 
-#: lib/vutuv_web/components/ui.ex:3496
+#: lib/vutuv_web/components/ui.ex:3530
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr "nur %{account}"
 
-#: lib/vutuv_web/components/post_components.ex:6617
+#: lib/vutuv_web/components/post_components.ex:6911
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -22732,17 +22732,17 @@ msgid_plural "shared this."
 msgstr[0] "hat das geteilt."
 msgstr[1] "haben das geteilt."
 
-#: lib/vutuv_web/components/ui.ex:566
+#: lib/vutuv_web/components/ui.ex:573
 #, elixir-autogen, elixir-format
 msgid "Editor view"
 msgstr "Ansicht"
 
-#: lib/vutuv_web/components/ui.ex:514
+#: lib/vutuv_web/components/ui.ex:521
 #, elixir-autogen, elixir-format
 msgid "Insert a block"
 msgstr "Block einfügen"
 
-#: lib/vutuv_web/components/ui.ex:526
+#: lib/vutuv_web/components/ui.ex:533
 #, elixir-autogen, elixir-format
 msgid "Nothing matches."
 msgstr "Nichts gefunden."
@@ -22868,7 +22868,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr "Schreiben"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3690
+#: lib/vutuv_web/live/post_live/feed.ex:3697
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "%{formatted} rule"
@@ -22921,7 +22921,7 @@ msgstr "Von diesem Beitrag bleibt nichts übrig."
 msgid "Replace with"
 msgstr "Ersetzen durch"
 
-#: lib/vutuv_web/components/ui.ex:5192
+#: lib/vutuv_web/components/ui.ex:5226
 #, elixir-autogen, elixir-format
 msgid "Rewrite what an account's posts say, for you alone"
 msgstr "Text in den Beiträgen eines Kontos umschreiben, nur für Sie"
@@ -22936,10 +22936,10 @@ msgstr "Regeln für %{account}"
 msgid "Rules that rewrite the text of one account's posts before you read them: a footer under every post, a signature, a wall of hashtags. Only you see the difference. Open the ⋯ menu on any post to write rules for its author."
 msgstr "Regeln, die den Text der Beiträge eines Kontos umschreiben, bevor Sie ihn lesen: eine Fußzeile unter jedem Beitrag, eine Signatur, eine Wand aus Hashtags. Nur Sie sehen den Unterschied. Öffnen Sie das ⋯-Menü an einem Beitrag, um Regeln für dessen Autor zu schreiben."
 
-#: lib/vutuv_web/components/post_components.ex:1424
-#: lib/vutuv_web/components/post_components.ex:2863
-#: lib/vutuv_web/components/post_components.ex:3941
-#: lib/vutuv_web/components/ui.ex:5191
+#: lib/vutuv_web/components/post_components.ex:1464
+#: lib/vutuv_web/components/post_components.ex:3143
+#: lib/vutuv_web/components/post_components.ex:4225
+#: lib/vutuv_web/components/ui.ex:5225
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
 #: lib/vutuv_web/live/post_rewrites_live.ex:264
@@ -22995,12 +22995,12 @@ msgstr "Ihre gespeicherten Regeln ändern diesen Beitrag von %{who} wie gezeigt.
 msgid "\\1 puts back what the first (…) group matched, \\0 the whole match."
 msgstr "\\1 setzt ein, was die erste (…)-Gruppe getroffen hat, \\0 den ganzen Treffer."
 
-#: lib/vutuv_web/components/ui.ex:5193
+#: lib/vutuv_web/components/ui.ex:5227
 #, elixir-autogen, elixir-format
 msgid "regex regular expression rewrite replace footer signature strip"
 msgstr "regex regulärer ausdruck umschreiben ersetzen fußzeile signatur entfernen suchen"
 
-#: lib/vutuv_web/components/ui.ex:5262
+#: lib/vutuv_web/components/ui.ex:5296
 #, elixir-autogen, elixir-format
 msgid "Smaller pictures and a plain composer on a slow connection"
 msgstr "Kleinere Bilder und ein einfacher Editor bei langsamer Verbindung"
@@ -23010,12 +23010,12 @@ msgstr "Kleinere Bilder und ein einfacher Editor bei langsamer Verbindung"
 msgid "That endorsement is not possible."
 msgstr "Diese Empfehlung ist nicht möglich."
 
-#: lib/vutuv_web/components/ui.ex:5264
+#: lib/vutuv_web/components/ui.ex:5298
 #, elixir-autogen, elixir-format
 msgid "bandwidth slow internet mobile data saving saver volume metered compression pictures images screenshots editor langsam daten sparen datensparmodus volumen schmalband komprimierung bilder"
 msgstr "bandbreite langsam internet mobil daten sparen datensparmodus volumen schmalband komprimierung bilder fotos screenshots editor bandwidth slow data saving"
 
-#: lib/vutuv_web/components/ui.ex:5236
+#: lib/vutuv_web/components/ui.ex:5270
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr "Darstellung"
@@ -23027,7 +23027,7 @@ msgid_plural "%{count} videos in progress"
 msgstr[0] "%{count} Video in Arbeit"
 msgstr[1] "%{count} Videos in Arbeit"
 
-#: lib/vutuv_web/components/video_components.ex:257
+#: lib/vutuv_web/components/video_components.ex:258
 #, elixir-autogen, elixir-format
 msgid "About %{minutes} min of video"
 msgstr "Etwa %{minutes} Min. Video"
@@ -23037,39 +23037,39 @@ msgstr "Etwa %{minutes} Min. Video"
 msgid "Add video"
 msgstr "Video hinzufügen"
 
-#: lib/vutuv_web/components/video_components.ex:199
+#: lib/vutuv_web/components/video_components.ex:200
 #, elixir-autogen, elixir-format
 msgid "Converting · %{percent} %"
 msgstr "Wird umgewandelt · %{percent} %"
 
-#: lib/vutuv_web/components/video_components.ex:280
+#: lib/vutuv_web/components/video_components.ex:281
 #, elixir-autogen, elixir-format
 msgid "Delete this post"
 msgstr "Diesen Beitrag löschen"
 
-#: lib/vutuv_web/components/video_components.ex:216
+#: lib/vutuv_web/components/video_components.ex:217
 #, elixir-autogen, elixir-format
 msgid "Our AI check refused this video (at %{time})."
 msgstr "Unsere KI-Prüfung hat dieses Video abgelehnt (bei %{time})."
 
-#: lib/vutuv_web/components/video_components.ex:218
+#: lib/vutuv_web/components/video_components.ex:219
 #, elixir-autogen, elixir-format
 msgid "Our AI check refused this video."
 msgstr "Unsere KI-Prüfung hat dieses Video abgelehnt."
 
-#: lib/vutuv_web/components/video_components.ex:204
+#: lib/vutuv_web/components/video_components.ex:205
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking it."
 msgid_plural "Our AI is checking it, %{done} of %{total} frames done."
 msgstr[0] "Unsere KI prüft es gerade."
 msgstr[1] "Unsere KI prüft es gerade, %{done} von %{total} Bildern sind durch."
 
-#: lib/vutuv_web/components/video_components.ex:272
+#: lib/vutuv_web/components/video_components.ex:273
 #, elixir-autogen, elixir-format
 msgid "Post without the video"
 msgstr "Ohne das Video veröffentlichen"
 
-#: lib/vutuv_web/components/video_components.ex:196
+#: lib/vutuv_web/components/video_components.ex:197
 #, elixir-autogen, elixir-format
 msgid "Reading the frames"
 msgstr "Standbilder werden gelesen"
@@ -23104,7 +23104,7 @@ msgstr "Dieses Bild konnte nicht verwendet werden."
 msgid "The video could not be attached."
 msgstr "Das Video konnte nicht angehängt werden."
 
-#: lib/vutuv_web/components/video_components.ex:262
+#: lib/vutuv_web/components/video_components.ex:263
 #, elixir-autogen, elixir-format
 msgid "The video is gone."
 msgstr "Das Video ist nicht mehr da."
@@ -23114,12 +23114,12 @@ msgstr "Das Video ist nicht mehr da."
 msgid "The video is longer than %{seconds} seconds."
 msgstr "Das Video ist länger als %{seconds} Sekunden."
 
-#: lib/vutuv_web/components/video_components.ex:246
+#: lib/vutuv_web/components/video_components.ex:247
 #, elixir-autogen, elixir-format
 msgid "This post is still waiting for you"
 msgstr "Dieser Beitrag wartet noch auf Sie"
 
-#: lib/vutuv_web/components/video_components.ex:219
+#: lib/vutuv_web/components/video_components.ex:220
 #, elixir-autogen, elixir-format
 msgid "This video could not be converted."
 msgstr "Dieses Video konnte nicht umgewandelt werden."
@@ -23128,8 +23128,8 @@ msgstr "Dieses Video konnte nicht umgewandelt werden."
 #: lib/vutuv_web/agent_docs/markdown.ex:1417
 #: lib/vutuv_web/agent_docs/text.ex:899
 #: lib/vutuv_web/agent_docs/text.ex:900
-#: lib/vutuv_web/components/post_components.ex:2579
-#: lib/vutuv_web/components/video_components.ex:126
+#: lib/vutuv_web/components/post_components.ex:2857
+#: lib/vutuv_web/components/video_components.ex:127
 #: lib/vutuv_web/live/post_live/composer.ex:2458
 #, elixir-autogen, elixir-format
 msgid "Video"
@@ -23145,7 +23145,7 @@ msgstr "Videobeschreibung"
 msgid "Videos cannot be uploaded here."
 msgstr "Hier können keine Videos hochgeladen werden."
 
-#: lib/vutuv_web/components/video_components.ex:195
+#: lib/vutuv_web/components/video_components.ex:196
 #, elixir-autogen, elixir-format
 msgid "Waiting in line"
 msgstr "Wartet in der Warteschlange"
@@ -23160,7 +23160,7 @@ msgstr "Was im Video zu sehen ist, für Menschen, die es nicht ansehen können"
 msgid "You can post now — the post appears as soon as the video is ready."
 msgstr "Sie können jetzt veröffentlichen: Der Beitrag erscheint, sobald das Video fertig ist."
 
-#: lib/vutuv_web/components/video_components.ex:247
+#: lib/vutuv_web/components/video_components.ex:248
 #, elixir-autogen, elixir-format
 msgid "Your post appears as soon as the video is ready"
 msgstr "Ihr Beitrag erscheint, sobald das Video fertig ist"
@@ -23191,7 +23191,7 @@ msgstr[1] "%{formatted} neue Follower"
 msgid "Last 30 days: %{parts}"
 msgstr "Letzte 30 Tage: %{parts}"
 
-#: lib/vutuv_web/components/post_components.ex:4496
+#: lib/vutuv_web/components/post_components.ex:4788
 #: lib/vutuv_web/live/notification_live/index.ex:1004
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -23232,12 +23232,12 @@ msgstr "hat Sie erwähnt."
 msgid "replied in the thread."
 msgstr "hat im Thread geantwortet."
 
-#: lib/vutuv_web/components/ui.ex:1335
+#: lib/vutuv_web/components/ui.ex:1369
 #, elixir-autogen, elixir-format
 msgid "Standard quality. Load this picture in HD."
 msgstr "Standardqualität. Dieses Bild in HD laden."
 
-#: lib/vutuv_web/components/video_components.ex:117
+#: lib/vutuv_web/components/video_components.ex:118
 #, elixir-autogen, elixir-format
 msgid "Standard quality. Play this video in HD."
 msgstr "Standardqualität. Dieses Video in HD abspielen."
@@ -23495,7 +23495,7 @@ msgstr "Ein Fediverse-Konto, das hier mehreren Profilen folgt, zählt trotzdem a
 msgid "Accounts whose posts stay out of your feed, and accounts whose reposts do. This list is yours alone: it is never shared and nobody is told they are on it."
 msgstr "Konten, deren Beiträge nicht in Ihrem Feed erscheinen, und Konten, deren Reposts Sie ausgeblendet haben. Diese Liste gehört Ihnen allein: sie wird nie geteilt, und niemand erfährt, dass er darauf steht."
 
-#: lib/vutuv_web/components/ui.ex:5185
+#: lib/vutuv_web/components/ui.ex:5219
 #, elixir-autogen, elixir-format
 msgid "Accounts you have silenced, and whose reposts you hide"
 msgstr "Konten, die Sie stummgeschaltet haben, und deren Reposts Sie ausblenden"
@@ -23505,8 +23505,8 @@ msgstr "Konten, die Sie stummgeschaltet haben, und deren Reposts Sie ausblenden"
 msgid "Hidden. What they pass on stays out of your feed; their own posts do not."
 msgstr "Ausgeblendet. Was dieses Konto weiterreicht, erscheint nicht mehr in Ihrem Feed, die eigenen Beiträge schon."
 
-#: lib/vutuv_web/components/post_components.ex:2835
-#: lib/vutuv_web/components/post_components.ex:3935
+#: lib/vutuv_web/components/post_components.ex:3115
+#: lib/vutuv_web/components/post_components.ex:4219
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr "Reposts ausblenden"
@@ -23521,7 +23521,7 @@ msgstr "Suchen Sie stattdessen nach Wörtern, Wendungen oder Tags?"
 msgid "Mute everything"
 msgstr "Ganz stummschalten"
 
-#: lib/vutuv_web/components/ui.ex:5184
+#: lib/vutuv_web/components/ui.ex:5218
 #: lib/vutuv_web/controllers/settings_controller.ex:713
 #: lib/vutuv_web/templates/settings/mutes.html.heex:1
 #: lib/vutuv_web/templates/settings/mutes.html.heex:3
@@ -23565,7 +23565,7 @@ msgstr "Sie haben noch niemanden stummgeschaltet."
 msgid "You mute an account where you meet it: the ⋯ menu on any of its posts, or its own page. Muting works whether or not you follow them."
 msgstr "Stummschalten können Sie ein Konto dort, wo Sie ihm begegnen: im ⋯-Menü eines seiner Beiträge oder auf seiner eigenen Seite. Das geht auch bei Konten, denen Sie nicht folgen."
 
-#: lib/vutuv_web/components/ui.ex:5187
+#: lib/vutuv_web/components/ui.ex:5221
 #, elixir-autogen, elixir-format
 msgid "mute unmute hide account reposts boosts feed stumm stummschalten ausblenden konto"
 msgstr "stumm stummschalten stummschaltung ausblenden verbergen konto account reposts boosts feed"
@@ -23665,7 +23665,7 @@ msgstr "Die Länge Ihres Feeds folgt wieder der Voreinstellung."
 msgid "Feed settings saved."
 msgstr "Feed-Einstellungen gespeichert."
 
-#: lib/vutuv_web/components/ui.ex:5255
+#: lib/vutuv_web/components/ui.ex:5289
 #, elixir-autogen, elixir-format
 msgid "How many load at once, and how many “Load more” adds"
 msgstr "Wie viele auf einmal geladen werden und wie viele „Mehr laden“ ergänzt"
@@ -23675,7 +23675,7 @@ msgstr "Wie viele auf einmal geladen werden und wie viele „Mehr laden“ ergä
 msgid "How many posts your feed shows before the “Load more” button, and how many that button adds. More posts mean a longer wait for the page."
 msgstr "Wie viele Beiträge Ihr Feed vor dem Knopf „Mehr laden“ zeigt und wie viele dieser Knopf ergänzt. Mehr Beiträge bedeuten eine längere Wartezeit auf die Seite."
 
-#: lib/vutuv_web/components/ui.ex:5254
+#: lib/vutuv_web/components/ui.ex:5288
 #: lib/vutuv_web/controllers/settings_controller.ex:963
 #: lib/vutuv_web/templates/settings/feed.html.heex:12
 #, elixir-autogen, elixir-format
@@ -23687,8 +23687,8 @@ msgstr "Beiträge in Ihrem Feed"
 msgid "Posts loaded at once"
 msgstr "Beiträge auf einmal"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3626
-#: lib/vutuv_web/live/post_live/feed.ex:3630
+#: lib/vutuv_web/live/post_live/feed.ex:3633
+#: lib/vutuv_web/live/post_live/feed.ex:3637
 #, elixir-autogen, elixir-format
 msgid "Posts per page"
 msgstr "Beiträge pro Seite"
@@ -23698,65 +23698,65 @@ msgstr "Beiträge pro Seite"
 msgid "You can change this under the feed itself as well, right below the “Load more” button."
 msgstr "Sie können das auch direkt im Feed ändern, gleich unter „Mehr laden“."
 
-#: lib/vutuv_web/components/ui.ex:5257
+#: lib/vutuv_web/components/ui.ex:5291
 #, elixir-autogen, elixir-format
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr "feed länge seitengröße beiträge anzahl menge mehr laden scrollen blättern seite umfang page size posts number load more"
 
-#: lib/vutuv_web/components/post_components.ex:6608
-#: lib/vutuv_web/components/post_components.ex:6609
+#: lib/vutuv_web/components/post_components.ex:6902
+#: lib/vutuv_web/components/post_components.ex:6903
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr "Ein Wort oder eine Wortgruppe …"
 
-#: lib/vutuv_web/components/post_components.ex:6636
+#: lib/vutuv_web/components/post_components.ex:6930
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr "Für wen %{thing} ausgeblendet wird"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3687
-#: lib/vutuv_web/live/post_live/feed.ex:3846
-#: lib/vutuv_web/live/post_live/feed.ex:3855
+#: lib/vutuv_web/live/post_live/feed.ex:3694
+#: lib/vutuv_web/live/post_live/feed.ex:3853
+#: lib/vutuv_web/live/post_live/feed.ex:3862
 #, elixir-autogen, elixir-format
 msgid "Hidden"
 msgstr "Ausgeblendet"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3820
+#: lib/vutuv_web/live/post_live/feed.ex:3827
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr "Etwas aus dem Feed ausblenden"
 
-#: lib/vutuv_web/components/post_components.ex:6556
+#: lib/vutuv_web/components/post_components.ex:6850
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr "Nicht mehr zeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3861
+#: lib/vutuv_web/live/post_live/feed.ex:3868
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr "Was hiervon getroffen wird, klappt im Feed auf eine Zeile zu."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3881
+#: lib/vutuv_web/live/post_live/feed.ex:3888
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr "Wörter & Tags"
 
-#: lib/vutuv_web/components/post_components.ex:6640
+#: lib/vutuv_web/components/post_components.ex:6934
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr "bei allen"
 
-#: lib/vutuv_web/components/post_components.ex:6643
+#: lib/vutuv_web/components/post_components.ex:6937
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr "nur %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:6612
+#: lib/vutuv_web/components/post_components.ex:6906
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr "dieses Wort"
 
-#: lib/vutuv_web/components/post_components.ex:6653
+#: lib/vutuv_web/components/post_components.ex:6947
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "nur %{server}"
@@ -23808,7 +23808,7 @@ msgstr "Diese Website ist gerade offline."
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr "Die Website läuft, nur diese Adresse gibt es hier nicht. Wahrscheinlich ist der Link alt oder enthält einen Tippfehler."
 
-#: lib/vutuv_web/components/post_components.ex:5966
+#: lib/vutuv_web/components/post_components.ex:6260
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr "Screenshot vergrößern"
@@ -23908,8 +23908,8 @@ msgstr "Ihr Inhalt wurde nach einer Meldung automatisch verborgen. Auf der Falls
 msgid "Hidden. What other people pass on of them stays out of your feed; their own posts do not."
 msgstr "Ausgeblendet. Was andere von diesem Konto weiterreichen, erscheint nicht mehr in Ihrem Feed, die eigenen Beiträge schon."
 
-#: lib/vutuv_web/components/post_components.ex:2821
-#: lib/vutuv_web/components/post_components.ex:3923
+#: lib/vutuv_web/components/post_components.ex:3101
+#: lib/vutuv_web/components/post_components.ex:4207
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr "Ausblenden, wenn andere reposten"
@@ -24171,3 +24171,46 @@ msgstr "Ihr Titelbild wurde nicht ersetzt: Eine Meldung dazu ist noch offen. Öf
 #, elixir-autogen, elixir-format
 msgid "Your profile picture was not replaced: a report about it is still open. Open the case to remove the picture or to say that it is yours."
 msgstr "Ihr Profilbild wurde nicht ersetzt: Eine Meldung dazu ist noch offen. Öffnen Sie den Fall, um das Bild zu entfernen oder zu sagen, dass es Ihres ist."
+
+#: lib/vutuv_web/components/post_components.ex:2439
+#, elixir-autogen, elixir-format
+msgid "Fetching the answers from the servers that hold them…"
+msgstr "Die Antworten werden von den Servern geholt, auf denen sie liegen …"
+
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:250
+#, elixir-autogen, elixir-format
+msgid "Not every answer could be fetched. The rest are on the origin server."
+msgstr "Nicht jede Antwort ließ sich holen. Der Rest steht auf dem Ursprungsserver."
+
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:240
+#, elixir-autogen, elixir-format
+msgid "Nothing here we are allowed to show you."
+msgstr "Hier ist nichts, was wir Ihnen zeigen dürfen."
+
+#: lib/vutuv_web/components/post_components.ex:2454
+#, elixir-autogen, elixir-format
+msgid "Show more answers"
+msgstr "Weitere Antworten anzeigen"
+
+#: lib/vutuv_web/components/post_components.ex:2371
+#: lib/vutuv_web/components/post_components.ex:2373
+#, elixir-autogen, elixir-format
+msgid "Show the one answer"
+msgid_plural "Show the %{count} answers"
+msgstr[0] "Die eine Antwort anzeigen"
+msgstr[1] "Die %{count} Antworten anzeigen"
+
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:257
+#, elixir-autogen, elixir-format
+msgid "That is enough answers fetched for one hour. Try again later."
+msgstr "Für diese Stunde sind genug Antworten geholt. Versuchen Sie es später noch einmal."
+
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:262
+#, elixir-autogen, elixir-format
+msgid "The answers could not be fetched from the servers that hold them."
+msgstr "Die Antworten ließen sich nicht von den Servern holen, auf denen sie liegen."
+
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:265
+#, elixir-autogen, elixir-format
+msgid "The rest could not be fetched right now."
+msgstr "Der Rest ließ sich gerade nicht holen."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -17,8 +17,8 @@ msgstr ""
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4811
-#: lib/vutuv_web/components/ui.ex:4816
+#: lib/vutuv_web/components/ui.ex:4845
+#: lib/vutuv_web/components/ui.ex:4850
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
 #: lib/vutuv_web/live/organization_live/domains.ex:287
@@ -64,7 +64,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/text.ex:71
-#: lib/vutuv_web/components/ui.ex:5148
+#: lib/vutuv_web/components/ui.ex:5182
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -77,14 +77,14 @@ msgstr ""
 msgid "Addresses"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1732
+#: lib/vutuv_web/components/ui.ex:1766
 #: lib/vutuv_web/templates/page/index.html.heex:325
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4602
-#: lib/vutuv_web/components/ui.ex:4701
+#: lib/vutuv_web/components/ui.ex:4636
+#: lib/vutuv_web/components/ui.ex:4735
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -112,8 +112,8 @@ msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:104
-#: lib/vutuv_web/components/ui.ex:4596
-#: lib/vutuv_web/components/video_components.ex:280
+#: lib/vutuv_web/components/ui.ex:4630
+#: lib/vutuv_web/components/video_components.ex:281
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
 #: lib/vutuv_web/live/admin/user_delete_live.ex:202
@@ -163,8 +163,8 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3880
-#: lib/vutuv_web/components/ui.ex:4703
+#: lib/vutuv_web/components/post_components.ex:4164
+#: lib/vutuv_web/components/ui.ex:4737
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:657
@@ -211,8 +211,8 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3845
-#: lib/vutuv_web/components/ui.ex:4694
+#: lib/vutuv_web/components/post_components.ex:4129
+#: lib/vutuv_web/components/ui.ex:4728
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
@@ -286,7 +286,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:5112
+#: lib/vutuv_web/components/ui.ex:5146
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -326,8 +326,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:698
 #: lib/vutuv_web/agent_docs/text.ex:658
 #: lib/vutuv_web/components/fediverse_components.ex:468
-#: lib/vutuv_web/components/ui.ex:3029
-#: lib/vutuv_web/components/ui.ex:3064
+#: lib/vutuv_web/components/ui.ex:3063
+#: lib/vutuv_web/components/ui.ex:3098
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:618
@@ -475,7 +475,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:793
+#: lib/vutuv_web/components/post_components.ex:806
 #: lib/vutuv_web/live/notification_live/index.ex:777
 #: lib/vutuv_web/live/organization_live/activity.ex:136
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -615,7 +615,7 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4595
+#: lib/vutuv_web/components/ui.ex:4629
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2201
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -659,7 +659,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1812
+#: lib/vutuv_web/components/post_components.ex:1852
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -790,7 +790,7 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5108
+#: lib/vutuv_web/components/ui.ex:5142
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:832
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -842,7 +842,7 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1539
+#: lib/vutuv_web/components/ui.ex:1573
 #: lib/vutuv_web/views/user_html.ex:582
 #: lib/vutuv_web/views/user_html.ex:583
 #: lib/vutuv_web/views/user_html.ex:597
@@ -850,14 +850,14 @@ msgstr ""
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4764
+#: lib/vutuv_web/components/ui.ex:4798
 #: lib/vutuv_web/templates/user/show.html.heex:982
 #: lib/vutuv_web/templates/user/show.html.heex:1005
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5271
+#: lib/vutuv_web/components/ui.ex:5305
 #: lib/vutuv_web/controllers/settings_controller.ex:175
 #: lib/vutuv_web/live/job_posting_live/form.ex:818
 #: lib/vutuv_web/live/organization_live/edit.ex:339
@@ -1180,7 +1180,7 @@ msgstr ""
 msgid "All tag urls"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4487
+#: lib/vutuv_web/components/post_components.ex:4779
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:638
@@ -1352,7 +1352,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:584
 #: lib/vutuv_web/agent_docs/text.ex:850
-#: lib/vutuv_web/components/ui.ex:5133
+#: lib/vutuv_web/components/ui.ex:5167
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3188
+#: lib/vutuv_web/components/ui.ex:3222
 #: lib/vutuv_web/components/welcome_components.ex:125
 #: lib/vutuv_web/components/welcome_components.ex:131
 #: lib/vutuv_web/live/admin/job_live.ex:321
@@ -1654,20 +1654,20 @@ msgstr ""
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2271
-#: lib/vutuv_web/components/ui.ex:2280
-#: lib/vutuv_web/components/ui.ex:2758
+#: lib/vutuv_web/components/ui.ex:2305
+#: lib/vutuv_web/components/ui.ex:2314
+#: lib/vutuv_web/components/ui.ex:2792
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:244
-#: lib/vutuv_web/components/ui.ex:2994
-#: lib/vutuv_web/components/ui.ex:2994
-#: lib/vutuv_web/components/ui.ex:3011
-#: lib/vutuv_web/components/ui.ex:3020
-#: lib/vutuv_web/components/ui.ex:3036
-#: lib/vutuv_web/components/ui.ex:3098
+#: lib/vutuv_web/components/ui.ex:3028
+#: lib/vutuv_web/components/ui.ex:3028
+#: lib/vutuv_web/components/ui.ex:3045
+#: lib/vutuv_web/components/ui.ex:3054
+#: lib/vutuv_web/components/ui.ex:3070
+#: lib/vutuv_web/components/ui.ex:3132
 #: lib/vutuv_web/live/fediverse_account_live.ex:422
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:320
@@ -1732,8 +1732,8 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:472
-#: lib/vutuv_web/components/ui.ex:4813
+#: lib/vutuv_web/components/post_components.ex:485
+#: lib/vutuv_web/components/ui.ex:4847
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
@@ -1749,7 +1749,7 @@ msgid "Nothing new yet."
 msgstr ""
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:5170
+#: lib/vutuv_web/components/ui.ex:5204
 #: lib/vutuv_web/controllers/page_controller.ex:219
 #: lib/vutuv_web/live/notification_live/index.ex:155
 #: lib/vutuv_web/live/notification_live/index.ex:441
@@ -1888,14 +1888,14 @@ msgstr ""
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4096
-#: lib/vutuv_web/components/ui.ex:4241
+#: lib/vutuv_web/components/ui.ex:4130
+#: lib/vutuv_web/components/ui.ex:4275
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4838
+#: lib/vutuv_web/components/ui.ex:4872
 #: lib/vutuv_web/live/organization_live/activity.ex:159
 #: lib/vutuv_web/live/organization_live/feed.ex:258
 #: lib/vutuv_web/live/organization_live/show.ex:787
@@ -1908,13 +1908,13 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4605
+#: lib/vutuv_web/components/ui.ex:4639
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1934
-#: lib/vutuv_web/components/ui.ex:1944
+#: lib/vutuv_web/components/ui.ex:1968
+#: lib/vutuv_web/components/ui.ex:1978
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr ""
@@ -1953,12 +1953,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3555
+#: lib/vutuv_web/components/ui.ex:3589
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3559
+#: lib/vutuv_web/components/ui.ex:3593
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -1984,37 +1984,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3563
+#: lib/vutuv_web/components/ui.ex:3597
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3553
+#: lib/vutuv_web/components/ui.ex:3587
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3552
+#: lib/vutuv_web/components/ui.ex:3586
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3558
+#: lib/vutuv_web/components/ui.ex:3592
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3557
+#: lib/vutuv_web/components/ui.ex:3591
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3554
+#: lib/vutuv_web/components/ui.ex:3588
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3556
+#: lib/vutuv_web/components/ui.ex:3590
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2029,17 +2029,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3562
+#: lib/vutuv_web/components/ui.ex:3596
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3561
+#: lib/vutuv_web/components/ui.ex:3595
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3560
+#: lib/vutuv_web/components/ui.ex:3594
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2078,7 +2078,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3877
+#: lib/vutuv_web/components/post_components.ex:4161
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2123,8 +2123,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3831
-#: lib/vutuv_web/components/post_components.ex:3833
+#: lib/vutuv_web/components/post_components.ex:4115
+#: lib/vutuv_web/components/post_components.ex:4117
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3576
+#: lib/vutuv_web/live/post_live/feed.ex:3583
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2189,13 +2189,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4360
-#: lib/vutuv_web/components/post_components.ex:4364
+#: lib/vutuv_web/components/post_components.ex:4652
+#: lib/vutuv_web/components/post_components.ex:4656
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4361
+#: lib/vutuv_web/components/post_components.ex:4653
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2205,7 +2205,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:497
 #: lib/vutuv_web/components/job_exclusion_components.ex:189
-#: lib/vutuv_web/components/post_components.ex:1421
+#: lib/vutuv_web/components/post_components.ex:1461
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:229
@@ -2271,7 +2271,7 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5515
+#: lib/vutuv_web/components/ui.ex:5549
 #: lib/vutuv_web/live/shell_live.ex:1582
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2290,32 +2290,32 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3828
+#: lib/vutuv_web/components/post_components.ex:4112
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5984
+#: lib/vutuv_web/components/post_components.ex:6278
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5988
+#: lib/vutuv_web/components/post_components.ex:6282
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5986
+#: lib/vutuv_web/components/post_components.ex:6280
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5987
+#: lib/vutuv_web/components/post_components.ex:6281
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3633
+#: lib/vutuv_web/components/ui.ex:3667
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
@@ -2354,9 +2354,9 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2104
-#: lib/vutuv_web/components/post_components.ex:6084
-#: lib/vutuv_web/components/ui.ex:4163
+#: lib/vutuv_web/components/post_components.ex:2165
+#: lib/vutuv_web/components/post_components.ex:6378
+#: lib/vutuv_web/components/ui.ex:4197
 #: lib/vutuv_web/views/user_html.ex:481
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2373,9 +2373,9 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2055
-#: lib/vutuv_web/components/post_components.ex:6322
-#: lib/vutuv_web/components/ui.ex:4149
+#: lib/vutuv_web/components/post_components.ex:2109
+#: lib/vutuv_web/components/post_components.ex:6616
+#: lib/vutuv_web/components/ui.ex:4183
 #: lib/vutuv_web/notification_line.ex:293
 #: lib/vutuv_web/views/user_html.ex:491
 #, elixir-autogen, elixir-format
@@ -2383,7 +2383,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1263
-#: lib/vutuv_web/components/post_components.ex:6332
+#: lib/vutuv_web/components/post_components.ex:6626
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1590
@@ -2404,40 +2404,40 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6072
+#: lib/vutuv_web/components/post_components.ex:6366
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2103
-#: lib/vutuv_web/components/post_components.ex:6083
+#: lib/vutuv_web/components/post_components.ex:2164
+#: lib/vutuv_web/components/post_components.ex:6377
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:481
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2084
-#: lib/vutuv_web/components/post_components.ex:6068
+#: lib/vutuv_web/components/post_components.ex:2145
+#: lib/vutuv_web/components/post_components.ex:6362
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2372
-#: lib/vutuv_web/components/post_components.ex:5091
+#: lib/vutuv_web/components/post_components.ex:2649
+#: lib/vutuv_web/components/post_components.ex:5384
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2083
-#: lib/vutuv_web/components/post_components.ex:6067
+#: lib/vutuv_web/components/post_components.ex:2144
+#: lib/vutuv_web/components/post_components.ex:6361
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2054
-#: lib/vutuv_web/components/post_components.ex:6321
+#: lib/vutuv_web/components/post_components.ex:2108
+#: lib/vutuv_web/components/post_components.ex:6615
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:491
 #, elixir-autogen, elixir-format
@@ -2445,10 +2445,10 @@ msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:498
-#: lib/vutuv_web/components/post_components.ex:2855
-#: lib/vutuv_web/components/ui.ex:2989
-#: lib/vutuv_web/components/ui.ex:2989
-#: lib/vutuv_web/components/ui.ex:3065
+#: lib/vutuv_web/components/post_components.ex:3135
+#: lib/vutuv_web/components/ui.ex:3023
+#: lib/vutuv_web/components/ui.ex:3023
+#: lib/vutuv_web/components/ui.ex:3099
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
 #: lib/vutuv_web/live/organization_live/show.ex:621
@@ -2465,20 +2465,20 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6376
+#: lib/vutuv_web/components/post_components.ex:6670
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:430
+#: lib/vutuv_web/components/post_components.ex:443
 #: lib/vutuv_web/live/notification_live/index.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2068
-#: lib/vutuv_web/components/post_components.ex:6359
-#: lib/vutuv_web/components/post_components.ex:6360
+#: lib/vutuv_web/components/post_components.ex:2354
+#: lib/vutuv_web/components/post_components.ex:6653
+#: lib/vutuv_web/components/post_components.ex:6654
 #: lib/vutuv_web/live/notification_live/index.ex:994
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:290
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3795
+#: lib/vutuv_web/components/post_components.ex:4075
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3321
+#: lib/vutuv_web/components/post_components.ex:3601
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2515,14 +2515,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3767
+#: lib/vutuv_web/components/post_components.ex:4047
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3758
-#: lib/vutuv_web/components/post_components.ex:3787
-#: lib/vutuv_web/components/post_components.ex:3790
+#: lib/vutuv_web/components/post_components.ex:4038
+#: lib/vutuv_web/components/post_components.ex:4067
+#: lib/vutuv_web/components/post_components.ex:4070
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2583,7 +2583,7 @@ msgstr ""
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3312
+#: lib/vutuv_web/components/ui.ex:3346
 #: lib/vutuv_web/live/message_live/index.ex:760
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2670,7 +2670,7 @@ msgstr ""
 msgid "Okay, let's start over."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:862
+#: lib/vutuv_web/components/ui.ex:869
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr ""
@@ -2681,7 +2681,7 @@ msgstr ""
 msgid "Too many PIN requests. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:883
+#: lib/vutuv_web/components/ui.ex:890
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr ""
@@ -2731,8 +2731,8 @@ msgstr ""
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4329
-#: lib/vutuv_web/components/ui.ex:4766
+#: lib/vutuv_web/components/ui.ex:4363
+#: lib/vutuv_web/components/ui.ex:4800
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:109
@@ -2745,7 +2745,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:870
+#: lib/vutuv_web/components/post_components.ex:883
 #: lib/vutuv_web/controllers/page_controller.ex:216
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2783,7 +2783,7 @@ msgstr[1] ""
 msgid "Connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1530
+#: lib/vutuv_web/components/ui.ex:1564
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2793,7 +2793,7 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1546
+#: lib/vutuv_web/components/ui.ex:1580
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
@@ -2803,7 +2803,7 @@ msgstr ""
 msgid "People who aren't my connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1531
+#: lib/vutuv_web/components/ui.ex:1565
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -2821,7 +2821,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5985
+#: lib/vutuv_web/components/post_components.ex:6279
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3080,7 +3080,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3734
+#: lib/vutuv_web/components/post_components.ex:4014
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3124,7 +3124,7 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5102
+#: lib/vutuv_web/components/ui.ex:5136
 #: lib/vutuv_web/live/shell_live.ex:1373
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3149,9 +3149,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1434
-#: lib/vutuv_web/components/post_components.ex:2875
-#: lib/vutuv_web/components/post_components.ex:3944
+#: lib/vutuv_web/components/post_components.ex:1474
+#: lib/vutuv_web/components/post_components.ex:3155
+#: lib/vutuv_web/components/post_components.ex:4228
 #: lib/vutuv_web/live/organization_live/show.ex:661
 #: lib/vutuv_web/templates/user/show.html.heex:242
 #, elixir-autogen, elixir-format
@@ -3234,7 +3234,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4011
+#: lib/vutuv_web/components/ui.ex:4045
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -4299,12 +4299,12 @@ msgstr ""
 msgid "Bookings are open through %{last}. Next available day: %{day}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3585
+#: lib/vutuv_web/components/ui.ex:3619
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3581
+#: lib/vutuv_web/components/ui.ex:3615
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr ""
@@ -4314,27 +4314,27 @@ msgstr ""
 msgid "One ad per calendar day: pick a free day in the calendar; struck-through days are already booked."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3586
+#: lib/vutuv_web/components/ui.ex:3620
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3587
+#: lib/vutuv_web/components/ui.ex:3621
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3584
+#: lib/vutuv_web/components/ui.ex:3618
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3582
+#: lib/vutuv_web/components/ui.ex:3616
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3583
+#: lib/vutuv_web/components/ui.ex:3617
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr ""
@@ -4466,7 +4466,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5275
+#: lib/vutuv_web/components/ui.ex:5309
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4508,7 +4508,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3581
+#: lib/vutuv_web/live/post_live/feed.ex:3588
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4586,8 +4586,8 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:427
-#: lib/vutuv_web/components/post_components.ex:446
+#: lib/vutuv_web/components/post_components.ex:440
+#: lib/vutuv_web/components/post_components.ex:459
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -5233,7 +5233,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5325
+#: lib/vutuv_web/components/ui.ex:5359
 #: lib/vutuv_web/controllers/settings_controller.ex:161
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:439
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5312,10 +5312,10 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5422
-#: lib/vutuv_web/components/ui.ex:5427
-#: lib/vutuv_web/components/ui.ex:5506
-#: lib/vutuv_web/components/ui.ex:5570
+#: lib/vutuv_web/components/ui.ex:5456
+#: lib/vutuv_web/components/ui.ex:5461
+#: lib/vutuv_web/components/ui.ex:5540
+#: lib/vutuv_web/components/ui.ex:5604
 #: lib/vutuv_web/controllers/settings_controller.ex:68
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5385,9 +5385,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4022
-#: lib/vutuv_web/components/post_components.ex:4074
-#: lib/vutuv_web/components/post_components.ex:4608
+#: lib/vutuv_web/components/post_components.ex:4306
+#: lib/vutuv_web/components/post_components.ex:4358
+#: lib/vutuv_web/components/post_components.ex:4900
 #: lib/vutuv_web/live/notification_live/index.ex:1070
 #: lib/vutuv_web/views/user_html.ex:131
 #, elixir-autogen, elixir-format
@@ -5433,7 +5433,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5295
+#: lib/vutuv_web/components/ui.ex:5329
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5454,7 +5454,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5140
+#: lib/vutuv_web/components/ui.ex:5174
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5489,7 +5489,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5269
+#: lib/vutuv_web/components/ui.ex:5303
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -5601,7 +5601,7 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5318
+#: lib/vutuv_web/components/ui.ex:5352
 #: lib/vutuv_web/controllers/settings_controller.ex:185
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5805,21 +5805,21 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3649
+#: lib/vutuv_web/components/ui.ex:3683
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3648
+#: lib/vutuv_web/components/ui.ex:3682
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3647
+#: lib/vutuv_web/components/ui.ex:3681
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -5886,7 +5886,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3646
+#: lib/vutuv_web/components/ui.ex:3680
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -6028,7 +6028,7 @@ msgstr ""
 msgid "Tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:480
+#: lib/vutuv_web/components/ui.ex:487
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:916
@@ -6178,7 +6178,7 @@ msgid "Previous day"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1263
-#: lib/vutuv_web/components/post_components.ex:429
+#: lib/vutuv_web/components/post_components.ex:442
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6215,9 +6215,9 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2271
-#: lib/vutuv_web/components/ui.ex:2280
-#: lib/vutuv_web/components/ui.ex:2759
+#: lib/vutuv_web/components/ui.ex:2305
+#: lib/vutuv_web/components/ui.ex:2314
+#: lib/vutuv_web/components/ui.ex:2793
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6278,7 +6278,7 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2712
+#: lib/vutuv_web/components/ui.ex:2746
 #: lib/vutuv_web/live/notification_live/index.ex:708
 #: lib/vutuv_web/live/notification_live/index.ex:723
 #: lib/vutuv_web/live/notification_live/index.ex:1223
@@ -6573,10 +6573,10 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2802
-#: lib/vutuv_web/components/post_components.ex:3897
-#: lib/vutuv_web/components/post_components.ex:3911
-#: lib/vutuv_web/components/ui.ex:3137
+#: lib/vutuv_web/components/post_components.ex:3082
+#: lib/vutuv_web/components/post_components.ex:4181
+#: lib/vutuv_web/components/post_components.ex:4195
+#: lib/vutuv_web/components/ui.ex:3171
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
@@ -6603,8 +6603,8 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3897
-#: lib/vutuv_web/components/ui.ex:3136
+#: lib/vutuv_web/components/post_components.ex:4181
+#: lib/vutuv_web/components/ui.ex:3170
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
@@ -7208,13 +7208,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4105
+#: lib/vutuv_web/components/ui.ex:4139
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4117
+#: lib/vutuv_web/components/ui.ex:4151
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7296,7 +7296,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:6232
+#: lib/vutuv_web/components/post_components.ex:6526
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #: lib/vutuv_web/live/shell_live.ex:1812
 #, elixir-autogen, elixir-format
@@ -7400,7 +7400,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3870
+#: lib/vutuv_web/live/post_live/feed.ex:3877
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #, elixir-autogen
 msgid "Done"
@@ -7966,7 +7966,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4108
+#: lib/vutuv_web/components/ui.ex:4142
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8096,7 +8096,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:5116
+#: lib/vutuv_web/components/ui.ex:5150
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8151,7 +8151,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5306
+#: lib/vutuv_web/components/ui.ex:5340
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8180,7 +8180,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5144
+#: lib/vutuv_web/components/ui.ex:5178
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8274,7 +8274,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4381
+#: lib/vutuv_web/components/ui.ex:4415
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8349,13 +8349,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5104
+#: lib/vutuv_web/components/ui.ex:5138
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5238
+#: lib/vutuv_web/components/ui.ex:5272
 #: lib/vutuv_web/controllers/settings_controller.ex:129
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8367,7 +8367,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5297
+#: lib/vutuv_web/components/ui.ex:5331
 #: lib/vutuv_web/controllers/settings_controller.ex:112
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8377,7 +8377,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5310
+#: lib/vutuv_web/components/ui.ex:5344
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8486,7 +8486,7 @@ msgstr[1] ""
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1548
+#: lib/vutuv_web/components/ui.ex:1582
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -8582,8 +8582,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:648
 #: lib/vutuv_web/agent_docs/text.ex:652
 #: lib/vutuv_web/components/organization_components.ex:276
-#: lib/vutuv_web/components/ui.ex:1749
-#: lib/vutuv_web/components/ui.ex:5287
+#: lib/vutuv_web/components/ui.ex:1783
+#: lib/vutuv_web/components/ui.ex:5321
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:366
 #: lib/vutuv_web/controllers/settings_controller.ex:433
@@ -8733,12 +8733,12 @@ msgstr ""
 msgid "This is the print view of this CV. Use your browser's print dialog (Ctrl+P or Cmd+P) and choose \"Save as PDF\" to get a PDF file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1838
+#: lib/vutuv_web/components/ui.ex:1872
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5094
+#: lib/vutuv_web/components/post_components.ex:5387
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -8771,7 +8771,7 @@ msgstr ""
 msgid "Header"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1848
+#: lib/vutuv_web/components/ui.ex:1882
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -8803,7 +8803,7 @@ msgstr ""
 msgid "The CV is public, on your profile: a visitor's download contains only what they can see there anyway, and private email addresses appear only in your own."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1840
+#: lib/vutuv_web/components/ui.ex:1874
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -8957,8 +8957,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2315
-#: lib/vutuv_web/components/ui.ex:2316
+#: lib/vutuv_web/components/ui.ex:2349
+#: lib/vutuv_web/components/ui.ex:2350
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9527,7 +9527,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:5120
+#: lib/vutuv_web/components/ui.ex:5154
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -9723,13 +9723,13 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3762
+#: lib/vutuv_web/components/ui.ex:3796
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3761
-#: lib/vutuv_web/components/ui.ex:3769
+#: lib/vutuv_web/components/ui.ex:3795
+#: lib/vutuv_web/components/ui.ex:3803
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -9903,17 +9903,17 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:468
+#: lib/vutuv_web/components/ui.ex:475
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:520
+#: lib/vutuv_web/components/ui.ex:527
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:523
+#: lib/vutuv_web/components/ui.ex:530
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr ""
@@ -9928,13 +9928,13 @@ msgstr ""
 msgid "Delete your code list? All its codes stop working immediately."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:452
+#: lib/vutuv_web/components/ui.ex:459
 #, elixir-autogen, elixir-format
 msgid "Formatting"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:587
-#: lib/vutuv_web/components/ui.ex:588
+#: lib/vutuv_web/components/ui.ex:594
+#: lib/vutuv_web/components/ui.ex:595
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr ""
@@ -9949,29 +9949,29 @@ msgstr ""
 msgid "Generate code list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:461
-#: lib/vutuv_web/components/ui.ex:518
+#: lib/vutuv_web/components/ui.ex:468
+#: lib/vutuv_web/components/ui.ex:525
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:464
-#: lib/vutuv_web/components/ui.ex:519
+#: lib/vutuv_web/components/ui.ex:471
+#: lib/vutuv_web/components/ui.ex:526
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:477
+#: lib/vutuv_web/components/ui.ex:484
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:471
+#: lib/vutuv_web/components/ui.ex:478
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:408
+#: lib/vutuv_web/components/ui.ex:415
 #, elixir-autogen, elixir-format
 msgid "Link URL"
 msgstr ""
@@ -9987,7 +9987,7 @@ msgstr ""
 msgid "Not set up."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:521
+#: lib/vutuv_web/components/ui.ex:528
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr ""
@@ -10002,7 +10002,7 @@ msgstr ""
 msgid "Print this page or write the codes down. Crossed-out codes have been used."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:522
+#: lib/vutuv_web/components/ui.ex:529
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr ""
@@ -10023,7 +10023,7 @@ msgstr ""
 msgid "Set up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:474
+#: lib/vutuv_web/components/ui.ex:481
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr ""
@@ -10683,7 +10683,7 @@ msgstr ""
 msgid "Queued"
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:213
+#: lib/vutuv_web/components/video_components.ex:214
 #: lib/vutuv_web/live/admin/screenshot_live.ex:525
 #, elixir-autogen, elixir-format
 msgid "Ready"
@@ -11025,12 +11025,12 @@ msgstr ""
 msgid "State / region (optional)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4435
+#: lib/vutuv_web/components/ui.ex:4469
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4437
+#: lib/vutuv_web/components/ui.ex:4471
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr ""
@@ -11450,7 +11450,7 @@ msgstr ""
 msgid "The link text can be anything. A hidden <link rel=\"me\"> in the page head works too."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1085
+#: lib/vutuv_web/components/ui.ex:1119
 #: lib/vutuv_web/live/section_reorder_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -11718,7 +11718,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:462
-#: lib/vutuv_web/components/ui.ex:5314
+#: lib/vutuv_web/components/ui.ex:5348
 #: lib/vutuv_web/controllers/settings_controller.ex:222
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
@@ -12931,7 +12931,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5223
+#: lib/vutuv_web/components/ui.ex:5257
 #: lib/vutuv_web/controllers/settings_controller.ex:629
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -12950,7 +12950,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3280
+#: lib/vutuv_web/components/post_components.ex:3560
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -13307,27 +13307,27 @@ msgstr[1] ""
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:497
+#: lib/vutuv_web/components/ui.ex:504
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:494
+#: lib/vutuv_web/components/ui.ex:501
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:500
+#: lib/vutuv_web/components/ui.ex:507
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:491
+#: lib/vutuv_web/components/ui.ex:498
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:524
+#: lib/vutuv_web/components/ui.ex:531
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr ""
@@ -13364,22 +13364,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:469
+#: lib/vutuv_web/components/post_components.ex:482
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:471
+#: lib/vutuv_web/components/post_components.ex:484
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:470
+#: lib/vutuv_web/components/post_components.ex:483
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:428
+#: lib/vutuv_web/components/post_components.ex:441
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13389,7 +13389,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5206
+#: lib/vutuv_web/components/ui.ex:5240
 #: lib/vutuv_web/controllers/settings_controller.ex:643
 #: lib/vutuv_web/live/post_live/feed.ex:710
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13464,7 +13464,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:63
-#: lib/vutuv_web/components/ui.ex:5163
+#: lib/vutuv_web/components/ui.ex:5197
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13492,14 +13492,14 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4520
+#: lib/vutuv_web/components/ui.ex:4554
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:4530
+#: lib/vutuv_web/components/ui.ex:4564
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
@@ -13549,34 +13549,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5782
+#: lib/vutuv_web/components/post_components.ex:6075
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:5739
+#: lib/vutuv_web/components/post_components.ex:6032
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5783
+#: lib/vutuv_web/components/post_components.ex:6076
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5785
+#: lib/vutuv_web/components/post_components.ex:6078
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5781
+#: lib/vutuv_web/components/post_components.ex:6074
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:5738
+#: lib/vutuv_web/components/post_components.ex:6031
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13587,12 +13587,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5780
+#: lib/vutuv_web/components/post_components.ex:6073
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5784
+#: lib/vutuv_web/components/post_components.ex:6077
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13612,7 +13612,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5821
+#: lib/vutuv_web/components/post_components.ex:6114
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13620,27 +13620,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5851
+#: lib/vutuv_web/components/post_components.ex:6144
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5852
+#: lib/vutuv_web/components/post_components.ex:6145
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5850
+#: lib/vutuv_web/components/post_components.ex:6143
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5810
+#: lib/vutuv_web/components/post_components.ex:6103
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5857
+#: lib/vutuv_web/components/post_components.ex:6150
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13670,7 +13670,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5624
+#: lib/vutuv_web/components/post_components.ex:5917
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13713,17 +13713,17 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5615
+#: lib/vutuv_web/components/post_components.ex:5908
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2449
+#: lib/vutuv_web/components/ui.ex:2483
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2453
+#: lib/vutuv_web/components/ui.ex:2487
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -14060,14 +14060,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3561
+#: lib/vutuv_web/components/post_components.ex:3841
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3584
+#: lib/vutuv_web/components/post_components.ex:3864
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14094,7 +14094,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6331
+#: lib/vutuv_web/components/post_components.ex:6625
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14252,7 +14252,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5177
+#: lib/vutuv_web/components/ui.ex:5211
 #: lib/vutuv_web/controllers/settings_controller.ex:773
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -14886,252 +14886,252 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5105
+#: lib/vutuv_web/components/ui.ex:5139
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5110
+#: lib/vutuv_web/components/ui.ex:5144
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5113
+#: lib/vutuv_web/components/ui.ex:5147
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5114
+#: lib/vutuv_web/components/ui.ex:5148
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5117
+#: lib/vutuv_web/components/ui.ex:5151
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5118
+#: lib/vutuv_web/components/ui.ex:5152
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5121
+#: lib/vutuv_web/components/ui.ex:5155
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5122
+#: lib/vutuv_web/components/ui.ex:5156
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5129
+#: lib/vutuv_web/components/ui.ex:5163
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5130
+#: lib/vutuv_web/components/ui.ex:5164
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5131
+#: lib/vutuv_web/components/ui.ex:5165
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5134
+#: lib/vutuv_web/components/ui.ex:5168
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5135
+#: lib/vutuv_web/components/ui.ex:5169
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5315
+#: lib/vutuv_web/components/ui.ex:5349
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5316
+#: lib/vutuv_web/components/ui.ex:5350
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5138
+#: lib/vutuv_web/components/ui.ex:5172
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5141
+#: lib/vutuv_web/components/ui.ex:5175
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5142
+#: lib/vutuv_web/components/ui.ex:5176
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5145
+#: lib/vutuv_web/components/ui.ex:5179
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5146
+#: lib/vutuv_web/components/ui.ex:5180
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5149
+#: lib/vutuv_web/components/ui.ex:5183
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5150
+#: lib/vutuv_web/components/ui.ex:5184
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5152
+#: lib/vutuv_web/components/ui.ex:5186
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5153
+#: lib/vutuv_web/components/ui.ex:5187
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5154
+#: lib/vutuv_web/components/ui.ex:5188
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5156
+#: lib/vutuv_web/components/ui.ex:5190
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5157
+#: lib/vutuv_web/components/ui.ex:5191
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5159
+#: lib/vutuv_web/components/ui.ex:5193
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5164
+#: lib/vutuv_web/components/ui.ex:5198
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5165
+#: lib/vutuv_web/components/ui.ex:5199
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5168
+#: lib/vutuv_web/components/ui.ex:5202
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5171
+#: lib/vutuv_web/components/ui.ex:5205
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5178
+#: lib/vutuv_web/components/ui.ex:5212
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5179
+#: lib/vutuv_web/components/ui.ex:5213
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5207
+#: lib/vutuv_web/components/ui.ex:5241
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5208
+#: lib/vutuv_web/components/ui.ex:5242
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5224
+#: lib/vutuv_web/components/ui.ex:5258
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5225
+#: lib/vutuv_web/components/ui.ex:5259
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5272
+#: lib/vutuv_web/components/ui.ex:5306
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5273
+#: lib/vutuv_web/components/ui.ex:5307
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5276
+#: lib/vutuv_web/components/ui.ex:5310
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5277
+#: lib/vutuv_web/components/ui.ex:5311
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5298
+#: lib/vutuv_web/components/ui.ex:5332
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5299
+#: lib/vutuv_web/components/ui.ex:5333
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5307
+#: lib/vutuv_web/components/ui.ex:5341
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5308
+#: lib/vutuv_web/components/ui.ex:5342
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5311
+#: lib/vutuv_web/components/ui.ex:5345
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5312
+#: lib/vutuv_web/components/ui.ex:5346
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5326
+#: lib/vutuv_web/components/ui.ex:5360
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5327
+#: lib/vutuv_web/components/ui.ex:5361
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15239,7 +15239,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6277
+#: lib/vutuv_web/components/post_components.ex:6571
 #: lib/vutuv_web/live/notification_live/index.ex:1593
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -15247,7 +15247,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6281
+#: lib/vutuv_web/components/post_components.ex:6575
 #: lib/vutuv_web/live/notification_live/index.ex:1587
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15255,7 +15255,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6285
+#: lib/vutuv_web/components/post_components.ex:6579
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15263,7 +15263,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:6236
+#: lib/vutuv_web/components/post_components.ex:6530
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15281,14 +15281,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1549
-#: lib/vutuv_web/components/post_components.ex:2301
+#: lib/vutuv_web/components/post_components.ex:1589
+#: lib/vutuv_web/components/post_components.ex:2578
 #: lib/vutuv_web/live/fediverse_account_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1419
+#: lib/vutuv_web/components/post_components.ex:1459
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15317,7 +15317,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1431
+#: lib/vutuv_web/components/post_components.ex:1471
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15327,7 +15327,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1445
+#: lib/vutuv_web/components/post_components.ex:1485
 #: lib/vutuv_web/live/notification_live/index.ex:1118
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15359,9 +15359,9 @@ msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1501
-#: lib/vutuv_web/components/post_components.ex:1480
-#: lib/vutuv_web/components/post_components.ex:1680
-#: lib/vutuv_web/components/post_components.ex:3138
+#: lib/vutuv_web/components/post_components.ex:1520
+#: lib/vutuv_web/components/post_components.ex:1720
+#: lib/vutuv_web/components/post_components.ex:3418
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -15590,7 +15590,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5301
+#: lib/vutuv_web/components/ui.ex:5335
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -15937,7 +15937,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5302
+#: lib/vutuv_web/components/ui.ex:5336
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -15973,7 +15973,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5304
+#: lib/vutuv_web/components/ui.ex:5338
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16025,22 +16025,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3746
+#: lib/vutuv_web/components/post_components.ex:4026
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3864
+#: lib/vutuv_web/components/post_components.ex:4148
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3872
+#: lib/vutuv_web/components/post_components.ex:4156
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3858
+#: lib/vutuv_web/components/post_components.ex:4142
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16128,7 +16128,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1429
 #: lib/vutuv_web/agent_docs/text.ex:915
-#: lib/vutuv_web/components/ui.ex:3191
+#: lib/vutuv_web/components/ui.ex:3225
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16153,7 +16153,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3190
+#: lib/vutuv_web/components/ui.ex:3224
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16163,17 +16163,17 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3333
+#: lib/vutuv_web/components/post_components.ex:3613
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4739
+#: lib/vutuv_web/components/post_components.ex:5032
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4888
+#: lib/vutuv_web/components/post_components.ex:5181
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16186,12 +16186,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1462
 #: lib/vutuv_web/agent_docs/text.ex:890
-#: lib/vutuv_web/components/post_components.ex:4970
+#: lib/vutuv_web/components/post_components.ex:5263
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3189
+#: lib/vutuv_web/components/ui.ex:3223
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr ""
@@ -16212,7 +16212,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3386
+#: lib/vutuv_web/components/post_components.ex:3666
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16232,7 +16232,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3377
+#: lib/vutuv_web/components/post_components.ex:3657
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16242,12 +16242,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3395
+#: lib/vutuv_web/components/post_components.ex:3675
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3329
+#: lib/vutuv_web/components/post_components.ex:3609
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16262,7 +16262,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3390
+#: lib/vutuv_web/components/post_components.ex:3670
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16272,7 +16272,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3343
+#: lib/vutuv_web/components/post_components.ex:3623
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16347,13 +16347,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1319
-#: lib/vutuv_web/components/post_components.ex:6274
+#: lib/vutuv_web/components/post_components.ex:6568
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1317
-#: lib/vutuv_web/components/post_components.ex:6271
+#: lib/vutuv_web/components/post_components.ex:6565
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16363,7 +16363,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6161
+#: lib/vutuv_web/components/post_components.ex:6455
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -16481,7 +16481,7 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5288
+#: lib/vutuv_web/components/ui.ex:5322
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
@@ -16684,7 +16684,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5290
+#: lib/vutuv_web/components/ui.ex:5324
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -16704,7 +16704,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2897
+#: lib/vutuv_web/components/post_components.ex:3177
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16714,7 +16714,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3137
+#: lib/vutuv_web/components/post_components.ex:3417
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16734,12 +16734,12 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1815
+#: lib/vutuv_web/components/post_components.ex:1855
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3078
+#: lib/vutuv_web/components/post_components.ex:3358
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr ""
@@ -16754,7 +16754,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2870
+#: lib/vutuv_web/components/post_components.ex:3150
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -16978,27 +16978,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2473
+#: lib/vutuv_web/components/post_components.ex:2751
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2506
+#: lib/vutuv_web/components/post_components.ex:2784
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2501
+#: lib/vutuv_web/components/post_components.ex:2779
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3236
+#: lib/vutuv_web/components/post_components.ex:3516
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3242
+#: lib/vutuv_web/components/post_components.ex:3522
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr ""
@@ -17008,7 +17008,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3381
+#: lib/vutuv_web/components/post_components.ex:3661
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17018,7 +17018,7 @@ msgstr ""
 msgid "This post was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_actions_component.ex:181
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:302
 #, elixir-autogen, elixir-format
 msgid "Reposted. Your followers see it now."
 msgstr ""
@@ -17053,12 +17053,12 @@ msgstr ""
 msgid "Your feed shows the posts of members you follow. Follow a few to fill it."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:239
+#: lib/vutuv_web/components/ui.ex:246
 #, elixir-autogen, elixir-format
 msgid "Add another tag"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:262
+#: lib/vutuv_web/components/ui.ex:269
 #, elixir-autogen, elixir-format
 msgid "Remove the tag %{name}"
 msgstr ""
@@ -17184,7 +17184,7 @@ msgstr ""
 msgid "Your username is your public identity here. It changes only once you confirm with your passkey or a valid code below."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:622
+#: lib/vutuv_web/components/ui.ex:629
 #, elixir-autogen, elixir-format
 msgid "Markdown help"
 msgstr ""
@@ -17205,7 +17205,7 @@ msgid "Address of the post"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:688
-#: lib/vutuv_web/live/post_live/remote_actions_component.ex:276
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:414
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings"
 msgstr ""
@@ -17621,12 +17621,12 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:461
+#: lib/vutuv_web/components/post_components.ex:474
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:458
+#: lib/vutuv_web/components/post_components.ex:471
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
@@ -17669,7 +17669,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3239
+#: lib/vutuv_web/components/post_components.ex:3519
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -17710,8 +17710,8 @@ msgstr ""
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1600
-#: lib/vutuv_web/components/ui.ex:1601
+#: lib/vutuv_web/components/ui.ex:1634
+#: lib/vutuv_web/components/ui.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr ""
@@ -17726,7 +17726,7 @@ msgstr ""
 msgid "Source code"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:268
+#: lib/vutuv_web/components/ui.ex:275
 #, elixir-autogen, elixir-format
 msgid "At most %{max} tags. Remove one to add another."
 msgstr ""
@@ -17741,19 +17741,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5264
+#: lib/vutuv_web/components/post_components.ex:5557
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5266
+#: lib/vutuv_web/components/post_components.ex:5559
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5277
+#: lib/vutuv_web/components/post_components.ex:5570
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -17880,7 +17880,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:5124
+#: lib/vutuv_web/components/ui.ex:5158
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -17925,7 +17925,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3599
+#: lib/vutuv_web/live/post_live/feed.ex:3606
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -18075,7 +18075,7 @@ msgstr ""
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5125
+#: lib/vutuv_web/components/ui.ex:5159
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
@@ -18086,7 +18086,7 @@ msgstr ""
 msgid "Zwischenzeugnis"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5127
+#: lib/vutuv_web/components/ui.ex:5161
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -18341,7 +18341,7 @@ msgstr ""
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4421
+#: lib/vutuv_web/components/ui.ex:4455
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -18617,12 +18617,12 @@ msgstr ""
 msgid "Enter the PIN from the email"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:854
+#: lib/vutuv_web/components/ui.ex:861
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:882
+#: lib/vutuv_web/components/ui.ex:889
 #, elixir-autogen, elixir-format
 msgid "Cancel registration"
 msgstr ""
@@ -18632,7 +18632,7 @@ msgstr ""
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:837
+#: lib/vutuv_web/components/ui.ex:844
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
@@ -18657,7 +18657,7 @@ msgstr ""
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5106
+#: lib/vutuv_web/components/ui.ex:5140
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
@@ -18753,7 +18753,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5281
+#: lib/vutuv_web/components/ui.ex:5315
 #: lib/vutuv_web/controllers/settings_controller.ex:256
 #: lib/vutuv_web/controllers/settings_controller.ex:335
 #: lib/vutuv_web/controllers/settings_controller.ex:347
@@ -18850,7 +18850,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5283
+#: lib/vutuv_web/components/ui.ex:5317
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -18959,7 +18959,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5285
+#: lib/vutuv_web/components/ui.ex:5319
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -19333,7 +19333,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3269
+#: lib/vutuv_web/components/post_components.ex:3549
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -19750,22 +19750,22 @@ msgstr ""
 msgid "The PIN has expired."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:958
+#: lib/vutuv_web/components/ui.ex:965
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:960
+#: lib/vutuv_web/components/ui.ex:967
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:959
+#: lib/vutuv_web/components/ui.ex:966
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:961
+#: lib/vutuv_web/components/ui.ex:968
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr ""
@@ -20201,27 +20201,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5158
+#: lib/vutuv_web/components/post_components.ex:5451
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5194
+#: lib/vutuv_web/components/post_components.ex:5487
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5203
+#: lib/vutuv_web/components/post_components.ex:5496
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5206
+#: lib/vutuv_web/components/post_components.ex:5499
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5183
+#: lib/vutuv_web/components/post_components.ex:5476
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20231,8 +20231,8 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5173
-#: lib/vutuv_web/components/ui.ex:5199
+#: lib/vutuv_web/components/post_components.ex:5466
+#: lib/vutuv_web/components/ui.ex:5233
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -20360,20 +20360,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4936
+#: lib/vutuv_web/components/post_components.ex:5229
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4933
+#: lib/vutuv_web/components/post_components.ex:5226
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2527
-#: lib/vutuv_web/components/post_components.ex:4144
+#: lib/vutuv_web/components/post_components.ex:2805
+#: lib/vutuv_web/components/post_components.ex:4436
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20443,7 +20443,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5319
+#: lib/vutuv_web/components/ui.ex:5353
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
@@ -20489,7 +20489,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5321
+#: lib/vutuv_web/components/ui.ex:5355
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -20524,7 +20524,7 @@ msgstr ""
 msgid "Find your LinkedIn contacts"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5215
+#: lib/vutuv_web/components/ui.ex:5249
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format
@@ -20632,7 +20632,7 @@ msgstr ""
 msgid "See which of them are already on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5217
+#: lib/vutuv_web/components/ui.ex:5251
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr ""
@@ -20704,7 +20704,7 @@ msgstr ""
 msgid "Your export also lists your LinkedIn contacts."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5219
+#: lib/vutuv_web/components/ui.ex:5253
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr ""
@@ -20886,7 +20886,7 @@ msgstr ""
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2850
+#: lib/vutuv_web/components/post_components.ex:3130
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
@@ -20961,7 +20961,7 @@ msgstr ""
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5173
+#: lib/vutuv_web/components/ui.ex:5207
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
@@ -21011,7 +21011,7 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3764
+#: lib/vutuv_web/live/post_live/feed.ex:3771
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
@@ -21021,43 +21021,43 @@ msgstr ""
 msgid "New here"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1769
+#: lib/vutuv_web/components/ui.ex:1803
 #, elixir-autogen, elixir-format
 msgid "New public posts arrive in any feed reader. No account needed either."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1765
+#: lib/vutuv_web/components/ui.ex:1799
 #, elixir-autogen, elixir-format
 msgid "Or with an RSS reader"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1645
-#: lib/vutuv_web/components/ui.ex:1714
+#: lib/vutuv_web/components/ui.ex:1679
+#: lib/vutuv_web/components/ui.ex:1748
 #, elixir-autogen, elixir-format
 msgid "Subscribe"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1766
+#: lib/vutuv_web/components/ui.ex:1800
 #, elixir-autogen, elixir-format
 msgid "With an RSS reader"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1726
+#: lib/vutuv_web/components/ui.ex:1760
 #, elixir-autogen, elixir-format
 msgid "Create a free account"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1741
+#: lib/vutuv_web/components/ui.ex:1775
 #, elixir-autogen, elixir-format
 msgid "No vutuv account? These ways work too:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1719
+#: lib/vutuv_web/components/ui.ex:1753
 #, elixir-autogen, elixir-format
 msgid "The best way: follow %{name} here. New posts land in your feed, and you can reply and join in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1717
+#: lib/vutuv_web/components/ui.ex:1751
 #, elixir-autogen, elixir-format
 msgid "With a vutuv account"
 msgstr ""
@@ -21182,22 +21182,22 @@ msgstr ""
 msgid "Shown in the language it was written in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5200
+#: lib/vutuv_web/components/ui.ex:5234
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5202
+#: lib/vutuv_web/components/ui.ex:5236
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5240
+#: lib/vutuv_web/components/ui.ex:5274
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5244
+#: lib/vutuv_web/components/ui.ex:5278
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -21310,7 +21310,7 @@ msgstr ""
 msgid "Your LinkedIn profile can come along."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1155
+#: lib/vutuv_web/components/ui.ex:1189
 #, elixir-autogen, elixir-format
 msgid "Being checked"
 msgstr ""
@@ -21499,13 +21499,13 @@ msgid "Hide a word or a whole phrase …"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:709
-#: lib/vutuv_web/live/post_live/feed.ex:3927
+#: lib/vutuv_web/live/post_live/feed.ex:3934
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:708
-#: lib/vutuv_web/live/post_live/feed.ex:3916
+#: lib/vutuv_web/live/post_live/feed.ex:3923
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr ""
@@ -21531,7 +21531,7 @@ msgstr ""
 msgid "Move %{card}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:412
+#: lib/vutuv_web/components/ui.ex:419
 #: lib/vutuv_web/live/post_live/filter_band.ex:584
 #, elixir-autogen, elixir-format
 msgid "No account found."
@@ -21572,7 +21572,7 @@ msgstr ""
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3790
+#: lib/vutuv_web/live/post_live/feed.ex:3797
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
@@ -21611,7 +21611,7 @@ msgid "Show posts by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:707
-#: lib/vutuv_web/live/post_live/feed.ex:3882
+#: lib/vutuv_web/live/post_live/feed.ex:3889
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr ""
@@ -21670,7 +21670,7 @@ msgid_plural "Show %{formatted} posts in the feed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2444
+#: lib/vutuv_web/components/post_components.ex:2722
 #, elixir-autogen, elixir-format
 msgid "Picture unavailable"
 msgstr ""
@@ -21695,7 +21695,7 @@ msgstr ""
 msgid "Your organization page was updated, but that picture could not be used as a logo. Please pick another one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4427
+#: lib/vutuv_web/components/ui.ex:4461
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -21716,7 +21716,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3556
+#: lib/vutuv_web/live/post_live/feed.ex:3563
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr ""
@@ -21726,7 +21726,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3602
+#: lib/vutuv_web/live/post_live/feed.ex:3609
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -21748,7 +21748,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3552
+#: lib/vutuv_web/live/post_live/feed.ex:3559
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -21842,7 +21842,7 @@ msgid_plural "New (%{formatted}):"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3005
+#: lib/vutuv_web/components/post_components.ex:3285
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr ""
@@ -21857,12 +21857,12 @@ msgstr ""
 msgid "Quotes %{url}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:411
+#: lib/vutuv_web/components/ui.ex:418
 #, elixir-autogen, elixir-format
 msgid "Mention an account"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:415
+#: lib/vutuv_web/components/ui.ex:422
 #, elixir-autogen, elixir-format
 msgid "{used} of {max} mentions"
 msgstr ""
@@ -21893,12 +21893,12 @@ msgstr ""
 msgid "Only these accounts (empty = all) …"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3496
+#: lib/vutuv_web/components/ui.ex:3530
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6617
+#: lib/vutuv_web/components/post_components.ex:6911
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -21945,17 +21945,17 @@ msgid_plural "shared this."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:566
+#: lib/vutuv_web/components/ui.ex:573
 #, elixir-autogen, elixir-format
 msgid "Editor view"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:514
+#: lib/vutuv_web/components/ui.ex:521
 #, elixir-autogen, elixir-format
 msgid "Insert a block"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:526
+#: lib/vutuv_web/components/ui.ex:533
 #, elixir-autogen, elixir-format
 msgid "Nothing matches."
 msgstr ""
@@ -22081,7 +22081,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3690
+#: lib/vutuv_web/live/post_live/feed.ex:3697
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "%{formatted} rule"
@@ -22134,7 +22134,7 @@ msgstr ""
 msgid "Replace with"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5192
+#: lib/vutuv_web/components/ui.ex:5226
 #, elixir-autogen, elixir-format
 msgid "Rewrite what an account's posts say, for you alone"
 msgstr ""
@@ -22149,10 +22149,10 @@ msgstr ""
 msgid "Rules that rewrite the text of one account's posts before you read them: a footer under every post, a signature, a wall of hashtags. Only you see the difference. Open the ⋯ menu on any post to write rules for its author."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1424
-#: lib/vutuv_web/components/post_components.ex:2863
-#: lib/vutuv_web/components/post_components.ex:3941
-#: lib/vutuv_web/components/ui.ex:5191
+#: lib/vutuv_web/components/post_components.ex:1464
+#: lib/vutuv_web/components/post_components.ex:3143
+#: lib/vutuv_web/components/post_components.ex:4225
+#: lib/vutuv_web/components/ui.ex:5225
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
 #: lib/vutuv_web/live/post_rewrites_live.ex:264
@@ -22208,12 +22208,12 @@ msgstr ""
 msgid "\\1 puts back what the first (…) group matched, \\0 the whole match."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5193
+#: lib/vutuv_web/components/ui.ex:5227
 #, elixir-autogen, elixir-format
 msgid "regex regular expression rewrite replace footer signature strip"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5262
+#: lib/vutuv_web/components/ui.ex:5296
 #, elixir-autogen, elixir-format
 msgid "Smaller pictures and a plain composer on a slow connection"
 msgstr ""
@@ -22223,12 +22223,12 @@ msgstr ""
 msgid "That endorsement is not possible."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5264
+#: lib/vutuv_web/components/ui.ex:5298
 #, elixir-autogen, elixir-format
 msgid "bandwidth slow internet mobile data saving saver volume metered compression pictures images screenshots editor langsam daten sparen datensparmodus volumen schmalband komprimierung bilder"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5236
+#: lib/vutuv_web/components/ui.ex:5270
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr ""
@@ -22240,7 +22240,7 @@ msgid_plural "%{count} videos in progress"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/video_components.ex:257
+#: lib/vutuv_web/components/video_components.ex:258
 #, elixir-autogen, elixir-format
 msgid "About %{minutes} min of video"
 msgstr ""
@@ -22250,39 +22250,39 @@ msgstr ""
 msgid "Add video"
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:199
+#: lib/vutuv_web/components/video_components.ex:200
 #, elixir-autogen, elixir-format
 msgid "Converting · %{percent} %"
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:280
+#: lib/vutuv_web/components/video_components.ex:281
 #, elixir-autogen, elixir-format
 msgid "Delete this post"
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:216
+#: lib/vutuv_web/components/video_components.ex:217
 #, elixir-autogen, elixir-format
 msgid "Our AI check refused this video (at %{time})."
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:218
+#: lib/vutuv_web/components/video_components.ex:219
 #, elixir-autogen, elixir-format
 msgid "Our AI check refused this video."
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:204
+#: lib/vutuv_web/components/video_components.ex:205
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking it."
 msgid_plural "Our AI is checking it, %{done} of %{total} frames done."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/video_components.ex:272
+#: lib/vutuv_web/components/video_components.ex:273
 #, elixir-autogen, elixir-format
 msgid "Post without the video"
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:196
+#: lib/vutuv_web/components/video_components.ex:197
 #, elixir-autogen, elixir-format
 msgid "Reading the frames"
 msgstr ""
@@ -22317,7 +22317,7 @@ msgstr ""
 msgid "The video could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:262
+#: lib/vutuv_web/components/video_components.ex:263
 #, elixir-autogen, elixir-format
 msgid "The video is gone."
 msgstr ""
@@ -22327,12 +22327,12 @@ msgstr ""
 msgid "The video is longer than %{seconds} seconds."
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:246
+#: lib/vutuv_web/components/video_components.ex:247
 #, elixir-autogen, elixir-format
 msgid "This post is still waiting for you"
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:219
+#: lib/vutuv_web/components/video_components.ex:220
 #, elixir-autogen, elixir-format
 msgid "This video could not be converted."
 msgstr ""
@@ -22341,8 +22341,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1417
 #: lib/vutuv_web/agent_docs/text.ex:899
 #: lib/vutuv_web/agent_docs/text.ex:900
-#: lib/vutuv_web/components/post_components.ex:2579
-#: lib/vutuv_web/components/video_components.ex:126
+#: lib/vutuv_web/components/post_components.ex:2857
+#: lib/vutuv_web/components/video_components.ex:127
 #: lib/vutuv_web/live/post_live/composer.ex:2458
 #, elixir-autogen, elixir-format
 msgid "Video"
@@ -22358,7 +22358,7 @@ msgstr ""
 msgid "Videos cannot be uploaded here."
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:195
+#: lib/vutuv_web/components/video_components.ex:196
 #, elixir-autogen, elixir-format
 msgid "Waiting in line"
 msgstr ""
@@ -22373,7 +22373,7 @@ msgstr ""
 msgid "You can post now — the post appears as soon as the video is ready."
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:247
+#: lib/vutuv_web/components/video_components.ex:248
 #, elixir-autogen, elixir-format
 msgid "Your post appears as soon as the video is ready"
 msgstr ""
@@ -22404,7 +22404,7 @@ msgstr[1] ""
 msgid "Last 30 days: %{parts}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4496
+#: lib/vutuv_web/components/post_components.ex:4788
 #: lib/vutuv_web/live/notification_live/index.ex:1004
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -22445,12 +22445,12 @@ msgstr ""
 msgid "replied in the thread."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1335
+#: lib/vutuv_web/components/ui.ex:1369
 #, elixir-autogen, elixir-format
 msgid "Standard quality. Load this picture in HD."
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:117
+#: lib/vutuv_web/components/video_components.ex:118
 #, elixir-autogen, elixir-format
 msgid "Standard quality. Play this video in HD."
 msgstr ""
@@ -22708,7 +22708,7 @@ msgstr ""
 msgid "Accounts whose posts stay out of your feed, and accounts whose reposts do. This list is yours alone: it is never shared and nobody is told they are on it."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5185
+#: lib/vutuv_web/components/ui.ex:5219
 #, elixir-autogen, elixir-format
 msgid "Accounts you have silenced, and whose reposts you hide"
 msgstr ""
@@ -22718,8 +22718,8 @@ msgstr ""
 msgid "Hidden. What they pass on stays out of your feed; their own posts do not."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2835
-#: lib/vutuv_web/components/post_components.ex:3935
+#: lib/vutuv_web/components/post_components.ex:3115
+#: lib/vutuv_web/components/post_components.ex:4219
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr ""
@@ -22734,7 +22734,7 @@ msgstr ""
 msgid "Mute everything"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5184
+#: lib/vutuv_web/components/ui.ex:5218
 #: lib/vutuv_web/controllers/settings_controller.ex:713
 #: lib/vutuv_web/templates/settings/mutes.html.heex:1
 #: lib/vutuv_web/templates/settings/mutes.html.heex:3
@@ -22778,7 +22778,7 @@ msgstr ""
 msgid "You mute an account where you meet it: the ⋯ menu on any of its posts, or its own page. Muting works whether or not you follow them."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5187
+#: lib/vutuv_web/components/ui.ex:5221
 #, elixir-autogen, elixir-format
 msgid "mute unmute hide account reposts boosts feed stumm stummschalten ausblenden konto"
 msgstr ""
@@ -22878,7 +22878,7 @@ msgstr ""
 msgid "Feed settings saved."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5255
+#: lib/vutuv_web/components/ui.ex:5289
 #, elixir-autogen, elixir-format
 msgid "How many load at once, and how many “Load more” adds"
 msgstr ""
@@ -22888,7 +22888,7 @@ msgstr ""
 msgid "How many posts your feed shows before the “Load more” button, and how many that button adds. More posts mean a longer wait for the page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5254
+#: lib/vutuv_web/components/ui.ex:5288
 #: lib/vutuv_web/controllers/settings_controller.ex:963
 #: lib/vutuv_web/templates/settings/feed.html.heex:12
 #, elixir-autogen, elixir-format
@@ -22900,8 +22900,8 @@ msgstr ""
 msgid "Posts loaded at once"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3626
-#: lib/vutuv_web/live/post_live/feed.ex:3630
+#: lib/vutuv_web/live/post_live/feed.ex:3633
+#: lib/vutuv_web/live/post_live/feed.ex:3637
 #, elixir-autogen, elixir-format
 msgid "Posts per page"
 msgstr ""
@@ -22911,65 +22911,65 @@ msgstr ""
 msgid "You can change this under the feed itself as well, right below the “Load more” button."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5257
+#: lib/vutuv_web/components/ui.ex:5291
 #, elixir-autogen, elixir-format
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6608
-#: lib/vutuv_web/components/post_components.ex:6609
+#: lib/vutuv_web/components/post_components.ex:6902
+#: lib/vutuv_web/components/post_components.ex:6903
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6636
+#: lib/vutuv_web/components/post_components.ex:6930
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3687
-#: lib/vutuv_web/live/post_live/feed.ex:3846
-#: lib/vutuv_web/live/post_live/feed.ex:3855
+#: lib/vutuv_web/live/post_live/feed.ex:3694
+#: lib/vutuv_web/live/post_live/feed.ex:3853
+#: lib/vutuv_web/live/post_live/feed.ex:3862
 #, elixir-autogen, elixir-format
 msgid "Hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3820
+#: lib/vutuv_web/live/post_live/feed.ex:3827
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6556
+#: lib/vutuv_web/components/post_components.ex:6850
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3861
+#: lib/vutuv_web/live/post_live/feed.ex:3868
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3881
+#: lib/vutuv_web/live/post_live/feed.ex:3888
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6640
+#: lib/vutuv_web/components/post_components.ex:6934
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6643
+#: lib/vutuv_web/components/post_components.ex:6937
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6612
+#: lib/vutuv_web/components/post_components.ex:6906
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6653
+#: lib/vutuv_web/components/post_components.ex:6947
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr ""
@@ -23021,7 +23021,7 @@ msgstr ""
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5966
+#: lib/vutuv_web/components/post_components.ex:6260
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr ""
@@ -23121,8 +23121,8 @@ msgstr ""
 msgid "Hidden. What other people pass on of them stays out of your feed; their own posts do not."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2821
-#: lib/vutuv_web/components/post_components.ex:3923
+#: lib/vutuv_web/components/post_components.ex:3101
+#: lib/vutuv_web/components/post_components.ex:4207
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr ""
@@ -23345,4 +23345,47 @@ msgstr ""
 #: lib/vutuv_web/controllers/user_controller.ex:320
 #, elixir-autogen, elixir-format
 msgid "Your profile picture was not replaced: a report about it is still open. Open the case to remove the picture or to say that it is yours."
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:2439
+#, elixir-autogen, elixir-format
+msgid "Fetching the answers from the servers that hold them…"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:250
+#, elixir-autogen, elixir-format
+msgid "Not every answer could be fetched. The rest are on the origin server."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:240
+#, elixir-autogen, elixir-format
+msgid "Nothing here we are allowed to show you."
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:2454
+#, elixir-autogen, elixir-format
+msgid "Show more answers"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:2371
+#: lib/vutuv_web/components/post_components.ex:2373
+#, elixir-autogen, elixir-format
+msgid "Show the one answer"
+msgid_plural "Show the %{count} answers"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:257
+#, elixir-autogen, elixir-format
+msgid "That is enough answers fetched for one hour. Try again later."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:262
+#, elixir-autogen, elixir-format
+msgid "The answers could not be fetched from the servers that hold them."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:265
+#, elixir-autogen, elixir-format
+msgid "The rest could not be fetched right now."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -15,8 +15,8 @@ msgstr "Language: en\n"
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4811
-#: lib/vutuv_web/components/ui.ex:4816
+#: lib/vutuv_web/components/ui.ex:4845
+#: lib/vutuv_web/components/ui.ex:4850
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
 #: lib/vutuv_web/live/organization_live/domains.ex:287
@@ -62,7 +62,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/text.ex:71
-#: lib/vutuv_web/components/ui.ex:5148
+#: lib/vutuv_web/components/ui.ex:5182
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -75,14 +75,14 @@ msgstr ""
 msgid "Addresses"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1732
+#: lib/vutuv_web/components/ui.ex:1766
 #: lib/vutuv_web/templates/page/index.html.heex:325
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4602
-#: lib/vutuv_web/components/ui.ex:4701
+#: lib/vutuv_web/components/ui.ex:4636
+#: lib/vutuv_web/components/ui.ex:4735
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -110,8 +110,8 @@ msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:104
-#: lib/vutuv_web/components/ui.ex:4596
-#: lib/vutuv_web/components/video_components.ex:280
+#: lib/vutuv_web/components/ui.ex:4630
+#: lib/vutuv_web/components/video_components.ex:281
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
 #: lib/vutuv_web/live/admin/user_delete_live.ex:202
@@ -161,8 +161,8 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3880
-#: lib/vutuv_web/components/ui.ex:4703
+#: lib/vutuv_web/components/post_components.ex:4164
+#: lib/vutuv_web/components/ui.ex:4737
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:657
@@ -209,8 +209,8 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3845
-#: lib/vutuv_web/components/ui.ex:4694
+#: lib/vutuv_web/components/post_components.ex:4129
+#: lib/vutuv_web/components/ui.ex:4728
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
@@ -284,7 +284,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:5112
+#: lib/vutuv_web/components/ui.ex:5146
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -324,8 +324,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:698
 #: lib/vutuv_web/agent_docs/text.ex:658
 #: lib/vutuv_web/components/fediverse_components.ex:468
-#: lib/vutuv_web/components/ui.ex:3029
-#: lib/vutuv_web/components/ui.ex:3064
+#: lib/vutuv_web/components/ui.ex:3063
+#: lib/vutuv_web/components/ui.ex:3098
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:618
@@ -473,7 +473,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:793
+#: lib/vutuv_web/components/post_components.ex:806
 #: lib/vutuv_web/live/notification_live/index.ex:777
 #: lib/vutuv_web/live/organization_live/activity.ex:136
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4595
+#: lib/vutuv_web/components/ui.ex:4629
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2201
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -657,7 +657,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1812
+#: lib/vutuv_web/components/post_components.ex:1852
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -788,7 +788,7 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5108
+#: lib/vutuv_web/components/ui.ex:5142
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:832
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -840,7 +840,7 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1539
+#: lib/vutuv_web/components/ui.ex:1573
 #: lib/vutuv_web/views/user_html.ex:582
 #: lib/vutuv_web/views/user_html.ex:583
 #: lib/vutuv_web/views/user_html.ex:597
@@ -848,14 +848,14 @@ msgstr ""
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4764
+#: lib/vutuv_web/components/ui.ex:4798
 #: lib/vutuv_web/templates/user/show.html.heex:982
 #: lib/vutuv_web/templates/user/show.html.heex:1005
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5271
+#: lib/vutuv_web/components/ui.ex:5305
 #: lib/vutuv_web/controllers/settings_controller.ex:175
 #: lib/vutuv_web/live/job_posting_live/form.ex:818
 #: lib/vutuv_web/live/organization_live/edit.ex:339
@@ -1178,7 +1178,7 @@ msgstr ""
 msgid "All tag urls"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4487
+#: lib/vutuv_web/components/post_components.ex:4779
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:638
@@ -1350,7 +1350,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:584
 #: lib/vutuv_web/agent_docs/text.ex:850
-#: lib/vutuv_web/components/ui.ex:5133
+#: lib/vutuv_web/components/ui.ex:5167
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1593,7 +1593,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3188
+#: lib/vutuv_web/components/ui.ex:3222
 #: lib/vutuv_web/components/welcome_components.ex:125
 #: lib/vutuv_web/components/welcome_components.ex:131
 #: lib/vutuv_web/live/admin/job_live.ex:321
@@ -1652,20 +1652,20 @@ msgstr ""
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2271
-#: lib/vutuv_web/components/ui.ex:2280
-#: lib/vutuv_web/components/ui.ex:2758
+#: lib/vutuv_web/components/ui.ex:2305
+#: lib/vutuv_web/components/ui.ex:2314
+#: lib/vutuv_web/components/ui.ex:2792
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:244
-#: lib/vutuv_web/components/ui.ex:2994
-#: lib/vutuv_web/components/ui.ex:2994
-#: lib/vutuv_web/components/ui.ex:3011
-#: lib/vutuv_web/components/ui.ex:3020
-#: lib/vutuv_web/components/ui.ex:3036
-#: lib/vutuv_web/components/ui.ex:3098
+#: lib/vutuv_web/components/ui.ex:3028
+#: lib/vutuv_web/components/ui.ex:3028
+#: lib/vutuv_web/components/ui.ex:3045
+#: lib/vutuv_web/components/ui.ex:3054
+#: lib/vutuv_web/components/ui.ex:3070
+#: lib/vutuv_web/components/ui.ex:3132
 #: lib/vutuv_web/live/fediverse_account_live.ex:422
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:320
@@ -1730,8 +1730,8 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:472
-#: lib/vutuv_web/components/ui.ex:4813
+#: lib/vutuv_web/components/post_components.ex:485
+#: lib/vutuv_web/components/ui.ex:4847
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
@@ -1747,7 +1747,7 @@ msgid "Nothing new yet."
 msgstr ""
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:5170
+#: lib/vutuv_web/components/ui.ex:5204
 #: lib/vutuv_web/controllers/page_controller.ex:219
 #: lib/vutuv_web/live/notification_live/index.ex:155
 #: lib/vutuv_web/live/notification_live/index.ex:441
@@ -1886,14 +1886,14 @@ msgstr ""
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4096
-#: lib/vutuv_web/components/ui.ex:4241
+#: lib/vutuv_web/components/ui.ex:4130
+#: lib/vutuv_web/components/ui.ex:4275
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4838
+#: lib/vutuv_web/components/ui.ex:4872
 #: lib/vutuv_web/live/organization_live/activity.ex:159
 #: lib/vutuv_web/live/organization_live/feed.ex:258
 #: lib/vutuv_web/live/organization_live/show.ex:787
@@ -1906,13 +1906,13 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4605
+#: lib/vutuv_web/components/ui.ex:4639
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1934
-#: lib/vutuv_web/components/ui.ex:1944
+#: lib/vutuv_web/components/ui.ex:1968
+#: lib/vutuv_web/components/ui.ex:1978
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr ""
@@ -1951,12 +1951,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3555
+#: lib/vutuv_web/components/ui.ex:3589
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3559
+#: lib/vutuv_web/components/ui.ex:3593
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -1982,37 +1982,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3563
+#: lib/vutuv_web/components/ui.ex:3597
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3553
+#: lib/vutuv_web/components/ui.ex:3587
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3552
+#: lib/vutuv_web/components/ui.ex:3586
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3558
+#: lib/vutuv_web/components/ui.ex:3592
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3557
+#: lib/vutuv_web/components/ui.ex:3591
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3554
+#: lib/vutuv_web/components/ui.ex:3588
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3556
+#: lib/vutuv_web/components/ui.ex:3590
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2027,17 +2027,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3562
+#: lib/vutuv_web/components/ui.ex:3596
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3561
+#: lib/vutuv_web/components/ui.ex:3595
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3560
+#: lib/vutuv_web/components/ui.ex:3594
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2076,7 +2076,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3877
+#: lib/vutuv_web/components/post_components.ex:4161
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2121,8 +2121,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3831
-#: lib/vutuv_web/components/post_components.ex:3833
+#: lib/vutuv_web/components/post_components.ex:4115
+#: lib/vutuv_web/components/post_components.ex:4117
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3576
+#: lib/vutuv_web/live/post_live/feed.ex:3583
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2187,13 +2187,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4360
-#: lib/vutuv_web/components/post_components.ex:4364
+#: lib/vutuv_web/components/post_components.ex:4652
+#: lib/vutuv_web/components/post_components.ex:4656
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4361
+#: lib/vutuv_web/components/post_components.ex:4653
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2203,7 +2203,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:497
 #: lib/vutuv_web/components/job_exclusion_components.ex:189
-#: lib/vutuv_web/components/post_components.ex:1421
+#: lib/vutuv_web/components/post_components.ex:1461
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:229
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5515
+#: lib/vutuv_web/components/ui.ex:5549
 #: lib/vutuv_web/live/shell_live.ex:1582
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2288,32 +2288,32 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3828
+#: lib/vutuv_web/components/post_components.ex:4112
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5984
+#: lib/vutuv_web/components/post_components.ex:6278
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5988
+#: lib/vutuv_web/components/post_components.ex:6282
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5986
+#: lib/vutuv_web/components/post_components.ex:6280
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5987
+#: lib/vutuv_web/components/post_components.ex:6281
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3633
+#: lib/vutuv_web/components/ui.ex:3667
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
@@ -2352,9 +2352,9 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2104
-#: lib/vutuv_web/components/post_components.ex:6084
-#: lib/vutuv_web/components/ui.ex:4163
+#: lib/vutuv_web/components/post_components.ex:2165
+#: lib/vutuv_web/components/post_components.ex:6378
+#: lib/vutuv_web/components/ui.ex:4197
 #: lib/vutuv_web/views/user_html.ex:481
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2371,9 +2371,9 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2055
-#: lib/vutuv_web/components/post_components.ex:6322
-#: lib/vutuv_web/components/ui.ex:4149
+#: lib/vutuv_web/components/post_components.ex:2109
+#: lib/vutuv_web/components/post_components.ex:6616
+#: lib/vutuv_web/components/ui.ex:4183
 #: lib/vutuv_web/notification_line.ex:293
 #: lib/vutuv_web/views/user_html.ex:491
 #, elixir-autogen, elixir-format
@@ -2381,7 +2381,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1263
-#: lib/vutuv_web/components/post_components.ex:6332
+#: lib/vutuv_web/components/post_components.ex:6626
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1590
@@ -2402,40 +2402,40 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6072
+#: lib/vutuv_web/components/post_components.ex:6366
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2103
-#: lib/vutuv_web/components/post_components.ex:6083
+#: lib/vutuv_web/components/post_components.ex:2164
+#: lib/vutuv_web/components/post_components.ex:6377
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:481
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2084
-#: lib/vutuv_web/components/post_components.ex:6068
+#: lib/vutuv_web/components/post_components.ex:2145
+#: lib/vutuv_web/components/post_components.ex:6362
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2372
-#: lib/vutuv_web/components/post_components.ex:5091
+#: lib/vutuv_web/components/post_components.ex:2649
+#: lib/vutuv_web/components/post_components.ex:5384
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2083
-#: lib/vutuv_web/components/post_components.ex:6067
+#: lib/vutuv_web/components/post_components.ex:2144
+#: lib/vutuv_web/components/post_components.ex:6361
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2054
-#: lib/vutuv_web/components/post_components.ex:6321
+#: lib/vutuv_web/components/post_components.ex:2108
+#: lib/vutuv_web/components/post_components.ex:6615
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:491
 #, elixir-autogen, elixir-format
@@ -2443,10 +2443,10 @@ msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:498
-#: lib/vutuv_web/components/post_components.ex:2855
-#: lib/vutuv_web/components/ui.ex:2989
-#: lib/vutuv_web/components/ui.ex:2989
-#: lib/vutuv_web/components/ui.ex:3065
+#: lib/vutuv_web/components/post_components.ex:3135
+#: lib/vutuv_web/components/ui.ex:3023
+#: lib/vutuv_web/components/ui.ex:3023
+#: lib/vutuv_web/components/ui.ex:3099
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
 #: lib/vutuv_web/live/organization_live/show.ex:621
@@ -2463,20 +2463,20 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6376
+#: lib/vutuv_web/components/post_components.ex:6670
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:430
+#: lib/vutuv_web/components/post_components.ex:443
 #: lib/vutuv_web/live/notification_live/index.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2068
-#: lib/vutuv_web/components/post_components.ex:6359
-#: lib/vutuv_web/components/post_components.ex:6360
+#: lib/vutuv_web/components/post_components.ex:2354
+#: lib/vutuv_web/components/post_components.ex:6653
+#: lib/vutuv_web/components/post_components.ex:6654
 #: lib/vutuv_web/live/notification_live/index.ex:994
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:290
@@ -2484,7 +2484,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3795
+#: lib/vutuv_web/components/post_components.ex:4075
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2505,7 +2505,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3321
+#: lib/vutuv_web/components/post_components.ex:3601
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2513,14 +2513,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3767
+#: lib/vutuv_web/components/post_components.ex:4047
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3758
-#: lib/vutuv_web/components/post_components.ex:3787
-#: lib/vutuv_web/components/post_components.ex:3790
+#: lib/vutuv_web/components/post_components.ex:4038
+#: lib/vutuv_web/components/post_components.ex:4067
+#: lib/vutuv_web/components/post_components.ex:4070
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2581,7 +2581,7 @@ msgstr ""
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3312
+#: lib/vutuv_web/components/ui.ex:3346
 #: lib/vutuv_web/live/message_live/index.ex:760
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2668,7 +2668,7 @@ msgstr ""
 msgid "Okay, let's start over."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:862
+#: lib/vutuv_web/components/ui.ex:869
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr ""
@@ -2679,7 +2679,7 @@ msgstr ""
 msgid "Too many PIN requests. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:883
+#: lib/vutuv_web/components/ui.ex:890
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr ""
@@ -2729,8 +2729,8 @@ msgstr ""
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4329
-#: lib/vutuv_web/components/ui.ex:4766
+#: lib/vutuv_web/components/ui.ex:4363
+#: lib/vutuv_web/components/ui.ex:4800
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:109
@@ -2743,7 +2743,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:870
+#: lib/vutuv_web/components/post_components.ex:883
 #: lib/vutuv_web/controllers/page_controller.ex:216
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2781,7 +2781,7 @@ msgstr[1] ""
 msgid "Connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1530
+#: lib/vutuv_web/components/ui.ex:1564
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2791,7 +2791,7 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1546
+#: lib/vutuv_web/components/ui.ex:1580
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
@@ -2801,7 +2801,7 @@ msgstr ""
 msgid "People who aren't my connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1531
+#: lib/vutuv_web/components/ui.ex:1565
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -2819,7 +2819,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5985
+#: lib/vutuv_web/components/post_components.ex:6279
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3078,7 +3078,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3734
+#: lib/vutuv_web/components/post_components.ex:4014
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3122,7 +3122,7 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5102
+#: lib/vutuv_web/components/ui.ex:5136
 #: lib/vutuv_web/live/shell_live.ex:1373
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3147,9 +3147,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1434
-#: lib/vutuv_web/components/post_components.ex:2875
-#: lib/vutuv_web/components/post_components.ex:3944
+#: lib/vutuv_web/components/post_components.ex:1474
+#: lib/vutuv_web/components/post_components.ex:3155
+#: lib/vutuv_web/components/post_components.ex:4228
 #: lib/vutuv_web/live/organization_live/show.ex:661
 #: lib/vutuv_web/templates/user/show.html.heex:242
 #, elixir-autogen, elixir-format
@@ -3232,7 +3232,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4011
+#: lib/vutuv_web/components/ui.ex:4045
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -4297,12 +4297,12 @@ msgstr ""
 msgid "Bookings are open through %{last}. Next available day: %{day}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3585
+#: lib/vutuv_web/components/ui.ex:3619
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3581
+#: lib/vutuv_web/components/ui.ex:3615
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr ""
@@ -4312,27 +4312,27 @@ msgstr ""
 msgid "One ad per calendar day: pick a free day in the calendar; struck-through days are already booked."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3586
+#: lib/vutuv_web/components/ui.ex:3620
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3587
+#: lib/vutuv_web/components/ui.ex:3621
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3584
+#: lib/vutuv_web/components/ui.ex:3618
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3582
+#: lib/vutuv_web/components/ui.ex:3616
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3583
+#: lib/vutuv_web/components/ui.ex:3617
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr ""
@@ -4464,7 +4464,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5275
+#: lib/vutuv_web/components/ui.ex:5309
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4506,7 +4506,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3581
+#: lib/vutuv_web/live/post_live/feed.ex:3588
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4584,8 +4584,8 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:427
-#: lib/vutuv_web/components/post_components.ex:446
+#: lib/vutuv_web/components/post_components.ex:440
+#: lib/vutuv_web/components/post_components.ex:459
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -5231,7 +5231,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5325
+#: lib/vutuv_web/components/ui.ex:5359
 #: lib/vutuv_web/controllers/settings_controller.ex:161
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:439
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5310,10 +5310,10 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5422
-#: lib/vutuv_web/components/ui.ex:5427
-#: lib/vutuv_web/components/ui.ex:5506
-#: lib/vutuv_web/components/ui.ex:5570
+#: lib/vutuv_web/components/ui.ex:5456
+#: lib/vutuv_web/components/ui.ex:5461
+#: lib/vutuv_web/components/ui.ex:5540
+#: lib/vutuv_web/components/ui.ex:5604
 #: lib/vutuv_web/controllers/settings_controller.ex:68
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5383,9 +5383,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4022
-#: lib/vutuv_web/components/post_components.ex:4074
-#: lib/vutuv_web/components/post_components.ex:4608
+#: lib/vutuv_web/components/post_components.ex:4306
+#: lib/vutuv_web/components/post_components.ex:4358
+#: lib/vutuv_web/components/post_components.ex:4900
 #: lib/vutuv_web/live/notification_live/index.ex:1070
 #: lib/vutuv_web/views/user_html.ex:131
 #, elixir-autogen, elixir-format
@@ -5431,7 +5431,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5295
+#: lib/vutuv_web/components/ui.ex:5329
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5452,7 +5452,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5140
+#: lib/vutuv_web/components/ui.ex:5174
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5487,7 +5487,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5269
+#: lib/vutuv_web/components/ui.ex:5303
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -5599,7 +5599,7 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5318
+#: lib/vutuv_web/components/ui.ex:5352
 #: lib/vutuv_web/controllers/settings_controller.ex:185
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5803,21 +5803,21 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3649
+#: lib/vutuv_web/components/ui.ex:3683
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3648
+#: lib/vutuv_web/components/ui.ex:3682
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3647
+#: lib/vutuv_web/components/ui.ex:3681
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -5884,7 +5884,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3646
+#: lib/vutuv_web/components/ui.ex:3680
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -6026,7 +6026,7 @@ msgstr ""
 msgid "Tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:480
+#: lib/vutuv_web/components/ui.ex:487
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:916
@@ -6176,7 +6176,7 @@ msgid "Previous day"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1263
-#: lib/vutuv_web/components/post_components.ex:429
+#: lib/vutuv_web/components/post_components.ex:442
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6213,9 +6213,9 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2271
-#: lib/vutuv_web/components/ui.ex:2280
-#: lib/vutuv_web/components/ui.ex:2759
+#: lib/vutuv_web/components/ui.ex:2305
+#: lib/vutuv_web/components/ui.ex:2314
+#: lib/vutuv_web/components/ui.ex:2793
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6276,7 +6276,7 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2712
+#: lib/vutuv_web/components/ui.ex:2746
 #: lib/vutuv_web/live/notification_live/index.ex:708
 #: lib/vutuv_web/live/notification_live/index.ex:723
 #: lib/vutuv_web/live/notification_live/index.ex:1223
@@ -6571,10 +6571,10 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2802
-#: lib/vutuv_web/components/post_components.ex:3897
-#: lib/vutuv_web/components/post_components.ex:3911
-#: lib/vutuv_web/components/ui.ex:3137
+#: lib/vutuv_web/components/post_components.ex:3082
+#: lib/vutuv_web/components/post_components.ex:4181
+#: lib/vutuv_web/components/post_components.ex:4195
+#: lib/vutuv_web/components/ui.ex:3171
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
@@ -6601,8 +6601,8 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3897
-#: lib/vutuv_web/components/ui.ex:3136
+#: lib/vutuv_web/components/post_components.ex:4181
+#: lib/vutuv_web/components/ui.ex:3170
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
@@ -7206,13 +7206,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4105
+#: lib/vutuv_web/components/ui.ex:4139
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4117
+#: lib/vutuv_web/components/ui.ex:4151
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7294,7 +7294,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:6232
+#: lib/vutuv_web/components/post_components.ex:6526
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #: lib/vutuv_web/live/shell_live.ex:1812
 #, elixir-autogen, elixir-format
@@ -7398,7 +7398,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3870
+#: lib/vutuv_web/live/post_live/feed.ex:3877
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #, elixir-autogen
 msgid "Done"
@@ -7964,7 +7964,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4108
+#: lib/vutuv_web/components/ui.ex:4142
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8094,7 +8094,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:5116
+#: lib/vutuv_web/components/ui.ex:5150
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8149,7 +8149,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5306
+#: lib/vutuv_web/components/ui.ex:5340
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8178,7 +8178,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5144
+#: lib/vutuv_web/components/ui.ex:5178
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8272,7 +8272,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4381
+#: lib/vutuv_web/components/ui.ex:4415
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8347,13 +8347,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5104
+#: lib/vutuv_web/components/ui.ex:5138
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5238
+#: lib/vutuv_web/components/ui.ex:5272
 #: lib/vutuv_web/controllers/settings_controller.ex:129
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8365,7 +8365,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5297
+#: lib/vutuv_web/components/ui.ex:5331
 #: lib/vutuv_web/controllers/settings_controller.ex:112
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8375,7 +8375,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5310
+#: lib/vutuv_web/components/ui.ex:5344
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8484,7 +8484,7 @@ msgstr[1] ""
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1548
+#: lib/vutuv_web/components/ui.ex:1582
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -8580,8 +8580,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:648
 #: lib/vutuv_web/agent_docs/text.ex:652
 #: lib/vutuv_web/components/organization_components.ex:276
-#: lib/vutuv_web/components/ui.ex:1749
-#: lib/vutuv_web/components/ui.ex:5287
+#: lib/vutuv_web/components/ui.ex:1783
+#: lib/vutuv_web/components/ui.ex:5321
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:366
 #: lib/vutuv_web/controllers/settings_controller.ex:433
@@ -8731,12 +8731,12 @@ msgstr ""
 msgid "This is the print view of this CV. Use your browser's print dialog (Ctrl+P or Cmd+P) and choose \"Save as PDF\" to get a PDF file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1838
+#: lib/vutuv_web/components/ui.ex:1872
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5094
+#: lib/vutuv_web/components/post_components.ex:5387
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -8769,7 +8769,7 @@ msgstr ""
 msgid "Header"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1848
+#: lib/vutuv_web/components/ui.ex:1882
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -8801,7 +8801,7 @@ msgstr ""
 msgid "The CV is public, on your profile: a visitor's download contains only what they can see there anyway, and private email addresses appear only in your own."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1840
+#: lib/vutuv_web/components/ui.ex:1874
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -8955,8 +8955,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2315
-#: lib/vutuv_web/components/ui.ex:2316
+#: lib/vutuv_web/components/ui.ex:2349
+#: lib/vutuv_web/components/ui.ex:2350
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9525,7 +9525,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:5120
+#: lib/vutuv_web/components/ui.ex:5154
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -9721,13 +9721,13 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3762
+#: lib/vutuv_web/components/ui.ex:3796
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3761
-#: lib/vutuv_web/components/ui.ex:3769
+#: lib/vutuv_web/components/ui.ex:3795
+#: lib/vutuv_web/components/ui.ex:3803
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -9901,17 +9901,17 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:468
+#: lib/vutuv_web/components/ui.ex:475
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:520
+#: lib/vutuv_web/components/ui.ex:527
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:523
+#: lib/vutuv_web/components/ui.ex:530
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr ""
@@ -9926,13 +9926,13 @@ msgstr ""
 msgid "Delete your code list? All its codes stop working immediately."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:452
+#: lib/vutuv_web/components/ui.ex:459
 #, elixir-autogen, elixir-format
 msgid "Formatting"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:587
-#: lib/vutuv_web/components/ui.ex:588
+#: lib/vutuv_web/components/ui.ex:594
+#: lib/vutuv_web/components/ui.ex:595
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr ""
@@ -9947,29 +9947,29 @@ msgstr ""
 msgid "Generate code list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:461
-#: lib/vutuv_web/components/ui.ex:518
+#: lib/vutuv_web/components/ui.ex:468
+#: lib/vutuv_web/components/ui.ex:525
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:464
-#: lib/vutuv_web/components/ui.ex:519
+#: lib/vutuv_web/components/ui.ex:471
+#: lib/vutuv_web/components/ui.ex:526
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:477
+#: lib/vutuv_web/components/ui.ex:484
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:471
+#: lib/vutuv_web/components/ui.ex:478
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:408
+#: lib/vutuv_web/components/ui.ex:415
 #, elixir-autogen, elixir-format
 msgid "Link URL"
 msgstr ""
@@ -9985,7 +9985,7 @@ msgstr ""
 msgid "Not set up."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:521
+#: lib/vutuv_web/components/ui.ex:528
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr ""
@@ -10000,7 +10000,7 @@ msgstr ""
 msgid "Print this page or write the codes down. Crossed-out codes have been used."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:522
+#: lib/vutuv_web/components/ui.ex:529
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr ""
@@ -10021,7 +10021,7 @@ msgstr ""
 msgid "Set up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:474
+#: lib/vutuv_web/components/ui.ex:481
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr ""
@@ -10681,7 +10681,7 @@ msgstr ""
 msgid "Queued"
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:213
+#: lib/vutuv_web/components/video_components.ex:214
 #: lib/vutuv_web/live/admin/screenshot_live.ex:525
 #, elixir-autogen, elixir-format
 msgid "Ready"
@@ -11023,12 +11023,12 @@ msgstr ""
 msgid "State / region (optional)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4435
+#: lib/vutuv_web/components/ui.ex:4469
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4437
+#: lib/vutuv_web/components/ui.ex:4471
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr ""
@@ -11448,7 +11448,7 @@ msgstr ""
 msgid "The link text can be anything. A hidden <link rel=\"me\"> in the page head works too."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1085
+#: lib/vutuv_web/components/ui.ex:1119
 #: lib/vutuv_web/live/section_reorder_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -11716,7 +11716,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:462
-#: lib/vutuv_web/components/ui.ex:5314
+#: lib/vutuv_web/components/ui.ex:5348
 #: lib/vutuv_web/controllers/settings_controller.ex:222
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
@@ -12929,7 +12929,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5223
+#: lib/vutuv_web/components/ui.ex:5257
 #: lib/vutuv_web/controllers/settings_controller.ex:629
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -12948,7 +12948,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3280
+#: lib/vutuv_web/components/post_components.ex:3560
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -13305,27 +13305,27 @@ msgstr[1] ""
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:497
+#: lib/vutuv_web/components/ui.ex:504
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:494
+#: lib/vutuv_web/components/ui.ex:501
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:500
+#: lib/vutuv_web/components/ui.ex:507
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:491
+#: lib/vutuv_web/components/ui.ex:498
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:524
+#: lib/vutuv_web/components/ui.ex:531
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr ""
@@ -13362,22 +13362,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:469
+#: lib/vutuv_web/components/post_components.ex:482
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:471
+#: lib/vutuv_web/components/post_components.ex:484
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:470
+#: lib/vutuv_web/components/post_components.ex:483
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:428
+#: lib/vutuv_web/components/post_components.ex:441
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13387,7 +13387,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5206
+#: lib/vutuv_web/components/ui.ex:5240
 #: lib/vutuv_web/controllers/settings_controller.ex:643
 #: lib/vutuv_web/live/post_live/feed.ex:710
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13462,7 +13462,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:63
-#: lib/vutuv_web/components/ui.ex:5163
+#: lib/vutuv_web/components/ui.ex:5197
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13490,14 +13490,14 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4520
+#: lib/vutuv_web/components/ui.ex:4554
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:4530
+#: lib/vutuv_web/components/ui.ex:4564
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
@@ -13547,34 +13547,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5782
+#: lib/vutuv_web/components/post_components.ex:6075
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:5739
+#: lib/vutuv_web/components/post_components.ex:6032
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5783
+#: lib/vutuv_web/components/post_components.ex:6076
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5785
+#: lib/vutuv_web/components/post_components.ex:6078
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5781
+#: lib/vutuv_web/components/post_components.ex:6074
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:5738
+#: lib/vutuv_web/components/post_components.ex:6031
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13585,12 +13585,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5780
+#: lib/vutuv_web/components/post_components.ex:6073
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5784
+#: lib/vutuv_web/components/post_components.ex:6077
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13610,7 +13610,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5821
+#: lib/vutuv_web/components/post_components.ex:6114
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13618,27 +13618,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5851
+#: lib/vutuv_web/components/post_components.ex:6144
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5852
+#: lib/vutuv_web/components/post_components.ex:6145
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5850
+#: lib/vutuv_web/components/post_components.ex:6143
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5810
+#: lib/vutuv_web/components/post_components.ex:6103
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5857
+#: lib/vutuv_web/components/post_components.ex:6150
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13668,7 +13668,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5624
+#: lib/vutuv_web/components/post_components.ex:5917
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13711,17 +13711,17 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5615
+#: lib/vutuv_web/components/post_components.ex:5908
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2449
+#: lib/vutuv_web/components/ui.ex:2483
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2453
+#: lib/vutuv_web/components/ui.ex:2487
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -14058,14 +14058,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3561
+#: lib/vutuv_web/components/post_components.ex:3841
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3584
+#: lib/vutuv_web/components/post_components.ex:3864
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14092,7 +14092,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6331
+#: lib/vutuv_web/components/post_components.ex:6625
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14250,7 +14250,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5177
+#: lib/vutuv_web/components/ui.ex:5211
 #: lib/vutuv_web/controllers/settings_controller.ex:773
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -14884,252 +14884,252 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5105
+#: lib/vutuv_web/components/ui.ex:5139
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5110
+#: lib/vutuv_web/components/ui.ex:5144
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5113
+#: lib/vutuv_web/components/ui.ex:5147
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5114
+#: lib/vutuv_web/components/ui.ex:5148
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5117
+#: lib/vutuv_web/components/ui.ex:5151
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5118
+#: lib/vutuv_web/components/ui.ex:5152
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5121
+#: lib/vutuv_web/components/ui.ex:5155
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5122
+#: lib/vutuv_web/components/ui.ex:5156
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5129
+#: lib/vutuv_web/components/ui.ex:5163
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5130
+#: lib/vutuv_web/components/ui.ex:5164
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5131
+#: lib/vutuv_web/components/ui.ex:5165
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5134
+#: lib/vutuv_web/components/ui.ex:5168
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5135
+#: lib/vutuv_web/components/ui.ex:5169
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5315
+#: lib/vutuv_web/components/ui.ex:5349
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5316
+#: lib/vutuv_web/components/ui.ex:5350
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5138
+#: lib/vutuv_web/components/ui.ex:5172
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5141
+#: lib/vutuv_web/components/ui.ex:5175
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5142
+#: lib/vutuv_web/components/ui.ex:5176
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5145
+#: lib/vutuv_web/components/ui.ex:5179
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5146
+#: lib/vutuv_web/components/ui.ex:5180
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5149
+#: lib/vutuv_web/components/ui.ex:5183
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5150
+#: lib/vutuv_web/components/ui.ex:5184
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5152
+#: lib/vutuv_web/components/ui.ex:5186
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5153
+#: lib/vutuv_web/components/ui.ex:5187
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5154
+#: lib/vutuv_web/components/ui.ex:5188
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5156
+#: lib/vutuv_web/components/ui.ex:5190
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5157
+#: lib/vutuv_web/components/ui.ex:5191
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5159
+#: lib/vutuv_web/components/ui.ex:5193
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5164
+#: lib/vutuv_web/components/ui.ex:5198
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5165
+#: lib/vutuv_web/components/ui.ex:5199
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5168
+#: lib/vutuv_web/components/ui.ex:5202
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5171
+#: lib/vutuv_web/components/ui.ex:5205
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5178
+#: lib/vutuv_web/components/ui.ex:5212
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5179
+#: lib/vutuv_web/components/ui.ex:5213
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5207
+#: lib/vutuv_web/components/ui.ex:5241
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5208
+#: lib/vutuv_web/components/ui.ex:5242
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5224
+#: lib/vutuv_web/components/ui.ex:5258
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5225
+#: lib/vutuv_web/components/ui.ex:5259
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5272
+#: lib/vutuv_web/components/ui.ex:5306
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5273
+#: lib/vutuv_web/components/ui.ex:5307
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5276
+#: lib/vutuv_web/components/ui.ex:5310
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5277
+#: lib/vutuv_web/components/ui.ex:5311
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5298
+#: lib/vutuv_web/components/ui.ex:5332
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5299
+#: lib/vutuv_web/components/ui.ex:5333
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5307
+#: lib/vutuv_web/components/ui.ex:5341
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5308
+#: lib/vutuv_web/components/ui.ex:5342
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5311
+#: lib/vutuv_web/components/ui.ex:5345
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5312
+#: lib/vutuv_web/components/ui.ex:5346
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5326
+#: lib/vutuv_web/components/ui.ex:5360
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5327
+#: lib/vutuv_web/components/ui.ex:5361
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15237,7 +15237,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6277
+#: lib/vutuv_web/components/post_components.ex:6571
 #: lib/vutuv_web/live/notification_live/index.ex:1593
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
@@ -15245,7 +15245,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6281
+#: lib/vutuv_web/components/post_components.ex:6575
 #: lib/vutuv_web/live/notification_live/index.ex:1587
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15253,7 +15253,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6285
+#: lib/vutuv_web/components/post_components.ex:6579
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15261,7 +15261,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:6236
+#: lib/vutuv_web/components/post_components.ex:6530
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15279,14 +15279,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1549
-#: lib/vutuv_web/components/post_components.ex:2301
+#: lib/vutuv_web/components/post_components.ex:1589
+#: lib/vutuv_web/components/post_components.ex:2578
 #: lib/vutuv_web/live/fediverse_account_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1419
+#: lib/vutuv_web/components/post_components.ex:1459
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15315,7 +15315,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1431
+#: lib/vutuv_web/components/post_components.ex:1471
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15325,7 +15325,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1445
+#: lib/vutuv_web/components/post_components.ex:1485
 #: lib/vutuv_web/live/notification_live/index.ex:1118
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15357,9 +15357,9 @@ msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1501
-#: lib/vutuv_web/components/post_components.ex:1480
-#: lib/vutuv_web/components/post_components.ex:1680
-#: lib/vutuv_web/components/post_components.ex:3138
+#: lib/vutuv_web/components/post_components.ex:1520
+#: lib/vutuv_web/components/post_components.ex:1720
+#: lib/vutuv_web/components/post_components.ex:3418
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -15588,7 +15588,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5301
+#: lib/vutuv_web/components/ui.ex:5335
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -15935,7 +15935,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5302
+#: lib/vutuv_web/components/ui.ex:5336
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -15971,7 +15971,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5304
+#: lib/vutuv_web/components/ui.ex:5338
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16023,22 +16023,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3746
+#: lib/vutuv_web/components/post_components.ex:4026
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3864
+#: lib/vutuv_web/components/post_components.ex:4148
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3872
+#: lib/vutuv_web/components/post_components.ex:4156
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3858
+#: lib/vutuv_web/components/post_components.ex:4142
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16126,7 +16126,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1429
 #: lib/vutuv_web/agent_docs/text.ex:915
-#: lib/vutuv_web/components/ui.ex:3191
+#: lib/vutuv_web/components/ui.ex:3225
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16151,7 +16151,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3190
+#: lib/vutuv_web/components/ui.ex:3224
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16161,17 +16161,17 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3333
+#: lib/vutuv_web/components/post_components.ex:3613
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4739
+#: lib/vutuv_web/components/post_components.ex:5032
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4888
+#: lib/vutuv_web/components/post_components.ex:5181
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16184,12 +16184,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1462
 #: lib/vutuv_web/agent_docs/text.ex:890
-#: lib/vutuv_web/components/post_components.ex:4970
+#: lib/vutuv_web/components/post_components.ex:5263
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3189
+#: lib/vutuv_web/components/ui.ex:3223
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous photo"
 msgstr ""
@@ -16210,7 +16210,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3386
+#: lib/vutuv_web/components/post_components.ex:3666
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16230,7 +16230,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3377
+#: lib/vutuv_web/components/post_components.ex:3657
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16240,12 +16240,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3395
+#: lib/vutuv_web/components/post_components.ex:3675
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3329
+#: lib/vutuv_web/components/post_components.ex:3609
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16260,7 +16260,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3390
+#: lib/vutuv_web/components/post_components.ex:3670
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16270,7 +16270,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3343
+#: lib/vutuv_web/components/post_components.ex:3623
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16345,13 +16345,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1319
-#: lib/vutuv_web/components/post_components.ex:6274
+#: lib/vutuv_web/components/post_components.ex:6568
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1317
-#: lib/vutuv_web/components/post_components.ex:6271
+#: lib/vutuv_web/components/post_components.ex:6565
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16361,7 +16361,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6161
+#: lib/vutuv_web/components/post_components.ex:6455
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -16479,7 +16479,7 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5288
+#: lib/vutuv_web/components/ui.ex:5322
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
@@ -16682,7 +16682,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5290
+#: lib/vutuv_web/components/ui.ex:5324
 #, elixir-autogen, elixir-format, fuzzy
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -16702,7 +16702,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2897
+#: lib/vutuv_web/components/post_components.ex:3177
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16712,7 +16712,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3137
+#: lib/vutuv_web/components/post_components.ex:3417
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16732,12 +16732,12 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1815
+#: lib/vutuv_web/components/post_components.ex:1855
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3078
+#: lib/vutuv_web/components/post_components.ex:3358
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marked as sensitive by its author"
 msgstr ""
@@ -16752,7 +16752,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2870
+#: lib/vutuv_web/components/post_components.ex:3150
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -16976,27 +16976,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2473
+#: lib/vutuv_web/components/post_components.ex:2751
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2506
+#: lib/vutuv_web/components/post_components.ex:2784
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2501
+#: lib/vutuv_web/components/post_components.ex:2779
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3236
+#: lib/vutuv_web/components/post_components.ex:3516
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3242
+#: lib/vutuv_web/components/post_components.ex:3522
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is not here any more."
 msgstr ""
@@ -17006,7 +17006,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3381
+#: lib/vutuv_web/components/post_components.ex:3661
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17016,7 +17016,7 @@ msgstr ""
 msgid "This post was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_actions_component.ex:181
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:302
 #, elixir-autogen, elixir-format
 msgid "Reposted. Your followers see it now."
 msgstr ""
@@ -17051,12 +17051,12 @@ msgstr ""
 msgid "Your feed shows the posts of members you follow. Follow a few to fill it."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:239
+#: lib/vutuv_web/components/ui.ex:246
 #, elixir-autogen, elixir-format
 msgid "Add another tag"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:262
+#: lib/vutuv_web/components/ui.ex:269
 #, elixir-autogen, elixir-format
 msgid "Remove the tag %{name}"
 msgstr ""
@@ -17182,7 +17182,7 @@ msgstr ""
 msgid "Your username is your public identity here. It changes only once you confirm with your passkey or a valid code below."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:622
+#: lib/vutuv_web/components/ui.ex:629
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Markdown help"
 msgstr ""
@@ -17203,7 +17203,7 @@ msgid "Address of the post"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:688
-#: lib/vutuv_web/live/post_live/remote_actions_component.ex:276
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:414
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Fediverse settings"
 msgstr ""
@@ -17619,12 +17619,12 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:461
+#: lib/vutuv_web/components/post_components.ex:474
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:458
+#: lib/vutuv_web/components/post_components.ex:471
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
@@ -17667,7 +17667,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3239
+#: lib/vutuv_web/components/post_components.ex:3519
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -17708,8 +17708,8 @@ msgstr ""
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1600
-#: lib/vutuv_web/components/ui.ex:1601
+#: lib/vutuv_web/components/ui.ex:1634
+#: lib/vutuv_web/components/ui.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr ""
@@ -17724,7 +17724,7 @@ msgstr ""
 msgid "Source code"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:268
+#: lib/vutuv_web/components/ui.ex:275
 #, elixir-autogen, elixir-format
 msgid "At most %{max} tags. Remove one to add another."
 msgstr ""
@@ -17739,19 +17739,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5264
+#: lib/vutuv_web/components/post_components.ex:5557
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5266
+#: lib/vutuv_web/components/post_components.ex:5559
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5277
+#: lib/vutuv_web/components/post_components.ex:5570
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -17878,7 +17878,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:5124
+#: lib/vutuv_web/components/ui.ex:5158
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -17923,7 +17923,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3599
+#: lib/vutuv_web/live/post_live/feed.ex:3606
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Loading…"
@@ -18073,7 +18073,7 @@ msgstr ""
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5125
+#: lib/vutuv_web/components/ui.ex:5159
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
@@ -18084,7 +18084,7 @@ msgstr ""
 msgid "Zwischenzeugnis"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5127
+#: lib/vutuv_web/components/ui.ex:5161
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -18339,7 +18339,7 @@ msgstr ""
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4421
+#: lib/vutuv_web/components/ui.ex:4455
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -18615,12 +18615,12 @@ msgstr ""
 msgid "Enter the PIN from the email"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:854
+#: lib/vutuv_web/components/ui.ex:861
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:882
+#: lib/vutuv_web/components/ui.ex:889
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cancel registration"
 msgstr ""
@@ -18630,7 +18630,7 @@ msgstr ""
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:837
+#: lib/vutuv_web/components/ui.ex:844
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
@@ -18655,7 +18655,7 @@ msgstr ""
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5106
+#: lib/vutuv_web/components/ui.ex:5140
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
@@ -18751,7 +18751,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5281
+#: lib/vutuv_web/components/ui.ex:5315
 #: lib/vutuv_web/controllers/settings_controller.ex:256
 #: lib/vutuv_web/controllers/settings_controller.ex:335
 #: lib/vutuv_web/controllers/settings_controller.ex:347
@@ -18848,7 +18848,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5283
+#: lib/vutuv_web/components/ui.ex:5317
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -18957,7 +18957,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5285
+#: lib/vutuv_web/components/ui.ex:5319
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -19331,7 +19331,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3269
+#: lib/vutuv_web/components/post_components.ex:3549
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -19748,22 +19748,22 @@ msgstr ""
 msgid "The PIN has expired."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:958
+#: lib/vutuv_web/components/ui.ex:965
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:960
+#: lib/vutuv_web/components/ui.ex:967
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:959
+#: lib/vutuv_web/components/ui.ex:966
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:961
+#: lib/vutuv_web/components/ui.ex:968
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr ""
@@ -20199,27 +20199,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5158
+#: lib/vutuv_web/components/post_components.ex:5451
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5194
+#: lib/vutuv_web/components/post_components.ex:5487
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5203
+#: lib/vutuv_web/components/post_components.ex:5496
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5206
+#: lib/vutuv_web/components/post_components.ex:5499
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5183
+#: lib/vutuv_web/components/post_components.ex:5476
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20229,8 +20229,8 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5173
-#: lib/vutuv_web/components/ui.ex:5199
+#: lib/vutuv_web/components/post_components.ex:5466
+#: lib/vutuv_web/components/ui.ex:5233
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -20358,20 +20358,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4936
+#: lib/vutuv_web/components/post_components.ex:5229
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4933
+#: lib/vutuv_web/components/post_components.ex:5226
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2527
-#: lib/vutuv_web/components/post_components.ex:4144
+#: lib/vutuv_web/components/post_components.ex:2805
+#: lib/vutuv_web/components/post_components.ex:4436
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20441,7 +20441,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5319
+#: lib/vutuv_web/components/ui.ex:5353
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
@@ -20487,7 +20487,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5321
+#: lib/vutuv_web/components/ui.ex:5355
 #, elixir-autogen, elixir-format, fuzzy
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -20522,7 +20522,7 @@ msgstr ""
 msgid "Find your LinkedIn contacts"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5215
+#: lib/vutuv_web/components/ui.ex:5249
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format, fuzzy
@@ -20630,7 +20630,7 @@ msgstr ""
 msgid "See which of them are already on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5217
+#: lib/vutuv_web/components/ui.ex:5251
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr ""
@@ -20702,7 +20702,7 @@ msgstr ""
 msgid "Your export also lists your LinkedIn contacts."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5219
+#: lib/vutuv_web/components/ui.ex:5253
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr ""
@@ -20884,7 +20884,7 @@ msgstr ""
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2850
+#: lib/vutuv_web/components/post_components.ex:3130
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
@@ -20959,7 +20959,7 @@ msgstr ""
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5173
+#: lib/vutuv_web/components/ui.ex:5207
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
@@ -21009,7 +21009,7 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3764
+#: lib/vutuv_web/live/post_live/feed.ex:3771
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
@@ -21019,43 +21019,43 @@ msgstr ""
 msgid "New here"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1769
+#: lib/vutuv_web/components/ui.ex:1803
 #, elixir-autogen, elixir-format
 msgid "New public posts arrive in any feed reader. No account needed either."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1765
+#: lib/vutuv_web/components/ui.ex:1799
 #, elixir-autogen, elixir-format
 msgid "Or with an RSS reader"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1645
-#: lib/vutuv_web/components/ui.ex:1714
+#: lib/vutuv_web/components/ui.ex:1679
+#: lib/vutuv_web/components/ui.ex:1748
 #, elixir-autogen, elixir-format
 msgid "Subscribe"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1766
+#: lib/vutuv_web/components/ui.ex:1800
 #, elixir-autogen, elixir-format
 msgid "With an RSS reader"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1726
+#: lib/vutuv_web/components/ui.ex:1760
 #, elixir-autogen, elixir-format
 msgid "Create a free account"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1741
+#: lib/vutuv_web/components/ui.ex:1775
 #, elixir-autogen, elixir-format
 msgid "No vutuv account? These ways work too:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1719
+#: lib/vutuv_web/components/ui.ex:1753
 #, elixir-autogen, elixir-format
 msgid "The best way: follow %{name} here. New posts land in your feed, and you can reply and join in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1717
+#: lib/vutuv_web/components/ui.ex:1751
 #, elixir-autogen, elixir-format
 msgid "With a vutuv account"
 msgstr ""
@@ -21180,22 +21180,22 @@ msgstr ""
 msgid "Shown in the language it was written in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5200
+#: lib/vutuv_web/components/ui.ex:5234
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5202
+#: lib/vutuv_web/components/ui.ex:5236
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5240
+#: lib/vutuv_web/components/ui.ex:5274
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5244
+#: lib/vutuv_web/components/ui.ex:5278
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -21308,7 +21308,7 @@ msgstr ""
 msgid "Your LinkedIn profile can come along."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1155
+#: lib/vutuv_web/components/ui.ex:1189
 #, elixir-autogen, elixir-format
 msgid "Being checked"
 msgstr ""
@@ -21497,13 +21497,13 @@ msgid "Hide a word or a whole phrase …"
 msgstr "Hide a word or a whole phrase …"
 
 #: lib/vutuv_web/live/post_live/feed.ex:709
-#: lib/vutuv_web/live/post_live/feed.ex:3927
+#: lib/vutuv_web/live/post_live/feed.ex:3934
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Hide tags"
 
 #: lib/vutuv_web/live/post_live/feed.ex:708
-#: lib/vutuv_web/live/post_live/feed.ex:3916
+#: lib/vutuv_web/live/post_live/feed.ex:3923
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Hide words"
@@ -21529,7 +21529,7 @@ msgstr ""
 msgid "Move %{card}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:412
+#: lib/vutuv_web/components/ui.ex:419
 #: lib/vutuv_web/live/post_live/filter_band.ex:584
 #, elixir-autogen, elixir-format
 msgid "No account found."
@@ -21570,7 +21570,7 @@ msgstr "Posts carrying one of these tags are folded the same way."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3790
+#: lib/vutuv_web/live/post_live/feed.ex:3797
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
@@ -21609,7 +21609,7 @@ msgid "Show posts by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:707
-#: lib/vutuv_web/live/post_live/feed.ex:3882
+#: lib/vutuv_web/live/post_live/feed.ex:3889
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sources"
 msgstr ""
@@ -21668,7 +21668,7 @@ msgid_plural "Show %{formatted} posts in the feed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2444
+#: lib/vutuv_web/components/post_components.ex:2722
 #, elixir-autogen, elixir-format
 msgid "Picture unavailable"
 msgstr "Picture unavailable"
@@ -21693,7 +21693,7 @@ msgstr ""
 msgid "Your organization page was updated, but that picture could not be used as a logo. Please pick another one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4427
+#: lib/vutuv_web/components/ui.ex:4461
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -21714,7 +21714,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3556
+#: lib/vutuv_web/live/post_live/feed.ex:3563
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to now"
 msgstr ""
@@ -21724,7 +21724,7 @@ msgstr ""
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3602
+#: lib/vutuv_web/live/post_live/feed.ex:3609
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -21746,7 +21746,7 @@ msgstr ""
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3552
+#: lib/vutuv_web/live/post_live/feed.ex:3559
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
@@ -21840,7 +21840,7 @@ msgid_plural "New (%{formatted}):"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3005
+#: lib/vutuv_web/components/post_components.ex:3285
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Quoted post"
 msgstr ""
@@ -21855,12 +21855,12 @@ msgstr ""
 msgid "Quotes %{url}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:411
+#: lib/vutuv_web/components/ui.ex:418
 #, elixir-autogen, elixir-format
 msgid "Mention an account"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:415
+#: lib/vutuv_web/components/ui.ex:422
 #, elixir-autogen, elixir-format
 msgid "{used} of {max} mentions"
 msgstr ""
@@ -21891,12 +21891,12 @@ msgstr ""
 msgid "Only these accounts (empty = all) …"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3496
+#: lib/vutuv_web/components/ui.ex:3530
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6617
+#: lib/vutuv_web/components/post_components.ex:6911
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -21943,17 +21943,17 @@ msgid_plural "shared this."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:566
+#: lib/vutuv_web/components/ui.ex:573
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Editor view"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:514
+#: lib/vutuv_web/components/ui.ex:521
 #, elixir-autogen, elixir-format
 msgid "Insert a block"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:526
+#: lib/vutuv_web/components/ui.ex:533
 #, elixir-autogen, elixir-format
 msgid "Nothing matches."
 msgstr ""
@@ -22079,7 +22079,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3690
+#: lib/vutuv_web/live/post_live/feed.ex:3697
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} rule"
@@ -22132,7 +22132,7 @@ msgstr ""
 msgid "Replace with"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5192
+#: lib/vutuv_web/components/ui.ex:5226
 #, elixir-autogen, elixir-format
 msgid "Rewrite what an account's posts say, for you alone"
 msgstr ""
@@ -22147,10 +22147,10 @@ msgstr ""
 msgid "Rules that rewrite the text of one account's posts before you read them: a footer under every post, a signature, a wall of hashtags. Only you see the difference. Open the ⋯ menu on any post to write rules for its author."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1424
-#: lib/vutuv_web/components/post_components.ex:2863
-#: lib/vutuv_web/components/post_components.ex:3941
-#: lib/vutuv_web/components/ui.ex:5191
+#: lib/vutuv_web/components/post_components.ex:1464
+#: lib/vutuv_web/components/post_components.ex:3143
+#: lib/vutuv_web/components/post_components.ex:4225
+#: lib/vutuv_web/components/ui.ex:5225
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
 #: lib/vutuv_web/live/post_rewrites_live.ex:264
@@ -22206,12 +22206,12 @@ msgstr ""
 msgid "\\1 puts back what the first (…) group matched, \\0 the whole match."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5193
+#: lib/vutuv_web/components/ui.ex:5227
 #, elixir-autogen, elixir-format
 msgid "regex regular expression rewrite replace footer signature strip"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5262
+#: lib/vutuv_web/components/ui.ex:5296
 #, elixir-autogen, elixir-format
 msgid "Smaller pictures and a plain composer on a slow connection"
 msgstr ""
@@ -22221,12 +22221,12 @@ msgstr ""
 msgid "That endorsement is not possible."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5264
+#: lib/vutuv_web/components/ui.ex:5298
 #, elixir-autogen, elixir-format
 msgid "bandwidth slow internet mobile data saving saver volume metered compression pictures images screenshots editor langsam daten sparen datensparmodus volumen schmalband komprimierung bilder"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5236
+#: lib/vutuv_web/components/ui.ex:5270
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr ""
@@ -22238,7 +22238,7 @@ msgid_plural "%{count} videos in progress"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/video_components.ex:257
+#: lib/vutuv_web/components/video_components.ex:258
 #, elixir-autogen, elixir-format
 msgid "About %{minutes} min of video"
 msgstr ""
@@ -22248,39 +22248,39 @@ msgstr ""
 msgid "Add video"
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:199
+#: lib/vutuv_web/components/video_components.ex:200
 #, elixir-autogen, elixir-format
 msgid "Converting · %{percent} %"
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:280
+#: lib/vutuv_web/components/video_components.ex:281
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delete this post"
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:216
+#: lib/vutuv_web/components/video_components.ex:217
 #, elixir-autogen, elixir-format
 msgid "Our AI check refused this video (at %{time})."
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:218
+#: lib/vutuv_web/components/video_components.ex:219
 #, elixir-autogen, elixir-format
 msgid "Our AI check refused this video."
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:204
+#: lib/vutuv_web/components/video_components.ex:205
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking it."
 msgid_plural "Our AI is checking it, %{done} of %{total} frames done."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/video_components.ex:272
+#: lib/vutuv_web/components/video_components.ex:273
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post without the video"
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:196
+#: lib/vutuv_web/components/video_components.ex:197
 #, elixir-autogen, elixir-format
 msgid "Reading the frames"
 msgstr ""
@@ -22315,7 +22315,7 @@ msgstr ""
 msgid "The video could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:262
+#: lib/vutuv_web/components/video_components.ex:263
 #, elixir-autogen, elixir-format
 msgid "The video is gone."
 msgstr ""
@@ -22325,12 +22325,12 @@ msgstr ""
 msgid "The video is longer than %{seconds} seconds."
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:246
+#: lib/vutuv_web/components/video_components.ex:247
 #, elixir-autogen, elixir-format
 msgid "This post is still waiting for you"
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:219
+#: lib/vutuv_web/components/video_components.ex:220
 #, elixir-autogen, elixir-format
 msgid "This video could not be converted."
 msgstr ""
@@ -22339,8 +22339,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1417
 #: lib/vutuv_web/agent_docs/text.ex:899
 #: lib/vutuv_web/agent_docs/text.ex:900
-#: lib/vutuv_web/components/post_components.ex:2579
-#: lib/vutuv_web/components/video_components.ex:126
+#: lib/vutuv_web/components/post_components.ex:2857
+#: lib/vutuv_web/components/video_components.ex:127
 #: lib/vutuv_web/live/post_live/composer.ex:2458
 #, elixir-autogen, elixir-format
 msgid "Video"
@@ -22356,7 +22356,7 @@ msgstr ""
 msgid "Videos cannot be uploaded here."
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:195
+#: lib/vutuv_web/components/video_components.ex:196
 #, elixir-autogen, elixir-format
 msgid "Waiting in line"
 msgstr ""
@@ -22371,7 +22371,7 @@ msgstr ""
 msgid "You can post now — the post appears as soon as the video is ready."
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:247
+#: lib/vutuv_web/components/video_components.ex:248
 #, elixir-autogen, elixir-format
 msgid "Your post appears as soon as the video is ready"
 msgstr ""
@@ -22402,7 +22402,7 @@ msgstr[1] ""
 msgid "Last 30 days: %{parts}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4496
+#: lib/vutuv_web/components/post_components.ex:4788
 #: lib/vutuv_web/live/notification_live/index.ex:1004
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Less"
@@ -22443,12 +22443,12 @@ msgstr ""
 msgid "replied in the thread."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1335
+#: lib/vutuv_web/components/ui.ex:1369
 #, elixir-autogen, elixir-format
 msgid "Standard quality. Load this picture in HD."
 msgstr ""
 
-#: lib/vutuv_web/components/video_components.ex:117
+#: lib/vutuv_web/components/video_components.ex:118
 #, elixir-autogen, elixir-format
 msgid "Standard quality. Play this video in HD."
 msgstr ""
@@ -22706,7 +22706,7 @@ msgstr ""
 msgid "Accounts whose posts stay out of your feed, and accounts whose reposts do. This list is yours alone: it is never shared and nobody is told they are on it."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5185
+#: lib/vutuv_web/components/ui.ex:5219
 #, elixir-autogen, elixir-format
 msgid "Accounts you have silenced, and whose reposts you hide"
 msgstr ""
@@ -22716,8 +22716,8 @@ msgstr ""
 msgid "Hidden. What they pass on stays out of your feed; their own posts do not."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2835
-#: lib/vutuv_web/components/post_components.ex:3935
+#: lib/vutuv_web/components/post_components.ex:3115
+#: lib/vutuv_web/components/post_components.ex:4219
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr ""
@@ -22732,7 +22732,7 @@ msgstr ""
 msgid "Mute everything"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5184
+#: lib/vutuv_web/components/ui.ex:5218
 #: lib/vutuv_web/controllers/settings_controller.ex:713
 #: lib/vutuv_web/templates/settings/mutes.html.heex:1
 #: lib/vutuv_web/templates/settings/mutes.html.heex:3
@@ -22776,7 +22776,7 @@ msgstr ""
 msgid "You mute an account where you meet it: the ⋯ menu on any of its posts, or its own page. Muting works whether or not you follow them."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5187
+#: lib/vutuv_web/components/ui.ex:5221
 #, elixir-autogen, elixir-format
 msgid "mute unmute hide account reposts boosts feed stumm stummschalten ausblenden konto"
 msgstr ""
@@ -22876,7 +22876,7 @@ msgstr ""
 msgid "Feed settings saved."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5255
+#: lib/vutuv_web/components/ui.ex:5289
 #, elixir-autogen, elixir-format
 msgid "How many load at once, and how many “Load more” adds"
 msgstr ""
@@ -22886,7 +22886,7 @@ msgstr ""
 msgid "How many posts your feed shows before the “Load more” button, and how many that button adds. More posts mean a longer wait for the page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5254
+#: lib/vutuv_web/components/ui.ex:5288
 #: lib/vutuv_web/controllers/settings_controller.ex:963
 #: lib/vutuv_web/templates/settings/feed.html.heex:12
 #, elixir-autogen, elixir-format
@@ -22898,8 +22898,8 @@ msgstr ""
 msgid "Posts loaded at once"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3626
-#: lib/vutuv_web/live/post_live/feed.ex:3630
+#: lib/vutuv_web/live/post_live/feed.ex:3633
+#: lib/vutuv_web/live/post_live/feed.ex:3637
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posts per page"
 msgstr ""
@@ -22909,65 +22909,65 @@ msgstr ""
 msgid "You can change this under the feed itself as well, right below the “Load more” button."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5257
+#: lib/vutuv_web/components/ui.ex:5291
 #, elixir-autogen, elixir-format
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6608
-#: lib/vutuv_web/components/post_components.ex:6609
+#: lib/vutuv_web/components/post_components.ex:6902
+#: lib/vutuv_web/components/post_components.ex:6903
 #, elixir-autogen, elixir-format, fuzzy
 msgid "A word or phrase …"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6636
+#: lib/vutuv_web/components/post_components.ex:6930
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3687
-#: lib/vutuv_web/live/post_live/feed.ex:3846
-#: lib/vutuv_web/live/post_live/feed.ex:3855
+#: lib/vutuv_web/live/post_live/feed.ex:3694
+#: lib/vutuv_web/live/post_live/feed.ex:3853
+#: lib/vutuv_web/live/post_live/feed.ex:3862
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Hidden"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3820
+#: lib/vutuv_web/live/post_live/feed.ex:3827
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6556
+#: lib/vutuv_web/components/post_components.ex:6850
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3861
+#: lib/vutuv_web/live/post_live/feed.ex:3868
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3881
+#: lib/vutuv_web/live/post_live/feed.ex:3888
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6640
+#: lib/vutuv_web/components/post_components.ex:6934
 #, elixir-autogen, elixir-format, fuzzy
 msgid "everyone"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6643
+#: lib/vutuv_web/components/post_components.ex:6937
 #, elixir-autogen, elixir-format, fuzzy
 msgid "only %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6612
+#: lib/vutuv_web/components/post_components.ex:6906
 #, elixir-autogen, elixir-format, fuzzy
 msgid "this word"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6653
+#: lib/vutuv_web/components/post_components.ex:6947
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "only %{server}"
@@ -23019,7 +23019,7 @@ msgstr ""
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5966
+#: lib/vutuv_web/components/post_components.ex:6260
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr ""
@@ -23119,8 +23119,8 @@ msgstr ""
 msgid "Hidden. What other people pass on of them stays out of your feed; their own posts do not."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2821
-#: lib/vutuv_web/components/post_components.ex:3923
+#: lib/vutuv_web/components/post_components.ex:3101
+#: lib/vutuv_web/components/post_components.ex:4207
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr ""
@@ -23343,4 +23343,47 @@ msgstr ""
 #: lib/vutuv_web/controllers/user_controller.ex:320
 #, elixir-autogen, elixir-format
 msgid "Your profile picture was not replaced: a report about it is still open. Open the case to remove the picture or to say that it is yours."
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:2439
+#, elixir-autogen, elixir-format
+msgid "Fetching the answers from the servers that hold them…"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:250
+#, elixir-autogen, elixir-format
+msgid "Not every answer could be fetched. The rest are on the origin server."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:240
+#, elixir-autogen, elixir-format
+msgid "Nothing here we are allowed to show you."
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:2454
+#, elixir-autogen, elixir-format
+msgid "Show more answers"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:2371
+#: lib/vutuv_web/components/post_components.ex:2373
+#, elixir-autogen, elixir-format
+msgid "Show the one answer"
+msgid_plural "Show the %{count} answers"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:257
+#, elixir-autogen, elixir-format
+msgid "That is enough answers fetched for one hour. Try again later."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:262
+#, elixir-autogen, elixir-format
+msgid "The answers could not be fetched from the servers that hold them."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:265
+#, elixir-autogen, elixir-format
+msgid "The rest could not be fetched right now."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -17,8 +17,8 @@ msgstr ""
 msgid "About us"
 msgstr "Note legali"
 
-#: lib/vutuv_web/components/ui.ex:4811
-#: lib/vutuv_web/components/ui.ex:4816
+#: lib/vutuv_web/components/ui.ex:4845
+#: lib/vutuv_web/components/ui.ex:4850
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
 #: lib/vutuv_web/live/organization_live/domains.ex:287
@@ -64,7 +64,7 @@ msgstr "Indirizzo aggiornato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/text.ex:71
-#: lib/vutuv_web/components/ui.ex:5148
+#: lib/vutuv_web/components/ui.ex:5182
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -77,14 +77,14 @@ msgstr "Indirizzo aggiornato."
 msgid "Addresses"
 msgstr "Indirizzi"
 
-#: lib/vutuv_web/components/ui.ex:1732
+#: lib/vutuv_web/components/ui.ex:1766
 #: lib/vutuv_web/templates/page/index.html.heex:325
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr "È già iscritto? Acceda qui."
 
-#: lib/vutuv_web/components/ui.ex:4602
-#: lib/vutuv_web/components/ui.ex:4701
+#: lib/vutuv_web/components/ui.ex:4636
+#: lib/vutuv_web/components/ui.ex:4735
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -112,8 +112,8 @@ msgid "Birthday"
 msgstr "Compleanno"
 
 #: lib/vutuv_web/components/saved_search_components.ex:104
-#: lib/vutuv_web/components/ui.ex:4596
-#: lib/vutuv_web/components/video_components.ex:280
+#: lib/vutuv_web/components/ui.ex:4630
+#: lib/vutuv_web/components/video_components.ex:281
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
 #: lib/vutuv_web/live/admin/user_delete_live.ex:202
@@ -163,8 +163,8 @@ msgstr "Contatto"
 msgid "Couldn't follow back to %{name}."
 msgstr "Non è stato possibile ricambiare il follow a %{name}."
 
-#: lib/vutuv_web/components/post_components.ex:3880
-#: lib/vutuv_web/components/ui.ex:4703
+#: lib/vutuv_web/components/post_components.ex:4164
+#: lib/vutuv_web/components/ui.ex:4737
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:657
@@ -211,8 +211,8 @@ msgstr "Disattiva"
 msgid "Download"
 msgstr "Scarica"
 
-#: lib/vutuv_web/components/post_components.ex:3845
-#: lib/vutuv_web/components/ui.ex:4694
+#: lib/vutuv_web/components/post_components.ex:4129
+#: lib/vutuv_web/components/ui.ex:4728
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
@@ -286,7 +286,7 @@ msgstr "Inserisca il Suo indirizzo e-mail"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:5112
+#: lib/vutuv_web/components/ui.ex:5146
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -326,8 +326,8 @@ msgstr "Follower"
 #: lib/vutuv_web/agent_docs/markdown.ex:698
 #: lib/vutuv_web/agent_docs/text.ex:658
 #: lib/vutuv_web/components/fediverse_components.ex:468
-#: lib/vutuv_web/components/ui.ex:3029
-#: lib/vutuv_web/components/ui.ex:3064
+#: lib/vutuv_web/components/ui.ex:3063
+#: lib/vutuv_web/components/ui.ex:3098
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:618
@@ -477,7 +477,7 @@ msgstr "Altro"
 msgid "Name"
 msgstr "Nome"
 
-#: lib/vutuv_web/components/post_components.ex:793
+#: lib/vutuv_web/components/post_components.ex:806
 #: lib/vutuv_web/live/notification_live/index.ex:777
 #: lib/vutuv_web/live/organization_live/activity.ex:136
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -617,7 +617,7 @@ msgstr "Piattaforma"
 msgid "Public"
 msgstr "Pubblico"
 
-#: lib/vutuv_web/components/ui.ex:4595
+#: lib/vutuv_web/components/ui.ex:4629
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2201
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -661,7 +661,7 @@ msgstr "Salva"
 msgid "Search"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:1812
+#: lib/vutuv_web/components/post_components.ex:1852
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -792,7 +792,7 @@ msgstr "Utente aggiornato."
 msgid "User verified successfully."
 msgstr "Utente verificato."
 
-#: lib/vutuv_web/components/ui.ex:5108
+#: lib/vutuv_web/components/ui.ex:5142
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:832
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -844,7 +844,7 @@ msgstr "Nome utente"
 msgid "Users"
 msgstr "Utenti"
 
-#: lib/vutuv_web/components/ui.ex:1539
+#: lib/vutuv_web/components/ui.ex:1573
 #: lib/vutuv_web/views/user_html.ex:582
 #: lib/vutuv_web/views/user_html.ex:583
 #: lib/vutuv_web/views/user_html.ex:597
@@ -852,14 +852,14 @@ msgstr "Utenti"
 msgid "vCard"
 msgstr "vCard"
 
-#: lib/vutuv_web/components/ui.ex:4764
+#: lib/vutuv_web/components/ui.ex:4798
 #: lib/vutuv_web/templates/user/show.html.heex:982
 #: lib/vutuv_web/templates/user/show.html.heex:1005
 #, elixir-autogen
 msgid "View All"
 msgstr "Mostra tutti"
 
-#: lib/vutuv_web/components/ui.ex:5271
+#: lib/vutuv_web/components/ui.ex:5305
 #: lib/vutuv_web/controllers/settings_controller.ex:175
 #: lib/vutuv_web/live/job_posting_live/form.ex:818
 #: lib/vutuv_web/live/organization_live/edit.ex:339
@@ -1201,7 +1201,7 @@ msgstr "Tutti i sinonimi dei tag"
 msgid "All tag urls"
 msgstr "Tutti gli URL dei tag"
 
-#: lib/vutuv_web/components/post_components.ex:4487
+#: lib/vutuv_web/components/post_components.ex:4779
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:638
@@ -1375,7 +1375,7 @@ msgstr "URL dei tag"
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:584
 #: lib/vutuv_web/agent_docs/text.ex:850
-#: lib/vutuv_web/components/ui.ex:5133
+#: lib/vutuv_web/components/ui.ex:5167
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1623,7 +1623,7 @@ msgstr "Torna alla pagina iniziale"
 msgid "Check your inbox"
 msgstr "Controlli la Sua casella di posta"
 
-#: lib/vutuv_web/components/ui.ex:3188
+#: lib/vutuv_web/components/ui.ex:3222
 #: lib/vutuv_web/components/welcome_components.ex:125
 #: lib/vutuv_web/components/welcome_components.ex:131
 #: lib/vutuv_web/live/admin/job_live.ex:321
@@ -1682,20 +1682,20 @@ msgstr "Elimina il mio account"
 msgid "Edit profile"
 msgstr "Modifica profilo"
 
-#: lib/vutuv_web/components/ui.ex:2271
-#: lib/vutuv_web/components/ui.ex:2280
-#: lib/vutuv_web/components/ui.ex:2758
+#: lib/vutuv_web/components/ui.ex:2305
+#: lib/vutuv_web/components/ui.ex:2314
+#: lib/vutuv_web/components/ui.ex:2792
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr "Conferma"
 
 #: lib/vutuv_web/components/fediverse_components.ex:244
-#: lib/vutuv_web/components/ui.ex:2994
-#: lib/vutuv_web/components/ui.ex:2994
-#: lib/vutuv_web/components/ui.ex:3011
-#: lib/vutuv_web/components/ui.ex:3020
-#: lib/vutuv_web/components/ui.ex:3036
-#: lib/vutuv_web/components/ui.ex:3098
+#: lib/vutuv_web/components/ui.ex:3028
+#: lib/vutuv_web/components/ui.ex:3028
+#: lib/vutuv_web/components/ui.ex:3045
+#: lib/vutuv_web/components/ui.ex:3054
+#: lib/vutuv_web/components/ui.ex:3070
+#: lib/vutuv_web/components/ui.ex:3132
 #: lib/vutuv_web/live/fediverse_account_live.ex:422
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:320
@@ -1762,8 +1762,8 @@ msgstr "Messaggi"
 msgid "Network"
 msgstr "Rete"
 
-#: lib/vutuv_web/components/post_components.ex:472
-#: lib/vutuv_web/components/ui.ex:4813
+#: lib/vutuv_web/components/post_components.ex:485
+#: lib/vutuv_web/components/ui.ex:4847
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
@@ -1779,7 +1779,7 @@ msgid "Nothing new yet."
 msgstr "Ancora nessuna novità."
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:5170
+#: lib/vutuv_web/components/ui.ex:5204
 #: lib/vutuv_web/controllers/page_controller.ex:219
 #: lib/vutuv_web/live/notification_live/index.ex:155
 #: lib/vutuv_web/live/notification_live/index.ex:441
@@ -1924,14 +1924,14 @@ msgstr "ora è collegato con Lei."
 msgid "started following you."
 msgstr "ha iniziato a seguirla."
 
-#: lib/vutuv_web/components/ui.ex:4096
-#: lib/vutuv_web/components/ui.ex:4241
+#: lib/vutuv_web/components/ui.ex:4130
+#: lib/vutuv_web/components/ui.ex:4275
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr "Paginazione"
 
-#: lib/vutuv_web/components/ui.ex:4838
+#: lib/vutuv_web/components/ui.ex:4872
 #: lib/vutuv_web/live/organization_live/activity.ex:159
 #: lib/vutuv_web/live/organization_live/feed.ex:258
 #: lib/vutuv_web/live/organization_live/show.ex:787
@@ -1946,13 +1946,13 @@ msgstr ""
 "L'indirizzo non può essere modificato. Per usarne un altro, lo aggiunga come"
 " nuovo indirizzo e-mail ed elimini questo."
 
-#: lib/vutuv_web/components/ui.ex:4605
+#: lib/vutuv_web/components/ui.ex:4639
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Elimina voce"
 
-#: lib/vutuv_web/components/ui.ex:1934
-#: lib/vutuv_web/components/ui.ex:1944
+#: lib/vutuv_web/components/ui.ex:1968
+#: lib/vutuv_web/components/ui.ex:1978
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr "Opzioni"
@@ -1991,12 +1991,12 @@ msgstr "Aggiungi un'immagine di copertina"
 msgid "Add cover photo"
 msgstr "Aggiungi immagine di copertina"
 
-#: lib/vutuv_web/components/ui.ex:3555
+#: lib/vutuv_web/components/ui.ex:3589
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr "Aprile"
 
-#: lib/vutuv_web/components/ui.ex:3559
+#: lib/vutuv_web/components/ui.ex:3593
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr "Agosto"
@@ -2022,37 +2022,37 @@ msgstr "Immagine di copertina"
 msgid "Cover photo of %{name}"
 msgstr "Immagine di copertina di %{name}"
 
-#: lib/vutuv_web/components/ui.ex:3563
+#: lib/vutuv_web/components/ui.ex:3597
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr "Dicembre"
 
-#: lib/vutuv_web/components/ui.ex:3553
+#: lib/vutuv_web/components/ui.ex:3587
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr "Febbraio"
 
-#: lib/vutuv_web/components/ui.ex:3552
+#: lib/vutuv_web/components/ui.ex:3586
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr "Gennaio"
 
-#: lib/vutuv_web/components/ui.ex:3558
+#: lib/vutuv_web/components/ui.ex:3592
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr "Luglio"
 
-#: lib/vutuv_web/components/ui.ex:3557
+#: lib/vutuv_web/components/ui.ex:3591
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr "Giugno"
 
-#: lib/vutuv_web/components/ui.ex:3554
+#: lib/vutuv_web/components/ui.ex:3588
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr "Marzo"
 
-#: lib/vutuv_web/components/ui.ex:3556
+#: lib/vutuv_web/components/ui.ex:3590
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr "Maggio"
@@ -2067,17 +2067,17 @@ msgstr "Membro da %{month} %{year}"
 msgid "Member since %{year}"
 msgstr "Membro dal %{year}"
 
-#: lib/vutuv_web/components/ui.ex:3562
+#: lib/vutuv_web/components/ui.ex:3596
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr "Novembre"
 
-#: lib/vutuv_web/components/ui.ex:3561
+#: lib/vutuv_web/components/ui.ex:3595
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr "Ottobre"
 
-#: lib/vutuv_web/components/ui.ex:3560
+#: lib/vutuv_web/components/ui.ex:3594
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr "Settembre"
@@ -2118,7 +2118,7 @@ msgstr "Annulla il caricamento"
 msgid "Delete post"
 msgstr "Elimina il post"
 
-#: lib/vutuv_web/components/post_components.ex:3877
+#: lib/vutuv_web/components/post_components.ex:4161
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2163,8 +2163,8 @@ msgstr "Nascondi a una persona specifica…"
 msgid "Hide this post from…"
 msgstr "Nascondi questo post a…"
 
-#: lib/vutuv_web/components/post_components.ex:3831
-#: lib/vutuv_web/components/post_components.ex:3833
+#: lib/vutuv_web/components/post_components.ex:4115
+#: lib/vutuv_web/components/post_components.ex:4117
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Pubblico limitato"
@@ -2180,7 +2180,7 @@ msgstr "Visitatori non connessi"
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3576
+#: lib/vutuv_web/live/post_live/feed.ex:3583
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2231,13 +2231,13 @@ msgstr "Post eliminato."
 msgid "Posts"
 msgstr "Post"
 
-#: lib/vutuv_web/components/post_components.ex:4360
-#: lib/vutuv_web/components/post_components.ex:4364
+#: lib/vutuv_web/components/post_components.ex:4652
+#: lib/vutuv_web/components/post_components.ex:4656
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Leggi tutto"
 
-#: lib/vutuv_web/components/post_components.ex:4361
+#: lib/vutuv_web/components/post_components.ex:4653
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2247,7 +2247,7 @@ msgstr "Mostra meno"
 
 #: lib/vutuv_web/components/fediverse_components.ex:497
 #: lib/vutuv_web/components/job_exclusion_components.ex:189
-#: lib/vutuv_web/components/post_components.ex:1421
+#: lib/vutuv_web/components/post_components.ex:1461
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:229
@@ -2315,7 +2315,7 @@ msgstr "Troppi file."
 msgid "Upload failed."
 msgstr "Caricamento non riuscito."
 
-#: lib/vutuv_web/components/ui.ex:5515
+#: lib/vutuv_web/components/ui.ex:5549
 #: lib/vutuv_web/live/shell_live.ex:1582
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2334,32 +2334,32 @@ msgstr "Che c'è di nuovo?"
 msgid "What's new? Markdown is supported."
 msgstr "Che c'è di nuovo? Markdown è supportato."
 
-#: lib/vutuv_web/components/post_components.ex:3828
+#: lib/vutuv_web/components/post_components.ex:4112
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "modificato"
 
-#: lib/vutuv_web/components/post_components.ex:5984
+#: lib/vutuv_web/components/post_components.ex:6278
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "tutti gli altri"
 
-#: lib/vutuv_web/components/post_components.ex:5988
+#: lib/vutuv_web/components/post_components.ex:6282
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "visitatori non connessi"
 
-#: lib/vutuv_web/components/post_components.ex:5986
+#: lib/vutuv_web/components/post_components.ex:6280
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "persone che non La seguono"
 
-#: lib/vutuv_web/components/post_components.ex:5987
+#: lib/vutuv_web/components/post_components.ex:6281
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "persone che non segue"
 
-#: lib/vutuv_web/components/ui.ex:3633
+#: lib/vutuv_web/components/ui.ex:3667
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
@@ -2398,9 +2398,9 @@ msgstr "Vedi tutti i %{count} post"
 msgid "All posts"
 msgstr "Tutti i post"
 
-#: lib/vutuv_web/components/post_components.ex:2104
-#: lib/vutuv_web/components/post_components.ex:6084
-#: lib/vutuv_web/components/ui.ex:4163
+#: lib/vutuv_web/components/post_components.ex:2165
+#: lib/vutuv_web/components/post_components.ex:6378
+#: lib/vutuv_web/components/ui.ex:4197
 #: lib/vutuv_web/views/user_html.ex:481
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2417,9 +2417,9 @@ msgstr "Salva"
 msgid "Bookmarks"
 msgstr "Salvati"
 
-#: lib/vutuv_web/components/post_components.ex:2055
-#: lib/vutuv_web/components/post_components.ex:6322
-#: lib/vutuv_web/components/ui.ex:4149
+#: lib/vutuv_web/components/post_components.ex:2109
+#: lib/vutuv_web/components/post_components.ex:6616
+#: lib/vutuv_web/components/ui.ex:4183
 #: lib/vutuv_web/notification_line.ex:293
 #: lib/vutuv_web/views/user_html.ex:491
 #, elixir-autogen, elixir-format
@@ -2427,7 +2427,7 @@ msgid "Like"
 msgstr "Mi piace"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1263
-#: lib/vutuv_web/components/post_components.ex:6332
+#: lib/vutuv_web/components/post_components.ex:6626
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1590
@@ -2448,40 +2448,40 @@ msgstr "Qui non c'è ancora nulla. I post che salva compaiono qui."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Qui non c'è ancora nulla. I post a cui mette Mi piace compaiono qui."
 
-#: lib/vutuv_web/components/post_components.ex:6072
+#: lib/vutuv_web/components/post_components.ex:6366
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Solo i post pubblici possono essere ripubblicati."
 
-#: lib/vutuv_web/components/post_components.ex:2103
-#: lib/vutuv_web/components/post_components.ex:6083
+#: lib/vutuv_web/components/post_components.ex:2164
+#: lib/vutuv_web/components/post_components.ex:6377
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:481
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Rimuovi dai salvati"
 
-#: lib/vutuv_web/components/post_components.ex:2084
-#: lib/vutuv_web/components/post_components.ex:6068
+#: lib/vutuv_web/components/post_components.ex:2145
+#: lib/vutuv_web/components/post_components.ex:6362
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Ripubblica"
 
-#: lib/vutuv_web/components/post_components.ex:2372
-#: lib/vutuv_web/components/post_components.ex:5091
+#: lib/vutuv_web/components/post_components.ex:2649
+#: lib/vutuv_web/components/post_components.ex:5384
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Ripubblicato da %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:2083
-#: lib/vutuv_web/components/post_components.ex:6067
+#: lib/vutuv_web/components/post_components.ex:2144
+#: lib/vutuv_web/components/post_components.ex:6361
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Annulla la ripubblicazione"
 
-#: lib/vutuv_web/components/post_components.ex:2054
-#: lib/vutuv_web/components/post_components.ex:6321
+#: lib/vutuv_web/components/post_components.ex:2108
+#: lib/vutuv_web/components/post_components.ex:6615
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:491
 #, elixir-autogen, elixir-format
@@ -2489,10 +2489,10 @@ msgid "Unlike"
 msgstr "Togli Mi piace"
 
 #: lib/vutuv_web/components/fediverse_components.ex:498
-#: lib/vutuv_web/components/post_components.ex:2855
-#: lib/vutuv_web/components/ui.ex:2989
-#: lib/vutuv_web/components/ui.ex:2989
-#: lib/vutuv_web/components/ui.ex:3065
+#: lib/vutuv_web/components/post_components.ex:3135
+#: lib/vutuv_web/components/ui.ex:3023
+#: lib/vutuv_web/components/ui.ex:3023
+#: lib/vutuv_web/components/ui.ex:3099
 #: lib/vutuv_web/live/organization_live/following.ex:392
 #: lib/vutuv_web/live/organization_live/following.ex:476
 #: lib/vutuv_web/live/organization_live/show.ex:621
@@ -2509,20 +2509,20 @@ msgstr "Non seguire più"
 msgid "Welcome to vutuv!"
 msgstr "Benvenuto su vutuv."
 
-#: lib/vutuv_web/components/post_components.ex:6376
+#: lib/vutuv_web/components/post_components.ex:6670
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Solo ai post pubblici si può rispondere."
 
-#: lib/vutuv_web/components/post_components.ex:430
+#: lib/vutuv_web/components/post_components.ex:443
 #: lib/vutuv_web/live/notification_live/index.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Risposte"
 
-#: lib/vutuv_web/components/post_components.ex:2068
-#: lib/vutuv_web/components/post_components.ex:6359
-#: lib/vutuv_web/components/post_components.ex:6360
+#: lib/vutuv_web/components/post_components.ex:2354
+#: lib/vutuv_web/components/post_components.ex:6653
+#: lib/vutuv_web/components/post_components.ex:6654
 #: lib/vutuv_web/live/notification_live/index.ex:994
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:290
@@ -2530,7 +2530,7 @@ msgstr "Risposte"
 msgid "Reply"
 msgstr "Rispondi"
 
-#: lib/vutuv_web/components/post_components.ex:3795
+#: lib/vutuv_web/components/post_components.ex:4075
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Risposta a un post eliminato"
@@ -2556,7 +2556,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr "ha risposto al Suo post."
 
-#: lib/vutuv_web/components/post_components.ex:3321
+#: lib/vutuv_web/components/post_components.ex:3601
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2564,14 +2564,14 @@ msgstr "ha risposto al Suo post."
 msgid "Reply to %{handle}"
 msgstr "Rispondi a %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:3767
+#: lib/vutuv_web/components/post_components.ex:4047
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Risposta a un post di %{handle} ora eliminato"
 
-#: lib/vutuv_web/components/post_components.ex:3758
-#: lib/vutuv_web/components/post_components.ex:3787
-#: lib/vutuv_web/components/post_components.ex:3790
+#: lib/vutuv_web/components/post_components.ex:4038
+#: lib/vutuv_web/components/post_components.ex:4067
+#: lib/vutuv_web/components/post_components.ex:4070
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "In risposta a %{handle}"
@@ -2632,7 +2632,7 @@ msgstr "Membro non trovato."
 msgid "No conversations yet."
 msgstr "Ancora nessuna conversazione."
 
-#: lib/vutuv_web/components/ui.ex:3312
+#: lib/vutuv_web/components/ui.ex:3346
 #: lib/vutuv_web/live/message_live/index.ex:760
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2721,7 +2721,7 @@ msgstr "Un nuovo PIN è in arrivo nella Sua casella di posta."
 msgid "Okay, let's start over."
 msgstr "Va bene, ricominciamo."
 
-#: lib/vutuv_web/components/ui.ex:862
+#: lib/vutuv_web/components/ui.ex:869
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr "Invia di nuovo il PIN"
@@ -2732,7 +2732,7 @@ msgstr "Invia di nuovo il PIN"
 msgid "Too many PIN requests. Please try again later."
 msgstr "Troppe richieste di PIN. Riprovi più tardi."
 
-#: lib/vutuv_web/components/ui.ex:883
+#: lib/vutuv_web/components/ui.ex:890
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr "Usa un altro indirizzo e-mail"
@@ -2782,8 +2782,8 @@ msgstr "Aggiungi un'esperienza lavorativa"
 msgid "Write your first post"
 msgstr "Scriva il Suo primo post"
 
-#: lib/vutuv_web/components/ui.ex:4329
-#: lib/vutuv_web/components/ui.ex:4766
+#: lib/vutuv_web/components/ui.ex:4363
+#: lib/vutuv_web/components/ui.ex:4800
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:109
@@ -2796,7 +2796,7 @@ msgstr "Scriva il Suo primo post"
 msgid "Manage"
 msgstr "Gestisci"
 
-#: lib/vutuv_web/components/post_components.ex:870
+#: lib/vutuv_web/components/post_components.ex:883
 #: lib/vutuv_web/controllers/page_controller.ex:216
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2834,7 +2834,7 @@ msgstr[1] "+%{formatted} altri tag"
 msgid "Connections"
 msgstr "Collegamenti"
 
-#: lib/vutuv_web/components/ui.ex:1530
+#: lib/vutuv_web/components/ui.ex:1564
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr "Markdown"
@@ -2844,7 +2844,7 @@ msgstr "Markdown"
 msgid "No connections yet."
 msgstr "Ancora nessun collegamento."
 
-#: lib/vutuv_web/components/ui.ex:1546
+#: lib/vutuv_web/components/ui.ex:1580
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr "Altri formati"
@@ -2854,7 +2854,7 @@ msgstr "Altri formati"
 msgid "People who aren't my connections"
 msgstr "Persone che non sono miei collegamenti"
 
-#: lib/vutuv_web/components/ui.ex:1531
+#: lib/vutuv_web/components/ui.ex:1565
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr "Solo testo"
@@ -2872,7 +2872,7 @@ msgid_plural "connections"
 msgstr[0] "collegamento"
 msgstr[1] "collegamenti"
 
-#: lib/vutuv_web/components/post_components.ex:5985
+#: lib/vutuv_web/components/post_components.ex:6279
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "persone che non sono Suoi collegamenti"
@@ -3150,7 +3150,7 @@ msgstr "Nudità, violenza o altri contenuti che non hanno posto su vutuv."
 msgid "Only visible to you"
 msgstr "Visibile solo a Lei"
 
-#: lib/vutuv_web/components/post_components.ex:3734
+#: lib/vutuv_web/components/post_components.ex:4014
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solo Lei può vedere questo post finché la segnalazione è in corso."
@@ -3197,7 +3197,7 @@ msgstr ""
 msgid "Private message"
 msgstr "Messaggio privato"
 
-#: lib/vutuv_web/components/ui.ex:5102
+#: lib/vutuv_web/components/ui.ex:5136
 #: lib/vutuv_web/live/shell_live.ex:1373
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3222,9 +3222,9 @@ msgstr "Respinta"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Lo rimuova. La segnalazione si chiude, senza altre domande."
 
-#: lib/vutuv_web/components/post_components.ex:1434
-#: lib/vutuv_web/components/post_components.ex:2875
-#: lib/vutuv_web/components/post_components.ex:3944
+#: lib/vutuv_web/components/post_components.ex:1474
+#: lib/vutuv_web/components/post_components.ex:3155
+#: lib/vutuv_web/components/post_components.ex:4228
 #: lib/vutuv_web/live/organization_live/show.ex:661
 #: lib/vutuv_web/templates/user/show.html.heex:242
 #, elixir-autogen, elixir-format
@@ -3311,7 +3311,7 @@ msgstr ""
 "Le segnalazioni sono anonime; non diciamo mai chi ha segnalato. Le nostre "
 "regole:"
 
-#: lib/vutuv_web/components/ui.ex:4011
+#: lib/vutuv_web/components/ui.ex:4045
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -4452,12 +4452,12 @@ msgstr ""
 "Le prenotazioni sono aperte fino al %{last}. Prossimo giorno disponibile: "
 "%{day}"
 
-#: lib/vutuv_web/components/ui.ex:3585
+#: lib/vutuv_web/components/ui.ex:3619
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr "Ve"
 
-#: lib/vutuv_web/components/ui.ex:3581
+#: lib/vutuv_web/components/ui.ex:3615
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr "Lu"
@@ -4469,27 +4469,27 @@ msgstr ""
 "Una pubblicità al giorno: scelga un giorno libero nel calendario; i giorni "
 "barrati sono già prenotati."
 
-#: lib/vutuv_web/components/ui.ex:3586
+#: lib/vutuv_web/components/ui.ex:3620
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr "Sa"
 
-#: lib/vutuv_web/components/ui.ex:3587
+#: lib/vutuv_web/components/ui.ex:3621
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr "Do"
 
-#: lib/vutuv_web/components/ui.ex:3584
+#: lib/vutuv_web/components/ui.ex:3618
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr "Gi"
 
-#: lib/vutuv_web/components/ui.ex:3582
+#: lib/vutuv_web/components/ui.ex:3616
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr "Ma"
 
-#: lib/vutuv_web/components/ui.ex:3583
+#: lib/vutuv_web/components/ui.ex:3617
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr "Me"
@@ -4632,7 +4632,7 @@ msgstr ""
 " la vostra conversazione e impedisce ogni interazione in entrambe le "
 "direzioni. Sbloccare non ripristina ciò che è stato rimosso."
 
-#: lib/vutuv_web/components/ui.ex:5275
+#: lib/vutuv_web/components/ui.ex:5309
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4679,7 +4679,7 @@ msgstr "Non ha bloccato nessuno."
 msgid "You unblocked @%{slug}."
 msgstr "Ha sbloccato @%{slug}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3581
+#: lib/vutuv_web/live/post_live/feed.ex:3588
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Scopra persone da seguire"
@@ -4757,8 +4757,8 @@ msgstr "I risultati compaiono dopo almeno tre lettere."
 msgid "Similar names"
 msgstr "Nomi simili"
 
-#: lib/vutuv_web/components/post_components.ex:427
-#: lib/vutuv_web/components/post_components.ex:446
+#: lib/vutuv_web/components/post_components.ex:440
+#: lib/vutuv_web/components/post_components.ex:459
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -5440,7 +5440,7 @@ msgstr "Token API (%{date})"
 msgid "API documentation"
 msgstr "Documentazione dell'API"
 
-#: lib/vutuv_web/components/ui.ex:5325
+#: lib/vutuv_web/components/ui.ex:5359
 #: lib/vutuv_web/controllers/settings_controller.ex:161
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:439
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5523,10 +5523,10 @@ msgstr "Scorciatoie da tastiera"
 msgid "Navigation"
 msgstr "Navigazione"
 
-#: lib/vutuv_web/components/ui.ex:5422
-#: lib/vutuv_web/components/ui.ex:5427
-#: lib/vutuv_web/components/ui.ex:5506
-#: lib/vutuv_web/components/ui.ex:5570
+#: lib/vutuv_web/components/ui.ex:5456
+#: lib/vutuv_web/components/ui.ex:5461
+#: lib/vutuv_web/components/ui.ex:5540
+#: lib/vutuv_web/components/ui.ex:5604
 #: lib/vutuv_web/controllers/settings_controller.ex:68
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5596,9 +5596,9 @@ msgstr "Navigazione principale"
 msgid "Footer navigation"
 msgstr "Navigazione a piè di pagina"
 
-#: lib/vutuv_web/components/post_components.ex:4022
-#: lib/vutuv_web/components/post_components.ex:4074
-#: lib/vutuv_web/components/post_components.ex:4608
+#: lib/vutuv_web/components/post_components.ex:4306
+#: lib/vutuv_web/components/post_components.ex:4358
+#: lib/vutuv_web/components/post_components.ex:4900
 #: lib/vutuv_web/live/notification_live/index.ex:1070
 #: lib/vutuv_web/views/user_html.ex:131
 #, elixir-autogen, elixir-format
@@ -5644,7 +5644,7 @@ msgstr "Tipo di indirizzo e-mail"
 msgid "About you"
 msgstr "Su di Lei"
 
-#: lib/vutuv_web/components/ui.ex:5295
+#: lib/vutuv_web/components/ui.ex:5329
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5665,7 +5665,7 @@ msgstr "Modifica"
 msgid "Download everything vutuv stores about you, as one file."
 msgstr "Scarichi in un unico file tutto ciò che vutuv conserva su di Lei."
 
-#: lib/vutuv_web/components/ui.ex:5140
+#: lib/vutuv_web/components/ui.ex:5174
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5700,7 +5700,7 @@ msgstr "Token personali per l'API di vutuv."
 msgid "Photos"
 msgstr "Foto"
 
-#: lib/vutuv_web/components/ui.ex:5269
+#: lib/vutuv_web/components/ui.ex:5303
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -5814,7 +5814,7 @@ msgstr "@%{slug} ha iniziato a seguirla su vutuv"
 msgid "Apps"
 msgstr "App"
 
-#: lib/vutuv_web/components/ui.ex:5318
+#: lib/vutuv_web/components/ui.ex:5352
 #: lib/vutuv_web/controllers/settings_controller.ex:185
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -6021,21 +6021,21 @@ msgid "Sort"
 msgstr "Ordina"
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3649
+#: lib/vutuv_web/components/ui.ex:3683
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "%{count} giorno fa"
 msgstr[1] "%{count} giorni fa"
 
-#: lib/vutuv_web/components/ui.ex:3648
+#: lib/vutuv_web/components/ui.ex:3682
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "%{count} ora fa"
 msgstr[1] "%{count} ore fa"
 
-#: lib/vutuv_web/components/ui.ex:3647
+#: lib/vutuv_web/components/ui.ex:3681
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -6102,7 +6102,7 @@ msgstr "Questo dispositivo"
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr "È il primo accesso che vediamo da questo dispositivo o browser."
 
-#: lib/vutuv_web/components/ui.ex:3646
+#: lib/vutuv_web/components/ui.ex:3680
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "adesso"
@@ -6251,7 +6251,7 @@ msgstr "Aggiungi una descrizione breve"
 msgid "Tagline"
 msgstr "Descrizione breve"
 
-#: lib/vutuv_web/components/ui.ex:480
+#: lib/vutuv_web/components/ui.ex:487
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:916
@@ -6405,7 +6405,7 @@ msgid "Previous day"
 msgstr "Giorno precedente"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1263
-#: lib/vutuv_web/components/post_components.ex:429
+#: lib/vutuv_web/components/post_components.ex:442
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6444,9 +6444,9 @@ msgstr "Sposta giù"
 msgid "Move up"
 msgstr "Sposta su"
 
-#: lib/vutuv_web/components/ui.ex:2271
-#: lib/vutuv_web/components/ui.ex:2280
-#: lib/vutuv_web/components/ui.ex:2759
+#: lib/vutuv_web/components/ui.ex:2305
+#: lib/vutuv_web/components/ui.ex:2314
+#: lib/vutuv_web/components/ui.ex:2793
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr "Ritira la conferma"
@@ -6511,7 +6511,7 @@ msgstr "Membri che hanno confermato %{name} per %{tag}"
 msgid "No endorsements yet."
 msgstr "Ancora nessuna conferma."
 
-#: lib/vutuv_web/components/ui.ex:2712
+#: lib/vutuv_web/components/ui.ex:2746
 #: lib/vutuv_web/live/notification_live/index.ex:708
 #: lib/vutuv_web/live/notification_live/index.ex:723
 #: lib/vutuv_web/live/notification_live/index.ex:1223
@@ -6833,10 +6833,10 @@ msgstr ""
 "Se disattiva un'opzione, la relativa esclusione viaggia con le pagine e le "
 "risposte che La riguardano. Con entrambe disattivate, ad esempio:"
 
-#: lib/vutuv_web/components/post_components.ex:2802
-#: lib/vutuv_web/components/post_components.ex:3897
-#: lib/vutuv_web/components/post_components.ex:3911
-#: lib/vutuv_web/components/ui.ex:3137
+#: lib/vutuv_web/components/post_components.ex:3082
+#: lib/vutuv_web/components/post_components.ex:4181
+#: lib/vutuv_web/components/post_components.ex:4195
+#: lib/vutuv_web/components/ui.ex:3171
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
@@ -6863,8 +6863,8 @@ msgstr "Nuovi messaggi e nuovi collegamenti"
 msgid "Remove this connection? You will stop following them."
 msgstr "Rimuovere questo collegamento? Smetterà di seguire questa persona."
 
-#: lib/vutuv_web/components/post_components.ex:3897
-#: lib/vutuv_web/components/ui.ex:3136
+#: lib/vutuv_web/components/post_components.ex:4181
+#: lib/vutuv_web/components/ui.ex:3170
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
@@ -7490,13 +7490,13 @@ msgstr "I loro membri vengono aggiunti a questo (unione)."
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr "pagina %{page} di %{pages}, %{total} in totale"
 
-#: lib/vutuv_web/components/ui.ex:4105
+#: lib/vutuv_web/components/ui.ex:4139
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Precedente"
 
-#: lib/vutuv_web/components/ui.ex:4117
+#: lib/vutuv_web/components/ui.ex:4151
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7580,7 +7580,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "vale per l'intero elenco, non solo per questa pagina"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:6232
+#: lib/vutuv_web/components/post_components.ex:6526
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
 #: lib/vutuv_web/live/shell_live.ex:1812
 #, elixir-autogen, elixir-format
@@ -7689,7 +7689,7 @@ msgstr "Si aggiorna da sola. Può lasciare questa pagina: l'invio prosegue."
 
 #: lib/vutuv_web/components/welcome_components.ex:362
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3870
+#: lib/vutuv_web/live/post_live/feed.ex:3877
 #: lib/vutuv_web/live/post_rewrites_live.ex:447
 #, elixir-autogen
 msgid "Done"
@@ -8301,7 +8301,7 @@ msgstr "PIN scaduto"
 msgid "PIN registered"
 msgstr "Registrato con PIN"
 
-#: lib/vutuv_web/components/ui.ex:4108
+#: lib/vutuv_web/components/ui.ex:4142
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr "Pagina %{page} di %{pages}"
@@ -8440,7 +8440,7 @@ msgstr "Titolo di studio"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:5116
+#: lib/vutuv_web/components/ui.ex:5150
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8499,7 +8499,7 @@ msgstr ""
 "Ecco cosa abbiamo trovato nella Sua esportazione. Tolga la spunta a ciò che "
 "non desidera. Le voci già presenti sul Suo profilo sono già senza spunta."
 
-#: lib/vutuv_web/components/ui.ex:5306
+#: lib/vutuv_web/components/ui.ex:5340
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importa"
@@ -8528,7 +8528,7 @@ msgstr "Importati: %{items}."
 msgid "Nothing new to import."
 msgstr "Nulla di nuovo da importare."
 
-#: lib/vutuv_web/components/ui.ex:5144
+#: lib/vutuv_web/components/ui.ex:5178
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8624,7 +8624,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Troppe importazioni. Riprovi tra poco."
 
-#: lib/vutuv_web/components/ui.ex:4381
+#: lib/vutuv_web/components/ui.ex:4415
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8714,13 +8714,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr "Trascini qui il Suo file ZIP, oppure prema per sceglierne uno."
 
-#: lib/vutuv_web/components/ui.ex:5104
+#: lib/vutuv_web/components/ui.ex:5138
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr "Dati di base e foto"
 
-#: lib/vutuv_web/components/ui.ex:5238
+#: lib/vutuv_web/components/ui.ex:5272
 #: lib/vutuv_web/controllers/settings_controller.ex:129
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8732,7 +8732,7 @@ msgstr "Lingua e visualizzazione"
 msgid "More profile sections"
 msgstr "Altre sezioni del profilo"
 
-#: lib/vutuv_web/components/ui.ex:5297
+#: lib/vutuv_web/components/ui.ex:5331
 #: lib/vutuv_web/controllers/settings_controller.ex:112
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8742,7 +8742,7 @@ msgstr "Altre sezioni del profilo"
 msgid "Sign-in & security"
 msgstr "Accesso e sicurezza"
 
-#: lib/vutuv_web/components/ui.ex:5310
+#: lib/vutuv_web/components/ui.ex:5344
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8858,7 +8858,7 @@ msgstr[1] "%{formatted} membri"
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr "La pagina %{letter} dell'elenco dei membri, ordinata per cognome."
 
-#: lib/vutuv_web/components/ui.ex:1548
+#: lib/vutuv_web/components/ui.ex:1582
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -8966,8 +8966,8 @@ msgstr "La scriva in Amministrazione › Pagine legali"
 #: lib/vutuv_web/agent_docs/text.ex:648
 #: lib/vutuv_web/agent_docs/text.ex:652
 #: lib/vutuv_web/components/organization_components.ex:276
-#: lib/vutuv_web/components/ui.ex:1749
-#: lib/vutuv_web/components/ui.ex:5287
+#: lib/vutuv_web/components/ui.ex:1783
+#: lib/vutuv_web/components/ui.ex:5321
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:366
 #: lib/vutuv_web/controllers/settings_controller.ex:433
@@ -9126,12 +9126,12 @@ msgstr ""
 "Questa è la versione di stampa del CV. Usi la finestra di stampa del browser"
 " (Ctrl+P o Cmd+P) e scelga \"Salva come PDF\" per ottenere un file PDF."
 
-#: lib/vutuv_web/components/ui.ex:1838
+#: lib/vutuv_web/components/ui.ex:1872
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr "Download del CV"
 
-#: lib/vutuv_web/components/post_components.ex:5094
+#: lib/vutuv_web/components/post_components.ex:5387
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9164,7 +9164,7 @@ msgstr "Ogni download rispecchia le parti che ha selezionato."
 msgid "Header"
 msgstr "Intestazione"
 
-#: lib/vutuv_web/components/ui.ex:1848
+#: lib/vutuv_web/components/ui.ex:1882
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -9201,7 +9201,7 @@ msgstr ""
 "solo ciò che può già vedere lì, e gli indirizzi e-mail privati compaiono "
 "solo nel Suo."
 
-#: lib/vutuv_web/components/ui.ex:1840
+#: lib/vutuv_web/components/ui.ex:1874
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -9374,8 +9374,8 @@ msgstr "Questo tag può essere rimosso solo da un amministratore del sito."
 msgid "Yes"
 msgstr "Sì"
 
-#: lib/vutuv_web/components/ui.ex:2315
-#: lib/vutuv_web/components/ui.ex:2316
+#: lib/vutuv_web/components/ui.ex:2349
+#: lib/vutuv_web/components/ui.ex:2350
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9954,7 +9954,7 @@ msgstr "Certificati"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:5120
+#: lib/vutuv_web/components/ui.ex:5154
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -10157,13 +10157,13 @@ msgstr "Link permanente al profilo"
 msgid "Dismiss"
 msgstr "Chiudi"
 
-#: lib/vutuv_web/components/ui.ex:3762
+#: lib/vutuv_web/components/ui.ex:3796
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Copiato"
 
-#: lib/vutuv_web/components/ui.ex:3761
-#: lib/vutuv_web/components/ui.ex:3769
+#: lib/vutuv_web/components/ui.ex:3795
+#: lib/vutuv_web/components/ui.ex:3803
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Copia"
@@ -10355,17 +10355,17 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr "App di autenticazione disattivata."
 
-#: lib/vutuv_web/components/ui.ex:468
+#: lib/vutuv_web/components/ui.ex:475
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr "Grassetto"
 
-#: lib/vutuv_web/components/ui.ex:520
+#: lib/vutuv_web/components/ui.ex:527
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr "Elenco puntato"
 
-#: lib/vutuv_web/components/ui.ex:523
+#: lib/vutuv_web/components/ui.ex:530
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr "Blocco di codice"
@@ -10382,13 +10382,13 @@ msgstr ""
 "Eliminare il Suo elenco di codici? Tutti i suoi codici smettono subito di "
 "funzionare."
 
-#: lib/vutuv_web/components/ui.ex:452
+#: lib/vutuv_web/components/ui.ex:459
 #, elixir-autogen, elixir-format
 msgid "Formatting"
 msgstr "Formattazione"
 
-#: lib/vutuv_web/components/ui.ex:587
-#: lib/vutuv_web/components/ui.ex:588
+#: lib/vutuv_web/components/ui.ex:594
+#: lib/vutuv_web/components/ui.ex:595
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr "Schermo intero"
@@ -10403,29 +10403,29 @@ msgstr "Genera un nuovo elenco"
 msgid "Generate code list"
 msgstr "Genera l'elenco dei codici"
 
-#: lib/vutuv_web/components/ui.ex:461
-#: lib/vutuv_web/components/ui.ex:518
+#: lib/vutuv_web/components/ui.ex:468
+#: lib/vutuv_web/components/ui.ex:525
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr "Titolo 1"
 
-#: lib/vutuv_web/components/ui.ex:464
-#: lib/vutuv_web/components/ui.ex:519
+#: lib/vutuv_web/components/ui.ex:471
+#: lib/vutuv_web/components/ui.ex:526
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr "Titolo 2"
 
-#: lib/vutuv_web/components/ui.ex:477
+#: lib/vutuv_web/components/ui.ex:484
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr "Codice in linea"
 
-#: lib/vutuv_web/components/ui.ex:471
+#: lib/vutuv_web/components/ui.ex:478
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr "Corsivo"
 
-#: lib/vutuv_web/components/ui.ex:408
+#: lib/vutuv_web/components/ui.ex:415
 #, elixir-autogen, elixir-format
 msgid "Link URL"
 msgstr "URL del link"
@@ -10441,7 +10441,7 @@ msgstr "Codici di accesso"
 msgid "Not set up."
 msgstr "Non configurata."
 
-#: lib/vutuv_web/components/ui.ex:521
+#: lib/vutuv_web/components/ui.ex:528
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr "Elenco numerato"
@@ -10458,7 +10458,7 @@ msgstr ""
 "Stampi questa pagina o annoti i codici. I codici barrati sono già stati "
 "usati."
 
-#: lib/vutuv_web/components/ui.ex:522
+#: lib/vutuv_web/components/ui.ex:529
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr "Citazione"
@@ -10484,7 +10484,7 @@ msgstr ""
 msgid "Set up"
 msgstr "Configura"
 
-#: lib/vutuv_web/components/ui.ex:474
+#: lib/vutuv_web/components/ui.ex:481
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr "Barrato"
@@ -11214,7 +11214,7 @@ msgstr "Coda"
 msgid "Queued"
 msgstr "In coda"
 
-#: lib/vutuv_web/components/video_components.ex:213
+#: lib/vutuv_web/components/video_components.ex:214
 #: lib/vutuv_web/live/admin/screenshot_live.ex:525
 #, elixir-autogen, elixir-format
 msgid "Ready"
@@ -11579,12 +11579,12 @@ msgstr "Pubblichi questo file all'indirizzo:"
 msgid "State / region (optional)"
 msgstr "Provincia / regione (facoltativo)"
 
-#: lib/vutuv_web/components/ui.ex:4435
+#: lib/vutuv_web/components/ui.ex:4469
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr "Questo tipo di file non è ammesso."
 
-#: lib/vutuv_web/components/ui.ex:4437
+#: lib/vutuv_web/components/ui.ex:4471
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr "Il caricamento non è riuscito."
@@ -12016,7 +12016,7 @@ msgstr ""
 "Il testo del link può essere qualsiasi. Va bene anche un <link rel=\"me\"> "
 "nascosto nell'head della pagina."
 
-#: lib/vutuv_web/components/ui.ex:1085
+#: lib/vutuv_web/components/ui.ex:1119
 #: lib/vutuv_web/live/section_reorder_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -12323,7 +12323,7 @@ msgstr "Organizzazione sbloccata."
 #: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:462
-#: lib/vutuv_web/components/ui.ex:5314
+#: lib/vutuv_web/components/ui.ex:5348
 #: lib/vutuv_web/controllers/settings_controller.ex:222
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
@@ -13604,7 +13604,7 @@ msgstr "Salva la ricerca"
 msgid "Saved search deleted."
 msgstr "Ricerca salvata eliminata."
 
-#: lib/vutuv_web/components/ui.ex:5223
+#: lib/vutuv_web/components/ui.ex:5257
 #: lib/vutuv_web/controllers/settings_controller.ex:629
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13624,7 +13624,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "Interrompere gli avvisi via e-mail per la Sua ricerca salvata \"%{label}\"?"
 
-#: lib/vutuv_web/components/post_components.ex:3280
+#: lib/vutuv_web/components/post_components.ex:3560
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -14032,27 +14032,27 @@ msgstr[1] ""
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "ha cambiato il proprio handle da @%{old} a @%{new}."
 
-#: lib/vutuv_web/components/ui.ex:497
+#: lib/vutuv_web/components/ui.ex:504
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr "Al centro"
 
-#: lib/vutuv_web/components/ui.ex:494
+#: lib/vutuv_web/components/ui.ex:501
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr "Allinea a sinistra"
 
-#: lib/vutuv_web/components/ui.ex:500
+#: lib/vutuv_web/components/ui.ex:507
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr "Allinea a destra"
 
-#: lib/vutuv_web/components/ui.ex:491
+#: lib/vutuv_web/components/ui.ex:498
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr "A tutta larghezza"
 
-#: lib/vutuv_web/components/ui.ex:524
+#: lib/vutuv_web/components/ui.ex:531
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr "Inserisci un'immagine"
@@ -14091,22 +14091,22 @@ msgstr "Cellulare privato"
 msgid "Work mobile"
 msgstr "Cellulare di lavoro"
 
-#: lib/vutuv_web/components/post_components.ex:469
+#: lib/vutuv_web/components/post_components.ex:482
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr "Ancora nessun post."
 
-#: lib/vutuv_web/components/post_components.ex:471
+#: lib/vutuv_web/components/post_components.ex:484
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr "Ancora nessuna risposta."
 
-#: lib/vutuv_web/components/post_components.ex:470
+#: lib/vutuv_web/components/post_components.ex:483
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr "Ancora nessuna ripubblicazione."
 
-#: lib/vutuv_web/components/post_components.ex:428
+#: lib/vutuv_web/components/post_components.ex:441
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr "Post propri"
@@ -14119,7 +14119,7 @@ msgstr ""
 "persone note per quel tag compaiono tra i Suoi suggerimenti. Segua un tag "
 "dalla sua pagina."
 
-#: lib/vutuv_web/components/ui.ex:5206
+#: lib/vutuv_web/components/ui.ex:5240
 #: lib/vutuv_web/controllers/settings_controller.ex:643
 #: lib/vutuv_web/live/post_live/feed.ex:710
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -14199,7 +14199,7 @@ msgstr "Messenger aggiornato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:63
-#: lib/vutuv_web/components/ui.ex:5163
+#: lib/vutuv_web/components/ui.ex:5197
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -14227,14 +14227,14 @@ msgstr "Messenger di %{name}"
 msgid "Select a messenger"
 msgstr "Selezioni un messenger"
 
-#: lib/vutuv_web/components/ui.ex:4520
+#: lib/vutuv_web/components/ui.ex:4554
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] "Avvisa il mio follower"
 msgstr[1] "Avvisa i miei %{formatted} follower"
 
-#: lib/vutuv_web/components/ui.ex:4530
+#: lib/vutuv_web/components/ui.ex:4564
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
@@ -14289,34 +14289,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr "ha aggiunto %{count} nuove voci al proprio CV:"
 
-#: lib/vutuv_web/components/post_components.ex:5782
+#: lib/vutuv_web/components/post_components.ex:6075
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Audiolibro"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:5739
+#: lib/vutuv_web/components/post_components.ex:6032
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Recensione di un libro"
 
-#: lib/vutuv_web/components/post_components.ex:5783
+#: lib/vutuv_web/components/post_components.ex:6076
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Cinema"
 
-#: lib/vutuv_web/components/post_components.ex:5785
+#: lib/vutuv_web/components/post_components.ex:6078
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:5781
+#: lib/vutuv_web/components/post_components.ex:6074
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:5738
+#: lib/vutuv_web/components/post_components.ex:6031
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Recensione di un film"
@@ -14327,12 +14327,12 @@ msgstr "Recensione di un film"
 msgid "Look up"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:5780
+#: lib/vutuv_web/components/post_components.ex:6073
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Libro cartaceo"
 
-#: lib/vutuv_web/components/post_components.ex:5784
+#: lib/vutuv_web/components/post_components.ex:6077
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14352,7 +14352,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Anno"
 
-#: lib/vutuv_web/components/post_components.ex:5821
+#: lib/vutuv_web/components/post_components.ex:6114
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14360,27 +14360,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} pagina"
 msgstr[1] "%{formatted} pagine"
 
-#: lib/vutuv_web/components/post_components.ex:5851
+#: lib/vutuv_web/components/post_components.ex:6144
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} h"
 
-#: lib/vutuv_web/components/post_components.ex:5852
+#: lib/vutuv_web/components/post_components.ex:6145
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} h %{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:5850
+#: lib/vutuv_web/components/post_components.ex:6143
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:5810
+#: lib/vutuv_web/components/post_components.ex:6103
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(edizione cartacea)"
 
-#: lib/vutuv_web/components/post_components.ex:5857
+#: lib/vutuv_web/components/post_components.ex:6150
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "circa %{duration}"
@@ -14412,7 +14412,7 @@ msgstr "Con certificazione:"
 msgid "With qualification: %{name}"
 msgstr "Con certificazione: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5624
+#: lib/vutuv_web/components/post_components.ex:5917
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Editore:"
@@ -14455,17 +14455,17 @@ msgstr "ora La seguono."
 msgid "endorsed you for %{tags}."
 msgstr "L'ha confermata per %{tags}."
 
-#: lib/vutuv_web/components/post_components.ex:5615
+#: lib/vutuv_web/components/post_components.ex:5908
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "di:"
 
-#: lib/vutuv_web/components/ui.ex:2449
+#: lib/vutuv_web/components/ui.ex:2483
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr "Confermato da %{name}"
 
-#: lib/vutuv_web/components/ui.ex:2453
+#: lib/vutuv_web/components/ui.ex:2487
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -14832,14 +14832,14 @@ msgstr "Cerchi un account da bloccare"
 msgid "See all frozen accounts"
 msgstr "Vedi tutti gli account bloccati"
 
-#: lib/vutuv_web/components/post_components.ex:3561
+#: lib/vutuv_web/components/post_components.ex:3841
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "Mostra %{formatted} post precedente"
 msgstr[1] "Mostra %{formatted} post precedenti"
 
-#: lib/vutuv_web/components/post_components.ex:3584
+#: lib/vutuv_web/components/post_components.ex:3864
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14868,7 +14868,7 @@ msgstr ""
 "Digiti un nome, un @handle o un indirizzo e-mail per trovare un account da "
 "bloccare."
 
-#: lib/vutuv_web/components/post_components.ex:6331
+#: lib/vutuv_web/components/post_components.ex:6625
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Non può mettere Mi piace al Suo stesso post."
@@ -15047,7 +15047,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr "Corrispondenza solo su parole intere (parola o frase)"
 
-#: lib/vutuv_web/components/ui.ex:5177
+#: lib/vutuv_web/components/ui.ex:5211
 #: lib/vutuv_web/controllers/settings_controller.ex:773
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -15752,259 +15752,259 @@ msgstr "Il Suo server"
 msgid "moved to %{address}"
 msgstr "spostato a %{address}"
 
-#: lib/vutuv_web/components/ui.ex:5105
+#: lib/vutuv_web/components/ui.ex:5139
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr "Nome, foto, immagine di copertina, descrizione breve"
 
-#: lib/vutuv_web/components/ui.ex:5110
+#: lib/vutuv_web/components/ui.ex:5144
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr "handle soprannome rinomina slug profilo indirizzo url menzione"
 
-#: lib/vutuv_web/components/ui.ex:5113
+#: lib/vutuv_web/components/ui.ex:5147
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr "Gli impieghi e i ruoli nel Suo CV"
 
-#: lib/vutuv_web/components/ui.ex:5114
+#: lib/vutuv_web/components/ui.ex:5148
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr "cv curriculum carriera datore di lavoro posizione qualifica azienda"
 
-#: lib/vutuv_web/components/ui.ex:5117
+#: lib/vutuv_web/components/ui.ex:5151
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr "Scuole, università, titoli di studio"
 
-#: lib/vutuv_web/components/ui.ex:5118
+#: lib/vutuv_web/components/ui.ex:5152
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr "cv curriculum studio studi scuola università laurea titolo"
 
-#: lib/vutuv_web/components/ui.ex:5121
+#: lib/vutuv_web/components/ui.ex:5155
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr "Credenziali, con documenti di prova"
 
-#: lib/vutuv_web/components/ui.ex:5122
+#: lib/vutuv_web/components/ui.ex:5156
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 "certificato abilitazione diploma credenziale riconoscimento prova documento"
 
-#: lib/vutuv_web/components/ui.ex:5129
+#: lib/vutuv_web/components/ui.ex:5163
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr "Competenze linguistiche"
 
-#: lib/vutuv_web/components/ui.ex:5130
+#: lib/vutuv_web/components/ui.ex:5164
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr "Le lingue che parla"
 
-#: lib/vutuv_web/components/ui.ex:5131
+#: lib/vutuv_web/components/ui.ex:5165
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr "lingua parlare parlata fluente madrelingua"
 
-#: lib/vutuv_web/components/ui.ex:5134
+#: lib/vutuv_web/components/ui.ex:5168
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr "Gli argomenti per cui è conosciuto"
 
-#: lib/vutuv_web/components/ui.ex:5135
+#: lib/vutuv_web/components/ui.ex:5169
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr "competenza argomento parola chiave esperienza conferma"
 
-#: lib/vutuv_web/components/ui.ex:5315
+#: lib/vutuv_web/components/ui.ex:5349
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr "Pagine aziendali che gestisce"
 
-#: lib/vutuv_web/components/ui.ex:5316
+#: lib/vutuv_web/components/ui.ex:5350
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr "azienda datore di lavoro impresa attività organizzazione pagina"
 
-#: lib/vutuv_web/components/ui.ex:5138
+#: lib/vutuv_web/components/ui.ex:5172
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr "Recapiti"
 
-#: lib/vutuv_web/components/ui.ex:5141
+#: lib/vutuv_web/components/ui.ex:5175
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr "Dove La raggiungiamo, e quale indirizzo è pubblico"
 
-#: lib/vutuv_web/components/ui.ex:5142
+#: lib/vutuv_web/components/ui.ex:5176
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr "posta e-mail indirizzo principale"
 
-#: lib/vutuv_web/components/ui.ex:5145
+#: lib/vutuv_web/components/ui.ex:5179
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr "Fisso, cellulare, fax"
 
-#: lib/vutuv_web/components/ui.ex:5146
+#: lib/vutuv_web/components/ui.ex:5180
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr "telefono cellulare fax numero"
 
-#: lib/vutuv_web/components/ui.ex:5149
+#: lib/vutuv_web/components/ui.ex:5183
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr "Indirizzi postali sul Suo profilo"
 
-#: lib/vutuv_web/components/ui.ex:5150
+#: lib/vutuv_web/components/ui.ex:5184
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr "via città cap paese posta mappa"
 
-#: lib/vutuv_web/components/ui.ex:5152
+#: lib/vutuv_web/components/ui.ex:5186
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr "Siti web e link"
 
-#: lib/vutuv_web/components/ui.ex:5153
+#: lib/vutuv_web/components/ui.ex:5187
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr "Il Suo sito e gli altri link"
 
-#: lib/vutuv_web/components/ui.ex:5154
+#: lib/vutuv_web/components/ui.ex:5188
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr "url sito web homepage blog link verifica rel=me"
 
-#: lib/vutuv_web/components/ui.ex:5156
+#: lib/vutuv_web/components/ui.ex:5190
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr "Profili sui social"
 
-#: lib/vutuv_web/components/ui.ex:5157
+#: lib/vutuv_web/components/ui.ex:5191
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr "Mastodon, Bluesky, GitHub e gli altri"
 
-#: lib/vutuv_web/components/ui.ex:5159
+#: lib/vutuv_web/components/ui.ex:5193
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 
-#: lib/vutuv_web/components/ui.ex:5164
+#: lib/vutuv_web/components/ui.ex:5198
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr "Signal, Threema, Matrix e gli altri"
 
-#: lib/vutuv_web/components/ui.ex:5165
+#: lib/vutuv_web/components/ui.ex:5199
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr "signal threema matrix xmpp telegram whatsapp chat messenger"
 
-#: lib/vutuv_web/components/ui.ex:5168
+#: lib/vutuv_web/components/ui.ex:5202
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr "Notifiche e feed"
 
-#: lib/vutuv_web/components/ui.ex:5171
+#: lib/vutuv_web/components/ui.ex:5205
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr "Quali e-mail inviamo, e cosa Le dice la campanella"
 
-#: lib/vutuv_web/components/ui.ex:5178
+#: lib/vutuv_web/components/ui.ex:5212
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr "Tenga dei post fuori dal Suo feed"
 
-#: lib/vutuv_web/components/ui.ex:5179
+#: lib/vutuv_web/components/ui.ex:5213
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr "silenzia blocca nascondi filtro parola chiave parola tag feed"
 
-#: lib/vutuv_web/components/ui.ex:5207
+#: lib/vutuv_web/components/ui.ex:5241
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr "Argomenti i cui post arrivano nel Suo feed"
 
-#: lib/vutuv_web/components/ui.ex:5208
+#: lib/vutuv_web/components/ui.ex:5242
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr "tag argomento iscriviti segui feed"
 
-#: lib/vutuv_web/components/ui.ex:5224
+#: lib/vutuv_web/components/ui.ex:5258
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 "Ricerche di lavoro e di persone che Le inviano per e-mail le nuove "
 "corrispondenze"
 
-#: lib/vutuv_web/components/ui.ex:5225
+#: lib/vutuv_web/components/ui.ex:5259
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr "lavoro avviso ricerca agente osservati"
 
-#: lib/vutuv_web/components/ui.ex:5272
+#: lib/vutuv_web/components/ui.ex:5306
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr "Motori di ricerca, IA, stato online"
 
-#: lib/vutuv_web/components/ui.ex:5273
+#: lib/vutuv_web/components/ui.ex:5307
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 "privacy google motore di ricerca ia llm crawler noindex online pallino "
 "pubblico"
 
-#: lib/vutuv_web/components/ui.ex:5276
+#: lib/vutuv_web/components/ui.ex:5310
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr "Persone che non possono interagire con Lei"
 
-#: lib/vutuv_web/components/ui.ex:5277
+#: lib/vutuv_web/components/ui.ex:5311
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr "blocca bandisci silenzia segnala abuso molestie stalker"
 
-#: lib/vutuv_web/components/ui.ex:5298
+#: lib/vutuv_web/components/ui.ex:5332
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr "Passkey, dispositivi connessi, codici di accesso"
 
-#: lib/vutuv_web/components/ui.ex:5299
+#: lib/vutuv_web/components/ui.ex:5333
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 "password accesso entrare uscire sessione dispositivo passkey totp 2fa pin"
 
-#: lib/vutuv_web/components/ui.ex:5307
+#: lib/vutuv_web/components/ui.ex:5341
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr "Porti i Suoi dati da LinkedIn"
 
-#: lib/vutuv_web/components/ui.ex:5308
+#: lib/vutuv_web/components/ui.ex:5342
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr "linkedin caricamento zip migrazione trasferimento"
 
-#: lib/vutuv_web/components/ui.ex:5311
+#: lib/vutuv_web/components/ui.ex:5345
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr "Scarichi tutto ciò che conserviamo su di Lei"
 
-#: lib/vutuv_web/components/ui.ex:5312
+#: lib/vutuv_web/components/ui.ex:5346
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr "download gdpr rgpd dati backup json cv"
 
-#: lib/vutuv_web/components/ui.ex:5326
+#: lib/vutuv_web/components/ui.ex:5360
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr "Rimuova il Suo account e tutto ciò che contiene"
 
-#: lib/vutuv_web/components/ui.ex:5327
+#: lib/vutuv_web/components/ui.ex:5361
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr "elimina rimuovi chiudi esci cancella abbandona"
@@ -16134,7 +16134,7 @@ msgstr ""
 " vedere dove va a finire. Modificare o eliminare un post su vutuv è solo una"
 " richiesta rivolta a quei server, e non tutti la rispettano."
 
-#: lib/vutuv_web/components/post_components.ex:6277
+#: lib/vutuv_web/components/post_components.ex:6571
 #: lib/vutuv_web/live/notification_live/index.ex:1593
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -16142,7 +16142,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} risposta"
 msgstr[1] "%{formatted} risposte"
 
-#: lib/vutuv_web/components/post_components.ex:6281
+#: lib/vutuv_web/components/post_components.ex:6575
 #: lib/vutuv_web/live/notification_live/index.ex:1587
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -16150,7 +16150,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Mi piace"
 msgstr[1] "%{formatted} Mi piace"
 
-#: lib/vutuv_web/components/post_components.ex:6285
+#: lib/vutuv_web/components/post_components.ex:6579
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16158,7 +16158,7 @@ msgstr[0] "%{formatted} ripubblicazione"
 msgstr[1] "%{formatted} ripubblicazioni"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:6236
+#: lib/vutuv_web/components/post_components.ex:6530
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Già conteggiate nei numeri qui sopra."
@@ -16181,14 +16181,14 @@ msgstr ""
 msgid "Content warning"
 msgstr "Avviso sul contenuto"
 
-#: lib/vutuv_web/components/post_components.ex:1549
-#: lib/vutuv_web/components/post_components.ex:2301
+#: lib/vutuv_web/components/post_components.ex:1589
+#: lib/vutuv_web/components/post_components.ex:2578
 #: lib/vutuv_web/live/fediverse_account_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Da un'altra rete"
 
-#: lib/vutuv_web/components/post_components.ex:1419
+#: lib/vutuv_web/components/post_components.ex:1459
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Rimuovere questa risposta dal Suo post?"
@@ -16217,7 +16217,7 @@ msgstr "Risposta da un'altra rete"
 msgid "Reply removed."
 msgstr "Risposta rimossa."
 
-#: lib/vutuv_web/components/post_components.ex:1431
+#: lib/vutuv_web/components/post_components.ex:1471
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -16228,7 +16228,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr "Segnalata come non appropriata"
 
-#: lib/vutuv_web/components/post_components.ex:1445
+#: lib/vutuv_web/components/post_components.ex:1485
 #: lib/vutuv_web/live/notification_live/index.ex:1118
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -16260,9 +16260,9 @@ msgid "That reply is not yours to remove."
 msgstr "Questa risposta non spetta a Lei rimuoverla."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1501
-#: lib/vutuv_web/components/post_components.ex:1480
-#: lib/vutuv_web/components/post_components.ex:1680
-#: lib/vutuv_web/components/post_components.ex:3138
+#: lib/vutuv_web/components/post_components.ex:1520
+#: lib/vutuv_web/components/post_components.ex:1720
+#: lib/vutuv_web/components/post_components.ex:3418
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -16504,7 +16504,7 @@ msgstr "Token di accesso creato"
 msgid "Access token revoked"
 msgstr "Token di accesso revocato"
 
-#: lib/vutuv_web/components/ui.ex:5301
+#: lib/vutuv_web/components/ui.ex:5335
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16865,7 +16865,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr "Cosa è cambiato sul Suo account, ed esattamente quando."
 
-#: lib/vutuv_web/components/ui.ex:5302
+#: lib/vutuv_web/components/ui.ex:5336
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr "Cosa è cambiato sul Suo account, e quando"
@@ -16901,7 +16901,7 @@ msgstr "da chi gestisce il sito"
 msgid "from a signed-in session"
 msgstr "da una sessione connessa"
 
-#: lib/vutuv_web/components/ui.ex:5304
+#: lib/vutuv_web/components/ui.ex:5338
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16958,22 +16958,22 @@ msgstr ""
 msgid "device or detail"
 msgstr "dispositivo o dettaglio"
 
-#: lib/vutuv_web/components/post_components.ex:3746
+#: lib/vutuv_web/components/post_components.ex:4026
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Post fissato"
 
-#: lib/vutuv_web/components/post_components.ex:3864
+#: lib/vutuv_web/components/post_components.ex:4148
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "Fissa sul profilo"
 
-#: lib/vutuv_web/components/post_components.ex:3872
+#: lib/vutuv_web/components/post_components.ex:4156
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Togli dal profilo"
 
-#: lib/vutuv_web/components/post_components.ex:3858
+#: lib/vutuv_web/components/post_components.ex:4142
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -17068,7 +17068,7 @@ msgstr "Descriva la foto per chi non può vederla"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1429
 #: lib/vutuv_web/agent_docs/text.ex:915
-#: lib/vutuv_web/components/ui.ex:3191
+#: lib/vutuv_web/components/ui.ex:3225
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Scarica l'originale"
@@ -17095,7 +17095,7 @@ msgstr "Risoluzione piena, direttamente dal post."
 msgid "Just the picture"
 msgstr "Solo l'immagine"
 
-#: lib/vutuv_web/components/ui.ex:3190
+#: lib/vutuv_web/components/ui.ex:3224
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Foto successiva"
@@ -17105,17 +17105,17 @@ msgstr "Foto successiva"
 msgid "No image description yet"
 msgstr "Ancora nessuna descrizione dell'immagine"
 
-#: lib/vutuv_web/components/post_components.ex:3333
+#: lib/vutuv_web/components/post_components.ex:3613
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Apri le impostazioni del Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:4739
+#: lib/vutuv_web/components/post_components.ex:5032
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} di %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:4888
+#: lib/vutuv_web/components/post_components.ex:5181
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "La foto è in fase di controllo"
@@ -17128,12 +17128,12 @@ msgstr "Opzioni della foto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1462
 #: lib/vutuv_web/agent_docs/text.ex:890
-#: lib/vutuv_web/components/post_components.ex:4970
+#: lib/vutuv_web/components/post_components.ex:5263
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Foto:"
 
-#: lib/vutuv_web/components/ui.ex:3189
+#: lib/vutuv_web/components/ui.ex:3223
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Foto precedente"
@@ -17156,7 +17156,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr "Mostra le impostazioni della fotocamera"
 
-#: lib/vutuv_web/components/post_components.ex:3386
+#: lib/vutuv_web/components/post_components.ex:3666
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -17182,7 +17182,7 @@ msgstr ""
 "Questa foto porta con sé il luogo in cui è stata scattata. Chiunque scarichi"
 " il file esatto può leggerlo."
 
-#: lib/vutuv_web/components/post_components.ex:3377
+#: lib/vutuv_web/components/post_components.ex:3657
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -17197,12 +17197,12 @@ msgstr ""
 "inviare le Sue parole a quella rete, cosa che vutuv fa solo per i membri che"
 " hanno attivato la partecipazione al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:3395
+#: lib/vutuv_web/components/post_components.ex:3675
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Questo sito non partecipa al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:3329
+#: lib/vutuv_web/components/post_components.ex:3609
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Attivi la partecipazione al Fediverso per rispondere"
@@ -17218,7 +17218,7 @@ msgid "You have sent a lot of answers to other networks in the past hour. Please
 msgstr ""
 "Nell'ultima ora ha inviato molte risposte ad altre reti. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:3390
+#: lib/vutuv_web/components/post_components.ex:3670
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -17232,7 +17232,7 @@ msgstr ""
 "Al momento le Sue impostazioni del Fediverso non consentono di inviare una "
 "risposta."
 
-#: lib/vutuv_web/components/post_components.ex:3343
+#: lib/vutuv_web/components/post_components.ex:3623
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -17315,13 +17315,13 @@ msgstr[1] ""
 "il file esatto lo rivela."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1319
-#: lib/vutuv_web/components/post_components.ex:6274
+#: lib/vutuv_web/components/post_components.ex:6568
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "A %{handle} è piaciuto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1317
-#: lib/vutuv_web/components/post_components.ex:6271
+#: lib/vutuv_web/components/post_components.ex:6565
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} lo ha condiviso"
@@ -17331,7 +17331,7 @@ msgstr "%{handle} lo ha condiviso"
 msgid "Fediverse reactions"
 msgstr "Reazioni dal Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:6161
+#: lib/vutuv_web/components/post_components.ex:6455
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Da altre reti"
@@ -17458,7 +17458,7 @@ msgstr "Un account su un'altra rete"
 msgid "Cancel request"
 msgstr "Annulla la richiesta"
 
-#: lib/vutuv_web/components/ui.ex:5288
+#: lib/vutuv_web/components/ui.ex:5322
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Segua account su Mastodon, e si faccia seguire da lì"
@@ -17694,7 +17694,7 @@ msgstr ""
 "reti e non può seguire nessuno lì. La sospensione decade da sé quando "
 "termina."
 
-#: lib/vutuv_web/components/ui.ex:5290
+#: lib/vutuv_web/components/ui.ex:5324
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -17718,7 +17718,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr "Post in cache"
 
-#: lib/vutuv_web/components/post_components.ex:2897
+#: lib/vutuv_web/components/post_components.ex:3177
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Solo per i follower di questo account"
@@ -17728,7 +17728,7 @@ msgstr "Solo per i follower di questo account"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Grazie. La nostra copia è stata eliminata subito."
 
-#: lib/vutuv_web/components/post_components.ex:3137
+#: lib/vutuv_web/components/post_components.ex:3417
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Vota sull'originale"
@@ -17754,12 +17754,12 @@ msgstr "Post in cache segnalato, rimosso per tutti qui"
 msgid "Content from other networks taken down by members"
 msgstr "Contenuti da altre reti rimossi dai membri"
 
-#: lib/vutuv_web/components/post_components.ex:1815
+#: lib/vutuv_web/components/post_components.ex:1855
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Nascondi"
 
-#: lib/vutuv_web/components/post_components.ex:3078
+#: lib/vutuv_web/components/post_components.ex:3358
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Contrassegnato come sensibile dal suo autore"
@@ -17774,7 +17774,7 @@ msgstr "Silenziato. Continua a seguirlo; i suoi post spariscono dal Suo feed."
 msgid "Nobody has removed or reported anything yet."
 msgstr "Nessuno ha ancora rimosso o segnalato nulla."
 
-#: lib/vutuv_web/components/post_components.ex:2870
+#: lib/vutuv_web/components/post_components.ex:3150
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -18038,27 +18038,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(un'immagine)"
 msgstr[1] "(%{count} immagini)"
 
-#: lib/vutuv_web/components/post_components.ex:2473
+#: lib/vutuv_web/components/post_components.ex:2751
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr "L'immagine è in fase di controllo"
 
-#: lib/vutuv_web/components/post_components.ex:2506
+#: lib/vutuv_web/components/post_components.ex:2784
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Coprila di nuovo"
 
-#: lib/vutuv_web/components/post_components.ex:2501
+#: lib/vutuv_web/components/post_components.ex:2779
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Contenuto sensibile. Mostra l'immagine."
 
-#: lib/vutuv_web/components/post_components.ex:3236
+#: lib/vutuv_web/components/post_components.ex:3516
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Sono molti Mi piace in un'ora. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:3242
+#: lib/vutuv_web/components/post_components.ex:3522
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Quel post non è più qui."
@@ -18068,7 +18068,7 @@ msgstr "Quel post non è più qui."
 msgid "Back to the feed"
 msgstr "Torna al feed"
 
-#: lib/vutuv_web/components/post_components.ex:3381
+#: lib/vutuv_web/components/post_components.ex:3661
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18083,7 +18083,7 @@ msgstr ""
 "le Sue parole a quella rete, cosa che vutuv fa solo per i membri che hanno "
 "attivato la partecipazione al Fediverso."
 
-#: lib/vutuv_web/live/post_live/remote_actions_component.ex:181
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:302
 #, elixir-autogen, elixir-format
 msgid "Reposted. Your followers see it now."
 msgstr "Ripubblicato. Ora i Suoi follower lo vedono."
@@ -18124,12 +18124,12 @@ msgstr ""
 "Il Suo feed mostra i post dei membri che segue. Ne segua qualcuno per "
 "riempirlo."
 
-#: lib/vutuv_web/components/ui.ex:239
+#: lib/vutuv_web/components/ui.ex:246
 #, elixir-autogen, elixir-format
 msgid "Add another tag"
 msgstr "Aggiungi un altro tag"
 
-#: lib/vutuv_web/components/ui.ex:262
+#: lib/vutuv_web/components/ui.ex:269
 #, elixir-autogen, elixir-format
 msgid "Remove the tag %{name}"
 msgstr "Rimuovi il tag %{name}"
@@ -18271,7 +18271,7 @@ msgstr ""
 "Il Suo nome utente è la Sua identità pubblica qui. Cambia solo dopo che avrà"
 " confermato con la Sua passkey o con un codice valido qui sotto."
 
-#: lib/vutuv_web/components/ui.ex:622
+#: lib/vutuv_web/components/ui.ex:629
 #, elixir-autogen, elixir-format
 msgid "Markdown help"
 msgstr "Guida a Markdown"
@@ -18292,7 +18292,7 @@ msgid "Address of the post"
 msgstr "Indirizzo del post"
 
 #: lib/vutuv_web/components/fediverse_components.ex:688
-#: lib/vutuv_web/live/post_live/remote_actions_component.ex:276
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:414
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings"
 msgstr "Impostazioni del Fediverso"
@@ -18750,14 +18750,14 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr "Elenco dei bloccati per gli screenshot"
 
-#: lib/vutuv_web/components/post_components.ex:461
+#: lib/vutuv_web/components/post_components.ex:474
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 "Ancora nulla dal Fediverso. Segua account là fuori per riempire questa "
 "scheda."
 
-#: lib/vutuv_web/components/post_components.ex:458
+#: lib/vutuv_web/components/post_components.ex:471
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr "Ancora nulla da vutuv. Segua persone qui per riempire questa scheda."
@@ -18800,7 +18800,7 @@ msgstr "Nessun post su vutuv porta ancora questo tag."
 msgid "word in a post"
 msgstr "parola in un post"
 
-#: lib/vutuv_web/components/post_components.ex:3239
+#: lib/vutuv_web/components/post_components.ex:3519
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Quella risposta non è più qui."
@@ -18845,8 +18845,8 @@ msgstr ""
 "Questa è la copia vutuv di un post pubblicato su %{host}. Viene conservata "
 "finché qualcuno qui segue il suo autore."
 
-#: lib/vutuv_web/components/ui.ex:1600
-#: lib/vutuv_web/components/ui.ex:1601
+#: lib/vutuv_web/components/ui.ex:1634
+#: lib/vutuv_web/components/ui.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr "Si iscriva a questo feed nel Suo lettore RSS"
@@ -18861,7 +18861,7 @@ msgstr "Documentazione per sviluppatori"
 msgid "Source code"
 msgstr "Codice sorgente"
 
-#: lib/vutuv_web/components/ui.ex:268
+#: lib/vutuv_web/components/ui.ex:275
 #, elixir-autogen, elixir-format
 msgid "At most %{max} tags. Remove one to add another."
 msgstr "Al massimo %{max} tag. Ne rimuova uno per aggiungerne un altro."
@@ -18878,19 +18878,19 @@ msgstr ""
 msgid "Liked by"
 msgstr "Piace a"
 
-#: lib/vutuv_web/components/post_components.ex:5264
+#: lib/vutuv_web/components/post_components.ex:5557
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Piace a %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5266
+#: lib/vutuv_web/components/post_components.ex:5559
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Piace a %{name} e a %{formatted} altro"
 msgstr[1] "Piace a %{name} e ad altri %{formatted}"
 
-#: lib/vutuv_web/components/post_components.ex:5277
+#: lib/vutuv_web/components/post_components.ex:5570
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -19026,7 +19026,7 @@ msgstr "Attestato di lavoro aggiornato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:5124
+#: lib/vutuv_web/components/ui.ex:5158
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -19071,7 +19071,7 @@ msgstr "Rilasciato il"
 msgid "Label"
 msgstr "Etichetta"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3599
+#: lib/vutuv_web/live/post_live/feed.ex:3606
 #: lib/vutuv_web/live/reference_check_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -19230,7 +19230,7 @@ msgstr ""
 "Ha modificato il testo dopo questa analisi. L'analisi descrive la versione "
 "precedente."
 
-#: lib/vutuv_web/components/ui.ex:5125
+#: lib/vutuv_web/components/ui.ex:5159
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr "I Suoi Arbeitszeugnisse, privati finché non li pubblica"
@@ -19241,7 +19241,7 @@ msgstr "I Suoi Arbeitszeugnisse, privati finché non li pubblica"
 msgid "Zwischenzeugnis"
 msgstr "Zwischenzeugnis"
 
-#: lib/vutuv_web/components/ui.ex:5127
+#: lib/vutuv_web/components/ui.ex:5161
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -19517,7 +19517,7 @@ msgstr "Trascini qui il file, oppure ne scelga uno"
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr "PDF, JPG, PNG o WebP, fino a %{limit}"
 
-#: lib/vutuv_web/components/ui.ex:4421
+#: lib/vutuv_web/components/ui.ex:4455
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -19823,14 +19823,14 @@ msgstr "PIN di 6 cifre"
 msgid "Enter the PIN from the email"
 msgstr "Inserisca il PIN che trova nell'e-mail"
 
-#: lib/vutuv_web/components/ui.ex:854
+#: lib/vutuv_web/components/ui.ex:861
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 "Se ha aggiunto altri indirizzi al Suo account vutuv, provi ad accedere con "
 "uno di quelli."
 
-#: lib/vutuv_web/components/ui.ex:882
+#: lib/vutuv_web/components/ui.ex:889
 #, elixir-autogen, elixir-format
 msgid "Cancel registration"
 msgstr "Annulla la registrazione"
@@ -19842,7 +19842,7 @@ msgstr ""
 "Benvenuto su vutuv. Può cambiare il Suo nome utente {handle} su {url}, e su "
 "{import_url} può importare un profilo LinkedIn esistente."
 
-#: lib/vutuv_web/components/ui.ex:837
+#: lib/vutuv_web/components/ui.ex:844
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
@@ -19871,7 +19871,7 @@ msgstr ""
 "Le percentuali si riferiscono ai %{answered} membri che hanno risposto. "
 "%{unanswered} non hanno risposto."
 
-#: lib/vutuv_web/components/ui.ex:5106
+#: lib/vutuv_web/components/ui.ex:5140
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr "immagine profilo ritratto foto compleanno genere su di me"
@@ -19973,7 +19973,7 @@ msgstr "Elimina anche"
 msgid "Always keep"
 msgstr "Conserva sempre"
 
-#: lib/vutuv_web/components/ui.ex:5281
+#: lib/vutuv_web/components/ui.ex:5315
 #: lib/vutuv_web/controllers/settings_controller.ex:256
 #: lib/vutuv_web/controllers/settings_controller.ex:335
 #: lib/vutuv_web/controllers/settings_controller.ex:347
@@ -20083,7 +20083,7 @@ msgstr "Conserva i post con foto"
 msgid "Keep posts that did well"
 msgstr "Conserva i post andati bene"
 
-#: lib/vutuv_web/components/ui.ex:5283
+#: lib/vutuv_web/components/ui.ex:5317
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr "Lasci scadere i Suoi post dopo un tempo che decide Lei"
@@ -20207,7 +20207,7 @@ msgstr "Prima può scaricare tutto ciò che ha qui:"
 msgid "Your rule"
 msgstr "La Sua regola"
 
-#: lib/vutuv_web/components/ui.ex:5285
+#: lib/vutuv_web/components/ui.ex:5319
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -20619,7 +20619,7 @@ msgstr ""
 msgid "Start over"
 msgstr "Ricomincia"
 
-#: lib/vutuv_web/components/post_components.ex:3269
+#: lib/vutuv_web/components/post_components.ex:3549
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -21086,22 +21086,22 @@ msgstr "Si registri di nuovo"
 msgid "The PIN has expired."
 msgstr "Il PIN è scaduto."
 
-#: lib/vutuv_web/components/ui.ex:958
+#: lib/vutuv_web/components/ui.ex:965
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr "Il PIN è valido per un altro minuto."
 
-#: lib/vutuv_web/components/ui.ex:960
+#: lib/vutuv_web/components/ui.ex:967
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr "Il PIN è valido per un altro secondo."
 
-#: lib/vutuv_web/components/ui.ex:959
+#: lib/vutuv_web/components/ui.ex:966
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr "Il PIN è valido per altri {n} minuti."
 
-#: lib/vutuv_web/components/ui.ex:961
+#: lib/vutuv_web/components/ui.ex:968
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr "Il PIN è valido per altri {n} secondi."
@@ -21581,27 +21581,27 @@ msgstr "Lingua"
 msgid "The language this post is written in"
 msgstr "La lingua in cui è scritto questo post"
 
-#: lib/vutuv_web/components/post_components.ex:5158
+#: lib/vutuv_web/components/post_components.ex:5451
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Mostra l'originale"
 
-#: lib/vutuv_web/components/post_components.ex:5194
+#: lib/vutuv_web/components/post_components.ex:5487
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Traduci"
 
-#: lib/vutuv_web/components/post_components.ex:5203
+#: lib/vutuv_web/components/post_components.ex:5496
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Tradotto"
 
-#: lib/vutuv_web/components/post_components.ex:5206
+#: lib/vutuv_web/components/post_components.ex:5499
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Tradotto da %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:5183
+#: lib/vutuv_web/components/post_components.ex:5476
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Traduzione in corso…"
@@ -21612,8 +21612,8 @@ msgid "Feed language settings reset to the site defaults."
 msgstr ""
 "Impostazioni delle lingue del feed riportate ai valori predefiniti del sito."
 
-#: lib/vutuv_web/components/post_components.ex:5173
-#: lib/vutuv_web/components/ui.ex:5199
+#: lib/vutuv_web/components/post_components.ex:5466
+#: lib/vutuv_web/components/ui.ex:5233
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -21755,7 +21755,7 @@ msgid "Your username, or paste the address of your profile page."
 msgstr ""
 "Il Suo nome utente, oppure incolli l'indirizzo della Sua pagina di profilo."
 
-#: lib/vutuv_web/components/post_components.ex:4936
+#: lib/vutuv_web/components/post_components.ex:5229
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
@@ -21766,13 +21766,13 @@ msgstr[1] ""
 "La nostra IA le sta ancora controllando, %{done} su %{total} fatte. Appena "
 "avrà finito con l'ultima, le foto compariranno da sé."
 
-#: lib/vutuv_web/components/post_components.ex:4933
+#: lib/vutuv_web/components/post_components.ex:5226
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Il Suo post è pubblicato, la foto non c'è ancora."
 
-#: lib/vutuv_web/components/post_components.ex:2527
-#: lib/vutuv_web/components/post_components.ex:4144
+#: lib/vutuv_web/components/post_components.ex:2805
+#: lib/vutuv_web/components/post_components.ex:4436
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -21855,7 +21855,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr "Accesso delle app Mastodon modificato"
 
-#: lib/vutuv_web/components/ui.ex:5319
+#: lib/vutuv_web/components/ui.ex:5353
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr "App Mastodon, app collegate e token di accesso"
@@ -21911,7 +21911,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr "Il Suo account è allora %{handle}."
 
-#: lib/vutuv_web/components/ui.ex:5321
+#: lib/vutuv_web/components/ui.ex:5355
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -21948,7 +21948,7 @@ msgstr "Trovi le persone che conosce da LinkedIn"
 msgid "Find your LinkedIn contacts"
 msgstr "Trovi i Suoi contatti LinkedIn"
 
-#: lib/vutuv_web/components/ui.ex:5215
+#: lib/vutuv_web/components/ui.ex:5249
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format
@@ -22062,7 +22062,7 @@ msgstr "Cerchi per nome"
 msgid "See which of them are already on vutuv"
 msgstr "Veda quali di loro sono già su vutuv"
 
-#: lib/vutuv_web/components/ui.ex:5217
+#: lib/vutuv_web/components/ui.ex:5251
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr "Veda quali dei Suoi contatti LinkedIn sono già su vutuv"
@@ -22146,7 +22146,7 @@ msgstr "I Suoi contatti su vutuv"
 msgid "Your export also lists your LinkedIn contacts."
 msgstr "La Sua esportazione elenca anche i Suoi contatti LinkedIn."
 
-#: lib/vutuv_web/components/ui.ex:5219
+#: lib/vutuv_web/components/ui.ex:5253
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr ""
@@ -22345,7 +22345,7 @@ msgstr ""
 "Questa pagina sta seguendo il numero massimo di account che consentiamo "
 "(%{max})."
 
-#: lib/vutuv_web/components/post_components.ex:2850
+#: lib/vutuv_web/components/post_components.ex:3130
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr "Smettere di seguire %{handle}? I suoi post spariscono dal Suo feed."
@@ -22432,7 +22432,7 @@ msgstr ""
 "Ha attivato le notifiche del browser. A questo browser non è ancora stato "
 "chiesto il permesso."
 
-#: lib/vutuv_web/components/ui.ex:5173
+#: lib/vutuv_web/components/ui.ex:5207
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
@@ -22488,7 +22488,7 @@ msgstr ""
 "Segua #%{tag} da Mastodon o da qualsiasi altra app del Fediverso e i suoi "
 "post pubblici arriveranno nella Sua cronologia. Non serve un account vutuv."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3764
+#: lib/vutuv_web/live/post_live/feed.ex:3771
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Saluti gli altri membri"
@@ -22498,47 +22498,47 @@ msgstr "Saluti gli altri membri"
 msgid "New here"
 msgstr "Nuovi qui"
 
-#: lib/vutuv_web/components/ui.ex:1769
+#: lib/vutuv_web/components/ui.ex:1803
 #, elixir-autogen, elixir-format
 msgid "New public posts arrive in any feed reader. No account needed either."
 msgstr ""
 "I nuovi post pubblici arrivano in qualsiasi lettore di feed. Anche qui non "
 "serve un account."
 
-#: lib/vutuv_web/components/ui.ex:1765
+#: lib/vutuv_web/components/ui.ex:1799
 #, elixir-autogen, elixir-format
 msgid "Or with an RSS reader"
 msgstr "Oppure con un lettore RSS"
 
-#: lib/vutuv_web/components/ui.ex:1645
-#: lib/vutuv_web/components/ui.ex:1714
+#: lib/vutuv_web/components/ui.ex:1679
+#: lib/vutuv_web/components/ui.ex:1748
 #, elixir-autogen, elixir-format
 msgid "Subscribe"
 msgstr "Iscriviti"
 
-#: lib/vutuv_web/components/ui.ex:1766
+#: lib/vutuv_web/components/ui.ex:1800
 #, elixir-autogen, elixir-format
 msgid "With an RSS reader"
 msgstr "Con un lettore RSS"
 
-#: lib/vutuv_web/components/ui.ex:1726
+#: lib/vutuv_web/components/ui.ex:1760
 #, elixir-autogen, elixir-format
 msgid "Create a free account"
 msgstr "Crei un account gratuito"
 
-#: lib/vutuv_web/components/ui.ex:1741
+#: lib/vutuv_web/components/ui.ex:1775
 #, elixir-autogen, elixir-format
 msgid "No vutuv account? These ways work too:"
 msgstr "Non ha un account vutuv? Funzionano anche questi modi:"
 
-#: lib/vutuv_web/components/ui.ex:1719
+#: lib/vutuv_web/components/ui.ex:1753
 #, elixir-autogen, elixir-format
 msgid "The best way: follow %{name} here. New posts land in your feed, and you can reply and join in."
 msgstr ""
 "Il modo migliore: segua %{name} qui. I nuovi post arrivano nel Suo feed, e "
 "può rispondere e partecipare."
 
-#: lib/vutuv_web/components/ui.ex:1717
+#: lib/vutuv_web/components/ui.ex:1751
 #, elixir-autogen, elixir-format
 msgid "With a vutuv account"
 msgstr "Con un account vutuv"
@@ -22666,22 +22666,22 @@ msgstr "Vengono nascosti dal Suo feed."
 msgid "Shown in the language it was written in."
 msgstr "Vengono mostrati nella lingua in cui sono stati scritti."
 
-#: lib/vutuv_web/components/ui.ex:5200
+#: lib/vutuv_web/components/ui.ex:5234
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr "Quali lingue arrivano fino a Lei e cosa succede al resto"
 
-#: lib/vutuv_web/components/ui.ex:5202
+#: lib/vutuv_web/components/ui.ex:5236
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr "lingua tradurre traduzione italiano tedesco inglese originale nascondere lingua straniera ordine priorità feed language translate sprache"
 
-#: lib/vutuv_web/components/ui.ex:5240
+#: lib/vutuv_web/components/ui.ex:5274
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr "Lingua dell'interfaccia, formato della data e fuso orario, mappe, come vengono accorciati i post"
 
-#: lib/vutuv_web/components/ui.ex:5244
+#: lib/vutuv_web/components/ui.ex:5278
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr "italiano tedesco inglese lingua mappa carattere lunghezza sillabazione fuso orario timezone utc data ora orologio 24 ore formato della data"
@@ -22800,7 +22800,7 @@ msgstr "Nessun account premium a pagamento."
 msgid "Your LinkedIn profile can come along."
 msgstr "Il suo profilo LinkedIn può venire con lei."
 
-#: lib/vutuv_web/components/ui.ex:1155
+#: lib/vutuv_web/components/ui.ex:1189
 #, elixir-autogen, elixir-format
 msgid "Being checked"
 msgstr "In verifica"
@@ -22989,13 +22989,13 @@ msgid "Hide a word or a whole phrase …"
 msgstr "Nascondi una parola o un'intera frase …"
 
 #: lib/vutuv_web/live/post_live/feed.ex:709
-#: lib/vutuv_web/live/post_live/feed.ex:3927
+#: lib/vutuv_web/live/post_live/feed.ex:3934
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Nascondi tag"
 
 #: lib/vutuv_web/live/post_live/feed.ex:708
-#: lib/vutuv_web/live/post_live/feed.ex:3916
+#: lib/vutuv_web/live/post_live/feed.ex:3923
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Nascondi parole"
@@ -23021,7 +23021,7 @@ msgstr "Altri dei tuoi %{formatted} account"
 msgid "Move %{card}"
 msgstr "Sposta %{card}"
 
-#: lib/vutuv_web/components/ui.ex:412
+#: lib/vutuv_web/components/ui.ex:419
 #: lib/vutuv_web/live/post_live/filter_band.ex:584
 #, elixir-autogen, elixir-format
 msgid "No account found."
@@ -23062,7 +23062,7 @@ msgstr "I post con uno di questi tag vengono ridotti allo stesso modo."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "I post che contengono una di queste parole vengono ridotti a una riga — non eliminati, e con un modo per aprirli comunque."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3790
+#: lib/vutuv_web/live/post_live/feed.ex:3797
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Messe da parte:"
@@ -23101,7 +23101,7 @@ msgid "Show posts by %{name}"
 msgstr "Mostra i post di %{name}"
 
 #: lib/vutuv_web/live/post_live/feed.ex:707
-#: lib/vutuv_web/live/post_live/feed.ex:3882
+#: lib/vutuv_web/live/post_live/feed.ex:3889
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr "Fonti"
@@ -23160,7 +23160,7 @@ msgid_plural "Show %{formatted} posts in the feed"
 msgstr[0] "Mostra %{formatted} post nel feed"
 msgstr[1] "Mostra %{formatted} post nel feed"
 
-#: lib/vutuv_web/components/post_components.ex:2444
+#: lib/vutuv_web/components/post_components.ex:2722
 #, elixir-autogen, elixir-format
 msgid "Picture unavailable"
 msgstr "Immagine non disponibile"
@@ -23189,7 +23189,7 @@ msgstr ""
 "La pagina della Sua organizzazione è stata aggiornata, ma non è stato "
 "possibile usare quell'immagine come logo. Ne scelga un'altra."
 
-#: lib/vutuv_web/components/ui.ex:4427
+#: lib/vutuv_web/components/ui.ex:4461
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -23210,7 +23210,7 @@ msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} post il %{day}"
 msgstr[1] "%{count} post il %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3556
+#: lib/vutuv_web/live/post_live/feed.ex:3563
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Torna al presente"
@@ -23220,7 +23220,7 @@ msgstr "Torna al presente"
 msgid "Busy month: the shading counts at least this much."
 msgstr "Mese intenso: la tonalità indica almeno questo valore."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3602
+#: lib/vutuv_web/live/post_live/feed.ex:3609
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -23242,7 +23242,7 @@ msgstr "Mese successivo"
 msgid "Next year"
 msgstr "Anno successivo"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3552
+#: lib/vutuv_web/live/post_live/feed.ex:3559
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Il %{day} non è arrivato nulla nel Suo feed."
@@ -23336,7 +23336,7 @@ msgid_plural "New (%{formatted}):"
 msgstr[0] "Nuovo:"
 msgstr[1] "Nuovi (%{formatted}):"
 
-#: lib/vutuv_web/components/post_components.ex:3005
+#: lib/vutuv_web/components/post_components.ex:3285
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr "Post citato"
@@ -23351,12 +23351,12 @@ msgstr "Cita %{name}: %{url}"
 msgid "Quotes %{url}"
 msgstr "Cita %{url}"
 
-#: lib/vutuv_web/components/ui.ex:411
+#: lib/vutuv_web/components/ui.ex:418
 #, elixir-autogen, elixir-format
 msgid "Mention an account"
 msgstr "Menziona un account"
 
-#: lib/vutuv_web/components/ui.ex:415
+#: lib/vutuv_web/components/ui.ex:422
 #, elixir-autogen, elixir-format
 msgid "{used} of {max} mentions"
 msgstr "{used} di {max} menzioni"
@@ -23387,12 +23387,12 @@ msgstr "Lascia vuoto il campo degli account e la regola vale per tutti; %{exampl
 msgid "Only these accounts (empty = all) …"
 msgstr "Solo questi account (vuoto = tutti) …"
 
-#: lib/vutuv_web/components/ui.ex:3496
+#: lib/vutuv_web/components/ui.ex:3530
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr "solo %{account}"
 
-#: lib/vutuv_web/components/post_components.ex:6617
+#: lib/vutuv_web/components/post_components.ex:6911
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -23439,17 +23439,17 @@ msgid_plural "shared this."
 msgstr[0] "lo ha condiviso."
 msgstr[1] "lo hanno condiviso."
 
-#: lib/vutuv_web/components/ui.ex:566
+#: lib/vutuv_web/components/ui.ex:573
 #, elixir-autogen, elixir-format
 msgid "Editor view"
 msgstr "Vista"
 
-#: lib/vutuv_web/components/ui.ex:514
+#: lib/vutuv_web/components/ui.ex:521
 #, elixir-autogen, elixir-format
 msgid "Insert a block"
 msgstr "Inserisci un blocco"
 
-#: lib/vutuv_web/components/ui.ex:526
+#: lib/vutuv_web/components/ui.ex:533
 #, elixir-autogen, elixir-format
 msgid "Nothing matches."
 msgstr "Nessun risultato."
@@ -23575,7 +23575,7 @@ msgctxt "phone tab bar"
 msgid "Write"
 msgstr "Scrivi"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3690
+#: lib/vutuv_web/live/post_live/feed.ex:3697
 #: lib/vutuv_web/live/post_rewrites_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "%{formatted} rule"
@@ -23628,7 +23628,7 @@ msgstr "Di questo post non resta nulla."
 msgid "Replace with"
 msgstr "Sostituisci con"
 
-#: lib/vutuv_web/components/ui.ex:5192
+#: lib/vutuv_web/components/ui.ex:5226
 #, elixir-autogen, elixir-format
 msgid "Rewrite what an account's posts say, for you alone"
 msgstr "Riscrivere il testo dei post di un account, solo per Lei"
@@ -23643,10 +23643,10 @@ msgstr "Regole per %{account}"
 msgid "Rules that rewrite the text of one account's posts before you read them: a footer under every post, a signature, a wall of hashtags. Only you see the difference. Open the ⋯ menu on any post to write rules for its author."
 msgstr "Regole che riscrivono il testo dei post di un account prima che Lei li legga: un piè di pagina sotto ogni post, una firma, un muro di hashtag. Solo Lei vede la differenza. Apra il menu ⋯ di un post per scrivere regole per il suo autore."
 
-#: lib/vutuv_web/components/post_components.ex:1424
-#: lib/vutuv_web/components/post_components.ex:2863
-#: lib/vutuv_web/components/post_components.ex:3941
-#: lib/vutuv_web/components/ui.ex:5191
+#: lib/vutuv_web/components/post_components.ex:1464
+#: lib/vutuv_web/components/post_components.ex:3143
+#: lib/vutuv_web/components/post_components.ex:4225
+#: lib/vutuv_web/components/ui.ex:5225
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
 #: lib/vutuv_web/live/post_rewrites_live.ex:264
@@ -23702,12 +23702,12 @@ msgstr "Le Sue regole salvate modificano questo post di %{who} come mostrato."
 msgid "\\1 puts back what the first (…) group matched, \\0 the whole match."
 msgstr "\\1 reinserisce ciò che ha trovato il primo gruppo (…), \\0 l'intera corrispondenza."
 
-#: lib/vutuv_web/components/ui.ex:5193
+#: lib/vutuv_web/components/ui.ex:5227
 #, elixir-autogen, elixir-format
 msgid "regex regular expression rewrite replace footer signature strip"
 msgstr "regex espressione regolare riscrivere sostituire piè di pagina firma rimuovere cerca"
 
-#: lib/vutuv_web/components/ui.ex:5262
+#: lib/vutuv_web/components/ui.ex:5296
 #, elixir-autogen, elixir-format
 msgid "Smaller pictures and a plain composer on a slow connection"
 msgstr "Immagini più piccole e un editor semplice con una connessione lenta"
@@ -23717,12 +23717,12 @@ msgstr "Immagini più piccole e un editor semplice con una connessione lenta"
 msgid "That endorsement is not possible."
 msgstr "Questa conferma non è possibile."
 
-#: lib/vutuv_web/components/ui.ex:5264
+#: lib/vutuv_web/components/ui.ex:5298
 #, elixir-autogen, elixir-format
 msgid "bandwidth slow internet mobile data saving saver volume metered compression pictures images screenshots editor langsam daten sparen datensparmodus volumen schmalband komprimierung bilder"
 msgstr "banda lento internet mobile risparmio dati volume compressione immagini foto screenshot editor bandwidth slow data saving"
 
-#: lib/vutuv_web/components/ui.ex:5236
+#: lib/vutuv_web/components/ui.ex:5270
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr "Aspetto"
@@ -23734,7 +23734,7 @@ msgid_plural "%{count} videos in progress"
 msgstr[0] "%{count} video in lavorazione"
 msgstr[1] "%{count} video in lavorazione"
 
-#: lib/vutuv_web/components/video_components.ex:257
+#: lib/vutuv_web/components/video_components.ex:258
 #, elixir-autogen, elixir-format
 msgid "About %{minutes} min of video"
 msgstr "Circa %{minutes} min di video"
@@ -23744,39 +23744,39 @@ msgstr "Circa %{minutes} min di video"
 msgid "Add video"
 msgstr "Aggiungi video"
 
-#: lib/vutuv_web/components/video_components.ex:199
+#: lib/vutuv_web/components/video_components.ex:200
 #, elixir-autogen, elixir-format
 msgid "Converting · %{percent} %"
 msgstr "Conversione · %{percent} %"
 
-#: lib/vutuv_web/components/video_components.ex:280
+#: lib/vutuv_web/components/video_components.ex:281
 #, elixir-autogen, elixir-format
 msgid "Delete this post"
 msgstr "Elimina questo post"
 
-#: lib/vutuv_web/components/video_components.ex:216
+#: lib/vutuv_web/components/video_components.ex:217
 #, elixir-autogen, elixir-format
 msgid "Our AI check refused this video (at %{time})."
 msgstr "Il nostro controllo IA ha rifiutato questo video (a %{time})."
 
-#: lib/vutuv_web/components/video_components.ex:218
+#: lib/vutuv_web/components/video_components.ex:219
 #, elixir-autogen, elixir-format
 msgid "Our AI check refused this video."
 msgstr "Il nostro controllo IA ha rifiutato questo video."
 
-#: lib/vutuv_web/components/video_components.ex:204
+#: lib/vutuv_web/components/video_components.ex:205
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking it."
 msgid_plural "Our AI is checking it, %{done} of %{total} frames done."
 msgstr[0] "La nostra IA lo sta controllando."
 msgstr[1] "La nostra IA lo sta controllando, %{done} di %{total} fotogrammi verificati."
 
-#: lib/vutuv_web/components/video_components.ex:272
+#: lib/vutuv_web/components/video_components.ex:273
 #, elixir-autogen, elixir-format
 msgid "Post without the video"
 msgstr "Pubblica senza il video"
 
-#: lib/vutuv_web/components/video_components.ex:196
+#: lib/vutuv_web/components/video_components.ex:197
 #, elixir-autogen, elixir-format
 msgid "Reading the frames"
 msgstr "Lettura dei fotogrammi"
@@ -23811,7 +23811,7 @@ msgstr "Questo fotogramma non può essere usato."
 msgid "The video could not be attached."
 msgstr "Il video non può essere allegato."
 
-#: lib/vutuv_web/components/video_components.ex:262
+#: lib/vutuv_web/components/video_components.ex:263
 #, elixir-autogen, elixir-format
 msgid "The video is gone."
 msgstr "Il video non c'è più."
@@ -23821,12 +23821,12 @@ msgstr "Il video non c'è più."
 msgid "The video is longer than %{seconds} seconds."
 msgstr "Il video dura più di %{seconds} secondi."
 
-#: lib/vutuv_web/components/video_components.ex:246
+#: lib/vutuv_web/components/video_components.ex:247
 #, elixir-autogen, elixir-format
 msgid "This post is still waiting for you"
 msgstr "Questo post La sta ancora aspettando"
 
-#: lib/vutuv_web/components/video_components.ex:219
+#: lib/vutuv_web/components/video_components.ex:220
 #, elixir-autogen, elixir-format
 msgid "This video could not be converted."
 msgstr "Questo video non può essere convertito."
@@ -23835,8 +23835,8 @@ msgstr "Questo video non può essere convertito."
 #: lib/vutuv_web/agent_docs/markdown.ex:1417
 #: lib/vutuv_web/agent_docs/text.ex:899
 #: lib/vutuv_web/agent_docs/text.ex:900
-#: lib/vutuv_web/components/post_components.ex:2579
-#: lib/vutuv_web/components/video_components.ex:126
+#: lib/vutuv_web/components/post_components.ex:2857
+#: lib/vutuv_web/components/video_components.ex:127
 #: lib/vutuv_web/live/post_live/composer.ex:2458
 #, elixir-autogen, elixir-format
 msgid "Video"
@@ -23852,7 +23852,7 @@ msgstr "Descrizione del video"
 msgid "Videos cannot be uploaded here."
 msgstr "Qui non è possibile caricare video."
 
-#: lib/vutuv_web/components/video_components.ex:195
+#: lib/vutuv_web/components/video_components.ex:196
 #, elixir-autogen, elixir-format
 msgid "Waiting in line"
 msgstr "In attesa in coda"
@@ -23867,7 +23867,7 @@ msgstr "Cosa mostra il video, per chi non può guardarlo"
 msgid "You can post now — the post appears as soon as the video is ready."
 msgstr "Può pubblicare subito: il post apparirà appena il video sarà pronto."
 
-#: lib/vutuv_web/components/video_components.ex:247
+#: lib/vutuv_web/components/video_components.ex:248
 #, elixir-autogen, elixir-format
 msgid "Your post appears as soon as the video is ready"
 msgstr "Il Suo post apparirà appena il video sarà pronto"
@@ -23898,7 +23898,7 @@ msgstr[1] "%{formatted} follower"
 msgid "Last 30 days: %{parts}"
 msgstr "Ultimi 30 giorni"
 
-#: lib/vutuv_web/components/post_components.ex:4496
+#: lib/vutuv_web/components/post_components.ex:4788
 #: lib/vutuv_web/live/notification_live/index.ex:1004
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -23939,12 +23939,12 @@ msgstr "L'ha menzionata in un post."
 msgid "replied in the thread."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1335
+#: lib/vutuv_web/components/ui.ex:1369
 #, elixir-autogen, elixir-format
 msgid "Standard quality. Load this picture in HD."
 msgstr "Qualità standard. Carica questa immagine in HD."
 
-#: lib/vutuv_web/components/video_components.ex:117
+#: lib/vutuv_web/components/video_components.ex:118
 #, elixir-autogen, elixir-format
 msgid "Standard quality. Play this video in HD."
 msgstr "Qualità standard. Riproduci questo video in HD."
@@ -24202,7 +24202,7 @@ msgstr ""
 msgid "Accounts whose posts stay out of your feed, and accounts whose reposts do. This list is yours alone: it is never shared and nobody is told they are on it."
 msgstr "Account i cui post non compaiono nel Suo feed e account di cui ha nascosto le ripubblicazioni. Questo elenco è solo Suo: non viene mai condiviso e nessuno viene informato di farne parte."
 
-#: lib/vutuv_web/components/ui.ex:5185
+#: lib/vutuv_web/components/ui.ex:5219
 #, elixir-autogen, elixir-format
 msgid "Accounts you have silenced, and whose reposts you hide"
 msgstr "Account che ha silenziato e account di cui nasconde le ripubblicazioni"
@@ -24212,8 +24212,8 @@ msgstr "Account che ha silenziato e account di cui nasconde le ripubblicazioni"
 msgid "Hidden. What they pass on stays out of your feed; their own posts do not."
 msgstr "Nascosto. Ciò che questo account ripubblica non compare più nel Suo feed, i suoi post sì."
 
-#: lib/vutuv_web/components/post_components.ex:2835
-#: lib/vutuv_web/components/post_components.ex:3935
+#: lib/vutuv_web/components/post_components.ex:3115
+#: lib/vutuv_web/components/post_components.ex:4219
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr "Nascondi le ripubblicazioni"
@@ -24228,7 +24228,7 @@ msgstr "Cerca invece parole, frasi o tag?"
 msgid "Mute everything"
 msgstr "Silenzia tutto"
 
-#: lib/vutuv_web/components/ui.ex:5184
+#: lib/vutuv_web/components/ui.ex:5218
 #: lib/vutuv_web/controllers/settings_controller.ex:713
 #: lib/vutuv_web/templates/settings/mutes.html.heex:1
 #: lib/vutuv_web/templates/settings/mutes.html.heex:3
@@ -24272,7 +24272,7 @@ msgstr "Non ha ancora silenziato nessuno."
 msgid "You mute an account where you meet it: the ⋯ menu on any of its posts, or its own page. Muting works whether or not you follow them."
 msgstr "Può silenziare un account dove lo incontra: nel menu ⋯ di uno dei suoi post oppure sulla sua pagina. Funziona anche con gli account che non segue."
 
-#: lib/vutuv_web/components/ui.ex:5187
+#: lib/vutuv_web/components/ui.ex:5221
 #, elixir-autogen, elixir-format
 msgid "mute unmute hide account reposts boosts feed stumm stummschalten ausblenden konto"
 msgstr "silenzia silenziare nascondere account ripubblicazioni boost feed"
@@ -24372,7 +24372,7 @@ msgstr ""
 msgid "Feed settings saved."
 msgstr "Impostazioni del feed salvate."
 
-#: lib/vutuv_web/components/ui.ex:5255
+#: lib/vutuv_web/components/ui.ex:5289
 #, elixir-autogen, elixir-format
 msgid "How many load at once, and how many “Load more” adds"
 msgstr ""
@@ -24382,7 +24382,7 @@ msgstr ""
 msgid "How many posts your feed shows before the “Load more” button, and how many that button adds. More posts mean a longer wait for the page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5254
+#: lib/vutuv_web/components/ui.ex:5288
 #: lib/vutuv_web/controllers/settings_controller.ex:963
 #: lib/vutuv_web/templates/settings/feed.html.heex:12
 #, elixir-autogen, elixir-format
@@ -24394,8 +24394,8 @@ msgstr ""
 msgid "Posts loaded at once"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:3626
-#: lib/vutuv_web/live/post_live/feed.ex:3630
+#: lib/vutuv_web/live/post_live/feed.ex:3633
+#: lib/vutuv_web/live/post_live/feed.ex:3637
 #, elixir-autogen, elixir-format
 msgid "Posts per page"
 msgstr "Post per pagina"
@@ -24405,65 +24405,65 @@ msgstr "Post per pagina"
 msgid "You can change this under the feed itself as well, right below the “Load more” button."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5257
+#: lib/vutuv_web/components/ui.ex:5291
 #, elixir-autogen, elixir-format
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6608
-#: lib/vutuv_web/components/post_components.ex:6609
+#: lib/vutuv_web/components/post_components.ex:6902
+#: lib/vutuv_web/components/post_components.ex:6903
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr "Una parola o un'espressione …"
 
-#: lib/vutuv_web/components/post_components.ex:6636
+#: lib/vutuv_web/components/post_components.ex:6930
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr "Per chi %{thing} viene nascosto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3687
-#: lib/vutuv_web/live/post_live/feed.ex:3846
-#: lib/vutuv_web/live/post_live/feed.ex:3855
+#: lib/vutuv_web/live/post_live/feed.ex:3694
+#: lib/vutuv_web/live/post_live/feed.ex:3853
+#: lib/vutuv_web/live/post_live/feed.ex:3862
 #, elixir-autogen, elixir-format
 msgid "Hidden"
 msgstr "Nascosti"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3820
+#: lib/vutuv_web/live/post_live/feed.ex:3827
 #, elixir-autogen, elixir-format
 msgid "Hide something from your feed"
 msgstr "Nascondi qualcosa dal tuo feed"
 
-#: lib/vutuv_web/components/post_components.ex:6556
+#: lib/vutuv_web/components/post_components.ex:6850
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr "Non mostrare più"
 
-#: lib/vutuv_web/live/post_live/feed.ex:3861
+#: lib/vutuv_web/live/post_live/feed.ex:3868
 #, elixir-autogen, elixir-format
 msgid "Whatever these match is folded to a single line in your feed."
 msgstr "Ciò che corrisponde viene ridotto a una riga nel tuo feed."
 
-#: lib/vutuv_web/live/post_live/feed.ex:3881
+#: lib/vutuv_web/live/post_live/feed.ex:3888
 #, elixir-autogen, elixir-format
 msgid "Words & tags"
 msgstr "Parole e tag"
 
-#: lib/vutuv_web/components/post_components.ex:6640
+#: lib/vutuv_web/components/post_components.ex:6934
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr "per tutti"
 
-#: lib/vutuv_web/components/post_components.ex:6643
+#: lib/vutuv_web/components/post_components.ex:6937
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr "solo %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:6612
+#: lib/vutuv_web/components/post_components.ex:6906
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr "questa parola"
 
-#: lib/vutuv_web/components/post_components.ex:6653
+#: lib/vutuv_web/components/post_components.ex:6947
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "solo %{server}"
@@ -24515,7 +24515,7 @@ msgstr "Questo sito è offline in questo momento."
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr "Il sito funziona, è questo indirizzo a non essere uno dei nostri. Probabilmente il link è vecchio oppure contiene un errore di battitura."
 
-#: lib/vutuv_web/components/post_components.ex:5966
+#: lib/vutuv_web/components/post_components.ex:6260
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr "Ingrandisci lo screenshot"
@@ -24615,8 +24615,8 @@ msgstr "Il Suo contenuto è stato nascosto automaticamente dopo una segnalazione
 msgid "Hidden. What other people pass on of them stays out of your feed; their own posts do not."
 msgstr "Nascosto. Ciò che altri ripubblicano di questo account non compare più nel Suo feed, i suoi post sì."
 
-#: lib/vutuv_web/components/post_components.ex:2821
-#: lib/vutuv_web/components/post_components.ex:3923
+#: lib/vutuv_web/components/post_components.ex:3101
+#: lib/vutuv_web/components/post_components.ex:4207
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr "Nascondi quando altri lo ripubblicano"
@@ -24876,3 +24876,46 @@ msgstr "La tua immagine di copertina non è stata sostituita: una segnalazione �
 #, elixir-autogen, elixir-format
 msgid "Your profile picture was not replaced: a report about it is still open. Open the case to remove the picture or to say that it is yours."
 msgstr "La tua immagine del profilo non è stata sostituita: una segnalazione è ancora aperta. Apri il caso per rimuovere l'immagine o per dire che è tua."
+
+#: lib/vutuv_web/components/post_components.ex:2439
+#, elixir-autogen, elixir-format
+msgid "Fetching the answers from the servers that hold them…"
+msgstr "Le risposte vengono recuperate dai server che le ospitano…"
+
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:250
+#, elixir-autogen, elixir-format
+msgid "Not every answer could be fetched. The rest are on the origin server."
+msgstr "Non è stato possibile recuperare tutte le risposte. Le altre sono sul server di origine."
+
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:240
+#, elixir-autogen, elixir-format
+msgid "Nothing here we are allowed to show you."
+msgstr "Qui non c'è nulla che possiamo mostrarti."
+
+#: lib/vutuv_web/components/post_components.ex:2454
+#, elixir-autogen, elixir-format
+msgid "Show more answers"
+msgstr "Mostra altre risposte"
+
+#: lib/vutuv_web/components/post_components.ex:2371
+#: lib/vutuv_web/components/post_components.ex:2373
+#, elixir-autogen, elixir-format
+msgid "Show the one answer"
+msgid_plural "Show the %{count} answers"
+msgstr[0] "Mostra l'unica risposta"
+msgstr[1] "Mostra le %{count} risposte"
+
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:257
+#, elixir-autogen, elixir-format
+msgid "That is enough answers fetched for one hour. Try again later."
+msgstr "Per quest'ora sono state recuperate abbastanza risposte. Riprova più tardi."
+
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:262
+#, elixir-autogen, elixir-format
+msgid "The answers could not be fetched from the servers that hold them."
+msgstr "Non è stato possibile recuperare le risposte dai server che le ospitano."
+
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:265
+#, elixir-autogen, elixir-format
+msgid "The rest could not be fetched right now."
+msgstr "Non è stato possibile recuperare il resto in questo momento."

--- a/priv/repo/migrations/20260906150018_add_reply_counts_to_fediverse_objects.exs
+++ b/priv/repo/migrations/20260906150018_add_reply_counts_to_fediverse_objects.exs
@@ -1,0 +1,103 @@
+defmodule Vutuv.Repo.Migrations.AddReplyCountsToFediverseObjects do
+  use Ecto.Migration
+
+  # How many people answered an object out there, and the index that lets us
+  # show those answers.
+  #
+  # The sibling of the like and repost figures beside it, with one difference
+  # that decides the whole design: `likes` and `shares` arrive as a
+  # `totalItems` in the object itself, `replies` does not. Forty objects from
+  # our own cache were asked before this was written and **not one** of their
+  # servers served a `totalItems` on that collection — Mastodon serialises
+  # `replies` as a Collection whose first page carries the author's own
+  # follow-ups and whose second (`only_other_accounts=true`) carries everybody
+  # else's, 60 ids to a page and no total anywhere. So the figure is counted,
+  # not read, and counting costs a request of its own. That is why this gets its
+  # own clock instead of riding `counts_checked_at`: the ask happens on a much
+  # flatter ladder than the one the two cheap figures run on.
+  #
+  # Nullable for the same reason as those two: `replies` is MAY in ActivityPub
+  # §5.7, flipboard.com (19 % of everything we cache) serves none of the three,
+  # and "we have not been told" must stay distinguishable from "nobody
+  # answered". A zero is a claim, and not ours to make for somebody else.
+  #
+  # All plain additions, so N-1 compatible: the release currently serving
+  # traffic never reads them.
+  def change do
+    for table <- [:fediverse_posts, :fediverse_notes] do
+      alter table(table) do
+        add(:replies_count, :integer)
+        add(:replies_checked_at, :utc_datetime)
+        # Consecutive failed asks, driving the same doubling backoff the like
+        # figures use, so a server having a bad day stops seeing us.
+        add(:replies_failures, :integer, null: false, default: 0)
+      end
+
+      # No index on `replies_checked_at`: nothing queries it. The count rides
+      # the like ask, which has already selected its object, so due-ness is
+      # decided in Elixir on a row in hand — an index here would be written on
+      # every stamp and read by nobody.
+
+      # The origin serves none of these collections, so there is nothing here to
+      # ask about ever again. Not a failure — the server answered, correctly,
+      # with a document that simply carries no figures — and therefore not a
+      # strike: the backoff exists for servers having a bad day, this is a
+      # property of the software.
+      #
+      # It earns its column by what it costs not to have it. On a copy of
+      # production, flipboard.com held 1.026 of the 2.627 objects on the ladder
+      # (39 %) and had answered 0 of its 1.478 stored posts with a figure of any
+      # kind; the ladder was so far behind that 2.511 of those 2.627 objects
+      # were overdue, the median one asked at 1,9 times its own interval and the
+      # p90 at ten times. A five-minute tier that is really reached every 87
+      # minutes is not a ladder, and this is what pays for the reply figure
+      # above without asking anybody for more traffic.
+      alter table(table) do
+        add(:counts_absent, :boolean, null: false, default: false)
+      end
+
+      # And the ladder's own index narrowed to the rows it still serves.
+      # Filtering absent rows out of the query is not enough on its own: they
+      # are never stamped again, so they keep the oldest `counts_checked_at`
+      # values there are and sit permanently at the head of an
+      # `asc_nulls_first` scan the planner then has to walk past — 1.026 of
+      # 2.627 rows, on every run, forever. A partial index is where they stop
+      # existing for this query at all.
+      create(
+        index(table, [:counts_checked_at],
+          where: "counts_absent = false",
+          name: :"#{table}_counts_due_index"
+        )
+      )
+    end
+
+    # An answer we fetched **because somebody opened a thread**, rather than
+    # because anybody here follows its author. It is a cached post in every
+    # other respect (card, action bar, report, retention), and this column is
+    # what keeps it out of the surfaces that list an account's posts.
+    #
+    # Without it the feature would quietly rewrite people's feeds: a delivered
+    # reply is only ever stored when it continues a thread of the **same**
+    # account (`own_thread?/2`), so an answer by somebody a member follows has
+    # never been feed material here. Fetching one as thread context would drop
+    # it into that member's feed at its own old timestamp, days back, with
+    # nobody having asked for it.
+    alter table(:fediverse_posts) do
+      add(:thread_context, :boolean, null: false, default: false)
+    end
+
+    # The answers themselves are cached posts like any other (a reply *is* a
+    # post, and storing it as one is what gives it a card, an action bar, a
+    # report path and a retention clock for free). Reading them back means
+    # asking for every cached post that answers this one, which is a column
+    # nothing indexed before — every other reader of `in_reply_to_uri` had a
+    # single row in hand. Partial: only a reply carries the column at all, and
+    # most cached posts are not replies.
+    create(
+      index(:fediverse_posts, [:in_reply_to_uri],
+        where: "in_reply_to_uri IS NOT NULL",
+        name: :fediverse_posts_in_reply_to_uri_index
+      )
+    )
+  end
+end

--- a/test/vutuv/fediverse_thread_replies_test.exs
+++ b/test/vutuv/fediverse_thread_replies_test.exs
@@ -1,0 +1,581 @@
+defmodule Vutuv.FediverseThreadRepliesTest do
+  @moduledoc """
+  How many people answered a post from another network, and reading those
+  answers here.
+
+  The like and repost figures beside this one are read out of a document we
+  already hold. The answer count is not: forty objects from this installation's
+  own cache were asked before the feature was built and **not one** of their
+  servers put a `totalItems` on `replies`. So the figure is counted by walking
+  the collection, which costs a request, and everything in here is about paying
+  that price once and no more often than it is worth.
+
+  `async: false` — the stub is a global `Application.put_env/3` and the hourly
+  fetch budget lives in the shared `Vutuv.RateLimiter` table, which the SQL
+  sandbox does not roll back.
+  """
+  use Vutuv.DataCase, async: false
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Fediverse.RemotePostTag
+  alias Vutuv.FeedBand
+  alias Vutuv.Tags.Timeline
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    :ok
+  end
+
+  defp account(host \\ "social.example") do
+    uri = "https://#{host}/users/them#{System.unique_integer([:positive])}"
+
+    Repo.insert!(%RemoteAccount{
+      actor_uri: uri,
+      host: host,
+      handle: "them",
+      inbox_uri: uri <> "/inbox"
+    })
+  end
+
+  defp federating_member do
+    user = insert(:activated_user, fediverse_followers?: true)
+    {:ok, _actor} = Fediverse.ensure_actor(user)
+    Repo.reload!(user)
+  end
+
+  defp follow(user, acc) do
+    Repo.insert!(%Follow{
+      user_id: user.id,
+      remote_account_id: acc.id,
+      state: "accepted",
+      follow_activity_id: "https://vutuv.test/#{user.id}/actor#f/#{acc.id}"
+    })
+  end
+
+  defp cached_post(acc, attrs) do
+    now = DateTime.utc_now(:second)
+
+    Repo.insert!(
+      struct(
+        %RemotePost{
+          remote_account_id: acc.id,
+          object_uri: "https://#{acc.host}/p/#{System.unique_integer([:positive])}",
+          content_text: "Welche Distro soll ich nehmen?",
+          audience: "public",
+          kind: "note",
+          published_at: now,
+          received_at: now,
+          expires_at: DateTime.add(now, 86_400)
+        },
+        attrs
+      )
+    )
+    |> Repo.preload(:remote_account)
+  end
+
+  defp followed_post(attrs \\ %{}) do
+    acc = account()
+    user = federating_member()
+    follow(user, acc)
+    {cached_post(acc, attrs), user}
+  end
+
+  # A fake network: every request is answered from `routes`, keyed by the full
+  # URL. Anything not listed is a 404, which is what an id nobody serves really
+  # does — so a test never passes on a stub being generous.
+  defp serve(routes, opts \\ []) do
+    seen = Keyword.get(opts, :seen)
+
+    Application.put_env(:vutuv, :fediverse_req_options,
+      plug: fn conn ->
+        url = "https://#{conn.host}#{conn.request_path}" <> query_suffix(conn)
+        if seen, do: send(seen, {:asked, url})
+
+        case Map.fetch(routes, url) do
+          {:ok, doc} ->
+            conn
+            |> Plug.Conn.put_resp_content_type("application/activity+json")
+            |> Plug.Conn.send_resp(200, Jason.encode!(doc))
+
+          :error ->
+            Plug.Conn.send_resp(conn, 404, "")
+        end
+      end
+    )
+
+    on_exit(fn -> Application.delete_env(:vutuv, :fediverse_req_options) end)
+  end
+
+  defp query_suffix(%{query_string: ""}), do: ""
+  defp query_suffix(%{query_string: query}), do: "?" <> query
+
+  defp object(post, overrides \\ %{}) do
+    Map.merge(
+      %{
+        "id" => post.object_uri,
+        "type" => "Note",
+        "content" => "<p>Welche Distro soll ich nehmen?</p>",
+        "to" => ["https://www.w3.org/ns/activitystreams#Public"],
+        "attributedTo" => post.remote_account.actor_uri,
+        "likes" => %{"type" => "Collection", "totalItems" => 28},
+        "shares" => %{"type" => "Collection", "totalItems" => 22}
+      },
+      overrides
+    )
+  end
+
+  # Mastodon's exact shape: the collection's first page is embedded in the
+  # object and carries the author's own follow-ups, and its `next` is where
+  # everybody else's answers are.
+  defp replies_collection(post, own, others_page) do
+    %{
+      "id" => post.object_uri <> "/replies",
+      "type" => "Collection",
+      "first" =>
+        %{
+          "type" => "CollectionPage",
+          "partOf" => post.object_uri <> "/replies",
+          "items" => own
+        }
+        |> put_next(others_page)
+    }
+  end
+
+  defp put_next(page, nil), do: page
+  defp put_next(page, uri), do: Map.put(page, "next", uri)
+
+  defp page(items, next \\ nil) do
+    put_next(%{"type" => "CollectionPage", "items" => items}, next)
+  end
+
+  describe "counting the answers" do
+    test "walks the collection and stores what it counted" do
+      {post, _user} = followed_post()
+      others = post.object_uri <> "/replies?only_other_accounts=true&page=true"
+
+      serve(%{
+        post.object_uri => object(post, %{"replies" => replies_collection(post, [], others)}),
+        others =>
+          page([
+            "https://a.example/1",
+            "https://b.example/2",
+            "https://c.example/3"
+          ])
+      })
+
+      assert :updated = Fediverse.refresh_counts(post)
+
+      stored = Repo.get!(RemotePost, post.id)
+      assert stored.replies_count == 3
+      assert stored.replies_checked_at
+      assert stored.replies_failures == 0
+      # The two cheap figures still ride the same ask.
+      assert stored.likes_count == 28
+      assert stored.shares_count == 22
+    end
+
+    test "the author's own follow-ups on the embedded first page are counted too" do
+      {post, _user} = followed_post()
+      others = post.object_uri <> "/replies?only_other_accounts=true&page=true"
+
+      serve(%{
+        post.object_uri =>
+          object(post, %{
+            "replies" => replies_collection(post, ["https://social.example/p/self"], others)
+          }),
+        others => page(["https://a.example/1"])
+      })
+
+      assert :updated = Fediverse.refresh_counts(post)
+      assert Repo.get!(RemotePost, post.id).replies_count == 2
+    end
+
+    test "stops after the page cap rather than walking a thousand answers" do
+      {post, _user} = followed_post()
+      p2 = post.object_uri <> "/replies?page=2"
+      p3 = post.object_uri <> "/replies?page=3"
+      p4 = post.object_uri <> "/replies?page=4"
+
+      serve(%{
+        post.object_uri => object(post, %{"replies" => replies_collection(post, [], p2)}),
+        p2 => page(["https://a.example/1"], p3),
+        p3 => page(["https://a.example/2"], p4),
+        # Never asked for: three pages is the cap, and the fourth is where the
+        # exact figure stops being what anybody is reading.
+        p4 => page(["https://a.example/3"])
+      })
+
+      assert :updated = Fediverse.refresh_counts(post)
+      assert Repo.get!(RemotePost, post.id).replies_count == 2
+    end
+
+    test "a totalItems is believed rather than counted past" do
+      {post, _user} = followed_post()
+
+      serve(%{
+        post.object_uri =>
+          object(post, %{
+            "replies" => %{"type" => "Collection", "totalItems" => 940, "items" => []}
+          })
+      })
+
+      assert :updated = Fediverse.refresh_counts(post)
+      assert Repo.get!(RemotePost, post.id).replies_count == 940
+    end
+
+    # The deadlock this guards against is the one issue #1316 shipped: an
+    # object that can never be worked on stays due forever, holds the front of
+    # every batch, and the sweep silently stops doing anything at all.
+    test "an origin that serves no replies collection is not asked again and again" do
+      {post, _user} = followed_post()
+      serve(%{post.object_uri => object(post)})
+
+      assert :updated = Fediverse.refresh_counts(post)
+
+      stored = Repo.get!(RemotePost, post.id)
+      # Nothing to count, so no figure — a `0` would be a claim we cannot make.
+      assert is_nil(stored.replies_count)
+      # But the clock moved, which is what keeps it out of the next batch.
+      assert stored.replies_checked_at
+      assert stored.replies_failures == 0
+    end
+
+    test "a second ask inside the tier does not walk the collection again" do
+      {post, _user} = followed_post()
+      others = post.object_uri <> "/replies?only_other_accounts=true&page=true"
+
+      routes = %{
+        post.object_uri => object(post, %{"replies" => replies_collection(post, [], others)}),
+        others => page(["https://a.example/1"])
+      }
+
+      serve(routes)
+      assert :updated = Fediverse.refresh_counts(post)
+
+      serve(routes, seen: self())
+      Fediverse.refresh_counts(Repo.get!(RemotePost, post.id))
+
+      assert_received {:asked, _object}
+      refute_received {:asked, ^others}
+    end
+
+    test "an unreachable collection is a strike, and the stored figure stands" do
+      {post, _user} = followed_post()
+      others = post.object_uri <> "/replies?only_other_accounts=true&page=true"
+
+      serve(%{
+        post.object_uri => object(post, %{"replies" => replies_collection(post, [], others)}),
+        others => page(["https://a.example/1", "https://b.example/2"])
+      })
+
+      assert :updated = Fediverse.refresh_counts(post)
+
+      # The page goes away, the object stays. Backdated so the ladder is due.
+      Repo.update_all(from(p in RemotePost, where: p.id == ^post.id),
+        set: [replies_checked_at: DateTime.add(DateTime.utc_now(:second), -3600)]
+      )
+
+      serve(%{
+        post.object_uri => object(post, %{"replies" => replies_collection(post, [], others)})
+      })
+
+      Fediverse.refresh_counts(Repo.get!(RemotePost, post.id))
+
+      stored = Repo.get!(RemotePost, post.id)
+      assert stored.replies_count == 2
+      assert stored.replies_failures == 1
+    end
+
+    test "the count reaches every open page like the other two figures" do
+      {post, _user} = followed_post()
+      others = post.object_uri <> "/replies?only_other_accounts=true&page=true"
+
+      serve(%{
+        post.object_uri => object(post, %{"replies" => replies_collection(post, [], others)}),
+        others => page(["https://a.example/1"])
+      })
+
+      Fediverse.subscribe_counts()
+      assert :updated = Fediverse.refresh_counts(post)
+
+      assert_received {:fediverse_counts, :remote_post, _id, %{replies: 1, likes: 28}}
+    end
+  end
+
+  describe "an origin that serves no figures at all" do
+    # flipboard.com, 19 % of everything this installation caches: `likes`,
+    # `shares` and `replies` are all absent, and 0 of its 1.478 stored posts
+    # had ever carried a figure — while it held 1.026 of the 2.627 objects on
+    # the ladder.
+    test "leaves the ladder after one ask, without taking a strike" do
+      {post, _user} = followed_post()
+      serve(%{post.object_uri => object(post) |> Map.drop(["likes", "shares"])})
+
+      assert :unchanged = Fediverse.refresh_counts(post)
+
+      stored = Repo.get!(RemotePost, post.id)
+      assert stored.counts_absent
+      # Not a failure: the server answered, and answered correctly.
+      assert stored.counts_failures == 0
+      refute stored.id in Enum.map(Fediverse.due_for_counts(50), & &1.id)
+    end
+
+    test "an origin serving one of the three stays on the ladder" do
+      {post, _user} = followed_post()
+      serve(%{post.object_uri => object(post) |> Map.drop(["shares"])})
+
+      assert :updated = Fediverse.refresh_counts(post)
+      refute Repo.get!(RemotePost, post.id).counts_absent
+    end
+  end
+
+  describe "reading the answers" do
+    # One answer on some third server, with the actor document a card needs in
+    # order to name who wrote it. Neither host is ours and neither is the
+    # origin's, which is the ordinary case: a thread of 60 answers on
+    # mastodon.social listed authors on nine other hosts.
+    defp answer(host, parent, text) do
+      actor = "https://#{host}/users/somebody"
+      uri = "https://#{host}/notes/#{System.unique_integer([:positive])}"
+
+      {uri,
+       %{
+         uri => %{
+           "id" => uri,
+           "type" => "Note",
+           "attributedTo" => actor,
+           "content" => "<p>#{text}</p>",
+           "inReplyTo" => parent.object_uri,
+           "to" => ["https://www.w3.org/ns/activitystreams#Public"],
+           "published" => "2026-09-06T12:00:00Z"
+         },
+         actor => %{
+           "id" => actor,
+           "type" => "Person",
+           "inbox" => actor <> "/inbox",
+           "preferredUsername" => "somebody",
+           "name" => "Somebody"
+         }
+       }}
+    end
+
+    defp thread(post, answers) do
+      others = post.object_uri <> "/replies?only_other_accounts=true&page=true"
+      {uris, docs} = Enum.unzip(answers)
+
+      routes =
+        Enum.reduce(docs, %{}, &Map.merge(&2, &1))
+        |> Map.merge(%{
+          post.object_uri => object(post, %{"replies" => replies_collection(post, [], others)}),
+          others => page(uris)
+        })
+
+      {uris, routes}
+    end
+
+    test "fetches the answers and keeps each one as thread context" do
+      {post, user} = followed_post()
+
+      {[first, second], routes} =
+        thread(post, [
+          answer("a.example", post, "Nimm Mint."),
+          answer("b.example", post, "Oder Fedora.")
+        ])
+
+      serve(routes)
+
+      assert {:ok, %{replies: [one, two], pending: []}} =
+               Fediverse.fetch_thread_replies(user, post)
+
+      assert one.object_uri == first
+      assert two.object_uri == second
+      assert one.content_text == "Nimm Mint."
+      # Stored as ordinary cached posts, which is what gives them a card and an
+      # action bar — and flagged, which is what keeps them off the listings.
+      assert Repo.get_by!(RemotePost, object_uri: first).thread_context
+      assert one.remote_account.handle == "somebody"
+    end
+
+    test "an answer already stored costs no request at all" do
+      {post, user} = followed_post()
+      {[uri], routes} = thread(post, [answer("a.example", post, "Nimm Mint.")])
+
+      serve(routes)
+      assert {:ok, %{replies: [_one]}} = Fediverse.fetch_thread_replies(user, post)
+
+      serve(routes, seen: self())
+      assert {:ok, %{replies: [one]}} = Fediverse.fetch_thread_replies(user, post)
+      assert one.object_uri == uri
+
+      # The collection is walked again (the thread may have grown), the answer
+      # itself is not re-fetched.
+      refute_received {:asked, ^uri}
+    end
+
+    test "the leftovers are handed back so a second press walks nothing again" do
+      {post, user} = followed_post()
+
+      answers = for n <- 1..12, do: answer("a.example", post, "Antwort #{n}")
+      {uris, routes} = thread(post, answers)
+      serve(routes)
+
+      assert {:ok, %{replies: first_ten, pending: pending}} =
+               Fediverse.fetch_thread_replies(user, post)
+
+      assert length(first_ten) == 10
+      assert length(pending) == 2
+
+      assert {:ok, %{replies: rest, pending: []}} =
+               Fediverse.fetch_thread_replies(user, post, pending: pending)
+
+      assert Enum.map(rest, & &1.object_uri) == Enum.take(uris, -2)
+    end
+
+    test "an origin that serves no replies collection says so instead of guessing" do
+      {post, user} = followed_post()
+      serve(%{post.object_uri => object(post)})
+
+      assert {:error, :unavailable} = Fediverse.fetch_thread_replies(user, post)
+    end
+
+    test "the hourly budget refuses rather than letting one member walk the fediverse" do
+      {post, user} = followed_post()
+      {_uris, routes} = thread(post, [answer("a.example", post, "Nimm Mint.")])
+      serve(routes)
+
+      Application.put_env(:vutuv, :fediverse_thread_fetch_limit, 1)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_thread_fetch_limit) end)
+
+      assert {:ok, _first} = Fediverse.fetch_thread_replies(user, post)
+      assert {:error, :capped} = Fediverse.fetch_thread_replies(user, post)
+    end
+
+    test "the stored half paints without asking anybody" do
+      {post, user} = followed_post()
+      {_uris, routes} = thread(post, [answer("a.example", post, "Nimm Mint.")])
+      serve(routes)
+      assert {:ok, _fetched} = Fediverse.fetch_thread_replies(user, post)
+
+      serve(%{}, seen: self())
+      assert [one] = Fediverse.stored_thread_replies(post, user)
+      assert one.content_text == "Nimm Mint."
+      refute_received {:asked, _url}
+    end
+  end
+
+  describe "an answer is not feed material" do
+    # An answer stored the way a press stores one, by an author this member
+    # follows — the case where the flag is the only thing between a thread
+    # answer and somebody's feed.
+    defp stored_answer(post, acc) do
+      now = DateTime.utc_now(:second)
+
+      Repo.insert!(%RemotePost{
+        remote_account_id: acc.id,
+        object_uri: "https://#{acc.host}/notes/#{System.unique_integer([:positive])}",
+        in_reply_to_uri: post.object_uri,
+        content_text: "Nimm Mint.",
+        audience: "public",
+        kind: "note",
+        published_at: now,
+        received_at: now,
+        expires_at: DateTime.add(now, 86_400),
+        thread_context: true
+      })
+    end
+
+    # The feed hands its rows back as entries, whose ids carry the source's own
+    # prefix. Read through one helper so the two halves of the calibration
+    # below cannot compare different things.
+    defp feed_ids(user) do
+      user
+      |> Fediverse.feed_remote_posts(20, nil, shape: :posts)
+      |> Enum.map(& &1.remote_post.id)
+    end
+
+    test "a followed author's answer stays out of the feed" do
+      {post, user} = followed_post()
+      answering = account("a.example")
+      follow(user, answering)
+      answer = stored_answer(post, answering)
+
+      refute answer.id in feed_ids(user)
+      # Calibration: the very same row without the flag is feed material, so
+      # this test fails if the flag stops being read.
+      Repo.update_all(from(p in RemotePost, where: p.id == ^answer.id),
+        set: [thread_context: false]
+      )
+
+      assert answer.id in feed_ids(user)
+    end
+
+    test "and off its author's account page" do
+      {post, user} = followed_post()
+      answering = account("a.example")
+      follow(user, answering)
+      stored_answer(post, answering)
+
+      assert {[], false} = Fediverse.account_posts(answering, user)
+    end
+
+    # The remaining surfaces that list an account's posts. They are here as one
+    # test rather than four because the risk they share is a fifth being added
+    # without the scope — `RemotePost.timeline_scope/1` is the seam, and this is
+    # the list of everything that has to go through it.
+    test "and off the page feed, the federated timeline and the tag page" do
+      {post, user} = followed_post()
+      answering = account("a.example")
+      follow(user, answering)
+      answer = stored_answer(post, answering)
+
+      page = insert(:organization)
+
+      Repo.insert!(%Follow{
+        organization_id: page.id,
+        remote_account_id: answering.id,
+        state: "accepted",
+        follow_activity_id: "https://vutuv.test/#{page.id}/actor#f/#{answering.id}"
+      })
+
+      page_ids = page |> Fediverse.organization_feed_remote_posts(20, nil) |> Enum.map(& &1.id)
+      refute answer.id in page_ids
+
+      federated = Fediverse.recent_public_remote_posts(limit: 50)
+      refute answer.id in Enum.map(federated, & &1.id)
+
+      # A tag page reaches its posts through the hashtag join, which a thread
+      # answer never enters — and the query narrows by the flag as well, since
+      # this one is a public page.
+      tag = insert(:tag)
+      Repo.insert!(%RemotePostTag{remote_post_id: answer.id, tag_id: tag.id})
+
+      tagged = tag |> Timeline.remote_posts_query() |> Repo.all()
+      refute answer.id in Enum.map(tagged, & &1.id)
+
+      # And it is not counted as one of the account's recent posts in the feed's
+      # server bar, which orders the accounts by how busy they have been.
+      servers = FeedBand.servers(user)
+      assert Enum.find(servers, &(&1.host == "a.example")).posts == 0
+    end
+  end
+
+  describe "retention" do
+    test "an answer lives as long as the post it answers" do
+      {post, _user} = followed_post()
+      answer = stored_answer(post, account("a.example"))
+
+      # Nobody follows the answer's author, which is the normal case for an
+      # answer and exactly what this purge deletes.
+      Fediverse.purge_unfollowed_remote_posts()
+      assert Repo.get(RemotePost, answer.id)
+
+      # The post it hangs under goes, and it goes with it.
+      Repo.delete!(post)
+      Fediverse.purge_unfollowed_remote_posts()
+      refute Repo.get(RemotePost, answer.id)
+    end
+  end
+end

--- a/test/vutuv_web/live/fediverse_post_live_test.exs
+++ b/test/vutuv_web/live/fediverse_post_live_test.exs
@@ -200,7 +200,10 @@ defmodule VutuvWeb.FediversePostLiveTest do
       Phoenix.PubSub.broadcast(
         Vutuv.PubSub,
         Vutuv.Fediverse.counts_topic(),
-        {:fediverse_counts, :remote_post, post.id, %{likes: 40, shares: 5}}
+        # The whole map `Vutuv.Fediverse.counts/1` broadcasts, answer count
+        # included: the bar reads all three, and a hand-built two-key map here
+        # would only prove that this test knows less than the sender.
+        {:fediverse_counts, :remote_post, post.id, %{likes: 40, shares: 5, replies: nil}}
       )
 
       # The hook forwards with `send_update/2`, which LiveView applies on the

--- a/test/vutuv_web/live/thread_replies_live_test.exs
+++ b/test/vutuv_web/live/thread_replies_live_test.exs
@@ -1,0 +1,212 @@
+defmodule VutuvWeb.ThreadRepliesLiveTest do
+  @moduledoc """
+  Pressing the answer figure on a card from another network, on the page that
+  card links to.
+
+  The control is two targets in one slot — a glyph that leads to the answering
+  page, a figure that unfolds the thread — and the reason it is built that way
+  is what these tests pin: the number is the button, and the two are far enough
+  apart to hit separately.
+
+  `async: false` — the fetch behind the press goes through the global
+  `:fediverse_req_options` stub, and the hourly budget lives in the shared
+  `Vutuv.RateLimiter` table, which the SQL sandbox does not roll back.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    # Nothing in these tests wants a real request; a press with no stub would
+    # make one. An empty routing table answers 404 to everything, which is what
+    # the "could not be fetched" path is.
+    stub(%{})
+    :ok
+  end
+
+  defp stub(routes) do
+    Application.put_env(:vutuv, :fediverse_req_options,
+      plug: fn conn ->
+        url = "https://#{conn.host}#{conn.request_path}"
+
+        case Map.fetch(routes, url) do
+          {:ok, doc} ->
+            conn
+            |> Plug.Conn.put_resp_content_type("application/activity+json")
+            |> Plug.Conn.send_resp(200, Jason.encode!(doc))
+
+          :error ->
+            Plug.Conn.send_resp(conn, 404, "")
+        end
+      end
+    )
+
+    on_exit(fn -> Application.delete_env(:vutuv, :fediverse_req_options) end)
+  end
+
+  defp account(host \\ "ard.social", handle \\ "tagesschau") do
+    uri = "https://#{host}/users/#{handle}"
+
+    Repo.insert!(%RemoteAccount{
+      actor_uri: uri,
+      host: host,
+      handle: handle,
+      name: handle,
+      inbox_uri: uri <> "/inbox"
+    })
+  end
+
+  defp follow(user, account) do
+    Repo.insert!(%Follow{
+      user_id: user.id,
+      remote_account_id: account.id,
+      state: "accepted",
+      follow_activity_id: "https://vutuv.test/#{user.id}/actor#follows/#{account.id}"
+    })
+  end
+
+  defp cached_post(account, attrs \\ %{}) do
+    now = DateTime.utc_now(:second)
+
+    Repo.insert!(
+      struct(
+        %RemotePost{
+          remote_account_id: account.id,
+          object_uri: "https://#{account.host}/posts/#{System.unique_integer([:positive])}",
+          content_text: "Welche Distro soll ich nehmen?",
+          audience: "public",
+          kind: "note",
+          published_at: now,
+          received_at: now,
+          expires_at: DateTime.add(now, 86_400)
+        },
+        attrs
+      )
+    )
+  end
+
+  defp stored_answer(post, text) do
+    now = DateTime.utc_now(:second)
+
+    Repo.insert!(%RemotePost{
+      remote_account_id:
+        account("chaos.social", "somebody#{System.unique_integer([:positive])}").id,
+      object_uri: "https://chaos.social/notes/#{System.unique_integer([:positive])}",
+      in_reply_to_uri: post.object_uri,
+      content_text: text,
+      audience: "public",
+      kind: "note",
+      published_at: now,
+      received_at: now,
+      expires_at: DateTime.add(now, 86_400),
+      thread_context: true
+    })
+  end
+
+  # Logged in and reading in German, which is the language this site is
+  # actually read in: `ConnTest` defaults to English, so a label asserted
+  # without this header proves nothing about what a real visitor sees. The
+  # header rides along from here because `recycle/1` carries `accept-language`
+  # into every following request of the same conn.
+  defp login_de(conn) do
+    conn
+    |> Plug.Conn.put_req_header("accept-language", "de-DE,de;q=0.9")
+    |> create_and_login_user()
+  end
+
+  defp open_page(conn, post) do
+    live(conn, ~p"/system/fediverse/post/#{post.id}")
+  end
+
+  test "the figure is a button of its own beside the answering glyph", %{conn: conn} do
+    {conn, _user} = login_de(conn)
+    post = cached_post(account(), %{replies_count: 7})
+
+    {:ok, view, html} = open_page(conn, post)
+
+    assert has_element?(view, ~s{[data-remote-replies="#{post.id}"]})
+    assert has_element?(view, ~s{[data-remote-reply-link="#{post.id}"]})
+    # The reader is told what the number means before they press it.
+    assert html =~ "Die 7 Antworten anzeigen"
+  end
+
+  test "no figure where the origin never told us of any answer", %{conn: conn} do
+    {conn, _user} = login_de(conn)
+    post = cached_post(account())
+
+    {:ok, view, _html} = open_page(conn, post)
+
+    # The glyph stays — answering is always offered — and the figure does not
+    # appear as a `0` we would be inventing.
+    assert has_element?(view, ~s{[data-remote-reply-link="#{post.id}"]})
+    refute has_element?(view, ~s{[data-remote-replies="#{post.id}"]})
+  end
+
+  test "pressing it unfolds what we already hold, without asking anybody", %{conn: conn} do
+    {conn, user} = login_de(conn)
+    acc = account()
+    follow(user, acc)
+    post = cached_post(acc, %{replies_count: 1})
+    stored_answer(post, "Nimm Mint.")
+
+    {:ok, view, _html} = open_page(conn, post)
+    refute has_element?(view, "[data-thread-replies]")
+
+    html = view |> element(~s{[data-remote-replies="#{post.id}"]}) |> render_click()
+
+    assert html =~ "Nimm Mint."
+    assert has_element?(view, "[data-thread-replies]")
+  end
+
+  test "a second press folds the thread again", %{conn: conn} do
+    {conn, user} = login_de(conn)
+    acc = account()
+    follow(user, acc)
+    post = cached_post(acc, %{replies_count: 1})
+    stored_answer(post, "Nimm Mint.")
+
+    {:ok, view, _html} = open_page(conn, post)
+    view |> element(~s{[data-remote-replies="#{post.id}"]}) |> render_click()
+    render_async(view)
+    assert has_element?(view, "[data-thread-replies]")
+
+    view |> element(~s{[data-remote-replies="#{post.id}"]}) |> render_click()
+    refute has_element?(view, "[data-thread-replies]")
+  end
+
+  test "an unreachable origin says so instead of leaving an empty box", %{conn: conn} do
+    {conn, user} = login_de(conn)
+    acc = account()
+    follow(user, acc)
+    post = cached_post(acc, %{replies_count: 3})
+
+    {:ok, view, _html} = open_page(conn, post)
+    view |> element(~s{[data-remote-replies="#{post.id}"]}) |> render_click()
+
+    assert render_async(view) =~ "Die Antworten ließen sich nicht"
+  end
+
+  test "an answer inside the thread offers no thread of its own", %{conn: conn} do
+    {conn, user} = login_de(conn)
+    acc = account()
+    follow(user, acc)
+    post = cached_post(acc, %{replies_count: 1})
+    answer = stored_answer(post, "Nimm Mint.")
+
+    # The answer has answers of its own out there, and its card still says so —
+    # it just cannot be pressed, or a thread would nest inside a thread.
+    Repo.update_all(from(p in RemotePost, where: p.id == ^answer.id), set: [replies_count: 4])
+
+    {:ok, view, _html} = open_page(conn, post)
+    view |> element(~s{[data-remote-replies="#{post.id}"]}) |> render_click()
+    html = render_async(view)
+
+    assert html =~ "Nimm Mint."
+    refute has_element?(view, ~s{[data-remote-replies="#{answer.id}"]})
+  end
+end


### PR DESCRIPTION
A card from another network showed nothing beside its reply arrow, while a discussion was running under the post out there. Now the origin's own answer count sits there, and pressing that number unfolds the answers under the card.

The figure has to be counted, not read: of forty objects from our own cache, **not one** server serves a `totalItems` on `replies`. Walking the collection matches Mastodon's own `replies_count` (121/121, 51/51, 6/6, 2/2 on real threads). It rides the existing like/repost ask on a flatter ladder, so a count costs one page fetch.

It pays for itself by dropping origins that serve no figures at all: flipboard.com held 1.026 of the 2.627 objects on the ladder and had never answered with a figure, while 2.511 of them were overdue.

A fetched answer is stored as an ordinary cached post (card, action bar, report, retention) and carries `thread_context`, which keeps it off the six surfaces that list an account's posts — without it, answers would appear retroactively in people's feeds.

Where to look: `/system/fediverse/post/:id`, `Vutuv.Fediverse.collect_reply_pages/4`, `RemotePost.timeline_scope/1`.

https://claude.ai/code/session_01EEa5XkVDWgoYuN7uMSU7uy