### PR TITLE
Re-uploading the identical picture no longer settles its report

### DIFF
--- a/docs/architecture/moderation.md
+++ b/docs/architecture/moderation.md
@@ -173,10 +173,25 @@ reported. `frozen_at` is deliberately **not** in that upsert's replace list for
 the same reason. The refusal reads `frozen_at`, so it is about the **hold** and
 not about the case: a picture a house-rule report only flagged can be replaced,
 and that replacement overwrites the reported bytes, so
-`Vutuv.Accounts.store_new_image/7` settles the open case as `resolved_deleted`
+`Vutuv.Accounts.store_new_image/8` settles the open case as `resolved_deleted`
 (the same outcome the owner's own "remove it" reaches). Otherwise an admin's
 ruling — which for a picture is the one ruling that *deletes* — would land on
 whatever the member put there afterwards.
+
+**Only if the bytes really changed** (issue #2035). That settle first shipped on
+the upload itself, and re-uploading the **same file** then closed the case,
+dropped it out of the admin queue and told the reporters it was resolved — a
+door out of a complaint that cost the owner nothing, in the categories (`family`,
+`bullying`, `other`) where nothing was hidden in the first place, and equally in
+the window a copyright notice from outside spends `flagged` while its notifier
+has not confirmed it yet. So `store_new_image/8` reads the row's fingerprint
+**before** the upsert replaces it and settles the case only when the new one
+differs. The fingerprint is `sha256(original <> crop)`
+(`Vutuv.Uploads.content_hash/2`), so a re-crop of the same original counts — the
+picture everyone sees really is a different one — while the same file uploaded
+again does not, and the case stays exactly where it was. Nothing is said to the
+member about it: the case never promised that replacing the picture settles it,
+and their upload succeeded.
 
 ### Only a copyright notice hides a picture (issue #2030)
 

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -2232,9 +2232,14 @@ defmodule Vutuv.Accounts do
     # The moderation state comes back from the store rather than being read a
     # second time here: the store is where `:moderate_images` decided which tree
     # the bytes went into, so the row records the state that actually happened.
-    kind = scan_kind(field)
 
-    if Images.frozen?(user.id, kind) do
+    # One read of the row this upload is about to overwrite, answering both
+    # questions below: whether a takedown holds the picture, and which bytes a
+    # report about it named.
+    kind = scan_kind(field)
+    current = Images.profile_image(user.id, kind)
+
+    if current && current.frozen_at do
       # A copyright case holds this picture (issue #2012). Replacing it would
       # move the open case onto bytes nobody reported, so the upload is refused
       # here — before `store/2` writes anything — and the form says why
@@ -2243,13 +2248,16 @@ defmodule Vutuv.Accounts do
       Logger.warning("#{field} upload refused for user ##{user.id}: the picture is frozen")
       user
     else
-      store_new_image(user, field, crop_field, upload, crop, store, kind)
+      reported = current && current.fingerprint
+      store_new_image(user, field, crop_field, upload, crop, store, kind, reported)
     end
   end
 
   # The upload's own two writes, split off so the frozen guard above reads as
   # one sentence rather than wrapping this whole `with` in an else branch.
-  defp store_new_image(user, field, crop_field, upload, crop, store, kind) do
+  # `reported` is the fingerprint the row carried before this upload, or nil for
+  # a first picture.
+  defp store_new_image(user, field, crop_field, upload, crop, store, kind, reported) do
     with {:ok, file_name, fingerprint, moderation} <- store.({upload, user}, crop),
          image_attrs = %{
            file: file_name,
@@ -2267,12 +2275,18 @@ defmodule Vutuv.Accounts do
       ImageScans.enqueue(kind, saved.id, saved.id, fingerprint)
 
       # A picture whose case only flagged it may be replaced (the guard above is
-      # about the takedown hold, and a flagged case moved nothing), and this
-      # upload has just overwritten the very bytes that were reported. So the
-      # replacement settles the case the way the owner's own "remove it" does:
-      # left open, an admin's ruling — which for a picture is the one ruling that
-      # *deletes* — would land on whatever the member put there afterwards.
-      Moderation.content_deleted(image)
+      # about the takedown hold, and a flagged case moved nothing), and such an
+      # upload overwrites the very bytes that were reported. So the replacement
+      # settles the case the way the owner's own "remove it" does: left open, an
+      # admin's ruling — which for a picture is the one ruling that *deletes* —
+      # would land on whatever the member put there afterwards.
+      #
+      # But only a replacement. Uploading the same file again overwrites the
+      # reported bytes with themselves, and settling on that was a way to make a
+      # complaint vanish from the admin queue at no cost to the owner (issue
+      # #2035). The fingerprint answers it, crop and all
+      # (`Vutuv.Uploads.content_hash/2`).
+      if fingerprint != reported, do: Moderation.content_deleted(image)
       saved
     else
       _ ->

--- a/lib/vutuv/images.ex
+++ b/lib/vutuv/images.ex
@@ -192,14 +192,16 @@ defmodule Vutuv.Images do
   @doc """
   Whether this member's picture of that kind is held by a copyright freeze.
 
-  Asked at three layers on purpose, and each one is load-bearing:
-  `VutuvWeb.UserController.update/2` asks before the write so the form can say
-  *why* it refused rather than dropping the upload silently,
-  `Vutuv.Accounts.store_pending_image/6` asks before `store/3` writes a byte,
-  and `put_profile_image/3` refuses the row itself — the row's four columns are
-  what `unfreeze/1` restores from, so overwriting them would leave nothing to
-  put back. Three index probes on a path that spends hundreds of milliseconds
-  encoding AVIFs.
+  The question is asked at three layers on purpose, and each one is
+  load-bearing: `VutuvWeb.UserController.update/2` asks before the write so the
+  form can say *why* it refused rather than dropping the upload silently,
+  `Vutuv.Accounts.store_pending_image/6` asks before `store/3` writes a byte —
+  reading `frozen_at` off `profile_image/2` rather than calling this, since it
+  needs the row anyway to know which bytes an open case named (issue #2035) —
+  and `put_profile_image/3` refuses the row itself, because the row's four
+  columns are what `unfreeze/1` restores from, so overwriting them would leave
+  nothing to put back. Two index probes and one row read, on a path that spends
+  hundreds of milliseconds encoding AVIFs.
   """
   def frozen?(user_id, kind) when kind in @kinds do
     Repo.exists?(from(i in profile_query(user_id, kind), where: not is_nil(i.frozen_at)))

--- a/test/vutuv/moderation_image_takedown_test.exs
+++ b/test/vutuv/moderation_image_takedown_test.exs
@@ -295,14 +295,58 @@ defmodule Vutuv.ModerationImageTakedownTest do
       image = avatar_image(owner)
       {:ok, case_record} = Moderation.report_content(reporter, image, %{"category" => "family"})
 
-      {:ok, replaced} = Accounts.update_user(reload(owner), %{avatar: jpeg_upload("other.jpg")})
+      # A different colour, not just a different name: `jpeg_upload/2` encodes
+      # deterministically, so a rename alone is the byte-identical re-upload of
+      # the test below.
+      {:ok, replaced} =
+        Accounts.update_user(reload(owner), %{avatar: jpeg_upload("other.jpg", [220, 60, 30])})
 
       assert replaced.avatar == "other.jpg"
       assert Repo.get!(ImageRow, image.id).file == "other.jpg"
+      assert replaced.avatar_fingerprint != owner.avatar_fingerprint
 
       # And the case is settled with them: the reported bytes are gone, so
       # leaving it open would point an admin's ruling at a picture nobody
       # reported.
+      assert Repo.get!(Moderation.Case, case_record.id).status == "resolved_deleted"
+    end
+
+    # Issue #2035: the settle above is earned by the bytes changing, not by an
+    # upload happening. Putting the very same file back replaced nothing, so it
+    # must not close the report — that was a way to make a complaint disappear
+    # without an admin ever seeing it, and it cost the owner nothing.
+    test "re-uploading the identical picture does not settle the case",
+         %{owner: owner, reporter: reporter} do
+      image = avatar_image(owner)
+      {:ok, case_record} = Moderation.report_content(reporter, image, %{"category" => "family"})
+      queue_before = Moderation.open_queue_count()
+
+      {:ok, same} = Accounts.update_user(reload(owner), %{avatar: jpeg_upload()})
+
+      # Same file in, same fingerprint out: the row still names the bytes the
+      # report is about.
+      assert same.avatar_fingerprint == owner.avatar_fingerprint
+      assert Repo.get!(ImageRow, image.id).fingerprint == owner.avatar_fingerprint
+
+      assert Repo.get!(Moderation.Case, case_record.id).status == "flagged"
+      assert Moderation.open_queue_count() == queue_before
+    end
+
+    # The crop is folded into the fingerprint, so a re-crop of the same original
+    # is a different served picture — and everybody who follows the report's
+    # link now sees different bytes.
+    test "re-cropping the same original counts as a replacement",
+         %{owner: owner, reporter: reporter} do
+      image = avatar_image(owner)
+      {:ok, case_record} = Moderation.report_content(reporter, image, %{"category" => "family"})
+
+      {:ok, cropped} =
+        Accounts.update_user(reload(owner), %{
+          "avatar" => jpeg_upload(),
+          "avatar_crop" => "0.25,0,0.5,1"
+        })
+
+      assert cropped.avatar_fingerprint != owner.avatar_fingerprint
       assert Repo.get!(Moderation.Case, case_record.id).status == "resolved_deleted"
     end
   end


### PR DESCRIPTION
Uploading the very same profile picture again closed the moderation case about it: the case left `/admin/moderation` as `resolved_deleted`, the reporters were told it was settled, and it cost the owner nothing. Since #2030 a *replacement* settles the case on purpose — the upload overwrites the reported bytes, and an upheld picture case deletes — but nothing checked that the bytes had changed.

`Vutuv.Accounts.store_new_image/8` now reads the `images` row's fingerprint before the upsert replaces it and settles the case only when the new one differs. The fingerprint is `sha256(original <> crop)`, so re-cropping the same original still counts as a replacement, while the identical file does not. The pre-upload freeze guard reads that same row instead of a second probe.

The member sees nothing new: the upload succeeds as before, and the case simply stays where it was. Left alone: the same "nothing actually changed" hole on `content_edited/1` for posts and job postings.

Closes #2035

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01UGPe7bHVS11M1W7fNehSku

<!-- closing-note #2035 -->
Re-uploading the identical picture no longer settles its report: the case stays open and in the admin queue, and only a genuinely different picture (or a new crop of the same original, which changes what everyone sees) still closes it as the owner's own "remove it" would. I kept that settle rather than restricting which statuses an upload may close, because a flagged picture case is exactly the one a real replacement has to settle — otherwise an upheld ruling would delete the innocent replacement. I left the same gap on posts and job postings alone, where an edit that changes nothing still settles a case and unfreezes the content; that one is wider than this issue and wants its own fix.

*An AI agent wrote this text in my name. I know that is problematic.*
