### PR TITLE
Opening a bell-panel row counts that notification down

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -551,6 +551,29 @@ document.addEventListener("click", (event) => {
   if (event.target.closest("[data-notify-allow]")) requestNotifyPermission()
 })
 
+// Telling the server "I have seen this one event" on the way to `url`. The
+// server has to hear it BEFORE the tab navigates: leaving tears the socket down
+// and a push in flight goes with it. So navigation waits for the reply - and
+// for a socket that is slow or already gone, a short timer takes the member to
+// the page anyway. Whichever comes first wins; `done` is what keeps them from
+// being sent twice.
+//
+// Both ways out of one notification share it: clicking the browser popup, and
+// clicking a row of the bell's preview panel.
+function acknowledgeSeen(hook, ack, url) {
+  let done = false
+  const go = () => {
+    if (done) return
+    done = true
+    if (url) window.location.href = url
+  }
+
+  if (!ack) return go()
+
+  hook.pushEvent("notify:seen", ack, go)
+  window.setTimeout(go, 700)
+}
+
 // -- Service worker and Web Push (issue #1729) -----------------------------
 //
 // What the section above does works only while a vutuv page is open: a
@@ -1412,6 +1435,32 @@ const Hooks = {
       this.el.addEventListener("mouseleave", this.disarm)
       this.el.addEventListener("focusin", this.arm)
       this.el.addEventListener("focusout", this.disarm)
+
+      this.onRowClick = (event) => this.rowClicked(event)
+      this.el.addEventListener("click", this.onRowClick)
+    },
+    // Opening a row is reading that one event — and the close that marks the
+    // panel read never arrives, because the page is already leaving. So the row
+    // hands its own reference back first (the same acknowledgement the popup
+    // makes), and the badge drops by one rather than to zero.
+    //
+    // A modified click opens the row in a second tab and leaves this panel
+    // standing under the pointer, so its close is still coming and there is
+    // nothing to do here.
+    rowClicked(event) {
+      if (!plainClick(event)) return
+
+      const link = event.target.closest("a[data-seen-kind]")
+      if (!link) return
+
+      event.preventDefault()
+
+      const ack = {
+        kind: link.dataset.seenKind,
+        source_id: link.dataset.seenSourceId,
+      }
+
+      acknowledgeSeen(this, ack, link.href)
     },
     armOpen() {
       clearTimeout(this.closeTimer)
@@ -1439,6 +1488,7 @@ const Hooks = {
       this.el.removeEventListener("mouseleave", this.disarm)
       this.el.removeEventListener("focusin", this.arm)
       this.el.removeEventListener("focusout", this.disarm)
+      this.el.removeEventListener("click", this.onRowClick)
     },
   },
   // Browser notifications (issue #1249): a popup for activity that arrives while
@@ -1550,35 +1600,15 @@ const Hooks = {
       notification.onclick = () => {
         window.focus()
         notification.close()
-        this.acknowledge(ack, () => {
-          if (url) window.location.href = url
-        })
+        // Clicking a popup means the member has seen that one event, so the
+        // bell should drop it and keep the rest.
+        acknowledgeSeen(this, ack, url)
       }
 
       // Only ever fired for a test: it is what tells the settings card that a
       // popup really was constructed, so the card can stop waiting instead of
       // leaving the member to guess whether anything happened.
       if (test) window.dispatchEvent(new CustomEvent("vutuv:notify-shown"))
-    },
-    // Clicking a popup means the member has seen that one event, so the bell
-    // should drop it and keep the rest. The server needs to hear that BEFORE
-    // the tab navigates: assigning `location.href` tears the socket down, and
-    // a push in flight would go with it. So navigation waits for the server's
-    // reply - and for a socket that is slow or already gone, a short timer
-    // takes them to the page anyway. Whichever comes first wins; `done` is
-    // what keeps the member from being sent twice.
-    acknowledge(ack, then) {
-      if (!ack) return then()
-
-      let done = false
-      const go = () => {
-        if (done) return
-        done = true
-        then()
-      }
-
-      this.pushEvent("notify:seen", ack, go)
-      window.setTimeout(go, 700)
     },
   },
   // The admin member browser (VutuvWeb.Admin.UserLive) pages in place over the

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -492,6 +492,7 @@ the pointer on the bell drops a small panel under it instead — one round kind
 badge, who did what, how long ago, six of them at most and a "+N more" footer
 into the page — and **looking away marks them read**. The gesture says "I have
 seen this" as plainly as opening the page does, so it carries the same weight.
+Opening one of the rows says it about that one event; both gestures are below.
 
 The panel is `ShellLive`'s; only the gesture is the client's, because a hover is
 not something a LiveView binding can see. The `BellPreview` hook pushes
@@ -529,6 +530,20 @@ and `dismissed_event_ids/1` — or the panel and the number would disagree.
 Nothing is marked read by the close alone: the marker's own
 `:notifications_changed` broadcast is what recounts the badge, like every other
 change.
+
+**Opening a row is the second gesture, and it reads exactly one event.** The
+click takes the member off this page, so the close never fires and the badge
+would otherwise stand at what it said before — the number pointing at something
+they were just shown and then followed. So each row carries the reference of the
+event it stands for (`Activity.dismiss_ref/1` again, this time off a derived feed
+item, which knows only the id `event_id/2` composed for it), and the hook hands
+that back through the same `notify:seen` the browser popup uses before assigning
+`location.href`: the badge drops **by one**, not to zero, since the rest of the
+panel was shown and not opened. Navigation waits for the server's reply, with a
+700 ms timer taking the member to the page anyway when the socket is slow or
+already gone — a push in flight dies with the socket the navigation tears down.
+A modified click (a second tab) leaves the panel standing under the pointer, so
+that one is left to the close as before.
 
 ### The notifications page (2026-09 cards)
 

--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -523,18 +523,39 @@ defmodule Vutuv.Activity do
   `%{kind: kind, source_id: id}`, or nil for an event the tally cannot single
   out again.
 
-  The browser notification carries this back when the member clicks it, so the
-  kind vocabulary stays here rather than being spelled again in the shell.
+  The browser notification carries this back when the member clicks it, and so
+  does a row of the bell's preview panel, so the kind vocabulary stays here
+  rather than being spelled again in the shell.
+
+  Takes a live push and a derived feed item alike: the push names its row
+  outright, the feed item carries only the event id it was built with.
   """
   def dismiss_ref(%{kind: kind} = notification) do
     kind = dismiss_kind(kind, notification)
-    source_id = notification[:source_id]
+    source_id = dismiss_source_id(kind, notification)
 
     if kind in dismissable_kinds() and is_binary(source_id),
       do: %{kind: kind, source_id: source_id}
   end
 
   def dismiss_ref(_notification), do: nil
+
+  # The feed item's half: `event_id/2` run backwards, which is why the two can
+  # only agree. The cast is what refuses an id this kind did not compose — one
+  # prefix really is a prefix of another (`report-protection` of
+  # `report-protection-restored`), so the severed kind would otherwise read the
+  # restore half's id as `restored-<uuid>` and dismiss the wrong event.
+  defp dismiss_source_id(_kind, %{source_id: source_id}) when is_binary(source_id),
+    do: source_id
+
+  defp dismiss_source_id(kind, %{id: id}) when is_binary(id) do
+    case String.split(id, id_prefix(kind) <> "-", parts: 2) do
+      ["", source_id] -> if match?({:ok, _}, Vutuv.UUIDv7.cast(source_id)), do: source_id
+      _ -> nil
+    end
+  end
+
+  defp dismiss_source_id(_kind, _notification), do: nil
 
   # The severance row behind `report_protection` produces two events at
   # different times, so the pair (kind, source_id) needs the family to tell
@@ -569,11 +590,28 @@ defmodule Vutuv.Activity do
   but `cv_update`, plus the second name `report_protection` needs for its
   restore half. A kind cannot end up storing dismissals the tally then ignores,
   because both answers come from the same declaration.
+
+  Reading it costs 1,433 reductions, because `kind_specs/1` builds 38 Ecto
+  queries and 18 closures to hand back eighteen strings that never change. That
+  was affordable once per pushed notification and is not once per rendered row
+  of the bell's panel, so the answer is computed on the first call and kept in
+  `:persistent_term` (the `VutuvWeb.OgCard` arrangement): the registry stays the
+  single declaration, it is just read from once per node.
   """
   def dismissable_kinds do
-    for spec <- kind_specs(Vutuv.UUIDv7.generate()),
-        {kind, _shape} <- spec.dismiss,
-        do: kind
+    case :persistent_term.get({__MODULE__, :dismissable_kinds}, nil) do
+      nil ->
+        kinds =
+          for spec <- kind_specs(Vutuv.UUIDv7.generate()),
+              {kind, _shape} <- spec.dismiss,
+              do: kind
+
+        :persistent_term.put({__MODULE__, :dismissable_kinds}, kinds)
+        kinds
+
+      kinds ->
+        kinds
+    end
   end
 
   @doc """

--- a/lib/vutuv_web/live/shell_live.ex
+++ b/lib/vutuv_web/live/shell_live.ex
@@ -1764,8 +1764,13 @@ defmodule VutuvWeb.ShellLive do
           aria-label={gettext("New notifications")}
         >
           <li :for={row <- @rows} data-bell-preview-item>
+            <%!-- The row names the one event it stands for, so the hook can
+            hand it back before the click takes the member off this page: the
+            close that would otherwise have marked it read never arrives. --%>
             <.link
               href={row.href}
+              data-seen-kind={row.dismiss[:kind]}
+              data-seen-source-id={row.dismiss[:source_id]}
               class="flex items-start gap-2.5 px-4 py-2.5 hover:bg-slate-50 dark:hover:bg-slate-800"
             >
               <span
@@ -1828,7 +1833,8 @@ defmodule VutuvWeb.ShellLive do
       title: title,
       body: body,
       at: item[:at],
-      href: NotificationLine.notification_url(item, viewer)
+      href: NotificationLine.notification_url(item, viewer),
+      dismiss: Activity.dismiss_ref(item)
     }
   end
 

--- a/test/vutuv/notification_dismissal_test.exs
+++ b/test/vutuv/notification_dismissal_test.exs
@@ -95,13 +95,30 @@ defmodule Vutuv.NotificationDismissalTest do
 
         notification = pushed(me, act)
         ref = Activity.dismiss_ref(notification)
+        item = item_of_kind(me.id, kind)
 
         assert %{kind: ^kind} = ref,
                "the #{kind} push carries no dismissable reference"
 
-        assert Activity.event_id(ref.kind, ref.source_id) == item_of_kind(me.id, kind).id,
+        assert Activity.event_id(ref.kind, ref.source_id) == item.id,
                "the #{kind} push and its feed item name different rows"
+
+        # The bell's preview panel lists *feed* items, and clicking one makes
+        # the same statement as clicking the popup — but a feed item carries no
+        # `:source_id`, only the event id it was built from. So the reference
+        # has to come back out of that id, and be the one the push made.
+        assert Activity.dismiss_ref(item) == ref,
+               "the #{kind} feed item names a different row than its push"
       end
+    end
+
+    test "an id one kind's prefix can read out of another's is refused" do
+      # `report-protection` really is a prefix of `report-protection-restored`,
+      # so the severed half must not read the restore half's id as a row of its
+      # own — it would dismiss the wrong one of the pair.
+      restored = Activity.event_id("report_protection_restored", Vutuv.UUIDv7.generate())
+
+      refute Activity.dismiss_ref(%{kind: "report_protection", status: "severed", id: restored})
     end
   end
 

--- a/test/vutuv_web/live/shell_bell_preview_test.exs
+++ b/test/vutuv_web/live/shell_bell_preview_test.exs
@@ -59,6 +59,31 @@ defmodule VutuvWeb.ShellBellPreviewTest do
     assert has_element?(view, @bell_badge, "1")
   end
 
+  test "opening one row takes that event off the badge and leaves the rest", %{conn: conn} do
+    # Clicking a row takes the member off this page, so the close event the
+    # pointer would have sent never arrives — the row has to say for itself
+    # which event it stands for, and the hook hands that back before it
+    # navigates.
+    user = insert(:user)
+    follower_event(user, ~N[2024-03-01 12:00:00])
+    opened = follower_event(user, ~N[2024-03-02 12:00:00])
+
+    {:ok, view, _html} = shell(conn, user)
+    render_hook(view, "bell:preview", %{})
+
+    assert has_element?(
+             view,
+             ~s(a[data-seen-kind="follower"][data-seen-source-id="#{opened.id}"])
+           )
+
+    render_hook(view, "notify:seen", %{"kind" => "follower", "source_id" => opened.id})
+
+    # By one, not to zero: the older follow was on the panel too and nobody
+    # opened it.
+    assert has_element?(view, @bell_badge, "1")
+    assert Activity.unread_notification_count(user.id) == 1
+  end
+
   test "moving the pointer away marks exactly what was shown as read", %{conn: conn} do
     user = insert(:user)
     follower_event(user, ~N[2024-03-01 12:00:00])


### PR DESCRIPTION
Clicking a row of the bell's hover preview took you to the profile it announced and left the badge saying 1 — the panel is marked read by the pointer *leaving* it, and that event never arrives when the click has already navigated the page away.

Each row now carries the reference of its one event (`data-seen-kind` / `data-seen-source-id`), and the `BellPreview` hook in `assets/js/app.js` hands it back through the existing `notify:seen` before assigning `location.href`, waiting for the reply with the popup's 700 ms escape hatch. The badge drops **by one**: the rest of the panel was shown, not opened.

For that, `Vutuv.Activity.dismiss_ref/1` reads a derived feed item too, which knows only the id `event_id/2` composed for it. `dismissable_kinds/0` moved into `:persistent_term` — it rebuilt 38 Ecto queries per call, and a panel now asks six times.

Verified in a browser: bell at 2, one row opened, profile loaded, badge 1.

https://claude.ai/code/session_01JCTNdG7ZExSVDYP9t1QW1d
