### PR TITLE
A job posting's picture becomes a row in the shared images table

### DIFF
--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -691,26 +691,30 @@ Run on the server, against the release:
   cannot re-derive them; this is their equivalent after an upgrade that
   changes the cover size. Needs outbound network and `FETCH_BOOK_METADATA=true`,
   and paces itself (3s per cover) to stay inside Open Library's rate limit.
-- `bin/vutuv eval "Vutuv.Release.backfill_image_rows()"` — brings every profile
-  picture and cover uploaded before the shared `images` table into it, and
-  corrects any row that disagrees with the member's own columns. Moves no file
-  and changes no URL, so it is safe while the app serves traffic; safe to run
-  again if it is interrupted (a deploy stopping the slot mid-run leaves every
-  member it reached already correct). The release that moved every avatar and
-  cover URL onto those rows (issue #2027) does **not** require it — a picture
-  with no row is still served from the member's own columns — but run it before
-  the upgrade after that one, which removes that fallback. Until it is green, a
-  picture with no row cannot be reported on its own; the profile's Report
-  covers it meanwhile.
-- `bin/vutuv eval "Vutuv.Release.check_image_rows()"` — counts every member
-  picture against its row and against its file on disk, writing nothing. It
-  prints one line per kind, names the members behind each mismatch, and
-  **fails the command** when anything is outstanding, so a deploy script can
-  stand on its exit status. A picture whose file is missing is the one class
-  the backfill cannot repair. This is the gate on the later upgrade that
-  removes the member row's own image columns — do not take that upgrade with a
-  mismatch outstanding. `mix vutuv.images.backfill --check` is the same check
-  in a source checkout, and a plain `mix vutuv.images.backfill` ends with it.
+- `bin/vutuv eval "Vutuv.Release.backfill_image_rows()"` — brings every picture
+  uploaded before the shared `images` table into it, and corrects any row that
+  disagrees with the picture's own columns. Moves no file and changes no URL,
+  so it is safe while the app serves traffic; safe to run again if it is
+  interrupted (a deploy stopping the slot mid-run leaves every picture it
+  reached already correct). It covers profile pictures and covers, and the
+  kinds that still keep a table of their own — a job-posting picture since the
+  release that added `--only job_posting_image`. The release that moved every
+  avatar and cover URL onto those rows (issue #2027) does **not** require it —
+  a picture with no row is still served from the member's own columns — but run
+  it before the upgrade after that one, which removes that fallback. Until it
+  is green, a picture with no row cannot be reported on its own; the profile's
+  Report covers it meanwhile.
+- `bin/vutuv eval "Vutuv.Release.check_image_rows()"` — counts every picture
+  against its row and against its file on disk, writing nothing. It prints one
+  line per kind, names the pictures behind each mismatch, and **fails the
+  command** when anything is outstanding, so a deploy script can stand on its
+  exit status. A picture whose file is missing is the one class the backfill
+  cannot repair. This is the gate on the later upgrade that removes the member
+  row's own image columns, and on each upgrade that retires one of the older
+  per-kind image tables — do not take those with a mismatch outstanding.
+  `mix vutuv.images.backfill --check` is the same check in a source checkout,
+  and a plain `mix vutuv.images.backfill` ends with it. Both take
+  `--only <kind>` / `only: "<kind>"` to look at one kind alone.
 - `bin/vutuv eval 'Vutuv.Release.promote_admin("handle-or-email")'` — grants
   admin rights.
 

--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -325,9 +325,25 @@ no half-pair, and the second run created the other 1,438 and corrected none).
 `from: "<user id>"` resumes from a progress line instead of re-reading the
 table.
 
+Since #2054 the same two commands cover the gallery kinds as well.
+`Vutuv.Images.Backfill` has exactly two shapes — `%{cols: …}`, the truth in
+columns on a parent row joined by a pointer, and `%{gallery: …}`, the truth in
+a row of the picture's own joined by its token — and everything around them
+(the keyset walk, the classes, the repair, the sample, the printing, both
+operator paths) is shared. A gallery source builds itself from
+`Vutuv.Images.mirror_source/1`, so adding a kind touches nothing in the
+backfill at all; its repair is the same `mirror/2` upsert the request path
+writes, so create and correct are one statement and need no transaction; and
+it reports no `missing_pointer`, which the report leaves out rather than
+printing as a zero. The one thing to check when the next kind arrives is the
+store's `version_path/2` signature: `Vutuv.PostImageStore` and
+`Vutuv.JobPostingImageStore` take the row, `Vutuv.OrganizationImageStore` takes
+the token, and `Vutuv.Moderation.ImageSubjects.image_path_arg/2` is the adapter
+that already knows.
+
 `Backfill.check/1` (`mix vutuv.images.backfill --check`, or
 `bin/vutuv eval "Vutuv.Release.check_image_rows()"`) is the gate before the
-cut: it counts every member picture against its row *and* against its file on
+cut: it counts every picture against its row *and* against its file on
 disk — the quarantine tree while the picture is `"pending"`, the served tree
 otherwise — prints one line per kind plus the members behind each class of
 mismatch, and **fails the command** when anything is outstanding. Both of
@@ -396,10 +412,115 @@ permission, and the only off switch is moving the bytes out of that tree —
 the quarantine tree the AI gate already uses
 (`Vutuv.Uploads.quarantine_dir/1`), which nginx has no location for. `:proxy`
 means every byte goes through a controller that authorizes the reader first,
-so the row is the off switch. Avatars and covers are `:static`; the kinds
-#2015 brings are mostly `:proxy`. It raises for a kind nobody has declared,
-because a picture that inherits a default is one nobody knows how to take
-offline.
+so the row is the off switch. Avatars and covers are `:static`, a job-posting
+picture is `:proxy`; the remaining kinds #2015 brings are mostly `:proxy` too.
+It raises for a kind nobody has declared, because a picture that inherits a
+default is one nobody knows how to take offline.
+
+### The gallery kinds (issue #2015)
+
+A post photo, an organization image, a job-posting picture and a review cover
+each kept a table and an uploader of their own, so the `image` report type and
+the freeze knew one kind only. They move in one release per kind, smallest
+first — a **job-posting picture** went first (#2054) precisely to settle the
+shape.
+
+**Three of the four are the same shape; the review cover is not.** A post
+photo, an organization image and a job-posting picture each have a row of their
+own with a `token`, so they move as *gallery* pictures, below. A review's cover
+is `cover` / `cover_status` / `cover_moderation` **columns on the review row**
+with no token and no table of its own (`Vutuv.Posts.PostReview`), which is the
+profile picture's shape, not this one — #2055 lands on `member_columns/0`'s side
+of the fence, and `Vutuv.Images.Backfill`'s `%{cols: …}` source is what it
+extends. What #2052 and #2053 copy from here is everything below.
+
+**The token is the join key, not a pointer.** #2013 added
+`users.avatar_image_id` because a member row had no stable handle of its own;
+a gallery row has carried a `token` from the start, `images.token` has been
+unique across the whole table since #2013 for exactly this, and a gallery token
+is minted once and never re-minted (a re-upload is a different row). So the
+`images` row simply repeats the token, there is no reverse pointer to keep in
+step, and this kind has no `missing_pointer` class in the check. It also means
+the contract deploy drops the old table outright rather than a column at a
+time.
+
+**One kind's own column, six shared ones.** `images` gained `job_posting_id`
+(nullable — a posting image is uploaded before the posting is saved, and no
+other kind has a posting) plus `alt`, `position`, `width`, `height`,
+`content_type` and `size_bytes`, taken with the types `job_posting_images`
+holds them at (`alt` and `content_type` varchar(255), the rest plain
+`integer`). `post_images` and `organization_images` carry those same six under
+the same names, so #2052 and #2053 add their own parent column plus whatever
+they hold beyond the six — a post photo also brings `caption`, `crop`, seven
+EXIF columns and its download flags. The `images_profile_kind_has_owner` check
+constraint was **extended** rather than the nullable `user_id` widened, which is
+what #2013's migration asked for; the parent index is **partial**
+(`WHERE job_posting_id IS NOT NULL`), because every other kind's row is NULL
+there and the waste would multiply by four — Postgres proves `IS NOT NULL` from
+the cascade's strict `= $1` and uses it (measured: 16 kB against 48 kB).
+
+**The double write is one upsert and one delete.**
+`Vutuv.Images.mirror/2` takes one gallery row or a list of them and upserts on
+the token — one statement however many, so saving ten pictures costs one — and
+`Vutuv.Images.forget/2` deletes by token. `Vutuv.Images.write_mirrored/2` pairs
+a write with its mirror in one transaction, which is the door a context's own
+insert and update go through. `Vutuv.Images.mirror_source/1` is the **one**
+per-kind registry — the copied columns, the source schema, the store — so a
+kind cannot be mirrored on the request path and invisible to the backfill,
+whose check would otherwise print *"Safe to cut"* for a kind it never looked
+at. The names are identical on both sides, so the copy is a per-field
+`Map.fetch!/2`: a listed name the source lacks raises. The other direction — a
+column added to `job_posting_images` and never listed — nothing can see, so a
+drift test compares the schema against the list and fails the build.
+
+Every place that writes a job-posting picture goes through one of those: the
+upload and the alt edit (`write_mirrored/2`), the attach and detach on save,
+the pending sweep, and the AI gate's approve and reject in
+`Vutuv.Moderation.ImageSubjects` — which asks `Vutuv.Images.mirrored?/1` first,
+so the next kind's release is one entry in `Vutuv.Images` and nothing there. A
+deleted posting or member needs no call: `images.job_posting_id` and
+`images.user_id` cascade exactly as the gallery table's own columns do. **The
+`frozen_at` column is deliberately outside the upsert's replace list**, so an
+ordinary write can never lift a takedown.
+
+**What an interruption leaves.** The upload and the alt edit are atomic. The
+attach-and-prune on save is not, and never was — it runs after the save — so a
+slot dying between an attach and its mirror leaves a `mismatched_row` (the
+parent disagrees) and one between a prune and its `forget/2` leaves an
+`orphan_row`. Both are classes the backfill names and repairs; neither is
+invisible.
+
+**Nothing reads the new row yet, and that is the whole of the expand half.**
+Every URL is the one it was (`/job_posting_images/<token>/<version>.avif`),
+`VutuvWeb.JobPostingImageController` still authorizes off `job_posting_images`,
+and the edit form still renders from `posting.images` — so no render path pays
+a query for the mirror. The consequence to know: `Vutuv.Images.freeze/1`,
+`unfreeze/1` and `purge/1` **raise** for such a row rather than half-hiding
+it, and `Vutuv.Moderation` refuses a report that names one
+(`Vutuv.Images.takedown_ready?/1`), because a case opened on a row nothing
+consults would go through an uphold that takes nothing offline. A member
+reports the posting instead, which is all there was before the row existed.
+
+**Retiring `job_posting_images` is not this release.** It is the deploy after,
+and it has to remove the double write in the same step — the mirror, the
+`forget/2` calls, the `@gallery_sources` entry in the backfill and
+`Vutuv.Images.mirrored?/1`'s answer — because a migration may drop only what
+the currently deployed release has stopped using. Before it: run
+`mix vutuv.images.backfill --only job_posting_image` and read the check. The
+release in between is the one that moves the proxy, the form and the freeze
+onto the row, which is what makes the old table unread in the first place; and
+that release, not this one, is where the kind decides whether it wants a
+**bridge** the way `member_image/2` has one.
+
+**This kind needs no bridge.** #2027 needed one because it moved every reader
+onto the row in the same deploy as the row's first appearance, so a picture the
+backfill had not reached would have rendered as no picture at all. Here no
+reader has moved: a job-posting picture with no mirror row is served exactly as
+before, by its own table, so an installation that never runs the backfill sees
+nothing change. The bridge question belongs to the release that moves the
+readers, and it will have a simpler answer than #2027's — the old row *is* the
+picture, so the fallback is a lookup in the table it is about to leave rather
+than four columns read as a row.
 
 ### The takedown hold (issue #2012)
 

--- a/docs/architecture/jobs.md
+++ b/docs/architecture/jobs.md
@@ -38,6 +38,24 @@ through the authorizing `/job_posting_images/:token/:version` proxy, purged with
 the posting), and `job_posting_likes` / `job_posting_bookmarks` (the shared
 Engagement building block, both cascading on posting or user deletion).
 
+**`job_posting_images` is on its way out** (issues #2015 / #2054). Since that
+release every write to it also writes a row in the shared `images` table with
+`kind: "job_posting_image"`, joined on the `token` both carry, so a picture can
+eventually be taken offline on its own by the copyright freeze rather than only
+with the whole posting. Nothing reads the new row yet: the proxy, the edit form
+and the AI gate all still work off this table, and every URL is unchanged. The
+double write is `Vutuv.Images.write_mirrored/2` (the upload and the alt edit,
+each atomic with its own write), `Vutuv.Images.mirror/2` (the attach on save)
+and `Vutuv.Images.forget/2` (`delete_pending_image/1`, the prune on save,
+`sweep_pending_images/1`) — plus `Vutuv.Moderation.ImageSubjects` for the
+gate's verdict. A deleted posting or member needs no call
+(`images.job_posting_id` and `images.user_id` cascade). **If you add a column
+here, add it to `Vutuv.Images.mirror_source/1` and to `images` in a migration**,
+or the mirror will not carry it and the deploy that retires this table loses
+it; a drift test in `test/vutuv/images/job_posting_images_test.exs` compares
+the two and fails the build. The reasoning and the order of the remaining
+deploys are in [images.md](images.md).
+
 ## Lifecycle
 
 ```

--- a/lib/mix/tasks/vutuv.images.backfill.ex
+++ b/lib/mix/tasks/vutuv.images.backfill.ex
@@ -1,21 +1,26 @@
 defmodule Mix.Tasks.Vutuv.Images.Backfill do
-  @shortdoc "Brings every existing profile picture and cover into the images table"
+  @shortdoc "Brings every existing picture into the shared images table"
 
   @moduledoc """
-  Reconciles every member's profile picture and cover with its row in the
-  shared `images` table — the **contract** half of issue #2013. See
-  `Vutuv.Images.Backfill`.
+  Reconciles every picture with its row in the shared `images` table — the
+  **contract** half of issue #2013 for profile pictures and covers, and of
+  #2015 for the kinds that still keep a table of their own (a job-posting
+  picture since #2054). See `Vutuv.Images.Backfill`.
 
-      mix vutuv.images.backfill              # reconcile, then check
+      mix vutuv.images.backfill              # reconcile every kind, then check
       mix vutuv.images.backfill --dry-run    # report what would change
       mix vutuv.images.backfill --check      # check only, write nothing
       mix vutuv.images.backfill --only cover
+      mix vutuv.images.backfill --only job_posting_image
       mix vutuv.images.backfill --from 019f0000-0000-7000-8000-000000000000
 
-  Moves no file and changes no URL: the four member-row columns stay the source
-  of truth, and this copies what they say into a row. Idempotent — a run that
-  is interrupted (a deploy stopping the slot) is simply run again, and every
-  member it already reached reports `unchanged`.
+  Moves no file and changes no URL: what a picture already lives in stays the
+  source of truth (four member-row columns for a profile picture, its own row
+  for a gallery one), and this copies what it says into a row. Idempotent — a
+  run that is interrupted (a deploy stopping the slot) is simply run again, and
+  every picture it already reached reports `unchanged`. `--from` is a member id
+  for a profile kind and a gallery row id for the rest, so pair it with
+  `--only`.
 
   Every run ends with the check, which prints what it found and **fails the
   command only when something is outstanding** — that non-zero exit is the gate

--- a/lib/vutuv/images.ex
+++ b/lib/vutuv/images.ex
@@ -5,17 +5,28 @@ defmodule Vutuv.Images do
   and what is contract, and what a member row still holds meanwhile — is in
   `docs/architecture/images.md`.
 
-  The invariant this module carries: **this release writes both and reads the
-  row, falling back to the columns when there is no row yet.** A picture is a
-  row here *and* the four columns it has always lived in on the member row;
-  every write still fills both, and since #2027 the row is what every URL
-  builder and every display gate reads (`member_image/2`). Its third answer,
-  the **bridge**, reads those columns for a picture the backfill has not
-  reached, so taking this release before running `mix vutuv.images.backfill`
-  cannot blank every face on the site. Bridge and column writes go together, in
-  the deploy before the migration — which is the only order a blue/green switch
-  allows, since a migration may drop only what the *currently deployed* release
-  has stopped reading.
+  Two kinds of picture live here, at two different stages of the same move.
+
+  **A profile picture and cover: this release writes both and reads the row**,
+  falling back to the columns when there is no row yet. Such a picture is a row
+  here *and* the four columns it has always lived in on the member row; every
+  write still fills both, and since #2027 the row is what every URL builder and
+  every display gate reads (`member_image/2`). Its third answer, the **bridge**,
+  reads those columns for a picture the backfill has not reached, so taking this
+  release before running `mix vutuv.images.backfill` cannot blank every face on
+  the site. Bridge and column writes go together, in the deploy before the
+  migration — which is the only order a blue/green switch allows, since a
+  migration may drop only what the *currently deployed* release has stopped
+  reading.
+
+  **A gallery picture (#2015, a job-posting picture first in #2054): this
+  release writes both and reads the old table.** Its truth is still its own row
+  — the proxy, the form and the AI gate all work off that — and the row here is
+  a mirror, written by `mirror/2` and dropped by `forget/2`, joined on the
+  `token` both carry rather than by a pointer. Nothing here reads it yet, which
+  is why `freeze/1` raises for one and `takedown_ready?/1` answers false: a case
+  opened on a row nobody consults would take nothing offline. Moving the readers
+  across, and only then retiring the old table, is the deploy after.
 
   `serving/1` is the second thing here that is not a column: how a kind reaches
   a reader decides what its off switch is, and a kind nobody has declared
@@ -29,13 +40,70 @@ defmodule Vutuv.Images do
   alias Vutuv.Repo
   alias Vutuv.Uploads
 
-  # The kinds that have a row today. `Vutuv.Moderation.ImageScans` uses the
-  # same two strings for its scan kinds, so a scan row and an image row name
-  # the same thing. #2015 brings the rest.
-  @kinds ~w(avatar cover)
+  # The two kinds that live *only* here: a member's profile picture and cover,
+  # whose truth is still the four columns on the member row beside them.
+  # `Vutuv.Moderation.ImageScans` uses the same strings for its scan kinds, so
+  # a scan row and an image row name the same thing.
+  @profile_kinds ~w(avatar cover)
+
+  # Every kind that has a row in this table. Written out rather than derived
+  # from `@mirrored` below, because a contract release **deletes** an entry
+  # there — at which point that kind lives here and nowhere else, so dropping
+  # it from this list would be exactly backwards.
+  @kinds ~w(avatar cover job_posting_image)
+
+  # Of those, the kinds whose truth is still a table of their own, and
+  # everything about the copy: which columns it carries, where the source rows
+  # are, and the store that knows where their files are. One registry, so a
+  # kind cannot be mirrored by one half of the system and invisible to the
+  # other — `Vutuv.Images.Backfill` reads its whole source from here.
+  #
+  # The column names are identical on both sides, so the copy is a per-field
+  # `Map.fetch!/2` rather than a translation table: a name listed here that the
+  # source schema does not have raises instead of quietly writing nothing. The
+  # other direction — a column added to the source table and not to this list —
+  # nothing can see, so the drift test in `job_posting_images_test.exs`
+  # compares the two and fails the build on it.
+  #
+  # An entry goes when that kind's contract release retires its old table,
+  # together with the double write; `takedown_ready?/1` below flips with it.
+  # #2052 (post photos) and #2053 (organization images) add one entry each;
+  # #2055 (review covers) does **not** — a review's cover is columns on the
+  # review row with no token and no table, which is the `@profile_columns`
+  # shape below, not this one.
+  @mirrored %{
+    "job_posting_image" => %{
+      fields: ~w(
+        token user_id job_posting_id alt position width height content_type size_bytes moderation
+      )a,
+      schema: Vutuv.Jobs.JobPostingImage,
+      store: Vutuv.JobPostingImageStore,
+      # The version the backfill's file probe asks the store for.
+      preview: "thumb"
+    }
+  }
 
   @doc "The image kinds that live in this table today."
   def kinds, do: @kinds
+
+  @doc """
+  Whether this kind still lives in a table of its own that this release mirrors
+  into `images` — what the generic moderation paths ask before writing the
+  second copy, so a kind #2015 has not reached yet is passed over rather than
+  mirrored into nothing.
+  """
+  def mirrored?(kind) when is_binary(kind), do: is_map_key(@mirrored, kind)
+
+  @doc "The kinds `mirrored?/1` answers true for."
+  def mirrored_kinds, do: @mirrored |> Map.keys() |> Enum.sort()
+
+  @doc """
+  Everything the mirror of a kind is made of: the `:fields` it copies, the
+  `:schema` the source rows live in, the `:store` that owns their files and the
+  `:preview` version a file probe asks for. `Vutuv.Images.Backfill` builds its
+  whole source from this, so there is no second per-kind list to keep in step.
+  """
+  def mirror_source(kind) when is_map_key(@mirrored, kind), do: @mirrored[kind]
 
   @doc """
   How this kind reaches a reader.
@@ -52,7 +120,13 @@ defmodule Vutuv.Images do
   Raises for an undeclared kind: a picture that inherits a default is one
   nobody knows how to take offline.
   """
-  def serving(kind) when kind in @kinds, do: :static
+  def serving(kind) when kind in @profile_kinds, do: :static
+
+  # Every byte of a job-posting picture already goes through
+  # `VutuvWeb.JobPostingImageController`, which asks whether the reader may see
+  # the posting — so the row is the off switch, and this release changes
+  # nothing about how one is served.
+  def serving("job_posting_image"), do: :proxy
 
   def serving(kind),
     do:
@@ -367,7 +441,7 @@ defmodule Vutuv.Images do
   report that named the old picture should point at nothing rather than quietly
   at the new one.
   """
-  def put_profile_image(%User{} = user, kind, attrs) when kind in @kinds do
+  def put_profile_image(%User{} = user, kind, attrs) when kind in @profile_kinds do
     if frozen?(user.id, kind) do
       {:error, :frozen}
     else
@@ -399,12 +473,12 @@ defmodule Vutuv.Images do
   nothing to put back. Two index probes and one row read, on a path that spends
   hundreds of milliseconds encoding AVIFs.
   """
-  def frozen?(user_id, kind) when kind in @kinds do
+  def frozen?(user_id, kind) when kind in @profile_kinds do
     Repo.exists?(from(i in profile_query(user_id, kind), where: not is_nil(i.frozen_at)))
   end
 
   @doc "The member's row for this kind, or nil."
-  def profile_image(user_id, kind) when kind in @kinds,
+  def profile_image(user_id, kind) when kind in @profile_kinds,
     do: Repo.one(profile_query(user_id, kind))
 
   @doc """
@@ -417,7 +491,7 @@ defmodule Vutuv.Images do
   Ecto), so it is answered as "no such picture".
   """
   def mark_moderation(user_id, kind, fingerprint, state)
-      when kind in @kinds and is_binary(fingerprint) do
+      when kind in @profile_kinds and is_binary(fingerprint) do
     {count, _} =
       user_id
       |> profile_query(kind)
@@ -447,7 +521,7 @@ defmodule Vutuv.Images do
     do: discard(user_id, kind, fingerprint, moderation: "pending")
 
   defp discard(user_id, kind, fingerprint, filters)
-       when kind in @kinds and is_binary(fingerprint) do
+       when kind in @profile_kinds and is_binary(fingerprint) do
     query =
       profile_query(user_id, kind)
       |> where([i], i.fingerprint == ^fingerprint)
@@ -477,6 +551,134 @@ defmodule Vutuv.Images do
 
   def sync_fingerprint(nil, _fingerprint), do: :ok
 
+  ## The gallery kinds (issue #2015, this one #2054)
+
+  @doc """
+  Runs a write against a gallery picture's own table and mirrors the row it
+  produces, in one transaction — the door every double-write call site goes
+  through. `fun` returns what `Repo.insert/1` and `Repo.update/1` return, and
+  the caller meets the same `{:ok, row}` / `{:error, changeset}` it always did.
+
+  Together or not at all, for the reason the profile upload gives: by the time
+  a picture's row is written its files are already on disk, so a failure
+  between the two writes would leave a picture that exists everywhere except in
+  the table the copyright freeze reads.
+  """
+  def write_mirrored(kind, fun) when is_map_key(@mirrored, kind) and is_function(fun, 0) do
+    Repo.transaction(fn ->
+      case fun.() do
+        {:ok, row} ->
+          :ok = mirror(kind, row)
+          row
+
+        {:error, changeset} ->
+          Repo.rollback(changeset)
+      end
+    end)
+  end
+
+  @doc """
+  Writes (or rewrites) the row that stands beside a gallery picture's own row —
+  the **expand** half of moving a kind in here. Takes one source row or a list
+  of them, and copies the columns `mirror_source/1` names, which are spelled
+  the same on both sides.
+
+  **The join key is the `token`, not a pointer.** #2013 added
+  `users.avatar_image_id` because a member row had no stable handle of its own;
+  a gallery row has carried one from the start, `images.token` has been unique
+  across the whole table since #2013 for exactly this, and a gallery token is
+  minted once and never re-minted (a re-upload is a new row). So this is an
+  upsert on the token: it is idempotent, it is what makes the backfill and the
+  request path the same function, and this kind has no `missing_pointer` class
+  to reconcile.
+
+  One statement however many rows are handed over, so the editor saving ten
+  pictures costs one upsert rather than ten. `Repo.insert_all/3` autogenerates
+  neither the id nor the timestamps, so both are minted here — `Vutuv.UUIDv7`,
+  like every id in this system.
+
+  **`kind`, `id`, `inserted_at` and `frozen_at` are deliberately not in the
+  replace list.** The first three identify the row and the last is a takedown:
+  a mirror that runs on every ordinary write must never be able to lift one,
+  the same rule `put_profile_image/3` states for a profile picture.
+
+  The source row's own changeset is the validation, and this must not add a
+  stricter one: every column here has the type and the bound of the column it
+  copies (`alt` and `content_type` are varchar(255) on both sides), so a value
+  the source accepted fits, and a mirror that could refuse what the source
+  stored would turn a saved picture into a failed upload.
+  """
+  def mirror(kind, source_or_sources) when is_map_key(@mirrored, kind) do
+    fields = @mirrored[kind].fields
+    now = now()
+
+    entries =
+      for source <- List.wrap(source_or_sources) do
+        fields
+        |> Map.new(&{&1, Map.fetch!(source, &1)})
+        |> Map.merge(%{
+          id: Vutuv.UUIDv7.generate(),
+          kind: kind,
+          inserted_at: now,
+          updated_at: now
+        })
+      end
+
+    Repo.insert_all(Image, entries,
+      on_conflict: {:replace, [:updated_at | fields -- [:token]]},
+      conflict_target: :token
+    )
+
+    :ok
+  end
+
+  @doc """
+  Forgets the rows behind these tokens — the other half of the double write,
+  called wherever the gallery's own row and its files are deleted (a discarded
+  upload, a picture the editor removed on save, the pending sweep, a rejected
+  scan). One statement, and a no-op for an empty list.
+
+  A posting or a member that is deleted needs no call: `images.job_posting_id`
+  and `images.user_id` both cascade, exactly as the gallery table's own columns
+  do.
+  """
+  def forget(_kind, []), do: :ok
+
+  def forget(kind, tokens) when is_map_key(@mirrored, kind) and is_list(tokens) do
+    Repo.delete_all(from(i in Image, where: i.kind == ^kind and i.token in ^tokens))
+    :ok
+  end
+
+  @doc """
+  Whether a copyright case can act on this picture at all — what
+  `Vutuv.Moderation` asks before letting a report name it.
+
+  A gallery kind that has only just arrived here (#2054 and its siblings ship
+  the **expand** half: the row exists, every URL and every gate still reads the
+  old table) has no takedown path yet, and `freeze/1` below has no clause for
+  it. Answering "yes" would open a case whose uphold raises, so a report is
+  refused until the kind's own contract release wires the freeze — which is all
+  there was before the row existed.
+
+  Derived from `mirrored?/1` rather than listed a second time, so the two
+  cannot drift: "this picture's truth is still elsewhere" and "nothing here can
+  take it offline" are one fact, and the contract release that deletes the
+  mirror entry flips both at once.
+  """
+  def takedown_ready?(%Image{kind: kind}), do: kind in @kinds and not mirrored?(kind)
+
+  # A kind whose row exists but whose freeze does not. Loud rather than
+  # half-done: the alternative is a stamped `frozen_at` no reader consults and
+  # files nothing moved, which reads from the case page exactly like a
+  # completed takedown.
+  defp no_takedown_path!(%Image{kind: kind}, action) do
+    raise ArgumentError, """
+    cannot #{action} an image of kind #{inspect(kind)}: this release mirrors it \
+    into the images table but no reader consults the row yet, so nothing would \
+    go offline. Wire the kind's freeze before letting a case reach it.\
+    """
+  end
+
   ## The copyright freeze (issue #2012)
 
   @doc """
@@ -501,7 +703,7 @@ defmodule Vutuv.Images do
   already invisible and a job `reconcile_holds/0` finishes. The other order
   would leave files in a hold that nothing knows to bring back.
   """
-  def freeze(%Image{} = image) do
+  def freeze(%Image{kind: kind} = image) when kind in @profile_kinds do
     # `is_nil(frozen_at)` so a second pass — `reconcile_holds/0` finishing an
     # interrupted move — re-asserts the freeze without moving the moment it
     # happened, which is what the case and the statement of reasons quote.
@@ -517,6 +719,8 @@ defmodule Vutuv.Images do
 
     :ok
   end
+
+  def freeze(%Image{} = image), do: no_takedown_path!(image, "freeze")
 
   @doc """
   Puts a frozen picture back exactly where it was: every file returns to the
@@ -534,7 +738,7 @@ defmodule Vutuv.Images do
   only once the member row names the files again, so a half-finished restore is
   still a hold for `reconcile_holds/0` to find.
   """
-  def unfreeze(%Image{} = image) do
+  def unfreeze(%Image{kind: kind} = image) when kind in @profile_kinds do
     {_count, _} =
       Repo.update_all(from(i in Image, where: i.id == ^image.id),
         set: [frozen_at: nil, updated_at: now()]
@@ -552,6 +756,8 @@ defmodule Vutuv.Images do
     :ok
   end
 
+  def unfreeze(%Image{} = image), do: no_takedown_path!(image, "unfreeze")
+
   @doc """
   Deletes this picture for good — every derived version, the private original
   and the held copies — and forgets the row. What an upheld copyright case does,
@@ -561,7 +767,7 @@ defmodule Vutuv.Images do
   nothing points at (which `reconcile_holds/0` collects), never a member row
   naming files that are gone.
   """
-  def purge(%Image{} = image) do
+  def purge(%Image{kind: kind} = image) when kind in @profile_kinds do
     case owner(image) do
       %User{} = user ->
         config = @profile_columns[image.kind]
@@ -578,6 +784,8 @@ defmodule Vutuv.Images do
     Uploads.purge_hold(image.id)
     :ok
   end
+
+  def purge(%Image{} = image), do: no_takedown_path!(image, "purge")
 
   @doc """
   Finishes every move a dying slot left half-done, in both directions — the

--- a/lib/vutuv/images/backfill.ex
+++ b/lib/vutuv/images/backfill.ex
@@ -1,14 +1,16 @@
 defmodule Vutuv.Images.Backfill do
   @moduledoc """
-  Brings every profile picture and cover that existed before the shared
-  `images` table into it — the **contract** half of issue #2013, in the same
+  Brings every picture that existed before the shared `images` table into it —
+  the **contract** half of issue #2013 for a profile picture and cover, and of
+  #2015 for the kinds that still keep a table of their own — in the same
   expand/contract shape the fingerprint migration used
   (`Vutuv.Uploads.Regenerator` expand, `Vutuv.Uploads.LegacySweeper` contract).
 
-  It **moves no file and changes no URL.** The four member-row columns stay the
-  source of truth every URL builder and every display gate reads; this only
-  copies what they say into a row and points the member row at it, so the
-  previous release keeps serving unchanged through the whole deploy window.
+  It **moves no file and changes no URL.** Whatever a picture already lives in
+  stays the source of truth every URL builder and every display gate reads —
+  four member-row columns for a profile picture, its own gallery row for the
+  rest — and this only copies what that says into a row, so the previous
+  release keeps serving unchanged through the whole deploy window.
 
   ## Reconcile, not insert-where-missing
 
@@ -27,33 +29,60 @@ defmodule Vutuv.Images.Backfill do
   a row" and "there is a picture" are the same statement (the same reason
   `Vutuv.Images.discard_profile_image/3` deletes rather than blanks).
 
-  `classify/3` is what decides which of those a member is, and `run/1` and
+  `classify/3` is what decides which of those a picture is, and `run/1` and
   `check/1` both go through it — otherwise the gate would be answering a
   slightly different question from the repair it gates.
 
   ## Interrupted halfway
 
   Nothing here is a queue and nothing holds state in memory. Work is a keyset
-  scan over `users.id` with **one transaction per member**, and each member's
-  outcome depends only on that member's own columns — so a run killed
-  mid-flight (a deploy stopping the slot, `Ctrl-C`) leaves every member it
-  reached already correct and every member it did not reach exactly as before.
-  **Simply run it again**: the members already done cost no write and report
-  `unchanged`. `from: "<user id>"` picks up where a log line left off when
+  scan over the source table's `id` with **one transaction per picture**, and
+  each picture's outcome depends only on its own columns — so a run killed
+  mid-flight (a deploy stopping the slot, `Ctrl-C`) leaves every picture it
+  reached already correct and every picture it did not reach exactly as before.
+  **Simply run it again**: the ones already done cost no write and report
+  `unchanged`. `from: "<id>"` picks up where a log line left off when
   re-reading the whole table is not wanted, and `check/1` — which reads no
   state the run holds — is what says whether anything is still outstanding.
 
-  Per member rather than per batch on purpose: one bad row then fails alone and
-  the run carries on. It is a one-shot job over the pictures an installation
-  has (1,747 on vutuv.de), so the writes are not batched and no index is added
-  for it; the reads are `@batch` members at a time.
+  Per picture rather than per batch on purpose: one bad row then fails alone
+  and the run carries on. It is a one-shot job over the pictures an
+  installation has (1,747 on vutuv.de), so the writes are not batched and no
+  index is added for it; the reads are `@batch` at a time.
 
   ## The check before the cut
 
-  `check/1` counts every member picture against its row *and* against its file
-  on disk, and answers `ok?: false` with a bounded sample of the member ids
-  behind each class of mismatch. That is the gate on the deploy that drops the
-  columns: run it, read it, and only cut when it is green.
+  `check/1` counts every picture against its row *and* against its file on
+  disk, and answers `ok?: false` with a bounded sample of the ids behind each
+  class of mismatch. That is the gate on the deploy that drops the columns (or
+  retires a gallery kind's table): run it, read it, and only cut when it is
+  green.
+
+  ## Two shapes, one machine (issue #2015)
+
+  `source/1` is the only per-kind thing here, and it has two shapes:
+
+    * `%{cols: …}` — the truth is columns on a **parent row** (a member's
+      avatar and cover today; a review's cover when #2055 lands, which is this
+      shape and not the other one), joined by a pointer.
+    * `%{gallery: …}` — the truth is a **row of the picture's own**, joined by
+      the `token` both sides carry. A job-posting picture since #2054, post
+      photos and organization images to follow.
+
+  Everything around them is shared: the keyset walk, the class vocabulary, the
+  repair, the sample, the printing and both operator commands. A gallery kind
+  has no `missing_pointer` class — there is no pointer to lose — and a source
+  names the classes it can produce, so the report never prints a zero for a
+  class that kind cannot have.
+
+  **A gallery kind adds nothing here at all**: `source/1` builds itself from
+  `Vutuv.Images.mirror_source/1`, which is the one registry, so a kind cannot
+  be mirrored on the request path and invisible to this pass. The one thing to
+  check when the next kind arrives is the store's `version_path/2` signature —
+  `Vutuv.PostImageStore` and `Vutuv.JobPostingImageStore` take the row,
+  `Vutuv.OrganizationImageStore` takes the token, and
+  `Vutuv.Moderation.ImageSubjects.image_path_arg/2` is the adapter that already
+  knows.
   """
 
   import Ecto.Query
@@ -79,41 +108,55 @@ defmodule Vutuv.Images.Backfill do
   # never on presence.
   @copied [:file, :fingerprint, :crop, :moderation]
 
-  @classes [:missing_row, :mismatched_row, :missing_pointer, :missing_file, :orphan_row]
-
-  @doc "The profile-image kinds this backfill covers."
-  def kinds, do: Images.member_columns() |> Map.keys() |> Enum.sort()
+  # Which classes each shape can report. Written out rather than derived from
+  # each other, so the list reads as what a kind of that shape can be wrong in
+  # rather than as an arithmetic on another list.
+  @member_classes [:missing_row, :mismatched_row, :missing_pointer, :missing_file, :orphan_row]
+  @gallery_classes [:missing_row, :mismatched_row, :missing_file, :orphan_row]
 
   @doc """
-  Reconciles every member's picture with its row.
+  The image kinds this backfill covers: the profile kinds, plus the kinds whose
+  own table is still the truth (`Vutuv.Images.mirrored_kinds/0`).
 
-  Options: `only: "avatar" | "cover"`, `dry_run: true` (report, write nothing),
-  `from: "<user id>"` (resume the keyset scan above that id).
+  Derived, never listed here. A second per-kind list would let a kind be
+  mirrored on the request path and invisible to this one, and the failure is
+  the worst shape there is: the check would print *"Every picture has its row
+  and its file. Safe to cut."* for a kind it never looked at.
+  """
+  def kinds, do: Enum.sort(Map.keys(Images.member_columns()) ++ Images.mirrored_kinds())
+
+  @doc """
+  Reconciles every picture with its row.
+
+  Options: `only: "<kind>"` (one of `kinds/0`), `dry_run: true` (report, write
+  nothing), `from: "<id>"` (resume the keyset scan above that id — a member id
+  for a profile kind, a gallery row id for the rest).
 
   Returns `%{"avatar" => %{pictures: n, created: n, corrected: n, unchanged: n,
-  dropped: n, failed: n}, "cover" => …}`.
+  dropped: n, failed: n}, "cover" => …}`, one entry per kind.
   """
   def run(opts \\ []) do
     for kind <- selected_kinds(opts), into: %{}, do: {kind, run_kind(kind, opts)}
   end
 
   @doc """
-  Counts every member picture against its row and its file on disk, without
-  writing anything. Same `only:` option as `run/1`.
+  Counts every picture against its row and its file on disk, without writing
+  anything. Same `only:` option as `run/1`.
 
   Returns `%{kinds: %{"avatar" => …}, ok?: boolean}`, where each kind carries a
-  `%{count: n, sample: [user id]}` per class of mismatch:
+  `%{count: n, sample: [id]}` per class of mismatch it can have — a class the
+  kind cannot have is simply not a key:
 
     * `missing_row` — a picture with no row at all (the backfill has not run)
-    * `mismatched_row` — a row that disagrees with the member's own columns
-    * `missing_pointer` — a row the member row does not point at
-    * `orphan_row` — a row whose member has no picture of that kind any more
-      (sampled by row id, not member id)
-    * `missing_file` — the file the member row names is not on disk (in the
-      quarantine tree while the picture is `"pending"`, in the served tree
-      otherwise). The backfill cannot repair this one — it predates the table
-      and the bytes are simply gone — but the cut must not happen with it
-      unread.
+    * `mismatched_row` — a row that disagrees with the picture's own columns
+    * `missing_pointer` — a row the member row does not point at (profile
+      kinds only; a gallery picture is joined on its token and has no pointer)
+    * `orphan_row` — a row whose picture is gone (sampled by row id)
+    * `missing_file` — the file the row names is not on disk (in the quarantine
+      tree while a profile picture is `"pending"`, in the served tree
+      otherwise; a gallery picture's proxy serves straight out of its token
+      directory). The backfill cannot repair this one — the bytes are simply
+      gone — but the cut must not happen with it unread.
 
   It **prints what it found** on the way out, through the same log as `run/1`.
   Both operator paths (`mix vutuv.images.backfill --check` and `bin/vutuv eval
@@ -133,7 +176,7 @@ defmodule Vutuv.Images.Backfill do
   # that say what each one means.
   @labels [
     missing_row: "without a row",
-    mismatched_row: "disagreeing with the member row",
+    mismatched_row: "disagreeing with the source row",
     missing_pointer: "not pointed at",
     missing_file: "with no file on disk",
     orphan_row: "orphan row(s)"
@@ -141,22 +184,26 @@ defmodule Vutuv.Images.Backfill do
 
   defp report(%{kinds: kinds, ok?: ok?}) do
     for {kind, result} <- kinds do
+      # A result carries a key only for the classes its kind can have, which is
+      # what decides the line this prints.
+      labels = Enum.filter(@labels, fn {class, _label} -> Map.has_key?(result, class) end)
+
       log(
         "#{kind}: #{result.pictures} picture(s), #{result.rows} row(s) — " <>
-          Enum.map_join(@labels, ", ", fn {class, label} ->
+          Enum.map_join(labels, ", ", fn {class, label} ->
             "#{Map.fetch!(result, class).count} #{label}"
           end)
       )
 
-      for {class, label} <- @labels, Map.fetch!(result, class).count > 0 do
+      for {class, label} <- labels, Map.fetch!(result, class).count > 0 do
         log("  #{label}: #{sample_line(Map.fetch!(result, class))}")
       end
     end
 
     log(
       if ok?,
-        do: "Every member picture has its row and its file. Safe to cut.",
-        else: "MISMATCH — do not drop the member row's image columns yet."
+        do: "Every picture has its row and its file. Safe to cut.",
+        else: "MISMATCH — do not retire the old image columns or tables yet."
     )
   end
 
@@ -174,15 +221,48 @@ defmodule Vutuv.Images.Backfill do
     end
   end
 
-  ## What is wrong with this member, if anything
+  ## The source a kind is reconciled from
+
+  # One map per kind, naming where the pictures are and which classes that kind
+  # can report. Everything below dispatches on its shape — `%{cols: …}` for a
+  # profile picture whose truth is four member-row columns, `%{gallery: …}` for
+  # a picture whose truth is a row in a table of its own — and nothing below is
+  # written twice.
+  defp source(kind) do
+    if Images.mirrored?(kind) do
+      gallery = Images.mirror_source(kind)
+
+      %{
+        kind: kind,
+        classes: @gallery_classes,
+        # Which columns are compared. `token` is the join key, so it is equal
+        # by construction and comparing it would only ever say "no".
+        gallery: Map.put(gallery, :compared, gallery.fields -- [:token])
+      }
+    else
+      %{kind: kind, classes: @member_classes, cols: Images.member_columns(kind)}
+    end
+  end
+
+  ## What is wrong with this picture, if anything
 
   # The one place that decides. `run/1` repairs what this names and `check/1`
   # reports it, so a class added here can never be invisible to the gate.
-  defp classify(user, row, cols) do
+  defp classify(%{cols: cols}, user, row) do
     cond do
       is_nil(row) -> :missing_row
       drifted?(row, desired(user, cols)) -> :mismatched_row
       Map.get(user, cols.pointer) != row.id -> :missing_pointer
+      true -> :ok
+    end
+  end
+
+  # No pointer to lose: the token both rows carry is the join key, and the row
+  # was found by it.
+  defp classify(%{gallery: gallery}, gallery_row, row) do
+    cond do
+      is_nil(row) -> :missing_row
+      drifted?(row, Map.take(gallery_row, gallery.compared)) -> :mismatched_row
       true -> :ok
     end
   end
@@ -195,7 +275,7 @@ defmodule Vutuv.Images.Backfill do
   ## Reconcile
 
   defp run_kind(kind, opts) do
-    cols = Images.member_columns(kind)
+    source = source(kind)
     tally = %{pictures: 0, created: 0, corrected: 0, unchanged: 0, dropped: 0, failed: 0}
 
     log("#{kind}: reconciling#{if opts[:dry_run], do: " — dry run", else: ""}")
@@ -206,17 +286,16 @@ defmodule Vutuv.Images.Backfill do
 
     tally
     |> each_batch(
-      kind,
-      cols,
+      source,
       Keyword.get(opts, :from),
-      fn {user, row}, acc ->
+      fn {picture, row}, acc ->
         acc
         |> bump(:pictures)
-        |> bump(repair(classify(user, row, cols), user, row, kind, cols, opts))
+        |> bump(repair(source, classify(source, picture, row), picture, row, opts))
       end,
       on_batch
     )
-    |> drop_orphans(kind, cols, opts)
+    |> drop_orphans(source, opts)
     |> tap(fn t ->
       log(
         "#{kind}: #{t.pictures} picture(s) — #{t.created} row(s) created, " <>
@@ -226,23 +305,23 @@ defmodule Vutuv.Images.Backfill do
     end)
   end
 
-  # The keyset walk both halves share. One SELECT per batch carries the member
-  # and its row together, so a member that is already right costs no second
-  # statement.
-  defp each_batch(acc, kind, cols, cursor, fun, on_batch \\ fn _id -> :ok end) do
-    case Repo.all(batch_query(kind, cols, cursor)) do
+  # The keyset walk every kind and both halves share. One SELECT per batch
+  # carries the picture and its row together, so a picture that is already
+  # right costs no second statement.
+  defp each_batch(acc, source, cursor, fun, on_batch \\ fn _id -> :ok end) do
+    case Repo.all(batch_query(source, cursor)) do
       [] ->
         acc
 
       rows ->
         acc = Enum.reduce(rows, acc, fun)
-        {last_user, _row} = List.last(rows)
-        on_batch.(last_user.id)
-        each_batch(acc, kind, cols, last_user.id, fun, on_batch)
+        {last, _row} = List.last(rows)
+        on_batch.(last.id)
+        each_batch(acc, source, last.id, fun, on_batch)
     end
   end
 
-  defp batch_query(kind, cols, cursor) do
+  defp batch_query(%{kind: kind, cols: cols}, cursor) do
     query =
       from(u in User,
         left_join: i in Image,
@@ -256,21 +335,37 @@ defmodule Vutuv.Images.Backfill do
     if cursor, do: where(query, [u], u.id > ^cursor), else: query
   end
 
-  defp repair(:ok, _user, _row, _kind, _cols, _opts), do: :unchanged
+  # The join is on the token, which is unique in both tables — so this is the
+  # same one-SELECT-per-batch shape, and the gallery row it carries is exactly
+  # what `Vutuv.Images.mirror/2` takes.
+  defp batch_query(%{kind: kind, gallery: gallery}, cursor) do
+    query =
+      from(g in gallery.schema,
+        left_join: i in Image,
+        on: i.token == g.token and i.kind == ^kind,
+        order_by: [asc: g.id],
+        limit: @batch,
+        select: {g, i}
+      )
 
-  defp repair(verdict, user, row, kind, cols, opts) do
+    if cursor, do: where(query, [g], g.id > ^cursor), else: query
+  end
+
+  defp repair(_source, :ok, _picture, _row, _opts), do: :unchanged
+
+  defp repair(source, verdict, picture, row, opts) do
     outcome = if verdict == :missing_row, do: :created, else: :corrected
 
     if opts[:dry_run],
       do: outcome,
-      else: write(user, cols, outcome, fn -> mend(verdict, user, row, kind, cols) end)
+      else: write(source, picture, outcome, fn -> mend(source, verdict, picture, row) end)
   end
 
   # A create goes through `Images.put_profile_image/3`, the same function the
   # upload path uses: it mints the fresh token and carries the upsert against
   # the partial unique index, so a row an upload writes between this batch's
   # SELECT and this write converges instead of failing.
-  defp mend(:missing_row, user, _row, kind, cols) do
+  defp mend(%{kind: kind, cols: cols}, :missing_row, user, _row) do
     with {:ok, image} <- Images.put_profile_image(user, kind, desired(user, cols)),
          do: point_at(user, cols, image.id)
   end
@@ -282,7 +377,7 @@ defmodule Vutuv.Images.Backfill do
   # only, because a token names the bytes: a row corrected back to a different
   # file must not keep a handle that named the other one, and a row whose
   # moderation state alone drifted must not lose the handle it has.
-  defp mend(:mismatched_row, user, row, _kind, cols) do
+  defp mend(%{cols: cols}, :mismatched_row, user, row) do
     desired = desired(user, cols)
 
     with {:ok, image} <-
@@ -295,7 +390,18 @@ defmodule Vutuv.Images.Backfill do
 
   # The row is right and only the member row's pointer is not — the shape a
   # half-committed upload leaves behind.
-  defp mend(:missing_pointer, user, row, _kind, cols), do: point_at(user, cols, row.id)
+  defp mend(%{cols: cols}, :missing_pointer, user, row), do: point_at(user, cols, row.id)
+
+  # A gallery picture has one repair for both verdicts, and it is the same
+  # upsert the request path writes: `Vutuv.Images.mirror/2` keys on the token,
+  # so creating the row that was never written and correcting one that drifted
+  # are the same statement. The token is never re-minted here — for a gallery
+  # picture it is minted once at upload and a re-upload is a different row, so
+  # there is no "the bytes changed under the handle" case to answer.
+  defp mend(%{kind: kind, gallery: _}, verdict, gallery_row, _row)
+       when verdict in [:missing_row, :mismatched_row] do
+    Images.mirror(kind, gallery_row)
+  end
 
   # `token` is set programmatically, never cast, so the fresh one is put on the
   # changeset here rather than smuggled in through the attrs.
@@ -312,108 +418,138 @@ defmodule Vutuv.Images.Backfill do
     :ok
   end
 
-  # Row and pointer move together or not at all, so an interrupted run can
-  # never leave the pair the upload path used to be able to leave. A member the
-  # database refuses is logged and counted, never fatal to the run.
-  defp write(user, cols, outcome, fun) do
-    result =
-      Repo.transaction(fn ->
-        case fun.() do
-          :ok -> :ok
-          {:error, reason} -> Repo.rollback(reason)
-        end
-      end)
-
-    case result do
-      {:ok, :ok} ->
-        outcome
-
-      {:error, reason} ->
-        log("  FAIL #{cols.file} #{user.id}: #{inspect(reason)}")
-        :failed
+  # A picture the database refuses is logged and counted, never fatal to the
+  # run.
+  defp write(source, picture, outcome, fun) do
+    case attempt(source, fun) do
+      :ok -> outcome
+      {:error, reason} -> failed(source, picture, reason)
     end
   rescue
-    exception ->
-      log("  FAIL #{cols.file} #{user.id}: #{inspect(exception)}")
-      :failed
+    exception -> failed(source, picture, exception)
   end
 
-  # A row whose member has no picture of that kind any more, deleted in one
-  # statement (`Vutuv.Images.discard_profile_image/3` is its single-row twin on
-  # the moderation path). The member row's pointer follows by itself
-  # (`on_delete: :nilify_all`).
-  defp drop_orphans(tally, kind, cols, opts) do
+  # A profile repair writes the row **and** the member row's pointer, so the two
+  # move together or not at all — that half-committed pair is the very thing
+  # this backfill exists to mend. A gallery repair is one idempotent upsert, so
+  # a transaction around it would be a BEGIN and a COMMIT buying nothing.
+  defp attempt(%{cols: _}, fun) do
+    case Repo.transaction(fn -> or_rollback(fun.()) end) do
+      {:ok, :ok} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp attempt(%{gallery: _}, fun), do: fun.()
+
+  defp or_rollback(:ok), do: :ok
+  defp or_rollback({:error, reason}), do: Repo.rollback(reason)
+
+  defp failed(source, picture, reason) do
+    log("  FAIL #{source.kind} #{picture.id}: #{inspect(reason)}")
+    :failed
+  end
+
+  # A row whose picture is gone, deleted in one statement
+  # (`Vutuv.Images.discard_profile_image/3` and `Vutuv.Images.forget/2` are its
+  # single-row twins on the request path). A member row's pointer follows by
+  # itself (`on_delete: :nilify_all`); a gallery row has no pointer to clear.
+  defp drop_orphans(tally, source, opts) do
     dropped =
       if opts[:dry_run] do
-        Repo.aggregate(orphan_query(kind, cols), :count)
+        Repo.aggregate(orphan_query(source), :count)
       else
-        {count, _} = Repo.delete_all(orphan_query(kind, cols))
+        {count, _} = Repo.delete_all(orphan_query(source))
         count
       end
 
     %{tally | dropped: tally.dropped + dropped}
   end
 
-  # Deletable as it stands: `delete_all` takes a join-free query, so the "has
-  # this member still got a picture" half is a correlated subquery.
-  defp orphan_query(kind, cols) do
+  # Deletable as it stands: `delete_all` takes a join-free query, so the "is
+  # there still a picture" half is a correlated subquery.
+  #
+  # A frozen picture is *meant* to look gone from the old side — that is how a
+  # copyright freeze hides a profile picture (#2012), by clearing the member
+  # row — and the row is the only record of what the case is about and what an
+  # unfreeze has to write back. So it is never an orphan, here or in the
+  # check's count.
+  defp orphan_query(%{kind: kind, cols: cols}) do
     ownerless =
       from(u in User,
         where: u.id == parent_as(:image).user_id and is_nil(field(u, ^cols.file))
       )
 
-    # A frozen picture is *meant* to have empty member columns — that is how a
-    # copyright freeze hides it (#2012) — and the row is the only record of
-    # what the case is about and what an unfreeze has to write back. So it is
-    # not an orphan, here or in the check's count.
     from(i in Image,
       as: :image,
       where: i.kind == ^kind and is_nil(i.frozen_at) and exists(subquery(ownerless))
     )
   end
 
+  defp orphan_query(%{kind: kind, gallery: gallery}) do
+    still_there = from(g in gallery.schema, where: g.token == parent_as(:image).token)
+
+    from(i in Image,
+      as: :image,
+      where: i.kind == ^kind and is_nil(i.frozen_at) and not exists(subquery(still_there))
+    )
+  end
+
   ## Check
 
   defp check_kind(kind) do
-    cols = Images.member_columns(kind)
+    source = source(kind)
 
-    empty = %{
-      pictures: 0,
-      rows: Repo.aggregate(from(i in Image, where: i.kind == ^kind), :count),
-      missing_row: blank(),
-      mismatched_row: blank(),
-      missing_pointer: blank(),
-      missing_file: blank(),
-      orphan_row: orphan_class(kind, cols)
-    }
+    # Only the classes this kind can have, so `report/1` prints no zero for a
+    # class it cannot — a gallery picture has no pointer to lose, and a line
+    # saying "0 not pointed at" would invite somebody to go looking for one.
+    empty =
+      source.classes
+      |> Map.new(&{&1, blank()})
+      |> Map.merge(%{
+        pictures: 0,
+        rows: Repo.aggregate(from(i in Image, where: i.kind == ^kind), :count),
+        orphan_row: orphan_class(source)
+      })
 
     empty
-    |> each_batch(kind, cols, nil, fn {user, row}, acc ->
+    |> each_batch(source, nil, fn {picture, row}, acc ->
       acc
       |> Map.update!(:pictures, &(&1 + 1))
-      |> flag(classify(user, row, cols), user.id)
-      |> flag(file_verdict(user, row, kind), user.id)
+      |> flag(classify(source, picture, row), picture.id)
+      |> flag(file_verdict(source, picture, row), picture.id)
     end)
-    |> finish_check()
+    |> finish_check(source)
   end
 
-  # A member with no row yet is already named as `:missing_row`, and since
-  # #2027 the path is resolved from that row — so asking here too would report
-  # every un-backfilled member twice and call the second reading a missing file.
-  defp file_verdict(_user, nil, _kind), do: :ok
+  # A picture with no row yet is already named as `:missing_row`, and since
+  # #2027 the profile path is resolved from that row — so asking here too would
+  # report every un-backfilled member twice and call the second reading a
+  # missing file.
+  defp file_verdict(_source, _picture, nil), do: :ok
 
-  defp file_verdict(user, row, kind) do
+  defp file_verdict(%{kind: kind, cols: cols}, user, row) do
     # The row is in hand, so hand it over as the preload `member_image/2` would
     # otherwise look up: one query per member over the whole table, for nothing.
-    user = Map.put(user, Images.member_columns(kind).assoc, row)
+    user = Map.put(user, cols.assoc, row)
 
     if is_nil(Images.stored_path(user, kind)), do: :missing_file, else: :ok
   end
 
+  # A gallery picture is served through its own proxy off its own token, so the
+  # store answers straight from the row already in hand. No quarantine branch:
+  # these kinds never had one — the proxy is what holds a picture back while
+  # the AI gate runs, not a second tree.
+  defp file_verdict(%{gallery: gallery}, gallery_row, _row) do
+    if is_nil(gallery.store.version_path(gallery_row, gallery.preview)),
+      do: :missing_file,
+      else: :ok
+  end
+
   defp blank, do: %{count: 0, sample: []}
 
-  defp orphan_class(kind, cols) do
-    query = orphan_query(kind, cols)
+  defp orphan_class(source) do
+    query = orphan_query(source)
 
     %{
       count: Repo.aggregate(query, :count),
@@ -429,8 +565,8 @@ defmodule Vutuv.Images.Backfill do
     end)
   end
 
-  defp finish_check(result),
-    do: Map.put(result, :ok?, Enum.all?(@classes, &(Map.fetch!(result, &1).count == 0)))
+  defp finish_check(result, source),
+    do: Map.put(result, :ok?, Enum.all?(source.classes, &(Map.fetch!(result, &1).count == 0)))
 
   ## Shared
 

--- a/lib/vutuv/images/image.ex
+++ b/lib/vutuv/images/image.ex
@@ -17,6 +17,12 @@ defmodule Vutuv.Images.Image do
     field(:kind, :string)
     belongs_to(:user, Vutuv.Accounts.User)
 
+    # The parent a gallery picture belongs to. Nil for a profile picture, and
+    # nil for a posting image whose posting has not been saved yet. One column
+    # per parent kind, as #2013's migration asked for; the post and the
+    # organization add theirs when they move (#2052, #2053).
+    belongs_to(:job_posting, Vutuv.Jobs.JobPosting)
+
     field(:token, :string)
 
     # The upload's own file name, the content fingerprint baked into the
@@ -32,6 +38,17 @@ defmodule Vutuv.Images.Image do
 
     # Set by a copyright freeze (#2012). A freeze moves files, never deletes.
     field(:frozen_at, :naive_datetime)
+
+    # What a gallery row holds besides the above, copied column for column from
+    # the table it mirrors (`job_posting_images` today; `post_images` and
+    # `organization_images` carry the same six under the same names). Nil for a
+    # profile picture, which has none of them.
+    field(:alt, :string)
+    field(:position, :integer)
+    field(:width, :integer)
+    field(:height, :integer)
+    field(:content_type, :string)
+    field(:size_bytes, :integer)
 
     timestamps()
   end

--- a/lib/vutuv/jobs.ex
+++ b/lib/vutuv/jobs.ex
@@ -37,6 +37,7 @@ defmodule Vutuv.Jobs do
   alias Vutuv.Countries
   alias Vutuv.Engagement
   alias Vutuv.Geo
+  alias Vutuv.Images
   alias Vutuv.Jobs.Exclusions
   alias Vutuv.Jobs.JobPosting
   alias Vutuv.Jobs.JobPostingBookmark
@@ -587,6 +588,12 @@ defmodule Vutuv.Jobs do
 
   # --- images (post_images pattern) -----------------------------------------
 
+  # This gallery's name in the shared `images` table, in `Vutuv.Images.kinds/0`
+  # and in `Vutuv.Moderation.ImageScans` — one string for all three. Since
+  # #2054 every write below keeps a row there in step with the row here; the
+  # deploy that retires this table retires the double write with it.
+  @image_kind "job_posting_image"
+
   @doc "Creates a pending image (job_posting_id nil) from an upload, or `{:error, reason}`."
   def create_pending_image(%User{} = user, path, filename) do
     size = File.stat!(path).size
@@ -605,28 +612,40 @@ defmodule Vutuv.Jobs do
 
   # Fresh images start in AI-moderation limbo (owner-only, placecard for
   # everyone else) until the scan releases or deletes them.
+  #
+  # `Images.write_mirrored/2` writes the row here and its mirror in the shared
+  # `images` table in one transaction (issue #2054), and hands back exactly
+  # what `Repo.insert/1` would have.
   defp insert_scanned_image(user, token, meta) do
     insert =
-      %JobPostingImage{
-        user_id: user.id,
-        token: token,
-        moderation: ImageScans.initial_state()
-      }
-      |> Ecto.Changeset.change(meta)
-      |> Repo.insert()
+      Images.write_mirrored(@image_kind, fn ->
+        %JobPostingImage{
+          user_id: user.id,
+          token: token,
+          moderation: ImageScans.initial_state()
+        }
+        |> Ecto.Changeset.change(meta)
+        |> Repo.insert()
+      end)
 
     with {:ok, image} <- insert do
-      ImageScans.enqueue("job_posting_image", image.id, user.id)
+      ImageScans.enqueue(@image_kind, image.id, user.id)
       {:ok, image}
     end
   end
 
   def update_image_alt(%JobPostingImage{} = image, alt) do
-    image |> JobPostingImage.alt_changeset(%{"alt" => alt}) |> Repo.update()
+    Images.write_mirrored(@image_kind, fn ->
+      image |> JobPostingImage.alt_changeset(%{"alt" => alt}) |> Repo.update()
+    end)
   end
 
+  # Row, mirror, files — in that order, so an interruption can only ever leave
+  # something behind that a sweep collects (an orphan mirror row, then orphan
+  # files), never a row naming bytes that are gone.
   def delete_pending_image(%JobPostingImage{job_posting_id: nil, token: token} = image) do
     Repo.delete(image)
+    :ok = Images.forget(@image_kind, [token])
     Vutuv.JobPostingImageStore.delete(token)
     :ok
   end
@@ -652,11 +671,25 @@ defmodule Vutuv.Jobs do
 
   # Attach the chosen pending images to the posting; delete + purge those the
   # editor removed.
+  #
+  # This runs after the save rather than inside it, as it always has, so a slot
+  # dying mid-way is a real case — and each half leaves something the backfill
+  # names rather than something invisible: an attach that never reached its
+  # mirror is a `mismatched_row` (the parent disagrees), a prune that never
+  # reached `forget/2` is an `orphan_row` (no picture behind the token).
+  # `mix vutuv.images.backfill --only job_posting_image` repairs both.
   defp attach_images(%JobPosting{} = posting, %User{id: user_id}, keep_ids) do
-    from(i in JobPostingImage,
-      where: i.id in ^keep_ids and i.user_id == ^user_id and is_nil(i.job_posting_id)
-    )
-    |> Repo.update_all(set: [job_posting_id: posting.id])
+    # RETURNING the attached rows, so the mirror learns the new parent from the
+    # same statement rather than reading them back: ten pictures still cost one
+    # UPDATE and one upsert, never one of each per picture.
+    {_count, attached} =
+      from(i in JobPostingImage,
+        where: i.id in ^keep_ids and i.user_id == ^user_id and is_nil(i.job_posting_id),
+        select: i
+      )
+      |> Repo.update_all(set: [job_posting_id: posting.id])
+
+    :ok = Images.mirror(@image_kind, attached)
 
     # RETURNING the tokens in the same DELETE, so the predicate is written once
     # and there is no separate SELECT (Enum.each over [] is a no-op).
@@ -667,6 +700,7 @@ defmodule Vutuv.Jobs do
       )
       |> Repo.delete_all()
 
+    :ok = Images.forget(@image_kind, tokens)
     Enum.each(tokens, &Vutuv.JobPostingImageStore.delete/1)
     :ok
   end
@@ -682,6 +716,7 @@ defmodule Vutuv.Jobs do
       )
       |> Repo.delete_all()
 
+    :ok = Images.forget(@image_kind, tokens)
     Enum.each(tokens, &Vutuv.JobPostingImageStore.delete/1)
     count
   end
@@ -786,6 +821,11 @@ defmodule Vutuv.Jobs do
   @doc """
   Deletes a posting: purges its image files (the DB cascade drops the rows and
   every like/bookmark) and settles any open moderation case.
+
+  The mirror rows in `images` go with the same cascade — `images.job_posting_id`
+  carries the posting's `on_delete: :delete_all` exactly as this table's own
+  column does — so there is nothing to forget by hand here, and the same is
+  true of `Vutuv.Accounts.delete_user/1` through `images.user_id`.
   """
   def delete_job_posting(%JobPosting{} = posting) do
     tokens = image_tokens(posting.id)

--- a/lib/vutuv/moderation.ex
+++ b/lib/vutuv/moderation.ex
@@ -2165,7 +2165,14 @@ defmodule Vutuv.Moderation do
   defp reportable_by?(_reporter, %Organization{}), do: true
   # A profile picture is as public as the profile it sits on, and a rights
   # holder reporting one is exactly the stranger this type exists for.
-  defp reportable_by?(_reporter, %Image{}), do: true
+  #
+  # Only a picture whose takedown is actually wired, though. #2015 moves the
+  # gallery kinds into `images` one release at a time, and the expand half
+  # gives them a row before `Vutuv.Images.freeze/1` has a clause for them — a
+  # case opened on such a row would raise the moment an admin upheld it. Those
+  # keep the affordance they had before the row existed: reporting the post,
+  # the posting or the page the picture sits on.
+  defp reportable_by?(_reporter, %Image{} = image), do: Images.takedown_ready?(image)
 
   defp reportable_by?(reporter, %JobPosting{} = posting),
     do: Vutuv.Jobs.visible_to?(posting, reporter)

--- a/lib/vutuv/moderation/image_subjects.ex
+++ b/lib/vutuv/moderation/image_subjects.ex
@@ -361,17 +361,30 @@ defmodule Vutuv.Moderation.ImageSubjects do
     drop_pixelated(config, scan.subject_id)
 
     flipped =
-      from(i in config.schema, where: i.id == ^scan.subject_id and i.moderation == "pending")
+      from(i in config.schema,
+        where: i.id == ^scan.subject_id and i.moderation == "pending",
+        # The released row rides back with the write, the way the screenshot
+        # branch below already takes it: the mirror in the shared `images`
+        # table needs the token, and reading the row again for it would be a
+        # second statement per verdict.
+        select: i
+      )
       |> Repo.update_all(set: [moderation: "approved"])
 
     case flipped do
-      {1, _} ->
+      {1, [image]} ->
         # A released organization logo also flips the `organizations.logo`
         # pointer (the old logo kept showing during limbo).
         if kind == "organization_image" do
           {:ok, _organization} =
             Vutuv.Organizations.release_logo(Repo.get!(OrganizationImage, scan.subject_id))
         end
+
+        # The AI gate's half of the double write #2015 is doing one kind at a
+        # time: a kind that has moved into the shared `images` table keeps its
+        # row in step here, one that has not is passed over. The next kind's
+        # release is a line in `Vutuv.Images` and nothing here.
+        if Images.mirrored?(kind), do: :ok = Images.mirror(kind, image)
 
         settle_post_federation(kind, scan.subject_id)
         broadcast(scan, :approved)
@@ -574,6 +587,7 @@ defmodule Vutuv.Moderation.ImageSubjects do
       image ->
         config.store.delete(image.token)
         Repo.delete(image, allow_stale: true)
+        if Images.mirrored?(kind), do: :ok = Images.forget(kind, [image.token])
         clear_gallery_references(kind, image)
         # A rejected picture settles the post just as an approved one does: it
         # federates now, without the picture, which is what vetting first means.

--- a/lib/vutuv/release.ex
+++ b/lib/vutuv/release.ex
@@ -130,15 +130,17 @@ defmodule Vutuv.Release do
   end
 
   @doc """
-  Brings every profile picture and cover uploaded before the shared `images`
-  table into it, and corrects any row that disagrees with the member's own
-  columns (see `Vutuv.Images.Backfill`). Moves no file and changes no URL, so
-  it is safe while the app serves traffic and safe to run again after an
-  interruption:
+  Brings every picture uploaded before the shared `images` table into it, and
+  corrects any row that disagrees with the picture's own columns (see
+  `Vutuv.Images.Backfill`). Covers profile pictures and covers (#2013/#2014)
+  and the kinds that still keep a table of their own — a job-posting picture
+  since #2054. Moves no file and changes no URL, so it is safe while the app
+  serves traffic and safe to run again after an interruption:
 
       bin/vutuv eval "Vutuv.Release.backfill_image_rows()"
       bin/vutuv eval "Vutuv.Release.backfill_image_rows(dry_run: true)"
       bin/vutuv eval "Vutuv.Release.backfill_image_rows(only: \\"cover\\")"
+      bin/vutuv eval "Vutuv.Release.backfill_image_rows(only: \\"job_posting_image\\")"
   """
   def backfill_image_rows(opts \\ []) do
     load_app()
@@ -152,9 +154,10 @@ defmodule Vutuv.Release do
   end
 
   @doc """
-  Counts every member picture against its row and its file on disk, writing
-  nothing, and prints what it found. The gate on the deploy that drops the
-  member row's four columns per kind:
+  Counts every picture against its row and its file on disk, writing nothing,
+  and prints what it found. The gate on the deploy that drops the member row's
+  four columns per kind, and on the one that retires a gallery kind's own
+  table:
 
       bin/vutuv eval "Vutuv.Release.check_image_rows()"
 

--- a/priv/repo/migrations/20260907170753_add_job_posting_images_to_images.exs
+++ b/priv/repo/migrations/20260907170753_add_job_posting_images_to_images.exs
@@ -1,0 +1,99 @@
+defmodule Vutuv.Repo.Migrations.AddJobPostingImagesToImages do
+  use Ecto.Migration
+
+  # The first of the four kinds #2015 moves into the shared `images` table
+  # (issue #2054), and the smallest — so the shape settled here is the one the
+  # post photo, the organization image and the review cover repeat.
+  #
+  # Expand half only: this takes nothing away and nothing reads the new
+  # columns, so the release serving traffic while it runs is unaffected. The
+  # release it ships with writes a row here beside every `job_posting_images`
+  # row; the deploy after that retires the old table together with the double
+  # write.
+  #
+  # **Column types are the ones the values are copied from**, read off
+  # `job_posting_images` rather than defaulted: `alt` and `content_type` are
+  # varchar(255) there, `position`, `width`, `height` and `size_bytes` are
+  # plain `integer` (a posting image is capped at 6 MB, so `size_bytes` needs
+  # no bigint), and `token` and `moderation` already exist here with exactly
+  # those types.
+  #
+  # There is deliberately **no reverse pointer** the way `users.avatar_image_id`
+  # is one. A member row had no stable handle of its own, so #2013 had to add
+  # one; a gallery row already carries a `token` that is unique in both tables
+  # and never re-minted, and `images.token` has been unique across the whole
+  # table since #2013 precisely so these kinds could move in on it. The token
+  # is therefore the join key, which also means this kind has no
+  # `missing_pointer` class to reconcile.
+  def up do
+    alter table(:images) do
+      # The parent posting. Nullable because a posting image is uploaded
+      # *before* the posting is saved (`job_posting_id` stays nil while the
+      # composer's gallery is pending, and `Jobs.sweep_pending_images/1`
+      # collects what is never attached), and because no other kind has one.
+      add(:job_posting_id, references(:job_postings, type: :binary_id, on_delete: :delete_all))
+
+      # The six columns a gallery row holds beside the ones this table already
+      # has. `post_images` and `organization_images` carry the same six under
+      # the same names, so the next two kinds add none of them — only their own
+      # parent column above.
+      add(:alt, :string)
+      add(:position, :integer)
+      add(:width, :integer)
+      add(:height, :integer)
+      add(:content_type, :string)
+      add(:size_bytes, :integer)
+    end
+
+    # The cascade's own lookup, for the same reason `images.user_id` is indexed:
+    # deleting a posting would otherwise scan a table that ends up holding every
+    # picture in the system. No query this release adds needs it — the mirror
+    # upserts on `token`, `forget/2` filters on `token`, and the backfill joins
+    # on `token`, all served by `images_token_index`.
+    #
+    # **Partial**, unlike `images.user_id`, because every other kind's row has a
+    # NULL here and the waste multiplies by four as #2015's remaining kinds add
+    # a parent column each. Postgres proves `IS NOT NULL` from the referential
+    # trigger's strict `job_posting_id = $1` and uses it: measured on a copy of
+    # the dev database with 4,163 image rows of which 1,216 carry a posting, the
+    # trigger takes a Bitmap Index Scan on this index, and it is 16 kB against
+    # 48 kB for the full one. The next kinds should copy this rather than
+    # `images.user_id`, which predates the question.
+    create(index(:images, [:job_posting_id], where: "job_posting_id IS NOT NULL"))
+
+    # #2013 asked the kinds that arrive here to **extend** this constraint
+    # rather than widen the nullable `user_id` column. A posting image always
+    # has an uploader (`job_posting_images.user_id` is NOT NULL), so it joins
+    # the list. N-1 safe: the release serving traffic writes only avatar and
+    # cover rows, both of which already satisfy the wider check.
+    drop(constraint(:images, :images_profile_kind_has_owner))
+
+    create(
+      constraint(:images, :images_profile_kind_has_owner,
+        check: "kind NOT IN ('avatar', 'cover', 'job_posting_image') OR user_id IS NOT NULL"
+      )
+    )
+  end
+
+  def down do
+    drop(constraint(:images, :images_profile_kind_has_owner))
+
+    create(
+      constraint(:images, :images_profile_kind_has_owner,
+        check: "kind NOT IN ('avatar', 'cover') OR user_id IS NOT NULL"
+      )
+    )
+
+    drop(index(:images, [:job_posting_id], where: "job_posting_id IS NOT NULL"))
+
+    alter table(:images) do
+      remove(:job_posting_id)
+      remove(:alt)
+      remove(:position)
+      remove(:width)
+      remove(:height)
+      remove(:content_type)
+      remove(:size_bytes)
+    end
+  end
+end

--- a/test/support/image_helpers.ex
+++ b/test/support/image_helpers.ex
@@ -1,8 +1,9 @@
 defmodule Vutuv.ImageHelpers do
   @moduledoc """
-  A member's profile picture as both halves the application always writes: the
-  four columns on the member row and the row in the shared `images` table
-  (`Vutuv.Images`).
+  A picture as both halves the application always writes into the shared
+  `images` table (`Vutuv.Images`): for a member's profile picture, the four
+  columns on the member row plus the row here; for a gallery picture, its own
+  row plus the mirror `mirror_row/2` finds.
 
   Since #2027 every URL builder and every display gate reads the row, so a test
   that sets only `users.avatar` describes a member with no picture — a state no
@@ -78,4 +79,17 @@ defmodule Vutuv.ImageHelpers do
     |> Map.put(cols.assoc, nil)
     |> Map.put(cols.pointer, nil)
   end
+
+  @doc """
+  The `images` row standing beside a gallery picture (#2015), or `nil` — looked
+  up the way the application joins the two, on the `token` both carry rather
+  than on an id. Takes the picture's own row or its token.
+
+  One helper for every gallery kind, so #2052, #2053 and #2054's tests do not
+  each write the same `Repo.get_by/2`.
+  """
+  def mirror_row(kind, %{token: token}), do: mirror_row(kind, token)
+
+  def mirror_row(kind, token) when is_binary(token),
+    do: Repo.get_by(Image, token: token, kind: kind)
 end

--- a/test/vutuv/images/backfill_test.exs
+++ b/test/vutuv/images/backfill_test.exs
@@ -19,7 +19,12 @@ defmodule Vutuv.Images.BackfillTest do
   alias Vutuv.Images
   alias Vutuv.Images.Backfill
   alias Vutuv.Images.Image, as: ImageRow
+  alias Vutuv.Jobs.JobPostingImage
   alias Vutuv.Repo
+  alias Vutuv.Uploads
+  alias Vutuv.Uploads.Spec
+
+  @kind "job_posting_image"
 
   setup do
     tmp =
@@ -48,6 +53,19 @@ defmodule Vutuv.Images.BackfillTest do
   end
 
   defp reload(user), do: Repo.get!(User, user.id)
+
+  # A job-posting picture from before the mirror existed: its own row and its
+  # files on disk, nothing in `images`. The factory writes no files, so the
+  # served thumb the check probes for is written here.
+  defp stored_job_posting_image(attrs \\ []) do
+    picture = insert(:job_posting_image, attrs)
+    dir = Uploads.disk_dir(Path.join("job_posting_images", picture.token))
+    File.mkdir_p!(dir)
+    File.write!(Path.join(dir, "thumb#{Spec.served_ext()}"), "not really an avif")
+    picture
+  end
+
+  defp job_posting_row(picture), do: Vutuv.ImageHelpers.mirror_row(@kind, picture)
 
   defp jpeg_upload(name \\ "selfie.jpg") do
     src = Path.join(System.tmp_dir!(), "backfill_src_#{System.unique_integer([:positive])}.jpg")
@@ -217,6 +235,137 @@ defmodule Vutuv.Images.BackfillTest do
       assert Images.profile_image(user.id, "avatar").file == "old.jpg"
       assert Images.profile_image(user.id, "cover").file == "banner.jpg"
       assert reload(user).cover_image_id == Images.profile_image(user.id, "cover").id
+    end
+  end
+
+  describe "a gallery kind: the job-posting picture (issue #2054)" do
+    test "one that predates the mirror arrives with every column" do
+      picture = stored_job_posting_image()
+
+      assert %{"job_posting_image" => tally} = Backfill.run(only: @kind)
+      assert tally.pictures == 1
+      assert tally.created == 1
+
+      assert %ImageRow{} = row = job_posting_row(picture)
+      assert row.kind == @kind
+      assert row.user_id == picture.user_id
+      assert row.alt == picture.alt
+      assert row.width == picture.width
+      assert row.height == picture.height
+      assert row.content_type == picture.content_type
+      assert row.size_bytes == picture.size_bytes
+      assert row.moderation == picture.moderation
+    end
+
+    test "running it again changes nothing" do
+      stored_job_posting_image()
+      Backfill.run(only: @kind)
+
+      assert %{"job_posting_image" => tally} = Backfill.run(only: @kind)
+      assert tally.unchanged == 1
+      assert tally.created == 0
+      assert tally.corrected == 0
+    end
+
+    test "a row that drifted is corrected, and keeps its token" do
+      picture = stored_job_posting_image()
+      Backfill.run(only: @kind)
+      before = job_posting_row(picture)
+
+      Repo.update_all(from(i in ImageRow, where: i.id == ^before.id),
+        set: [alt: "stale", moderation: "pending"]
+      )
+
+      assert %{"job_posting_image" => tally} = Backfill.run(only: @kind)
+      assert tally.corrected == 1
+      assert tally.created == 0
+
+      after_run = job_posting_row(picture)
+      assert after_run.id == before.id
+      assert after_run.token == before.token
+      assert after_run.alt == picture.alt
+      assert after_run.moderation == picture.moderation
+    end
+
+    test "a row whose picture is gone is dropped" do
+      picture = stored_job_posting_image()
+      Backfill.run(only: @kind)
+      Repo.delete_all(from(i in JobPostingImage, where: i.id == ^picture.id))
+
+      assert %{"job_posting_image" => tally} = Backfill.run(only: @kind)
+      assert tally.dropped == 1
+      refute job_posting_row(picture)
+    end
+
+    # The proof is not that the first pass finished — it is that the second one
+    # finishes exactly the rest and touches nothing it already did.
+    test "a second run after an interruption finishes exactly the rest" do
+      [first, second] =
+        Enum.sort_by([stored_job_posting_image(), stored_job_posting_image()], & &1.id)
+
+      assert %{"job_posting_image" => %{created: 1}} =
+               Backfill.run(only: @kind, from: first.id)
+
+      refute job_posting_row(first)
+      assert job_posting_row(second)
+
+      assert %{"job_posting_image" => tally} = Backfill.run(only: @kind)
+      assert tally.created == 1
+      assert tally.unchanged == 1
+      assert tally.corrected == 0
+      assert job_posting_row(first)
+      assert Repo.aggregate(from(i in ImageRow, where: i.kind == ^@kind), :count) == 2
+    end
+
+    test "the check names the pictures with no row, and goes quiet once they have one" do
+      picture = stored_job_posting_image()
+
+      assert %{kinds: %{"job_posting_image" => before}, ok?: false} =
+               Backfill.check(only: @kind)
+
+      assert before.missing_row.count == 1
+      assert before.missing_row.sample == [picture.id]
+      assert before.missing_file.count == 0
+
+      Backfill.run(only: @kind)
+
+      assert %{ok?: true} = Backfill.check(only: @kind)
+    end
+
+    test "a picture whose file is gone is named and never repaired away" do
+      picture = stored_job_posting_image()
+      File.rm_rf!(Vutuv.Uploads.disk_dir(Path.join("job_posting_images", picture.token)))
+      Backfill.run(only: @kind)
+
+      assert %{kinds: %{"job_posting_image" => result}, ok?: false} =
+               Backfill.check(only: @kind)
+
+      assert result.missing_file.count == 1
+      assert result.missing_row.count == 0
+      assert job_posting_row(picture)
+    end
+
+    test "the report says nothing about a pointer this kind never had" do
+      put_config(:regenerator_quiet, false)
+      stored_job_posting_image()
+
+      output = capture_io(fn -> Backfill.check(only: @kind) end)
+
+      assert output =~ "job_posting_image: 1 picture(s), 0 row(s)"
+      assert output =~ "1 without a row"
+      refute output =~ "not pointed at"
+    end
+
+    test "the mix task takes the kind by name" do
+      put_config(:regenerator_quiet, false)
+      picture = stored_job_posting_image()
+
+      capture_io(fn ->
+        assert %{ok?: true} =
+                 Mix.Tasks.Vutuv.Images.Backfill.run(["--only", "job_posting_image"])
+      end)
+
+      assert job_posting_row(picture)
     end
   end
 

--- a/test/vutuv/images/job_posting_images_test.exs
+++ b/test/vutuv/images/job_posting_images_test.exs
@@ -1,0 +1,256 @@
+defmodule Vutuv.Images.JobPostingImagesTest do
+  @moduledoc """
+  The first of the four kinds #2015 moves into the shared `images` table
+  (issue #2054): a job-posting picture is a row there beside its own row, kept
+  in step by every write, and nothing about how it is stored or served has
+  moved.
+
+  Not async: the upload path writes files, so the module holds the global
+  `:uploads_dir_prefix` down for its lifetime.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.JobsHelpers
+  import Vutuv.WebPushHelpers, only: [put_config: 2]
+
+  alias Vutuv.ImageHelpers
+  alias Vutuv.Images
+  alias Vutuv.Images.Image, as: ImageRow
+  alias Vutuv.Jobs
+  alias Vutuv.Jobs.JobPostingImage
+  alias Vutuv.Moderation.ImageSubjects
+  alias Vutuv.Repo
+
+  @kind "job_posting_image"
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "vutuv_jp_images_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    put_config(:uploads_dir_prefix, tmp)
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    {:ok, tmp: tmp}
+  end
+
+  defp upload!(user, tmp) do
+    src = Path.join(tmp, "src-#{System.unique_integer([:positive])}.jpg")
+    {:ok, img} = Image.new(64, 48, color: [10, 200, 100])
+    {:ok, _} = Image.write(img, src)
+    {:ok, image} = Jobs.create_pending_image(user, src, "office.jpg")
+    image
+  end
+
+  defp mirror(picture), do: ImageHelpers.mirror_row(@kind, picture)
+
+  describe "the row beside the row" do
+    test "an upload writes one, column for column", %{tmp: tmp} do
+      user = poster_fixture()
+      image = upload!(user, tmp)
+
+      assert %ImageRow{} = row = mirror(image)
+      assert row.kind == @kind
+      assert row.user_id == user.id
+      assert row.job_posting_id == nil
+      assert row.token == image.token
+      assert row.alt == image.alt
+      assert row.position == image.position
+      assert row.width == image.width
+      assert row.height == image.height
+      assert row.content_type == image.content_type
+      assert row.size_bytes == image.size_bytes
+      assert row.moderation == image.moderation
+      assert row.frozen_at == nil
+    end
+
+    test "its id is a UUID v7 of its own, not the gallery row's", %{tmp: tmp} do
+      user = poster_fixture()
+      image = upload!(user, tmp)
+      row = mirror(image)
+
+      assert row.id != image.id
+      assert {:ok, <<_::48, 7::4, _::76>>} = Ecto.UUID.dump(row.id)
+    end
+
+    test "attaching the picture to a posting moves the parent across", %{tmp: tmp} do
+      user = poster_fixture()
+      image = upload!(user, tmp)
+      {:ok, draft} = Jobs.create_draft(user, %{"title" => "Backend Engineer (m/w/d)"})
+
+      {:ok, posting} = Jobs.publish(draft, user, job_attrs(%{"image_ids" => [image.id]}))
+
+      assert mirror(image).job_posting_id == posting.id
+    end
+
+    test "an edited alt text follows", %{tmp: tmp} do
+      user = poster_fixture()
+      image = upload!(user, tmp)
+
+      {:ok, _} = Jobs.update_image_alt(image, "Unser Büro in Köln")
+
+      assert mirror(image).alt == "Unser Büro in Köln"
+    end
+
+    test "the AI gate's release follows", %{tmp: tmp} do
+      user = poster_fixture()
+      image = upload!(user, tmp)
+
+      Repo.update_all(from(i in JobPostingImage, where: i.id == ^image.id),
+        set: [moderation: "pending"]
+      )
+
+      Repo.update_all(from(i in ImageRow, where: i.token == ^image.token),
+        set: [moderation: "pending"]
+      )
+
+      scan = insert(:image_scan, kind: @kind, subject_id: image.id, owner_user_id: user.id)
+      assert :ok = ImageSubjects.apply_approved(scan)
+
+      assert mirror(image).moderation == "approved"
+    end
+  end
+
+  describe "the row goes when the picture goes" do
+    test "a pending upload the member discards", %{tmp: tmp} do
+      user = poster_fixture()
+      image = upload!(user, tmp)
+
+      :ok = Jobs.delete_pending_image(image)
+
+      refute mirror(image)
+    end
+
+    test "a picture the editor removed on save", %{tmp: tmp} do
+      user = poster_fixture()
+      image = upload!(user, tmp)
+      {:ok, draft} = Jobs.create_draft(user, %{"title" => "Backend Engineer (m/w/d)"})
+      {:ok, posting} = Jobs.publish(draft, user, job_attrs(%{"image_ids" => [image.id]}))
+
+      {:ok, _} = Jobs.update_posting(posting, user, %{"image_ids" => []})
+
+      refute Repo.get(JobPostingImage, image.id)
+      refute mirror(image)
+    end
+
+    test "a pending upload nobody ever attached", %{tmp: tmp} do
+      user = poster_fixture()
+      image = upload!(user, tmp)
+      old = NaiveDateTime.add(NaiveDateTime.utc_now(:second), -25 * 3600, :second)
+
+      Repo.update_all(from(i in JobPostingImage, where: i.id == ^image.id),
+        set: [inserted_at: old]
+      )
+
+      assert Jobs.sweep_pending_images() == 1
+
+      refute mirror(image)
+    end
+
+    test "a posting that is deleted", %{tmp: tmp} do
+      user = poster_fixture()
+      image = upload!(user, tmp)
+      {:ok, draft} = Jobs.create_draft(user, %{"title" => "Backend Engineer (m/w/d)"})
+      {:ok, posting} = Jobs.publish(draft, user, job_attrs(%{"image_ids" => [image.id]}))
+
+      {:ok, _} = Jobs.delete_job_posting(posting)
+
+      refute mirror(image)
+    end
+
+    test "a picture the AI gate rejected", %{tmp: tmp} do
+      user = poster_fixture()
+      image = upload!(user, tmp)
+      scan = insert(:image_scan, kind: @kind, subject_id: image.id, owner_user_id: user.id)
+
+      assert :ok = ImageSubjects.apply_rejected(scan)
+
+      refute Repo.get(JobPostingImage, image.id)
+      refute mirror(image)
+    end
+  end
+
+  describe "the mirror carries the whole picture" do
+    # The mirror copies by name, and `Map.fetch!/2` makes a name listed in
+    # `Vutuv.Images` that the source does not have raise. The other direction —
+    # a column added to `job_posting_images` and never listed — nothing can
+    # see: the mirror simply would not carry it, and the backfill's own
+    # comparison reads the same list, so it would agree that all is well. This
+    # is what notices, and the deploy that retires the old table is what it
+    # protects: a column nobody mirrored is a column that is lost then.
+    #
+    # A column that genuinely belongs to the old row alone goes on the
+    # exclusion list below, with the reason.
+    test "every column of the gallery row is mirrored, or excluded on purpose" do
+      not_mirrored = [
+        # The two rows are separate records with separate lifetimes; the mirror
+        # mints a UUID v7 of its own and stamps its own timestamps.
+        :id,
+        :inserted_at,
+        :updated_at
+      ]
+
+      source = Vutuv.Images.mirror_source(@kind)
+      columns = source.schema.__schema__(:fields)
+
+      assert Enum.sort(columns) == Enum.sort(source.fields ++ not_mirrored),
+             """
+             `job_posting_images` and the mirror have drifted.
+
+             columns:  #{inspect(Enum.sort(columns))}
+             mirrored: #{inspect(Enum.sort(source.fields))}
+             excluded: #{inspect(Enum.sort(not_mirrored))}
+
+             Add the column to `Vutuv.Images`' mirror entry (and to the
+             `images` table in a migration), or to `not_mirrored` here with the
+             reason it belongs to the old row alone.
+             """
+    end
+
+    test "and every mirrored name is a column of the images row too" do
+      source = Vutuv.Images.mirror_source(@kind)
+      assert source.fields -- ImageRow.__schema__(:fields) == []
+    end
+  end
+
+  describe "nothing about serving moved" do
+    test "the URL is the one it always was", %{tmp: tmp} do
+      user = poster_fixture()
+      image = upload!(user, tmp)
+
+      assert JobPostingImage.url(image, "thumb") ==
+               "/job_posting_images/#{image.token}/thumb.avif"
+    end
+
+    test "the kind is served through its authorizing proxy, not off disk" do
+      assert Images.serving(@kind) == :proxy
+    end
+
+    # The report form addresses a picture by its `images` row id, and until this
+    # release no row of this kind existed — so nothing could name one. Now one
+    # does, and `Vutuv.Images.freeze/1` has no clause for it: the takedown is
+    # the contract half's work, not this release's. A report has to be refused
+    # rather than accepted into a case whose uphold would raise.
+    test "a copyright report cannot name one yet — the freeze has no path for it", %{tmp: tmp} do
+      user = poster_fixture()
+      image = upload!(user, tmp)
+      reporter = insert(:activated_user)
+      row = mirror(image)
+
+      # Both the form (`ReportController.new`) and the submit go through
+      # `can_report?/2`, so the picture cannot even be previewed for a notice.
+      refute Vutuv.Moderation.can_report?(reporter, row)
+
+      assert {:error, :not_allowed} =
+               Vutuv.Moderation.report_content(reporter, row, %{
+                 "category" => "copyright",
+                 "details" => "That is my photograph."
+               })
+    end
+
+    test "and the freeze itself refuses rather than half-hiding it", %{tmp: tmp} do
+      user = poster_fixture()
+      row = mirror(upload!(user, tmp))
+
+      assert_raise ArgumentError, ~r/job_posting_image/, fn -> Images.freeze(row) end
+    end
+  end
+end

--- a/test/vutuv/images_test.exs
+++ b/test/vutuv/images_test.exs
@@ -280,7 +280,7 @@ defmodule Vutuv.ImagesTest do
     test "avatars and covers are served straight off disk" do
       assert Images.serving("avatar") == :static
       assert Images.serving("cover") == :static
-      assert Images.kinds() == ~w(avatar cover)
+      assert Images.kinds() == ~w(avatar cover job_posting_image)
     end
 
     test "an undeclared kind raises rather than inheriting a default" do


### PR DESCRIPTION
A picture on a job posting kept a table and an uploader of its own, so the freeze that can take a profile picture offline could not see it: only the whole posting could go dark.

Every write now keeps an `images` row beside its `job_posting_images` row — the upload, the alt edit, attach and prune on save, the pending sweep, and the AI gate's verdict. The join key is the `token` both rows already carry, so there is no second pointer and no `missing_pointer` to reconcile; `mix vutuv.images.backfill --only job_posting_image` brings the older pictures in and gates the cut.

Expand half only. Nothing reads the new row: `VutuvWeb.JobPostingImageController`, every URL and the edit form are untouched, and a report naming such a row is refused until the freeze is wired. Retiring `job_posting_images` and the double write is the deploy after.

Where to start: `Vutuv.Images.mirror_source/1`, `docs/architecture/images.md`.

Closes #2054

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01UGPe7bHVS11M1W7fNehSku

<!-- closing-note #2054 -->
A job-posting picture now has a row in the shared `images` table beside its own, written and dropped by every path that touches the picture and reconciled by `mix vutuv.images.backfill --only job_posting_image`, so the copyright freeze will have something to act on. Joining the two on the `token` they already share rather than adding a pointer is the shape the post photo and the organization image should copy; the review cover is the profile shape, not this one, because its cover lives in columns on the review row. What I left out is the reading half: no URL, no proxy and no form has moved, so a report that names one of these rows is still refused, and the deploy that wires the freeze and retires the old table comes next.

*An AI agent wrote this text in my name. I know that is problematic.*
