### PR TITLE
Build every picture URL from the images row, not the member row

### DIFF
--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -696,7 +696,9 @@ Run on the server, against the release:
   corrects any row that disagrees with the member's own columns. Moves no file
   and changes no URL, so it is safe while the app serves traffic; safe to run
   again if it is interrupted (a deploy stopping the slot mid-run leaves every
-  member it reached already correct).
+  member it reached already correct). **Run it once before upgrading past the
+  release that moved every avatar and cover URL onto those rows** (issue
+  #2027): from there on a picture with no row is a picture nobody can see.
 - `bin/vutuv eval "Vutuv.Release.check_image_rows()"` — counts every member
   picture against its row and against its file on disk, writing nothing. It
   prints one line per kind, names the members behind each mismatch, and

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -696,9 +696,12 @@ Run on the server, against the release:
   corrects any row that disagrees with the member's own columns. Moves no file
   and changes no URL, so it is safe while the app serves traffic; safe to run
   again if it is interrupted (a deploy stopping the slot mid-run leaves every
-  member it reached already correct). **Run it once before upgrading past the
-  release that moved every avatar and cover URL onto those rows** (issue
-  #2027): from there on a picture with no row is a picture nobody can see.
+  member it reached already correct). The release that moved every avatar and
+  cover URL onto those rows (issue #2027) does **not** require it — a picture
+  with no row is still served from the member's own columns — but run it before
+  the upgrade after that one, which removes that fallback. Until it is green, a
+  picture with no row cannot be reported on its own; the profile's Report
+  covers it meanwhile.
 - `bin/vutuv eval "Vutuv.Release.check_image_rows()"` — counts every member
   picture against its row and against its file on disk, writing nothing. It
   prints one line per kind, names the members behind each mismatch, and

--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -211,10 +211,12 @@ The handle makes a downloaded file carry the username; the fingerprint makes the
 URL immutable, so it needs no `?v=` cache-buster and the **existing** nginx
 `alias` serves it directly (no rewrite).
 
-The fingerprint is stored in `users.avatar_fingerprint` / `cover_fingerprint`; a
-username change re-derives the files under the new handle. A row with no
-fingerprint has not been migrated yet and serves the legacy
-`avatar_<version>.avif?v=...` URL unchanged.
+The fingerprint is read off the picture's row in the shared `images` table
+(`images.fingerprint`, since #2027); a username change re-derives the files
+under the new handle. A picture with no fingerprint has not been migrated to
+this scheme yet and serves the legacy `avatar_<version>.avif?v=...` URL
+unchanged — one member on the production copy is still in that state, which is
+why "no fingerprint" must never be read as "no picture".
 
 The migration is **expand/contract**: the regenerator writes the new files and
 **keeps** the legacy ones (so the previous release and a rollback keep serving
@@ -239,13 +241,39 @@ an unguessable `token`, the three columns describing the stored file
 never deletes them).
 
 The table arrived **additively**. An upload writes the row *and* keeps filling
-all four member-row columns, which stay the source of truth every URL builder
-and every display gate reads; the member row only gains a pointer
+all four member-row columns; the member row gained a pointer
 (`users.avatar_image_id` / `cover_image_id`). Nothing about how a picture is
 stored or served moved — an avatar URL is byte for byte the one it was, which
 matters because other servers hold it in their copy of our ActivityPub actor
 document, search engines hold it, and sent mail holds it. #2015 moves the
 remaining kinds in.
+
+**Since #2027 the row is what every reader consults**, and the four columns per
+kind are dead weight the deploy after that one drops. `Vutuv.Images.member_image/2`
+is the one door: it takes the `belongs_to` when a caller preloaded it and falls
+back to one primary-key lookup on the pointer when nobody did, and answers `nil`
+— at no cost — for the 72 % of members who have no picture at all. Everything
+downstream reads that row: `Vutuv.Uploads` takes it as `{image, scope}` in place
+of the old `{file, scope}`, so `url/3`, `version_path/3`, `regenerate/3`,
+`reslug/2` and `sweep_legacy/3` never look at the member row again;
+`Vutuv.Avatar` and `Vutuv.Cover` resolve it once per call and hand it down.
+
+**Two things follow from that.** A **frozen** picture is now hidden by
+`frozen_at` rather than by the cleared columns (the freeze still clears them,
+because the previous release is still serving from them during the blue/green
+window) — `Vutuv.Images.shown_image/2` is the reader's door for that, and it
+answers `nil`, so a held picture draws the initials tile exactly as a member
+who never uploaded one does. A picture the AI gate merely holds is not that
+case: it keeps the grey silhouette, because it is coming back. And a
+**listing** query has to carry the pointer:
+`Vutuv.Accounts.User.listing_fields/0` selects `:avatar_image_id` instead of
+the two columns it used to, or a whole page of members would lose its pictures
+at once.
+
+**An installation must run the backfill before taking this release.** Nothing
+reads the columns any more, so a picture with no row is a picture nobody can
+see. `bin/vutuv eval "Vutuv.Release.check_image_rows()"` is the gate, and it
+was already the gate for the column drop.
 
 Which member-row column holds what is written **once**, in
 `Vutuv.Images.member_columns/0`; `Vutuv.Moderation.ImageSubjects` and
@@ -310,13 +338,26 @@ exactly like a clean bill of health. A missing file is the one class the
 backfill cannot repair; it predates the table and wants a human before the
 columns go.
 
-**The columns go two deploys later, not one.** The order is: this deploy ships
-the backfill (the columns still serve everything), the operator runs it and
-reads the check; a later deploy moves every URL builder and display gate onto
-the row; and only the deploy after *that* carries the migration dropping
+**The columns go two deploys later, not one**, and two of the three have
+shipped. The order is: #2014 shipped the backfill (the columns still served
+everything), the operator ran it and read the check; **#2027 moved every URL
+builder and display gate onto the row** and is the release this document
+describes; and only the deploy after *that* carries the migration dropping
 `avatar` / `avatar_fingerprint` / `avatar_crop` / `avatar_moderation` and the
 cover four. Each step is N-1 safe on its own, and no two can be merged: a
 migration may only drop what the *currently deployed* release no longer reads.
+
+**What the drop deploy can now assume.** Nothing outside `Vutuv.Images.Backfill`
+reads the four columns per kind. What still *writes* them, and therefore goes
+with the migration, is `Vutuv.Accounts.store_new_image/8`'s `user_attrs`,
+`Vutuv.Uploads.regenerate/3`'s `persist_fingerprint/4` (and the
+`:fingerprint_field` in both uploader `@config`s), `Vutuv.Images`'
+`hide_from_member_row/1` and `show_on_member_row/1` — the freeze's two halves,
+which the drop deletes outright — and
+`Vutuv.Moderation.ImageSubjects.clear_profile_columns/1` with its two callers'
+member-row writes. `Vutuv.Images.member_columns/0` is the one list of the
+names. The backfill itself is what the drop retires: it exists to compare the
+two copies, and after the cut there is one.
 
 **How a kind is served is a property of the kind, not a column**
 (`Vutuv.Images.serving/1`). `:static` means the derived files sit in a public
@@ -345,8 +386,11 @@ release handing a frozen picture back to the world.
 
 `Vutuv.Images.freeze/1` and `unfreeze/1` are the two halves, `purge/1` the
 deletion an upheld case (or the owner's own "remove it") performs. What each
-one does to the member row, and why clearing those four columns is what a
-reader notices, is in [moderation.md](moderation.md).
+one does to the member row is in [moderation.md](moderation.md). Since #2027 it
+is `frozen_at` itself that a reader notices — `Vutuv.Images.shown_image/2`
+answers `nil` for a held picture — and the member row's four columns are still
+cleared beside it so the release one step back, which is serving from those
+columns while the blue/green switch runs, hides the picture too.
 
 **A half-finished move is finished by itself.** The row's `frozen_at` is the
 *intent* and the disk is the state, so the stamp is written before the first

--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -265,15 +265,16 @@ window) — `Vutuv.Images.shown_image/2` is the reader's door for that, and it
 answers `nil`, so a held picture draws the initials tile exactly as a member
 who never uploaded one does. A picture the AI gate merely holds is not that
 case: it keeps the grey silhouette, because it is coming back. And a
-**listing** query has to carry the pointer:
-`Vutuv.Accounts.User.listing_fields/0` selects `:avatar_image_id` instead of
-the two columns it used to, or a whole page of members would lose its pictures
-at once.
+**listing** query has to carry the pointer *and* the two columns the bridge
+reads: `Vutuv.Accounts.User.listing_fields/0` selects `:avatar_image_id`
+beside `:avatar` and `:avatar_fingerprint`, or a whole page of members would
+lose its pictures at once.
 
-**An installation must run the backfill before taking this release.** Nothing
-reads the columns any more, so a picture with no row is a picture nobody can
-see. `bin/vutuv eval "Vutuv.Release.check_image_rows()"` is the gate, and it
-was already the gate for the column drop.
+**Taking this release does not require the backfill to have been run** — see
+the bridge under "The columns go in four steps" below. Run it all the same,
+and read `bin/vutuv eval "Vutuv.Release.check_image_rows()"`: it is the gate on
+the deploy that removes the bridge and the column writes, and until it is green
+a picture with no row is one nobody can report on its own.
 
 Which member-row column holds what is written **once**, in
 `Vutuv.Images.member_columns/0`; `Vutuv.Moderation.ImageSubjects` and
@@ -338,18 +339,47 @@ exactly like a clean bill of health. A missing file is the one class the
 backfill cannot repair; it predates the table and wants a human before the
 columns go.
 
-**The columns go two deploys later, not one**, and two of the three have
-shipped. The order is: #2014 shipped the backfill (the columns still served
-everything), the operator ran it and read the check; **#2027 moved every URL
-builder and display gate onto the row** and is the release this document
-describes; and only the deploy after *that* carries the migration dropping
-`avatar` / `avatar_fingerprint` / `avatar_crop` / `avatar_moderation` and the
-cover four. Each step is N-1 safe on its own, and no two can be merged: a
-migration may only drop what the *currently deployed* release no longer reads.
+**The columns go in four steps, and the order does not depend on an operator
+remembering anything.** #2014 shipped the backfill (the columns still served
+everything); **#2027 moved every URL builder and display gate onto the row**,
+which is the release this document describes; an operator then runs
+`mix vutuv.images.backfill` and reads its check; the deploy after that drops
+both the **bridge** (below) and the writes that keep the columns filled; and
+only the deploy after *that* carries the migration dropping `avatar` /
+`avatar_fingerprint` / `avatar_crop` / `avatar_moderation` and the cover four.
+Each step is N-1 safe on its own, and no two can be merged: a migration may
+only drop what the *currently deployed* release no longer reads.
 
-**What the drop deploy can now assume.** Nothing outside `Vutuv.Images.Backfill`
-reads the four columns per kind. What still *writes* them, and therefore goes
-with the migration, is `Vutuv.Accounts.store_new_image/8`'s `user_attrs`,
+**The bridge is what makes the middle two commute.** `Vutuv.Images.member_image/2`
+answers in three steps: the preloaded association, then a lookup on the
+pointer, then — when there is no row at all — the member row's own four
+columns, read as the row they will become (`bridge/3`, an unsaved `%Image{}`).
+Without it, taking the #2027 release before running the backfill would render
+**every** picture that predates the `images` table as no picture: initials
+instead of a face, no `og:image`, no ActivityPub icon, no vCard photo,
+`avatar_file: nil` in the GDPR export. Silently — nothing raises, nothing
+logs, and the deploy's own `regenerate_images` step would walk 0 rows and
+report success. Nothing enforces the backfill: it is not in
+`scripts/deploy.sh`, not in boot, not in `/health`. So the columns, which this
+release writes anyway, stand in until the deploy that removes both.
+
+Two things follow. `Vutuv.Accounts.User.listing_fields/0` and
+`Vutuv.Accounts`' `@admin_listing_fields` carry `:avatar` and
+`:avatar_fingerprint` beside the pointer, because a narrow select that omits
+them leaves the bridge nothing to read and a whole page loses its faces at
+once. And a **bridged picture cannot be reported on its own**: the report form
+names a picture by its row id and an unsaved row has none, so
+`Images.reportable_image/2` answers nil and the profile's own Report stands in
+until the backfill runs — which is all there was before #2012 anyway.
+
+**What the drop deploy can now assume.** No *reader* consults the four columns
+per kind. Three deliberate exceptions read them and go with the cut:
+`Vutuv.Images.Backfill`, which exists to compare the two copies;
+`Vutuv.Images.member_image/2`'s bridge; and
+`Vutuv.Images.hide_from_member_row/1`, whose `not is_nil(field(u, ^config.file))`
+is a convergence guard on its own write, not a display gate. What *writes* them,
+and therefore goes with the migration, is
+`Vutuv.Accounts.store_new_image/8`'s `user_attrs`,
 `Vutuv.Uploads.regenerate/3`'s `persist_fingerprint/4` (and the
 `:fingerprint_field` in both uploader `@config`s), `Vutuv.Images`'
 `hide_from_member_row/1` and `show_on_member_row/1` — the freeze's two halves,

--- a/docs/architecture/moderation.md
+++ b/docs/architecture/moderation.md
@@ -148,13 +148,16 @@ stamps `frozen_at`, clears the member row's four columns for that kind, and
 moves every derived version, the private original and anything still in AI
 quarantine into the picture's **takedown hold** — see the hold section in
 [images.md](images.md) for what that tree is and why an interrupted move is
-finished by itself. Clearing the columns is the half a reader notices: the
-member row is still what every URL builder and every display gate reads (#2027
-moves them onto the row), and "no picture of that kind" is the one answer all
-of them already agree on, so the profile, the cards, the vCard, the
-link-preview JPEG and the ActivityPub icon all fall back at once. Nothing is
-lost by clearing them — the row holds the same four values and the unfreeze
-writes them back.
+finished by itself. **`frozen_at` is the half a reader notices**: since #2027
+every URL builder and every display gate resolves the picture through
+`Vutuv.Images`, whose `servable?/1` and `shown_image/2` both answer "nothing
+here" for a stamped row, so the
+profile, the cards, the vCard, the link-preview JPEG and the ActivityPub icon
+all fall back at once and the header draws the initials tile a member with no
+picture gets. The four columns are cleared beside it because the release one
+step back is still serving from them while the blue/green switch runs; they go
+with the migration that drops them. Nothing is lost either way — the row holds
+the same four values and the unfreeze writes them back.
 
 **Rejecting the case restores the picture byte for byte**, at the same paths,
 so the old URL works again; **upholding it deletes** the held copies and the

--- a/lib/mix/tasks/vutuv.moderation.backfill.ex
+++ b/lib/mix/tasks/vutuv.moderation.backfill.ex
@@ -58,15 +58,17 @@ defmodule Mix.Tasks.Vutuv.Moderation.Backfill do
       {"avatars",
        Repo.all(
          from(u in User,
-           where: not is_nil(u.avatar),
-           select: {"avatar", u.id, u.id, u.avatar_fingerprint}
+           join: i in Image,
+           on: i.id == u.avatar_image_id,
+           select: {"avatar", u.id, u.id, i.fingerprint}
          )
        )},
       {"covers",
        Repo.all(
          from(u in User,
-           where: not is_nil(u.cover_photo),
-           select: {"cover", u.id, u.id, u.cover_fingerprint}
+           join: i in Image,
+           on: i.id == u.cover_image_id,
+           select: {"cover", u.id, u.id, i.fingerprint}
          )
        )},
       {"post images",

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -2225,9 +2225,9 @@ defmodule Vutuv.Accounts do
     # could half-commit: the row named the new picture, the member row still
     # named the old file whose bytes the store had just replaced, no scan was
     # ever queued to take the row out of "pending", and the member got a success
-    # flash. Nothing else moves: the four columns keep serving every URL and
-    # every display gate, and this release writes both (#2014's backfill brings
-    # the older pictures in; the columns go a deploy later).
+    # flash. Since #2027 the row is also what every URL and every display gate
+    # reads; the four columns are written for the release one step back, which
+    # is still serving from them, and go with the migration that drops them.
     #
     # The moderation state comes back from the store rather than being read a
     # second time here: the store is where `:moderate_images` decided which tree
@@ -2689,10 +2689,11 @@ defmodule Vutuv.Accounts do
     "updated" => :updated_at
   }
 
-  # The columns a member-browser row needs: the listing fields (avatar, name
-  # parts, slug) plus the timestamps and the status flags the table renders.
+  # The columns a member-browser row needs: the listing fields (the pointer at
+  # the avatar's row in the shared `images` table, name parts, slug) plus the
+  # timestamps and the status flags the table renders.
   @admin_listing_fields ~w(id first_name last_name honorific_prefix honorific_suffix username
-    avatar avatar_fingerprint updated_at inserted_at email_confirmed? admin?
+    avatar_image_id updated_at inserted_at email_confirmed? admin?
     identity_verified? frozen_at suspended_until deactivated_at unreachable_at
     moderation_reason)a
 
@@ -2747,6 +2748,7 @@ defmodule Vutuv.Accounts do
     |> select([u], struct(u, ^@admin_listing_fields))
     |> Pages.paginate(params, total, per_page)
     |> Repo.all()
+    |> Images.preload_member_images()
   end
 
   defp admin_users_base(filters) do

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -2690,10 +2690,12 @@ defmodule Vutuv.Accounts do
   }
 
   # The columns a member-browser row needs: the listing fields (the pointer at
-  # the avatar's row in the shared `images` table, name parts, slug) plus the
-  # timestamps and the status flags the table renders.
+  # the avatar's row in the shared `images` table, plus the two columns
+  # `Vutuv.Images.member_image/2`'s bridge reads for a member the backfill has
+  # not reached, name parts, slug) plus the timestamps and the status flags the
+  # table renders.
   @admin_listing_fields ~w(id first_name last_name honorific_prefix honorific_suffix username
-    avatar_image_id updated_at inserted_at email_confirmed? admin?
+    avatar_image_id avatar avatar_fingerprint updated_at inserted_at email_confirmed? admin?
     identity_verified? frozen_at suspended_until deactivated_at unreachable_at
     moderation_reason)a
 

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -576,6 +576,10 @@ defmodule Vutuv.Accounts.User do
     # `images` table, which is where every avatar URL is built from since
     # #2027. Leave it out and a whole listing page loses its pictures at once,
     # since `Vutuv.Images.member_image/2` has nothing to look the row up by.
+    # :avatar and :avatar_fingerprint stay beside it to feed that function's
+    # **bridge**, the fallback that reads a picture off the member row for a
+    # member the backfill has not reached; they go with the bridge and with the
+    # column writes, in the deploy before the migration.
     # :updated_at is still loaded for rows not yet on the fingerprinted scheme:
     # their avatar falls back to the legacy `?v=#{phash2(updated_at)}`
     # cache-buster, so a re-uploaded thumbnail doesn't keep serving the cached
@@ -587,7 +591,7 @@ defmodule Vutuv.Accounts.User do
     # `rel="nofollow"` for a member who opted out of search engines
     # (VutuvWeb.UserHelpers.profile_rel/1). Left out, the struct would carry the
     # schema default `false` and the link would silently fail open.
-    ~w(id first_name last_name honorific_prefix honorific_suffix username avatar_image_id updated_at profile_work_experience_id noindex?)a
+    ~w(id first_name last_name honorific_prefix honorific_suffix username avatar_image_id avatar avatar_fingerprint updated_at profile_work_experience_id noindex?)a
   end
 
   # :username is deliberately NOT here: the username is unique, rate-limited

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -572,11 +572,14 @@ defmodule Vutuv.Accounts.User do
   so their group-by doesn't drag all user columns through aggregate and sort.
   """
   def listing_fields do
-    # :avatar_fingerprint is loaded so listing-rendered avatars build the
-    # fingerprinted URL `<username>-<version>-<fp>.avif` (see Vutuv.Uploads).
-    # :updated_at is still loaded for rows not yet migrated to that scheme: their
-    # avatar falls back to the legacy `?v=#{phash2(updated_at)}` cache-buster, so
-    # a re-uploaded thumbnail doesn't keep serving the cached old image.
+    # :avatar_image_id is the pointer at the picture's row in the shared
+    # `images` table, which is where every avatar URL is built from since
+    # #2027. Leave it out and a whole listing page loses its pictures at once,
+    # since `Vutuv.Images.member_image/2` has nothing to look the row up by.
+    # :updated_at is still loaded for rows not yet on the fingerprinted scheme:
+    # their avatar falls back to the legacy `?v=#{phash2(updated_at)}`
+    # cache-buster, so a re-uploaded thumbnail doesn't keep serving the cached
+    # old image.
     # :profile_work_experience_id is loaded so a listing row's work line reflects
     # a member's pinned profile job title (issue #833) via work_information_map/2,
     # not just the automatic heuristic.
@@ -584,7 +587,7 @@ defmodule Vutuv.Accounts.User do
     # `rel="nofollow"` for a member who opted out of search engines
     # (VutuvWeb.UserHelpers.profile_rel/1). Left out, the struct would carry the
     # schema default `false` and the link would silently fail open.
-    ~w(id first_name last_name honorific_prefix honorific_suffix username avatar avatar_fingerprint updated_at profile_work_experience_id noindex?)a
+    ~w(id first_name last_name honorific_prefix honorific_suffix username avatar_image_id updated_at profile_work_experience_id noindex?)a
   end
 
   # :username is deliberately NOT here: the username is unique, rate-limited
@@ -1612,7 +1615,7 @@ defmodule Vutuv.Accounts.User do
 
     def path(user), do: "/" <> user.username
 
-    def image(user), do: user.avatar
+    def image(user), do: Vutuv.Images.shown_file(user, "avatar")
 
     def hidden?(user), do: not Vutuv.Moderation.profile_visible_to?(user, nil)
 

--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -47,6 +47,7 @@ defmodule Vutuv.Activity do
   alias Vutuv.Fediverse.Note
   alias Vutuv.Fediverse.Reaction
   alias Vutuv.Identity
+  alias Vutuv.Images
   alias Vutuv.MastodonApi.PushDispatcher
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Organizations.Organization
@@ -1447,6 +1448,7 @@ defmodule Vutuv.Activity do
     |> order_by([e], desc: e.at, desc: e.id)
     |> select([e, f, o], {e.id, e.at, struct(f, ^User.listing_fields()), o})
     |> Repo.all()
+    |> preload_actor_avatars(2)
     |> Enum.map(fn {id, at, follower, organization} ->
       actor_item(event_id("follower", id), "follower", at, follower || organization)
     end)
@@ -1465,6 +1467,7 @@ defmodule Vutuv.Activity do
     )
     |> at_or_before(cursor)
     |> Repo.all()
+    |> preload_actor_avatars(2)
     |> Enum.map(fn {id, at, endorser, tag_name} ->
       event_id("endorsement", id)
       |> actor_item("endorsement", at, endorser)
@@ -1527,6 +1530,7 @@ defmodule Vutuv.Activity do
       }
     )
     |> Repo.all()
+    |> preload_actor_avatars(:friend)
     |> Enum.map(fn %{id: id, at: at, friend: friend, self_closed: self_closed} ->
       event_id("connection", id)
       |> actor_item("connection", at, friend)
@@ -1548,6 +1552,7 @@ defmodule Vutuv.Activity do
     )
     |> at_or_before(cursor)
     |> Repo.all()
+    |> preload_actor_avatars(2)
     |> Enum.map(fn {id, at, replier, parent_post_id, reply_post_id} ->
       event_id("reply", id)
       |> actor_item("reply", at, replier)
@@ -1575,6 +1580,7 @@ defmodule Vutuv.Activity do
     )
     |> at_or_before(cursor)
     |> Repo.all()
+    |> preload_actor_avatars(2)
     |> Enum.map(fn {id, at, replier, root_post_id, reply_post_id} ->
       event_id("thread", id)
       |> actor_item("thread", at, replier)
@@ -1610,6 +1616,7 @@ defmodule Vutuv.Activity do
     )
     |> at_or_before(cursor)
     |> Repo.all()
+    |> preload_actor_avatars(2)
     |> Enum.map(fn {id, at, author, organization, post_id} ->
       actor = mention_actor(author, organization)
 
@@ -1869,6 +1876,7 @@ defmodule Vutuv.Activity do
     )
     |> at_or_before(cursor)
     |> Repo.all()
+    |> preload_actor_avatars(2)
     |> Enum.map(fn {id, at, liker, page, post_id} ->
       event_id("like", id)
       |> actor_item("like", at, liker || page)
@@ -1894,6 +1902,7 @@ defmodule Vutuv.Activity do
     )
     |> at_or_before(cursor)
     |> Repo.all()
+    |> preload_actor_avatars(2)
     |> Enum.map(fn {id, at, granter, role, name, slug} ->
       event_id("organization_role", id)
       |> actor_item("organization_role", at, granter)
@@ -1999,6 +2008,7 @@ defmodule Vutuv.Activity do
       |> at_or_before(cursor)
       |> select([s, u], {s.id, s.inserted_at, struct(u, ^User.listing_fields())})
       |> Repo.all()
+      |> preload_actor_avatars(2)
       |> Enum.map(fn {id, at, reported} ->
         protection_item(event_id("report_protection", id), "severed", at, reported)
       end)
@@ -2012,6 +2022,7 @@ defmodule Vutuv.Activity do
       |> restored_at_or_before(cursor)
       |> select([s, u], {s.id, s.restored_at, struct(u, ^User.listing_fields())})
       |> Repo.all()
+      |> preload_actor_avatars(2)
       |> Enum.map(fn {id, at, reported} ->
         protection_item(event_id("report_protection_restored", id), "restored", at, reported)
       end)
@@ -2037,6 +2048,7 @@ defmodule Vutuv.Activity do
     )
     |> at_or_before(cursor)
     |> Repo.all()
+    |> preload_actor_avatars(2)
     |> Enum.map(fn {id, at, actor, old_handle, new_handle, post_ids} ->
       event_id("handle_change", id)
       |> actor_item("handle_change", at, actor)
@@ -2054,6 +2066,7 @@ defmodule Vutuv.Activity do
   defp cv_update_items(user_id, limit, cursor) do
     user_id
     |> CvUpdates.page(limit, cursor)
+    |> preload_actor_avatars(:author)
     |> Enum.map(fn %{author: author} = group ->
       group
       |> Map.delete(:author)
@@ -2163,6 +2176,48 @@ defmodule Vutuv.Activity do
 
   defp actor_item(id, kind, at, actor) do
     Map.merge(actor_fields(actor), %{id: id, kind: kind, at: at})
+  end
+
+  # The picture row of every member a source's rows name, in one read, before
+  # the items are built. Each source fetches `offset + limit + 1` rows and
+  # `Vutuv.FeedPage` then merges the sources and keeps `limit` of them, so an
+  # avatar resolved on the way past is work thrown away for about nine rows in
+  # ten: page 1 of /notifications builds some 612 items to show 50, and
+  # `Vutuv.Images.member_image/2` answered each one with its own primary-key
+  # lookup (issue #2027).
+  #
+  # Only a `%User{}` that points at a picture is worth loading. Everybody else
+  # on these rows (a page, a remote actor, a member with no picture, the
+  # all-nil `%User{}` a missed LEFT join yields) costs no query either way and
+  # rides through untouched. `index` reads the actor out of a row tuple, `key`
+  # out of a row map, and each actor goes back on its own row by id.
+  defp preload_actor_avatars(rows, index) when is_integer(index),
+    do: put_actor_avatars(rows, &elem(&1, index), &put_elem(&1, index, &2))
+
+  defp preload_actor_avatars(rows, key) when is_atom(key),
+    do: put_actor_avatars(rows, &Map.fetch!(&1, key), &Map.put(&1, key, &2))
+
+  defp put_actor_avatars(rows, get, put) do
+    by_id =
+      rows
+      |> Enum.map(get)
+      |> Enum.filter(&match?(%User{avatar_image_id: id} when is_binary(id), &1))
+      |> Images.preload_avatars()
+      |> Map.new(&{&1.id, &1})
+
+    put_preloaded(rows, by_id, get, put)
+  end
+
+  # Nothing on this page had a picture, so there is nothing to put back.
+  defp put_preloaded(rows, by_id, _get, _put) when map_size(by_id) == 0, do: rows
+
+  defp put_preloaded(rows, by_id, get, put) do
+    Enum.map(rows, fn row ->
+      case get.(row) do
+        %User{id: id} = actor -> put.(row, Map.get(by_id, id, actor))
+        _no_member -> row
+      end
+    end)
   end
 
   # The actor half for somebody on **another** network (issue #1069). They have
@@ -2448,14 +2503,11 @@ defmodule Vutuv.Activity do
   defp actor_param(%Organization{slug: slug}), do: slug
   defp actor_param(_), do: nil
 
-  # nil (not the default-placeholder URL) when the actor has no picture, so
-  # the notifications page renders its colored kind glyph instead of a grey
-  # anonymous image.
-  defp actor_avatar(%User{avatar: nil}), do: nil
-  # An avatar in AI-moderation limbo renders like none (the kind glyph), not
-  # as the grey placeholder display_url would fall back to.
-  defp actor_avatar(%User{avatar_moderation: "pending"}), do: nil
-  defp actor_avatar(%User{} = user), do: Vutuv.Avatar.display_url(user, :thumb)
+  # nil (not the default-placeholder URL) when there is no picture a reader
+  # may see, so the notifications page renders its colored kind glyph instead
+  # of a grey anonymous image. `url/2` is already exactly that answer: no
+  # picture, one the AI gate still holds, one a copyright case froze.
+  defp actor_avatar(%User{} = user), do: Vutuv.Avatar.url(user, :thumb)
   # nil for an organization: the notifications page then draws its coloured kind
   # glyph, which is honest, where a member's avatar helper would not know how to
   # find a page's logo anyway.

--- a/lib/vutuv/chat.ex
+++ b/lib/vutuv/chat.ex
@@ -23,6 +23,7 @@ defmodule Vutuv.Chat do
   alias Vutuv.Accounts.User
   alias Vutuv.Activity
   alias Vutuv.Chat.{Conversation, Message, Participant}
+  alias Vutuv.Images
   alias Vutuv.Notifications.Emailer
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
@@ -755,6 +756,10 @@ defmodule Vutuv.Chat do
   defp listing_users_by_id(ids) do
     from(u in User, where: u.id in ^ids, select: struct(u, ^User.listing_fields()))
     |> Repo.all()
+    # The picture rows in the same batched shape as everything else here: the
+    # sidebar is unpaged, so a member with three hundred conversations would
+    # otherwise pay one lookup per row (issue #2027).
+    |> Images.preload_avatars()
     |> Map.new(&{&1.id, &1})
   end
 

--- a/lib/vutuv/directory.ex
+++ b/lib/vutuv/directory.ex
@@ -29,6 +29,7 @@ defmodule Vutuv.Directory do
   import Vutuv.SearchText, only: [cap: 1, contains: 1, normalize_search: 1]
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Images
   alias Vutuv.Pages
   alias Vutuv.Repo
 
@@ -270,7 +271,10 @@ defmodule Vutuv.Directory do
   defp page_with_total([]), do: %{users: [], total: 0}
 
   defp page_with_total([{_user, total} | _rest] = rows),
-    do: %{users: Enum.map(rows, &elem(&1, 0)), total: total}
+    do: %{
+      users: rows |> Enum.map(&elem(&1, 0)) |> Images.preload_member_images(),
+      total: total
+    }
 
   # "Zabel, Anna" before "Zabel, Zoe", with the id (creation order, UUID v7) as
   # the tiebreaker. One definition for the letter pages and the search, so a
@@ -343,6 +347,7 @@ defmodule Vutuv.Directory do
       |> filed_order()
       |> Pages.paginate(params, total, @per_page)
       |> Repo.all()
+      |> Images.preload_member_images()
 
     %{users: users, total: total}
   end

--- a/lib/vutuv/export.ex
+++ b/lib/vutuv/export.ex
@@ -18,6 +18,7 @@ defmodule Vutuv.Export do
   alias Vutuv.Fediverse.Note
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Images
   alias Vutuv.Jobs.{JobPostingBookmark, JobPostingLike}
   alias Vutuv.Organizations.{OrganizationBookmark, OrganizationLike}
   alias Vutuv.Posts.{Post, PostBookmark, PostDraft, PostLike, PostRepost}
@@ -362,8 +363,8 @@ defmodule Vutuv.Export do
       email_on_follower: user.email_on_follower?,
       cv_update_notifications: user.cv_update_notifications?,
       identity_verified: user.identity_verified?,
-      avatar_file: user.avatar,
-      cover_photo_file: user.cover_photo,
+      avatar_file: Images.shown_file(user, "avatar"),
+      cover_photo_file: Images.shown_file(user, "cover"),
       registered_at: user.inserted_at
     }
   end

--- a/lib/vutuv/images.ex
+++ b/lib/vutuv/images.ex
@@ -5,10 +5,13 @@ defmodule Vutuv.Images do
   and what is contract, and what a member row still holds meanwhile — is in
   `docs/architecture/images.md`.
 
-  The invariant this module carries: **this release writes both.** A picture is
-  a row here *and* the four columns it has always lived in on the member row,
-  which stay the source of truth for every URL and every display gate until
-  #2014 has backfilled the older pictures and dropped them.
+  The invariant this module carries: **this release writes both and reads one.**
+  A picture is a row here *and* the four columns it has always lived in on the
+  member row; every write still fills both, and since #2027 the row is what
+  every URL builder and every display gate reads (`member_image/2`). The
+  columns are dead weight the deploy after this one drops — which is the only
+  order a blue/green switch allows, since a migration may drop only what the
+  *currently deployed* release has stopped reading.
 
   `serving/1` is the second thing here that is not a column: how a kind reaches
   a reader decides what its off switch is, and a kind nobody has declared
@@ -68,6 +71,10 @@ defmodule Vutuv.Images do
       crop: :avatar_crop,
       moderation: :avatar_moderation,
       pointer: :avatar_image_id,
+      # The `belongs_to` the pointer backs. Beside it because `member_image/2`
+      # takes the preload when a caller remembered one and falls back to the
+      # pointer when nobody did.
+      assoc: :avatar_image,
       module: Vutuv.Avatar,
       prefix: "avatars",
       # The version a human is shown this kind at — the report form and the two
@@ -81,6 +88,7 @@ defmodule Vutuv.Images do
       crop: :cover_crop,
       moderation: :cover_moderation,
       pointer: :cover_image_id,
+      assoc: :cover_image,
       module: Vutuv.Cover,
       prefix: "covers",
       preview: :wide
@@ -105,6 +113,126 @@ defmodule Vutuv.Images do
     do: @profile_columns[kind].pointer
 
   @doc """
+  This member's picture of `kind` as its row — **the** source every URL builder
+  and every display gate reads since #2027, so the member row's four columns
+  per kind are dead weight the next deploy can drop.
+
+  Takes the `belongs_to` when a caller preloaded it and falls back to one
+  primary-key lookup on the pointer when nobody did: half the callers hand over
+  a bare row straight from a query, and a picture that depends on whether
+  somebody remembered a preload is not an answer. The pointer is a plain column
+  on the member row and is **not** one of the four going away, so a listing
+  select that carries it (`Vutuv.Accounts.User.listing_fields/0`) resolves
+  without a join.
+
+  `nil` for a member with no picture of that kind, which costs no query at all —
+  the commonest answer by a wide margin (28 % of the members on the production
+  copy have a profile picture).
+
+  Accepts any map, so the render kit's `<.avatar user={…}>` can pass whatever a
+  page handed it; a map that carries neither the association nor the pointer is
+  simply a member without a picture.
+  """
+  def member_image(user, kind) when is_map_key(@profile_columns, kind) do
+    config = @profile_columns[kind]
+
+    case Map.get(user, config.assoc) do
+      %Image{} = image -> image
+      _not_loaded -> lookup_image(Map.get(user, config.pointer))
+    end
+  end
+
+  defp lookup_image(id) when is_binary(id), do: Repo.get(Image, id)
+  defp lookup_image(_id), do: nil
+
+  @doc """
+  Preloads the avatar row on a member or a list of members, so a page that
+  renders many avatars pays one query instead of one per picture. The name to
+  reach for wherever a list of members is loaded for rendering; `member_image/2`
+  then costs nothing.
+  """
+  def preload_avatars(users), do: Repo.preload(users, :avatar_image)
+
+  @doc """
+  Both picture rows, for the two surfaces that draw a cover as well: the
+  profile and the settings form. `Repo.preload/2` costs a query per
+  association, so a page that shows only faces asks `preload_avatars/1`.
+  """
+  def preload_member_images(users), do: Repo.preload(users, [:avatar_image, :cover_image])
+
+  @doc """
+  Whether there is a picture here a reader may fetch: false for no picture, for
+  one the AI gate still holds in the quarantine tree, and for one a copyright
+  case moved into the takedown hold (issue #2012). The one statement of that
+  rule — `Vutuv.Uploads` asks it before building any URL, and `shown_image/2`
+  above answers the narrower "is there a picture at all" question beside it.
+  """
+  def servable?(%Image{moderation: "pending"}), do: false
+  def servable?(%Image{frozen_at: %NaiveDateTime{}}), do: false
+  def servable?(%Image{}), do: true
+  def servable?(nil), do: false
+
+  @doc """
+  The upload's own file name as far as a reader is told about it, or `nil` for
+  a member with no picture of that kind and for one a copyright case holds.
+  """
+  def shown_file(user, kind) when is_map_key(@profile_columns, kind) do
+    with %Image{} = image <- shown_image(user, kind), do: image.file
+  end
+
+  @doc """
+  Every member holding a picture of that kind, with the row preloaded — the
+  population the regeneration and legacy-sweep passes walk. Two statements for
+  the whole table, so a pass over 1,700 pictures does not resolve a row per
+  member.
+  """
+  def members_with_picture(kind) when is_map_key(@profile_columns, kind) do
+    config = @profile_columns[kind]
+
+    from(u in User, where: not is_nil(field(u, ^config.pointer)))
+    |> Repo.all()
+    |> Repo.preload(config.assoc)
+  end
+
+  @doc """
+  The member's picture of `kind` as far as a reader is even told it exists: the
+  row, or `nil` both when there is none and when a copyright case froze one.
+
+  A freeze is a takedown, so the page has to read exactly as it does for a
+  member who never uploaded a picture — which is what clearing the member row's
+  four columns used to do (#2012) and what the initials tile in place of the
+  grey silhouette says. A picture the AI gate is merely holding is **not** this
+  case: it is coming back, and it keeps the silhouette it has always shown.
+  """
+  def shown_image(user, kind) when is_map_key(@profile_columns, kind) do
+    case member_image(user, kind) do
+      %Image{frozen_at: nil} = image -> image
+      _none_or_frozen -> nil
+    end
+  end
+
+  @doc """
+  The crop rectangle the member positioned this picture with, or `nil` — what
+  the profile form's hidden crop input starts from and what a re-derive
+  re-applies.
+  """
+  def crop(user, kind) when is_map_key(@profile_columns, kind) do
+    case member_image(user, kind) do
+      %Image{crop: crop} -> crop
+      nil -> nil
+    end
+  end
+
+  @doc """
+  Whether this member's picture of that kind is still waiting for the AI gate
+  (`Vutuv.Moderation.ImageScans`) — what the profile and the settings form ask
+  to show the owner their amber "visible only to you" pill.
+  """
+  def pending?(user, kind) when is_map_key(@profile_columns, kind) do
+    match?(%Image{moderation: "pending"}, member_image(user, kind))
+  end
+
+  @doc """
   Where this member's picture of that kind actually is on disk right now, or
   `nil` when the row names a file that is not there.
 
@@ -121,9 +249,19 @@ defmodule Vutuv.Images do
     config = @profile_columns[kind]
     version = version || config.preview
 
-    if Map.get(user, config.moderation) == "pending",
-      do: config.module.pending_preview_path(user, version),
-      else: config.module.stored_path(user, version)
+    case member_image(user, kind) do
+      nil ->
+        nil
+
+      image ->
+        # Hand the row on as the preload the uploader would otherwise look up
+        # again, so one question about one picture costs one query.
+        user = Map.put(user, config.assoc, image)
+
+        if image.moderation == "pending",
+          do: config.module.pending_preview_path(user, version),
+          else: config.module.stored_path(user, version)
+    end
   end
 
   @doc """
@@ -213,27 +351,63 @@ defmodule Vutuv.Images do
 
   @doc """
   Applies the AI gate's verdict to the member's row, guarded on the bytes that
-  were scanned exactly as `Vutuv.Moderation.ImageSubjects` guards the member
-  row. A nil fingerprint would raise rather than match nothing (`where: x ==
-  ^nil` is not a silent no-op in Ecto), so it is answered as "no row".
+  were scanned and on the picture still waiting for one — since #2027 this row
+  **is** the guard `Vutuv.Moderation.ImageSubjects` used to put on the member
+  row, so it answers `:stale` for a verdict that lost a race against a
+  re-upload and the caller leaves everything alone. A nil fingerprint would
+  raise rather than match nothing (`where: x == ^nil` is not a silent no-op in
+  Ecto), so it is answered as "no such picture".
   """
   def mark_moderation(user_id, kind, fingerprint, state)
       when kind in @kinds and is_binary(fingerprint) do
-    user_id
-    |> profile_query(kind)
-    |> where([i], i.fingerprint == ^fingerprint)
-    |> Repo.update_all(set: [moderation: state, updated_at: now()])
+    {count, _} =
+      user_id
+      |> profile_query(kind)
+      |> where([i], i.fingerprint == ^fingerprint and i.moderation == "pending")
+      |> Repo.update_all(set: [moderation: state, updated_at: now()])
 
-    :ok
+    if count == 1, do: :ok, else: :stale
   end
 
-  def mark_moderation(_user_id, _kind, _fingerprint, _state), do: :ok
+  def mark_moderation(_user_id, _kind, _fingerprint, _state), do: :stale
+
+  @doc """
+  Drops the member's row for this kind, but only while it still names the bytes
+  the scan judged — the guard `Vutuv.Moderation.ImageSubjects` needs for a
+  picture the AI gate rejected, so a verdict that lost a race against a
+  re-upload deletes nothing.
+  """
+  def discard_profile_image(user_id, kind, fingerprint),
+    do: discard(user_id, kind, fingerprint, [])
+
+  @doc """
+  The same, narrowed to a picture still waiting for a verdict — which is what a
+  **canceled** scan means. A picture that has since been released is not the one
+  the cancel was about.
+  """
+  def discard_pending_image(user_id, kind, fingerprint),
+    do: discard(user_id, kind, fingerprint, moderation: "pending")
+
+  defp discard(user_id, kind, fingerprint, filters)
+       when kind in @kinds and is_binary(fingerprint) do
+    query =
+      profile_query(user_id, kind)
+      |> where([i], i.fingerprint == ^fingerprint)
+      |> where(^filters)
+
+    case Repo.delete_all(query) do
+      {1, _} -> :ok
+      _none -> :stale
+    end
+  end
+
+  defp discard(_user_id, _kind, _fingerprint, _filters), do: :stale
 
   @doc """
   Keeps the row's fingerprint in step when `Vutuv.Uploads.regenerate/3`
   re-derives a picture and writes a new one onto the member row. Takes the id
-  the member row points at, so a picture that has no row yet — every one
-  uploaded before this release, until #2014's backfill — costs no statement.
+  of the row the re-derive read from, so there is always one; the nil clause is
+  defensive.
   """
   def sync_fingerprint(image_id, fingerprint) when is_binary(image_id) do
     from(i in Image, where: i.id == ^image_id)
@@ -244,17 +418,6 @@ defmodule Vutuv.Images do
 
   def sync_fingerprint(nil, _fingerprint), do: :ok
 
-  @doc """
-  Drops the member's row for this kind — the picture is gone (the AI gate
-  rejected it, or the scan was canceled because the bytes vanished). Deleting
-  rather than blanking keeps "there is a row" and "there is a picture" the same
-  statement.
-  """
-  def forget_profile_image(user_id, kind) when kind in @kinds do
-    user_id |> profile_query(kind) |> Repo.delete_all()
-    :ok
-  end
-
   ## The copyright freeze (issue #2012)
 
   @doc """
@@ -262,15 +425,16 @@ defmodule Vutuv.Images do
   `frozen_at`, the member row's four columns for that kind are cleared, and
   every file moves into the hold (`Vutuv.Uploads.hold/3`).
 
-  Clearing the member columns is what a reader notices. Every URL builder and
-  every display gate still reads them (#2027 moves them onto the row), and
-  "this member has no picture of that kind" is the one answer all of them
-  already agree on — `Vutuv.Avatar.display_url/2` returns the silhouette, the
-  vCard and the link-preview JPEG return nothing, the actor document drops its
-  icon. Leaving them set and only moving the files would have given some sixty
-  render sites a broken image instead.
+  **`frozen_at` is what a reader notices.** Since #2027 every URL builder and
+  every display gate resolves the picture through this module, and `servable?/1`
+  and `shown_image/2` both answer "there is nothing here" for a stamped row: the
+  profile draws the initials tile, the vCard and the link-preview JPEG return
+  nothing, the actor document drops its icon.
 
-  Nothing is lost by clearing them, because the row holds the same four values:
+  The member row's four columns are cleared beside it because the **previous
+  release is still serving from them** while the blue/green switch runs, and it
+  has to hide the picture too. They go with the migration that drops them.
+  Nothing is lost either way, because the row holds the same four values:
   `unfreeze/1` writes them back.
 
   **Order matters.** The stamp goes first: it is the record that this picture is
@@ -343,9 +507,8 @@ defmodule Vutuv.Images do
       %User{} = user ->
         config = @profile_columns[image.kind]
         hide_from_member_row(image)
-        # By id rather than through `forget_profile_image/2`, its (user_id,
-        # kind) twin, so the kinds #2015 brings — which have no member owner —
-        # take the same path.
+        # By id rather than by (user_id, kind), so the kinds #2015 brings —
+        # which have no member owner — take the same path.
         Repo.delete_all(from(i in Image, where: i.id == ^image.id))
         config.module.delete(user)
 
@@ -406,8 +569,8 @@ defmodule Vutuv.Images do
   #
   # Guarded on the file column, so a converged freeze — `reconcile_holds/0`
   # passing over work that is already done — matches no row and writes nothing.
-  # Every reader is gated on that column, so a half-cleared row is invisible
-  # either way.
+  # This release's readers are gated on `frozen_at` and the release one back on
+  # this column, so a half-cleared row is invisible to both.
   defp hide_from_member_row(%Image{user_id: user_id, kind: kind}) do
     config = @profile_columns[kind]
 

--- a/lib/vutuv/images.ex
+++ b/lib/vutuv/images.ex
@@ -5,13 +5,17 @@ defmodule Vutuv.Images do
   and what is contract, and what a member row still holds meanwhile — is in
   `docs/architecture/images.md`.
 
-  The invariant this module carries: **this release writes both and reads one.**
-  A picture is a row here *and* the four columns it has always lived in on the
-  member row; every write still fills both, and since #2027 the row is what
-  every URL builder and every display gate reads (`member_image/2`). The
-  columns are dead weight the deploy after this one drops — which is the only
-  order a blue/green switch allows, since a migration may drop only what the
-  *currently deployed* release has stopped reading.
+  The invariant this module carries: **this release writes both and reads the
+  row, falling back to the columns when there is no row yet.** A picture is a
+  row here *and* the four columns it has always lived in on the member row;
+  every write still fills both, and since #2027 the row is what every URL
+  builder and every display gate reads (`member_image/2`). Its third answer,
+  the **bridge**, reads those columns for a picture the backfill has not
+  reached, so taking this release before running `mix vutuv.images.backfill`
+  cannot blank every face on the site. Bridge and column writes go together, in
+  the deploy before the migration — which is the only order a blue/green switch
+  allows, since a migration may drop only what the *currently deployed* release
+  has stopped reading.
 
   `serving/1` is the second thing here that is not a column: how a kind reaches
   a reader decides what its off switch is, and a kind nobody has declared
@@ -114,36 +118,76 @@ defmodule Vutuv.Images do
 
   @doc """
   This member's picture of `kind` as its row — **the** source every URL builder
-  and every display gate reads since #2027, so the member row's four columns
-  per kind are dead weight the next deploy can drop.
+  and every display gate reads since #2027, and the one place that resolution
+  happens.
 
-  Takes the `belongs_to` when a caller preloaded it and falls back to one
-  primary-key lookup on the pointer when nobody did: half the callers hand over
+  Three answers, in order. The `belongs_to` when a caller preloaded it; one
+  primary-key lookup on the pointer when nobody did (half the callers hand over
   a bare row straight from a query, and a picture that depends on whether
-  somebody remembered a preload is not an answer. The pointer is a plain column
-  on the member row and is **not** one of the four going away, so a listing
-  select that carries it (`Vutuv.Accounts.User.listing_fields/0`) resolves
-  without a join.
+  somebody remembered a preload is not an answer); and, when there is no row at
+  all, **the member row's own four columns, read as if they were one**.
+
+  That third answer is `bridge/2`, and it is the reason this release does not
+  depend on `mix vutuv.images.backfill` having been run. Without it a member
+  whose picture predates the `images` table would render as a member with no
+  picture — no avatar, no `og:image`, no ActivityPub icon, no vCard photo —
+  silently, with nothing in the log and nothing failing, and the deploy that
+  ships these readers would take every face on the site down until an operator
+  happened to run a manual command. Nothing enforces that command: it is not in
+  `scripts/deploy.sh`, not in boot, not in `/health`. So the columns, which this
+  release still writes anyway, stand in.
+
+  **The bridge is temporary and belongs to the same deploy as the writes.** The
+  order is: this release, then the backfill with a green
+  `Vutuv.Release.check_image_rows/0`, then the release that drops both the
+  bridge and the column writes, then the migration. See
+  `docs/architecture/images.md`.
 
   `nil` for a member with no picture of that kind, which costs no query at all —
-  the commonest answer by a wide margin (28 % of the members on the production
-  copy have a profile picture).
+  the commonest answer by a wide margin (72 % of the members on the production
+  copy have none).
 
   Accepts any map, so the render kit's `<.avatar user={…}>` can pass whatever a
-  page handed it; a map that carries neither the association nor the pointer is
-  simply a member without a picture.
+  page handed it; a map that carries none of the three is simply a member
+  without a picture.
   """
   def member_image(user, kind) when is_map_key(@profile_columns, kind) do
     config = @profile_columns[kind]
 
     case Map.get(user, config.assoc) do
       %Image{} = image -> image
-      _not_loaded -> lookup_image(Map.get(user, config.pointer))
+      _none -> lookup_image(Map.get(user, config.pointer)) || bridge(user, kind, config)
     end
   end
 
   defp lookup_image(id) when is_binary(id), do: Repo.get(Image, id)
   defp lookup_image(_id), do: nil
+
+  # A picture the backfill has not reached, read off the member row as the row
+  # it will become. Unsaved on purpose, and its `id` is therefore nil: a caller
+  # that needs a real row — the report form, which names a picture by its id —
+  # has to ask for one rather than trust this. Everything that only wants to
+  # *show* the picture reads the same four values either way, which is what
+  # makes the deploy order-independent.
+  #
+  # `frozen_at` is nil because a freeze writes the row first and only a row can
+  # carry one; a member with no row has no case against their picture.
+  defp bridge(user, kind, config) do
+    case Map.get(user, config.file) do
+      nil ->
+        nil
+
+      file ->
+        %Image{
+          kind: kind,
+          user_id: Map.get(user, :id),
+          file: file,
+          fingerprint: Map.get(user, config.fingerprint),
+          crop: Map.get(user, config.crop),
+          moderation: Map.get(user, config.moderation)
+        }
+    end
+  end
 
   @doc """
   Preloads the avatar row on a member or a list of members, so a page that
@@ -208,6 +252,20 @@ defmodule Vutuv.Images do
     case member_image(user, kind) do
       %Image{frozen_at: nil} = image -> image
       _none_or_frozen -> nil
+    end
+  end
+
+  @doc """
+  The same, narrowed to a picture that can be **named** from outside: the report
+  form addresses a picture by its row id, and `member_image/2`'s bridge answers
+  with an unsaved row for a member the backfill has not reached. Such a picture
+  falls back to reporting the whole profile, which is the only thing that was
+  available before #2012 anyway; the backfill turns the affordance on.
+  """
+  def reportable_image(user, kind) when is_map_key(@profile_columns, kind) do
+    case shown_image(user, kind) do
+      %Image{id: id} = image when is_binary(id) -> image
+      _bridged_or_none -> nil
     end
   end
 
@@ -406,8 +464,9 @@ defmodule Vutuv.Images do
   @doc """
   Keeps the row's fingerprint in step when `Vutuv.Uploads.regenerate/3`
   re-derives a picture and writes a new one onto the member row. Takes the id
-  of the row the re-derive read from, so there is always one; the nil clause is
-  defensive.
+  of the row the re-derive read from, which is `nil` for a picture the backfill
+  has not reached (`member_image/2`'s bridge) — such a picture has no row to
+  keep in step, so that costs no statement.
   """
   def sync_fingerprint(image_id, fingerprint) when is_binary(image_id) do
     from(i in Image, where: i.id == ^image_id)

--- a/lib/vutuv/images/backfill.ex
+++ b/lib/vutuv/images/backfill.ex
@@ -25,7 +25,7 @@ defmodule Vutuv.Images.Backfill do
 
   A row whose member has no picture of that kind any more is deleted: "there is
   a row" and "there is a picture" are the same statement (the same reason
-  `Vutuv.Images.forget_profile_image/2` deletes rather than blanks).
+  `Vutuv.Images.discard_profile_image/3` deletes rather than blanks).
 
   `classify/3` is what decides which of those a member is, and `run/1` and
   `check/1` both go through it — otherwise the gate would be answering a
@@ -339,7 +339,7 @@ defmodule Vutuv.Images.Backfill do
   end
 
   # A row whose member has no picture of that kind any more, deleted in one
-  # statement (`Vutuv.Images.forget_profile_image/2` is its single-row twin on
+  # statement (`Vutuv.Images.discard_profile_image/3` is its single-row twin on
   # the moderation path). The member row's pointer follows by itself
   # (`on_delete: :nilify_all`).
   defp drop_orphans(tally, kind, cols, opts) do
@@ -392,12 +392,21 @@ defmodule Vutuv.Images.Backfill do
       acc
       |> Map.update!(:pictures, &(&1 + 1))
       |> flag(classify(user, row, cols), user.id)
-      |> flag(file_verdict(user, kind), user.id)
+      |> flag(file_verdict(user, row, kind), user.id)
     end)
     |> finish_check()
   end
 
-  defp file_verdict(user, kind) do
+  # A member with no row yet is already named as `:missing_row`, and since
+  # #2027 the path is resolved from that row — so asking here too would report
+  # every un-backfilled member twice and call the second reading a missing file.
+  defp file_verdict(_user, nil, _kind), do: :ok
+
+  defp file_verdict(user, row, kind) do
+    # The row is in hand, so hand it over as the preload `member_image/2` would
+    # otherwise look up: one query per member over the whole table, for nothing.
+    user = Map.put(user, Images.member_columns(kind).assoc, row)
+
     if is_nil(Images.stored_path(user, kind)), do: :missing_file, else: :ok
   end
 

--- a/lib/vutuv/mastodon_api/presenter.ex
+++ b/lib/vutuv/mastodon_api/presenter.ex
@@ -629,15 +629,14 @@ defmodule Vutuv.MastodonApi.Presenter do
       Plug.HTML.html_escape(address) <> "</a>"
   end
 
-  # The AI image gate is not re-asked here: `Vutuv.Uploads.url/3` answers "no
-  # image" for a picture still in moderation limbo (the file waits in
-  # quarantine), so a pending avatar already comes back as the `data:` default
-  # and a pending cover as nil — the same chokepoint every website surface
-  # reads, and the stand-in falls out of it.
+  # The AI image gate is not re-asked here: `Vutuv.Avatar.url/2` answers nil for
+  # a picture still in moderation limbo (the file waits in quarantine) and for
+  # one a copyright case froze, the same chokepoint every website surface reads,
+  # so the stand-in falls out of it.
   defp user_avatar(user) do
-    case Avatar.display_url(user, :thumb) do
+    case Avatar.url(user, :thumb) do
       "/" <> _path = relative -> MastodonApi.main_url(relative)
-      "data:" <> _placeholder -> fallback_avatar()
+      nil -> fallback_avatar()
       absolute -> absolute
     end
   end

--- a/lib/vutuv/moderation/image_subjects.ex
+++ b/lib/vutuv/moderation/image_subjects.ex
@@ -7,10 +7,14 @@ defmodule Vutuv.Moderation.ImageSubjects do
   releases it (`apply_approved/1`) and how an unsafe verdict deletes it
   (`apply_rejected/1`).
 
-  Every state flip is an atomic, guarded `update_all`: the WHERE re-checks
-  the asset still holds the scanned bytes (fingerprint columns for assets
-  that change in place; gallery rows are immutable), so a verdict that lost a
-  race against a re-upload returns `:stale` and touches nothing.
+  Every state flip is guarded on the asset still holding the scanned bytes
+  (fingerprint columns for assets that change in place; gallery rows are
+  immutable), so a verdict that lost a race against a re-upload returns
+  `:stale` and touches nothing. For a **profile picture** that guard sits on
+  the picture's row in the shared `images` table since #2027, because that row
+  is what every reader consults; the member row's copy of the four columns
+  follows in a second statement, unguarded, and goes with the deploy that drops
+  them. Every other kind is still the single atomic `update_all`.
   """
 
   import Ecto.Query
@@ -142,8 +146,9 @@ defmodule Vutuv.Moderation.ImageSubjects do
     config = @profile_images[kind]
 
     with %User{} = user <- Repo.get(User, scan.subject_id),
-         true <- Map.get(user, config.file) != nil,
-         true <- Map.get(user, config.fingerprint) == scan.fingerprint do
+         %Images.Image{} = image <- Images.member_image(user, kind),
+         true <- image.file != nil,
+         true <- image.fingerprint == scan.fingerprint do
       # Fresh uploads have an original (and quarantine files while pending);
       # the served-file fallback covers legacy rows from before originals
       # were kept, so the backfill can judge them too.
@@ -328,23 +333,18 @@ defmodule Vutuv.Moderation.ImageSubjects do
   def apply_approved(%ImageScan{kind: kind} = scan) when is_map_key(@profile_images, kind) do
     config = @profile_images[kind]
 
-    flipped =
-      from(u in User,
-        where:
-          u.id == ^scan.subject_id and
-            field(u, ^config.fingerprint) == ^scan.fingerprint and
-            field(u, ^config.moderation) == "pending"
-      )
-      |> Repo.update_all(set: [{config.moderation, "approved"}])
-
-    case flipped do
-      {1, _} ->
-        Images.mark_moderation(scan.subject_id, scan.kind, scan.fingerprint, "approved")
+    # The picture's row carries the guard now (issue #2027): it is what every
+    # reader consults, so a verdict that lost a race against a re-upload has to
+    # be refused there. The member row's copy follows unguarded, because the
+    # row above already answered the same question about the same bytes.
+    case Images.mark_moderation(scan.subject_id, scan.kind, scan.fingerprint, "approved") do
+      :ok ->
+        sync_member_row(scan.subject_id, [{config.moderation, "approved"}])
         config.module.promote_from_quarantine(Repo.get!(User, scan.subject_id))
         broadcast(scan, :approved)
         :ok
 
-      _ ->
+      :stale ->
         :stale
     end
   end
@@ -549,20 +549,17 @@ defmodule Vutuv.Moderation.ImageSubjects do
   def apply_rejected(%ImageScan{kind: kind} = scan) when is_map_key(@profile_images, kind) do
     config = @profile_images[kind]
 
-    cleared =
-      from(u in User,
-        where: u.id == ^scan.subject_id and field(u, ^config.fingerprint) == ^scan.fingerprint
-      )
-      |> Repo.update_all(set: clear_profile_columns(config))
-
-    case cleared do
-      {1, _} ->
-        Images.forget_profile_image(scan.subject_id, scan.kind)
+    # Same order as the approve above: the row is the guard, the member row's
+    # four columns follow. An interruption between the two can only leave a
+    # member row naming a picture no reader can find, never the other way round.
+    case Images.discard_profile_image(scan.subject_id, scan.kind, scan.fingerprint) do
+      :ok ->
+        sync_member_row(scan.subject_id, clear_profile_columns(config))
         config.module.delete(%User{id: scan.subject_id})
         broadcast(scan, :rejected)
         :ok
 
-      _ ->
+      :stale ->
         :stale
     end
   end
@@ -862,19 +859,13 @@ defmodule Vutuv.Moderation.ImageSubjects do
   def cleanup_canceled(%ImageScan{kind: kind} = scan) when is_map_key(@profile_images, kind) do
     config = @profile_images[kind]
 
-    cleared =
-      from(u in User,
-        where:
-          u.id == ^scan.subject_id and
-            field(u, ^config.fingerprint) == ^scan.fingerprint and
-            field(u, ^config.moderation) == "pending"
-      )
-      |> Repo.update_all(set: clear_profile_columns(config))
-
-    # Only when this scan's own picture was the one cleared — the common case
-    # here is a stale cancel that matches nothing, and a delete then would take
-    # out the row of a picture uploaded since.
-    if match?({1, _}, cleared), do: Images.forget_profile_image(scan.subject_id, scan.kind)
+    # Only when this scan's own picture is still the one waiting — the common
+    # case here is a stale cancel that matches nothing, and clearing then would
+    # take out a picture uploaded since. The row answers that (issue #2027),
+    # and the member row's copy follows only once it has.
+    with :ok <- Images.discard_pending_image(scan.subject_id, scan.kind, scan.fingerprint) do
+      sync_member_row(scan.subject_id, clear_profile_columns(config))
+    end
 
     :ok
   end
@@ -889,11 +880,20 @@ defmodule Vutuv.Moderation.ImageSubjects do
 
   def cleanup_canceled(%ImageScan{}), do: :ok
 
+  # The member row's copy of a profile picture's four columns, kept in step
+  # with the row the verdict already decided on. Written here in one place, so
+  # the deploy that drops those columns deletes one function rather than
+  # hunting three `update_all`s (issue #2027).
+  defp sync_member_row(user_id, sets) do
+    from(u in User, where: u.id == ^user_id) |> Repo.update_all(set: sets)
+    :ok
+  end
+
   # The four profile-image columns (file, fingerprint, crop, moderation) and the
   # pointer at the shared `images` row reset to nil when a scan rejects the
-  # image or cancels a pending one. The row itself is deleted beside this
-  # (`Vutuv.Images.forget_profile_image/2`): "there is a row" and "there is a
-  # picture" stay the same statement.
+  # image or cancels a pending one. The row itself is deleted **before** this,
+  # by `Vutuv.Images.discard_profile_image/3`, which is also the guard: "there
+  # is a row" and "there is a picture" stay the same statement.
   defp clear_profile_columns(config),
     do: [
       {config.file, nil},
@@ -1038,13 +1038,15 @@ defmodule Vutuv.Moderation.ImageSubjects do
   end
 
   defp profile_stranded(kind) do
-    config = @profile_images[kind]
+    pointer = @profile_images[kind].pointer
 
     from(u in User,
       as: :subject,
-      where: field(u, ^config.moderation) == "pending",
+      join: i in Images.Image,
+      on: i.id == field(u, ^pointer),
+      where: i.moderation == "pending",
       where: not exists(open_scan_exists(kind)),
-      select: {u.id, field(u, ^config.fingerprint)}
+      select: {u.id, i.fingerprint}
     )
     |> Repo.all()
     |> Enum.map(fn {id, fingerprint} -> {kind, id, id, fingerprint} end)

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -6452,7 +6452,12 @@ defmodule Vutuv.Posts do
   # with fifty links still ships only the handful they proved — and ordered,
   # because an un-ordered multi-row preload comes back in whatever order
   # Postgres likes (id order is creation order, ids being UUID v7).
-  defp verified_links_preload, do: VerifiedLinks.preload_spec()
+  # The author's links plus the two rows their pictures are built from since
+  # #2027: one more batched query per page, never one per card. The cover is
+  # here for the Mastodon API's account object, which carries a header image
+  # and renders one account per status.
+  defp verified_links_preload,
+    do: [:avatar_image, :cover_image | VerifiedLinks.preload_spec()]
 
   @doc """
   The root-relative permalink path, e.g.

--- a/lib/vutuv/sessions.ex
+++ b/lib/vutuv/sessions.ex
@@ -86,12 +86,19 @@ defmodule Vutuv.Sessions do
   The active (not revoked) session for `raw_token`, or `nil` when the token is
   missing, unknown, or revoked. The owner preloaded, so the plug can apply the
   same suspension/deactivation gate it applies to a freshly loaded user.
+
+  The owner's avatar row rides along in the same query (issue #2027): the top
+  bar draws that face on every page and every socket connect, so resolving it
+  afterwards would be one extra round trip on the most-travelled path in the
+  app. A `left_join`, so a member without a picture still gets their session.
   """
   def active_session(token) when is_binary(token) do
     Repo.one(
       from(s in UserSession,
+        join: u in assoc(s, :user),
+        left_join: ai in assoc(u, :avatar_image),
         where: s.token_hash == ^hash_token(token) and is_nil(s.revoked_at),
-        preload: [:user]
+        preload: [user: {u, avatar_image: ai}]
       )
     )
   end

--- a/lib/vutuv/social.ex
+++ b/lib/vutuv/social.ex
@@ -16,6 +16,8 @@ defmodule Vutuv.Social do
 
   alias Vutuv.AccountEvents
   alias Vutuv.Accounts.User
+  alias Vutuv.Images
+  alias Vutuv.Images.Image
   alias Vutuv.Keyset
   alias Vutuv.Organizations.Organization
   alias Vutuv.Pages
@@ -781,7 +783,10 @@ defmodule Vutuv.Social do
       end
 
     query = Follow.latest(100, person) |> Pages.paginate(params, total)
-    user = Repo.preload(user, [{assoc, {query, [person]}}])
+    # `{person, :avatar_image}`: the row each listed member's avatar URL is
+    # built from (#2027), batched into the same page rather than one lookup per
+    # row.
+    user = Repo.preload(user, [{assoc, {query, [{person, :avatar_image}]}}])
 
     %{
       user: user,
@@ -1087,16 +1092,18 @@ defmodule Vutuv.Social do
   filtered at the call site, the way every candidate pool here is.
   """
   def newest_members_with_avatar(limit) do
-    Repo.all(
-      from(u in User,
-        where: account_confirmed_row(u) and not account_hidden_row(u),
-        where: not is_nil(u.avatar),
-        where: is_nil(u.avatar_moderation) or u.avatar_moderation == "approved",
-        order_by: [desc: u.id],
-        limit: ^limit,
-        select: struct(u, ^User.listing_fields())
-      )
+    from(u in User,
+      join: i in Image,
+      on: i.id == u.avatar_image_id,
+      where: account_confirmed_row(u) and not account_hidden_row(u),
+      where: is_nil(i.moderation) or i.moderation == "approved",
+      where: is_nil(i.frozen_at),
+      order_by: [desc: u.id],
+      limit: ^limit,
+      select: struct(u, ^User.listing_fields()),
+      preload: [avatar_image: i]
     )
+    |> Repo.all()
   end
 
   @doc """
@@ -1620,6 +1627,7 @@ defmodule Vutuv.Social do
       |> ordered_connections_query()
       |> Pages.paginate(params, total)
       |> Repo.all()
+      |> preload_row_avatars()
 
     %{user: user, connections: connections, total: total}
   end
@@ -1641,6 +1649,14 @@ defmodule Vutuv.Social do
   # The mutual-follow set ordered newest-pair-first and shaped into the
   # `%{user:, follow_id:, muted?:}` rows both the full list and the paginated
   # connections page render.
+  # The picture row of every member on a page of `%{user: …}` rows, in one
+  # read. `/:slug/connections` is public, crawlable and 250 rows deep, so a
+  # lookup per row is what this exists to prevent (issue #2027).
+  defp preload_row_avatars(rows) do
+    preloaded = rows |> Enum.map(& &1.user) |> Images.preload_avatars()
+    Enum.zip_with(rows, preloaded, &%{&1 | user: &2})
+  end
+
   defp ordered_connections_query(user_id) do
     mutual_follows_query(user_id)
     |> order_by([out, back], desc: fragment("GREATEST(?, ?)", out.id, back.id))

--- a/lib/vutuv/tags/user_tag_endorsement.ex
+++ b/lib/vutuv/tags/user_tag_endorsement.ex
@@ -45,6 +45,8 @@ defmodule Vutuv.Tags.UserTagEndorsement do
   proof on the profile Tags card — without an extra query per endorsement.
   """
   def visible_with_endorser(query \\ __MODULE__) do
-    from([e, u] in visible(query), preload: [user: u])
+    # The endorser's avatar row rides along: `/:slug/tags` draws up to fifteen
+    # tags of seven faces each, so one lookup per face is a hundred queries.
+    from([e, u] in visible(query), preload: [user: {u, :avatar_image}])
   end
 end

--- a/lib/vutuv/uploaders/avatar.ex
+++ b/lib/vutuv/uploaders/avatar.ex
@@ -10,12 +10,14 @@ defmodule Vutuv.Avatar do
 
       <uploads_dir_prefix>/avatars/<user.id>/<username>-<version>-<fingerprint>.avif
 
-  The fingerprint (`sha256(original)[0..11]`) is stored in `:avatar_fingerprint`;
-  the on-disk filename equals the URL's last segment, so the existing nginx
-  `alias` serves it directly (no rewrite). A row with no fingerprint has not been
-  migrated to this scheme yet and falls back to the legacy
-  `avatar_<version>.avif?v=...` URL (see `Vutuv.Uploads`); a username change
-  re-derives the files under the new handle (`reslug/1`).
+  The fingerprint (`sha256(original)[0..11]`) is read off the picture's row in
+  the shared `images` table (`Vutuv.Images.member_image/2`, since #2027) and
+  still written to `:avatar_fingerprint` beside it; the on-disk filename equals
+  the URL's last segment, so the existing nginx `alias` serves it directly (no
+  rewrite). A picture with no fingerprint has not been migrated to this scheme
+  yet and falls back to the legacy `avatar_<version>.avif?v=...` URL (see
+  `Vutuv.Uploads`); a username change re-derives the files under the new handle
+  (`reslug/1`).
 
   The uploaded **original** is kept verbatim (format + metadata) so better
   formats can be re-derived later (`Vutuv.Uploads.Regenerator`), but in a
@@ -32,7 +34,7 @@ defmodule Vutuv.Avatar do
   The store/serve/url/regenerate pipeline is shared with `Vutuv.Cover` and
   lives in `Vutuv.Uploads`; this module supplies the avatar layout (`@config`)
   and the avatar-only extras: the default inline-SVG fallback, `binary/2` for
-  the vCard export and `user_url/2`.
+  the vCard export and `og_jpeg/1` for the link-preview endpoint.
   """
 
   alias Vutuv.Images

--- a/lib/vutuv/uploaders/avatar.ex
+++ b/lib/vutuv/uploaders/avatar.ex
@@ -35,6 +35,7 @@ defmodule Vutuv.Avatar do
   the vCard export and `user_url/2`.
   """
 
+  alias Vutuv.Images
   alias Vutuv.LowBandwidth
   alias Vutuv.Uploads
   alias Vutuv.Uploads.Crop
@@ -49,16 +50,14 @@ defmodule Vutuv.Avatar do
     # nothing says they must.
     kind: "avatar",
     default_version: :medium,
-    # The user column holding this image's content fingerprint. When set, the
-    # served filename embeds the handle + fingerprint (`<username>-<version>-<fp>.avif`)
-    # and the URL needs no `?v=`; when nil the row predates the scheme and falls
-    # back to the legacy URL. See Vutuv.Uploads.served_url/4.
+    # The member-row column a re-derive writes the fresh fingerprint back into.
+    # A **write**: since #2027 the fingerprint every URL is built from is read
+    # off the `images` row, and this column only stays in step until the deploy
+    # that drops it. See `Vutuv.Uploads.regenerate/3`.
     fingerprint_field: :avatar_fingerprint,
-    crop_field: :avatar_crop,
-    # AI moderation state column: "pending" holds fresh uploads in the
-    # quarantine tree and makes every URL helper answer "no image"
-    # (Vutuv.Moderation.ImageScans).
-    moderation_field: :avatar_moderation
+    # The AI gate screens this kind, so a fresh upload's bytes go to the
+    # quarantine tree until it rules (`Vutuv.Moderation.ImageScans`).
+    moderated: true
   }
 
   @default_avatar ~s"data:image/svg+xml,%3Csvg%20width%3D%27200%27%20height%3D%27200%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20xmlns%3Axlink%3D%27http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%27%3E%3Cdefs%3E%3Ccircle%20id%3D%27a%27%20cx%3D%27100%27%20cy%3D%27100%27%20r%3D%27100%27%2F%3E%3C%2Fdefs%3E%3Cg%20fill%3D%27none%27%20fill-rule%3D%27evenodd%27%3E%3Cmask%20id%3D%27b%27%20fill%3D%27%23fff%27%3E%3Cuse%20xlink%3Ahref%3D%27%23a%27%2F%3E%3C%2Fmask%3E%3Cuse%20fill%3D%27%23EEE%27%20xlink%3Ahref%3D%27%23a%27%2F%3E%3Cpath%20d%3D%27M88.96%20154c-6.357-12.418-12.81-26.952-19.355-43.597C63.06%2093.76%2056.858%2075.626%2051%2056h29.437c1.247%204.844%202.714%2010.093%204.4%2015.743%201.682%205.653%203.428%2011.365%205.24%2017.143%201.808%205.772%203.615%2011.394%205.425%2016.86%201.81%205.466%203.59%2010.434%205.336%2014.904%201.618-4.47%203.365-9.438%205.234-14.905%201.87-5.465%203.71-11.087%205.518-16.86%201.807-5.777%203.554-11.49%205.237-17.142%201.682-5.65%203.15-10.9%204.395-15.743h28.71c-5.857%2019.626-12.055%2037.76-18.594%2054.403C124.8%20127.048%20118.352%20141.583%20112%20154H88.96z%27%20fill%3D%27%231A1918%27%20opacity%3D%27.1%27%20mask%3D%27url(%23b)%27%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E"
@@ -84,7 +83,7 @@ defmodule Vutuv.Avatar do
   `Vutuv.Uploads.Regenerator`.
   """
   def regenerate(user, opts \\ []) do
-    Uploads.regenerate(user, opts, @config)
+    Uploads.regenerate(pair(user), opts, @config)
   end
 
   @doc """
@@ -92,14 +91,15 @@ defmodule Vutuv.Avatar do
   (the handle is baked into the served filename). See
   `Vutuv.Uploads.reslug/2` and `Accounts.update_username/2`.
   """
-  def reslug(user), do: Uploads.reslug(user, @config)
+  def reslug(user), do: Uploads.reslug(pair(user), @config)
 
   @doc """
   Releases an approved avatar from the quarantine tree into the served tree —
   see `Vutuv.Uploads.promote_from_quarantine/2`. Called by the moderation
   verdict (`Vutuv.Moderation.ImageSubjects`).
   """
-  def promote_from_quarantine(user), do: Uploads.promote_from_quarantine(user, @config)
+  def promote_from_quarantine(user),
+    do: Uploads.promote_from_quarantine(pair(user), @config)
 
   @doc """
   Moves every avatar file of `user` into the takedown hold of `image_id`, and
@@ -115,7 +115,7 @@ defmodule Vutuv.Avatar do
   limbo — the owner-only preview (`VutuvWeb.PendingImageController`).
   """
   def pending_preview_path(user, version \\ @config.default_version) do
-    Uploads.quarantine_version_path(user, version, @config)
+    Uploads.quarantine_version_path(pair(user), version, @config)
   end
 
   @doc """
@@ -125,7 +125,7 @@ defmodule Vutuv.Avatar do
   `Vutuv.Images.Backfill.check/1` asks before the contract cut.
   """
   def stored_path(user, version \\ @config.default_version) do
-    Uploads.version_path({user.avatar, user}, version, @config)
+    Uploads.version_path(pair(user), version, @config)
   end
 
   @doc """
@@ -133,19 +133,21 @@ defmodule Vutuv.Avatar do
   the contract half of the migration. See `Vutuv.Uploads.sweep_legacy/3` and
   `mix vutuv.images.sweep_legacy`.
   """
-  def sweep_legacy(user, opts \\ []), do: Uploads.sweep_legacy(user, opts, @config)
+  def sweep_legacy(user, opts \\ []),
+    do: Uploads.sweep_legacy(pair(user), opts, @config)
 
   @doc """
-  Root-relative, URI-encoded URL for a given `{avatar, user}` and served
-  version. Returns `nil` when the user has no avatar or for `:original`
-  (the original is never URL-addressable).
-  """
-  def url(file_and_scope, version \\ @config.default_version) do
-    Uploads.url(file_and_scope, version, @config)
-  end
+  Root-relative, URI-encoded URL of this member's avatar at that version, or
+  `nil` when there is nothing a reader may fetch: no avatar, one the AI gate
+  still holds, one a copyright case froze, or `:original` (the private original
+  is never URL-addressable).
 
-  def user_url(user, version) do
-    Vutuv.Avatar.url({user.avatar, user}, version)
+  The one function that owns this URL, and since #2027 it is built from the
+  picture's row in the shared `images` table — the member row's four columns are
+  still written, but nothing reads them.
+  """
+  def url(user, version \\ @config.default_version) do
+    Uploads.url(pair(user), version, @config)
   end
 
   @doc """
@@ -160,14 +162,23 @@ defmodule Vutuv.Avatar do
   per profile render and buys the alternative to a two-deploy rollout: the
   avatar is simply not clickable yet, instead of being a link to a 404.
   """
-  def large_url(user), do: on_disk_url(user, :large)
+  def large_url(user), do: on_disk_url(image(user), user, :large)
 
   # The served URL of `version`, or nil while its file is not on disk — the
-  # answer both younger-than-the-rows versions need.
-  defp on_disk_url(user, version) do
-    if Uploads.version_path({user.avatar, user}, version, @config),
-      do: url({user.avatar, user}, version)
+  # answer both younger-than-the-rows versions need. Takes the already-resolved
+  # row, so a caller wanting two answers about one picture resolves it once.
+  defp on_disk_url(image, user, version) do
+    if Uploads.version_path({image, user}, version, @config),
+      do: Uploads.url({image, user}, version, @config)
   end
+
+  # This member's avatar row: the preload when a caller remembered one, one
+  # primary-key lookup on the member row's pointer when nobody did, and no
+  # query at all for a member without a picture.
+  defp image(user), do: Images.member_image(user, @config.kind)
+
+  # What the shared pipeline takes: the row beside the member it belongs to.
+  defp pair(user), do: {image(user), user}
 
   @doc """
   Removes the user's avatar files — the served versions and the private
@@ -181,8 +192,24 @@ defmodule Vutuv.Avatar do
   avatar in moderation limbo renders as the default for everyone — the
   owner's own preview is a separate, authenticated route.
   """
-  def display_url(%{avatar: nil}, _version), do: @default_avatar
-  def display_url(user, version), do: url({user.avatar, user}, version) || @default_avatar
+  def display_url(user, version), do: src(user, version) || @default_avatar
+
+  @doc """
+  What an `<img src>` gets for this member at that version, or `nil` when the
+  member has **no picture at all** — the answer `VutuvWeb.UI.avatar/1` needs to
+  draw its initials tile instead of the anonymous grey silhouette.
+
+  A picture that is only *held* is not "no picture": one the AI gate has in
+  quarantine renders the silhouette, as it always did. A picture a copyright
+  case froze **is** this case, because a takedown has to read the way a member
+  who never uploaded one reads — which is what clearing the member row's four
+  columns used to do (issue #2012). Both distinctions come out of one lookup,
+  which is why the caller asks this rather than pairing `url/2` with a
+  separate "has a picture?" question.
+  """
+  def src(user, version \\ @config.default_version) do
+    with %Images.Image{} = image <- shown(user), do: shown_src(image, user, version)
+  end
 
   @doc """
   What the profile picture at the top of a profile loads for this viewer
@@ -191,13 +218,33 @@ defmodule Vutuv.Avatar do
   (`Vutuv.LowBandwidth`) and the file is on disk. That slot is 96 CSS px and
   loads 192 px for HiDPI screens, so the thumb is the same picture at 1x — a
   third of the bytes, and the switch offers the sharp one. Which slot asks is
-  `VutuvWeb.UI.avatar/1`'s decision; every other slot loads the thumb
-  already. Asks the disk like `Vutuv.Cover.picture/1`: a version named
-  without looking is exactly the broken-picture case the lite rule rules out.
+  `VutuvWeb.UI.avatar/1`'s decision, and it asks only for the 96 px one: every
+  other slot loads the thumb already and has nothing cheaper to offer, so it
+  takes `src/2` and gets no switch. Asks the disk like `Vutuv.Cover.picture/1`:
+  a version named without looking is exactly the broken-picture case the lite
+  rule rules out. `:src` is `nil` for a member with no picture, like `src/2`.
   """
   def picture(user) do
-    LowBandwidth.picture(display_url(user, :medium), fn -> on_disk_url(user, :thumb) end)
+    case shown(user) do
+      nil ->
+        %{src: nil, lite: nil}
+
+      image ->
+        LowBandwidth.picture(
+          shown_src(image, user, @config.default_version),
+          fn -> on_disk_url(image, user, :thumb) end
+        )
+    end
   end
+
+  # The picture a reader is even told exists: no row, or a frozen one, is "no
+  # picture", and the caller draws its initials tile.
+  defp shown(user), do: Images.shown_image(user, @config.kind)
+
+  # The URL of a picture that exists, falling back to the silhouette for one
+  # nobody may see right now.
+  defp shown_src(image, user, version),
+    do: Uploads.url({image, user}, version, @config) || @default_avatar
 
   @doc """
   The avatar as a base64 JPEG `data:` URI (used by the vCard export — contact
@@ -205,9 +252,6 @@ defmodule Vutuv.Avatar do
   the requested version's dimensions. Falls back to the default inline SVG
   when the user has no avatar / the original is missing.
   """
-  def binary(%{avatar: nil}, _version), do: @default_avatar
-  def binary(%{avatar_moderation: "pending"}, _version), do: @default_avatar
-
   def binary(user, version) do
     %{fit: {:crop, width, height, gravity}} = Spec.version(:avatar, version)
 
@@ -230,9 +274,6 @@ defmodule Vutuv.Avatar do
   originals, from the largest served version — at #{@og_size}px square.
   `:error` when the user has no avatar or nothing usable is on disk.
   """
-  def og_jpeg(%{avatar: nil}), do: :error
-  # Limbo: the OG endpoint must not leak the unreleased original.
-  def og_jpeg(%{avatar_moderation: "pending"}), do: :error
   def og_jpeg(user), do: derive_jpeg(user, @og_size, @og_size, :center)
 
   # JPEG from the best available source, through the shared `Spec.og_jpeg/2`
@@ -242,15 +283,19 @@ defmodule Vutuv.Avatar do
   # The crop is applied only when deriving from the **original**; a served
   # version fallback (legacy uploads with no kept original) is already cropped,
   # so re-applying the fractions would double-crop it.
+  # `Vutuv.Images.servable?/1` is the gate, the same one every URL builder asks:
+  # neither the vCard's photo nor the link-preview JPEG may reach past a picture
+  # the AI gate is holding, or one a copyright case froze, into the private
+  # original.
   defp derive_jpeg(user, width, height, gravity) do
-    case source(user) do
-      nil ->
-        :error
+    with %Images.Image{} = image <- image(user),
+         true <- Images.servable?(image),
+         {origin, path} <- source(image, user) do
+      crop = if origin == :original, do: Crop.parse(image.crop)
 
-      {origin, path} ->
-        crop = if origin == :original, do: Crop.parse(Map.get(user, :avatar_crop))
-
-        Spec.og_jpeg(path, &crop_and_resize(&1, crop, width, height, gravity))
+      Spec.og_jpeg(path, &crop_and_resize(&1, crop, width, height, gravity))
+    else
+      _ -> :error
     end
   end
 
@@ -260,10 +305,10 @@ defmodule Vutuv.Avatar do
     end
   end
 
-  defp source(user) do
+  defp source(image, user) do
     case Originals.path("#{@config.prefix}/#{user.id}") do
       nil ->
-        case Uploads.version_path({user.avatar, user}, :medium, @config) do
+        case Uploads.version_path({image, user}, :medium, @config) do
           nil -> nil
           path -> {:served, path}
         end

--- a/lib/vutuv/uploaders/cover.ex
+++ b/lib/vutuv/uploaders/cover.ex
@@ -25,6 +25,7 @@ defmodule Vutuv.Cover do
   (`@config`).
   """
 
+  alias Vutuv.Images
   alias Vutuv.LowBandwidth
   alias Vutuv.Uploads
 
@@ -34,14 +35,10 @@ defmodule Vutuv.Cover do
     # This image's kind in the shared `images` table (`Vutuv.Images`).
     kind: "cover",
     default_version: :wide,
-    # See Vutuv.Avatar's @config: the user column holding this image's content
-    # fingerprint, baked into `<username>-<version>-<fp>.avif` when set.
+    # See Vutuv.Avatar's @config: a member-row column the write half still
+    # fills, not one anything reads, and the AI gate's screening flag.
     fingerprint_field: :cover_fingerprint,
-    crop_field: :cover_crop,
-    # AI moderation state column: "pending" holds fresh uploads in the
-    # quarantine tree and makes every URL helper answer "no image"
-    # (Vutuv.Moderation.ImageScans).
-    moderation_field: :cover_moderation
+    moderated: true
   }
 
   @doc """
@@ -64,7 +61,7 @@ defmodule Vutuv.Cover do
   `Vutuv.Uploads.Regenerator`.
   """
   def regenerate(user, opts \\ []) do
-    Uploads.regenerate(user, opts, @config)
+    Uploads.regenerate(pair(user), opts, @config)
   end
 
   @doc """
@@ -72,7 +69,8 @@ defmodule Vutuv.Cover do
   see `Vutuv.Uploads.promote_from_quarantine/2`. Called by the moderation
   verdict (`Vutuv.Moderation.ImageSubjects`).
   """
-  def promote_from_quarantine(user), do: Uploads.promote_from_quarantine(user, @config)
+  def promote_from_quarantine(user),
+    do: Uploads.promote_from_quarantine(pair(user), @config)
 
   @doc """
   Moves every cover file of `user` into the takedown hold of `image_id`, and
@@ -88,7 +86,7 @@ defmodule Vutuv.Cover do
   limbo — the owner-only preview (`VutuvWeb.PendingImageController`).
   """
   def pending_preview_path(user, version \\ @config.default_version) do
-    Uploads.quarantine_version_path(user, version, @config)
+    Uploads.quarantine_version_path(pair(user), version, @config)
   end
 
   @doc """
@@ -97,37 +95,42 @@ defmodule Vutuv.Cover do
   `Vutuv.Avatar.stored_path/2`.
   """
   def stored_path(user, version \\ @config.default_version) do
-    Uploads.version_path({user.cover_photo, user}, version, @config)
+    Uploads.version_path(pair(user), version, @config)
   end
 
   @doc """
   Re-derives the cover under the user's current handle after a username change.
   See `Vutuv.Uploads.reslug/2` and `Accounts.update_username/2`.
   """
-  def reslug(user), do: Uploads.reslug(user, @config)
+  def reslug(user), do: Uploads.reslug(pair(user), @config)
 
   @doc """
   Removes the legacy cover files once the row is on the fingerprinted scheme —
   the contract half of the migration. See `Vutuv.Uploads.sweep_legacy/3` and
   `mix vutuv.images.sweep_legacy`.
   """
-  def sweep_legacy(user, opts \\ []), do: Uploads.sweep_legacy(user, opts, @config)
+  def sweep_legacy(user, opts \\ []),
+    do: Uploads.sweep_legacy(pair(user), opts, @config)
 
   @doc """
-  Root-relative, URI-encoded URL for a given `{cover_photo, user}` and served
-  version. Returns `nil` when the user has no cover photo or for `:original`
-  (the original is never URL-addressable).
+  Root-relative, URI-encoded URL of this member's cover at that version, or
+  `nil` when there is nothing a reader may fetch: no cover, one the AI gate
+  still holds, one a copyright case froze, or `:original`.
+
+  The one function that owns this URL. Built from the picture's row in the
+  shared `images` table since #2027; the member row's four columns are still
+  written, but nothing reads them.
   """
-  def url(file_and_scope, version \\ @config.default_version) do
-    Uploads.url(file_and_scope, version, @config)
+  def url(user, version \\ @config.default_version) do
+    Uploads.url(pair(user), version, @config)
   end
 
   @doc """
-  The value templates put in an `<img src>`, or `nil` when the user has no cover
-  photo (so the caller can fall back to the gradient banner).
+  The polymorphic name `Vutuv.Images.preview_url/1` calls on either uploader.
+  The same answer as `url/2`; `Vutuv.Avatar`'s falls back to the silhouette,
+  this one leaves the caller its gradient.
   """
-  def display_url(%{cover_photo: nil}, _version), do: nil
-  def display_url(user, version), do: url({user.cover_photo, user}, version)
+  def display_url(user, version), do: url(user, version)
 
   @doc """
   What the profile header loads for this viewer (`VutuvWeb.UI.picture/1`):
@@ -143,15 +146,24 @@ defmodule Vutuv.Cover do
   broken banner on every profile in between.
   """
   def picture(user) do
-    LowBandwidth.picture(display_url(user, :wide), fn -> lite_url(user) end)
+    image = image(user)
+
+    LowBandwidth.picture(
+      Uploads.url({image, user}, @config.default_version, @config),
+      fn -> lite_url(image, user) end
+    )
   end
 
-  defp lite_url(%{cover_photo: nil}), do: nil
-
-  defp lite_url(user) do
-    if Uploads.version_path({user.cover_photo, user}, :lite, @config),
-      do: url({user.cover_photo, user}, :lite)
+  defp lite_url(image, user) do
+    if Uploads.version_path({image, user}, :lite, @config),
+      do: Uploads.url({image, user}, :lite, @config)
   end
+
+  # This member's cover row, and what the shared pipeline takes: the row beside
+  # the member it belongs to. See `Vutuv.Avatar`'s twins.
+  defp image(user), do: Images.member_image(user, @config.kind)
+
+  defp pair(user), do: {image(user), user}
 
   @doc """
   Removes the user's cover-photo files — the served version and the private

--- a/lib/vutuv/uploads.ex
+++ b/lib/vutuv/uploads.ex
@@ -10,11 +10,19 @@ defmodule Vutuv.Uploads do
   Directory orientation for new readers: `lib/vutuv/uploads/` (this context)
   is the shared pipeline; `lib/vutuv/uploaders/` holds the per-asset-type
   modules (avatar, cover, post image, screenshot) that configure it.
+
+  For a profile picture the avatar/cover half of this pipeline takes
+  `{image, scope}` — the picture's row in the shared `images` table
+  (`Vutuv.Images.member_image/2`, resolved once by the uploader) beside whose
+  it is. Since #2027 that row is where the file name, the fingerprint, the crop
+  and the moderation verdict are read from; the member row's four columns per
+  kind are still written but no longer read, and go a deploy later.
   """
 
   require Logger
 
   alias Vutuv.Images
+  alias Vutuv.Images.Image
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Repo
   alias Vutuv.Uploads.Crop
@@ -45,22 +53,24 @@ defmodule Vutuv.Uploads do
     * `:spec_key` — the `Vutuv.Uploads.Spec.versions/1` key (`:avatar | :cover`)
     * `:prefix` — the served-tree storage prefix (`"avatars"` / `"covers"`)
     * `:default_version` — the version `url/3` serves when none is given
-    * `:fingerprint_field` — the scope field holding this image's content
-      fingerprint (`:avatar_fingerprint` / `:cover_fingerprint`); absent for
-      uploaders not on the fingerprinted scheme
-    * `:crop_field` — the scope field holding the persisted crop string that
-      `regenerate/3` re-applies (`:avatar_crop` / `:cover_crop`); absent for
-      uploaders without a user-chosen crop
     * `:kind` — this image's kind in the shared `images` table
-      (`Vutuv.Images`), declared beside `:fingerprint_field` because the
-      re-derive has to keep that row naming the same bytes
+      (`Vutuv.Images`). Since #2027 the row of that kind is what every function
+      here reads the picture's `file` / `fingerprint` / `crop` / `moderation`
+      from; the caller resolves it once (`Vutuv.Images.member_image/2`) and
+      hands it in as `{image, scope}`
+    * `:fingerprint_field` — the **member-row column** a re-derive writes the
+      fresh fingerprint back into (`:avatar_fingerprint` /
+      `:cover_fingerprint`). A write, not a read: both copies stay in step
+      until the column drop
+    * `:moderated` — whether the AI image gate screens this kind, which decides
+      the tree a fresh upload's bytes land in
   """
   @type uploader_config :: %{
           required(:spec_key) => atom(),
           required(:prefix) => String.t(),
           required(:default_version) => atom(),
           optional(:fingerprint_field) => atom(),
-          optional(:crop_field) => atom(),
+          optional(:moderated) => boolean(),
           optional(:kind) => String.t()
         }
 
@@ -368,7 +378,7 @@ defmodule Vutuv.Uploads do
   # tree and is what the caller writes onto its row; nil is an uploader with no
   # moderation column, which has neither.
   defp initial_moderation(config) do
-    if Map.has_key?(config, :moderation_field), do: ImageScans.initial_state()
+    if Map.get(config, :moderated, false), do: ImageScans.initial_state()
   end
 
   @doc """
@@ -379,7 +389,7 @@ defmodule Vutuv.Uploads do
   (e.g. a username change while the image waited in limbo). Idempotent — an
   empty quarantine with converged served files is a no-op.
   """
-  def promote_from_quarantine(scope, config) do
+  def promote_from_quarantine({image, scope}, config) do
     storage_dir = storage_dir(scope, config)
     qdir = quarantine_dir(storage_dir)
     dir = disk_dir(storage_dir)
@@ -393,7 +403,7 @@ defmodule Vutuv.Uploads do
     File.rm_rf(qdir)
 
     # Converged rows return :unchanged here (cheap file-exists checks).
-    case regenerate(scope, [], config) do
+    case regenerate({image, scope}, [], config) do
       {:error, reason} -> Logger.warning("promote self-heal failed: #{inspect(reason)}")
       _ -> :ok
     end
@@ -438,20 +448,20 @@ defmodule Vutuv.Uploads do
   def valid_upload?(_), do: false
 
   @doc """
-  Root-relative, URI-encoded URL for a given `{file, scope}` and served
-  version per `config`. Returns `nil` when the user has no file or for
-  `:original` (the original is never URL-addressable).
+  Root-relative, URI-encoded URL for a given `{image, scope}` and served
+  version per `config` — `image` being the picture's row in the shared
+  `images` table (`Vutuv.Images.member_image/2`), or `nil` for a member with no
+  picture of that kind.
+
+  `nil` whenever there is nothing a reader may fetch: no picture, a picture the
+  AI gate still holds, a picture a copyright case froze, or `:original` (the
+  private original is never URL-addressable).
   """
-  def url({file, scope}, version, config) do
+  def url({image, scope}, version, config) do
     cond do
-      is_nil(file) -> nil
       version == :original -> nil
-      # Moderation limbo: to the world this image does not exist (the files
-      # are in quarantine anyway — nginx could not serve them). The owner's
-      # own preview goes through the authenticated pending-image route, never
-      # through here.
-      held_in_limbo?(scope, config) -> nil
-      true -> served_url(file, scope, version, config)
+      not servable?(image) -> nil
+      true -> served_url(image, scope, version, config)
     end
   end
 
@@ -462,40 +472,37 @@ defmodule Vutuv.Uploads do
   when no private original was kept (legacy uploads predate the kept
   originals).
   """
-  def version_path({file, scope}, version, config) do
-    if file do
-      dir = disk_dir(storage_dir(scope, config))
+  def version_path({%Image{} = image, scope}, version, config) do
+    dir = disk_dir(storage_dir(scope, config))
 
-      name =
-        case fingerprint(scope, config) do
-          nil -> served_filename(scope, version, file, config)
-          fp -> fingerprinted_filename(scope, version, fp, config)
-        end
+    name =
+      case image.fingerprint do
+        nil -> served_filename(scope, version, image.file, config)
+        fp -> fingerprinted_filename(scope, version, fp, config)
+      end
 
-      path = Path.join(dir, name)
-      if File.exists?(path), do: path
-    end
+    path = Path.join(dir, name)
+    if File.exists?(path), do: path
   end
+
+  def version_path({nil, _scope}, _version, _config), do: nil
 
   @doc """
   The on-disk path of a **quarantined** derived version — the owner's limbo
   preview (`VutuvWeb.PendingImageController`); nobody else ever sees these
   bytes. `nil` when absent.
   """
-  def quarantine_version_path(scope, version, config) do
-    case fingerprint(scope, config) do
-      nil ->
-        nil
+  def quarantine_version_path({%Image{fingerprint: fp}, scope}, version, config)
+      when is_binary(fp) do
+    path =
+      storage_dir(scope, config)
+      |> quarantine_dir()
+      |> Path.join(fingerprinted_filename(scope, version, fp, config))
 
-      fp ->
-        path =
-          storage_dir(scope, config)
-          |> quarantine_dir()
-          |> Path.join(fingerprinted_filename(scope, version, fp, config))
-
-        if File.exists?(path), do: path
-    end
+    if File.exists?(path), do: path
   end
+
+  def quarantine_version_path(_image_and_scope, _version, _config), do: nil
 
   @doc """
   Migrates one avatar/cover row to the fingerprinted scheme (or re-derives a row
@@ -513,15 +520,17 @@ defmodule Vutuv.Uploads do
   Returns `:ok` (migrated/re-derived), `:unchanged` (already converged),
   `{:skipped, :missing_original}` (files left untouched) or `{:error, reason}`.
   """
-  def regenerate(user, opts, config) do
+  def regenerate({image, user}, opts, config) do
     storage_dir = storage_dir(user, config)
     dir = disk_dir(storage_dir)
-    fingerprint = Map.get(user, config.fingerprint_field)
+    fingerprint = image && image.fingerprint
 
     cond do
-      # An image still in moderation limbo must never be materialized into
-      # the served tree — its files live in quarantine until the verdict.
-      held_in_limbo?(user, config) ->
+      # Nothing to re-derive, or nothing that MAY be re-derived: a picture the
+      # AI gate still holds lives in the quarantine tree and one a copyright
+      # case froze lives in the takedown hold, and writing fresh versions into
+      # the served tree would hand either of them back to the world.
+      not servable?(image) ->
         :unchanged
 
       opts[:dry_run] ->
@@ -532,7 +541,7 @@ defmodule Vutuv.Uploads do
         :unchanged
 
       true ->
-        migrate_to_fingerprinted(user, storage_dir, dir, config)
+        migrate_to_fingerprinted(image, user, storage_dir, dir, config)
     end
   end
 
@@ -543,9 +552,9 @@ defmodule Vutuv.Uploads do
   username-based). Works off the private original, so it never depends on the
   old-handle files still being present. See `Accounts.update_username/2`.
   """
-  def reslug(user, config) do
-    if Map.get(user, config.fingerprint_field) do
-      regenerate(user, [force: true], config)
+  def reslug({image, user}, config) do
+    if image && image.fingerprint do
+      regenerate({image, user}, [force: true], config)
     else
       :unchanged
     end
@@ -564,12 +573,15 @@ defmodule Vutuv.Uploads do
   `dry_run: true` reports without deleting. Returns `{:swept, names}`,
   `{:dry_run, names}` or `:unchanged`.
   """
-  def sweep_legacy(user, opts, config) do
-    fingerprint = Map.get(user, config.fingerprint_field)
+  def sweep_legacy({image, user}, opts, config) do
+    fingerprint = image && image.fingerprint
     dir = disk_dir(storage_dir(user, config))
 
     cond do
       is_nil(fingerprint) -> :unchanged
+      # A held picture's files are not in the served tree at all, so there is
+      # nothing here to call stale — and nothing to prove the scheme by.
+      not servable?(image) -> :unchanged
       not fingerprint_converged?(user, dir, fingerprint, config) -> :unchanged
       true -> remove_stale_files(user, dir, fingerprint, opts, config)
     end
@@ -607,7 +619,7 @@ defmodule Vutuv.Uploads do
     end)
   end
 
-  defp migrate_to_fingerprinted(user, storage_dir, dir, config) do
+  defp migrate_to_fingerprinted(image, user, storage_dir, dir, config) do
     case Originals.adopt(storage_dir, [Path.join(dir, "*_original.*")]) do
       nil ->
         {:skipped, :missing_original}
@@ -617,35 +629,32 @@ defmodule Vutuv.Uploads do
         # Re-apply the user's persisted crop so a re-derive from the kept
         # original never silently un-crops the served versions. The crop is
         # folded into the fingerprint (as it was at store time), so the
-        # recomputed fingerprint matches the persisted column and the migration
-        # stays idempotent. A nil crop_field (uploaders without a crop) is a
-        # no-op centered derive, byte-identical to the pre-crop behaviour.
-        crop = crop_for(user, config)
+        # recomputed fingerprint matches the stored one and the migration stays
+        # idempotent. A nil crop is a no-op centered derive, byte-identical to
+        # the pre-crop behaviour.
+        crop = image.crop
         fingerprint = content_hash(original, crop)
 
         with {:ok, rotated} <- Spec.open_rotated(original),
              {:ok, cropped} <- Crop.apply_to(rotated, Crop.parse(crop)),
              :ok <- write_derived_versions(cropped, dir, user, fingerprint, config),
-             {:ok, _user} <- persist_fingerprint(user, fingerprint, config) do
+             {:ok, _user} <- persist_fingerprint(image, user, fingerprint, config) do
           :ok
         end
     end
   end
 
-  # A re-derive writes a fresh fingerprint onto the member row, so the picture's
-  # row in the shared `images` table (issue #2013) has to name the same bytes.
-  # Keyed on the pointer the member row already holds, so a picture that has no
-  # row yet — every one uploaded before that table, until #2014's backfill —
-  # costs no statement, and creating one is not a side effect of a deploy.
-  defp persist_fingerprint(user, fingerprint, config) do
+  # A re-derive writes a fresh fingerprint onto both halves: the picture's row
+  # in the shared `images` table, which is what every URL is built from, and the
+  # member row's column, which the release one step back is still serving from.
+  # The row is the one the re-derive just read, so there is always one to
+  # update, and creating one is never a side effect of a deploy.
+  defp persist_fingerprint(image, user, fingerprint, config) do
     with {:ok, saved} <-
            user
            |> Ecto.Changeset.change(%{config.fingerprint_field => fingerprint})
            |> Repo.update() do
-      saved
-      |> Map.get(Images.pointer_field(config.kind))
-      |> Images.sync_fingerprint(fingerprint)
-
+      Images.sync_fingerprint(image.id, fingerprint)
       {:ok, saved}
     end
   end
@@ -658,19 +667,12 @@ defmodule Vutuv.Uploads do
     end
   end
 
-  defp crop_for(scope, config) do
-    case Map.get(config, :crop_field) do
-      nil -> nil
-      field -> Map.get(scope, field)
-    end
-  end
-
-  defp held_in_limbo?(scope, config) do
-    case Map.get(config, :moderation_field) do
-      nil -> false
-      field -> Map.get(scope, field) == "pending"
-    end
-  end
+  # Whether there is a picture here a reader may fetch. The rule belongs to
+  # `Vutuv.Images` — it is about `moderation` and `frozen_at`, not about files —
+  # so it is stated there and only asked here. Before #2027 it was three
+  # separate reads of the member row, and clearing those columns is what made a
+  # frozen picture disappear; now `frozen_at` is the off switch itself.
+  defp servable?(image), do: Images.servable?(image)
 
   @doc """
   Removes every stored file for `scope` per `config`: both the served tree
@@ -699,9 +701,9 @@ defmodule Vutuv.Uploads do
   #     so it serves exactly as before. The migration (Vutuv.Uploads.Regenerator)
   #     flips a row from legacy to fingerprinted by writing the new files and
   #     setting the column; nothing here changes until it does.
-  defp served_url(file, scope, version, config) do
-    case fingerprint(scope, config) do
-      nil -> legacy_served_url(file, scope, version, config)
+  defp served_url(%Image{} = image, scope, version, config) do
+    case image.fingerprint do
+      nil -> legacy_served_url(image.file, scope, version, config)
       fp -> fingerprinted_url(scope, version, fp, config)
     end
   end
@@ -732,16 +734,6 @@ defmodule Vutuv.Uploads do
   end
 
   defp handle(scope, config), do: Map.get(scope, :username) || to_string(config.spec_key)
-
-  # The fingerprint stored on the scope for this asset (`:avatar_fingerprint` /
-  # `:cover_fingerprint`), or nil when the row predates scheme B or the config
-  # opts out (`:fingerprint_field` absent).
-  defp fingerprint(scope, config) do
-    case Map.get(config, :fingerprint_field) do
-      nil -> nil
-      field -> Map.get(scope, field)
-    end
-  end
 
   defp legacy_served_url(file, scope, version, config) do
     local_path =

--- a/lib/vutuv/uploads.ex
+++ b/lib/vutuv/uploads.ex
@@ -647,8 +647,9 @@ defmodule Vutuv.Uploads do
   # A re-derive writes a fresh fingerprint onto both halves: the picture's row
   # in the shared `images` table, which is what every URL is built from, and the
   # member row's column, which the release one step back is still serving from.
-  # The row is the one the re-derive just read, so there is always one to
-  # update, and creating one is never a side effect of a deploy.
+  # A picture the backfill has not reached has no row (it came through
+  # `Vutuv.Images.member_image/2`'s bridge, whose id is nil), so it costs no
+  # statement there — creating one is never a side effect of a deploy.
   defp persist_fingerprint(image, user, fingerprint, config) do
     with {:ok, saved} <-
            user

--- a/lib/vutuv/uploads/legacy_sweeper.ex
+++ b/lib/vutuv/uploads/legacy_sweeper.ex
@@ -17,10 +17,7 @@ defmodule Vutuv.Uploads.LegacySweeper do
   `%{avatars: %{rows: 10, files_removed: 32, skipped: 1}, covers: %{…}}`.
   """
 
-  import Ecto.Query
-
-  alias Vutuv.Accounts.User
-  alias Vutuv.Repo
+  alias Vutuv.Images
 
   @types ~w(avatars covers)a
 
@@ -68,8 +65,11 @@ defmodule Vutuv.Uploads.LegacySweeper do
   defp sweep(:avatars, user, opts), do: Vutuv.Avatar.sweep_legacy(user, opts)
   defp sweep(:covers, user, opts), do: Vutuv.Cover.sweep_legacy(user, opts)
 
-  defp rows(:avatars), do: Repo.all(from(u in User, where: not is_nil(u.avatar_fingerprint)))
-  defp rows(:covers), do: Repo.all(from(u in User, where: not is_nil(u.cover_fingerprint)))
+  # Every member with a picture of that kind, the row preloaded;
+  # `Vutuv.Uploads.sweep_legacy/3` reads the fingerprint off it and leaves a
+  # picture without one entirely alone.
+  defp rows(:avatars), do: Images.members_with_picture("avatar")
+  defp rows(:covers), do: Images.members_with_picture("cover")
 
   # The quiet-flag logic lives once in Vutuv.Uploads.log/1.
   defp log(message), do: Vutuv.Uploads.log(message)

--- a/lib/vutuv/uploads/regenerator.ex
+++ b/lib/vutuv/uploads/regenerator.ex
@@ -34,7 +34,7 @@ defmodule Vutuv.Uploads.Regenerator do
 
   import Ecto.Query
 
-  alias Vutuv.Accounts.User
+  alias Vutuv.Images
   alias Vutuv.Organizations.OrganizationScreenshot
   alias Vutuv.Posts.PostImage
   alias Vutuv.Posts.PostScreenshot
@@ -182,8 +182,11 @@ defmodule Vutuv.Uploads.Regenerator do
     end
   end
 
-  defp rows(:avatars), do: Repo.all(from(u in User, where: not is_nil(u.avatar)))
-  defp rows(:covers), do: Repo.all(from(u in User, where: not is_nil(u.cover_photo)))
+  # Every member holding a picture of that kind, with the row the re-derive
+  # reads preloaded — `Vutuv.Images.members_with_picture/1` owns that query, so
+  # a whole-table pass costs one statement rather than one per member (#2027).
+  defp rows(:avatars), do: Images.members_with_picture("avatar")
+  defp rows(:covers), do: Images.members_with_picture("cover")
   # Every scope `Vutuv.Screenshot` stores under `screenshots/<id>`: a profile
   # link, a post's link and an organization's homepage. Listing only the
   # first left the other two on the old Spec for good — a member's feed is

--- a/lib/vutuv_web/agent_docs/profile_doc.ex
+++ b/lib/vutuv_web/agent_docs/profile_doc.ex
@@ -277,13 +277,13 @@ defmodule VutuvWeb.AgentDocs.ProfileDoc do
   end
 
   @doc """
-  The member's absolute avatar URL, or nil when only the inline-data
-  placeholder exists. Public because the JSON-LD Person (`VutuvWeb.JsonLd`)
-  shares it — the markup must mirror the doc.
+  The member's absolute avatar URL, or nil when there is no picture a reader
+  may fetch. Public because the JSON-LD Person (`VutuvWeb.JsonLd`) shares it —
+  the markup must mirror the doc.
   """
   def avatar_url(user) do
-    case Vutuv.Avatar.display_url(user, :medium) do
-      "data:" <> _ -> nil
+    case Vutuv.Avatar.url(user, :medium) do
+      nil -> nil
       "/" <> _ = path -> AgentDocs.abs_url(path)
       url -> url
     end

--- a/lib/vutuv_web/components/ui.ex
+++ b/lib/vutuv_web/components/ui.ex
@@ -3348,10 +3348,24 @@ defmodule VutuvWeb.UI do
     """
   end
 
+  # The picture is resolved once, here, and the two bodies below read its
+  # answer: resolving the picture costs one lookup of the member's row in
+  # the shared `images` table (none at all when the association is preloaded,
+  # and none for a member with no picture), so asking it twice would double
+  # that on every avatar a page draws.
+  defp avatar_inner(assigns) do
+    assigns
+    |> assign(:picture, avatar_picture(assigns.src, assigns.user, assigns.size))
+    |> avatar_body()
+  end
+
   # A user without a picture gets an initials tile (matching the shell's
   # top-bar avatar) instead of the anonymous placeholder image — initials
-  # tell people apart in lists, a shared grey silhouette does not.
-  defp avatar_inner(%{src: nil, user: %{avatar: nil} = user} = assigns) do
+  # tell people apart in lists, a shared grey silhouette does not. A `nil`
+  # `src` is that case and only that case: a picture the AI gate or a
+  # copyright case is holding still renders the silhouette below, exactly as
+  # it did while the member row carried the distinction.
+  defp avatar_body(%{picture: %{src: nil}, user: user} = assigns) do
     assigns = assign(assigns, :initials, name_initials(user))
 
     ~H"""
@@ -3374,14 +3388,12 @@ defmodule VutuvWeb.UI do
   # Through `picture/1`, so the 96 CSS px slot (`lg`) offers its lite to a
   # viewer in data-saving mode: without a lite the picture component is the
   # plain `<img>` this always rendered, so every other call site is untouched.
-  # The pair is derived in the attribute, not assigned, so change tracking
-  # keys it on `src` / `user` / `size` (the liveview rule on derived values).
   # `shrink-0` on the lite wrapper, since it stands in for the `<img>` inside
   # a flex row.
-  defp avatar_inner(assigns) do
+  defp avatar_body(assigns) do
     ~H"""
     <.picture
-      picture={avatar_picture(@src, @user, @size)}
+      picture={@picture}
       wrap_class="shrink-0"
       data-avatar
       alt={@alt}
@@ -3445,7 +3457,7 @@ defmodule VutuvWeb.UI do
   defp avatar_picture(nil, %{} = user, "lg"), do: Vutuv.Avatar.picture(user)
 
   defp avatar_picture(nil, %{} = user, size),
-    do: %{src: Vutuv.Avatar.display_url(user, avatar_url_size(size)), lite: nil}
+    do: %{src: Vutuv.Avatar.src(user, avatar_url_size(size)), lite: nil}
 
   defp avatar_picture(src, _user, _size), do: %{src: src || @fallback_avatar, lite: nil}
 

--- a/lib/vutuv_web/controllers/avatar_controller.ex
+++ b/lib/vutuv_web/controllers/avatar_controller.ex
@@ -29,9 +29,10 @@ defmodule VutuvWeb.AvatarController do
 
   def show(conn, %{"slug" => slug}) do
     bytes =
-      with %User{avatar: avatar} = user when not is_nil(avatar) <-
-             Repo.get_by(User, username: slug),
+      with %User{} = user <- Repo.get_by(User, username: slug),
            true <- Moderation.profile_visible_to?(user, nil) do
+        # `og_jpeg/1` answers `:error` for a member with no picture and for one
+        # nobody may see, so there is nothing left here to pre-check.
         Avatar.og_jpeg(user)
       end
 

--- a/lib/vutuv_web/controllers/mention_controller.ex
+++ b/lib/vutuv_web/controllers/mention_controller.ex
@@ -72,16 +72,11 @@ defmodule VutuvWeb.MentionController do
     }
   end
 
-  # `display_url/2` answers the inline-data placeholder for a member with no
-  # picture (and for one whose avatar is still in moderation limbo); the row
-  # wants a real URL or nothing, because the editor draws the initials tile
+  # `url/2` is already "a real URL or nothing" — nil for a member with no
+  # picture, for one the AI gate still holds and for one a copyright case froze
+  # — which is what the row wants, because the editor draws the initials tile
   # itself rather than a data URI it cannot size.
-  defp avatar_url(%User{} = user) do
-    case Avatar.display_url(user, :thumb) do
-      "data:" <> _placeholder -> nil
-      url -> url
-    end
-  end
+  defp avatar_url(%User{} = user), do: Avatar.url(user, :thumb)
 
   defp avatar_url(%Organization{logo: nil}), do: nil
 

--- a/lib/vutuv_web/controllers/pending_image_controller.ex
+++ b/lib/vutuv_web/controllers/pending_image_controller.ex
@@ -39,13 +39,20 @@ defmodule VutuvWeb.PendingImageController do
     end
   end
 
-  defp pending_path(user, "avatar", version) do
-    if user.avatar_moderation == "pending",
-      do: Vutuv.Avatar.pending_preview_path(user, String.to_existing_atom(version))
+  # The picture's row is read once and handed on as the preload the uploader
+  # would otherwise look up again (issue #2027).
+  defp pending_path(user, kind, version) do
+    case Vutuv.Images.member_image(user, kind) do
+      %Vutuv.Images.Image{moderation: "pending"} = image ->
+        user
+        |> Map.put(Vutuv.Images.member_columns(kind).assoc, image)
+        |> preview_path(kind, String.to_existing_atom(version))
+
+      _not_pending ->
+        nil
+    end
   end
 
-  defp pending_path(user, "cover", version) do
-    if user.cover_moderation == "pending",
-      do: Vutuv.Cover.pending_preview_path(user, String.to_existing_atom(version))
-  end
+  defp preview_path(user, "avatar", version), do: Vutuv.Avatar.pending_preview_path(user, version)
+  defp preview_path(user, "cover", version), do: Vutuv.Cover.pending_preview_path(user, version)
 end

--- a/lib/vutuv_web/cv/cv.ex
+++ b/lib/vutuv_web/cv/cv.ex
@@ -453,8 +453,6 @@ defmodule VutuvWeb.CV do
 
   # Only a real derived JPEG makes it into the CV — the silhouette
   # placeholder Avatar.binary/2 falls back to has no place on a Lebenslauf.
-  defp photo(%{avatar: nil}, _opts), do: nil
-
   defp photo(user, opts) do
     if Keyword.get(opts, :photo, false) do
       case Vutuv.Avatar.binary(user, :medium) do

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -172,10 +172,11 @@ defmodule VutuvWeb.Fediverse.Docs do
   # member whose picture a copyright freeze has taken offline (issue #2012) —
   # handed remote servers a URL that answers 404. A picture that is gone has to
   # be gone from the actor document too, or the takedown is a local fiction.
-  defp put_icon(doc, %{avatar: avatar} = user) when is_binary(avatar),
-    do: Map.put(doc, "icon", icon("#{base()}/#{user.username}/avatar.jpg"))
-
-  defp put_icon(doc, _user), do: doc
+  defp put_icon(doc, user) do
+    if Vutuv.Avatar.url(user, :medium),
+      do: Map.put(doc, "icon", icon("#{base()}/#{user.username}/avatar.jpg")),
+      else: doc
+  end
 
   @doc """
   A **topic's** actor document (issue #1330): AP type `Group`, which is what

--- a/lib/vutuv_web/live/shell_live.ex
+++ b/lib/vutuv_web/live/shell_live.ex
@@ -211,7 +211,7 @@ defmodule VutuvWeb.ShellLive do
     |> assign(:user_name, full_name(user))
     |> assign(:user_initials, name_initials(user))
     |> assign(:user_param, Phoenix.Param.to_param(user))
-    |> assign(:user_avatar, Vutuv.Avatar.user_url(user, :thumb))
+    |> assign(:user_avatar, Vutuv.Avatar.url(user, :thumb))
     |> assign(:user_admin?, user.admin?)
     |> assign_shell_defaults(path)
     |> assign(:browser_notifications?, user.browser_notifications?)

--- a/lib/vutuv_web/live/user_profile_live.ex
+++ b/lib/vutuv_web/live/user_profile_live.ex
@@ -480,15 +480,16 @@ defmodule VutuvWeb.UserProfileLive do
            :user,
            Map.merge(
              socket.assigns.user,
-             Map.take(user, [
-               :avatar,
-               :avatar_fingerprint,
-               :avatar_crop,
-               :avatar_moderation,
-               :cover_photo,
-               :cover_fingerprint,
-               :cover_crop,
-               :cover_moderation,
+             # The picture's row is what every reader consults now (#2027), so
+             # the pointer and the row itself are what has to travel; the four
+             # columns per kind would change nothing on the page.
+             user
+             |> Vutuv.Images.preload_member_images()
+             |> Map.take([
+               :avatar_image_id,
+               :avatar_image,
+               :cover_image_id,
+               :cover_image,
                :updated_at
              ])
            )
@@ -838,7 +839,9 @@ defmodule VutuvWeb.UserProfileLive do
   # controller that already answers 403/410 for the withheld cases, so there is
   # no half-page to draw here — the socket simply does not serve one.
   defp subject!(profile_user_id, viewer) do
-    user = Repo.get!(User, profile_user_id)
+    # The two picture rows come with it: every avatar and cover URL this page
+    # draws is built from them (#2027), and the header alone asks four times.
+    user = User |> Repo.get!(profile_user_id) |> Vutuv.Images.preload_member_images()
 
     if Moderation.profile_visible_to?(user, viewer) do
       user
@@ -1459,7 +1462,7 @@ defmodule VutuvWeb.UserProfileLive do
       # the top of a page whose fields are several screens apart.
       %{
         label: gettext("Add a profile photo"),
-        done: present?(user.avatar),
+        done: Vutuv.Images.member_image(user, "avatar") != nil,
         href: ~p"/settings/profile#avatar"
       },
       %{

--- a/lib/vutuv_web/open_graph.ex
+++ b/lib/vutuv_web/open_graph.ex
@@ -460,12 +460,17 @@ defmodule VutuvWeb.OpenGraph do
   defp image_alt(_post_image, %{organization: %Organization{name: name}}), do: name
   defp image_alt(_post_image, _ca), do: SiteName.get()
 
-  defp member_image(%{user: %User{avatar: avatar} = user}) when not is_nil(avatar) do
-    square_image(
-      abs_url("/#{user.username}/avatar.jpg"),
-      Vutuv.Avatar.og_size(),
-      UserHelpers.full_name(user)
-    )
+  # Named only while `/:slug/avatar.jpg` actually answers — `Vutuv.Avatar.url/2`
+  # is nil for a member with no picture, one the AI gate still holds and one a
+  # copyright case froze — so a scraper is never sent to a 404.
+  defp member_image(%{user: %User{} = user}) do
+    if Vutuv.Avatar.url(user, :medium) do
+      square_image(
+        abs_url("/#{user.username}/avatar.jpg"),
+        Vutuv.Avatar.og_size(),
+        UserHelpers.full_name(user)
+      )
+    end
   end
 
   defp member_image(_ca), do: nil

--- a/lib/vutuv_web/plugs/user_resolve_slugs.ex
+++ b/lib/vutuv_web/plugs/user_resolve_slugs.ex
@@ -44,9 +44,12 @@ defmodule VutuvWeb.Plug.UserResolveSlug do
         miss(conn, slug, opts)
 
       user ->
+        # Both picture rows come along, because every avatar and cover URL on a
+        # profile-scoped page is built from them since #2027 — two batched
+        # queries here instead of one lookup per render site.
         conn
         |> Plug.Conn.assign(:user_id, user.id)
-        |> Plug.Conn.assign(:user, user)
+        |> Plug.Conn.assign(:user, Vutuv.Images.preload_member_images(user))
     end
   end
 

--- a/lib/vutuv_web/templates/user/card_list.html.heex
+++ b/lib/vutuv_web/templates/user/card_list.html.heex
@@ -26,13 +26,15 @@ shows the name the way its owner writes it. --%>
       <% rel = profile_rel(user) %>
       <div class="profile-image">
         <%= link to: ~p"/#{user}", rel: rel do %>
-          <%!-- src is passed for users with a picture so the row keeps the
-                small :thumb version; without one, <.avatar> renders the
-                initials tile instead of the light-grey default image (a
-                bright white circle in dark mode). --%>
+          <%!-- src is passed so the row keeps the small :thumb version,
+                which this 48px slot would otherwise load as the 192px
+                :medium. `Vutuv.Avatar.src/2` answers nil for a member with no picture
+                at all, and <.avatar> then renders the initials tile instead
+                of the light-grey default image (a bright white circle in
+                dark mode). --%>
           <.avatar
             user={user}
-            src={user.avatar && Vutuv.Avatar.display_url(user, :thumb)}
+            src={Vutuv.Avatar.src(user, :thumb)}
             size="md"
             alt={"Avatar of #{full_name(user)}"}
             presence

--- a/lib/vutuv_web/templates/user/edit.html.heex
+++ b/lib/vutuv_web/templates/user/edit.html.heex
@@ -20,7 +20,7 @@ lands here). --%>
         long settings page; scroll-mt keeps the sticky top bar off it. --%>
         <div id="avatar" class="scroll-mt-24">
           <%= label f, :avatar, gettext("Avatar"), class: "block text-sm font-medium text-slate-900 dark:text-white" %>
-          <% avatar_pending? = @user.avatar_moderation == "pending" %>
+          <% avatar_pending? = Vutuv.Images.pending?(@user, "avatar") %>
           <div class="mt-2 flex items-center gap-3">
             <.avatar
               user={@user}
@@ -53,7 +53,11 @@ lands here). --%>
               crop_cancel: gettext("Cancel"),
               crop_zoom: gettext("Zoom")
             ] %>
-          <%= hidden_input f, :avatar_crop, id: "user_avatar_crop" %>
+          <%!-- The stored crop, off the picture's own row (#2027); the crop
+                dialog overwrites it before a submit that carries a new file. --%>
+          <%= hidden_input f, :avatar_crop,
+            id: "user_avatar_crop",
+            value: Vutuv.Images.crop(@user, "avatar") %>
           <% {avatar_w, avatar_h} = recommended_avatar_size() %>
           <p class="mt-1 text-xs text-slate-600 dark:text-slate-400">
             {gettext("Recommended: square, at least %{width} × %{height} pixels.",
@@ -94,7 +98,7 @@ lands here). --%>
         covering it after the jump. --%>
         <div id="cover" class="scroll-mt-24">
           <%= label f, :cover_photo, gettext("Cover photo"), class: "block text-sm font-medium text-slate-900 dark:text-white" %>
-          <% cover_pending? = @user.cover_moderation == "pending" %>
+          <% cover_pending? = Vutuv.Images.pending?(@user, "cover") %>
           <% cover_url =
             if cover_pending?,
               do: ~p"/settings/pending_image/cover/wide",
@@ -133,7 +137,9 @@ lands here). --%>
               crop_cancel: gettext("Cancel"),
               crop_zoom: gettext("Zoom")
             ] %>
-          <%= hidden_input f, :cover_crop, id: "user_cover_crop" %>
+          <%= hidden_input f, :cover_crop,
+            id: "user_cover_crop",
+            value: Vutuv.Images.crop(@user, "cover") %>
           <% {cover_w, cover_h} = recommended_cover_size() %>
           <p class="mt-1 text-xs text-slate-600 dark:text-slate-400">
             {gettext("Recommended: %{width} × %{height} pixels (%{ratio}).",

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -42,7 +42,7 @@ the resulting ~200px rail width. --%>
       <%!-- AI-moderation limbo: the owner previews their pending cover through
       the authenticated quarantine route (plus the amber pill); everyone else
       sees the brand gradient until the scan releases it. --%>
-      <% cover_pending? = @as_owner? and @user.cover_moderation == "pending" %>
+      <% cover_pending? = @as_owner? and Vutuv.Images.pending?(@user, "cover") %>
       <%!-- `Vutuv.Cover.picture/1` carries the lite version for a viewer in
             data-saving mode beside the banner; the owner's quarantine preview
             has no lite and never needs one. --%>
@@ -125,12 +125,18 @@ the resulting ~200px rail width. --%>
         <% saved_present? = not is_nil(@user_saved) %>
         <% report_path = ~p"/reports/new?#{[type: "user", id: @user.id, return_to: "/#{@user.username}"]}" %>
         <% block_confirm = VutuvWeb.BlockText.confirm(@user.username) %>
+        <%!-- A picture is reportable in its own right (issue #2012), so a rights
+        holder does not have to report the whole profile to get a stolen photo
+        taken down. Only a picture a reader can actually see: `shown_image/2`
+        resolves the row once, and its id is what the form names. --%>
+        <% reportable_avatar = Vutuv.Images.shown_image(@user, "avatar") %>
+        <% reportable_cover = Vutuv.Images.shown_image(@user, "cover") %>
         <%!-- The action cluster is pinned to the right of the avatar row
         (ml-auto), one short row. It now holds only the follow pill: the ⋯ menu
         moved down to the name row, so the pill gets the full width beside the
         avatar to breathe, below the cover, rather than riding up into the cover
         banner. (Owner sees Edit profile; a blocker sees Unblock.) --%>
-        <% avatar_pending? = @as_owner? and @user.avatar_moderation == "pending" %>
+        <% avatar_pending? = @as_owner? and Vutuv.Images.pending?(@user, "avatar") %>
         <div class="-mt-12 flex items-end gap-4">
           <%!-- The picture, and — once the 1024px `:large` version exists —
           the click that opens it in the photo lightbox (issue #1528).
@@ -240,22 +246,17 @@ the resulting ~200px rail width. --%>
               is what nobody reaches for often (Report) and what should not be
               one tap away (Block). --%>
               <:item id="report-profile" href={report_path}>{gettext("Report")}</:item>
-              <%!-- A picture is reportable in its own right (issue #2012), so a
-              rights holder does not have to report the whole profile to get a
-              stolen photo taken down. Shown only for a picture that has a row
-              in the shared `images` table — the member row's own pointer, so
-              it costs no query. --%>
               <:item
-                :if={@user.avatar && @user.avatar_image_id}
+                :if={reportable_avatar}
                 id="report-avatar"
-                href={image_report_path(@user, @user.avatar_image_id)}
+                href={image_report_path(@user, reportable_avatar.id)}
               >
                 {gettext("Report the profile picture")}
               </:item>
               <:item
-                :if={@user.cover_photo && @user.cover_image_id}
+                :if={reportable_cover}
                 id="report-cover"
-                href={image_report_path(@user, @user.cover_image_id)}
+                href={image_report_path(@user, reportable_cover.id)}
               >
                 {gettext("Report the cover photo")}
               </:item>
@@ -1423,7 +1424,7 @@ the resulting ~200px rail width. --%>
             >
               <.avatar
                 src={entry.feed.avatar}
-                user={%{avatar: nil, first_name: entry.feed.name, last_name: nil}}
+                user={%{first_name: entry.feed.name, last_name: nil}}
                 size="sm"
                 alt=""
               />

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -127,10 +127,14 @@ the resulting ~200px rail width. --%>
         <% block_confirm = VutuvWeb.BlockText.confirm(@user.username) %>
         <%!-- A picture is reportable in its own right (issue #2012), so a rights
         holder does not have to report the whole profile to get a stolen photo
-        taken down. Only a picture a reader can actually see: `shown_image/2`
-        resolves the row once, and its id is what the form names. --%>
-        <% reportable_avatar = Vutuv.Images.shown_image(@user, "avatar") %>
-        <% reportable_cover = Vutuv.Images.shown_image(@user, "cover") %>
+        taken down. Only a picture a reader can actually see, and only one with
+        a real row: the form names a picture by its id, and
+        `Vutuv.Images.member_image/2`'s bridge answers with an unsaved row
+        (`id: nil`) for a member the backfill has not reached. Those keep the
+        profile's own Report above, which is where a picture could be reported
+        before #2012 anyway. --%>
+        <% reportable_avatar = Vutuv.Images.reportable_image(@user, "avatar") %>
+        <% reportable_cover = Vutuv.Images.reportable_image(@user, "cover") %>
         <%!-- The action cluster is pinned to the right of the avatar row
         (ml-auto), one short row. It now holds only the follow pill: the ⋯ menu
         moved down to the name row, so the pill gets the full width beside the

--- a/lib/vutuv_web/templates/user_tag/endorsers.html.heex
+++ b/lib/vutuv_web/templates/user_tag/endorsers.html.heex
@@ -42,7 +42,6 @@
                 <.link href={~p"/#{user}"} rel={rel}>
                   <.avatar
                     user={user}
-                    src={user.avatar && Vutuv.Avatar.display_url(user, :thumb)}
                     size="sm"
                     alt={"Avatar of #{full_name(user)}"}
                     presence

--- a/lib/vutuv_web/views/layout_html.ex
+++ b/lib/vutuv_web/views/layout_html.ex
@@ -288,7 +288,7 @@ defmodule VutuvWeb.LayoutHTML do
           # display name can't leak into the initials.
           "user_initials" => name_initials(user),
           "user_param" => Phoenix.Param.to_param(user),
-          "user_avatar" => Vutuv.Avatar.user_url(user, :thumb),
+          "user_avatar" => Vutuv.Avatar.url(user, :thumb),
           "user_admin?" => user.admin?,
           "show_online" => user.show_online_status?,
           # The identity they are speaking as (issue #1335), for the throwaway

--- a/test/support/image_helpers.ex
+++ b/test/support/image_helpers.ex
@@ -1,0 +1,81 @@
+defmodule Vutuv.ImageHelpers do
+  @moduledoc """
+  A member's profile picture as both halves the application always writes: the
+  four columns on the member row and the row in the shared `images` table
+  (`Vutuv.Images`).
+
+  Since #2027 every URL builder and every display gate reads the row, so a test
+  that sets only `users.avatar` describes a member with no picture — a state no
+  upload can produce. These two helpers put the pair there: `with_image_rows/1`
+  for a member that is in the database, `put_image/3` for the struct-only tests
+  that never insert one.
+  """
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Images
+  alias Vutuv.Images.Image
+  alias Vutuv.Repo
+
+  alias Vutuv.UUIDv7
+
+  @doc """
+  Gives an **inserted** member the row its own columns already name, for each
+  kind whose file column is set, and points the member row at it. Returns the
+  member reloaded with both rows preloaded, so a later render costs no lookup.
+  """
+  def with_image_rows(%User{} = user) do
+    pointers =
+      for {kind, cols} <- Images.member_columns(),
+          not is_nil(Map.get(user, cols.file)),
+          into: [] do
+        # Through the same function an upload goes through, so a fixture cannot
+        # put a row in the database that no upload could write.
+        {:ok, image} =
+          Images.put_profile_image(user, kind, %{
+            file: Map.get(user, cols.file),
+            fingerprint: Map.get(user, cols.fingerprint),
+            crop: Map.get(user, cols.crop),
+            moderation: Map.get(user, cols.moderation)
+          })
+
+        {cols.pointer, image.id}
+      end
+
+    user
+    |> Ecto.Changeset.change(Map.new(pointers))
+    |> Repo.update!()
+    |> Images.preload_member_images()
+  end
+
+  @doc """
+  Hangs a picture row on a member **struct**, preloaded, without touching the
+  database — what the URL-convention tests need, which never insert a member.
+  `attrs` are the row's own columns (`:file`, `:fingerprint`, `:crop`,
+  `:moderation`, `:frozen_at`).
+  """
+  def put_image(%User{} = user, kind, attrs) when kind in ["avatar", "cover"] do
+    cols = Images.member_columns(kind)
+
+    image =
+      struct!(
+        %Image{id: UUIDv7.generate(), kind: kind, user_id: user.id, token: "token-#{kind}"},
+        attrs
+      )
+
+    user
+    |> Map.put(cols.assoc, image)
+    |> Map.put(cols.pointer, image.id)
+  end
+
+  @doc """
+  The same as `put_image/3` for a member who has no picture of that kind: the
+  association is loaded and empty, so nothing looks anything up.
+  """
+  def without_image(%User{} = user, kind) when kind in ["avatar", "cover"] do
+    cols = Images.member_columns(kind)
+
+    user
+    |> Map.put(cols.assoc, nil)
+    |> Map.put(cols.pointer, nil)
+  end
+end

--- a/test/vutuv/identity_test.exs
+++ b/test/vutuv/identity_test.exs
@@ -6,6 +6,7 @@ defmodule Vutuv.IdentityTest do
   import Vutuv.Identity.Query
 
   alias Vutuv.Identity
+  alias Vutuv.ImageHelpers
   alias Vutuv.Posts.Post
 
   describe "Identity protocol, User" do
@@ -31,7 +32,7 @@ defmodule Vutuv.IdentityTest do
     end
 
     test "image, topic and ap_type" do
-      user = insert(:user, avatar: "some-token")
+      user = insert(:user, avatar: "some-token") |> ImageHelpers.with_image_rows()
 
       assert Identity.image(user) == "some-token"
       assert Identity.topic(user) == "user:#{user.id}"

--- a/test/vutuv/images/reader_move_test.exs
+++ b/test/vutuv/images/reader_move_test.exs
@@ -1,0 +1,247 @@
+defmodule Vutuv.Images.ReaderMoveTest do
+  @moduledoc """
+  Every reader of a profile picture answers from the `images` row (issue
+  #2027), so the deploy after this one can drop the member row's four columns
+  per kind.
+
+  The whole file is calibrated the same way: it blanks the four member columns
+  and leaves the row alone — which is exactly the state the column drop
+  creates — and then asks every reader what it shows. Before this change every
+  one of them answered "no picture"; the columns were the source of truth.
+  """
+  # Not async: flips the global :uploads_dir_prefix and :moderate_images.
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.WebPushHelpers, only: [put_config: 2]
+
+  alias Vutuv.Accounts
+  alias Vutuv.Accounts.User
+  alias Vutuv.Images
+  alias Vutuv.Repo
+  alias VutuvWeb.Fediverse.Docs
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "vutuv_reader_move_#{System.unique_integer([:positive])}")
+    put_config(:uploads_dir_prefix, tmp)
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    user = insert(:activated_user)
+    insert(:email, user: user)
+
+    {:ok, user: user}
+  end
+
+  defp jpeg_upload(name \\ "selfie.jpg", color \\ [10, 120, 200]) do
+    src = Path.join(System.tmp_dir!(), "reader_move_#{System.unique_integer([:positive])}.jpg")
+    {:ok, img} = Image.new(300, 200, color: color)
+    {:ok, _} = Image.write(img, src)
+    on_exit(fn -> File.rm(src) end)
+    %Plug.Upload{filename: name, path: src, content_type: "image/jpeg"}
+  end
+
+  # The state the contract deploy creates: the row is intact, the four member
+  # columns of that kind are gone. Every assertion in this file is taken with
+  # the columns in this state, so a reader that still consults them fails.
+  defp drop_member_columns(user, kind) do
+    cols = Images.member_columns(kind)
+
+    {1, _} =
+      Repo.update_all(from(u in User, where: u.id == ^user.id),
+        set: [{cols.file, nil}, {cols.fingerprint, nil}, {cols.crop, nil}, {cols.moderation, nil}]
+      )
+
+    Repo.get!(User, user.id)
+  end
+
+  defp with_avatar(user, upload \\ nil) do
+    {:ok, user} = Accounts.update_user(user, %{avatar: upload || jpeg_upload()})
+    user
+  end
+
+  defp with_cover(user) do
+    {:ok, user} =
+      Accounts.update_user(user, %{cover_photo: jpeg_upload("wide.jpg", [200, 30, 30])})
+
+    user
+  end
+
+  describe "the avatar URL comes from the row" do
+    test "display_url, url and picture answer with the columns gone", %{user: user} do
+      user = with_avatar(user)
+      fingerprint = user.avatar_fingerprint
+      before = Vutuv.Avatar.display_url(user, :medium)
+
+      user = drop_member_columns(user, "avatar")
+
+      assert Vutuv.Avatar.display_url(user, :medium) == before
+
+      assert Vutuv.Avatar.url(user, :medium) ==
+               "/avatars/#{user.id}/#{user.username}-medium-#{fingerprint}.avif"
+
+      assert Vutuv.Avatar.picture(user).src == before
+    end
+
+    test "the served file still resolves on disk", %{user: user} do
+      user = user |> with_avatar() |> drop_member_columns("avatar")
+
+      path = Vutuv.Avatar.stored_path(user, :medium)
+      assert is_binary(path) and File.exists?(path)
+    end
+
+    test "a member with no picture at all has no row and no URL", %{user: user} do
+      assert Images.member_image(user, "avatar") == nil
+      assert Vutuv.Avatar.url(user, :medium) == nil
+      assert Vutuv.Avatar.picture(user).src == nil
+      assert Vutuv.Avatar.og_jpeg(user) == :error
+    end
+  end
+
+  describe "the cover URL comes from the row" do
+    test "display_url and picture answer with the columns gone", %{user: user} do
+      user = with_cover(user)
+      fingerprint = user.cover_fingerprint
+      before = Vutuv.Cover.display_url(user, :wide)
+
+      user = drop_member_columns(user, "cover")
+
+      assert Vutuv.Cover.display_url(user, :wide) == before
+
+      assert before == "/covers/#{user.id}/#{user.username}-wide-#{fingerprint}.avif"
+      assert Vutuv.Cover.picture(user).src == before
+    end
+  end
+
+  describe "the crop and the derived JPEGs come from the row" do
+    test "the vCard's base64 photo and the link-preview JPEG", %{user: user} do
+      {:ok, user} =
+        Accounts.update_user(user, %{
+          "avatar" => jpeg_upload(),
+          "avatar_crop" => "0,0,0.5,0.5"
+        })
+
+      user = drop_member_columns(user, "avatar")
+
+      assert "data:image/jpeg;base64," <> _rest = Vutuv.Avatar.binary(user, :medium)
+      assert {:ok, <<0xFF, 0xD8, _rest::binary>>} = Vutuv.Avatar.og_jpeg(user)
+      assert Images.member_image(user, "avatar").crop == "0.0000,0.0000,0.5000,0.5000"
+    end
+  end
+
+  describe "the ActivityPub actor document" do
+    test "still advertises the icon with the columns gone", %{user: user} do
+      user = user |> with_avatar() |> drop_member_columns("avatar")
+      {:ok, actor} = Vutuv.Fediverse.ensure_actor(user)
+
+      doc = Docs.actor(user, actor)
+
+      assert doc["icon"]["url"] == "#{VutuvWeb.Endpoint.url()}/#{user.username}/avatar.jpg"
+    end
+
+    test "names no icon for a member without a picture", %{user: user} do
+      {:ok, actor} = Vutuv.Fediverse.ensure_actor(user)
+      refute Map.has_key?(Docs.actor(user, actor), "icon")
+    end
+  end
+
+  describe "a row with no fingerprint" do
+    # One member on the production copy is still on the pre-fingerprint naming
+    # scheme, and the backfill copied that nil verbatim. A nil fingerprint is
+    # not "no picture": it is the legacy URL, and it has to keep resolving.
+    test "keeps serving the legacy URL", %{user: user} do
+      user = with_avatar(user)
+      image = Images.member_image(user, "avatar")
+
+      # The shape that row has: a file name, no fingerprint. The legacy files
+      # are named for the version, not the fingerprint.
+      dir = Path.join(Vutuv.Uploads.uploads_dir_prefix(), "avatars/#{user.id}")
+      File.mkdir_p!(dir)
+      File.write!(Path.join(dir, "avatar_medium.avif"), "x")
+      {:ok, _} = image |> Ecto.Changeset.change(%{fingerprint: nil}) |> Repo.update()
+
+      user = drop_member_columns(user, "avatar")
+
+      assert Vutuv.Avatar.url(user, :medium) =~ "/avatars/#{user.id}/avatar_medium.avif?v="
+      assert Vutuv.Avatar.stored_path(user, :medium) == Path.join(dir, "avatar_medium.avif")
+    end
+  end
+
+  describe "a frozen picture" do
+    # A freeze (#2012) clears the member row's four columns, which is what
+    # every reader used to notice. Now that they read the row, `frozen_at` is
+    # the off switch — so this leaves the member columns filled and only stamps
+    # the row.
+    test "renders as no picture even while the member columns still name it", %{user: user} do
+      user = with_avatar(user)
+      image = Images.member_image(user, "avatar")
+
+      {:ok, _} =
+        image
+        |> Ecto.Changeset.change(%{frozen_at: NaiveDateTime.utc_now(:second)})
+        |> Repo.update()
+
+      user = Repo.get!(User, user.id)
+
+      assert user.avatar, "the member columns are deliberately left filled here"
+      assert Vutuv.Avatar.url(user, :medium) == nil
+      assert Vutuv.Avatar.og_jpeg(user) == :error
+      # No picture at all, not the held-picture silhouette: a takedown has to
+      # read the way a member who never uploaded one reads, which is what
+      # clearing the four member columns used to do.
+      assert Vutuv.Avatar.picture(user).src == nil
+      assert Vutuv.Images.shown_image(user, "avatar") == nil
+    end
+
+    test "a picture the AI gate holds keeps the silhouette instead", %{user: user} do
+      put_config(:moderate_images, true)
+      user = with_avatar(user)
+
+      assert Vutuv.Avatar.url(user, :medium) == nil
+      assert Vutuv.Avatar.picture(user).src != nil, "limbo is not a takedown"
+    end
+  end
+
+  describe "a picture the AI gate still holds" do
+    setup do
+      put_config(:moderate_images, true)
+      :ok
+    end
+
+    test "renders as no picture, and the owner's preview still resolves", %{user: user} do
+      user = with_avatar(user)
+      assert user.avatar_moderation == "pending"
+
+      user = drop_member_columns(user, "avatar")
+
+      assert Vutuv.Avatar.url(user, :medium) == nil
+      assert Vutuv.Avatar.og_jpeg(user) == :error
+      assert Images.member_image(user, "avatar").moderation == "pending"
+      assert is_binary(Vutuv.Avatar.pending_preview_path(user, :medium))
+    end
+  end
+
+  describe "a listing row" do
+    # Listing queries select a narrow struct (`User.listing_fields/0`), so the
+    # pointer has to be in that list or a whole page of members loses its
+    # pictures at once.
+    test "carries the pointer, so it resolves an avatar", %{user: user} do
+      user = with_avatar(user)
+
+      row =
+        Repo.one!(
+          from(u in User, where: u.id == ^user.id, select: struct(u, ^User.listing_fields()))
+        )
+
+      assert row.avatar_image_id
+      assert Vutuv.Avatar.url(row, :thumb) == Vutuv.Avatar.url(user, :thumb)
+    end
+  end
+
+  describe "a preloaded association costs no query" do
+    test "member_image/2 takes the preload when it is there", %{user: user} do
+      user = user |> with_avatar() |> Repo.preload(:avatar_image)
+
+      assert %Images.Image{} = user.avatar_image
+      assert Images.member_image(user, "avatar").id == user.avatar_image.id
+    end
+  end
+end

--- a/test/vutuv/images/reader_move_test.exs
+++ b/test/vutuv/images/reader_move_test.exs
@@ -219,6 +219,74 @@ defmodule Vutuv.Images.ReaderMoveTest do
     end
   end
 
+  describe "a member the backfill has not reached" do
+    # The bridge (`Vutuv.Images.member_image/2`). Nothing enforces that an
+    # operator ran `mix vutuv.images.backfill` before taking this release — it
+    # is not in `scripts/deploy.sh`, not in boot, not in `/health` — so a
+    # picture with no row has to keep working off the member row's own columns.
+    # Without the bridge every one of these answers "no picture", silently.
+    setup %{user: user} do
+      user = with_avatar(user)
+      fingerprint = user.avatar_fingerprint
+
+      # Exactly the state an un-backfilled installation is in: the columns are
+      # filled, the row and the pointer are not.
+      {1, _} = Repo.delete_all(from(i in Images.Image, where: i.user_id == ^user.id))
+
+      {1, _} =
+        Repo.update_all(from(u in User, where: u.id == ^user.id),
+          set: [avatar_image_id: nil]
+        )
+
+      {:ok, user: Repo.get!(User, user.id), fingerprint: fingerprint}
+    end
+
+    test "still gets their avatar, at the address it always had", ctx do
+      %{user: user, fingerprint: fingerprint} = ctx
+
+      assert Vutuv.Avatar.url(user, :medium) ==
+               "/avatars/#{user.id}/#{user.username}-medium-#{fingerprint}.avif"
+
+      assert Vutuv.Avatar.picture(user).src == Vutuv.Avatar.url(user, :medium)
+      assert Vutuv.Avatar.src(user, :thumb) == Vutuv.Avatar.url(user, :thumb)
+      assert {:ok, <<0xFF, 0xD8, _rest::binary>>} = Vutuv.Avatar.og_jpeg(user)
+      assert Images.shown_file(user, "avatar") == "selfie.jpg"
+    end
+
+    test "the actor document still advertises the icon", %{user: user} do
+      {:ok, actor} = Vutuv.Fediverse.ensure_actor(user)
+
+      assert Docs.actor(user, actor)["icon"]["url"] ==
+               "#{VutuvWeb.Endpoint.url()}/#{user.username}/avatar.jpg"
+    end
+
+    # The one thing the bridge cannot answer: a report names a picture by its
+    # row id, and a bridged picture has none. It falls back to reporting the
+    # whole profile until the backfill runs.
+    test "cannot be reported on its own, having no row to name", %{user: user} do
+      assert %Images.Image{id: nil} = Images.member_image(user, "avatar")
+      assert Images.reportable_image(user, "avatar") == nil
+    end
+
+    # The narrow listing select has to carry what the bridge reads, or a whole
+    # page of members loses its faces while single-member pages keep theirs.
+    # Asserted against the URL string rather than against another call that
+    # would go nil in the same breath.
+    test "a listing row bridges too, so a whole page keeps its faces", ctx do
+      %{user: user, fingerprint: fingerprint} = ctx
+
+      row =
+        Repo.one!(
+          from(u in User, where: u.id == ^user.id, select: struct(u, ^User.listing_fields()))
+        )
+
+      assert row.avatar_image_id == nil
+
+      assert Vutuv.Avatar.src(row, :thumb) ==
+               "/avatars/#{user.id}/#{user.username}-thumb-#{fingerprint}.avif"
+    end
+  end
+
   describe "a listing row" do
     # Listing queries select a narrow struct (`User.listing_fields/0`), so the
     # pointer has to be in that list or a whole page of members loses its

--- a/test/vutuv/images_test.exs
+++ b/test/vutuv/images_test.exs
@@ -128,15 +128,16 @@ defmodule Vutuv.ImagesTest do
         })
 
       # The one shape other servers, Google and sent mail already hold:
-      # /avatars/<user id>/<handle>-<version>-<fingerprint>.avif — built from
-      # the member row's own columns, with the images row playing no part.
-      assert Vutuv.Avatar.url({user.avatar, user}, :medium) ==
+      # /avatars/<user id>/<handle>-<version>-<fingerprint>.avif. Since #2027
+      # the picture's row is what builds it — the string is byte-for-byte the
+      # one the member row's own columns produced, which is the whole point.
+      assert Vutuv.Avatar.url(user, :medium) ==
                "/avatars/#{user.id}/#{user.username}-medium-#{user.avatar_fingerprint}.avif"
 
       assert Vutuv.Avatar.display_url(user, :thumb) ==
                "/avatars/#{user.id}/#{user.username}-thumb-#{user.avatar_fingerprint}.avif"
 
-      assert Vutuv.Cover.url({user.cover_photo, user}, :wide) ==
+      assert Vutuv.Cover.url(user, :wide) ==
                "/covers/#{user.id}/#{user.username}-wide-#{user.cover_fingerprint}.avif"
     end
   end

--- a/test/vutuv/moderation/image_scans_test.exs
+++ b/test/vutuv/moderation/image_scans_test.exs
@@ -99,7 +99,7 @@ defmodule Vutuv.Moderation.ImageScansTest do
       refute Path.wildcard(Path.join(tmp, "quarantine/avatars/#{user.id}/*")) == []
 
       # Every public rendering answers "no image".
-      assert Vutuv.Avatar.url({user.avatar, user}, :medium) == nil
+      assert Vutuv.Avatar.url(user, :medium) == nil
       assert Vutuv.Avatar.display_url(user, :medium) =~ "data:image/svg+xml"
       assert Vutuv.Avatar.og_jpeg(user) == :error
       assert Vutuv.Avatar.binary(user, :thumb) =~ "data:image/svg+xml"
@@ -166,7 +166,7 @@ defmodule Vutuv.Moderation.ImageScansTest do
       # Quarantine emptied, served tree populated, URL live again.
       assert Path.wildcard(Path.join(tmp, "quarantine/avatars/#{user.id}/*")) == []
       refute Path.wildcard(Path.join(tmp, "avatars/#{user.id}/*")) == []
-      assert Vutuv.Avatar.url({user.avatar, user}, :medium) =~ "/avatars/#{user.id}/"
+      assert Vutuv.Avatar.url(user, :medium) =~ "/avatars/#{user.id}/"
 
       scan = Repo.one!(from(s in ImageScan, where: s.subject_id == ^user.id))
       assert scan.status == "approved"
@@ -438,7 +438,7 @@ defmodule Vutuv.Moderation.ImageScansTest do
       {:ok, user} = Accounts.update_user(user, %{cover_photo: jpeg_upload()})
       assert user.cover_moderation == "pending"
       assert open_scan("cover", user.id)
-      assert Vutuv.Cover.url({user.cover_photo, user}, :wide) == nil
+      assert Vutuv.Cover.url(user, :wide) == nil
     end
 
     test "job posting image", %{user: user} do

--- a/test/vutuv/uploaders/avatar_test.exs
+++ b/test/vutuv/uploaders/avatar_test.exs
@@ -14,9 +14,15 @@ defmodule Vutuv.AvatarTest do
   name-derived `<First Last>_thumb.avif`) keep resolving through a transitional
   fallback until `Vutuv.Uploads.Regenerator` has re-derived them under the
   stable name.
+
+  Every URL here is built from the picture's row in the shared `images` table
+  (`Vutuv.Images`, issue #2027), so each test hangs a row on the member struct
+  with `Vutuv.ImageHelpers.put_image/3` instead of setting a member column.
   """
   # Not async: these tests set the global `:uploads_dir_prefix` application env.
   use ExUnit.Case, async: false
+
+  import Vutuv.ImageHelpers
 
   alias Vix.Vips.Image, as: VipsImage
   alias Vix.Vips.MutableImage
@@ -37,10 +43,10 @@ defmodule Vutuv.AvatarTest do
   # `Vutuv.Uploads.served_url/4`. Constant here because `@user.updated_at` is.
   @v "?v=#{:erlang.phash2(~N[2024-03-02 10:20:30])}"
 
-  # A stand-in content fingerprint (sha256(original)[0..11]) for scheme B: when a
-  # user carries one, the served filename bakes in the handle + fingerprint and
-  # the URL drops the `?v=` (Vutuv.Uploads). 12 lowercase hex chars, like the
-  # real thing and like Vutuv.Screenshot.
+  # A stand-in content fingerprint (sha256(original)[0..11]) for scheme B: when
+  # the picture's row carries one, the served filename bakes in the handle +
+  # fingerprint and the URL drops the `?v=` (Vutuv.Uploads). 12 lowercase hex
+  # chars, like the real thing and like Vutuv.Screenshot.
   @fingerprint "1a2b3c4d5e6f"
 
   setup do
@@ -61,35 +67,35 @@ defmodule Vutuv.AvatarTest do
 
   describe "url/2 (the contract nginx + templates depend on)" do
     test "builds the stable, id-scoped version path with the served .avif extension" do
-      assert Vutuv.Avatar.url({"selfie.jpg", @user}, :thumb) ==
+      assert Vutuv.Avatar.url(avatar(@user, file: "selfie.jpg"), :thumb) ==
                "/avatars/7/avatar_thumb.avif" <> @v
 
-      assert Vutuv.Avatar.url({"selfie.jpg", @user}, :medium) ==
+      assert Vutuv.Avatar.url(avatar(@user, file: "selfie.jpg"), :medium) ==
                "/avatars/7/avatar_medium.avif" <> @v
     end
 
     test "the served filename does not embed the display name, so a rename keeps it (issue #773)" do
       renamed = %{@user | first_name: "Jane", last_name: "Smith"}
 
-      assert Vutuv.Avatar.url({"selfie.jpg", renamed}, :thumb) ==
+      assert Vutuv.Avatar.url(avatar(renamed, file: "selfie.jpg"), :thumb) ==
                "/avatars/7/avatar_thumb.avif" <> @v
     end
 
     test "the stored filename's extension does not leak into served URLs" do
-      assert Vutuv.Avatar.url({"selfie.PNG", @user}, :medium) ==
+      assert Vutuv.Avatar.url(avatar(@user, file: "selfie.PNG"), :medium) ==
                "/avatars/7/avatar_medium.avif" <> @v
     end
 
     test "the original is not URL-addressable" do
-      assert Vutuv.Avatar.url({"selfie.jpg", @user}, :original) == nil
+      assert Vutuv.Avatar.url(avatar(@user, file: "selfie.jpg"), :original) == nil
     end
 
     test "returns nil when there is no avatar" do
-      assert Vutuv.Avatar.url({nil, @user}, :thumb) == nil
+      assert Vutuv.Avatar.url(without_image(@user, "avatar"), :thumb) == nil
     end
 
     test "default version is :medium" do
-      assert Vutuv.Avatar.url({"selfie.jpg", @user}) ==
+      assert Vutuv.Avatar.url(avatar(@user, file: "selfie.jpg")) ==
                "/avatars/7/avatar_medium.avif" <> @v
     end
 
@@ -99,75 +105,74 @@ defmodule Vutuv.AvatarTest do
       {:ok, img} = Image.new(20, 20, color: [1, 2, 3])
       {:ok, _} = Image.write(img, Path.join(dir, "John Doe_thumb.jpg"))
 
-      assert Vutuv.Avatar.url({"selfie.jpg?63876543210", @user}, :thumb) ==
+      assert Vutuv.Avatar.url(avatar(@user, file: "selfie.jpg?63876543210"), :thumb) ==
                "/avatars/7/John%20Doe_thumb.jpg" <> @v
 
       # The name-derived .avif wins over the pre-AVIF legacy file.
       {:ok, _} = Image.write(img, Path.join(dir, "John Doe_thumb.avif"))
 
-      assert Vutuv.Avatar.url({"selfie.jpg?63876543210", @user}, :thumb) ==
+      assert Vutuv.Avatar.url(avatar(@user, file: "selfie.jpg?63876543210"), :thumb) ==
                "/avatars/7/John%20Doe_thumb.avif" <> @v
 
       # ...and once the regenerator has written the stable id-scoped file, that
       # wins over every name-derived legacy file (issue #773).
       {:ok, _} = Image.write(img, Path.join(dir, "avatar_thumb.avif"))
 
-      assert Vutuv.Avatar.url({"selfie.jpg?63876543210", @user}, :thumb) ==
+      assert Vutuv.Avatar.url(avatar(@user, file: "selfie.jpg?63876543210"), :thumb) ==
                "/avatars/7/avatar_thumb.avif" <> @v
     end
   end
 
   describe "cache-busting (a re-upload must not keep showing the cached image)" do
     test "appends a ?v= token derived from the scope's updated_at" do
-      assert Vutuv.Avatar.url({"selfie.jpg", @user}, :medium) ==
+      assert Vutuv.Avatar.url(avatar(@user, file: "selfie.jpg"), :medium) ==
                "/avatars/7/avatar_medium.avif?v=#{:erlang.phash2(@user.updated_at)}"
     end
 
     test "the token changes when updated_at changes (so the URL does too)" do
       touched = %{@user | updated_at: ~N[2024-03-02 10:20:31]}
 
-      refute Vutuv.Avatar.url({"selfie.jpg", touched}, :medium) ==
-               Vutuv.Avatar.url({"selfie.jpg", @user}, :medium)
+      refute Vutuv.Avatar.url(avatar(touched, file: "selfie.jpg"), :medium) ==
+               Vutuv.Avatar.url(avatar(@user, file: "selfie.jpg"), :medium)
     end
 
     test "the token is stable for an unchanged updated_at (URL stays cacheable)" do
-      assert Vutuv.Avatar.url({"selfie.jpg", @user}, :medium) ==
-               Vutuv.Avatar.url({"selfie.jpg", @user}, :medium)
+      assert Vutuv.Avatar.url(avatar(@user, file: "selfie.jpg"), :medium) ==
+               Vutuv.Avatar.url(avatar(@user, file: "selfie.jpg"), :medium)
     end
 
     test "no token when the scope carries no updated_at (e.g. an unpersisted struct)" do
-      assert Vutuv.Avatar.url({"selfie.jpg", %{@user | updated_at: nil}}, :medium) ==
+      assert Vutuv.Avatar.url(avatar(%{@user | updated_at: nil}, file: "selfie.jpg"), :medium) ==
                "/avatars/7/avatar_medium.avif"
     end
   end
 
   describe "fingerprinted URL (scheme B: handle + content hash in the filename)" do
     setup do
-      {:ok, user: %{@user | avatar: "selfie.jpg", avatar_fingerprint: @fingerprint}}
+      {:ok, user: avatar(@user, file: "selfie.jpg", fingerprint: @fingerprint)}
     end
 
     test "bakes <handle>-<version>-<fingerprint>.avif and drops the ?v= query", %{user: user} do
-      assert Vutuv.Avatar.url({"selfie.jpg", user}, :medium) ==
+      assert Vutuv.Avatar.url(user, :medium) ==
                "/avatars/7/john.doe-medium-#{@fingerprint}.avif"
 
-      assert Vutuv.Avatar.url({"selfie.jpg", user}, :thumb) ==
+      assert Vutuv.Avatar.url(user, :thumb) ==
                "/avatars/7/john.doe-thumb-#{@fingerprint}.avif"
 
-      refute Vutuv.Avatar.url({"selfie.jpg", user}, :medium) =~ "?"
+      refute Vutuv.Avatar.url(user, :medium) =~ "?"
     end
 
     test "the download filename moves with the handle when the slug changes", %{user: user} do
       renamed = %{user | username: "jane.smith"}
 
-      assert Vutuv.Avatar.url({"selfie.jpg", renamed}, :medium) ==
+      assert Vutuv.Avatar.url(renamed, :medium) ==
                "/avatars/7/jane.smith-medium-#{@fingerprint}.avif"
     end
 
     test "a new fingerprint changes the URL (the cache-buster lives in the name)", %{user: user} do
-      reuploaded = %{user | avatar_fingerprint: "ffffffffffff"}
+      reuploaded = avatar(@user, file: "selfie.jpg", fingerprint: "ffffffffffff")
 
-      refute Vutuv.Avatar.url({"selfie.jpg", reuploaded}, :medium) ==
-               Vutuv.Avatar.url({"selfie.jpg", user}, :medium)
+      refute Vutuv.Avatar.url(reuploaded, :medium) == Vutuv.Avatar.url(user, :medium)
     end
 
     test "display_url/2 emits the fingerprinted URL", %{user: user} do
@@ -175,25 +180,20 @@ defmodule Vutuv.AvatarTest do
                "/avatars/7/john.doe-medium-#{@fingerprint}.avif"
     end
 
-    test "a nil fingerprint still serves the legacy ?v= URL (row not yet migrated)" do
-      assert Vutuv.Avatar.url({"selfie.jpg", @user}, :medium) ==
+    test "a picture row with no fingerprint still serves the legacy ?v= URL (not yet migrated)" do
+      assert Vutuv.Avatar.url(avatar(@user, file: "selfie.jpg"), :medium) ==
                "/avatars/7/avatar_medium.avif" <> @v
     end
   end
 
-  test "user_url/2 reads the avatar field off the user" do
-    user = %{@user | avatar: "selfie.jpg"}
-    assert Vutuv.Avatar.user_url(user, :medium) == "/avatars/7/avatar_medium.avif" <> @v
-  end
-
   describe "binary/2 (base64 JPEG used by the vCard export)" do
     test "returns the default SVG data URI when the user has no avatar" do
-      data = Vutuv.Avatar.binary(%{@user | avatar: nil}, :thumb)
+      data = Vutuv.Avatar.binary(without_image(@user, "avatar"), :thumb)
       assert String.starts_with?(data, "data:image/svg+xml,")
     end
 
     test "returns the default SVG when the original is missing on disk" do
-      data = Vutuv.Avatar.binary(%{@user | avatar: "missing.jpg"}, :thumb)
+      data = Vutuv.Avatar.binary(avatar(@user, file: "missing.jpg"), :thumb)
       assert String.starts_with?(data, "data:image/svg+xml,")
     end
 
@@ -204,7 +204,7 @@ defmodule Vutuv.AvatarTest do
       {:ok, _} = Image.write(img, Path.join(dir, "original.jpg"))
 
       assert "data:image/jpeg;base64," <> data =
-               Vutuv.Avatar.binary(%{@user | avatar: "orig.jpg"}, :thumb)
+               Vutuv.Avatar.binary(avatar(@user, file: "orig.jpg"), :thumb)
 
       assert {:ok, _} = Base.decode64(data)
     end
@@ -216,7 +216,7 @@ defmodule Vutuv.AvatarTest do
       {:ok, _} = Image.write(img, Path.join(dir, "original.png"))
 
       assert "data:image/jpeg;base64," <> _ =
-               Vutuv.Avatar.binary(%{@user | avatar: "orig.png"}, :thumb)
+               Vutuv.Avatar.binary(avatar(@user, file: "orig.png"), :thumb)
     end
 
     test "the derived JPEG carries no EXIF from the original", %{tmp: tmp} do
@@ -232,7 +232,7 @@ defmodule Vutuv.AvatarTest do
       {:ok, _} = Image.write(tagged, Path.join(dir, "original.jpg"))
 
       assert "data:image/jpeg;base64," <> data =
-               Vutuv.Avatar.binary(%{@user | avatar: "orig.jpg"}, :thumb)
+               Vutuv.Avatar.binary(avatar(@user, file: "orig.jpg"), :thumb)
 
       {:ok, jpeg} = data |> Base.decode64!() |> Image.from_binary()
       {:ok, fields} = VipsImage.header_field_names(jpeg)
@@ -247,7 +247,7 @@ defmodule Vutuv.AvatarTest do
       {:ok, img} = Image.new(600, 400, color: [10, 120, 200])
       {:ok, _} = Image.write(img, Path.join(dir, "original.jpg"))
 
-      assert {:ok, data} = Vutuv.Avatar.og_jpeg(%{@user | avatar: "orig.jpg"})
+      assert {:ok, data} = Vutuv.Avatar.og_jpeg(avatar(@user, file: "orig.jpg"))
       {:ok, jpeg} = Image.from_binary(data)
       size = Vutuv.Avatar.og_size()
       assert {Image.width(jpeg), Image.height(jpeg)} == {size, size}
@@ -261,25 +261,25 @@ defmodule Vutuv.AvatarTest do
       {:ok, img} = Image.new(192, 192, color: [10, 120, 200])
       {:ok, _} = Image.write(img, Path.join(dir, "John Doe_medium.avif"))
 
-      assert {:ok, data} = Vutuv.Avatar.og_jpeg(%{@user | avatar: "selfie.jpg"})
+      assert {:ok, data} = Vutuv.Avatar.og_jpeg(avatar(@user, file: "selfie.jpg"))
       {:ok, jpeg} = Image.from_binary(data)
       assert Image.width(jpeg) == Vutuv.Avatar.og_size()
     end
 
     test ":error without an avatar or with nothing usable on disk" do
-      assert Vutuv.Avatar.og_jpeg(%{@user | avatar: nil}) == :error
-      assert Vutuv.Avatar.og_jpeg(%{@user | avatar: "missing.jpg"}) == :error
+      assert Vutuv.Avatar.og_jpeg(without_image(@user, "avatar")) == :error
+      assert Vutuv.Avatar.og_jpeg(avatar(@user, file: "missing.jpg")) == :error
     end
   end
 
   describe "display_url/2 (what templates put in <img src>)" do
     test "returns the nginx-served URL when the user has an avatar" do
-      user = %{@user | avatar: "selfie.jpg"}
+      user = avatar(@user, file: "selfie.jpg")
       assert Vutuv.Avatar.display_url(user, :medium) == "/avatars/7/avatar_medium.avif" <> @v
     end
 
     test "falls back to the default SVG when the user has no avatar" do
-      data = Vutuv.Avatar.display_url(%{@user | avatar: nil}, :thumb)
+      data = Vutuv.Avatar.display_url(without_image(@user, "avatar"), :thumb)
       assert String.starts_with?(data, "data:image/svg+xml,")
     end
   end
@@ -288,7 +288,7 @@ defmodule Vutuv.AvatarTest do
   # profile picture: the 96 px thumb, offered only when its file is there.
   describe "picture/1" do
     setup do
-      {:ok, user: %{@user | avatar: "selfie.jpg", avatar_fingerprint: @fingerprint}}
+      {:ok, user: avatar(@user, file: "selfie.jpg", fingerprint: @fingerprint)}
     end
 
     test "is the picture alone outside data-saving mode", %{user: user} do
@@ -316,9 +316,19 @@ defmodule Vutuv.AvatarTest do
              }
     end
 
-    test "without an avatar the default tile has no lite either way" do
+    # A member with no picture at all is now told apart from one nobody may see:
+    # the row answers since #2027, so this one has no `src` and the caller draws
+    # its initials tile, while the silhouette stays for a picture on hold.
+    test "without an avatar there is nothing to show, and no lite either way" do
       Vutuv.LowBandwidth.put(true)
-      %{src: src, lite: nil} = Vutuv.Avatar.picture(%{@user | avatar: nil})
+      assert Vutuv.Avatar.picture(without_image(@user, "avatar")) == %{src: nil, lite: nil}
+    end
+
+    test "an avatar the AI gate still holds shows the silhouette, and no lite" do
+      Vutuv.LowBandwidth.put(true)
+      held = avatar(@user, file: "selfie.jpg", fingerprint: @fingerprint, moderation: "pending")
+
+      assert %{src: src, lite: nil} = Vutuv.Avatar.picture(held)
       assert String.starts_with?(src, "data:image/svg+xml,")
     end
   end
@@ -351,10 +361,9 @@ defmodule Vutuv.AvatarTest do
     test "the returned fingerprint is what url/2 then serves (write == URL)", %{src: src} do
       upload = %Plug.Upload{filename: "selfie.jpg", path: src, content_type: "image/jpeg"}
       assert {:ok, file_name, fp, _} = Vutuv.Avatar.store({upload, @user})
-      stored = %{@user | avatar: file_name, avatar_fingerprint: fp}
+      stored = avatar(@user, file: file_name, fingerprint: fp)
 
-      assert Vutuv.Avatar.url({file_name, stored}, :medium) ==
-               "/avatars/7/john.doe-medium-#{fp}.avif"
+      assert Vutuv.Avatar.url(stored, :medium) == "/avatars/7/john.doe-medium-#{fp}.avif"
     end
 
     test "a re-upload clears the prior fingerprinted versions (no accumulation)",
@@ -451,6 +460,11 @@ defmodule Vutuv.AvatarTest do
       assert {"is not a valid image", _} = changeset.errors[:avatar]
     end
   end
+
+  # This member with an avatar row hung on the struct, which is what every URL
+  # builder reads since #2027 (`Vutuv.Images.member_image/2`). No database:
+  # nothing here inserts a member.
+  defp avatar(user, attrs), do: put_image(user, "avatar", attrs)
 
   defp dimensions(path) do
     {:ok, img} = Image.open(path)

--- a/test/vutuv/uploaders/cover_test.exs
+++ b/test/vutuv/uploaders/cover_test.exs
@@ -5,9 +5,15 @@ defmodule Vutuv.CoverTest do
   id-scoped `covers/<user.id>/cover_<version>.avif` (nginx `location /covers/`),
   which a rename never orphans (issue #773); the uploaded original is kept
   privately at `originals/covers/<user.id>/original<ext>` and is never served.
+
+  Every URL here is built from the picture's row in the shared `images` table
+  (`Vutuv.Images`, issue #2027), so each test hangs a row on the member struct
+  with `Vutuv.ImageHelpers.put_image/3` instead of setting a member column.
   """
   # Not async: these tests set the global `:uploads_dir_prefix` application env.
   use ExUnit.Case, async: false
+
+  import Vutuv.ImageHelpers
 
   alias Vix.Vips.Image, as: VipsImage
   alias Vix.Vips.MutableImage
@@ -26,8 +32,9 @@ defmodule Vutuv.CoverTest do
   # 30-day browser/nginx cache. See `Vutuv.Uploads.served_url/4`.
   @v "?v=#{:erlang.phash2(~N[2024-03-02 10:20:30])}"
 
-  # A stand-in content fingerprint for scheme B (see Vutuv.Uploads): when set,
-  # the served filename bakes in the handle + fingerprint and the URL drops `?v=`.
+  # A stand-in content fingerprint for scheme B (see Vutuv.Uploads): when the
+  # picture's row carries one, the served filename bakes in the handle +
+  # fingerprint and the URL drops `?v=`.
   @fingerprint "1a2b3c4d5e6f"
 
   setup do
@@ -48,41 +55,43 @@ defmodule Vutuv.CoverTest do
 
   describe "url/2 (the contract nginx + templates depend on)" do
     test "builds the stable, id-scoped version path with the served .avif extension" do
-      assert Vutuv.Cover.url({"banner.jpg", @user}, :wide) ==
+      assert Vutuv.Cover.url(cover(@user, file: "banner.jpg"), :wide) ==
                "/covers/7/cover_wide.avif" <> @v
     end
 
     test "the served filename does not embed the display name, so a rename keeps it (issue #773)" do
       renamed = %{@user | first_name: "Jane", last_name: "Smith"}
 
-      assert Vutuv.Cover.url({"banner.jpg", renamed}, :wide) ==
+      assert Vutuv.Cover.url(cover(renamed, file: "banner.jpg"), :wide) ==
                "/covers/7/cover_wide.avif" <> @v
     end
 
     test "the stored filename's extension does not leak into served URLs" do
-      assert Vutuv.Cover.url({"banner.PNG", @user}, :wide) ==
+      assert Vutuv.Cover.url(cover(@user, file: "banner.PNG"), :wide) ==
                "/covers/7/cover_wide.avif" <> @v
     end
 
     test "the original is not URL-addressable" do
-      assert Vutuv.Cover.url({"banner.jpg", @user}, :original) == nil
+      assert Vutuv.Cover.url(cover(@user, file: "banner.jpg"), :original) == nil
     end
 
     test "returns nil when there is no cover photo" do
-      assert Vutuv.Cover.url({nil, @user}, :wide) == nil
+      assert Vutuv.Cover.url(without_image(@user, "cover"), :wide) == nil
     end
 
     test "default version is :wide" do
-      assert Vutuv.Cover.url({"banner.jpg", @user}) == "/covers/7/cover_wide.avif" <> @v
+      assert Vutuv.Cover.url(cover(@user, file: "banner.jpg")) ==
+               "/covers/7/cover_wide.avif" <> @v
     end
 
     test "appends a cache-busting ?v= token that changes with updated_at" do
       touched = %{@user | updated_at: ~N[2024-03-02 10:20:31]}
 
-      assert Vutuv.Cover.url({"banner.jpg", @user}, :wide) =~ "/covers/7/cover_wide.avif?v="
+      assert Vutuv.Cover.url(cover(@user, file: "banner.jpg"), :wide) =~
+               "/covers/7/cover_wide.avif?v="
 
-      refute Vutuv.Cover.url({"banner.jpg", touched}, :wide) ==
-               Vutuv.Cover.url({"banner.jpg", @user}, :wide)
+      refute Vutuv.Cover.url(cover(touched, file: "banner.jpg"), :wide) ==
+               Vutuv.Cover.url(cover(@user, file: "banner.jpg"), :wide)
     end
 
     test "falls back to a not-yet-regenerated legacy file (incl. ?timestamp suffix)", %{tmp: tmp} do
@@ -91,19 +100,19 @@ defmodule Vutuv.CoverTest do
       {:ok, img} = Image.new(20, 20, color: [1, 2, 3])
       {:ok, _} = Image.write(img, Path.join(dir, "John Doe_wide.jpg"))
 
-      assert Vutuv.Cover.url({"banner.jpg?63876543210", @user}, :wide) ==
+      assert Vutuv.Cover.url(cover(@user, file: "banner.jpg?63876543210"), :wide) ==
                "/covers/7/John%20Doe_wide.jpg" <> @v
 
       # The name-derived .avif wins over the pre-AVIF legacy file.
       {:ok, _} = Image.write(img, Path.join(dir, "John Doe_wide.avif"))
 
-      assert Vutuv.Cover.url({"banner.jpg?63876543210", @user}, :wide) ==
+      assert Vutuv.Cover.url(cover(@user, file: "banner.jpg?63876543210"), :wide) ==
                "/covers/7/John%20Doe_wide.avif" <> @v
 
       # ...and the stable id-scoped file wins over every name-derived file (#773).
       {:ok, _} = Image.write(img, Path.join(dir, "cover_wide.avif"))
 
-      assert Vutuv.Cover.url({"banner.jpg?63876543210", @user}, :wide) ==
+      assert Vutuv.Cover.url(cover(@user, file: "banner.jpg?63876543210"), :wide) ==
                "/covers/7/cover_wide.avif" <> @v
     end
   end
@@ -113,7 +122,7 @@ defmodule Vutuv.CoverTest do
   # lite existed keeps showing its banner rather than a broken one.
   describe "picture/1" do
     setup do
-      {:ok, user: %{@user | cover_photo: "banner.jpg", cover_fingerprint: @fingerprint}}
+      {:ok, user: cover(@user, file: "banner.jpg", fingerprint: @fingerprint)}
     end
 
     test "is the banner alone outside data-saving mode", %{user: user} do
@@ -140,26 +149,25 @@ defmodule Vutuv.CoverTest do
 
     test "without a cover there is nothing to offer either way" do
       Vutuv.LowBandwidth.put(true)
-      assert Vutuv.Cover.picture(@user) == %{src: nil, lite: nil}
+      assert Vutuv.Cover.picture(without_image(@user, "cover")) == %{src: nil, lite: nil}
     end
   end
 
   describe "fingerprinted URL (scheme B: handle + content hash in the filename)" do
     setup do
-      {:ok, user: %{@user | cover_photo: "banner.jpg", cover_fingerprint: @fingerprint}}
+      {:ok, user: cover(@user, file: "banner.jpg", fingerprint: @fingerprint)}
     end
 
     test "bakes <handle>-wide-<fingerprint>.avif and drops the ?v= query", %{user: user} do
-      assert Vutuv.Cover.url({"banner.jpg", user}, :wide) ==
-               "/covers/7/john.doe-wide-#{@fingerprint}.avif"
+      assert Vutuv.Cover.url(user, :wide) == "/covers/7/john.doe-wide-#{@fingerprint}.avif"
 
-      refute Vutuv.Cover.url({"banner.jpg", user}, :wide) =~ "?"
+      refute Vutuv.Cover.url(user, :wide) =~ "?"
     end
 
     test "the download filename moves with the handle when the slug changes", %{user: user} do
       renamed = %{user | username: "jane.smith"}
 
-      assert Vutuv.Cover.url({"banner.jpg", renamed}, :wide) ==
+      assert Vutuv.Cover.url(renamed, :wide) ==
                "/covers/7/jane.smith-wide-#{@fingerprint}.avif"
     end
 
@@ -168,19 +176,20 @@ defmodule Vutuv.CoverTest do
                "/covers/7/john.doe-wide-#{@fingerprint}.avif"
     end
 
-    test "a nil fingerprint still serves the legacy ?v= URL (row not yet migrated)" do
-      assert Vutuv.Cover.url({"banner.jpg", @user}, :wide) == "/covers/7/cover_wide.avif" <> @v
+    test "a picture row with no fingerprint still serves the legacy ?v= URL (not yet migrated)" do
+      assert Vutuv.Cover.url(cover(@user, file: "banner.jpg"), :wide) ==
+               "/covers/7/cover_wide.avif" <> @v
     end
   end
 
   describe "display_url/2 (what the profile puts in <img src>)" do
     test "returns the nginx-served URL when the user has a cover photo" do
-      user = %{@user | cover_photo: "banner.jpg"}
+      user = cover(@user, file: "banner.jpg")
       assert Vutuv.Cover.display_url(user, :wide) == "/covers/7/cover_wide.avif" <> @v
     end
 
     test "returns nil when the user has no cover photo (gradient fallback)" do
-      assert Vutuv.Cover.display_url(%{@user | cover_photo: nil}, :wide) == nil
+      assert Vutuv.Cover.display_url(without_image(@user, "cover"), :wide) == nil
     end
   end
 
@@ -271,6 +280,11 @@ defmodule Vutuv.CoverTest do
       assert {"is not a valid image", _} = changeset.errors[:cover_photo]
     end
   end
+
+  # This member with a cover row hung on the struct, which is what every URL
+  # builder reads since #2027 (`Vutuv.Images.member_image/2`). No database:
+  # nothing here inserts a member.
+  defp cover(user, attrs), do: put_image(user, "cover", attrs)
 
   defp dimensions(path) do
     {:ok, img} = Image.open(path)

--- a/test/vutuv/uploaders/uploads_integration_test.exs
+++ b/test/vutuv/uploaders/uploads_integration_test.exs
@@ -8,6 +8,10 @@ defmodule Vutuv.UploadsIntegrationTest do
   use Vutuv.DataCase, async: false
 
   import Vutuv.Factory
+  # Since #2027 every URL builder reads the picture's row in the shared `images`
+  # table, so a fixture that fabricates a legacy member row has to write the row
+  # its own columns already name.
+  import Vutuv.ImageHelpers
 
   alias Vutuv.Accounts.User
   alias Vutuv.Profiles.Url
@@ -34,7 +38,11 @@ defmodule Vutuv.UploadsIntegrationTest do
   test "a legacy avatar value with a ?timestamp suffix still resolves", %{tmp: tmp} do
     # Simulate a row written by the old Waffle.Ecto type, whose derived file
     # is still the pre-AVIF .jpg on disk.
-    user = insert(:user, avatar: "selfie.jpg?63876543210", first_name: "Ada", last_name: "King")
+    user =
+      with_image_rows(
+        insert(:user, avatar: "selfie.jpg?63876543210", first_name: "Ada", last_name: "King")
+      )
+
     dir = Path.join(tmp, "avatars/#{user.id}")
     File.mkdir_p!(dir)
     {:ok, img} = Image.new(20, 20, color: [1, 2, 3])
@@ -47,7 +55,7 @@ defmodule Vutuv.UploadsIntegrationTest do
 
     # ...and the URL ignores the legacy timestamp, falling back to the
     # not-yet-regenerated legacy file (plus the cache-busting ?v= token).
-    assert Vutuv.Avatar.url({reloaded.avatar, reloaded}, :thumb) ==
+    assert Vutuv.Avatar.url(reloaded, :thumb) ==
              "/avatars/#{user.id}/Ada%20King_thumb.jpg?v=#{:erlang.phash2(reloaded.updated_at)}"
   end
 
@@ -120,7 +128,7 @@ defmodule Vutuv.UploadsIntegrationTest do
     # URL the app now emits points at a file that exists.
     assert File.exists?(Path.join(tmp, "avatars/#{renamed.id}/ada_new_handle-medium-#{fp}.avif"))
 
-    assert Vutuv.Avatar.url({renamed.avatar, renamed}, :medium) ==
+    assert Vutuv.Avatar.url(renamed, :medium) ==
              "/avatars/#{renamed.id}/ada_new_handle-medium-#{fp}.avif"
   end
 
@@ -263,7 +271,7 @@ defmodule Vutuv.UploadsIntegrationTest do
   end
 
   test "the vCard embeds a real avatar as a JPEG PHOTO line", %{tmp: tmp} do
-    user = insert(:user, first_name: "Ada", last_name: "King", avatar: "me.jpg")
+    user = with_image_rows(insert(:user, first_name: "Ada", last_name: "King", avatar: "me.jpg"))
     dir = Path.join(tmp, "originals/avatars/#{user.id}")
     File.mkdir_p!(dir)
     {:ok, img} = Image.new(300, 200, color: [10, 120, 200])

--- a/test/vutuv/uploads/legacy_sweeper_test.exs
+++ b/test/vutuv/uploads/legacy_sweeper_test.exs
@@ -9,6 +9,11 @@ defmodule Vutuv.Uploads.LegacySweeperTest do
   use Vutuv.DataCase, async: false
 
   import Vutuv.Factory
+  # Since #2027 a picture IS its row in the shared `images` table: this sweeper
+  # picks its rows by the member row's pointer at one and reads the fingerprint
+  # off the row, so a fixture that sets only `users.avatar` is a member with no
+  # picture at all.
+  import Vutuv.ImageHelpers
 
   alias Vutuv.Uploads.LegacySweeper
   alias Vutuv.Uploads.Spec
@@ -47,6 +52,7 @@ defmodule Vutuv.Uploads.LegacySweeperTest do
   defp migrated_avatar!(tmp, fp \\ "abc123abc123") do
     user = insert(:user, first_name: "Ada", last_name: "King", avatar: "selfie.jpg")
     {:ok, user} = user |> Ecto.Changeset.change(avatar_fingerprint: fp) |> Repo.update()
+    user = with_image_rows(user)
     dir = Path.join(tmp, "avatars/#{user.id}")
 
     for version <- @avatar_versions do
@@ -77,12 +83,19 @@ defmodule Vutuv.Uploads.LegacySweeperTest do
     assert length(File.ls!(dir)) == length(@avatar_versions) + 2
   end
 
-  test "never visits a row still on the legacy scheme (nil fingerprint)", %{tmp: tmp} do
-    user = insert(:user, first_name: "Ada", last_name: "King", avatar: "selfie.jpg")
+  # Since #2027 the query picks every member with a picture and the fingerprint
+  # is read off its row, so a legacy-scheme picture is loaded and then refused
+  # inside `Vutuv.Uploads.sweep_legacy/3` — it counts as skipped rather than
+  # being filtered out before the sweeper ever sees it. What must not move is
+  # the file: nothing is removed, either way.
+  test "never strips a row still on the legacy scheme (nil fingerprint)", %{tmp: tmp} do
+    user =
+      with_image_rows(insert(:user, first_name: "Ada", last_name: "King", avatar: "selfie.jpg"))
+
     dir = Path.join(tmp, "avatars/#{user.id}")
     touch!(Path.join(dir, "Ada King_thumb.jpg"))
 
-    assert %{avatars: %{rows: 0, files_removed: 0, skipped: 0}} =
+    assert %{avatars: %{rows: 0, files_removed: 0, skipped: 1}} =
              LegacySweeper.run(only: :avatars)
 
     assert File.exists?(Path.join(dir, "Ada King_thumb.jpg"))
@@ -91,7 +104,8 @@ defmodule Vutuv.Uploads.LegacySweeperTest do
   test "leaves a half-migrated row (current versions missing) untouched", %{tmp: tmp} do
     fp = "abc123abc123"
     user = insert(:user, first_name: "Ada", last_name: "King", avatar: "selfie.jpg")
-    {:ok, _} = user |> Ecto.Changeset.change(avatar_fingerprint: fp) |> Repo.update()
+    {:ok, user} = user |> Ecto.Changeset.change(avatar_fingerprint: fp) |> Repo.update()
+    _user = with_image_rows(user)
     dir = Path.join(tmp, "avatars/#{user.id}")
     # Only the legacy file exists; the current fingerprinted versions are absent,
     # so stripping the legacy file would leave the row with nothing.

--- a/test/vutuv/uploads/regenerator_test.exs
+++ b/test/vutuv/uploads/regenerator_test.exs
@@ -11,6 +11,10 @@ defmodule Vutuv.Uploads.RegeneratorTest do
   use Vutuv.DataCase, async: false
 
   import Vutuv.Factory
+  # Since #2027 a picture IS its row in the shared `images` table, and this tool
+  # picks its rows by the member row's pointer at one — so a fixture that sets
+  # only `users.avatar` describes a member with no picture, and no run visits it.
+  import Vutuv.ImageHelpers
 
   alias Vutuv.Uploads.Regenerator
   alias Vutuv.Uploads.Spec
@@ -43,7 +47,9 @@ defmodule Vutuv.Uploads.RegeneratorTest do
   # Waffle-era 512px `_large`, which current code never serves — and the
   # original sitting in the public tree.
   defp legacy_avatar_user!(tmp) do
-    user = insert(:user, first_name: "Ada", last_name: "King", avatar: "selfie.jpg")
+    user =
+      with_image_rows(insert(:user, first_name: "Ada", last_name: "King", avatar: "selfie.jpg"))
+
     dir = Path.join(tmp, "avatars/#{user.id}")
     jpeg!(Path.join(dir, "Ada King_thumb.jpg"))
     jpeg!(Path.join(dir, "Ada King_medium.jpg"))
@@ -100,7 +106,9 @@ defmodule Vutuv.Uploads.RegeneratorTest do
     end
 
     test "skips a row whose original is missing without touching its files", %{tmp: tmp} do
-      user = insert(:user, first_name: "Ada", last_name: "King", avatar: "selfie.jpg")
+      user =
+        with_image_rows(insert(:user, first_name: "Ada", last_name: "King", avatar: "selfie.jpg"))
+
       dir = Path.join(tmp, "avatars/#{user.id}")
       jpeg!(Path.join(dir, "Ada King_thumb.jpg"))
 
@@ -127,7 +135,9 @@ defmodule Vutuv.Uploads.RegeneratorTest do
     end
 
     test "an already-AVIF row (original already private) is migrated in place", %{tmp: tmp} do
-      user = insert(:user, first_name: "Ada", last_name: "King", avatar: "selfie.jpg")
+      user =
+        with_image_rows(insert(:user, first_name: "Ada", last_name: "King", avatar: "selfie.jpg"))
+
       jpeg!(Path.join(tmp, "originals/avatars/#{user.id}/original.jpg"))
 
       summary = Regenerator.run(only: :avatars)
@@ -146,7 +156,11 @@ defmodule Vutuv.Uploads.RegeneratorTest do
 
   describe "covers" do
     test "migrates to the fingerprinted wide version, keeps legacy", %{tmp: tmp} do
-      user = insert(:user, first_name: "Ada", last_name: "King", cover_photo: "banner.jpg")
+      user =
+        with_image_rows(
+          insert(:user, first_name: "Ada", last_name: "King", cover_photo: "banner.jpg")
+        )
+
       dir = Path.join(tmp, "covers/#{user.id}")
       jpeg!(Path.join(dir, "Ada King_wide.jpg"))
       jpeg!(Path.join(dir, "Ada King_original.jpg"), width: 1800, height: 600)
@@ -364,7 +378,9 @@ defmodule Vutuv.Uploads.RegeneratorTest do
   end
 
   test "a corrupt original counts as failed, not crashed", %{tmp: tmp} do
-    user = insert(:user, first_name: "Ada", last_name: "King", avatar: "selfie.jpg")
+    user =
+      with_image_rows(insert(:user, first_name: "Ada", last_name: "King", avatar: "selfie.jpg"))
+
     path = Path.join(tmp, "originals/avatars/#{user.id}/original.jpg")
     File.mkdir_p!(Path.dirname(path))
     File.write!(path, "not actually a jpeg")
@@ -379,8 +395,10 @@ defmodule Vutuv.Uploads.RegeneratorTest do
     src = jpeg!(Path.join(tmp, "fresh.jpg"))
     upload = %Plug.Upload{filename: "fresh.jpg", path: src, content_type: "image/jpeg"}
     {:ok, "fresh.jpg", fp, _} = Vutuv.Avatar.store({upload, user})
-    # Mirror what Accounts.store_pending_image persists after the store.
-    {:ok, _user} = user |> Ecto.Changeset.change(%{avatar_fingerprint: fp}) |> Repo.update()
+    # Mirror both halves Accounts.store_pending_image persists after the store:
+    # the member row's fingerprint and the picture's own row.
+    {:ok, user} = user |> Ecto.Changeset.change(%{avatar_fingerprint: fp}) |> Repo.update()
+    _user = with_image_rows(user)
 
     summary = Regenerator.run(only: :avatars)
 

--- a/test/vutuv_web/controllers/avatar_controller_test.exs
+++ b/test/vutuv_web/controllers/avatar_controller_test.exs
@@ -9,6 +9,7 @@ defmodule VutuvWeb.AvatarControllerTest do
 
   alias Vix.Vips.Image, as: VipsImage
   alias Vix.Vips.MutableImage
+  alias Vutuv.ImageHelpers
 
   setup %{conn: conn} do
     tmp = Path.join(System.tmp_dir!(), "vutuv_og_avatar_#{System.unique_integer([:positive])}")
@@ -26,8 +27,9 @@ defmodule VutuvWeb.AvatarControllerTest do
     {:ok, conn: conn, tmp: tmp}
   end
 
-  # A member with a really stored avatar (original on disk + DB column set),
-  # uploaded from a generated JPEG carrying an EXIF tag.
+  # A member with a really stored avatar (original on disk + the picture's row,
+  # which is what every URL builder reads), uploaded from a generated JPEG
+  # carrying an EXIF tag.
   defp member_with_avatar do
     user = insert_activated_user(first_name: "Ava")
 
@@ -48,6 +50,7 @@ defmodule VutuvWeb.AvatarControllerTest do
     user
     |> Ecto.Changeset.change(avatar: stored, avatar_fingerprint: fingerprint)
     |> Repo.update!()
+    |> ImageHelpers.with_image_rows()
   end
 
   test "serves the avatar as a square, metadata-free JPEG", %{conn: conn} do
@@ -76,7 +79,13 @@ defmodule VutuvWeb.AvatarControllerTest do
 
     assert get(conn, "/nobody_here/avatar.jpg").status == 404
 
-    sleepy = insert_activated_user(email_confirmed?: false, avatar: "selfie.jpg")
+    # A picture and its row, so the 404 is the unactivated account being
+    # withheld rather than a member who simply has nothing to serve.
+    sleepy =
+      [email_confirmed?: false, avatar: "selfie.jpg", avatar_fingerprint: "1a2b3c4d5e6f"]
+      |> insert_activated_user()
+      |> Vutuv.ImageHelpers.with_image_rows()
+
     assert get(conn, "/#{sleepy.username}/avatar.jpg").status == 404
   end
 

--- a/test/vutuv_web/controllers/cover_aspect_test.exs
+++ b/test/vutuv_web/controllers/cover_aspect_test.exs
@@ -1,6 +1,7 @@
 defmodule VutuvWeb.CoverAspectTest do
   use VutuvWeb.ConnCase, async: true
 
+  alias Vutuv.ImageHelpers
   alias Vutuv.Uploads.Spec
   alias VutuvWeb.UI
 
@@ -12,13 +13,16 @@ defmodule VutuvWeb.CoverAspectTest do
   # frames (`data-crop-aspect`) and what every rendered cover box is shaped like
   # (`UI.cover_aspect_class/0`).
 
+  # A member with a cover, written the way an upload writes one: the member
+  # row's columns and the picture's row in `images`, which is what every URL
+  # builder reads since #2027.
   defp with_cover(user) do
     {:ok, user} =
       Repo.update(
         Ecto.Changeset.change(user, cover_photo: "cover.jpg", cover_fingerprint: "abc123")
       )
 
-    user
+    ImageHelpers.with_image_rows(user)
   end
 
   # The tag carrying `marker`, so an assertion about one box cannot be satisfied

--- a/test/vutuv_web/controllers/follower_list_avatar_test.exs
+++ b/test/vutuv_web/controllers/follower_list_avatar_test.exs
@@ -1,6 +1,8 @@
 defmodule VutuvWeb.FollowerListAvatarTest do
   use VutuvWeb.ConnCase
 
+  alias Vutuv.ImageHelpers
+
   # The shared user card list (followers / following / search results /
   # most-followed) used to put `Vutuv.Avatar.display_url/2` straight into an
   # <img>, so a user without a picture got the light-grey default-avatar SVG —
@@ -22,7 +24,7 @@ defmodule VutuvWeb.FollowerListAvatarTest do
 
   test "a follower with a picture keeps a real <img> avatar", %{conn: conn} do
     user = insert_activated_user()
-    follower = insert_activated_user(avatar: "photo.jpg")
+    follower = ImageHelpers.with_image_rows(insert_activated_user(avatar: "photo.jpg"))
     follow!(follower, user)
 
     html = conn |> get(~p"/#{user}/followers") |> html_response(200)

--- a/test/vutuv_web/controllers/mastodon_api/fediverse_client_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/fediverse_client_test.exs
@@ -23,6 +23,7 @@ defmodule VutuvWeb.MastodonApi.FediverseClientTest do
 
   alias Vutuv.Fediverse.PostBoost
   alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.ImageHelpers
   alias Vutuv.MastodonApi
   alias Vutuv.MastodonApi.Presenter
   alias Vutuv.Posts
@@ -177,7 +178,9 @@ defmodule VutuvWeb.MastodonApi.FediverseClientTest do
 
   describe "a profile header" do
     test "is the member's cover photo, not the installation's icon", %{conn: conn} do
-      user = insert(:activated_user, cover_photo: "cover.avif", cover_moderation: "approved")
+      user =
+        insert(:activated_user, cover_photo: "cover.avif", cover_moderation: "approved")
+        |> ImageHelpers.with_image_rows()
 
       account =
         conn

--- a/test/vutuv_web/controllers/profile_avatar_zoom_test.exs
+++ b/test/vutuv_web/controllers/profile_avatar_zoom_test.exs
@@ -13,6 +13,7 @@ defmodule VutuvWeb.ProfileAvatarZoomTest do
   """
   use VutuvWeb.ConnCase, async: false
 
+  alias Vutuv.ImageHelpers
   alias Vutuv.Uploads.Spec
 
   @fingerprint "abc123def456"
@@ -36,11 +37,17 @@ defmodule VutuvWeb.ProfileAvatarZoomTest do
 
   # A member with an avatar whose derived files are exactly `versions` — which
   # is how a row looks between the deploy that adds a version and the
-  # regeneration that derives it.
-  defp with_avatar(user, tmp, versions) do
+  # regeneration that derives it. Writes both halves an upload writes: the
+  # member row's columns and the picture's row in `images`, which is what every
+  # URL builder reads.
+  defp with_avatar(user, tmp, versions, moderation \\ nil) do
     {:ok, user} =
       Repo.update(
-        change(user, avatar: "me.png", avatar_fingerprint: @fingerprint, avatar_moderation: nil)
+        change(user,
+          avatar: "me.png",
+          avatar_fingerprint: @fingerprint,
+          avatar_moderation: moderation
+        )
       )
 
     dir = Path.join(tmp, "avatars/#{user.id}")
@@ -50,7 +57,7 @@ defmodule VutuvWeb.ProfileAvatarZoomTest do
       File.write!(Path.join(dir, "#{user.username}-#{version}-#{@fingerprint}.avif"), "avif")
     end
 
-    user
+    ImageHelpers.with_image_rows(user)
   end
 
   defp zoom_link(html) do
@@ -112,9 +119,7 @@ defmodule VutuvWeb.ProfileAvatarZoomTest do
       tmp: tmp
     } do
       {conn, user} = create_and_login_user(conn)
-      user = with_avatar(user, tmp, [])
-
-      {:ok, user} = Repo.update(change(user, avatar_moderation: "pending"))
+      user = with_avatar(user, tmp, [], "pending")
 
       quarantine = Path.join(tmp, "quarantine/avatars/#{user.id}")
       File.mkdir_p!(quarantine)
@@ -138,8 +143,7 @@ defmodule VutuvWeb.ProfileAvatarZoomTest do
       tmp: tmp
     } do
       {conn, user} = create_and_login_user(conn)
-      user = with_avatar(user, tmp, [])
-      {:ok, user} = Repo.update(change(user, avatar_moderation: "pending"))
+      user = with_avatar(user, tmp, [], "pending")
 
       quarantine = Path.join(tmp, "quarantine/avatars/#{user.id}")
       File.mkdir_p!(quarantine)

--- a/test/vutuv_web/controllers/profile_edit_affordances_test.exs
+++ b/test/vutuv_web/controllers/profile_edit_affordances_test.exs
@@ -3,6 +3,8 @@ defmodule VutuvWeb.ProfileEditAffordancesTest do
 
   import Vutuv.Factory
 
+  alias Vutuv.ImageHelpers
+
   # The owner's add affordance is one visible "Add" button in each section's
   # card header (a <.add_action> brand link to the new-entry form, carrying a
   # data-add-action hook) — the same look and spot as the management pages, so
@@ -174,6 +176,10 @@ defmodule VutuvWeb.ProfileEditAffordancesTest do
 
       {:ok, user} =
         Repo.update(Ecto.Changeset.change(user, avatar: "me.jpg", headline: "Builder of things"))
+
+      # The picture step is done once the picture has its row in `images`,
+      # which is what the checklist reads since #2027.
+      user = ImageHelpers.with_image_rows(user)
 
       # The import step is done once the profile carries a career entry, which
       # is what the importer fills — typing one by hand counts just as much.

--- a/test/vutuv_web/controllers/user_controller_test.exs
+++ b/test/vutuv_web/controllers/user_controller_test.exs
@@ -982,7 +982,11 @@ defmodule VutuvWeb.UserControllerTest do
     refute html =~ "Current cover photo"
 
     # Once a cover photo exists, it is shown above the upload field.
-    {:ok, _} = user |> Ecto.Changeset.change(cover_photo: "cover.avif") |> Repo.update()
+    user
+    |> Ecto.Changeset.change(cover_photo: "cover.avif")
+    |> Repo.update!()
+    |> Vutuv.ImageHelpers.with_image_rows()
+
     html = conn |> recycle() |> get(~p"/settings/profile") |> html_response(200)
     assert html =~ "Current cover photo"
   end

--- a/test/vutuv_web/controllers/v_card_controller_test.exs
+++ b/test/vutuv_web/controllers/v_card_controller_test.exs
@@ -45,7 +45,12 @@ defmodule VutuvWeb.VCardControllerTest do
 
     # Record the uploaded avatar and place the original where Vutuv.Avatar
     # derives the vCard JPEG from: <prefix>/originals/avatars/<id>/original.jpg
-    user = user |> Ecto.Changeset.change(avatar: "selfie.jpg") |> Repo.update!()
+    user =
+      user
+      |> Ecto.Changeset.change(avatar: "selfie.jpg")
+      |> Repo.update!()
+      |> Vutuv.ImageHelpers.with_image_rows()
+
     dir = Path.join(tmp, "originals/avatars/#{user.id}")
     File.mkdir_p!(dir)
     {:ok, img} = Image.new(300, 200, color: [1, 2, 3])

--- a/test/vutuv_web/fediverse/docs_test.exs
+++ b/test/vutuv_web/fediverse/docs_test.exs
@@ -5,13 +5,17 @@ defmodule VutuvWeb.Fediverse.DocsTest do
   use Vutuv.DataCase, async: true
 
   alias Vutuv.Fediverse
+  alias Vutuv.ImageHelpers
   alias VutuvWeb.Fediverse.Docs
 
   defp base, do: VutuvWeb.Endpoint.url()
 
   describe "actor/2" do
     test "renders a Person with inbox, followers and the public key" do
-      user = insert(:activated_user, headline: "Grüße aus <Koblenz>", avatar: "selfie.jpg")
+      user =
+        insert(:activated_user, headline: "Grüße aus <Koblenz>", avatar: "selfie.jpg")
+        |> ImageHelpers.with_image_rows()
+
       {:ok, actor} = Fediverse.ensure_actor(user)
 
       doc = Docs.actor(user, actor)

--- a/test/vutuv_web/live/feed_newcomers_test.exs
+++ b/test/vutuv_web/live/feed_newcomers_test.exs
@@ -15,15 +15,20 @@ defmodule VutuvWeb.PostLive.FeedNewcomersTest do
 
   import Phoenix.LiveViewTest
 
+  alias Vutuv.ImageHelpers
   alias Vutuv.Repo
   alias Vutuv.Social
   alias Vutuv.Tags.UserTag
 
   # A member the card may draw: confirmed, with an avatar no scan is holding.
   # Newest-first ordering is by the UUID v7 primary key, so insertion order is
-  # registration order and no `inserted_at` juggling is needed.
+  # registration order and no `inserted_at` juggling is needed. The picture is
+  # the row in `images` as well as the member row's own columns, because the
+  # card's query joins that row (#2027).
   defp newcomer(attrs \\ []) do
-    insert(:activated_user, Keyword.put_new(attrs, :avatar, "selfie.jpg"))
+    :activated_user
+    |> insert(Keyword.put_new(attrs, :avatar, "selfie.jpg"))
+    |> ImageHelpers.with_image_rows()
   end
 
   # `count` tags on `user`, answering with their slugs — what the rendered chips
@@ -77,7 +82,12 @@ defmodule VutuvWeb.PostLive.FeedNewcomersTest do
 
     test "leaves out the viewer, the already-followed and the blocked", %{conn: conn} do
       {conn, me} = create_and_login_user(conn)
-      me = me |> Ecto.Changeset.change(avatar: "mine.jpg") |> Repo.update!()
+
+      me =
+        me
+        |> Ecto.Changeset.change(avatar: "mine.jpg")
+        |> Repo.update!()
+        |> ImageHelpers.with_image_rows()
 
       followed = newcomer()
       blocked = newcomer()

--- a/test/vutuv_web/live/feed_rail_arrangement_test.exs
+++ b/test/vutuv_web/live/feed_rail_arrangement_test.exs
@@ -13,6 +13,7 @@ defmodule VutuvWeb.PostLive.FeedRailArrangementTest do
 
   import Phoenix.LiveViewTest
 
+  alias Vutuv.ImageHelpers
   alias Vutuv.Posts
   alias VutuvWeb.FeedRailHelpers
 
@@ -35,8 +36,11 @@ defmodule VutuvWeb.PostLive.FeedRailArrangementTest do
     Vutuv.Tags.follow_tag(user, tag)
     # The "New here" card greets only members who show a face, and it is the
     # first block in the shipped order — without one the order under test is
-    # missing its head.
-    insert(:activated_user, first_name: "New", last_name: "Face", avatar: "selfie.jpg")
+    # missing its head. A face is the picture's row in `images` (#2027), so the
+    # member row's columns alone would leave the card empty.
+    :activated_user
+    |> insert(first_name: "New", last_name: "Face", avatar: "selfie.jpg")
+    |> ImageHelpers.with_image_rows()
 
     %{conn: conn, user: user}
   end

--- a/test/vutuv_web/live/feed_rails_test.exs
+++ b/test/vutuv_web/live/feed_rails_test.exs
@@ -11,6 +11,7 @@ defmodule VutuvWeb.PostLive.FeedRailsTest do
 
   import Phoenix.LiveViewTest
 
+  alias Vutuv.ImageHelpers
   alias Vutuv.Posts
   alias Vutuv.Tags
 
@@ -19,8 +20,13 @@ defmodule VutuvWeb.PostLive.FeedRailsTest do
     Tags.follow_tag(user, tag)
 
     # One newcomer for the welcome card — it only greets members who show a
-    # face.
-    newbie = insert(:activated_user, first_name: "New", last_name: "Face", avatar: "selfie.jpg")
+    # face, and a face is the picture's row in `images` (#2027), not just the
+    # member row's columns.
+    newbie =
+      :activated_user
+      |> insert(first_name: "New", last_name: "Face", avatar: "selfie.jpg")
+      |> ImageHelpers.with_image_rows()
+
     {:ok, post} = Posts.create_post(newbie, %{body: "hello from a new face"})
 
     %{tag: tag, newbie: newbie, post: post}

--- a/test/vutuv_web/live/notification_live_test.exs
+++ b/test/vutuv_web/live/notification_live_test.exs
@@ -7,6 +7,7 @@ defmodule VutuvWeb.NotificationLiveTest do
   import Phoenix.LiveViewTest
   import Vutuv.PostsHelpers
 
+  alias Vutuv.ImageHelpers
   alias Vutuv.Prefs
   alias Vutuv.Prefs.Cache
 
@@ -141,7 +142,9 @@ defmodule VutuvWeb.NotificationLiveTest do
       {conn, user} = create_and_login_user(conn)
 
       follower =
-        insert(:user, first_name: "Grace", last_name: "Hopper", avatar: "grace.jpg")
+        :user
+        |> insert(first_name: "Grace", last_name: "Hopper", avatar: "grace.jpg")
+        |> ImageHelpers.with_image_rows()
 
       insert(:follow, follower: follower, followee: user)
 
@@ -155,7 +158,9 @@ defmodule VutuvWeb.NotificationLiveTest do
       {conn, user} = create_and_login_user(conn)
 
       follower =
-        insert(:user, first_name: "Grace", last_name: "Hopper", avatar: "grace.jpg")
+        :user
+        |> insert(first_name: "Grace", last_name: "Hopper", avatar: "grace.jpg")
+        |> ImageHelpers.with_image_rows()
 
       insert(:follow, follower: follower, followee: user)
 

--- a/test/vutuv_web/live/shell_live_test.exs
+++ b/test/vutuv_web/live/shell_live_test.exs
@@ -3,6 +3,7 @@ defmodule VutuvWeb.ShellLiveTest do
 
   import Phoenix.LiveViewTest
 
+  alias Vutuv.ImageHelpers
   alias Vutuv.Sessions
 
   @bell_badge ~s(a[title="Notifications"] span.bg-accent)
@@ -180,7 +181,7 @@ defmodule VutuvWeb.ShellLiveTest do
   end
 
   test "shows the user's avatar in the top bar when they have one", %{conn: conn} do
-    user = stefan(avatar: "me.jpg")
+    user = ImageHelpers.with_image_rows(stefan(avatar: "me.jpg"))
     {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: shell_session(user))
 
     assert has_element?(view, ~s(summary[title="Stefan Wintermeyer"] img))
@@ -248,6 +249,8 @@ defmodule VutuvWeb.ShellLiveTest do
 
     {:ok, user} =
       Vutuv.Repo.update(Ecto.Changeset.change(user, avatar: "me.jpg"))
+
+    user = ImageHelpers.with_image_rows(user)
 
     # The search page renders no avatars of its own, so the only avatar URL in
     # the response is the one the shell chrome puts in the top bar.

--- a/test/vutuv_web/open_graph_test.exs
+++ b/test/vutuv_web/open_graph_test.exs
@@ -11,6 +11,7 @@ defmodule VutuvWeb.OpenGraphTest do
   import Vutuv.OrganizationsHelpers
   import Vutuv.PostsHelpers
 
+  alias Vutuv.ImageHelpers
   alias Vutuv.Organizations
   alias Vutuv.Posts
   alias VutuvWeb.OpenGraph
@@ -138,6 +139,7 @@ defmodule VutuvWeb.OpenGraphTest do
           last_name: "Tester",
           avatar: "selfie.jpg"
         )
+        |> ImageHelpers.with_image_rows()
 
       insert(:work_experience, user: user, title: "Developer", organization: "Acme Corp")
 
@@ -231,7 +233,10 @@ defmodule VutuvWeb.OpenGraphTest do
 
   describe "post pages" do
     test "a public post previews as an article with its first line", %{conn: conn} do
-      author = insert_activated_user(first_name: "Paula", avatar: "selfie.jpg")
+      author =
+        insert_activated_user(first_name: "Paula", avatar: "selfie.jpg")
+        |> ImageHelpers.with_image_rows()
+
       post = create_post!(author, %{"body" => "Hello preview world, this is the first line."})
 
       html = conn |> get(Posts.path(post)) |> html_response(200)
@@ -244,7 +249,10 @@ defmodule VutuvWeb.OpenGraphTest do
     end
 
     test "a post with images previews its first image instead of the avatar", %{conn: conn} do
-      author = insert_activated_user(first_name: "Painter", avatar: "selfie.jpg")
+      author =
+        insert_activated_user(first_name: "Painter", avatar: "selfie.jpg")
+        |> ImageHelpers.with_image_rows()
+
       post = create_post!(author, %{"body" => "look at this"})
 
       # Position decides "first", not insertion order.
@@ -271,7 +279,7 @@ defmodule VutuvWeb.OpenGraphTest do
     end
 
     test "a restricted post's image stays out of the preview", %{conn: conn} do
-      author = insert_activated_user(avatar: "selfie.jpg")
+      author = insert_activated_user(avatar: "selfie.jpg") |> ImageHelpers.with_image_rows()
 
       post =
         create_post!(author, %{


### PR DESCRIPTION
A member's profile picture has lived in two places since #2013: four columns on
the member row, and a row in the shared `images` table. Only the columns were
read, so the migration that drops them could not be scheduled: a migration may
drop only what the currently deployed release has stopped reading.

This moves the readers. Every avatar and cover URL, every display gate and every
maintenance pass now answers from `Vutuv.Images.member_image/2`. Both halves are
still written, so the release one step back keeps serving through the blue/green
switch, and there is no migration here.

No URL moves. Over the 1,679 avatars and 68 covers on a copy of production the
old and the new computation produce the same string, and a before/after run of
both releases against that copy served the same 43 URLs and byte-identical files,
actor documents and `avatar.jpg` included. A frozen picture is now hidden by
`frozen_at` rather than by the cleared columns.

Where: `Vutuv.Images`, `Vutuv.Uploads`, `Vutuv.Avatar` / `Vutuv.Cover`.

Closes #2027

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01UGPe7bHVS11M1W7fNehSku

<!-- closing-note #2027 -->
Every avatar and cover URL is now built from the picture's own row rather than
from the four columns on the member row, so the deploy after this one can drop
them; both copies are still written, because the release one step back is still
serving from the columns while the blue/green switch runs. The row also became
the off switch a copyright freeze uses, which is what let the freeze stop
depending on those columns being cleared. What I left out is the cut itself and
the write half: `Vutuv.Images.Backfill` still reads both sides on purpose, since
comparing them is what it is for.

*An AI agent wrote this text in my name. I know that is problematic.*
