### PR TITLE
Show the admin a held picture whatever scheme it was stored under

### DIFF
--- a/lib/vutuv/moderation.ex
+++ b/lib/vutuv/moderation.ex
@@ -803,6 +803,20 @@ defmodule Vutuv.Moderation do
     end)
   end
 
+  @doc """
+  The case row on its own, no preloads. Same contract as
+  `get_case_with_details/1` — raw params id in, nil on garbage input or no such
+  case — for the one page that needs the row and nothing hanging off it
+  (`VutuvWeb.ModerationCaseController.image/2`, which only asks what content
+  type the case is about).
+
+  Beside its fuller twin rather than a `Repo.get` in the controller: "a raw id
+  becomes a case, or nothing" is one rule, and a controller spelling it itself
+  read the id straight, where a malformed one raises rather than missing —
+  a 400 and an exception in the log for a wrong address (issue #2031).
+  """
+  def get_case(id), do: Vutuv.UUIDv7.with_cast(id, &Repo.get(Case, &1))
+
   @doc "The open case for this content item, if any."
   def open_case_for(content) do
     from(c in Case,

--- a/lib/vutuv/uploads.ex
+++ b/lib/vutuv/uploads.ex
@@ -20,6 +20,7 @@ defmodule Vutuv.Uploads do
   alias Vutuv.Uploads.Crop
   alias Vutuv.Uploads.Originals
   alias Vutuv.Uploads.Spec
+  alias Vutuv.UUIDv7
 
   @extension_whitelist ~w(.jpg .jpeg .png)
 
@@ -105,16 +106,26 @@ defmodule Vutuv.Uploads do
   def hold_dir(image_id) when is_binary(image_id), do: disk_dir(Path.join(@hold_root, image_id))
 
   @doc """
-  Every hold on disk, by image id. One `readdir` of a tree that is empty on
-  almost every installation, and the record `Vutuv.Images.reconcile_holds/0`
-  reads to find work a dying slot left half-done — the hold layout is written
-  here and nowhere else.
+  Every hold on disk, by image id — the record `Vutuv.Images.reconcile_holds/0`
+  reads to find work a dying slot left half-done. One `readdir` of a tree that
+  is empty on almost every installation, plus a `stat` per hold; the hold layout
+  is written here and nowhere else.
+
+  A hold is a **directory named by an image id**, and only those come back:
+  anything else in that root reaches `where: i.id in ^ids`, which raises rather
+  than matching nothing, and takes the whole pass with it (issue #2031).
   """
   def held_image_ids do
-    case File.ls(disk_dir(@hold_root)) do
-      {:ok, ids} -> ids
+    root = disk_dir(@hold_root)
+
+    case File.ls(root) do
+      {:ok, entries} -> Enum.filter(entries, &hold?(root, &1))
       {:error, _reason} -> []
     end
+  end
+
+  defp hold?(root, entry) do
+    UUIDv7.cast_or_nil(entry) != nil and File.dir?(Path.join(root, entry))
   end
 
   # Which tree each slot of a hold came from, so `release/3` puts every file
@@ -170,23 +181,35 @@ defmodule Vutuv.Uploads do
 
   @doc """
   The on-disk path of one held derived version, for the authorized preview the
-  case pages show (`VutuvWeb.ModerationCaseController.image/2`). Matched by
-  version and fingerprint rather than rebuilt from the handle, because a member
-  who renames while their picture is held keeps the old handle in the file
-  name. `nil` when there is none.
+  case pages show (`VutuvWeb.ModerationCaseController.image/2`). `nil` when
+  there is none.
+
+  The hold's twin of `version_path/3`, and deliberately not a call to it: a
+  member who renames while their picture is held keeps the old handle in the
+  file name, and no scope reaches here to rebuild it from, so this matches what
+  is on disk instead. Both schemes, because a hold has to answer for whichever
+  one the picture was stored under — the fingerprinted name first, then the
+  legacy one a row that never reached a fingerprint carries. Missing the second
+  drew a broken image on the case page for those pictures, and an admin who
+  cannot see a picture cannot rule on the claim about it (issue #2031).
   """
-  def held_version_path(image_id, version, fingerprint)
-      when is_binary(image_id) and is_binary(fingerprint) do
-    image_id
-    |> hold_dir()
-    # Every slot, not just `served/`: a picture frozen while the AI gate still
-    # had it keeps its versions under `quarantine/`.
-    |> Path.join("*/*-#{version}-#{fingerprint}#{Spec.served_ext()}")
-    |> Path.wildcard()
-    |> List.first()
+  def held_version_path(image_id, version, fingerprint) when is_binary(image_id) do
+    dir = hold_dir(image_id)
+
+    fingerprinted =
+      is_binary(fingerprint) && first_match(dir, fingerprinted_glob(version, fingerprint))
+
+    fingerprinted || first_match(dir, legacy_version_glob(version))
   end
 
   def held_version_path(_image_id, _version, _fingerprint), do: nil
+
+  # Every slot, not just `served/`: a picture frozen while the AI gate still had
+  # it keeps its versions under `quarantine/`. The private original stays out of
+  # reach — it is never shown to anybody, and neither glob matches its
+  # `original<ext>` name.
+  defp first_match(dir, glob),
+    do: dir |> Path.join("*/#{glob}") |> Path.wildcard() |> List.first()
 
   # One directory's files, moved one atomic rename at a time. Nothing recurses:
   # every tree an uploader writes is flat.
@@ -636,6 +659,14 @@ defmodule Vutuv.Uploads do
     "#{handle(scope, config)}-#{version}-#{fp}#{Spec.served_ext()}"
   end
 
+  # The same name with the handle left open, for a tree where nothing can say
+  # what the handle is: a takedown hold keeps the name the picture had when it
+  # was frozen, which a rename since then has made stale. Beside the builder on
+  # purpose — change one and the other has to change with it, or
+  # `held_version_path/3` stops finding the file and the case page goes back to
+  # drawing a broken image.
+  defp fingerprinted_glob(version, fp), do: "*-#{version}-#{fp}#{Spec.served_ext()}"
+
   defp fingerprinted_url(scope, version, fp, config) do
     "/"
     |> Path.join(storage_dir(scope, config))
@@ -724,6 +755,15 @@ defmodule Vutuv.Uploads do
   # so a rename can never orphan it and an unsanitized name can never escape the
   # directory (both #773).
   defp version_filename(config, version, ext), do: "#{config.spec_key}_#{version}#{ext}"
+
+  # Both pre-fingerprint names at once — the stable `avatar_<version>.avif`
+  # above and the pre-#773 `<First Last>_<version>.<ext>` of
+  # `legacy_name_filename/4` — for the takedown hold, which has neither the
+  # scope nor the config those two build from. The `_<version>.` in the middle
+  # is what tells them from a fingerprinted name (`-<version>-`) and from the
+  # private `original<ext>`. Beside the builders, so a change to the scheme
+  # meets its glob.
+  defp legacy_version_glob(version), do: "*_#{version}.*"
 
   defp extname(value) when is_binary(value) do
     value

--- a/lib/vutuv_web/controllers/moderation_case_controller.ex
+++ b/lib/vutuv_web/controllers/moderation_case_controller.ex
@@ -14,7 +14,6 @@ defmodule VutuvWeb.ModerationCaseController do
   alias Vutuv.Images.Image
   alias Vutuv.Moderation
   alias Vutuv.Moderation.Case
-  alias Vutuv.Repo
   alias VutuvWeb.ControllerHelpers
 
   def index(conn, _params) do
@@ -59,7 +58,7 @@ defmodule VutuvWeb.ModerationCaseController do
   with an upheld case — is a 404.
   """
   def image(conn, %{"id" => id}) do
-    with %Case{content_type: "image"} = case_record <- Repo.get(Case, id),
+    with %Case{content_type: "image"} = case_record <- Moderation.get_case(id),
          :ok <- authorize(conn, case_record),
          %Image{} = image <- Moderation.case_content(case_record),
          path when is_binary(path) <- Images.bytes_path(image) do

--- a/test/vutuv/moderation_image_takedown_test.exs
+++ b/test/vutuv/moderation_image_takedown_test.exs
@@ -88,6 +88,31 @@ defmodule Vutuv.ModerationImageTakedownTest do
 
   defp avatar_image(user), do: Images.profile_image(user.id, "avatar")
 
+  # A member whose avatar predates the fingerprinted file name: the row names
+  # the upload, the files on disk carry the stable legacy name
+  # (`avatar_<version>.avif`) and no fingerprint column is set. The backfill is
+  # what gives it its `images` row, exactly as it did in production.
+  defp legacy_avatar_owner(root) do
+    user = insert(:activated_user, avatar: "Image703.jpg?63659747708", avatar_fingerprint: nil)
+    insert(:email, user: user)
+
+    dir = Path.join([root, "avatars", user.id])
+    File.mkdir_p!(dir)
+
+    for version <- ~w(thumb medium large),
+        do: File.write!(Path.join(dir, "avatar_#{version}.avif"), "legacy #{version} bytes")
+
+    File.mkdir_p!(Path.join([root, "originals/avatars", user.id]))
+
+    File.write!(
+      Path.join([root, "originals/avatars", user.id, "original.jpg"]),
+      "legacy original"
+    )
+
+    Backfill.run(only: "avatar")
+    user
+  end
+
   # Whether one of the emails delivered so far went to this member.
   defp assert_mailed(%User{} = user) do
     address = Accounts.first_email_value(user)
@@ -294,6 +319,55 @@ defmodule Vutuv.ModerationImageTakedownTest do
       assert tally.dropped == 0
       assert Repo.get(ImageRow, image.id)
       assert Backfill.check(only: "avatar").kinds["avatar"].orphan_row.count == 0
+    end
+  end
+
+  describe "looking at a held picture (issue #2031)" do
+    # An admin ruling on a copyright claim has to see the picture, and a freeze
+    # has moved it out of every tree nginx serves — so `bytes_path/2` is the
+    # only way there. It looked for the fingerprinted file name alone, which a
+    # picture stored before that scheme does not have: the fallback then asked
+    # the member row, which the freeze had just cleared, and the case page drew
+    # a broken image. One picture of 1,747 on the current data is on the old
+    # scheme, so an admin meets this rarely and cannot place it when they do.
+    test "a picture on the pre-fingerprint naming scheme is found in the hold",
+         %{tmp: tmp, owner: owner, reporter: reporter} do
+      legacy = legacy_avatar_owner(tmp)
+      image = avatar_image(legacy)
+
+      assert image.fingerprint == nil
+
+      {:ok, _case} = Moderation.report_content(reporter, image, notice())
+
+      path = Images.bytes_path(image)
+      assert is_binary(path), "no path for a held picture on the legacy scheme"
+      assert File.exists?(path)
+      assert File.read!(path) == "legacy medium bytes"
+
+      # And the fingerprinted case still works, so the fallback did not take
+      # the precise answer's place.
+      current = avatar_image(owner)
+      {:ok, _} = Moderation.report_content(reporter, current, notice())
+      assert Images.bytes_path(current) |> File.exists?()
+    end
+
+    # `held_image_ids/0` handed every directory entry on as an image id, and a
+    # non-UUID in `where: i.id in ^ids` raises — so one stray file in the hold
+    # root killed the whole reconcile pass, every fifteen minutes, with the
+    # sweeper's later steps never running.
+    test "a stray entry in the hold root does not stop the reconcile pass",
+         %{tmp: tmp, owner: owner, reporter: reporter} do
+      image = avatar_image(owner)
+      {:ok, _case} = Moderation.report_content(reporter, image, notice())
+
+      # The freeze above created the hold root; this lands beside the real hold.
+      File.write!(Path.join([tmp, "frozen", ".DS_Store"]), "not an image id")
+
+      assert :ok = Images.reconcile_holds()
+
+      # The real hold is untouched, and the freeze still stands.
+      assert Repo.get!(ImageRow, image.id).frozen_at
+      assert held_files(tmp, image) != []
     end
   end
 

--- a/test/vutuv_web/controllers/moderation_case_controller_test.exs
+++ b/test/vutuv_web/controllers/moderation_case_controller_test.exs
@@ -138,6 +138,20 @@ defmodule VutuvWeb.ModerationCaseControllerTest do
     end
   end
 
+  describe "image" do
+    # Every neighbouring action resolves the id through
+    # `Vutuv.UUIDv7.with_cast/2`, so a typo in the URL is a miss. This one read
+    # it straight, where a malformed id raises `Ecto.Query.CastError` — a 400
+    # and an exception in the log for what is plainly a wrong address
+    # (issue #2031).
+    test "a malformed case id is a 404, like every other action", %{conn: conn} do
+      {conn, _owner, _post, _case} = owner_with_case(conn)
+
+      conn = get(conn, "/moderation/cases/not-a-uuid/image")
+      assert html_response(conn, 404)
+    end
+  end
+
   describe "dispute" do
     test "escalates the case and keeps the content frozen", %{conn: conn} do
       {conn, _owner, post, case_record} = owner_with_case(conn)


### PR DESCRIPTION
An admin ruling on a reported picture saw a broken image whenever that picture predates the fingerprinted file name — one of 1,747 on the current data. A freeze moves the bytes out of every tree nginx serves, so `/moderation/cases/:id/image` is the only way to look at it, and it searched for the fingerprinted name alone; the fallback then asked the member row the freeze had just cleared.

`Vutuv.Uploads.held_version_path/3` now answers for both naming schemes, and each glob sits beside the function that builds the name it wildcards, so a change to the scheme meets its glob.

Two smaller things on the same page come with it. A malformed case id is a 404 like every neighbouring action, through a slim `Moderation.get_case/1` instead of a `Repo.get` in the controller. And `held_image_ids/0` no longer hands a stray directory entry to a query that raises on it — one `.DS_Store` stopped `reconcile_holds/0` every fifteen minutes, taking the sweeper's later steps with it.

Smoke-tested in Chrome against a real legacy picture: the case page shows it, and `/moderation/cases/not-a-uuid/image` answers 404 with nothing in the log.

Closes #2031

https://claude.ai/code/session_01X3SMjwhk9kzQTLmdnJj5wn
