### PR TITLE
Store a picture with a very long file name instead of dropping it

### DIFF
--- a/lib/vutuv/images/image.ex
+++ b/lib/vutuv/images/image.ex
@@ -11,6 +11,8 @@ defmodule Vutuv.Images.Image do
 
   use VutuvWeb, :model
 
+  alias Vutuv.Uploads
+
   schema "images" do
     field(:kind, :string)
     belongs_to(:user, Vutuv.Accounts.User)
@@ -45,12 +47,17 @@ defmodule Vutuv.Images.Image do
   upload's own name, which a member chooses, and an over-long one would
   otherwise raise Postgres 22001 on a path no form guards. The others are
   derived here and bounded by construction, in varchar(255) columns.
+
+  The bound comes from `Vutuv.Uploads.max_stored_file_name/0`, which is also
+  what the uploader cuts the name to, so this validation and the cut guarding
+  the same write cannot drift apart. It is the second line, not the first: the
+  cut is what a member actually meets (issue #2025).
   """
   def changeset(image, attrs) do
     image
     |> cast(attrs, [:file, :fingerprint, :crop, :moderation])
     |> validate_required([:kind, :token])
-    |> validate_length(:file, max: 255)
+    |> validate_length(:file, max: Uploads.max_stored_file_name())
     |> unique_constraint(:token)
     |> unique_constraint(:kind, name: :images_member_profile_kind_index)
     |> check_constraint(:user_id, name: :images_profile_kind_has_owner)

--- a/lib/vutuv/uploads.ex
+++ b/lib/vutuv/uploads.ex
@@ -31,6 +31,11 @@ defmodule Vutuv.Uploads do
   # (one image's versions), which is all that shares a dir.
   @hash_length 12
 
+  # Every column an upload's own file name is written into is varchar(255):
+  # `users.avatar`, `users.cover_photo` and `images.file`. See
+  # `max_stored_file_name/0`.
+  @max_stored_file_name 255
+
   @typedoc """
   Per-uploader layout passed to the shared `store/3`, `url/3` and
   `regenerate/3` pipeline (`Vutuv.Avatar` and `Vutuv.Cover` differ only in
@@ -219,8 +224,9 @@ defmodule Vutuv.Uploads do
 
   @doc """
   Stores every derived version for `{upload, scope}` per `config` and returns
-  `{:ok, original_file_name, fingerprint, moderation}` — the verbatim upload
-  name, the content fingerprint (`sha256(original)[0..#{@hash_length - 1}]`)
+  `{:ok, original_file_name, fingerprint, moderation}` — the upload's own name
+  (cut to `max_stored_file_name/0`), the content
+  fingerprint (`sha256(original)[0..#{@hash_length - 1}]`)
   and the moderation state the bytes were actually stored under, all three for
   the caller's columns — or `{:error, :invalid_file}` when the extension is not
   whitelisted **or the file cannot be decoded as an image** (corrupt/truncated
@@ -268,7 +274,7 @@ defmodule Vutuv.Uploads do
            :ok <- write_derived_versions(cropped, target_dir, scope, fingerprint, config),
            :ok <- clear_displaced_versions(target_dir, dir),
            :ok <- Originals.store(storage_dir, upload.path, ext) do
-        {:ok, upload.filename, fingerprint, moderation}
+        {:ok, stored_file_name(upload.filename), fingerprint, moderation}
       else
         {:error, _reason} -> {:error, :invalid_file}
       end
@@ -276,6 +282,57 @@ defmodule Vutuv.Uploads do
       {:error, :invalid_file}
     end
   end
+
+  # The upload's own name, cut to what its columns hold, extension kept.
+  #
+  # A name comes off a phone or a scanner, not out of a form, and nothing
+  # resolves a file through it — the served name is
+  # `<handle>-<version>-<fingerprint>.avif`, the private original is
+  # `original<ext>` — so it is bookkeeping. That is why an over-long one is cut
+  # rather than refused: turning a good picture away over its *name* refuses it
+  # for something that is not about the picture (issue #2025).
+  defp stored_file_name(filename) when is_binary(filename) do
+    ext = Path.extname(filename)
+    keep = @max_stored_file_name - code_points(ext)
+
+    cond do
+      code_points(filename) <= @max_stored_file_name -> filename
+      # A name that is nearly all extension leaves no room to keep it.
+      keep < 1 -> cut_to_code_points(filename, @max_stored_file_name)
+      true -> cut_to_code_points(filename, keep) <> ext
+    end
+  end
+
+  # Measured and cut in **code points**, because that is what varchar(255)
+  # counts, while `String.length/1` counts graphemes — and the two differ on
+  # exactly the names this site gets. macOS hands over decomposed (NFD) names,
+  # where every `ä` is one grapheme and two code points, so a 200-character
+  # German name is 400 code points and still raises Postgres 22001. Cut on a
+  # grapheme boundary all the same, so the result never ends in an orphaned
+  # combining accent.
+  defp cut_to_code_points(string, max) do
+    string
+    |> String.graphemes()
+    |> Enum.reduce_while({[], 0}, fn grapheme, {kept, used} ->
+      used = used + code_points(grapheme)
+      if used <= max, do: {:cont, {[grapheme | kept], used}}, else: {:halt, {kept, used}}
+    end)
+    |> elem(0)
+    |> Enum.reverse()
+    |> Enum.join()
+  end
+
+  defp code_points(string), do: string |> String.to_charlist() |> length()
+
+  @doc """
+  How much of an upload's own file name is kept — the width of every column it
+  is written into (`users.avatar`, `users.cover_photo`, `images.file`), in
+  characters.
+
+  Read by `Vutuv.Images.Image.changeset/2` as well, so the cutter and the
+  validation guarding the same write cannot drift apart.
+  """
+  def max_stored_file_name, do: @max_stored_file_name
 
   # Quarantine-first uploads clear the old public image only after the new
   # derive succeeded (limbo shows the placeholder, per spec); the classic

--- a/test/vutuv/uploaders/uploads_integration_test.exs
+++ b/test/vutuv/uploaders/uploads_integration_test.exs
@@ -156,6 +156,72 @@ defmodule Vutuv.UploadsIntegrationTest do
     assert File.exists?(Path.join(tmp, "originals/covers/#{user.id}/original.png"))
   end
 
+  # Issue #2025. `users.avatar`, `users.cover_photo` and `images.file` are all
+  # varchar(255) and the name comes straight off the member's phone or camera.
+  # Before #2022 an over-long one raised Postgres 22001 and threw the member
+  # onto an error page; after it the image row's own length validation caught it
+  # first, the whole picture save was abandoned behind a `Logger.warning` — and
+  # the member got a **success** flash for a picture that never changed.
+  test "a file name past the column length is shortened, not dropped", %{tmp: tmp} do
+    user = insert(:user, first_name: "Ada", last_name: "King")
+    long = String.duplicate("a", 300) <> ".png"
+    upload = %Plug.Upload{filename: long, path: png_fixture(), content_type: "image/png"}
+
+    assert {:ok, updated} = Vutuv.Accounts.update_user(user, %{avatar: upload})
+
+    # The picture is really there — its absence is what the bug was.
+    assert updated.avatar_fingerprint =~ ~r/\A[0-9a-f]{12}\z/
+
+    assert File.exists?(
+             Path.join(
+               tmp,
+               "avatars/#{user.id}/#{updated.username}-thumb-#{updated.avatar_fingerprint}.avif"
+             )
+           )
+
+    # Shortened to fit, and the extension survives: it is what the name is for.
+    assert String.length(updated.avatar) == 255
+    assert String.ends_with?(updated.avatar, ".png")
+
+    # Both writes get the same name, so neither can overflow its column.
+    assert Vutuv.Images.profile_image(user.id, "avatar").file == updated.avatar
+  end
+
+  # The other column, through the other uploader.
+  test "a long cover photo name is shortened the same way" do
+    user = insert(:user, first_name: "Ada", last_name: "King")
+    long = String.duplicate("b", 300) <> ".png"
+    upload = %Plug.Upload{filename: long, path: png_fixture(), content_type: "image/png"}
+
+    assert {:ok, updated} = Vutuv.Accounts.update_user(user, %{cover_photo: upload})
+
+    assert updated.cover_fingerprint =~ ~r/\A[0-9a-f]{12}\z/
+    assert String.length(updated.cover_photo) == 255
+    assert String.ends_with?(updated.cover_photo, ".png")
+  end
+
+  # varchar(255) counts code points; `String.length/1` counts graphemes. macOS
+  # hands over decomposed (NFD) file names, so a German one is one grapheme and
+  # two code points per umlaut — 200 such graphemes are 400 code points, which
+  # Postgres refuses with 22001 (verified against the dev database) while every
+  # grapheme-based measure calls the name short enough.
+  test "a German file name is measured the way the column measures it" do
+    user = insert(:user, first_name: "Ada", last_name: "King")
+    long = :unicode.characters_to_nfd_binary(String.duplicate("ä", 200)) <> ".png"
+    upload = %Plug.Upload{filename: long, path: png_fixture(), content_type: "image/png"}
+
+    assert {:ok, updated} = Vutuv.Accounts.update_user(user, %{avatar: upload})
+
+    assert updated.avatar_fingerprint =~ ~r/\A[0-9a-f]{12}\z/
+    assert code_points(updated.avatar) <= 255
+    assert String.ends_with?(updated.avatar, ".png")
+
+    # Cut on a grapheme boundary: every kept character is still a whole "ä"
+    # (letter plus combining diaeresis), never a stranded accent.
+    base = String.replace_suffix(updated.avatar, ".png", "")
+    assert code_points(base) == 2 * String.length(base)
+  end
+
   test "an invalid cover photo extension is rejected with a changeset error" do
     user = insert(:user)
     upload = %Plug.Upload{filename: "evil.gif", path: png_fixture(), content_type: "image/gif"}
@@ -222,6 +288,8 @@ defmodule Vutuv.UploadsIntegrationTest do
     |> ProfileDoc.build(include_photo: true)
     |> VCard.render()
   end
+
+  defp code_points(string), do: string |> String.to_charlist() |> length()
 
   defp png_fixture(opts \\ []) do
     {:ok, img} = Image.new(300, 200, color: opts[:color] || [10, 120, 200])


### PR DESCRIPTION
Uploading a picture whose file name runs past 255 characters threw the member onto an error page; since #2022 it silently abandoned the picture save behind a `Logger.warning` while telling the member it had worked.

`Vutuv.Uploads.store/3` now cuts the name to the width of the columns it is written into (`users.avatar`, `users.cover_photo`, `images.file`), extension kept. Nothing resolves a file through that name — the served file is `<handle>-<version>-<fingerprint>.avif` — so it is bookkeeping, and refusing a good picture over its name refuses it for something that is not about the picture.

Measured and cut in **code points**, not graphemes: macOS hands over German file names decomposed, so 200 "ä" are 400 code points and still raise 22001, while every grapheme-based measure calls the name short enough. Verified against Postgres and covered by a test that goes red without it.

Smoke-tested in Chrome: a 300-character name uploaded through /settings/profile now really replaces the avatar.

Closes #2025

https://claude.ai/code/session_01X3SMjwhk9kzQTLmdnJj5wn
