### PR TITLE
Give every post photo a row in the shared images table

### DIFF
--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -698,7 +698,8 @@ Run on the server, against the release:
   interrupted (a deploy stopping the slot mid-run leaves every picture it
   reached already correct). It covers profile pictures and covers, and the
   kinds that still keep a table of their own — a job-posting picture since the
-  release that added `--only job_posting_image`. The release that moved every
+  release that added `--only job_posting_image`, a post photo since the one
+  that added `--only post_image`. The release that moved every
   avatar and cover URL onto those rows (issue #2027) does **not** require it —
   a picture with no row is still served from the member's own columns — but run
   it before the upgrade after that one, which removes that fallback. Until it

--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -424,7 +424,8 @@ A post photo, an organization image, a job-posting picture and a review cover
 each kept a table and an uploader of their own, so the `image` report type and
 the freeze knew one kind only. They move one kind at a time and three releases
 per kind (the sequence is spelled out below), smallest first — a **job-posting
-picture** went first (#2054) precisely to settle the shape.
+picture** went first (#2054) precisely to settle the shape, and the **post
+photo** followed (#2052) as the largest of them.
 
 **Three of the four are the same shape; the review cover is not.** A post
 photo, an organization image and a job-posting picture each have a row of their
@@ -435,7 +436,7 @@ profile picture's shape, not this one — #2055 lands on `member_columns/0`'s si
 of the fence, and `Vutuv.Images.Backfill`'s `%{cols: …}` source is what it
 extends. One thing it does share with the three: a report cannot name one of
 its pictures until the kind has a strategy in `Vutuv.Images`'s `@takedown`.
-What #2052 and #2053 copy from here is everything below.
+What #2053 copies from here is everything below.
 
 **The token is the join key, not a pointer.** #2013 added
 `users.avatar_image_id` because a member row had no stable handle of its own;
@@ -453,19 +454,52 @@ other kind has a posting) plus `alt`, `position`, `width`, `height`,
 `content_type` and `size_bytes`, taken with the types `job_posting_images`
 holds them at (`alt` and `content_type` varchar(255), the rest plain
 `integer`). `post_images` and `organization_images` carry those same six under
-the same names, so #2052 and #2053 add their own parent column plus whatever
-they hold beyond the six — a post photo also brings `caption`, `crop`, seven
-EXIF columns and its download flags. The `images_profile_kind_has_owner` check
+the same names, so each further kind adds only its own parent column plus
+whatever it holds beyond the six. The `images_profile_kind_has_owner` check
 constraint was **extended** rather than the nullable `user_id` widened, which is
 what #2013's migration asked for; the parent index is **partial**
 (`WHERE job_posting_id IS NOT NULL`), because every other kind's row is NULL
 there and the waste would multiply by four — Postgres proves `IS NOT NULL` from
 the cascade's strict `= $1` and uses it (measured: 16 kB against 48 kB).
 
+**The post photo is the same shape carrying much more (#2052).** It added
+`post_id` (nullable and partially indexed, like the posting's) and thirteen
+columns of its own: `caption`, the seven camera facts, `has_gps` and the
+author's three switches. `crop` is not among them — a profile picture's crop
+rectangle column holds exactly what a photo's does. **Almost every column of
+`post_images` is mirrored, and the reason is the third release rather than this
+one**: it drops that table, the second adds no migration, so a column left out
+now is a column lost then. Three types are worth naming. `caption` is `:text`
+on both sides, because a photographer's note runs to 1,000 characters through
+the composer and a varchar(255) copy would raise Postgres 22001 from
+`Vutuv.Images.mirror/2` — on the *write* path, where no changeset validation
+stands between the member and the error. The camera facts are display
+primitives in varchar(255) (`f/1.4`, `1/250 s`, `35 mm`), because that is the
+notation they are rendered in. And the four flags are `NOT NULL DEFAULT false`
+on `post_images` but plain nullable booleans here: an avatar row has no opinion
+about a camera panel, and NULL is how it says so.
+
+**One column stays behind, and it has a consequence for step 2: `inserted_at`.**
+The mirror stamps its own (`mirror/2` mints the row), which for a photo
+uploaded from #2052 on agrees with the photo's to the second — but a
+*backfilled* row's says when the backfill ran. The one reader that cares is the
+pixelated stand-in the AI gate shows while a picture waits:
+`Vutuv.Posts.image_pixelated_url/1` measures its window
+(`Vutuv.Moderation.Pixelation.window_seconds/0`) from the **upload** time, and a
+row that claims to be minutes old when the photo is months old would put an
+expired mosaic back on the page. So the release that moves the readers has to
+take that time from the photo rather than from the mirror — either by carrying
+`inserted_at` through `mirror/2` for this kind, or by leaving the window on the
+old row until the table goes. Nothing today reads it, which is why it is
+written down here rather than fixed there.
+
 **The double write is one upsert and one delete.**
 `Vutuv.Images.mirror/2` takes one gallery row or a list of them and upserts on
 the token — one statement however many, so saving ten pictures costs one — and
-`Vutuv.Images.forget/2` deletes by token. `Vutuv.Images.write_mirrored/2` pairs
+`Vutuv.Images.forget/2` deletes by token. The attach path is where the list
+form earns itself: `Vutuv.Posts.attach_images!/2` claims each photo with its
+own `UPDATE … RETURNING`, because each carries a different `position`, then
+hands the whole gallery to one upsert. `Vutuv.Images.write_mirrored/2` pairs
 a write with its mirror in one transaction, which is the door a context's own
 insert and update go through. `Vutuv.Images.mirror_source/1` is the **one**
 per-kind registry — the copied columns, the source schema, the store — so a
@@ -473,31 +507,45 @@ kind cannot be mirrored on the request path and invisible to the backfill,
 whose check would otherwise print *"Safe to cut"* for a kind it never looked
 at. The names are identical on both sides, so the copy is a per-field
 `Map.fetch!/2`: a listed name the source lacks raises. The other direction — a
-column added to `job_posting_images` and never listed — nothing can see, so a
-drift test compares the schema against the list and fails the build.
+column added to a mirrored table and never listed — nothing can see, so a
+drift test over every mirrored kind compares each schema against its list and
+fails the build, which also covers the kinds still to come the day their entry
+lands.
 
-Every place that writes a job-posting picture goes through one of those: the
-upload and the alt edit (`write_mirrored/2`), the attach and detach on save,
-the pending sweep, and the AI gate's approve and reject in
+Every place that writes such a picture goes through one of those: the upload
+and every edit (`write_mirrored/2` — for a photo that is the alt text, the
+per-photo panel and the crop), the attach and detach on save, the pending
+sweep, and the AI gate's approve and reject in
 `Vutuv.Moderation.ImageSubjects` — which asks `Vutuv.Images.mirrored?/1` first,
 so the next kind's release is one entry in `Vutuv.Images` and nothing there. A
-deleted posting or member needs no call: `images.job_posting_id` and
-`images.user_id` cascade exactly as the gallery table's own columns do. **The
-`frozen_at` column is deliberately outside the upsert's replace list**, so an
-ordinary write can never lift a takedown.
+deleted parent or member needs no call: `images.job_posting_id`,
+`images.post_id` and `images.user_id` cascade exactly as the gallery table's own
+columns do. **The `frozen_at` column is deliberately outside the upsert's
+replace list**, so an ordinary write can never lift a takedown.
 
-**What an interruption leaves.** The upload and the alt edit are atomic. The
-attach-and-prune on save is not, and never was — it runs after the save — so a
-slot dying between an attach and its mirror leaves a `mismatched_row` (the
-parent disagrees) and one between a prune and its `forget/2` leaves an
-`orphan_row`. Both are classes the backfill names and repairs; neither is
-invisible.
+**What an interruption leaves, and it differs by kind.** For a job-posting
+picture the upload and the alt edit are atomic, but the attach-and-prune on
+save is not and never was — it runs after the save — so a slot dying between an
+attach and its mirror leaves a `mismatched_row` (the parent disagrees) and one
+between a prune and its `forget/2` leaves an `orphan_row`. Both are classes the
+backfill names and repairs; neither is invisible. **A post photo has neither
+window**: `Vutuv.Posts` claims and prunes its photos *inside* the save
+transaction (`attach_images!/2` and `apply_update!/3`), so the mirror rides
+along in it and an interrupted save leaves neither half. The one write outside
+a transaction there is the pending sweep, which deletes row, mirror and files
+in that order — an interruption leaves an orphan mirror row, then orphan files,
+never a row naming bytes that are gone.
 
 **Nothing reads the new row yet, and that is the whole of the expand half.**
-Every URL is the one it was (`/job_posting_images/<token>/<version>.avif`),
-`VutuvWeb.JobPostingImageController` still authorizes off `job_posting_images`,
-and the edit form still renders from `posting.images` — so no render path pays
-a query for the mirror. The consequence to know: `Vutuv.Images.freeze/1`,
+Every URL is the one it was (`/job_posting_images/<token>/<version>.avif`,
+`/post_images/<token>/<version>.avif` and the photo's `og.jpg`, `original.orig`
+and pixelated siblings), the authorizing proxies still work off the old tables
+(`VutuvWeb.JobPostingImageController`, `VutuvWeb.PostImageController`), and the
+forms, the feed, the API and the agent documents still render from
+`posting.images` and `post.images` — so no render path pays a query for the
+mirror, which matters most on a feed that draws many photos at once. No file
+under `lib/vutuv_web`, `lib/vutuv/uploads` or `lib/vutuv/uploaders` changed for
+either kind. The consequence to know: `Vutuv.Images.freeze/1`,
 `unfreeze/1` and `purge/1` **raise** for such a row rather than half-hiding
 it, and `Vutuv.Moderation` refuses a report that names one
 (`Vutuv.Images.takedown_ready?/1`), because a case opened on a row nothing
@@ -506,15 +554,17 @@ reports the posting instead, which is all there was before the row existed.
 That gate reads `@takedown`, the map naming which kinds have a takedown at all,
 so it turns yes in step 2 below and not a moment earlier (issue #2057).
 
-**A gallery kind moves in three releases, and #2054 was the first.** Each is
-N-1 safe on its own and no two can be merged; this milestone has already paid
-for an off-by-one in that count once, in #2027.
+**A gallery kind moves in three releases.** #2054 was the first for
+`job_posting_image` and #2052 the first for `post_image`. Each is N-1 safe on
+its own and no two can be merged; this milestone has already paid for an
+off-by-one in that count once, in #2027.
 
-1. **Expand**: what #2054 shipped for `job_posting_image`. Every path that
-   touches the picture writes and drops the `images` row beside the old one,
-   while every reader, and the truth, stay in `job_posting_images`. Nothing
-   here can take such a picture offline yet: `freeze/1` raises for the row and
-   a report cannot name it. Between this release and the next, an operator runs
+1. **Expand**: what #2054 shipped for `job_posting_image` and #2052 for
+   `post_image`. Every path that touches the picture writes and drops the
+   `images` row beside the old one, while every reader, and the truth, stay in
+   the kind's own table. Nothing here can take such a picture offline yet:
+   `freeze/1` raises for the row and a report cannot name it. Between this
+   release and the next, an operator runs
    `mix vutuv.images.backfill --only <kind>` and reads its check; after step 2
    the two copies can no longer be compared, so this is the last chance.
 2. **Move the readers, the writes and the takedown onto the row.** The proxy,
@@ -530,14 +580,14 @@ for an off-by-one in that count once, in #2027.
    the report form on these pictures. No migration in this release: the old
    table is still standing and the release one step back is still reading and
    writing it.
-3. **Contract**: the migration that drops `job_posting_images`, and nothing
+3. **Contract**: the migration that drops the kind's own table, and nothing
    else. Step 2 is what stopped using the table, and step 2 is what serves
    while this migration runs.
 
-**This kind needs no bridge.** #2027 needed one because it moved every reader
-onto the row in the same deploy as the row's first appearance, so a picture the
-backfill had not reached would have rendered as no picture at all. Here no
-reader has moved: a job-posting picture with no mirror row is served exactly as
+**No expand release needs a bridge.** #2027 needed one because it moved every
+reader onto the row in the same deploy as the row's first appearance, so a
+picture the backfill had not reached would have rendered as no picture at all.
+Here no reader has moved: a picture with no mirror row is served exactly as
 before, by its own table, so an installation that never runs the backfill sees
 nothing change. The bridge question belongs to the release that moves the
 readers, and it will have a simpler answer than #2027's — the old row *is* the

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -1669,6 +1669,16 @@ on-the-fly `og.jpg` and the download filename.
 
 Legacy `…/feed.webp` URLs in old post bodies keep resolving.
 
+Since #2052 every `post_images` row also has a **mirror row in the shared
+`images` table**, joined on the `token` both carry and written by every path
+that touches a photo (`Vutuv.Images.write_mirrored/2`, `mirror/2`, `forget/2`
+from `Vutuv.Posts`). Nothing above reads it yet: this is the expand half of the
+three-release move #2015 is making one kind at a time, so every URL, the proxy
+and the audience check are unchanged, and a copyright report still cannot name
+a photo on its own. What the mirror carries, why almost every column of
+`post_images` is in it and what the release that moves the readers has to
+watch for are in the "gallery kinds" section of [images.md](images.md).
+
 A post can also carry one **video** (issue #1906): its own pipeline, its own
 waiting card and its own proxy, all in [video.md](video.md).
 

--- a/lib/mix/tasks/vutuv.images.backfill.ex
+++ b/lib/mix/tasks/vutuv.images.backfill.ex
@@ -5,13 +5,14 @@ defmodule Mix.Tasks.Vutuv.Images.Backfill do
   Reconciles every picture with its row in the shared `images` table — the
   **contract** half of issue #2013 for profile pictures and covers, and of
   #2015 for the kinds that still keep a table of their own (a job-posting
-  picture since #2054). See `Vutuv.Images.Backfill`.
+  picture since #2054, a post photo since #2052). See `Vutuv.Images.Backfill`.
 
       mix vutuv.images.backfill              # reconcile every kind, then check
       mix vutuv.images.backfill --dry-run    # report what would change
       mix vutuv.images.backfill --check      # check only, write nothing
       mix vutuv.images.backfill --only cover
       mix vutuv.images.backfill --only job_posting_image
+      mix vutuv.images.backfill --only post_image
       mix vutuv.images.backfill --from 019f0000-0000-7000-8000-000000000000
 
   Moves no file and changes no URL: what a picture already lives in stays the

--- a/lib/vutuv/images.ex
+++ b/lib/vutuv/images.ex
@@ -19,7 +19,8 @@ defmodule Vutuv.Images do
   migration may drop only what the *currently deployed* release has stopped
   reading.
 
-  **A gallery picture (#2015, a job-posting picture first in #2054): this
+  **A gallery picture (#2015, a job-posting picture first in #2054, a post
+  photo in #2052): this
   release writes both and reads the old table.** Its truth is still its own row
   — the proxy, the form and the AI gate all work off that — and the row here is
   a mirror, written by `mirror/2` and dropped by `forget/2`, joined on the
@@ -52,7 +53,16 @@ defmodule Vutuv.Images do
   # from `@mirrored` below, because a contract release **deletes** an entry
   # there — at which point that kind lives here and nowhere else, so dropping
   # it from this list would be exactly backwards.
-  @kinds ~w(avatar cover job_posting_image)
+  @kinds ~w(avatar cover job_posting_image post_image)
+
+  # Of those, the kinds every byte of which already goes through a controller
+  # that authorizes the reader first (`VutuvWeb.JobPostingImageController` asks
+  # whether the reader may see the posting, `VutuvWeb.PostImageController`
+  # whether they may see the post) — so the row is the off switch, and #2015's
+  # expand releases change nothing about how one is served. Written out rather
+  # than derived from `@mirrored`, because a kind keeps its serving strategy
+  # after the contract release deletes it from there. See `serving/1`.
+  @proxy_kinds ~w(job_posting_image post_image)
 
   # Of those, the kinds whose truth is still a table of their own, and
   # everything about the copy: which columns it carries, where the source rows
@@ -63,18 +73,18 @@ defmodule Vutuv.Images do
   # The column names are identical on both sides, so the copy is a per-field
   # `Map.fetch!/2` rather than a translation table: a name listed here that the
   # source schema does not have raises instead of quietly writing nothing. The
-  # other direction — a column added to the source table and not to this list —
-  # nothing can see, so the drift test in `job_posting_images_test.exs`
-  # compares the two and fails the build on it.
+  # other direction — a column added to a source table and not to this list —
+  # nothing can see, so a drift test in `images_test.exs` compares the two for
+  # every kind here and fails the build on it, which also means a kind added
+  # below is covered the day its entry lands.
   #
   # An entry goes when that kind's contract release retires its old table,
   # together with the double write. It does **not** take the report gate with
   # it: that reads `@takedown` below, which the release before that one, the one
   # that moves the readers and wires the takedown, is what extends.
-  # #2052 (post photos) and #2053 (organization images) add one entry each;
-  # #2055 (review covers) does **not** — a review's cover is columns on the
-  # review row with no token and no table, which is the `@profile_columns`
-  # shape below, not this one.
+  # #2053 (organization images) adds one entry; #2055 (review covers) does
+  # **not** — a review's cover is columns on the review row with no token and
+  # no table, which is the `@profile_columns` shape below, not this one.
   @mirrored %{
     "job_posting_image" => %{
       fields: ~w(
@@ -83,6 +93,26 @@ defmodule Vutuv.Images do
       schema: Vutuv.Jobs.JobPostingImage,
       store: Vutuv.JobPostingImageStore,
       # The version the backfill's file probe asks the store for.
+      preview: "thumb"
+    },
+    # The largest of the four (#2052). Almost every column of `post_images` is
+    # here, because the third release drops that table and the second adds no
+    # migration — a column left out now is a column lost then. `crop` is not
+    # new: a profile picture's crop rectangle column holds exactly what a
+    # photo's does. What stays behind is `inserted_at`, and the release that
+    # moves the readers has to answer for it; the reasoning and the one reader
+    # that cares are in `docs/architecture/images.md`.
+    "post_image" => %{
+      fields: ~w(
+        token user_id post_id alt caption position width height content_type size_bytes crop
+        camera lens focal_length aperture shutter iso taken_at has_gps
+        show_camera_info download_original download_exact moderation
+      )a,
+      schema: Vutuv.Posts.PostImage,
+      store: Vutuv.PostImageStore,
+      # `thumb` is derived for every stored photo and is the smallest of them;
+      # `lite` and `xl` are deliberately not, because both are allowed to be
+      # missing on a picture the regeneration has not reached.
       preview: "thumb"
     }
   }
@@ -126,11 +156,7 @@ defmodule Vutuv.Images do
   """
   def serving(kind) when kind in @profile_kinds, do: :static
 
-  # Every byte of a job-posting picture already goes through
-  # `VutuvWeb.JobPostingImageController`, which asks whether the reader may see
-  # the posting — so the row is the off switch, and this release changes
-  # nothing about how one is served.
-  def serving("job_posting_image"), do: :proxy
+  def serving(kind) when kind in @proxy_kinds, do: :proxy
 
   def serving(kind),
     do:
@@ -642,9 +668,9 @@ defmodule Vutuv.Images do
   upload, a picture the editor removed on save, the pending sweep, a rejected
   scan). One statement, and a no-op for an empty list.
 
-  A posting or a member that is deleted needs no call: `images.job_posting_id`
-  and `images.user_id` both cascade, exactly as the gallery table's own columns
-  do.
+  A parent or a member that is deleted needs no call: `images.job_posting_id`,
+  `images.post_id` and `images.user_id` all cascade, exactly as the gallery
+  table's own columns do.
   """
   def forget(_kind, []), do: :ok
 

--- a/lib/vutuv/images/backfill.ex
+++ b/lib/vutuv/images/backfill.ex
@@ -66,8 +66,8 @@ defmodule Vutuv.Images.Backfill do
       avatar and cover today; a review's cover when #2055 lands, which is this
       shape and not the other one), joined by a pointer.
     * `%{gallery: …}` — the truth is a **row of the picture's own**, joined by
-      the `token` both sides carry. A job-posting picture since #2054, post
-      photos and organization images to follow.
+      the `token` both sides carry. A job-posting picture since #2054 and a
+      post photo since #2052; organization images to follow.
 
   Everything around them is shared: the keyset walk, the class vocabulary, the
   repair, the sample, the printing and both operator commands. A gallery kind
@@ -75,9 +75,10 @@ defmodule Vutuv.Images.Backfill do
   names the classes it can produce, so the report never prints a zero for a
   class that kind cannot have.
 
-  **A gallery kind adds nothing here at all**: `source/1` builds itself from
-  `Vutuv.Images.mirror_source/1`, which is the one registry, so a kind cannot
-  be mirrored on the request path and invisible to this pass. The one thing to
+  **A gallery kind adds nothing here at all** — #2052 added not a line:
+  `source/1` builds itself from `Vutuv.Images.mirror_source/1`, which is the one
+  registry, so a kind cannot be mirrored on the request path and invisible to
+  this pass. The one thing to
   check when the next kind arrives is the store's `version_path/2` signature —
   `Vutuv.PostImageStore` and `Vutuv.JobPostingImageStore` take the row,
   `Vutuv.OrganizationImageStore` takes the token, and

--- a/lib/vutuv/images/image.ex
+++ b/lib/vutuv/images/image.ex
@@ -18,10 +18,12 @@ defmodule Vutuv.Images.Image do
     belongs_to(:user, Vutuv.Accounts.User)
 
     # The parent a gallery picture belongs to. Nil for a profile picture, and
-    # nil for a posting image whose posting has not been saved yet. One column
-    # per parent kind, as #2013's migration asked for; the post and the
-    # organization add theirs when they move (#2052, #2053).
+    # nil for a picture whose parent has not been saved yet — a posting image
+    # in the job editor, a photo in the composer. One column per parent kind,
+    # as #2013's migration asked for; the organization adds hers when she moves
+    # (#2053).
     belongs_to(:job_posting, Vutuv.Jobs.JobPosting)
+    belongs_to(:post, Vutuv.Posts.Post)
 
     field(:token, :string)
 
@@ -40,15 +42,34 @@ defmodule Vutuv.Images.Image do
     field(:frozen_at, :naive_datetime)
 
     # What a gallery row holds besides the above, copied column for column from
-    # the table it mirrors (`job_posting_images` today; `post_images` and
-    # `organization_images` carry the same six under the same names). Nil for a
-    # profile picture, which has none of them.
+    # the table it mirrors (`job_posting_images` and `post_images` today;
+    # `organization_images` carries the same six under the same names). Nil for
+    # a profile picture, which has none of them.
     field(:alt, :string)
     field(:position, :integer)
     field(:width, :integer)
     field(:height, :integer)
     field(:content_type, :string)
     field(:size_bytes, :integer)
+
+    # Picture attributes the post photo brought in (#2052) and the kinds that
+    # have them share, the way `crop` above is shared: the caption shown under
+    # the picture, the whitelisted camera facts `Vutuv.Uploads.Exif` parses at
+    # upload, the fact (never the coordinates) that the upload carried a
+    # location, and the author's three per-photo switches. Nil on a row of a
+    # kind that has no such thing.
+    field(:caption, :string)
+    field(:camera, :string)
+    field(:lens, :string)
+    field(:focal_length, :string)
+    field(:aperture, :string)
+    field(:shutter, :string)
+    field(:iso, :integer)
+    field(:taken_at, :naive_datetime)
+    field(:has_gps, :boolean)
+    field(:show_camera_info, :boolean)
+    field(:download_original, :boolean)
+    field(:download_exact, :boolean)
 
     timestamps()
   end

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -62,6 +62,7 @@ defmodule Vutuv.Posts do
   alias Vutuv.Fediverse.PostRepost, as: FediversePostRepost
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Images
   alias Vutuv.Keyset
   alias Vutuv.Mentions
   alias Vutuv.Moderation.ImageScans
@@ -153,6 +154,16 @@ defmodule Vutuv.Posts do
   @thread_skeleton_limit 1000
   @pending_max_age_hours 24
   @max_tags 5
+
+  # A post photo's name in the shared `images` table, in `Vutuv.Images.kinds/0`
+  # and in `Vutuv.Moderation.ImageScans` — one string for all three. Since
+  # #2052 every write to `post_images` keeps a row there in step with the row
+  # here (the "Images" section below); the deploy that moves the readers onto
+  # that row retires the double write. Declared up here because the first use
+  # is `attach_images!/2`, far above that section — a module attribute read
+  # before it is set is `nil`.
+  @image_kind "post_image"
+
   # How many likers the permalink names before the rest fold into the avatar
   # stack's `+N` chip (issue #1233). The same cap the row and the agent-format
   # siblings use, so both name the same people.
@@ -607,6 +618,10 @@ defmodule Vutuv.Posts do
       {:ok, updated} ->
         if removed != [] do
           Repo.delete_all(from(i in PostImage, where: i.id in ^Enum.map(removed, & &1.id)))
+          # The mirror rows go with them, in the same transaction and in one
+          # statement. The files follow only after the commit (`run_update/3`),
+          # so a rolled-back edit still has both rows and both files.
+          :ok = Images.forget(@image_kind, Enum.map(removed, & &1.token))
         end
 
         attach_images!(updated, image_ids)
@@ -622,6 +637,11 @@ defmodule Vutuv.Posts do
   `{:post_deleted, …}` to the author's followers' feeds and the post's topic
   (so feed entries drop and action bars empty). When the post was a reply, its
   parent's fresh reply count is re-broadcast.
+
+  The mirror rows in `images` go with the same cascade — `images.post_id`
+  carries the post's `on_delete: :delete_all` exactly as `post_images.post_id`
+  does — so there is nothing to forget by hand here, and the same is true of
+  `Vutuv.Accounts.delete_user/1` through `images.user_id`.
   """
   def delete_post(%Post{} = post) do
     # `:remote_reply_ref` is loaded before the delete on purpose: the sidecar row
@@ -907,25 +927,37 @@ defmodule Vutuv.Posts do
     now = NaiveDateTime.utc_now(:second)
     uploader_id = post.user_id || post.acting_user_id
 
-    image_ids
-    |> Enum.with_index()
-    |> Enum.each(fn {id, position} ->
-      # Belt and braces for a post that somehow names neither: rolling back
-      # beats handing the same nil to the query below.
-      if is_nil(uploader_id), do: Repo.rollback(:invalid_images)
+    attached =
+      image_ids
+      |> Enum.with_index()
+      |> Enum.map(fn {id, position} ->
+        # Belt and braces for a post that somehow names neither: rolling back
+        # beats handing the same nil to the query below.
+        if is_nil(uploader_id), do: Repo.rollback(:invalid_images)
 
-      {count, _} =
-        Repo.update_all(
-          from(i in PostImage,
-            where:
-              i.id == ^id and i.user_id == ^uploader_id and
-                (is_nil(i.post_id) or i.post_id == ^post.id)
-          ),
-          set: [post_id: post.id, position: position, updated_at: now]
-        )
+        # RETURNING the attached row, so the mirror learns the new parent and
+        # position from the same statement rather than reading them back.
+        updated =
+          Repo.update_all(
+            from(i in PostImage,
+              where:
+                i.id == ^id and i.user_id == ^uploader_id and
+                  (is_nil(i.post_id) or i.post_id == ^post.id),
+              select: i
+            ),
+            set: [post_id: post.id, position: position, updated_at: now]
+          )
 
-      if count != 1, do: Repo.rollback(:invalid_images)
-    end)
+        case updated do
+          {1, [image]} -> image
+          _none_or_many -> Repo.rollback(:invalid_images)
+        end
+      end)
+
+    # One upsert for the whole gallery, however many photos it holds — a post
+    # with ten pictures costs one statement here, not ten. Inside the caller's
+    # transaction, so an interrupted save leaves neither half.
+    :ok = Images.mirror(@image_kind, attached)
   end
 
   # Claims the clip for the post (issue #1906) the way the images are claimed:
@@ -6532,24 +6564,38 @@ defmodule Vutuv.Posts do
 
   # Fresh images start in AI-moderation limbo (owner-only, placecard for
   # everyone else) until the scan releases or deletes them.
+  #
+  # `Images.write_mirrored/2` writes the row here and its mirror in the shared
+  # `images` table in one transaction (issue #2052), and hands back exactly
+  # what `Repo.insert/1` would have.
   defp insert_scanned_image(user, token, meta) do
     insert =
-      %PostImage{
-        user_id: user.id,
-        token: token,
-        moderation: ImageScans.initial_state()
-      }
-      |> Ecto.Changeset.change(meta)
-      |> Repo.insert()
+      Images.write_mirrored(@image_kind, fn ->
+        %PostImage{
+          user_id: user.id,
+          token: token,
+          moderation: ImageScans.initial_state()
+        }
+        |> Ecto.Changeset.change(meta)
+        |> Repo.insert()
+      end)
 
     with {:ok, image} <- insert do
-      ImageScans.enqueue("post_image", image.id, user.id)
+      ImageScans.enqueue(@image_kind, image.id, user.id)
       {:ok, image}
     end
   end
 
+  # Every edit to a photo's row goes through here: the update and its mirror in
+  # the shared `images` table, in one transaction (issue #2052). Named rather
+  # than spelled at each of the three call sites, so "an edit writes both rows"
+  # has one place to read and one place for the release that retires the
+  # double write to delete.
+  defp mirrored_update(changeset),
+    do: Images.write_mirrored(@image_kind, fn -> Repo.update(changeset) end)
+
   def update_image_alt(%PostImage{} = image, alt) do
-    image |> PostImage.alt_changeset(%{alt: alt}) |> Repo.update()
+    image |> PostImage.alt_changeset(%{alt: alt}) |> mirrored_update()
   end
 
   @doc """
@@ -6592,11 +6638,14 @@ defmodule Vutuv.Posts do
   the cleaned label.
   """
   def update_image_settings(%PostImage{} = image, params) do
+    # The changeset is built before the transaction opens: both guards below
+    # stat the stored original, and disk I/O inside a transaction holds a
+    # connection open for it.
     image
     |> PostImage.settings_changeset(params)
     |> force_exact_when_uncleanable(image)
     |> block_exact_when_cropped(image)
-    |> Repo.update()
+    |> mirrored_update()
   end
 
   defp force_exact_when_uncleanable(changeset, image) do
@@ -6638,10 +6687,12 @@ defmodule Vutuv.Posts do
 
     case PostImageStore.apply_crop(image, crop) do
       {:ok, dimensions} ->
+        # The served frame, the dimensions that describe it and the exact-file
+        # download that has to go with them move together into both rows.
         image
         |> Ecto.Changeset.change(Map.put(dimensions, :crop, crop))
         |> drop_exact_for_crop(crop)
-        |> Repo.update()
+        |> mirrored_update()
 
       {:error, _reason} = error ->
         error
@@ -6742,7 +6793,14 @@ defmodule Vutuv.Posts do
     {count, _} =
       Repo.delete_all(from(i in PostImage, where: i.id == ^image.id and is_nil(i.post_id)))
 
-    if count == 1, do: PostImageStore.delete(image.token)
+    if count == 1 do
+      # Row, mirror, files — in that order, so an interruption can only ever
+      # leave something a sweep collects (an orphan mirror row, then orphan
+      # files), never a row naming bytes that are gone.
+      :ok = Images.forget(@image_kind, [image.token])
+      PostImageStore.delete(image.token)
+    end
+
     count == 1
   end
 

--- a/lib/vutuv/release.ex
+++ b/lib/vutuv/release.ex
@@ -134,13 +134,15 @@ defmodule Vutuv.Release do
   corrects any row that disagrees with the picture's own columns (see
   `Vutuv.Images.Backfill`). Covers profile pictures and covers (#2013/#2014)
   and the kinds that still keep a table of their own — a job-posting picture
-  since #2054. Moves no file and changes no URL, so it is safe while the app
-  serves traffic and safe to run again after an interruption:
+  since #2054, a post photo since #2052. Moves no file and changes no URL, so
+  it is safe while the app serves traffic and safe to run again after an
+  interruption:
 
       bin/vutuv eval "Vutuv.Release.backfill_image_rows()"
       bin/vutuv eval "Vutuv.Release.backfill_image_rows(dry_run: true)"
       bin/vutuv eval "Vutuv.Release.backfill_image_rows(only: \\"cover\\")"
       bin/vutuv eval "Vutuv.Release.backfill_image_rows(only: \\"job_posting_image\\")"
+      bin/vutuv eval "Vutuv.Release.backfill_image_rows(only: \\"post_image\\")"
   """
   def backfill_image_rows(opts \\ []) do
     load_app()

--- a/priv/repo/migrations/20260907212736_add_post_images_to_images.exs
+++ b/priv/repo/migrations/20260907212736_add_post_images_to_images.exs
@@ -1,0 +1,144 @@
+defmodule Vutuv.Repo.Migrations.AddPostImagesToImages do
+  use Ecto.Migration
+
+  # The second of the four kinds #2015 moves into the shared `images` table
+  # (issue #2052), and the largest: a post photo carries a caption, a crop,
+  # seven camera facts, a GPS flag and the author's three switches beside the
+  # columns every gallery row has.
+  #
+  # Expand half only: this takes nothing away and nothing reads the new
+  # columns, so the release serving traffic while it runs is unaffected. The
+  # release it ships with writes a row here beside every `post_images` row; the
+  # deploy after that moves the readers and the takedown onto it, and only the
+  # one after *that* retires the old table.
+  #
+  # **Column types are the ones the values are copied from**, read off
+  # `post_images` rather than defaulted. The one that matters is `caption`:
+  # `:text` there, because a photographer's note runs to 1,000 characters
+  # through the composer, and a varchar(255) copy would raise Postgres 22001
+  # from `Vutuv.Images.mirror/2` — on the *write* path, where no changeset
+  # validation stands between the member and the error. The camera facts are
+  # display primitives in varchar(255) (`f/1.4`, `1/250 s`, `35 mm`), `iso` is
+  # an integer, `taken_at` a naive_datetime and the four flags booleans.
+  #
+  # Six columns are **not** here because #2054 already added them for the
+  # job-posting picture — `alt`, `position`, `width`, `height`, `content_type`,
+  # `size_bytes` — and three more because a profile picture already had them:
+  # `token` (the join key), `moderation`, and `crop`, which holds exactly what
+  # `post_images.crop` holds (`"x,y,w,h"` fractions, ~27 bytes, varchar(255)).
+  #
+  # **Nullable, and no defaults**, the way #2054's six are, although four of
+  # these are `NOT NULL DEFAULT false` on `post_images`: an avatar row has no
+  # opinion about a camera panel, and NULL is how it says so. The mirror copies
+  # the real `false` for a photo, so nothing reads a NULL as "off".
+  #
+  # There is deliberately **no reverse pointer** the way `users.avatar_image_id`
+  # is one: a gallery row already carries a `token` that is unique in both
+  # tables and never re-minted, and `images.token` has been unique across the
+  # whole table since #2013 precisely so these kinds could move in on it.
+  #
+  # **Not concurrent, measured rather than assumed.** `images` holds 1,752 rows
+  # on the production copy (1,682 avatars, 70 covers; vutuv.de has no job
+  # postings) and this release's backfill adds one per post photo — 161 there,
+  # so ~1,913 rows in 88 kB. Adding a nullable column with no default is
+  # metadata-only since Postgres 11, and the index build and the constraint
+  # revalidation each scan that table once: measured on a copy of it with the
+  # 1,752 profile rows already in place, the whole migration took 14 ms (6 ms
+  # for the thirteen columns, 3 ms for the index, 3 ms for the constraint).
+  # `CREATE INDEX CONCURRENTLY` would cost two scans,
+  # `@disable_ddl_transaction` and a migration that cannot roll back, to save a
+  # lock nobody would notice. Revisit when `images` reaches the millions — the
+  # sentence to re-read then is this one, and the two shapes it wants are
+  # `CREATE INDEX CONCURRENTLY` and, for the constraint below (which is the
+  # other full scan here, under ACCESS EXCLUSIVE), `ADD CONSTRAINT … NOT VALID`
+  # followed by `VALIDATE CONSTRAINT`, which takes only SHARE UPDATE EXCLUSIVE
+  # and lets writes carry on.
+  def up do
+    alter table(:images) do
+      # The parent post. Nullable because a photo is uploaded *before* the post
+      # exists (the composer needs a URL to reference it inline, and
+      # `Vutuv.Posts.sweep_pending_images/1` collects what is never attached),
+      # and because no other kind has a post.
+      add(:post_id, references(:posts, type: :binary_id, on_delete: :delete_all))
+
+      # Shown under the photo to everyone, and distinct from `alt`, which
+      # describes the picture for people who cannot see it.
+      add(:caption, :text)
+
+      # The whitelisted camera facts (`Vutuv.Uploads.Exif`), parsed once at
+      # upload and stored as the notation they are rendered in.
+      add(:camera, :string)
+      add(:lens, :string)
+      add(:focal_length, :string)
+      add(:aperture, :string)
+      add(:shutter, :string)
+      add(:iso, :integer)
+      add(:taken_at, :naive_datetime)
+
+      # Whether the upload carried location data — never the coordinates. It is
+      # what lets the composer warn before the exact file is handed out, and it
+      # is the reason it has to survive the deploy that drops `post_images`.
+      add(:has_gps, :boolean)
+
+      # The author's three per-photo switches.
+      add(:show_camera_info, :boolean)
+      add(:download_original, :boolean)
+      add(:download_exact, :boolean)
+    end
+
+    # The cascade's own lookup, for the same reason `images.job_posting_id` has
+    # one: deleting a post would otherwise scan a table that ends up holding
+    # every picture in the system. No query this release adds needs it — the
+    # mirror upserts on `token`, `forget/2` filters on `token` and the backfill
+    # joins on `token`, all served by `images_token_index`.
+    #
+    # **Partial**, following #2054: every other kind's row is NULL here, and
+    # Postgres proves `IS NOT NULL` from the referential trigger's strict
+    # `post_id = $1` and uses it.
+    create(index(:images, [:post_id], where: "post_id IS NOT NULL"))
+
+    # #2013 asked the kinds that arrive here to **extend** this constraint
+    # rather than widen the nullable `user_id` column. A post photo always has
+    # an uploader (`post_images.user_id` is NOT NULL — for a page's post it is
+    # the member who uploaded it, not the page), so it joins the list. N-1
+    # safe: the release serving traffic writes only avatar, cover and
+    # job-posting rows, all of which already satisfy the wider check.
+    drop(constraint(:images, :images_profile_kind_has_owner))
+
+    create(
+      constraint(:images, :images_profile_kind_has_owner,
+        check:
+          "kind NOT IN ('avatar', 'cover', 'job_posting_image', 'post_image') " <>
+            "OR user_id IS NOT NULL"
+      )
+    )
+  end
+
+  def down do
+    drop(constraint(:images, :images_profile_kind_has_owner))
+
+    create(
+      constraint(:images, :images_profile_kind_has_owner,
+        check: "kind NOT IN ('avatar', 'cover', 'job_posting_image') OR user_id IS NOT NULL"
+      )
+    )
+
+    drop(index(:images, [:post_id], where: "post_id IS NOT NULL"))
+
+    alter table(:images) do
+      remove(:post_id)
+      remove(:caption)
+      remove(:camera)
+      remove(:lens)
+      remove(:focal_length)
+      remove(:aperture)
+      remove(:shutter)
+      remove(:iso)
+      remove(:taken_at)
+      remove(:has_gps)
+      remove(:show_camera_info)
+      remove(:download_original)
+      remove(:download_exact)
+    end
+  end
+end

--- a/test/vutuv/images/backfill_test.exs
+++ b/test/vutuv/images/backfill_test.exs
@@ -25,6 +25,7 @@ defmodule Vutuv.Images.BackfillTest do
   alias Vutuv.Uploads.Spec
 
   @kind "job_posting_image"
+  @post_kind "post_image"
 
   setup do
     tmp =
@@ -66,6 +67,18 @@ defmodule Vutuv.Images.BackfillTest do
   end
 
   defp job_posting_row(picture), do: Vutuv.ImageHelpers.mirror_row(@kind, picture)
+
+  # The same for a post photo (#2052), which is the same shape carrying far
+  # more columns — a caption, a crop, the camera facts and three switches.
+  defp stored_post_image(attrs \\ []) do
+    picture = insert(:post_image, attrs)
+    dir = Uploads.disk_dir(Path.join("post_images", picture.token))
+    File.mkdir_p!(dir)
+    File.write!(Path.join(dir, "thumb#{Spec.served_ext()}"), "not really an avif")
+    picture
+  end
+
+  defp post_image_row(picture), do: Vutuv.ImageHelpers.mirror_row(@post_kind, picture)
 
   defp jpeg_upload(name \\ "selfie.jpg") do
     src = Path.join(System.tmp_dir!(), "backfill_src_#{System.unique_integer([:positive])}.jpg")
@@ -366,6 +379,89 @@ defmodule Vutuv.Images.BackfillTest do
       end)
 
       assert job_posting_row(picture)
+    end
+  end
+
+  # The machinery above is the machinery here — a gallery source builds itself
+  # from `Vutuv.Images.mirror_source/1`, so the post photo added no line to
+  # `Vutuv.Images.Backfill`. What is worth its own tests is the part the second
+  # kind could get wrong on its own: the registry entry reaching this pass at
+  # all, and the columns no other kind has surviving the copy.
+  describe "a gallery kind: the post photo (issue #2052)" do
+    test "it is one of the kinds a bare run walks" do
+      assert @post_kind in Backfill.kinds()
+    end
+
+    test "one that predates the mirror arrives with the columns no other kind has" do
+      picture =
+        stored_post_image(
+          alt: "Ein Feld im Abendlicht",
+          caption: "Am letzten Morgen in Lissabon",
+          crop: "0.0000,0.0000,0.5000,0.5000",
+          camera: "Fujifilm X-T5",
+          lens: "XF 35mm F1.4 R",
+          focal_length: "35 mm",
+          aperture: "f/1.4",
+          shutter: "1/250 s",
+          iso: 400,
+          taken_at: ~N[2026-08-01 06:14:00],
+          has_gps: true,
+          show_camera_info: true,
+          download_original: true
+        )
+
+      assert %{@post_kind => tally} = Backfill.run(only: @post_kind)
+      assert tally.pictures == 1
+      assert tally.created == 1
+
+      assert %ImageRow{} = row = post_image_row(picture)
+      assert row.kind == @post_kind
+      assert row.user_id == picture.user_id
+      assert row.post_id == picture.post_id
+      assert row.caption == picture.caption
+      assert row.crop == picture.crop
+      assert row.camera == picture.camera
+      assert row.lens == picture.lens
+      assert row.focal_length == picture.focal_length
+      assert row.aperture == picture.aperture
+      assert row.shutter == picture.shutter
+      assert row.iso == picture.iso
+      assert row.taken_at == picture.taken_at
+      assert row.has_gps == true
+      assert row.show_camera_info == true
+      assert row.download_original == true
+      assert row.download_exact == false
+    end
+
+    test "a row whose caption drifted is corrected, and keeps its token" do
+      picture = stored_post_image(caption: "Am letzten Morgen in Lissabon")
+      Backfill.run(only: @post_kind)
+      before = post_image_row(picture)
+
+      Repo.update_all(from(i in ImageRow, where: i.id == ^before.id),
+        set: [caption: "stale", has_gps: true]
+      )
+
+      assert %{@post_kind => tally} = Backfill.run(only: @post_kind)
+      assert tally.corrected == 1
+
+      after_run = post_image_row(picture)
+      assert after_run.token == before.token
+      assert after_run.caption == picture.caption
+      assert after_run.has_gps == false
+    end
+
+    test "the check names the photos with no row, and goes quiet once they have one" do
+      picture = stored_post_image()
+
+      assert %{kinds: %{@post_kind => before}, ok?: false} = Backfill.check(only: @post_kind)
+      assert before.missing_row.count == 1
+      assert before.missing_row.sample == [picture.id]
+      assert before.missing_file.count == 0
+
+      Backfill.run(only: @post_kind)
+
+      assert %{ok?: true} = Backfill.check(only: @post_kind)
     end
   end
 

--- a/test/vutuv/images/job_posting_images_test.exs
+++ b/test/vutuv/images/job_posting_images_test.exs
@@ -168,49 +168,6 @@ defmodule Vutuv.Images.JobPostingImagesTest do
     end
   end
 
-  describe "the mirror carries the whole picture" do
-    # The mirror copies by name, and `Map.fetch!/2` makes a name listed in
-    # `Vutuv.Images` that the source does not have raise. The other direction —
-    # a column added to `job_posting_images` and never listed — nothing can
-    # see: the mirror simply would not carry it, and the backfill's own
-    # comparison reads the same list, so it would agree that all is well. This
-    # is what notices, and the deploy that retires the old table is what it
-    # protects: a column nobody mirrored is a column that is lost then.
-    #
-    # A column that genuinely belongs to the old row alone goes on the
-    # exclusion list below, with the reason.
-    test "every column of the gallery row is mirrored, or excluded on purpose" do
-      not_mirrored = [
-        # The two rows are separate records with separate lifetimes; the mirror
-        # mints a UUID v7 of its own and stamps its own timestamps.
-        :id,
-        :inserted_at,
-        :updated_at
-      ]
-
-      source = Vutuv.Images.mirror_source(@kind)
-      columns = source.schema.__schema__(:fields)
-
-      assert Enum.sort(columns) == Enum.sort(source.fields ++ not_mirrored),
-             """
-             `job_posting_images` and the mirror have drifted.
-
-             columns:  #{inspect(Enum.sort(columns))}
-             mirrored: #{inspect(Enum.sort(source.fields))}
-             excluded: #{inspect(Enum.sort(not_mirrored))}
-
-             Add the column to `Vutuv.Images`' mirror entry (and to the
-             `images` table in a migration), or to `not_mirrored` here with the
-             reason it belongs to the old row alone.
-             """
-    end
-
-    test "and every mirrored name is a column of the images row too" do
-      source = Vutuv.Images.mirror_source(@kind)
-      assert source.fields -- ImageRow.__schema__(:fields) == []
-    end
-  end
-
   describe "nothing about serving moved" do
     test "the URL is the one it always was", %{tmp: tmp} do
       user = poster_fixture()

--- a/test/vutuv/images/post_images_test.exs
+++ b/test/vutuv/images/post_images_test.exs
@@ -1,0 +1,301 @@
+defmodule Vutuv.Images.PostImagesTest do
+  @moduledoc """
+  The largest of the four kinds #2015 moves into the shared `images` table
+  (issue #2052): a post photo is a row there beside its own row, kept in step
+  by every write, and nothing about how it is stored or served has moved.
+
+  The shape is #2054's — the join is the `token` both rows carry, the mirror is
+  one upsert and one delete, and the registry in `Vutuv.Images` is what the
+  backfill reads. What is new here is how much a photo carries: a caption, a
+  crop, seven camera facts, a GPS flag and the author's three switches, all of
+  which have to survive the deploy that retires `post_images`.
+
+  Not async: the upload path writes files, so the module holds the global
+  `:uploads_dir_prefix` down for its lifetime.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.WebPushHelpers, only: [put_config: 2]
+
+  alias Vutuv.Accounts
+  alias Vutuv.ImageHelpers
+  alias Vutuv.Images
+  alias Vutuv.Images.Image, as: ImageRow
+  alias Vutuv.Moderation.ImageSubjects
+  alias Vutuv.Posts
+  alias Vutuv.Posts.PostImage
+  alias Vutuv.Repo
+
+  @kind "post_image"
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "vutuv_post_images_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    put_config(:uploads_dir_prefix, tmp)
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    {:ok, tmp: tmp, user: insert(:activated_user)}
+  end
+
+  defp upload!(user, tmp) do
+    src = Path.join(tmp, "src-#{System.unique_integer([:positive])}.jpg")
+    {:ok, img} = Image.new(640, 480, color: [10, 200, 100])
+    {:ok, _} = Image.write(img, src)
+    {:ok, image} = Posts.create_pending_image(user, src, "photo.jpg")
+    image
+  end
+
+  defp mirror(picture), do: ImageHelpers.mirror_row(@kind, picture)
+
+  describe "the row beside the row" do
+    # Field by field off the registry rather than off a list written a second
+    # time here, so a field added to `@mirrored` and forgotten on the request
+    # path fails this without anybody editing the test. The three assertions
+    # outside the loop are what the mirror sets rather than copies.
+    test "an upload writes one, column for column", %{tmp: tmp, user: user} do
+      image = upload!(user, tmp)
+
+      assert %ImageRow{} = row = mirror(image)
+      assert row.kind == @kind
+      assert row.id != image.id
+      assert row.frozen_at == nil
+
+      for field <- Images.mirror_source(@kind).fields do
+        assert Map.fetch!(row, field) == Map.fetch!(image, field),
+               "#{field} drifted: #{inspect(Map.fetch!(row, field))} != " <>
+                 inspect(Map.fetch!(image, field))
+      end
+    end
+
+    test "attaching the photo to a post moves the parent and the position across", %{
+      tmp: tmp,
+      user: user
+    } do
+      first = upload!(user, tmp)
+      second = upload!(user, tmp)
+
+      {:ok, post} =
+        Posts.create_post(user, %{body: "Zwei Fotos.", image_ids: [first.id, second.id]})
+
+      assert mirror(first).post_id == post.id
+      assert mirror(first).position == 0
+      assert mirror(second).post_id == post.id
+      assert mirror(second).position == 1
+    end
+
+    test "an edited alt text follows", %{tmp: tmp, user: user} do
+      image = upload!(user, tmp)
+
+      {:ok, _} = Posts.update_image_alt(image, "Blick über die Elbe")
+
+      assert mirror(image).alt == "Blick über die Elbe"
+    end
+
+    test "the composer's per-photo panel follows: caption and the two switches", %{
+      tmp: tmp,
+      user: user
+    } do
+      image = upload!(user, tmp)
+
+      {:ok, _} =
+        Posts.update_image_settings(image, %{
+          "alt" => "Ein Feld im Abendlicht",
+          "caption" => "Am letzten Morgen in Lissabon",
+          "show_camera_info" => "true",
+          "download_original" => "true",
+          "download_exact" => "true"
+        })
+
+      row = mirror(image)
+      assert row.caption == "Am letzten Morgen in Lissabon"
+      assert row.show_camera_info == true
+      assert row.download_original == true
+      assert row.download_exact == true
+    end
+
+    # A crop is the one edit that changes what the served frame *is*: the
+    # fractions, the dimensions they produce and the exact-file download that
+    # has to go with them all move together.
+    test "a crop follows, dimensions and exact-file flag included", %{tmp: tmp, user: user} do
+      image = upload!(user, tmp)
+      {:ok, _} = Posts.update_image_settings(image, %{"download_original" => "true"})
+
+      {:ok, cropped} = Posts.crop_image(Repo.reload!(image), "0,0,0.5,0.5")
+
+      row = mirror(image)
+      assert row.crop == cropped.crop
+      assert row.width == cropped.width
+      assert row.height == cropped.height
+      assert row.download_exact == false
+    end
+
+    # The camera facts are parsed at upload and never cast from params, so this
+    # writes them the way `Vutuv.Uploads.Exif` would and then makes an ordinary
+    # edit — which is the moment the mirror has to carry them.
+    test "the camera facts and the GPS flag ride along", %{tmp: tmp, user: user} do
+      image = upload!(user, tmp)
+
+      {:ok, image} =
+        image
+        |> Ecto.Changeset.change(%{
+          camera: "Fujifilm X-T5",
+          lens: "XF 35mm F1.4 R",
+          focal_length: "35 mm",
+          aperture: "f/1.4",
+          shutter: "1/250 s",
+          iso: 400,
+          taken_at: ~N[2026-08-01 06:14:00],
+          has_gps: true
+        })
+        |> Repo.update()
+
+      {:ok, _} = Posts.update_image_alt(image, "Sonnenaufgang")
+
+      row = mirror(image)
+      assert row.camera == "Fujifilm X-T5"
+      assert row.lens == "XF 35mm F1.4 R"
+      assert row.focal_length == "35 mm"
+      assert row.aperture == "f/1.4"
+      assert row.shutter == "1/250 s"
+      assert row.iso == 400
+      assert row.taken_at == ~N[2026-08-01 06:14:00]
+      assert row.has_gps == true
+    end
+
+    test "the AI gate's release follows", %{tmp: tmp, user: user} do
+      image = upload!(user, tmp)
+
+      Repo.update_all(from(i in PostImage, where: i.id == ^image.id),
+        set: [moderation: "pending"]
+      )
+
+      Repo.update_all(from(i in ImageRow, where: i.token == ^image.token),
+        set: [moderation: "pending"]
+      )
+
+      scan = insert(:image_scan, kind: @kind, subject_id: image.id, owner_user_id: user.id)
+      assert :ok = ImageSubjects.apply_approved(scan)
+
+      assert mirror(image).moderation == "approved"
+    end
+  end
+
+  describe "the row goes when the picture goes" do
+    test "a pending upload the member discards", %{tmp: tmp, user: user} do
+      image = upload!(user, tmp)
+      assert mirror(image)
+
+      :ok = Posts.delete_pending_image(image)
+
+      refute mirror(image)
+    end
+
+    test "a photo the author removed while editing the post", %{tmp: tmp, user: user} do
+      image = upload!(user, tmp)
+      {:ok, post} = Posts.create_post(user, %{body: "Mit Foto.", image_ids: [image.id]})
+      assert mirror(image)
+
+      {:ok, _} = Posts.update_post(post, %{body: "Ohne Foto.", image_ids: []})
+
+      refute Repo.get(PostImage, image.id)
+      refute mirror(image)
+    end
+
+    test "a pending upload nobody ever attached", %{tmp: tmp, user: user} do
+      image = upload!(user, tmp)
+      assert mirror(image)
+      old = NaiveDateTime.add(NaiveDateTime.utc_now(:second), -25 * 3600, :second)
+
+      Repo.update_all(from(i in PostImage, where: i.id == ^image.id), set: [inserted_at: old])
+
+      assert Posts.sweep_pending_images() == 1
+
+      refute mirror(image)
+    end
+
+    test "a post that is deleted", %{tmp: tmp, user: user} do
+      image = upload!(user, tmp)
+      {:ok, post} = Posts.create_post(user, %{body: "Mit Foto.", image_ids: [image.id]})
+      assert mirror(image)
+
+      {:ok, _} = Posts.delete_post(post)
+
+      refute mirror(image)
+    end
+
+    test "a photo the AI gate rejected", %{tmp: tmp, user: user} do
+      image = upload!(user, tmp)
+      assert mirror(image)
+      scan = insert(:image_scan, kind: @kind, subject_id: image.id, owner_user_id: user.id)
+
+      assert :ok = ImageSubjects.apply_rejected(scan)
+
+      refute Repo.get(PostImage, image.id)
+      refute mirror(image)
+    end
+
+    # No call anywhere does this: `images.user_id` carries the same
+    # `on_delete: :delete_all` the photo's own row does.
+    test "a member who deletes their account", %{tmp: tmp, user: user} do
+      image = upload!(user, tmp)
+      assert mirror(image)
+
+      {:ok, _} = Accounts.delete_user(user)
+
+      refute Repo.get(PostImage, image.id)
+      refute mirror(image)
+    end
+  end
+
+  describe "the mirror carries the whole picture" do
+    # That every column is copied, or excluded on purpose, is asserted for
+    # every mirrored kind at once in `Vutuv.ImagesTest`. This is the one column
+    # of the thirteen whose *type* the copy can get wrong: `caption` is `text`
+    # on `post_images` because a photographer's note runs long (1,000
+    # characters through the composer), and a varchar(255) copy would raise
+    # Postgres 22001 on the mirror — on the *write* path, where no changeset
+    # validation stands between the member and the error.
+    test "a caption at its full length survives the copy", %{tmp: tmp, user: user} do
+      image = upload!(user, tmp)
+      long = String.duplicate("ä", PostImage.max_caption_length())
+
+      {:ok, _} = Posts.update_image_settings(image, %{"caption" => long})
+
+      assert mirror(image).caption == long
+    end
+  end
+
+  describe "nothing about serving moved" do
+    test "the URL is the one it always was", %{tmp: tmp, user: user} do
+      image = upload!(user, tmp)
+      assert mirror(image)
+
+      assert PostImage.url(image, "feed") == "/post_images/#{image.token}/feed.avif"
+    end
+
+    # The report form addresses a picture by its `images` row id, and until this
+    # release no row of this kind existed — so nothing could name one. Now one
+    # does, and `Vutuv.Images.freeze/1` has no clause for it: the takedown is
+    # the next release's work. A report has to be refused rather than accepted
+    # into a case whose uphold would raise (issue #2057).
+    test "a copyright report cannot name one yet — the freeze has no path for it", %{
+      tmp: tmp,
+      user: user
+    } do
+      row = mirror(upload!(user, tmp))
+      reporter = insert(:activated_user)
+
+      refute Vutuv.Moderation.can_report?(reporter, row)
+
+      assert {:error, :not_allowed} =
+               Vutuv.Moderation.report_content(reporter, row, %{
+                 "category" => "copyright",
+                 "details" => "That is my photograph."
+               })
+    end
+
+    # That `freeze/1`, `unfreeze/1` and `purge/1` raise for every kind the gate
+    # refuses is asserted over `Images.kinds()` in
+    # `Vutuv.ModerationImageTakedownTest`, so adding this kind there covered it.
+  end
+end

--- a/test/vutuv/images_test.exs
+++ b/test/vutuv/images_test.exs
@@ -280,12 +280,80 @@ defmodule Vutuv.ImagesTest do
     test "avatars and covers are served straight off disk" do
       assert Images.serving("avatar") == :static
       assert Images.serving("cover") == :static
-      assert Images.kinds() == ~w(avatar cover job_posting_image)
+      assert Images.kinds() == ~w(avatar cover job_posting_image post_image)
     end
 
+    # Both gallery kinds that have moved go through an authorizing proxy, so
+    # the row is their off switch rather than the tree the bytes sit in.
+    test "a job-posting picture and a post photo go through their proxy" do
+      assert Images.serving("job_posting_image") == :proxy
+      assert Images.serving("post_image") == :proxy
+    end
+
+    # An organization image is the next kind #2015 brings (#2053); until it
+    # arrives, asking about it is asking about a picture nobody could take
+    # offline.
     test "an undeclared kind raises rather than inheriting a default" do
       assert_raise ArgumentError, ~r/no serving strategy declared/, fn ->
-        Images.serving("post_image")
+        Images.serving("organization_image")
+      end
+    end
+  end
+
+  describe "the mirror registry against the tables it copies (issue #2015)" do
+    # The copy is a per-field `Map.fetch!/2`, so a name listed in `@mirrored`
+    # that the source lacks raises the moment anything mirrors. The other
+    # direction — a column added to a gallery table and never listed — nothing
+    # can see: the mirror simply would not carry it, and the backfill's own
+    # comparison reads the same list, so it would agree that all is well. The
+    # deploy that retires the old table is what would lose it, and this is what
+    # notices.
+    #
+    # Written over `mirrored_kinds/0` rather than once per kind, so the kinds
+    # still to come (#2053) are covered the day their entry lands rather than
+    # the day somebody remembers to copy a test.
+    #
+    # A column that genuinely belongs to the old row alone goes in the map
+    # below, with the reason.
+    @not_mirrored %{
+      # The two rows are separate records with separate lifetimes: the mirror
+      # mints a UUID v7 of its own and stamps its own timestamps.
+      #
+      # For a post photo `inserted_at` is the one exclusion with a consequence.
+      # The pixelated stand-in's window is measured from the photo's upload
+      # (`Vutuv.Posts.image_pixelated_url/1`), and a backfilled mirror row's
+      # stamp says when the backfill ran — so the release that moves the
+      # readers has to take that time from the photo. See
+      # `docs/architecture/images.md`.
+      default: [:id, :inserted_at, :updated_at]
+    }
+
+    test "every column of a mirrored table is copied, or excluded on purpose" do
+      for kind <- Images.mirrored_kinds() do
+        source = Images.mirror_source(kind)
+        excluded = Map.get(@not_mirrored, kind, @not_mirrored.default)
+        columns = source.schema.__schema__(:fields)
+
+        assert Enum.sort(columns) == Enum.sort(source.fields ++ excluded),
+               """
+               #{inspect(source.schema)} and its mirror have drifted.
+
+               columns:  #{inspect(Enum.sort(columns))}
+               mirrored: #{inspect(Enum.sort(source.fields))}
+               excluded: #{inspect(Enum.sort(excluded))}
+
+               Add the column to `Vutuv.Images`' `@mirrored` entry for
+               #{inspect(kind)} (and to the `images` table in a migration), or
+               to `@not_mirrored` here with the reason it belongs to the old
+               row alone.
+               """
+      end
+    end
+
+    test "and every mirrored name is a column of the images row too" do
+      for kind <- Images.mirrored_kinds() do
+        assert Images.mirror_source(kind).fields -- ImageRow.__schema__(:fields) == [],
+               "#{kind} names a column the images row does not have"
       end
     end
   end

--- a/test/vutuv_web/live/notification_live_test.exs
+++ b/test/vutuv_web/live/notification_live_test.exs
@@ -10,6 +10,7 @@ defmodule VutuvWeb.NotificationLiveTest do
   alias Vutuv.ImageHelpers
   alias Vutuv.Prefs
   alias Vutuv.Prefs.Cache
+  alias Vutuv.ViewerClock
 
   # Install `overrides` as the cached installation defaults for one test (the
   # Cache GenServer is off in tests, so put_defaults/1 alone would not show).
@@ -907,10 +908,10 @@ defmodule VutuvWeb.NotificationLiveTest do
 
       # Oldest of the three, yet its unanswered reply puts it on top.
       open = insert(:post, user: user, body: "The open one")
-      backdate_post(open, NaiveDateTime.add(NaiveDateTime.utc_now(:second), -3600))
+      backdate_post(open, an_hour_ago_today())
       pending = insert(:post, user: insert(:user), body: "a reply waiting for me")
       insert(:post_reply, post: pending, parent_post: open, parent_author: user)
-      backdate_reply(pending, NaiveDateTime.add(NaiveDateTime.utc_now(:second), -3600))
+      backdate_reply(pending, an_hour_ago_today())
 
       html = render_the_page(conn)
 
@@ -1877,6 +1878,26 @@ defmodule VutuvWeb.NotificationLiveTest do
       from(c in Vutuv.Social.Follow, where: c.id == ^id),
       set: [inserted_at: at]
     )
+  end
+
+  # An hour ago, but never before the start of the **viewer's** day.
+  #
+  # These cards are grouped by `Vutuv.ViewerClock.today()`, not by UTC, and the
+  # installation's zone runs ahead of UTC — so between 22:00 and 23:00 UTC in
+  # summer a flat `utc_now() - 3600` lands on yesterday's page and an ordering
+  # assertion is then comparing two different days. That is not a flake anybody
+  # can reproduce on demand: it fails for exactly one hour a night and passes
+  # again by itself, which is what the standing rule about wall-clock tests is
+  # about. The clamp leaves a one-second window at midnight itself, where the
+  # card is a second old rather than an hour, and that is still today's page.
+  defp an_hour_ago_today do
+    now = NaiveDateTime.utc_now(:second)
+    {start_of_day, _end_of_day} = ViewerClock.day_window(ViewerClock.today())
+
+    an_hour_ago = NaiveDateTime.add(now, -3600)
+
+    [Enum.max([an_hour_ago, start_of_day], NaiveDateTime), NaiveDateTime.add(now, -1)]
+    |> Enum.min(NaiveDateTime)
   end
 
   defp backdate_post(%Vutuv.Posts.Post{id: id}, at) do


### PR DESCRIPTION
A photo on a post cannot be taken offline on its own: it lives in `post_images` with an uploader of its own, so the copyright freeze that hides a profile picture has nothing to act on.

This is the expand release for that kind, #2015's second after #2054. Every write in `Vutuv.Posts` that touches a photo now also writes or drops a mirror row in `images`, joined on the `token` both carry — one entry in `Vutuv.Images`'s `@mirrored` registry, which the backfill reads. Almost every column comes along, because release three drops `post_images` and release two adds no migration.

Nothing reads the new row: every URL, `VutuvWeb.PostImageController` and the feed are unchanged, a report still cannot name a photo, and no file under `lib/vutuv_web`, `lib/vutuv/uploads` or `lib/vutuv/uploaders` is in the diff.

Then run `mix vutuv.images.backfill --only post_image`. The second commit fixes an unrelated test that goes red for one hour a night on `main`.

Closes #2052

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01UGPe7bHVS11M1W7fNehSku

<!-- closing-note #2052 -->
A post photo now has a row in the shared `images` table beside its own, written and dropped by every path that touches a photo and reconciled by `mix vutuv.images.backfill --only post_image`, so the copyright freeze will have something to act on. Almost every column of `post_images` is mirrored — the caption, the crop, the camera facts and the author's three switches — because the deploy that drops that table is two releases away and the one in between carries no migration; the exception is `inserted_at`, which the pixelated stand-in's window reads from the photo, and the next release has to answer for it. What I left out is the reading half: no URL, no proxy and no form has moved, so a report that names one of these rows is still refused.

*An AI agent wrote this text in my name. I know that is problematic.*
