### PR TITLE
Only a copyright notice hides a profile picture

### DIFF
--- a/docs/architecture/moderation.md
+++ b/docs/architecture/moderation.md
@@ -82,6 +82,8 @@ shown publicly.
 Reporters with a bad track record lose the instant freeze (their reports only
 flag for review), whole profiles freeze only on a **second** independent trusted
 report, and `/admin/moderation/reporters` shows every reporter's track record.
+A **picture** is the one type where the category decides instead of the reporter
+— see "Only a copyright notice hides a picture" below.
 
 **Spam auto-defense:** distinct **spam-category** reports also freeze a whole
 profile pending admin review once enough pile up (`@spam_freeze_reporters`, 5),
@@ -166,13 +168,52 @@ auto-defense counts it.
 refuses the upsert and the profile form says why, because one row per member
 per kind means a replacement would move the open case onto bytes nobody
 reported. `frozen_at` is deliberately **not** in that upsert's replace list for
-the same reason.
+the same reason. The refusal reads `frozen_at`, so it is about the **hold** and
+not about the case: a picture a house-rule report only flagged can be replaced,
+and that replacement overwrites the reported bytes, so
+`Vutuv.Accounts.store_new_image/7` settles the open case as `resolved_deleted`
+(the same outcome the owner's own "remove it" reaches). Otherwise an admin's
+ruling — which for a picture is the one ruling that *deletes* — would land on
+whatever the member put there afterwards.
+
+### Only a copyright notice hides a picture (issue #2030)
+
+The picture freeze first shipped on the ordinary trust ladder, and that was the
+wrong dial: `trusted_reporter?/1` says yes to an account created a minute ago,
+because nothing of theirs has been rejected yet. So a throwaway account took any
+member's avatar off every surface with its first ever report, and the owner then
+could not replace it. `Vutuv.Moderation.initial_status/3` now gives `%Image{}`
+its own clause, split by **category**:
+
+* **`copyright`** keeps the instant reach on the ordinary trust rule. It is the
+  legal notice the machinery exists for, `Report.changeset/3` already refuses it
+  without a written explanation and a good-faith declaration, and taking the
+  picture down promptly is the point.
+* **`family` / `bullying` / `other`** — none of which requires so much as a note
+  — open a `flagged` case and mail every admin (`:notify_admins_urgent`), leaving
+  the picture where it is. That is exactly what a report against a whole profile
+  already does, and a `flagged` case is in the admin queue by definition
+  (`@queue_statuses`).
+
+`maybe_upgrade_case/4` carries the same split on the other way in, so a second
+house-rule report does not hide the picture either — two throwaway accounts are
+barely more work than one — while a copyright notice joining an already-flagged
+case freezes it on arrival. The owner is **not** notified for a flagged case, as
+for every other flag-only case: nothing of theirs moved.
+
+Two surfaces say which case they are in. The reporter's flash reads "our
+moderators have been notified and will review this picture" when nothing was
+hidden (the profile-report wording, which exists so a report that visibly
+changes nothing does not feel inert) and the ordinary "we take it from here"
+when the picture went offline. The admin case page reads the row's `frozen_at`
+and either promises that rejecting puts every file back, or says the picture is
+still on the profile — an admin ruling without knowing which is ruling blind.
 
 **The reported picture is only visible on the case pages.** `GET
 /moderation/cases/:id/image` authorizes owner-or-admin and streams the held
-copy (or the still-served one, when an untrusted reporter only flagged the
-picture); both the owner's case page and the admin's render it from that one
-route. Without it an admin could not see what a copyright claim is about.
+copy (or the still-served one, whenever a report only flagged the picture);
+both the owner's case page and the admin's render it from that one route.
+Without it an admin could not see what a copyright claim is about.
 
 ## The statement of reasons (issue #2010)
 

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -2263,8 +2263,16 @@ defmodule Vutuv.Accounts do
            crop_field => crop,
            moderation_field(field) => moderation
          },
-         {:ok, saved} <- store_image_pair(user, kind, image_attrs, user_attrs) do
+         {:ok, {saved, image}} <- store_image_pair(user, kind, image_attrs, user_attrs) do
       ImageScans.enqueue(kind, saved.id, saved.id, fingerprint)
+
+      # A picture whose case only flagged it may be replaced (the guard above is
+      # about the takedown hold, and a flagged case moved nothing), and this
+      # upload has just overwritten the very bytes that were reported. So the
+      # replacement settles the case the way the owner's own "remove it" does:
+      # left open, an admin's ruling — which for a picture is the one ruling that
+      # *deletes* — would land on whatever the member put there afterwards.
+      Moderation.content_deleted(image)
       saved
     else
       _ ->
@@ -2275,13 +2283,15 @@ defmodule Vutuv.Accounts do
 
   # The image row and the member row, or neither. The row goes first so the
   # member row can point at it in the one UPDATE; the transaction is what makes
-  # that order safe.
+  # that order safe. Both come back out: the caller settles an open case on the
+  # picture row this upload just overwrote, and re-reading it would be a fourth
+  # read of one row in the same request.
   defp store_image_pair(user, kind, image_attrs, user_attrs) do
     Repo.transaction(fn ->
       with {:ok, image} <- Images.put_profile_image(user, kind, image_attrs),
            attrs = Map.put(user_attrs, Images.pointer_field(kind), image.id),
            {:ok, saved} <- user |> Ecto.Changeset.change(attrs) |> Repo.update() do
-        saved
+        {saved, image}
       else
         {:error, reason} -> Repo.rollback(reason)
       end

--- a/lib/vutuv/moderation.ex
+++ b/lib/vutuv/moderation.ex
@@ -22,6 +22,12 @@ defmodule Vutuv.Moderation do
   profiles are never frozen by a single report — that takes a second,
   independent trusted reporter.
 
+  A **picture** is the one type where the category decides instead of the
+  reporter (issue #2030): only a copyright notice takes it offline, house-rule
+  complaints put it in front of an admin with the picture left where it is.
+  Trust would decide nothing here, because a minutes-old account counts as
+  trusted until a report of theirs has been rejected.
+
   Admin rulings: `uphold_case/2` confirms the violation and strikes the owner
   (warn → one-week suspension → permanent deactivation, strikes expire after
   a year); `reject_case/3` unfreezes and optionally marks reports as abusive,
@@ -164,7 +170,13 @@ defmodule Vutuv.Moderation do
     report_changeset =
       Report.changeset(%Report{reporter_id: reporter.id}, attrs, content_type(content))
 
-    {status, effects} = initial_status(reporter, content)
+    # Read off the changeset rather than out of `attrs`, so the answer does not
+    # depend on whether the caller passed string or atom keys. A crafted
+    # category buys nothing: the freeze runs only after the report insert
+    # commits, and `Report.changeset/3` refuses a copyright notice without its
+    # explanation and good-faith declaration.
+    category = Ecto.Changeset.get_field(report_changeset, :category)
+    {status, effects} = initial_status(reporter, content, category)
 
     case_changeset =
       %Case{
@@ -177,7 +189,7 @@ defmodule Vutuv.Moderation do
 
     case insert_case_with_report(case_changeset, report_changeset) do
       {:ok, case_record} ->
-        finish_new_case(case_record, reporter, content, attrs, effects)
+        finish_new_case(case_record, reporter, content, category, effects)
 
       # Lost the race: a concurrent first-report already opened the case, so join
       # it instead of 500ing the losing reporter (the conflict means the winner
@@ -213,8 +225,8 @@ defmodule Vutuv.Moderation do
     end
   end
 
-  defp finish_new_case(case_record, reporter, content, attrs, effects) do
-    log(case_record, reporter, "report_filed", %{"category" => attrs["category"]})
+  defp finish_new_case(case_record, reporter, content, category, effects) do
+    log(case_record, reporter, "report_filed", %{"category" => category})
 
     if :freeze in effects do
       freeze_content(content)
@@ -238,9 +250,9 @@ defmodule Vutuv.Moderation do
       )
 
     case Repo.insert(report_changeset) do
-      {:ok, _report} ->
-        log(open, reporter, "report_filed", %{"category" => attrs["category"]})
-        result = maybe_upgrade_case(open, reporter, content)
+      {:ok, report} ->
+        log(open, reporter, "report_filed", %{"category" => report.category})
+        result = maybe_upgrade_case(open, reporter, content, report.category)
         sever_relationship(open, reporter)
         result
 
@@ -259,7 +271,8 @@ defmodule Vutuv.Moderation do
   def maybe_upgrade_case(
         %Case{content_type: type, status: "flagged"} = open,
         _reporter,
-        content
+        content,
+        _category
       )
       when type in ["user", "organization"] do
     reports = Repo.preload(open, :reports).reports
@@ -282,15 +295,20 @@ defmodule Vutuv.Moderation do
     end
   end
 
-  def maybe_upgrade_case(%Case{status: "flagged"} = open, reporter, content) do
-    if trusted_reporter?(reporter) do
+  def maybe_upgrade_case(
+        %Case{content_type: type, status: "flagged"} = open,
+        reporter,
+        content,
+        category
+      ) do
+    if report_freezes?(type, category) and trusted_reporter?(reporter) do
       do_flagged_upgrade(open, content, "pending_owner", [:notify_owner_frozen])
     else
       {:ok, open}
     end
   end
 
-  def maybe_upgrade_case(open, _reporter, _content), do: {:ok, open}
+  def maybe_upgrade_case(open, _reporter, _content, _category), do: {:ok, open}
 
   defp do_flagged_upgrade(open, content, new_status, effects) do
     case claim_flagged_upgrade(open, new_status) do
@@ -326,21 +344,42 @@ defmodule Vutuv.Moderation do
     end
   end
 
-  # The initial case status plus the side effects it implies.
-  defp initial_status(_reporter, %User{}) do
-    # Whole profiles are the nuclear option: the first report never freezes,
-    # it lands in the admin queue marked urgent. See maybe_upgrade_case/3.
-    {"flagged", [:notify_admins_urgent]}
+  # The initial case status plus the side effects it implies. What a report can
+  # never hide lands in the admin queue marked urgent instead.
+  defp initial_status(reporter, content, category) do
+    if report_freezes?(content_type(content), category) do
+      trust_based_status(reporter, content)
+    else
+      {"flagged", [:notify_admins_urgent]}
+    end
   end
 
-  # An organization page is profile-style: a first report never freezes a verified
-  # business page, it goes to the admin queue; a second trusted reporter (or the
-  # spam threshold) freezes it in maybe_upgrade_case/3.
-  defp initial_status(_reporter, %Organization{}) do
-    {"flagged", [:notify_admins_urgent]}
-  end
+  # Whether a report of this category against this content type may take it
+  # offline at all — asked once here and once in `maybe_upgrade_case/4`, so the
+  # two ways into a freeze cannot answer it differently. It says *may*: a report
+  # that passes here still has to come from a reporter in good standing.
+  #
+  # Whole profiles are the nuclear option, so the first report never freezes one;
+  # that takes a second trusted reporter (or the spam threshold) in
+  # `maybe_upgrade_case/4`. An organization page is profile-style for the same
+  # reason.
+  defp report_freezes?(type, _category) when type in ["user", "organization"], do: false
 
-  defp initial_status(reporter, content) do
+  # A picture is the third thing a single report does not hide, and here the
+  # category decides rather than the reporter (issue #2030). `trusted_reporter?/1`
+  # trusts an account created a minute ago — nothing of theirs has been rejected
+  # yet — so before this split one throwaway account took any member's avatar off
+  # every surface with its first ever report, and two of them would have done it
+  # through the upgrade path. A copyright notice keeps the instant reach: it is
+  # the legal claim the machinery was built for and the only category that
+  # already demands a written explanation and a good-faith declaration. A
+  # house-rule complaint goes in front of an admin instead, with the picture left
+  # where it is, exactly as a report against a whole profile does.
+  defp report_freezes?("image", category), do: Report.copyright?(category)
+
+  defp report_freezes?(_type, _category), do: true
+
+  defp trust_based_status(reporter, content) do
     cond do
       previously_self_resolved?(content) ->
         # The owner already used their one self-service round on this content;

--- a/lib/vutuv_web/controllers/report_controller.ex
+++ b/lib/vutuv_web/controllers/report_controller.ex
@@ -133,14 +133,7 @@ defmodule VutuvWeb.ReportController do
   # if the report turns out unfounded. (The same explanation lands in their
   # notifications feed, which outlives the flash.)
   defp report_received_flash(case_record, reporter) do
-    base =
-      if case_record.content_type == "user" do
-        gettext(
-          "Thank you for your report. Our moderators have been notified and will review this account."
-        )
-      else
-        gettext("Thank you for your report. We take it from here.")
-      end
+    base = report_received_sentence(case_record)
 
     if Moderation.severed_for?(case_record.id, reporter.id) do
       base <>
@@ -151,6 +144,26 @@ defmodule VutuvWeb.ReportController do
     else
       base
     end
+  end
+
+  # A report that visibly changes nothing has to say so, or it feels inert. That
+  # is a whole profile, and since issue #2030 also a picture reported under the
+  # house rules: only a copyright notice takes a picture offline on the spot, so
+  # a "flagged" picture case is one where nothing moved.
+  defp report_received_sentence(%{content_type: "user"}) do
+    gettext(
+      "Thank you for your report. Our moderators have been notified and will review this account."
+    )
+  end
+
+  defp report_received_sentence(%{content_type: "image", status: "flagged"}) do
+    gettext(
+      "Thank you for your report. Our moderators have been notified and will review this picture."
+    )
+  end
+
+  defp report_received_sentence(_case_record) do
+    gettext("Thank you for your report. We take it from here.")
   end
 
   # A short quote of what is being reported, so the reporter can double-check

--- a/lib/vutuv_web/live/admin/moderation_case_live.ex
+++ b/lib/vutuv_web/live/admin/moderation_case_live.ex
@@ -235,10 +235,20 @@ defmodule VutuvWeb.Admin.ModerationCaseLive do
             alt={@case.content_snapshot}
             class="mt-1 max-h-[480px]"
           />
+          <%!-- Whether the picture is still on the profile decides what the two
+                rulings do, and an admin has to know which case they are in:
+                only a copyright notice takes one offline before a ruling
+                (issue #2030). Read off the row's own column. --%>
           <p class="mt-1 text-xs text-slate-600 dark:text-slate-400">
-            {gettext(
-              "Upholding the case deletes it, the private original included. Rejecting it puts every file back where it was."
-            )}
+            {if @content.frozen_at,
+              do:
+                gettext(
+                  "Upholding the case deletes it, the private original included. Rejecting it puts every file back where it was."
+                ),
+              else:
+                gettext(
+                  "This picture is still on the profile: only a copyright notice takes one offline before a ruling. Upholding the case deletes it, the private original included."
+                )}
           </p>
         </div>
 

--- a/lib/vutuv_web/templates/report/new.html.heex
+++ b/lib/vutuv_web/templates/report/new.html.heex
@@ -3,15 +3,37 @@
     <h1 class="text-xl font-bold text-slate-900 dark:text-white">
       {gettext("Report this content")}
     </h1>
-    <p :if={is_nil(@severed_owner)} class="mt-1 text-sm text-slate-600 dark:text-slate-400">
-      {gettext(
-        "Your report is anonymous. If it checks out, the content is hidden right away and the owner is asked to fix it."
-      )}
+    <%!-- A picture is the one type where the promise below is not true of every
+          category: only a copyright notice takes one offline on the spot, the
+          house-rule complaints go to an admin with the picture left in place
+          (issue #2030). The reveal machinery further down cannot help — it keys
+          on the copyright radio inside the form, and this sentence stands above
+          it — so the picture form says both halves up front. --%>
+    <p
+      :if={is_nil(@severed_owner)}
+      id="report-intro"
+      class="mt-1 text-sm text-slate-600 dark:text-slate-400"
+    >
+      <%= if @content_type == "image" do %>
+        {gettext(
+          "Your report is anonymous. A picture goes offline right away for a copyright notice; every other report goes to our admins with the picture left where it is."
+        )}
+      <% else %>
+        {gettext(
+          "Your report is anonymous. If it checks out, the content is hidden right away and the owner is asked to fix it."
+        )}
+      <% end %>
     </p>
-    <p :if={@severed_owner} class="mt-1 text-sm text-slate-600 dark:text-slate-400">
-      {gettext(
-        "If your report checks out, the content is hidden right away and the owner is asked to fix it."
-      )}
+    <p :if={@severed_owner} id="report-intro" class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+      <%= if @content_type == "image" do %>
+        {gettext(
+          "A picture goes offline right away for a copyright notice; every other report goes to our admins with the picture left where it is."
+        )}
+      <% else %>
+        {gettext(
+          "If your report checks out, the content is hidden right away and the owner is asked to fix it."
+        )}
+      <% end %>
     </p>
 
     <%!-- The reporter is tied to the owner: spell out the separation, the

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -123,7 +123,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:113
-#: lib/vutuv_web/templates/report/new.html.heex:164
+#: lib/vutuv_web/templates/report/new.html.heex:186
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:255
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
@@ -2011,7 +2011,7 @@ msgstr "Titelbild ändern"
 msgid "Change cover photo"
 msgstr "Titelbild ändern"
 
-#: lib/vutuv_web/controllers/report_controller.ex:169
+#: lib/vutuv_web/controllers/report_controller.ex:182
 #: lib/vutuv_web/templates/user/edit.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
@@ -2925,7 +2925,7 @@ msgstr[0] "%{formatted} Fall wartet auf eine Entscheidung."
 msgstr[1] "%{formatted} Fälle warten auf eine Entscheidung."
 
 #: lib/vutuv_web/live/admin/job_live.ex:335
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:284
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:294
 #: lib/vutuv_web/templates/moderation_evidence/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "(deleted account)"
@@ -2962,7 +2962,7 @@ msgstr "Ein Admin hat die Meldung bestätigt. Der Inhalt bleibt verborgen."
 msgid "An admin dismissed the report. The content is visible again."
 msgstr "Ein Admin hat die Meldung verworfen. Der Inhalt ist wieder sichtbar."
 
-#: lib/vutuv_web/templates/report/new.html.heex:115
+#: lib/vutuv_web/templates/report/new.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "Anything our admins should know? (optional)"
 msgstr "Gibt es etwas, das unsere Admins wissen sollten? (optional)"
@@ -2990,7 +2990,7 @@ msgstr ""
 "einwöchige Sperre, dann die endgültige Deaktivierung. Verwarnungspunkte "
 "verfallen nach zwölf Monaten."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:270
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Conversation context (the reported message last)"
 msgstr "Gesprächskontext (die gemeldete Nachricht zuletzt)"
@@ -3003,7 +3003,7 @@ msgstr ""
 "wiederholt unerwünschte Nachrichten führen zur Sperrung des Kontos, in "
 "öffentlichen Beiträgen genauso wie in privaten Nachrichten."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:262
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Current version (edited since the report)"
 msgstr "Aktuelle Version (seit der Meldung bearbeitet)"
@@ -3176,7 +3176,7 @@ msgstr "Eröffnet"
 msgid "Owner"
 msgstr "Besitzer"
 
-#: lib/vutuv_web/templates/report/new.html.heex:152
+#: lib/vutuv_web/templates/report/new.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Please report honestly. Reporting to harm someone breaks our"
 msgstr ""
@@ -3197,7 +3197,7 @@ msgstr "Private Nachricht"
 msgid "Profile"
 msgstr "Profil"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:396
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "Reject the report"
 msgstr "Meldung ablehnen"
@@ -3288,7 +3288,7 @@ msgstr "Melder"
 msgid "Reporter track records"
 msgstr "Melder-Bilanz"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:294
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:304
 #: lib/vutuv_web/live/admin/moderation_live.ex:57
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3319,7 +3319,7 @@ msgstr ""
 "Meldungen gelten als Mobbing und bringen dem Melder dieselben "
 "Verwarnungspunkte ein."
 
-#: lib/vutuv_web/templates/report/new.html.heex:166
+#: lib/vutuv_web/templates/report/new.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "Send report"
 msgstr "Meldung absenden"
@@ -3380,7 +3380,7 @@ msgstr "Zielt auf eine Person, würdigt sie herab oder bedroht sie."
 msgid "Tell us more in the note below."
 msgstr "Beschreiben Sie es in der Notiz unten genauer."
 
-#: lib/vutuv_web/controllers/report_controller.ex:142
+#: lib/vutuv_web/controllers/report_controller.ex:166
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. We take it from here."
 msgstr "Danke für Ihre Meldung. Wir übernehmen ab hier."
@@ -3404,14 +3404,14 @@ msgid "The queue is empty - the self-service flow settled everything."
 msgstr ""
 "Die Warteschlange ist leer, der Selbstbedienungs-Ablauf hat alles erledigt."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:390
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:400
 #, elixir-autogen, elixir-format
 msgid "The report by @%{slug} was a deliberate weapon (strikes the reporter)"
 msgstr ""
 "Die Meldung von @%{slug} war eine gezielte Waffe (Verwarnungspunkt für den "
 "Melder)"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:367
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:377
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content stays hidden and the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
@@ -3462,7 +3462,7 @@ msgstr ""
 msgid "Unwanted advertising, fraud or fake activity."
 msgstr "Unerwünschte Werbung, Betrug oder gefälschte Aktivität."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:372
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "Uphold the report"
 msgstr "Meldung bestätigen"
@@ -3482,7 +3482,7 @@ msgstr "Was nach einer Meldung passiert"
 msgid "Who reports, and how it holds up"
 msgstr "Wer meldet, und wie sich das bewährt"
 
-#: lib/vutuv_web/templates/report/new.html.heex:88
+#: lib/vutuv_web/templates/report/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Why are you reporting this?"
 msgstr "Warum melden Sie das?"
@@ -3520,7 +3520,7 @@ msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
 msgid "Your content was reported"
 msgstr "Ihr Inhalt wurde gemeldet"
 
-#: lib/vutuv_web/templates/report/new.html.heex:7
+#: lib/vutuv_web/templates/report/new.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "Your report is anonymous. If it checks out, the content is hidden right away and the owner is asked to fix it."
 msgstr ""
@@ -3528,7 +3528,7 @@ msgstr ""
 "verborgen und der Besitzer gebeten, ihn in Ordnung zu bringen."
 
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:135
-#: lib/vutuv_web/templates/report/new.html.heex:154
+#: lib/vutuv_web/templates/report/new.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "community guidelines"
 msgstr "Community-Richtlinien"
@@ -3651,14 +3651,14 @@ msgstr ""
 msgid "%{count} follows"
 msgstr "%{count} Follows"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:307
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "%{count} report so far"
 msgid_plural "%{count} reports so far"
 msgstr[0] "bisher %{count} Meldung"
 msgstr[1] "bisher %{count} Meldungen"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:307
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "%{rejected} rejected, %{abusive} abusive"
 msgstr "%{rejected} abgelehnt, %{abusive} missbräuchlich"
@@ -3678,7 +3678,7 @@ msgstr "Inhalt gelöscht"
 msgid "Content frozen"
 msgstr "Inhalt eingefroren"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:362
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "Decision"
 msgstr "Entscheidung"
@@ -3698,7 +3698,7 @@ msgstr "Eskaliert am %{date}"
 msgid "Evidence"
 msgstr "Beweismaterial"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:335
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr "Verlauf"
@@ -3755,7 +3755,7 @@ msgstr "Meldung bestätigt"
 msgid "Reported on %{date}"
 msgstr "Gemeldet am %{date}"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:324
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:334
 #, elixir-autogen, elixir-format
 msgid "Reporter and owner are separated since this report (connection, follows, messages)."
 msgstr ""
@@ -3787,12 +3787,12 @@ msgstr "Durch Löschung erledigt"
 msgid "Strike issued"
 msgstr "Verwarnungspunkt vergeben"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:320
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "The protective separation from the owner was lifted on %{date}."
 msgstr "Die schützende Trennung vom Besitzer wurde am %{date} aufgehoben."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:383
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "The report is unfounded. The content becomes visible again, any protective separation is lifted, and the rejection counts against each reporter's trust."
 msgstr ""
@@ -3845,32 +3845,32 @@ msgstr "Stufe %{level}, %{role}"
 msgid "messages"
 msgstr "Nachrichten"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "No history recorded - this case predates the audit log."
 msgstr "Kein Verlauf aufgezeichnet - dieser Fall ist älter als das Protokoll."
 
-#: lib/vutuv_web/templates/report/new.html.heex:37
+#: lib/vutuv_web/templates/report/new.html.heex:59
 #, elixir-autogen, elixir-format
 msgid "If our admins find the report unfounded, everything is restored."
 msgstr ""
 "Stufen unsere Admins die Meldung als unbegründet ein, wird alles "
 "wiederhergestellt."
 
-#: lib/vutuv_web/templates/report/new.html.heex:12
+#: lib/vutuv_web/templates/report/new.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "If your report checks out, the content is hidden right away and the owner is asked to fix it."
 msgstr ""
 "Wenn Ihre Meldung plausibel ist, wird der Inhalt sofort verborgen und der "
 "Besitzer gebeten, ihn in Ordnung zu bringen."
 
-#: lib/vutuv_web/templates/report/new.html.heex:26
+#: lib/vutuv_web/templates/report/new.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "Sending this report separates you and @%{handle} on the spot."
 msgstr ""
 "Mit dem Absenden dieser Meldung werden Sie und @%{handle} sofort getrennt."
 
-#: lib/vutuv_web/templates/report/new.html.heex:31
+#: lib/vutuv_web/templates/report/new.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "To protect you, your connection, follows and messages are paused in both directions - nobody should have to stay in contact with someone they just reported. Because of this, @%{handle} may recognize that the report came from you."
 msgstr ""
@@ -3889,7 +3889,7 @@ msgstr "Fall %{id}, aufgenommen %{at} UTC"
 msgid "Evidence screenshot captured"
 msgstr "Beweis-Screenshot aufgenommen"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:251
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Evidence screenshot captured when the report was filed"
 msgstr "Beweis-Screenshot, aufgenommen beim Eingang der Meldung"
@@ -3899,7 +3899,7 @@ msgstr "Beweis-Screenshot, aufgenommen beim Eingang der Meldung"
 msgid "Moderation evidence - reported private message with context"
 msgstr "Moderations-Beweismaterial - gemeldete private Nachricht mit Kontext"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:246
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "Screenshot at report time"
 msgstr "Screenshot zum Meldezeitpunkt"
@@ -3909,7 +3909,7 @@ msgstr "Screenshot zum Meldezeitpunkt"
 msgid "reported message"
 msgstr "gemeldete Nachricht"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:257
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
@@ -5444,7 +5444,7 @@ msgstr "API-Dokumentation"
 
 #: lib/vutuv_web/components/ui.ex:5359
 #: lib/vutuv_web/controllers/settings_controller.ex:161
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:439
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:449
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
@@ -10279,7 +10279,7 @@ msgstr "Konto wiederhergestellt. Das Mitglied kann sich wieder anmelden."
 msgid "Accounts removed as spam"
 msgstr "Als Spam entfernte Konten"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:406
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "Clear-cut spam or abuse?"
 msgstr "Eindeutiger Spam oder Missbrauch?"
@@ -10289,24 +10289,24 @@ msgstr "Eindeutiger Spam oder Missbrauch?"
 msgid "Could not restore this member."
 msgstr "Dieses Mitglied konnte nicht wiederhergestellt werden."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:421
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "Deactivate @%{slug} and mark the account as spam?"
 msgstr "@%{slug} deaktivieren und das Konto als Spam markieren?"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:424
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:434
 #, elixir-autogen, elixir-format
 msgid "Deactivate account"
 msgstr "Konto deaktivieren"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:433
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:443
 #, elixir-autogen, elixir-format
 msgid "Permanently DELETE @%{slug} and everything they posted? This cannot be undone."
 msgstr ""
 "@%{slug} und alle Beiträge dauerhaft LÖSCHEN? Das kann nicht rückgängig "
 "gemacht werden."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:409
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:419
 #, elixir-autogen, elixir-format
 msgid "Remove the account outright, skipping the warning ladder. Deactivating marks it as spam and is reversible from the member browser; deleting is permanent."
 msgstr ""
@@ -10335,7 +10335,7 @@ msgstr ""
 msgid "Spam"
 msgstr "Spam"
 
-#: lib/vutuv_web/controllers/report_controller.ex:138
+#: lib/vutuv_web/controllers/report_controller.ex:154
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. Our moderators have been notified and will review this account."
 msgstr ""
@@ -10353,7 +10353,7 @@ msgstr "deaktiviert"
 msgid "deleted"
 msgstr "gelöscht"
 
-#: lib/vutuv_web/controllers/report_controller.ex:148
+#: lib/vutuv_web/controllers/report_controller.ex:141
 #, elixir-autogen, elixir-format
 msgid "To protect you, the connection between you and the reported member is paused - no contact in either direction, including messages. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -23833,7 +23833,7 @@ msgstr "Für mein Konto einschalten"
 msgid "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."
 msgstr "Korrigieren. Einer unserer Admins sieht sich die Änderung dann an; bis dahin bleibt der Beitrag verborgen."
 
-#: lib/vutuv_web/templates/report/new.html.heex:145
+#: lib/vutuv_web/templates/report/new.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "I declare in good faith that this use is authorized neither by the rights holder nor by law."
 msgstr "Ich versichere nach bestem Wissen, dass diese Nutzung weder vom Rechteinhaber noch vom Gesetz gedeckt ist."
@@ -23858,7 +23858,7 @@ msgstr "Texte, Fotos und Videos gehören denen, die sie gemacht haben. Veröffen
 msgid "Uses a text, photo or video without the rights holder's permission"
 msgstr "Nutzt einen Text, ein Foto oder ein Video ohne Erlaubnis des Rechteinhabers"
 
-#: lib/vutuv_web/templates/report/new.html.heex:121
+#: lib/vutuv_web/templates/report/new.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "Which work is it, and where can the original be seen? (required)"
 msgstr "Um welches Werk geht es, und wo ist das Original zu sehen? (erforderlich)"
@@ -24137,7 +24137,7 @@ msgstr "Weder Ihr Profilbild noch Ihr Titelbild wurde ersetzt: Eine Meldung dazu
 msgid "Picture"
 msgstr "Bild"
 
-#: lib/vutuv_web/controllers/report_controller.ex:170
+#: lib/vutuv_web/controllers/report_controller.ex:183
 #, elixir-autogen, elixir-format
 msgid "Profile picture"
 msgstr "Profilbild"
@@ -24157,7 +24157,7 @@ msgstr "Profilbild melden"
 msgid "The reported picture"
 msgstr "Das gemeldete Bild"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:239
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Upholding the case deletes it, the private original included. Rejecting it puts every file back where it was."
 msgstr "Wird der Meldung stattgegeben, wird es gelöscht, auch das private Original. Wird sie abgelehnt, liegt jede Datei wieder an ihrem Platz."
@@ -24214,3 +24214,33 @@ msgstr "Die Antworten ließen sich nicht von den Servern holen, auf denen sie li
 #, elixir-autogen, elixir-format
 msgid "The rest could not be fetched right now."
 msgstr "Der Rest ließ sich gerade nicht holen."
+
+#: lib/vutuv_web/templates/report/new.html.heex:29
+#, elixir-autogen, elixir-format
+msgid "A picture goes offline right away for a copyright notice; every other report goes to our admins with the picture left where it is."
+msgstr ""
+"Bei einer Meldung wegen Urheberrechts geht das Bild sofort offline; jede "
+"andere Meldung geht an unsere Admins, das Bild bleibt sichtbar."
+
+#: lib/vutuv_web/controllers/report_controller.ex:160
+#, elixir-autogen, elixir-format
+msgid "Thank you for your report. Our moderators have been notified and will review this picture."
+msgstr ""
+"Danke für Ihre Meldung. Unsere Moderatoren wurden benachrichtigt und prüfen "
+"dieses Bild."
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:249
+#, elixir-autogen, elixir-format
+msgid "This picture is still on the profile: only a copyright notice takes one offline before a ruling. Upholding the case deletes it, the private original included."
+msgstr ""
+"Dieses Bild ist weiterhin im Profil zu sehen: Nur eine Meldung wegen "
+"Urheberrechts nimmt ein Bild schon vor der Entscheidung offline. Wird der "
+"Meldung stattgegeben, wird es gelöscht, auch das private Original."
+
+#: lib/vutuv_web/templates/report/new.html.heex:18
+#, elixir-autogen, elixir-format
+msgid "Your report is anonymous. A picture goes offline right away for a copyright notice; every other report goes to our admins with the picture left where it is."
+msgstr ""
+"Ihre Meldung ist anonym. Bei einer Meldung wegen Urheberrechts geht das Bild "
+"sofort offline; jede andere Meldung geht an unsere Admins, das Bild bleibt "
+"sichtbar."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -125,7 +125,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:113
-#: lib/vutuv_web/templates/report/new.html.heex:164
+#: lib/vutuv_web/templates/report/new.html.heex:186
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:255
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
@@ -1973,7 +1973,7 @@ msgstr ""
 msgid "Change cover photo"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:169
+#: lib/vutuv_web/controllers/report_controller.ex:182
 #: lib/vutuv_web/templates/user/edit.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
@@ -2881,7 +2881,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:335
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:284
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:294
 #: lib/vutuv_web/templates/moderation_evidence/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "(deleted account)"
@@ -2918,7 +2918,7 @@ msgstr ""
 msgid "An admin dismissed the report. The content is visible again."
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:115
+#: lib/vutuv_web/templates/report/new.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "Anything our admins should know? (optional)"
 msgstr ""
@@ -2943,7 +2943,7 @@ msgstr ""
 msgid "Confirmed violations follow three steps: a warning, then a one-week suspension, then permanent deactivation. Strikes expire after twelve months."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:270
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Conversation context (the reported message last)"
 msgstr ""
@@ -2953,7 +2953,7 @@ msgstr ""
 msgid "Criticize ideas, never people. Demeaning, threatening or repeatedly unwanted messages get accounts suspended - in public posts and in private messages alike."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:262
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Current version (edited since the report)"
 msgstr ""
@@ -3114,7 +3114,7 @@ msgstr ""
 msgid "Owner"
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:152
+#: lib/vutuv_web/templates/report/new.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Please report honestly. Reporting to harm someone breaks our"
 msgstr ""
@@ -3133,7 +3133,7 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:396
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "Reject the report"
 msgstr ""
@@ -3222,7 +3222,7 @@ msgstr ""
 msgid "Reporter track records"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:294
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:304
 #: lib/vutuv_web/live/admin/moderation_live.ex:57
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3247,7 +3247,7 @@ msgstr ""
 msgid "See something that breaks these rules? Report it - every post, message and profile has a report option, and reports are anonymous. But reporting is not a weapon: deliberately false reports count as bullying and earn the reporter the same strikes."
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:166
+#: lib/vutuv_web/templates/report/new.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "Send report"
 msgstr ""
@@ -3306,7 +3306,7 @@ msgstr ""
 msgid "Tell us more in the note below."
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:142
+#: lib/vutuv_web/controllers/report_controller.ex:166
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. We take it from here."
 msgstr ""
@@ -3326,12 +3326,12 @@ msgstr ""
 msgid "The queue is empty - the self-service flow settled everything."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:390
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:400
 #, elixir-autogen, elixir-format
 msgid "The report by @%{slug} was a deliberate weapon (strikes the reporter)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:367
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:377
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content stays hidden and the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
@@ -3378,7 +3378,7 @@ msgstr ""
 msgid "Unwanted advertising, fraud or fake activity."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:372
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "Uphold the report"
 msgstr ""
@@ -3398,7 +3398,7 @@ msgstr ""
 msgid "Who reports, and how it holds up"
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:88
+#: lib/vutuv_web/templates/report/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Why are you reporting this?"
 msgstr ""
@@ -3433,13 +3433,13 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:7
+#: lib/vutuv_web/templates/report/new.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "Your report is anonymous. If it checks out, the content is hidden right away and the owner is asked to fix it."
 msgstr ""
 
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:135
-#: lib/vutuv_web/templates/report/new.html.heex:154
+#: lib/vutuv_web/templates/report/new.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "community guidelines"
 msgstr ""
@@ -3555,14 +3555,14 @@ msgstr ""
 msgid "%{count} follows"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:307
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "%{count} report so far"
 msgid_plural "%{count} reports so far"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:307
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "%{rejected} rejected, %{abusive} abusive"
 msgstr ""
@@ -3582,7 +3582,7 @@ msgstr ""
 msgid "Content frozen"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:362
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "Decision"
 msgstr ""
@@ -3602,7 +3602,7 @@ msgstr ""
 msgid "Evidence"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:335
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr ""
@@ -3657,7 +3657,7 @@ msgstr ""
 msgid "Reported on %{date}"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:324
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:334
 #, elixir-autogen, elixir-format
 msgid "Reporter and owner are separated since this report (connection, follows, messages)."
 msgstr ""
@@ -3687,12 +3687,12 @@ msgstr ""
 msgid "Strike issued"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:320
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "The protective separation from the owner was lifted on %{date}."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:383
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "The report is unfounded. The content becomes visible again, any protective separation is lifted, and the rejection counts against each reporter's trust."
 msgstr ""
@@ -3737,27 +3737,27 @@ msgstr ""
 msgid "messages"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "No history recorded - this case predates the audit log."
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:37
+#: lib/vutuv_web/templates/report/new.html.heex:59
 #, elixir-autogen, elixir-format
 msgid "If our admins find the report unfounded, everything is restored."
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:12
+#: lib/vutuv_web/templates/report/new.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "If your report checks out, the content is hidden right away and the owner is asked to fix it."
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:26
+#: lib/vutuv_web/templates/report/new.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "Sending this report separates you and @%{handle} on the spot."
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:31
+#: lib/vutuv_web/templates/report/new.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "To protect you, your connection, follows and messages are paused in both directions - nobody should have to stay in contact with someone they just reported. Because of this, @%{handle} may recognize that the report came from you."
 msgstr ""
@@ -3772,7 +3772,7 @@ msgstr ""
 msgid "Evidence screenshot captured"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:251
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Evidence screenshot captured when the report was filed"
 msgstr ""
@@ -3782,7 +3782,7 @@ msgstr ""
 msgid "Moderation evidence - reported private message with context"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:246
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "Screenshot at report time"
 msgstr ""
@@ -3792,7 +3792,7 @@ msgstr ""
 msgid "reported message"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:257
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
@@ -5235,7 +5235,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5359
 #: lib/vutuv_web/controllers/settings_controller.ex:161
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:439
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:449
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
@@ -9812,7 +9812,7 @@ msgstr ""
 msgid "Accounts removed as spam"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:406
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "Clear-cut spam or abuse?"
 msgstr ""
@@ -9822,22 +9822,22 @@ msgstr ""
 msgid "Could not restore this member."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:421
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "Deactivate @%{slug} and mark the account as spam?"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:424
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:434
 #, elixir-autogen, elixir-format
 msgid "Deactivate account"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:433
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:443
 #, elixir-autogen, elixir-format
 msgid "Permanently DELETE @%{slug} and everything they posted? This cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:409
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:419
 #, elixir-autogen, elixir-format
 msgid "Remove the account outright, skipping the warning ladder. Deactivating marks it as spam and is reversible from the member browser; deleting is permanent."
 msgstr ""
@@ -9862,7 +9862,7 @@ msgstr ""
 msgid "Spam"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:138
+#: lib/vutuv_web/controllers/report_controller.ex:154
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. Our moderators have been notified and will review this account."
 msgstr ""
@@ -9878,7 +9878,7 @@ msgstr ""
 msgid "deleted"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:148
+#: lib/vutuv_web/controllers/report_controller.ex:141
 #, elixir-autogen, elixir-format
 msgid "To protect you, the connection between you and the reported member is paused - no contact in either direction, including messages. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -23046,7 +23046,7 @@ msgstr ""
 msgid "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:145
+#: lib/vutuv_web/templates/report/new.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "I declare in good faith that this use is authorized neither by the rights holder nor by law."
 msgstr ""
@@ -23071,7 +23071,7 @@ msgstr ""
 msgid "Uses a text, photo or video without the rights holder's permission"
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:121
+#: lib/vutuv_web/templates/report/new.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "Which work is it, and where can the original be seen? (required)"
 msgstr ""
@@ -23312,7 +23312,7 @@ msgstr ""
 msgid "Picture"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:170
+#: lib/vutuv_web/controllers/report_controller.ex:183
 #, elixir-autogen, elixir-format
 msgid "Profile picture"
 msgstr ""
@@ -23332,7 +23332,7 @@ msgstr ""
 msgid "The reported picture"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:239
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Upholding the case deletes it, the private original included. Rejecting it puts every file back where it was."
 msgstr ""
@@ -23388,4 +23388,24 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/remote_actions_component.ex:265
 #, elixir-autogen, elixir-format
 msgid "The rest could not be fetched right now."
+msgstr ""
+
+#: lib/vutuv_web/templates/report/new.html.heex:29
+#, elixir-autogen, elixir-format
+msgid "A picture goes offline right away for a copyright notice; every other report goes to our admins with the picture left where it is."
+msgstr ""
+
+#: lib/vutuv_web/controllers/report_controller.ex:160
+#, elixir-autogen, elixir-format
+msgid "Thank you for your report. Our moderators have been notified and will review this picture."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:249
+#, elixir-autogen, elixir-format
+msgid "This picture is still on the profile: only a copyright notice takes one offline before a ruling. Upholding the case deletes it, the private original included."
+msgstr ""
+
+#: lib/vutuv_web/templates/report/new.html.heex:18
+#, elixir-autogen, elixir-format
+msgid "Your report is anonymous. A picture goes offline right away for a copyright notice; every other report goes to our admins with the picture left where it is."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -123,7 +123,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:113
-#: lib/vutuv_web/templates/report/new.html.heex:164
+#: lib/vutuv_web/templates/report/new.html.heex:186
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:255
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
@@ -1971,7 +1971,7 @@ msgstr ""
 msgid "Change cover photo"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:169
+#: lib/vutuv_web/controllers/report_controller.ex:182
 #: lib/vutuv_web/templates/user/edit.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
@@ -2879,7 +2879,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:335
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:284
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:294
 #: lib/vutuv_web/templates/moderation_evidence/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "(deleted account)"
@@ -2916,7 +2916,7 @@ msgstr ""
 msgid "An admin dismissed the report. The content is visible again."
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:115
+#: lib/vutuv_web/templates/report/new.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "Anything our admins should know? (optional)"
 msgstr ""
@@ -2941,7 +2941,7 @@ msgstr ""
 msgid "Confirmed violations follow three steps: a warning, then a one-week suspension, then permanent deactivation. Strikes expire after twelve months."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:270
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Conversation context (the reported message last)"
 msgstr ""
@@ -2951,7 +2951,7 @@ msgstr ""
 msgid "Criticize ideas, never people. Demeaning, threatening or repeatedly unwanted messages get accounts suspended - in public posts and in private messages alike."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:262
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Current version (edited since the report)"
 msgstr ""
@@ -3112,7 +3112,7 @@ msgstr ""
 msgid "Owner"
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:152
+#: lib/vutuv_web/templates/report/new.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Please report honestly. Reporting to harm someone breaks our"
 msgstr ""
@@ -3131,7 +3131,7 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:396
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "Reject the report"
 msgstr ""
@@ -3220,7 +3220,7 @@ msgstr ""
 msgid "Reporter track records"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:294
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:304
 #: lib/vutuv_web/live/admin/moderation_live.ex:57
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3245,7 +3245,7 @@ msgstr ""
 msgid "See something that breaks these rules? Report it - every post, message and profile has a report option, and reports are anonymous. But reporting is not a weapon: deliberately false reports count as bullying and earn the reporter the same strikes."
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:166
+#: lib/vutuv_web/templates/report/new.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "Send report"
 msgstr ""
@@ -3304,7 +3304,7 @@ msgstr ""
 msgid "Tell us more in the note below."
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:142
+#: lib/vutuv_web/controllers/report_controller.ex:166
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. We take it from here."
 msgstr ""
@@ -3324,12 +3324,12 @@ msgstr ""
 msgid "The queue is empty - the self-service flow settled everything."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:390
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:400
 #, elixir-autogen, elixir-format
 msgid "The report by @%{slug} was a deliberate weapon (strikes the reporter)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:367
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:377
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content stays hidden and the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
@@ -3376,7 +3376,7 @@ msgstr ""
 msgid "Unwanted advertising, fraud or fake activity."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:372
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "Uphold the report"
 msgstr ""
@@ -3396,7 +3396,7 @@ msgstr ""
 msgid "Who reports, and how it holds up"
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:88
+#: lib/vutuv_web/templates/report/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Why are you reporting this?"
 msgstr ""
@@ -3431,13 +3431,13 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:7
+#: lib/vutuv_web/templates/report/new.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "Your report is anonymous. If it checks out, the content is hidden right away and the owner is asked to fix it."
 msgstr ""
 
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:135
-#: lib/vutuv_web/templates/report/new.html.heex:154
+#: lib/vutuv_web/templates/report/new.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "community guidelines"
 msgstr ""
@@ -3553,14 +3553,14 @@ msgstr ""
 msgid "%{count} follows"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:307
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "%{count} report so far"
 msgid_plural "%{count} reports so far"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:307
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "%{rejected} rejected, %{abusive} abusive"
 msgstr ""
@@ -3580,7 +3580,7 @@ msgstr ""
 msgid "Content frozen"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:362
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "Decision"
 msgstr ""
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Evidence"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:335
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr ""
@@ -3655,7 +3655,7 @@ msgstr ""
 msgid "Reported on %{date}"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:324
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:334
 #, elixir-autogen, elixir-format
 msgid "Reporter and owner are separated since this report (connection, follows, messages)."
 msgstr ""
@@ -3685,12 +3685,12 @@ msgstr ""
 msgid "Strike issued"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:320
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "The protective separation from the owner was lifted on %{date}."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:383
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "The report is unfounded. The content becomes visible again, any protective separation is lifted, and the rejection counts against each reporter's trust."
 msgstr ""
@@ -3735,27 +3735,27 @@ msgstr ""
 msgid "messages"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "No history recorded - this case predates the audit log."
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:37
+#: lib/vutuv_web/templates/report/new.html.heex:59
 #, elixir-autogen, elixir-format
 msgid "If our admins find the report unfounded, everything is restored."
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:12
+#: lib/vutuv_web/templates/report/new.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "If your report checks out, the content is hidden right away and the owner is asked to fix it."
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:26
+#: lib/vutuv_web/templates/report/new.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "Sending this report separates you and @%{handle} on the spot."
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:31
+#: lib/vutuv_web/templates/report/new.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "To protect you, your connection, follows and messages are paused in both directions - nobody should have to stay in contact with someone they just reported. Because of this, @%{handle} may recognize that the report came from you."
 msgstr ""
@@ -3770,7 +3770,7 @@ msgstr ""
 msgid "Evidence screenshot captured"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:251
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Evidence screenshot captured when the report was filed"
 msgstr ""
@@ -3780,7 +3780,7 @@ msgstr ""
 msgid "Moderation evidence - reported private message with context"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:246
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "Screenshot at report time"
 msgstr ""
@@ -3790,7 +3790,7 @@ msgstr ""
 msgid "reported message"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:257
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
@@ -5233,7 +5233,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5359
 #: lib/vutuv_web/controllers/settings_controller.ex:161
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:439
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:449
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
@@ -9810,7 +9810,7 @@ msgstr ""
 msgid "Accounts removed as spam"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:406
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "Clear-cut spam or abuse?"
 msgstr ""
@@ -9820,22 +9820,22 @@ msgstr ""
 msgid "Could not restore this member."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:421
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "Deactivate @%{slug} and mark the account as spam?"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:424
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:434
 #, elixir-autogen, elixir-format
 msgid "Deactivate account"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:433
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:443
 #, elixir-autogen, elixir-format
 msgid "Permanently DELETE @%{slug} and everything they posted? This cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:409
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:419
 #, elixir-autogen, elixir-format
 msgid "Remove the account outright, skipping the warning ladder. Deactivating marks it as spam and is reversible from the member browser; deleting is permanent."
 msgstr ""
@@ -9860,7 +9860,7 @@ msgstr ""
 msgid "Spam"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:138
+#: lib/vutuv_web/controllers/report_controller.ex:154
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. Our moderators have been notified and will review this account."
 msgstr ""
@@ -9876,7 +9876,7 @@ msgstr ""
 msgid "deleted"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:148
+#: lib/vutuv_web/controllers/report_controller.ex:141
 #, elixir-autogen, elixir-format
 msgid "To protect you, the connection between you and the reported member is paused - no contact in either direction, including messages. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -23044,7 +23044,7 @@ msgstr ""
 msgid "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:145
+#: lib/vutuv_web/templates/report/new.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "I declare in good faith that this use is authorized neither by the rights holder nor by law."
 msgstr ""
@@ -23069,7 +23069,7 @@ msgstr ""
 msgid "Uses a text, photo or video without the rights holder's permission"
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:121
+#: lib/vutuv_web/templates/report/new.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "Which work is it, and where can the original be seen? (required)"
 msgstr ""
@@ -23310,7 +23310,7 @@ msgstr ""
 msgid "Picture"
 msgstr ""
 
-#: lib/vutuv_web/controllers/report_controller.ex:170
+#: lib/vutuv_web/controllers/report_controller.ex:183
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Profile picture"
 msgstr ""
@@ -23330,7 +23330,7 @@ msgstr ""
 msgid "The reported picture"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:239
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Upholding the case deletes it, the private original included. Rejecting it puts every file back where it was."
 msgstr ""
@@ -23386,4 +23386,24 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/remote_actions_component.ex:265
 #, elixir-autogen, elixir-format
 msgid "The rest could not be fetched right now."
+msgstr ""
+
+#: lib/vutuv_web/templates/report/new.html.heex:29
+#, elixir-autogen, elixir-format
+msgid "A picture goes offline right away for a copyright notice; every other report goes to our admins with the picture left where it is."
+msgstr ""
+
+#: lib/vutuv_web/controllers/report_controller.ex:160
+#, elixir-autogen, elixir-format
+msgid "Thank you for your report. Our moderators have been notified and will review this picture."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:249
+#, elixir-autogen, elixir-format
+msgid "This picture is still on the profile: only a copyright notice takes one offline before a ruling. Upholding the case deletes it, the private original included."
+msgstr ""
+
+#: lib/vutuv_web/templates/report/new.html.heex:18
+#, elixir-autogen, elixir-format
+msgid "Your report is anonymous. A picture goes offline right away for a copyright notice; every other report goes to our admins with the picture left where it is."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -125,7 +125,7 @@ msgstr "Compleanno"
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:113
-#: lib/vutuv_web/templates/report/new.html.heex:164
+#: lib/vutuv_web/templates/report/new.html.heex:186
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:255
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
@@ -2011,7 +2011,7 @@ msgstr "Cambia copertina"
 msgid "Change cover photo"
 msgstr "Cambia immagine di copertina"
 
-#: lib/vutuv_web/controllers/report_controller.ex:169
+#: lib/vutuv_web/controllers/report_controller.ex:182
 #: lib/vutuv_web/templates/user/edit.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
@@ -2932,7 +2932,7 @@ msgstr[0] "%{formatted} caso attende una decisione."
 msgstr[1] "%{formatted} casi attendono una decisione."
 
 #: lib/vutuv_web/live/admin/job_live.ex:335
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:284
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:294
 #: lib/vutuv_web/templates/moderation_evidence/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "(deleted account)"
@@ -2975,7 +2975,7 @@ msgstr ""
 "Un amministratore ha respinto la segnalazione. Il contenuto è di nuovo "
 "visibile."
 
-#: lib/vutuv_web/templates/report/new.html.heex:115
+#: lib/vutuv_web/templates/report/new.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "Anything our admins should know? (optional)"
 msgstr "Qualcosa che i nostri amministratori dovrebbero sapere? (facoltativo)"
@@ -3003,7 +3003,7 @@ msgstr ""
 "sospensione di una settimana, poi la disattivazione definitiva. I richiami "
 "decadono dopo dodici mesi."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:270
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Conversation context (the reported message last)"
 msgstr "Contesto della conversazione (il messaggio segnalato per ultimo)"
@@ -3016,7 +3016,7 @@ msgstr ""
 "ripetutamente indesiderati portano alla sospensione dell'account, tanto nei "
 "post pubblici quanto nei messaggi privati."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:262
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Current version (edited since the report)"
 msgstr "Versione attuale (modificata dopo la segnalazione)"
@@ -3186,7 +3186,7 @@ msgstr "Aperto"
 msgid "Owner"
 msgstr "Proprietario"
 
-#: lib/vutuv_web/templates/report/new.html.heex:152
+#: lib/vutuv_web/templates/report/new.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Please report honestly. Reporting to harm someone breaks our"
 msgstr ""
@@ -3206,7 +3206,7 @@ msgstr "Messaggio privato"
 msgid "Profile"
 msgstr "Profilo"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:396
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "Reject the report"
 msgstr "Respingi la segnalazione"
@@ -3297,7 +3297,7 @@ msgstr "Segnalante"
 msgid "Reporter track records"
 msgstr "Storico dei segnalanti"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:294
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:304
 #: lib/vutuv_web/live/admin/moderation_live.ex:57
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3328,7 +3328,7 @@ msgstr ""
 " segnalazione non è un'arma: le segnalazioni deliberatamente false valgono "
 "come bullismo e portano al segnalante gli stessi richiami."
 
-#: lib/vutuv_web/templates/report/new.html.heex:166
+#: lib/vutuv_web/templates/report/new.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "Send report"
 msgstr "Invia la segnalazione"
@@ -3389,7 +3389,7 @@ msgstr "Prende di mira, umilia o minaccia una persona."
 msgid "Tell us more in the note below."
 msgstr "Ci dica di più nella nota qui sotto."
 
-#: lib/vutuv_web/controllers/report_controller.ex:142
+#: lib/vutuv_web/controllers/report_controller.ex:166
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. We take it from here."
 msgstr "Grazie per la segnalazione. Ce ne occupiamo noi."
@@ -3412,14 +3412,14 @@ msgstr ""
 msgid "The queue is empty - the self-service flow settled everything."
 msgstr "La coda è vuota: la procedura autonoma ha risolto tutto."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:390
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:400
 #, elixir-autogen, elixir-format
 msgid "The report by @%{slug} was a deliberate weapon (strikes the reporter)"
 msgstr ""
 "La segnalazione di @%{slug} è stata un'arma deliberata (richiamo al "
 "segnalante)"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:367
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:377
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content stays hidden and the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
@@ -3470,7 +3470,7 @@ msgstr ""
 msgid "Unwanted advertising, fraud or fake activity."
 msgstr "Pubblicità indesiderata, frode o attività falsa."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:372
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "Uphold the report"
 msgstr "Accogli la segnalazione"
@@ -3490,7 +3490,7 @@ msgstr "Cosa succede dopo una segnalazione"
 msgid "Who reports, and how it holds up"
 msgstr "Chi segnala, e quanto regge"
 
-#: lib/vutuv_web/templates/report/new.html.heex:88
+#: lib/vutuv_web/templates/report/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Why are you reporting this?"
 msgstr "Perché lo segnala?"
@@ -3528,7 +3528,7 @@ msgstr "Ha corretto un contenuto segnalato; il caso è chiuso."
 msgid "Your content was reported"
 msgstr "Un Suo contenuto è stato segnalato"
 
-#: lib/vutuv_web/templates/report/new.html.heex:7
+#: lib/vutuv_web/templates/report/new.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "Your report is anonymous. If it checks out, the content is hidden right away and the owner is asked to fix it."
 msgstr ""
@@ -3536,7 +3536,7 @@ msgstr ""
 "nascosto subito e al proprietario viene chiesto di correggerlo."
 
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:135
-#: lib/vutuv_web/templates/report/new.html.heex:154
+#: lib/vutuv_web/templates/report/new.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "community guidelines"
 msgstr "regole della community"
@@ -3658,14 +3658,14 @@ msgstr ""
 msgid "%{count} follows"
 msgstr "%{count} follow"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:307
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "%{count} report so far"
 msgid_plural "%{count} reports so far"
 msgstr[0] "%{count} segnalazione finora"
 msgstr[1] "%{count} segnalazioni finora"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:307
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "%{rejected} rejected, %{abusive} abusive"
 msgstr "%{rejected} respinte, %{abusive} abusive"
@@ -3685,7 +3685,7 @@ msgstr "Contenuto eliminato"
 msgid "Content frozen"
 msgstr "Contenuto bloccato"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:362
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "Decision"
 msgstr "Decisione"
@@ -3705,7 +3705,7 @@ msgstr "Inoltrato il %{date}"
 msgid "Evidence"
 msgstr "Prove"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:335
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr "Cronologia"
@@ -3762,7 +3762,7 @@ msgstr "Segnalazione accolta"
 msgid "Reported on %{date}"
 msgstr "Segnalato il %{date}"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:324
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:334
 #, elixir-autogen, elixir-format
 msgid "Reporter and owner are separated since this report (connection, follows, messages)."
 msgstr ""
@@ -3794,13 +3794,13 @@ msgstr "Chiuso con l'eliminazione"
 msgid "Strike issued"
 msgstr "Richiamo assegnato"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:320
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "The protective separation from the owner was lifted on %{date}."
 msgstr ""
 "La separazione protettiva dal proprietario è stata revocata il %{date}."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:383
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "The report is unfounded. The content becomes visible again, any protective separation is lifted, and the rejection counts against each reporter's trust."
 msgstr ""
@@ -3853,34 +3853,34 @@ msgstr "livello %{level}, %{role}"
 msgid "messages"
 msgstr "messaggi"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "No history recorded - this case predates the audit log."
 msgstr ""
 "Nessuna cronologia registrata: questo caso è precedente al registro delle "
 "attività."
 
-#: lib/vutuv_web/templates/report/new.html.heex:37
+#: lib/vutuv_web/templates/report/new.html.heex:59
 #, elixir-autogen, elixir-format
 msgid "If our admins find the report unfounded, everything is restored."
 msgstr ""
 "Se i nostri amministratori riterranno la segnalazione infondata, tutto verrà"
 " ripristinato."
 
-#: lib/vutuv_web/templates/report/new.html.heex:12
+#: lib/vutuv_web/templates/report/new.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "If your report checks out, the content is hidden right away and the owner is asked to fix it."
 msgstr ""
 "Se la Sua segnalazione risulta fondata, il contenuto viene nascosto subito e"
 " al proprietario viene chiesto di correggerlo."
 
-#: lib/vutuv_web/templates/report/new.html.heex:26
+#: lib/vutuv_web/templates/report/new.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "Sending this report separates you and @%{handle} on the spot."
 msgstr ""
 "Inviando questa segnalazione, Lei e @%{handle} venite separati all'istante."
 
-#: lib/vutuv_web/templates/report/new.html.heex:31
+#: lib/vutuv_web/templates/report/new.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "To protect you, your connection, follows and messages are paused in both directions - nobody should have to stay in contact with someone they just reported. Because of this, @%{handle} may recognize that the report came from you."
 msgstr ""
@@ -3899,7 +3899,7 @@ msgstr "Caso %{id}, acquisito il %{at} UTC"
 msgid "Evidence screenshot captured"
 msgstr "Screenshot di prova acquisito"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:251
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Evidence screenshot captured when the report was filed"
 msgstr "Screenshot di prova acquisito al momento della segnalazione"
@@ -3909,7 +3909,7 @@ msgstr "Screenshot di prova acquisito al momento della segnalazione"
 msgid "Moderation evidence - reported private message with context"
 msgstr "Prova di moderazione: messaggio privato segnalato con il contesto"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:246
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "Screenshot at report time"
 msgstr "Screenshot al momento della segnalazione"
@@ -3919,7 +3919,7 @@ msgstr "Screenshot al momento della segnalazione"
 msgid "reported message"
 msgstr "messaggio segnalato"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:257
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Scorra dentro il riquadro, o prema per aprire l'immagine intera."
@@ -5442,7 +5442,7 @@ msgstr "Documentazione dell'API"
 
 #: lib/vutuv_web/components/ui.ex:5359
 #: lib/vutuv_web/controllers/settings_controller.ex:161
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:439
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:449
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
@@ -10248,7 +10248,7 @@ msgstr "Account ripristinato. Il membro può accedere di nuovo."
 msgid "Accounts removed as spam"
 msgstr "Account rimossi come spam"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:406
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "Clear-cut spam or abuse?"
 msgstr "Spam o abuso lampante?"
@@ -10258,24 +10258,24 @@ msgstr "Spam o abuso lampante?"
 msgid "Could not restore this member."
 msgstr "Non è stato possibile ripristinare questo membro."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:421
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "Deactivate @%{slug} and mark the account as spam?"
 msgstr "Disattivare @%{slug} e contrassegnare l'account come spam?"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:424
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:434
 #, elixir-autogen, elixir-format
 msgid "Deactivate account"
 msgstr "Disattiva l'account"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:433
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:443
 #, elixir-autogen, elixir-format
 msgid "Permanently DELETE @%{slug} and everything they posted? This cannot be undone."
 msgstr ""
 "ELIMINARE definitivamente @%{slug} e tutto ciò che ha pubblicato? "
 "L'operazione non si può annullare."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:409
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:419
 #, elixir-autogen, elixir-format
 msgid "Remove the account outright, skipping the warning ladder. Deactivating marks it as spam and is reversible from the member browser; deleting is permanent."
 msgstr ""
@@ -10303,7 +10303,7 @@ msgstr "Ripristinare questo account perché il membro possa accedere di nuovo?"
 msgid "Spam"
 msgstr "Spam"
 
-#: lib/vutuv_web/controllers/report_controller.ex:138
+#: lib/vutuv_web/controllers/report_controller.ex:154
 #, elixir-autogen, elixir-format
 msgid "Thank you for your report. Our moderators have been notified and will review this account."
 msgstr ""
@@ -10321,7 +10321,7 @@ msgstr "disattivato"
 msgid "deleted"
 msgstr "eliminato"
 
-#: lib/vutuv_web/controllers/report_controller.ex:148
+#: lib/vutuv_web/controllers/report_controller.ex:141
 #, elixir-autogen, elixir-format
 msgid "To protect you, the connection between you and the reported member is paused - no contact in either direction, including messages. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -24540,7 +24540,7 @@ msgstr "Attiva per il mio account"
 msgid "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."
 msgstr "Correggilo. Uno dei nostri amministratori esaminerà poi la modifica; fino ad allora il contributo resta nascosto."
 
-#: lib/vutuv_web/templates/report/new.html.heex:145
+#: lib/vutuv_web/templates/report/new.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "I declare in good faith that this use is authorized neither by the rights holder nor by law."
 msgstr "Dichiaro in buona fede che questo utilizzo non è autorizzato né dal titolare dei diritti né dalla legge."
@@ -24565,7 +24565,7 @@ msgstr "Testi, foto e video appartengono a chi li ha creati. Pubblica opere tue 
 msgid "Uses a text, photo or video without the rights holder's permission"
 msgstr "Usa un testo, una foto o un video senza il permesso del titolare dei diritti"
 
-#: lib/vutuv_web/templates/report/new.html.heex:121
+#: lib/vutuv_web/templates/report/new.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "Which work is it, and where can the original be seen? (required)"
 msgstr "Di quale opera si tratta e dove si può vedere l'originale? (obbligatorio)"
@@ -24842,7 +24842,7 @@ msgstr "Né la tua immagine del profilo né quella di copertina sono state sosti
 msgid "Picture"
 msgstr "Immagine"
 
-#: lib/vutuv_web/controllers/report_controller.ex:170
+#: lib/vutuv_web/controllers/report_controller.ex:183
 #, elixir-autogen, elixir-format
 msgid "Profile picture"
 msgstr "Immagine del profilo"
@@ -24862,7 +24862,7 @@ msgstr "Segnala l'immagine del profilo"
 msgid "The reported picture"
 msgstr "L'immagine segnalata"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:239
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Upholding the case deletes it, the private original included. Rejecting it puts every file back where it was."
 msgstr "Se il caso viene accolto, l'immagine viene eliminata, originale privato compreso. Se viene respinto, ogni file torna al suo posto."
@@ -24919,3 +24919,34 @@ msgstr "Non è stato possibile recuperare le risposte dai server che le ospitano
 #, elixir-autogen, elixir-format
 msgid "The rest could not be fetched right now."
 msgstr "Non è stato possibile recuperare il resto in questo momento."
+
+#: lib/vutuv_web/templates/report/new.html.heex:29
+#, elixir-autogen, elixir-format
+msgid "A picture goes offline right away for a copyright notice; every other report goes to our admins with the picture left where it is."
+msgstr ""
+"Con una segnalazione per violazione del diritto d'autore l'immagine va "
+"offline subito; ogni altra segnalazione arriva ai nostri amministratori e "
+"l'immagine resta visibile."
+
+#: lib/vutuv_web/controllers/report_controller.ex:160
+#, elixir-autogen, elixir-format
+msgid "Thank you for your report. Our moderators have been notified and will review this picture."
+msgstr ""
+"Grazie per la segnalazione. I nostri moderatori sono stati avvisati ed "
+"esamineranno questa immagine."
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:249
+#, elixir-autogen, elixir-format
+msgid "This picture is still on the profile: only a copyright notice takes one offline before a ruling. Upholding the case deletes it, the private original included."
+msgstr ""
+"L'immagine è ancora sul profilo: solo una segnalazione per violazione del "
+"diritto d'autore la mette offline prima di una decisione. Se il caso viene "
+"accolto, l'immagine viene eliminata, originale privato compreso."
+
+#: lib/vutuv_web/templates/report/new.html.heex:18
+#, elixir-autogen, elixir-format
+msgid "Your report is anonymous. A picture goes offline right away for a copyright notice; every other report goes to our admins with the picture left where it is."
+msgstr ""
+"La Sua segnalazione è anonima. Con una segnalazione per violazione del "
+"diritto d'autore l'immagine va offline subito; ogni altra segnalazione "
+"arriva ai nostri amministratori e l'immagine resta visibile."

--- a/test/vutuv/moderation_image_takedown_test.exs
+++ b/test/vutuv/moderation_image_takedown_test.exs
@@ -39,6 +39,7 @@ defmodule Vutuv.ModerationImageTakedownTest do
     reporter = insert(:activated_user)
     insert(:email, user: reporter)
     admin = insert(:activated_user, admin?: true)
+    insert(:email, user: admin)
 
     {:ok, owner} = Accounts.update_user(owner, %{avatar: jpeg_upload()})
 
@@ -86,6 +87,15 @@ defmodule Vutuv.ModerationImageTakedownTest do
   defp held_files(root, image), do: Path.wildcard(Path.join([root, "frozen", image.id, "**"]))
 
   defp avatar_image(user), do: Images.profile_image(user.id, "avatar")
+
+  # Whether one of the emails delivered so far went to this member.
+  defp assert_mailed(%User{} = user) do
+    address = Accounts.first_email_value(user)
+    recipients = Enum.flat_map(flush_emails(), fn email -> Enum.map(email.to, &elem(&1, 1)) end)
+
+    assert address in recipients,
+           "no email to #{address}; got #{inspect(recipients)}"
+  end
 
   describe "reporting a profile picture" do
     test "the freeze moves every file into the hold and the reject brings them all back",
@@ -184,6 +194,91 @@ defmodule Vutuv.ModerationImageTakedownTest do
 
       assert Path.join([tmp, "frozen", image.id, "served", "leftover-medium-deadbeef.avif"])
              |> File.exists?()
+    end
+  end
+
+  describe "which report takes a picture offline (issue #2030)" do
+    # The freeze is calibrated to the category, not to the reporter's standing.
+    # `trusted_reporter?/1` says yes to an account created a minute ago —
+    # nothing of theirs has been rejected yet — so before this split one
+    # throwaway account took any member's avatar off every surface with its
+    # first ever report.
+    test "a house-rule report leaves the picture where it is and puts the case in the queue",
+         %{tmp: tmp, owner: owner, reporter: reporter, admin: admin} do
+      image = avatar_image(owner)
+      before = tree(tmp)
+
+      {:ok, case_record} =
+        Moderation.report_content(reporter, image, %{"category" => "bullying"})
+
+      assert case_record.status == "flagged"
+      assert Repo.get!(ImageRow, image.id).frozen_at == nil
+
+      # Not one byte moved, and the profile still shows the picture.
+      assert tree(tmp) == before
+      assert held_files(tmp, image) == []
+      assert reload(owner).avatar == "selfie.jpg"
+
+      # An admin has it in front of them all the same.
+      assert case_record.id in Enum.map(Moderation.list_queue(), & &1.id)
+      assert_mailed(admin)
+    end
+
+    test "a second house-rule report does not hide it either",
+         %{tmp: tmp, owner: owner, reporter: reporter} do
+      image = avatar_image(owner)
+      other = insert(:activated_user)
+
+      {:ok, _first} = Moderation.report_content(reporter, image, %{"category" => "family"})
+      {:ok, second} = Moderation.report_content(other, image, %{"category" => "bullying"})
+
+      assert second.status == "flagged"
+      assert Repo.get!(ImageRow, image.id).frozen_at == nil
+      assert served_files(tmp, owner) != []
+    end
+
+    test "a copyright notice still takes it offline on the spot",
+         %{tmp: tmp, owner: owner, reporter: reporter} do
+      image = avatar_image(owner)
+
+      {:ok, case_record} = Moderation.report_content(reporter, image, notice())
+
+      assert case_record.status == "pending_owner"
+      assert Repo.get!(ImageRow, image.id).frozen_at
+      assert served_files(tmp, owner) == []
+    end
+
+    # A copyright notice joining a case a house-rule report opened is still a
+    # legal notice, so it freezes the picture the moment it arrives.
+    test "a copyright notice on an already-flagged case freezes it",
+         %{tmp: tmp, owner: owner, reporter: reporter} do
+      image = avatar_image(owner)
+      rights_holder = insert(:activated_user)
+
+      {:ok, _flagged} = Moderation.report_content(reporter, image, %{"category" => "other"})
+      {:ok, upgraded} = Moderation.report_content(rights_holder, image, notice())
+
+      assert upgraded.status == "pending_owner"
+      assert Repo.get!(ImageRow, image.id).frozen_at
+      assert served_files(tmp, owner) == []
+    end
+
+    # The refusal is about the hold, not about the case: nothing was moved, so
+    # there is nothing a replacement could strand.
+    test "the owner can replace a picture that was only flagged",
+         %{owner: owner, reporter: reporter} do
+      image = avatar_image(owner)
+      {:ok, case_record} = Moderation.report_content(reporter, image, %{"category" => "family"})
+
+      {:ok, replaced} = Accounts.update_user(reload(owner), %{avatar: jpeg_upload("other.jpg")})
+
+      assert replaced.avatar == "other.jpg"
+      assert Repo.get!(ImageRow, image.id).file == "other.jpg"
+
+      # And the case is settled with them: the reported bytes are gone, so
+      # leaving it open would point an admin's ruling at a picture nobody
+      # reported.
+      assert Repo.get!(Moderation.Case, case_record.id).status == "resolved_deleted"
     end
   end
 

--- a/test/vutuv/moderation_test.exs
+++ b/test/vutuv/moderation_test.exs
@@ -183,12 +183,12 @@ defmodule Vutuv.ModerationTest do
 
       # First reporter wins the atomic claim: one freeze, one content_frozen
       # log row, one owner notification.
-      assert {:ok, first} = Moderation.maybe_upgrade_case(flagged, trusted_b, post)
+      assert {:ok, first} = Moderation.maybe_upgrade_case(flagged, trusted_b, post, "bullying")
       assert first.status == "pending_owner"
 
       # Second reporter holds the same stale flagged struct and loses the claim,
       # so it must NOT freeze/log/notify a second time.
-      assert {:ok, second} = Moderation.maybe_upgrade_case(flagged, trusted_c, post)
+      assert {:ok, second} = Moderation.maybe_upgrade_case(flagged, trusted_c, post, "bullying")
       assert second.status == "pending_owner"
 
       frozen_events =

--- a/test/vutuv_web/image_report_test.exs
+++ b/test/vutuv_web/image_report_test.exs
@@ -27,7 +27,7 @@ defmodule VutuvWeb.ImageReportTest do
     # with a test's own logins hands one of them somebody else's PIN.
     {owner_conn, owner} = create_and_login_user(conn)
     {reporter_conn, reporter} = create_and_login_user(conn)
-    {admin_conn, _admin} = create_and_login_admin(conn)
+    {admin_conn, admin} = create_and_login_admin(conn)
 
     {:ok, owner} = Accounts.update_user(owner, %{avatar: jpeg_upload()})
 
@@ -35,6 +35,7 @@ defmodule VutuvWeb.ImageReportTest do
      owner_conn: owner_conn,
      reporter_conn: reporter_conn,
      admin_conn: admin_conn,
+     admin: admin,
      owner: owner,
      reporter: reporter,
      image: Images.profile_image(owner.id, "avatar")}
@@ -84,6 +85,10 @@ defmodule VutuvWeb.ImageReportTest do
       # they are about to file a legal notice over.
       assert html =~ "/avatars/#{image.user_id}/"
       assert html =~ "value=\"copyright\""
+
+      # And the intro says which report actually hides a picture (issue #2030).
+      assert html =~ "goes offline right away for a copyright notice"
+      refute html =~ "the content is hidden right away"
     end
 
     test "the German form says what it is", %{reporter_conn: conn, image: image} do
@@ -95,6 +100,9 @@ defmodule VutuvWeb.ImageReportTest do
         |> html_response(200)
 
       assert html =~ "Profilbild"
+
+      assert html =~
+               "Bei einer Meldung wegen Urheberrechts geht das Bild sofort offline"
     end
   end
 
@@ -137,6 +145,81 @@ defmodule VutuvWeb.ImageReportTest do
       conn
       |> get(~p"/moderation/cases/#{case_record.id}/image")
       |> response(200)
+    end
+  end
+
+  describe "what the two paths say (issue #2030)" do
+    test "a house-rule report says the moderators will look, and hides nothing", %{
+      reporter_conn: conn,
+      owner: owner,
+      image: image
+    } do
+      conn =
+        post(conn, ~p"/reports", %{
+          "report" => %{"type" => "image", "id" => image.id, "category" => "bullying"}
+        })
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "will review this picture"
+
+      # The picture is still where it was, on the profile the reporter came from.
+      assert conn |> recycle() |> get(~p"/#{owner}") |> html_response(200) =~
+               "/avatars/#{owner.id}/"
+    end
+
+    test "the German wording names the picture", %{reporter_conn: conn, image: image} do
+      conn =
+        conn
+        |> recycle()
+        |> put_req_header("accept-language", "de-DE,de")
+        |> post(~p"/reports", %{
+          "report" => %{"type" => "image", "id" => image.id, "category" => "family"}
+        })
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~
+               "Unsere Moderatoren wurden benachrichtigt und prüfen dieses Bild."
+    end
+
+    test "a copyright notice still says nothing about reviewing, because it acted", %{
+      reporter_conn: conn,
+      owner: owner,
+      image: image
+    } do
+      conn =
+        post(conn, ~p"/reports", %{
+          "report" => %{
+            "type" => "image",
+            "id" => image.id,
+            "category" => "copyright",
+            "note" => "That is my photograph.",
+            "good_faith?" => "true"
+          }
+        })
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "We take it from here."
+
+      refute conn |> recycle() |> get(~p"/#{owner}") |> html_response(200) =~
+               "/avatars/#{owner.id}/"
+    end
+
+    test "the admin case page says whether the picture is still on the profile", %{
+      admin_conn: conn,
+      owner: owner,
+      reporter: reporter,
+      admin: admin,
+      image: image
+    } do
+      {:ok, flagged} = Moderation.report_content(reporter, image, %{"category" => "bullying"})
+
+      html = conn |> get(~p"/admin/moderation/#{flagged.id}") |> html_response(200)
+      assert html =~ "This picture is still on the profile"
+      refute html =~ "puts every file back where it was"
+
+      {:ok, _} = Moderation.reject_case(flagged, admin)
+      frozen = report!(insert(:activated_user), Images.profile_image(owner.id, "avatar"))
+
+      html = conn |> recycle() |> get(~p"/admin/moderation/#{frozen.id}") |> html_response(200)
+      assert html =~ "puts every file back where it was"
+      refute html =~ "This picture is still on the profile"
     end
   end
 


### PR DESCRIPTION
One report from a minutes-old throwaway account took any member's profile picture off every surface, and the owner could not replace it afterwards. The picture freeze hung on `trusted_reporter?/1`, which trusts every account with no rejected report yet.

The category decides now, not the reporter. A **copyright** notice keeps the instant takedown: it is the legal claim this machinery was built for and the only category that already demands a written explanation and a good-faith declaration. **family / bullying / other** open a `flagged` case, mail the admins and leave the picture where it is, exactly as a report against a whole profile does. `Vutuv.Moderation.report_freezes?/2` answers this for both ways into a freeze, so two throwaway accounts cannot take through the upgrade path what the first report lost.

Left out: the AI scan's own delete path, which settles no case either (pre-existing, all content types).

Where: `Vutuv.Moderation.initial_status/3`, `/reports/new`, `/admin/moderation/:id`.

Closes #2030

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01UGPe7bHVS11M1W7fNehSku

<!-- closing-note #2030 -->
A house-rule complaint about a profile picture now puts the case in front of an admin without hiding the picture first, and only a copyright notice still takes one offline on the spot. Replacing a picture that was merely flagged is allowed again and settles the case, because the upload overwrites the very bytes that were reported. I did not extend this to the AI scan's own delete path, which leaves an open case behind for every content type and wants its own fix.

*An AI agent wrote this text in my name. I know that is problematic.*
