### PR TITLE
Give a book review's cover a row in the shared images table

### DIFF
--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -325,21 +325,30 @@ no half-pair, and the second run created the other 1,438 and corrected none).
 `from: "<user id>"` resumes from a progress line instead of re-reading the
 table.
 
-Since #2054 the same two commands cover the gallery kinds as well.
+Since #2054 the same two commands cover every other kind as well.
 `Vutuv.Images.Backfill` has exactly two shapes — `%{cols: …}`, the truth in
-columns on a parent row joined by a pointer, and `%{gallery: …}`, the truth in
-a row of the picture's own joined by its token — and everything around them
-(the keyset walk, the classes, the repair, the sample, the printing, both
-operator paths) is shared. A gallery source builds itself from
+columns on a parent row, and `%{gallery: …}`, the truth in a row of the
+picture's own joined by its token — and everything around them (the keyset
+walk, the classes, the repair, the sample, the printing, both operator paths)
+is shared. A gallery source builds itself from
 `Vutuv.Images.mirror_source/1`, so adding a kind touches nothing in the
 backfill at all; its repair is the same `mirror/2` upsert the request path
 writes, so create and correct are one statement and need no transaction; and
 it reports no `missing_pointer`, which the report leaves out rather than
 printing as a zero. The one thing to check when the next kind arrives is the
-store's `version_path/2` signature: `Vutuv.PostImageStore` and
-`Vutuv.JobPostingImageStore` take the row, `Vutuv.OrganizationImageStore` takes
-the token, and `Vutuv.Moderation.ImageSubjects.image_path_arg/2` is the adapter
-that already knows.
+store's `version_path/2` signature: all three gallery stores take the row today
+(`Vutuv.OrganizationImageStore` learned to take either in #2053), so a store
+that takes something else is the one thing that needs an adapter.
+
+The `%{cols: …}` shape stopped meaning "a member" in #2055: it now reads its
+whole source from `Vutuv.Images.column_source/1` — the parent `:schema`, the
+`:owner` column on `images` that names it, and the `:copied` map — so a
+member's avatar and a review's cover walk the same keyset scan against
+different tables. Two things follow from that kind having no pointer. The
+`missing_pointer` class is added **per source** rather than per shape, so the
+review's report never prints a zero for a pointer it cannot lose; and its
+repair is one idempotent statement (`sync_review_cover/1`), so create and
+correct collapse the way a gallery kind's do and no transaction wraps it.
 
 `Backfill.check/1` (`mix vutuv.images.backfill --check`, or
 `bin/vutuv eval "Vutuv.Release.check_image_rows()"`) is the gate before the
@@ -413,31 +422,32 @@ permission, and the only off switch is moving the bytes out of that tree —
 the quarantine tree the AI gate already uses
 (`Vutuv.Uploads.quarantine_dir/1`), which nginx has no location for. `:proxy`
 means every byte goes through a controller that authorizes the reader first,
-so the row is the off switch. Avatars and covers are `:static`, a job-posting
-picture, a post photo and an organization image are `:proxy`; the review
-cover #2015 still has to bring will be too.
+so the row is the off switch. Avatars and covers are `:static`; a job-posting
+picture, a post photo, an organization image and a review cover are `:proxy`.
 It raises for a kind nobody has declared, because a picture that inherits a
 default is one nobody knows how to take offline.
 
 ### The gallery kinds (issue #2015)
 
-A post photo, an organization image, a job-posting picture and a review cover
-each kept a table and an uploader of their own, so the `image` report type and
-the freeze knew one kind only. They move one kind at a time and three releases
-per kind (the sequence is spelled out below), smallest first — a **job-posting
-picture** went first (#2054) precisely to settle the shape, the **post photo**
-followed (#2052) as the largest of them, and the **organization image** third
-(#2053) as the one whose owner is not a member.
+A post photo, an organization image and a job-posting picture each kept a table
+and an uploader of their own, and a review cover kept three columns and an
+uploader, so the `image` report type and the freeze knew one kind only. They
+move one kind at a time and three releases per kind (the sequence is spelled
+out below), smallest first — a **job-posting picture** went first (#2054)
+precisely to settle the shape, the **post photo** followed (#2052) as the
+largest of them, the **organization image** third (#2053) as the one whose
+owner is not a member, and the **review cover** last (#2055) as the one that is
+not a gallery at all.
 
 **Three of the four are the same shape; the review cover is not.** A post
 photo, an organization image and a job-posting picture each have a row of their
 own with a `token`, so they move as *gallery* pictures, below. A review's cover
 is `cover` / `cover_status` / `cover_moderation` **columns on the review row**
 with no token and no table of its own (`Vutuv.Posts.PostReview`), which is the
-profile picture's shape, not this one — #2055 lands on `member_columns/0`'s side
-of the fence, and `Vutuv.Images.Backfill`'s `%{cols: …}` source is what it
-extends. One thing it does share with the three: a report cannot name one of
-its pictures until the kind has a strategy in `Vutuv.Images`'s `@takedown`.
+profile picture's shape, not this one — so #2055 landed on
+`Vutuv.Images.Backfill`'s `%{cols: …}` side of the fence and has a section of
+its own below. One thing it does share with the three: a report cannot name one
+of its pictures until the kind has a strategy in `Vutuv.Images`'s `@takedown`.
 
 **The token is the join key, not a pointer.** #2013 added
 `users.avatar_image_id` because a member row had no stable handle of its own;
@@ -594,17 +604,80 @@ mirror, files), so a slot dying between the first two leaves an `orphan_row`
 and between the second and third leaves orphan files. Both are what the
 backfill and `Vutuv.Uploads`' sweeps already name.
 
+### The review cover, the one that is not a gallery (issue #2055)
+
+The cover of a book review is fetched from Open Library by ISBN
+(`Vutuv.Posts.ReviewCovers`), and it has always lived as three columns on the
+review row: `cover` (the fingerprinted file name), `cover_status` (the fetch
+lifecycle) and `cover_moderation` (the AI gate's verdict). No token, no table,
+so nothing to join a mirror on — **`images.post_review_id` is both the parent
+and the join key**, unique and partially indexed, because a review has exactly
+one cover.
+
+**Nobody uploaded it, and the owner columns say so.** `images.user_id` means a
+member *owner* and is `ON DELETE CASCADE`. The reviewer is not the owner of a
+publisher's picture, and the post under the review need not have a member
+author at all — an organization publishes reviews too, and `posts.user_id` is
+NULL for those, so a row keyed on a member owner could not exist for one.
+`user_id` therefore stays empty for this kind, the review owns the row, and
+`images_review_kind_owned_by_review` holds both halves of that in the database
+(`post_review_id IS NOT NULL AND user_id IS NULL`) — not a comment, because
+`sync_review_cover/1` writes through `insert_all` and no changeset stands in
+the way. Like `organization_image`, this kind is deliberately **not** in
+`images_profile_kind_has_owner`.
+
+**Two columns are copied and two facts stay behind.** `cover` becomes `file`
+and `cover_moderation` becomes `moderation`, both varchar(255) on both sides.
+*`cover_status` is not copied*: it is the **fetch** lifecycle (`none` →
+`pending` → `ready`/`failed`), and while it says anything but `ready` there is
+no picture at all — the row's existence already carries what a copy would, and
+the row is written and dropped by exactly the writes that set and clear
+`cover`. *`fingerprint` stays empty* for the mirror image of that reason: the
+content hash is **inside** `file` (`Vutuv.ReviewCover.version_name/1` reads it
+back out as `cover-<hash>`), and a second column holding it would be one fact
+in two places. So the contract release drops `cover` and `cover_moderation`
+and **keeps `cover_status`**, which is the one place this kind's three
+releases differ from the other three.
+
+**The token is minted here, and re-minted only when the bytes change.** A
+gallery row brings its own; a review row has nothing unguessable, so
+`sync_review_cover/1` mints one — and a re-fetch of a different cover gets a
+fresh one, because a token names the bytes and a report that named the old
+cover must point at nothing rather than quietly at the new picture. That
+decision is made *inside* the upsert (a `CASE … IS DISTINCT FROM EXCLUDED.file`
+on the conflict update), not by reading the row first, so two fetches racing on
+one review cannot both win.
+
+**One door, four callers.** `Vutuv.Images.sync_review_cover/1` takes the review
+row as it stands after a write and makes the picture row agree: a review naming
+a file has one, a review naming none has none. Create, correct and drop are the
+same call, which is what lets `Vutuv.Images.Backfill` repair with the very
+function the request path writes. It is called from `ReviewCovers` when a fetch
+stores a cover, from `Vutuv.Moderation.ImageSubjects`' two review-cover
+verdicts, and from `Vutuv.Posts.update_post/2` — each inside the transaction of
+the write it follows, so there is **no interruption window at all** for this
+kind. The post edit reads the cover columns back from the database rather than
+trusting the struct in hand: a caller that preloaded the post before the fetch
+holds `cover: nil`, and `change(cover: nil)` on such a struct records no
+change, so syncing from it would drop the row of a picture that is still there.
+`create_post/2` needs no call — a review that has just been inserted can have
+no row — and no deletion needs one either, since `post_review_id` cascades the
+way `post_reviews.post_id` does.
+
 **Nothing reads the new row yet, and that is the whole of the expand half.**
 Every URL is the one it was (`/job_posting_images/<token>/<version>.avif`,
-`/post_images/<token>/<version>.avif`, `/organization_images/<token>/<version>.avif`
+`/post_images/<token>/<version>.avif`, `/organization_images/<token>/<version>.avif`,
+`/review_covers/<review id>/cover-<hash>.avif`
 and the photo's `og.jpg`, `original.orig` and pixelated siblings), the
-authorizing proxies still work off the old tables
+authorizing proxies still work off the old columns and tables
 (`VutuvWeb.JobPostingImageController`, `VutuvWeb.PostImageController`,
-`VutuvWeb.OrganizationImageController`), and the forms, the feed, the API and
-the agent documents still render from `posting.images`, `post.images` and
-`organizations.logo` — so no render path pays a query for the mirror, which
+`VutuvWeb.OrganizationImageController`, `VutuvWeb.ReviewCoverController`), and
+the forms, the feed, the API and
+the agent documents still render from `posting.images`, `post.images`,
+`organizations.logo` and `post.review` — so no render path pays a query for the
+mirror, which
 matters most on a feed that draws many photos at once. No file under
-`lib/vutuv_web` or `lib/vutuv/uploads` changed for any of the three, and the
+`lib/vutuv_web` or `lib/vutuv/uploads` changed for any of the four, and the
 one change under `lib/vutuv/uploaders` is the extra `version_path/2` clause
 described above, which takes nothing away. The consequence to know: `Vutuv.Images.freeze/1`,
 `unfreeze/1` and `purge/1` **raise** for such a row rather than half-hiding
@@ -615,15 +688,18 @@ reports the posting instead, which is all there was before the row existed.
 That gate reads `@takedown`, the map naming which kinds have a takedown at all,
 so it turns yes in step 2 below and not a moment earlier (issue #2057).
 
-**A gallery kind moves in three releases.** #2054 was the first for
-`job_posting_image`, #2052 for `post_image` and #2053 for
-`organization_image`. Each is N-1 safe on its own and no two can be merged;
-this milestone has already paid for an off-by-one in that count once, in #2027.
+**A kind moves in three releases.** #2054 was the first for
+`job_posting_image`, #2052 for `post_image`, #2053 for `organization_image`
+and #2055 for `review_cover`. Each is N-1 safe on its own and no two can be
+merged; this milestone has already paid for an off-by-one in that count once,
+in #2027.
 
 1. **Expand**: what #2054 shipped for `job_posting_image`, #2052 for
-   `post_image` and #2053 for `organization_image`. Every path that touches the picture writes and drops the
+   `post_image`, #2053 for `organization_image` and #2055 for `review_cover`.
+   Every path that touches the picture writes and drops the
    `images` row beside the old one, while every reader, and the truth, stay in
-   the kind's own table. Nothing here can take such a picture offline yet:
+   the kind's own table (its own columns, for a review cover). Nothing here can
+   take such a picture offline yet:
    `freeze/1` raises for the row and a report cannot name it. Between this
    release and the next, an operator runs
    `mix vutuv.images.backfill --only <kind>` and reads its check; after step 2
@@ -632,28 +708,62 @@ this milestone has already paid for an off-by-one in that count once, in #2027.
    the edit form and the AI gate read the `images` row, and the context writes
    that row directly, so the mirror goes out in the same change: the
    `write_mirrored/2`, `mirror/2` and `forget/2` calls and the kind's entry in
-   `@mirrored` (`Vutuv.Images.mirror_source/1`, `mirrored?/1`). *The backfill
+   `@mirrored` (`Vutuv.Images.mirror_source/1`, `mirrored?/1`) — for a review
+   cover, the four `sync_review_cover/1` calls and its entry in
+   `@column_sources`. *The backfill
    needs nothing removed*, at this step or any other: `Backfill.kinds/0` is
-   `Vutuv.Images.mirrored_kinds/0` plus the profile kinds, and every gallery
+   `Vutuv.Images.mirrored_kinds/0` plus `column_kinds/0`, and every gallery
    source builds itself from `mirror_source/1`, so it holds no per-kind list of
    its own. The kind also gets its takedown here: a strategy in `@takedown` and
    the `freeze`/`unfreeze`/`purge` clauses that go with it, which is what opens
    the report form on these pictures. No migration in this release: the old
    table is still standing and the release one step back is still reading and
    writing it.
-3. **Contract**: the migration that drops the kind's own table, and nothing
-   else. Step 2 is what stopped using the table, and step 2 is what serves
-   while this migration runs.
+3. **Contract**: the migration that drops the kind's own table — or, for a
+   review cover, its two columns — and nothing else. Step 2 is what stopped
+   using them, and step 2 is what serves while this migration runs.
+
+**All four kinds are mirrored now, so this is what steps 2 and 3 have in front
+of them.** What is already in the `images` row: every column of
+`job_posting_images` and `organization_images` bar `id`/`inserted_at`/
+`updated_at`, almost every column of `post_images` (the exception is
+`inserted_at`, and the pixelated stand-in's window is what cares — see above),
+and `post_reviews`' `cover` and `cover_moderation`.
+
+What **step 2** has to move, per kind: the proxy
+(`VutuvWeb.JobPostingImageController`, `PostImageController`,
+`OrganizationImageController`, `ReviewCoverController`), the store lookups
+behind them, the edit forms, the AI gate's read side
+(`Vutuv.Moderation.ImageScans`/`ImageSubjects`, whose scan `subject_id` is
+still the old row's id — a review cover's is the *review* id, not the
+picture's), and the writes in `Vutuv.Jobs`, `Vutuv.Posts`,
+`Vutuv.Organizations` and `Vutuv.Posts.ReviewCovers`. Three per-kind facts to
+carry: an organization image's `privileged_viewer?/2` and "visible to its
+uploader" branch must read `uploader_user_id`, not `user_id`; a post photo's
+pixelated window must take its time from the photo rather than the mirror's
+`inserted_at`; and a review cover's readers need `post_review_id` for the
+directory and `file` for the version segment, while **`cover_status` stays on
+the review row** — it says whether a fetch is due, not whether a picture
+exists, and `ReviewCovers.reconcile/1` and `refresh_all/1` both select on it.
+No kind's takedown is written yet: `@takedown` is still profile-only, so all
+four are refused by `takedown_ready?/1` until the release that wires them.
+
+What **step 3** drops: `job_posting_images`, `post_images` and
+`organization_images` outright, and `post_reviews.cover` +
+`post_reviews.cover_moderation` — but not `post_reviews` and not
+`cover_status`.
 
 **No expand release needs a bridge.** #2027 needed one because it moved every
 reader onto the row in the same deploy as the row's first appearance, so a
 picture the backfill had not reached would have rendered as no picture at all.
 Here no reader has moved: a picture with no mirror row is served exactly as
-before, by its own table, so an installation that never runs the backfill sees
-nothing change. The bridge question belongs to the release that moves the
-readers, and it will have a simpler answer than #2027's — the old row *is* the
-picture, so the fallback is a lookup in the table it is about to leave rather
-than four columns read as a row.
+before, by its own table or its own columns, so an installation that never runs
+the backfill sees nothing change. The bridge question belongs to the release
+that moves the readers, and it will have a simpler answer than #2027's — the
+old row *is* the picture, so the fallback is a lookup in the table it is about
+to leave rather than four columns read as a row. For the review cover the
+fallback is simpler still: the review row is already in hand wherever its cover
+is rendered.
 
 ### The takedown hold (issue #2012)
 

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -2188,6 +2188,16 @@ checked per request, content-fingerprinted filename, so an outdated cover URL
 stops resolving). Files live under `review_covers/<review.id>/`
 (`Vutuv.ReviewCover`); post deletion and account deletion purge them.
 
+Since #2055 a stored cover also has a row in the shared `images` table, so a
+copyright case has something to act on — the expand half of #2015's last kind,
+described in the "review cover" section of [images.md](images.md). The review
+row stays the truth and no reader here has moved; `cover` and
+`cover_moderation` are mirrored, `cover_status` deliberately is not (it says
+whether a *fetch* is due, and the row's existence already says whether a
+picture exists), and the picture has no member owner at all — a publisher's
+artwork is not the reviewer's, and a page's review post has no member author
+to name.
+
 A cover is the one image vutuv holds that is **not ours**: publisher artwork,
 quoted at thumbnail size beside a review (§ 51 UrhG). Open Library passes the
 images through and grants no rights to them, so the pipeline is built to keep

--- a/lib/mix/tasks/vutuv.images.backfill.ex
+++ b/lib/mix/tasks/vutuv.images.backfill.ex
@@ -4,8 +4,9 @@ defmodule Mix.Tasks.Vutuv.Images.Backfill do
   @moduledoc """
   Reconciles every picture with its row in the shared `images` table — the
   **contract** half of issue #2013 for profile pictures and covers, and of
-  #2015 for the kinds that still keep a table of their own (a job-posting
-  picture since #2054, a post photo since #2052). See `Vutuv.Images.Backfill`.
+  #2015 for the kinds that still keep their truth outside it (a job-posting
+  picture since #2054, a post photo since #2052, an organization image since
+  #2053, a review cover since #2055). See `Vutuv.Images.Backfill`.
 
       mix vutuv.images.backfill              # reconcile every kind, then check
       mix vutuv.images.backfill --dry-run    # report what would change
@@ -13,15 +14,17 @@ defmodule Mix.Tasks.Vutuv.Images.Backfill do
       mix vutuv.images.backfill --only cover
       mix vutuv.images.backfill --only job_posting_image
       mix vutuv.images.backfill --only post_image
+      mix vutuv.images.backfill --only organization_image
+      mix vutuv.images.backfill --only review_cover
       mix vutuv.images.backfill --from 019f0000-0000-7000-8000-000000000000
 
   Moves no file and changes no URL: what a picture already lives in stays the
-  source of truth (four member-row columns for a profile picture, its own row
-  for a gallery one), and this copies what it says into a row. Idempotent — a
-  run that is interrupted (a deploy stopping the slot) is simply run again, and
-  every picture it already reached reports `unchanged`. `--from` is a member id
-  for a profile kind and a gallery row id for the rest, so pair it with
-  `--only`.
+  source of truth (columns on a parent row for a profile picture and a review
+  cover, its own row for a gallery one), and this copies what it says into a
+  row. Idempotent — a run that is interrupted (a deploy stopping the slot) is
+  simply run again, and every picture it already reached reports `unchanged`.
+  `--from` is a parent-row id for a column kind (a member, a review) and a
+  gallery row id for the rest, so pair it with `--only`.
 
   Every run ends with the check, which prints what it found and **fails the
   command only when something is outstanding** — that non-zero exit is the gate

--- a/lib/vutuv/images.ex
+++ b/lib/vutuv/images.ex
@@ -19,6 +19,13 @@ defmodule Vutuv.Images do
   migration may drop only what the *currently deployed* release has stopped
   reading.
 
+  **A review's cover (#2055, the last of #2015): this release writes both and
+  reads the review row.** Its truth is `cover` / `cover_status` /
+  `cover_moderation` on `post_reviews` — columns on a parent row, the profile
+  shape rather than the gallery one, so it joins on `images.post_review_id`
+  and `sync_review_cover/1` is its one door. Nobody uploaded it, so it has no
+  member owner and a check constraint says so.
+
   **A gallery picture (#2015: a job-posting picture first in #2054, a post
   photo in #2052, an organization image in #2053): this
   release writes both and reads the old table.** Its truth is still its own row
@@ -53,17 +60,20 @@ defmodule Vutuv.Images do
   # from `@mirrored` below, because a contract release **deletes** an entry
   # there — at which point that kind lives here and nowhere else, so dropping
   # it from this list would be exactly backwards.
-  @kinds ~w(avatar cover job_posting_image organization_image post_image)
+  @kinds ~w(avatar cover job_posting_image organization_image post_image review_cover)
 
   # Of those, the kinds every byte of which already goes through a controller
   # that authorizes the reader first (`VutuvWeb.JobPostingImageController` asks
   # whether the reader may see the posting, `VutuvWeb.PostImageController`
   # whether they may see the post, `VutuvWeb.OrganizationImageController`
-  # whether they may see the page) — so the row is the off switch, and #2015's
-  # expand releases change nothing about how one is served. Written out rather
-  # than derived from `@mirrored`, because a kind keeps its serving strategy
-  # after the contract release deletes it from there. See `serving/1`.
-  @proxy_kinds ~w(job_posting_image organization_image post_image)
+  # whether they may see the page, `VutuvWeb.ReviewCoverController` whether
+  # they may see the post the review sits on) — so the row is the off switch,
+  # and #2015's expand releases change nothing about how one is served.
+  # Written out rather than derived from `@mirrored`, because a kind keeps its
+  # serving strategy after the contract release deletes it from there — and
+  # because the review cover is in no such registry at all: it is the
+  # parent-column shape below, not the gallery one.
+  @proxy_kinds ~w(job_posting_image organization_image post_image review_cover)
 
   # Of those, the kinds whose truth is still a table of their own, and
   # everything about the copy: which columns it carries, where the source rows
@@ -89,7 +99,7 @@ defmodule Vutuv.Images do
   # it: that reads `@takedown` below, which the release before that one, the one
   # that moves the readers and wires the takedown, is what extends.
   # #2055 (review covers) adds **no** entry — a review's cover is columns on the
-  # review row with no token and no table, which is the `@profile_columns` shape
+  # review row with no token and no table, which is the `@column_sources` shape
   # below, not this one.
   @mirrored %{
     "job_posting_image" => %{
@@ -271,6 +281,106 @@ defmodule Vutuv.Images do
   """
   def member_columns, do: @profile_columns
   def member_columns(kind) when is_map_key(@profile_columns, kind), do: @profile_columns[kind]
+
+  # Every kind whose truth is still **columns on a parent row** rather than a
+  # table of its own, in one shape whatever the parent is. Two parents today:
+  # a member row (avatar, cover — the four columns above) and a review row
+  # (`review_cover`, #2055).
+  #
+  #   * `:schema` — where the parent rows are.
+  #   * `:owner`  — the `images` column naming the parent. It is what the
+  #     mirror is joined on, and what the delete cascades through.
+  #   * `:copied` — `images` column to parent column, the whole of the copy.
+  #   * `:pointer` / `:assoc` — the parent's own pointer back at the row, for
+  #     a parent that had no stable handle of its own (#2013 added
+  #     `users.avatar_image_id` for exactly that). **Absent for a review**: a
+  #     review row has an id and at most one cover, so `post_review_id` is
+  #     already a well-defined join key and there is no second copy of the
+  #     link to keep in step — and therefore no `missing_pointer` class in
+  #     `Vutuv.Images.Backfill`.
+  #
+  # Derived from `@profile_columns` above rather than written out beside it,
+  # so the two cannot say different things about an avatar.
+  #
+  # **A review cover has no member owner, and that is a constraint, not a
+  # convention.** Nobody here uploaded it: it is a publisher's picture fetched
+  # from Open Library beside a review (`Vutuv.Posts.ReviewCovers`), so a
+  # refusal notifies nobody the way it does for an upload. `images.user_id`
+  # means a member *owner* and is `ON DELETE CASCADE`, so naming the reviewer
+  # there would arm a deletion on somebody else's picture — and the post under
+  # the review need not have a member author at all, since an organization
+  # publishes reviews too and `posts.user_id` is NULL for those. The review
+  # owns it, `images_review_kind_owned_by_review` holds that shape in the
+  # database, and this kind is deliberately **not** in
+  # `images_profile_kind_has_owner`.
+  @column_sources @profile_columns
+                  |> Map.new(fn {kind, config} ->
+                    {kind,
+                     Map.merge(
+                       %{
+                         schema: User,
+                         owner: :user_id,
+                         # Taken rather than re-assigned key by key, so a
+                         # transposition (`fingerprint: config.crop`) cannot
+                         # compile in the one map whose whole purpose is that
+                         # the two cannot disagree.
+                         copied: Map.take(config, [:file, :fingerprint, :crop, :moderation])
+                       },
+                       Map.take(config, [:pointer, :assoc])
+                     )}
+                  end)
+                  |> Map.put("review_cover", %{
+                    schema: Vutuv.Posts.PostReview,
+                    owner: :post_review_id,
+                    # `post_reviews.cover` and `cover_moderation` are
+                    # varchar(255), the types `file` and `moderation` already
+                    # are. `cover_status` stays behind on purpose: it is the
+                    # *fetch* lifecycle (none → pending → ready/failed) and
+                    # there is no picture at all while it is not "ready", so
+                    # the row's existence already says everything a mirrored
+                    # copy could. `fingerprint` stays empty for the same
+                    # reason in reverse — the content hash is *inside* `cover`
+                    # (`Vutuv.ReviewCover.version_name/1` reads it back out),
+                    # and a second column holding it would be one fact in two
+                    # places. Both are written down in
+                    # `docs/architecture/images.md` for the release that moves
+                    # the readers.
+                    copied: %{file: :cover, moderation: :cover_moderation},
+                    # This parent keeps no pointer back at the row — a review
+                    # has one cover and `post_review_id` is already a
+                    # well-defined join key — so it carries its own repair
+                    # instead, the way a gallery source carries its `:store`.
+                    # `Vutuv.Images.Backfill` reads both from here rather than
+                    # branching on the parent, so a second such kind is an
+                    # entry rather than three more clauses.
+                    sync: {__MODULE__, :sync_review_cover},
+                    store: Vutuv.ReviewCover
+                  })
+
+  @doc """
+  Where a kind whose truth is still columns on a **parent row** keeps them, in
+  one shape whatever the parent is — the member row for a profile picture and
+  a cover, the review row for a review cover (#2055).
+  `Vutuv.Images.Backfill` reads its whole `%{cols: …}` source from here.
+  """
+  def column_source(kind) when is_map_key(@column_sources, kind), do: @column_sources[kind]
+
+  @doc "The kinds `column_source/1` answers for."
+  def column_kinds, do: Map.keys(@column_sources)
+
+  @doc """
+  The row this parent row becomes, as a plain map of `images` column to value —
+  the `column_source/1` twin of `mirror_attrs/2`, and for the same reason: the
+  write and `Vutuv.Images.Backfill`'s "has it drifted" comparison have to read
+  one list. A column added to a source's `:copied` map that only one of them
+  honoured would leave the backfill correcting a row forever with a statement
+  that never writes the column.
+  """
+  def column_attrs(kind, parent) when is_map_key(@column_sources, kind) do
+    Map.new(@column_sources[kind].copied, fn {field, column} ->
+      {field, Map.fetch!(parent, column)}
+    end)
+  end
 
   @doc """
   The member-row column pointing at this kind's row. The one place that name is
@@ -740,6 +850,101 @@ defmodule Vutuv.Images do
   def forget(kind, tokens) when is_map_key(@mirrored, kind) and is_list(tokens) do
     Repo.delete_all(from(i in Image, where: i.kind == ^kind and i.token in ^tokens))
     :ok
+  end
+
+  ## The review cover (issue #2015, this one #2055)
+
+  @review_kind "review_cover"
+
+  @doc """
+  Brings the row beside a book review's fetched cover into step with the review
+  row — the **one door** for this kind, so creating the row, correcting it and
+  dropping it are the same call on the request path and in
+  `Vutuv.Images.Backfill`. That collapse is what #2054 got out of `mirror/2`
+  for the gallery kinds; here it also removes the question of which of the
+  three a caller is in, because `post_reviews.cover` is the whole state: a
+  review that names a file has a row, a review that names none has none.
+
+  Takes the review row **as it stands after the write** (any map carrying
+  `:id`, `:cover` and `:cover_moderation` will do), so every caller hands over
+  what it just saved rather than re-reading it.
+
+  **The join is `post_review_id`, not a token.** A review's cover is columns on
+  the review row with nothing unguessable of its own, so the token is minted
+  here — and re-minted only when the bytes change, because a token names the
+  bytes: after a re-fetch, a report that named the old cover should point at
+  nothing rather than quietly at the new picture. One statement decides that,
+  so two slots racing on the same review cannot both win.
+
+  `frozen_at` and `inserted_at` are deliberately outside the conflict update:
+  the first is a takedown an ordinary write must never lift, the second
+  identifies the row.
+  """
+  def sync_review_cover(%{id: id, cover: nil}) when is_binary(id) do
+    Repo.delete_all(from(i in Image, where: i.kind == @review_kind and i.post_review_id == ^id))
+
+    :ok
+  end
+
+  def sync_review_cover(%{id: id, cover: cover} = review)
+      when is_binary(id) and is_binary(cover) do
+    now = now()
+
+    entry =
+      @review_kind
+      |> column_attrs(review)
+      |> Map.merge(%{
+        id: Vutuv.UUIDv7.generate(),
+        kind: @review_kind,
+        post_review_id: id,
+        token: Uploads.gen_token(),
+        inserted_at: now,
+        updated_at: now
+      })
+
+    Repo.insert_all(Image, [entry],
+      on_conflict: review_cover_conflict(),
+      conflict_target: {:unsafe_fragment, "(post_review_id) WHERE post_review_id IS NOT NULL"}
+    )
+
+    :ok
+  end
+
+  # The columns the conflict update below replaces. `fragment/1` takes a
+  # literal, so this list cannot be built from the registry at run time — but a
+  # column added to `:copied` and forgotten here would be written on insert and
+  # skipped on update, which the backfill would meet as a row it "corrects"
+  # forever with a statement that never touches the column. So the two are
+  # compared at compile time instead, and disagreeing fails the build.
+  @review_replaced [:file, :moderation]
+
+  if Enum.sort(@review_replaced) != Enum.sort(Map.keys(@column_sources["review_cover"].copied)) do
+    raise """
+    Vutuv.Images: the review cover's @review_replaced list and the :copied map \
+    in @column_sources have drifted. Every copied column has to appear in \
+    review_cover_conflict/0's `set`, or an existing row never receives it.\
+    """
+  end
+
+  # A `{:replace, …}` list cannot say "only when the bytes changed", and the
+  # alternative — read the row, compare, then write — is two statements with a
+  # race between them on a path two fetches can reach at once.
+  defp review_cover_conflict do
+    from(i in Image,
+      update: [
+        set: [
+          file: fragment("EXCLUDED.file"),
+          moderation: fragment("EXCLUDED.moderation"),
+          token:
+            fragment(
+              "CASE WHEN ? IS DISTINCT FROM EXCLUDED.file THEN EXCLUDED.token ELSE ? END",
+              i.file,
+              i.token
+            ),
+          updated_at: fragment("EXCLUDED.updated_at")
+        ]
+      ]
+    )
   end
 
   # Which takedown a kind gets, and (by the presence of a key) whether it has

--- a/lib/vutuv/images/backfill.ex
+++ b/lib/vutuv/images/backfill.ex
@@ -8,9 +8,9 @@ defmodule Vutuv.Images.Backfill do
 
   It **moves no file and changes no URL.** Whatever a picture already lives in
   stays the source of truth every URL builder and every display gate reads —
-  four member-row columns for a profile picture, its own gallery row for the
-  rest — and this only copies what that says into a row, so the previous
-  release keeps serving unchanged through the whole deploy window.
+  columns on a parent row for a profile picture and a review cover, its own
+  gallery row for the rest — and this only copies what that says into a row, so
+  the previous release keeps serving unchanged through the whole deploy window.
 
   ## Reconcile, not insert-where-missing
 
@@ -62,30 +62,33 @@ defmodule Vutuv.Images.Backfill do
 
   `source/1` is the only per-kind thing here, and it has two shapes:
 
-    * `%{cols: …}` — the truth is columns on a **parent row** (a member's
-      avatar and cover today; a review's cover when #2055 lands, which is this
-      shape and not the other one), joined by a pointer.
+    * `%{cols: …}` — the truth is columns on a **parent row**, joined by the
+      `images` column naming that parent. A member's avatar and cover, and
+      since #2055 a review's cover, which is this shape and not the other one.
+      Read whole from `Vutuv.Images.column_source/1`.
     * `%{gallery: …}` — the truth is a **row of the picture's own**, joined by
       the `token` both sides carry. A job-posting picture since #2054, a post
-      photo since #2052 and an organization image since #2053.
+      photo since #2052 and an organization image since #2053. Read whole from
+      `Vutuv.Images.mirror_source/1`.
 
   Everything around them is shared: the keyset walk, the class vocabulary, the
-  repair, the sample, the printing and both operator commands. A gallery kind
-  has no `missing_pointer` class — there is no pointer to lose — and a source
-  names the classes it can produce, so the report never prints a zero for a
-  class that kind cannot have.
+  repair, the sample, the printing and both operator commands. `missing_pointer`
+  is the one class a source has to earn — only a parent that keeps a pointer
+  back at the row can lose one — so the report never prints a zero for a class
+  that kind cannot have.
 
-  **A gallery kind adds no per-kind branch here** — `source/1` builds itself
-  from `Vutuv.Images.mirror_source/1`, which is the one registry, so a kind
-  cannot be mirrored on the request path and invisible to this pass. #2052
-  added not a line; #2053 changed one, and it is shared rather than per-kind:
-  an organization image is the first source with a column spelled differently
-  on the two sides, so the desired values come from
-  `Vutuv.Images.mirror_attrs/2` — the same function the mirror writes through —
+  **A kind adds no per-kind branch here.** Both registries carry what this pass
+  needs: which columns are copied, the schema, the store, and (for a parent
+  with no pointer) the function that repairs one row. So a kind cannot be
+  written on the request path and be invisible to this pass, and no clause here
+  matches a schema module. #2052 added not a line; #2053 changed one, shared
+  rather than per-kind — an organization image is the first source with a
+  column spelled differently on the two sides, so the desired values come from
+  `Vutuv.Images.mirror_attrs/2`, the same function the mirror writes through,
   rather than a `Map.take/2` on the source row, which would have skipped that
-  column in silence. Its store took the token rather than the row; that
-  difference is gone, `Vutuv.OrganizationImageStore.version_path/2` now answers
-  either.
+  column in silence. #2055 gave the column shape the same treatment:
+  `Vutuv.Images.column_attrs/2` is the twin, so the write and the comparison
+  read one list there too.
   """
 
   import Ecto.Query
@@ -106,16 +109,12 @@ defmodule Vutuv.Images.Backfill do
   # what the operator needs, a sample is what makes it actionable.
   @sample 100
 
-  # The four the member row holds and the row copies. `:crop` and `:moderation`
-  # are legitimately nil on old rows, so a comparison has to be on equality,
-  # never on presence.
-  @copied [:file, :fingerprint, :crop, :moderation]
-
-  # Which classes each shape can report. Written out rather than derived from
-  # each other, so the list reads as what a kind of that shape can be wrong in
-  # rather than as an arithmetic on another list.
-  @member_classes [:missing_row, :mismatched_row, :missing_pointer, :missing_file, :orphan_row]
-  @gallery_classes [:missing_row, :mismatched_row, :missing_file, :orphan_row]
+  # What a picture of any shape can be wrong in. `missing_pointer` is the one
+  # class that is not universal: it belongs to a parent that keeps a pointer
+  # back at the row — a member row does (`users.avatar_image_id`, #2013), a
+  # review row and a gallery row do not — so `source/1` appends it per source
+  # rather than a second list repeating these four.
+  @classes [:missing_row, :mismatched_row, :missing_file, :orphan_row]
 
   @doc """
   The image kinds this backfill covers: the profile kinds, plus the kinds whose
@@ -126,7 +125,7 @@ defmodule Vutuv.Images.Backfill do
   the worst shape there is: the check would print *"Every picture has its row
   and its file. Safe to cut."* for a kind it never looked at.
   """
-  def kinds, do: Enum.sort(Map.keys(Images.member_columns()) ++ Images.mirrored_kinds())
+  def kinds, do: Enum.sort(Images.column_kinds() ++ Images.mirrored_kinds())
 
   @doc """
   Reconciles every picture with its row.
@@ -233,23 +232,26 @@ defmodule Vutuv.Images.Backfill do
   # written twice.
   defp source(kind) do
     if Images.mirrored?(kind) do
-      gallery = Images.mirror_source(kind)
-
-      %{kind: kind, classes: @gallery_classes, gallery: gallery}
+      %{kind: kind, classes: @classes, gallery: Images.mirror_source(kind)}
     else
-      %{kind: kind, classes: @member_classes, cols: Images.member_columns(kind)}
+      cols = Images.column_source(kind)
+
+      %{kind: kind, classes: @classes ++ pointer_class(cols), cols: cols}
     end
   end
+
+  defp pointer_class(%{pointer: _}), do: [:missing_pointer]
+  defp pointer_class(_cols), do: []
 
   ## What is wrong with this picture, if anything
 
   # The one place that decides. `run/1` repairs what this names and `check/1`
   # reports it, so a class added here can never be invisible to the gate.
-  defp classify(%{cols: cols}, user, row) do
+  defp classify(%{kind: kind, cols: cols}, parent, row) do
     cond do
       is_nil(row) -> :missing_row
-      drifted?(row, desired(user, cols)) -> :mismatched_row
-      Map.get(user, cols.pointer) != row.id -> :missing_pointer
+      drifted?(row, Images.column_attrs(kind, parent)) -> :mismatched_row
+      pointer_lost?(cols, parent, row) -> :missing_pointer
       true -> :ok
     end
   end
@@ -271,13 +273,16 @@ defmodule Vutuv.Images.Backfill do
     end
   end
 
+  # Only a parent that keeps a pointer can lose one. A review row has none:
+  # `images.post_review_id` is the join key itself, so a row that was found is
+  # a row that is pointed at.
+  defp pointer_lost?(%{pointer: pointer}, parent, row), do: Map.get(parent, pointer) != row.id
+  defp pointer_lost?(_cols, _parent, _row), do: false
+
   # `token` is the join key, so it is equal by construction and comparing it
   # would only ever say "no".
   defp desired_mirror(kind, gallery_row),
     do: kind |> Images.mirror_attrs(gallery_row) |> Map.delete(:token)
-
-  defp desired(user, cols),
-    do: Map.new(@copied, fn field -> {field, Map.get(user, cols[field])} end)
 
   defp drifted?(row, desired), do: Enum.any?(desired, fn {f, v} -> Map.get(row, f) != v end)
 
@@ -330,18 +335,21 @@ defmodule Vutuv.Images.Backfill do
     end
   end
 
+  # The parent is a member row for a profile picture and a review row for a
+  # review cover, and the join is the `images` column naming it — the same
+  # shape either way, which is what `Vutuv.Images.column_source/1` is for.
   defp batch_query(%{kind: kind, cols: cols}, cursor) do
     query =
-      from(u in User,
+      from(p in cols.schema,
         left_join: i in Image,
-        on: i.user_id == u.id and i.kind == ^kind,
-        where: not is_nil(field(u, ^cols.file)),
-        order_by: [asc: u.id],
+        on: field(i, ^cols.owner) == p.id and i.kind == ^kind,
+        where: not is_nil(field(p, ^cols.copied.file)),
+        order_by: [asc: p.id],
         limit: @batch,
-        select: {u, i}
+        select: {p, i}
       )
 
-    if cursor, do: where(query, [u], u.id > ^cursor), else: query
+    if cursor, do: where(query, [p], p.id > ^cursor), else: query
   end
 
   # The join is on the token, which is unique in both tables — so this is the
@@ -374,8 +382,20 @@ defmodule Vutuv.Images.Backfill do
   # upload path uses: it mints the fresh token and carries the upsert against
   # the partial unique index, so a row an upload writes between this batch's
   # SELECT and this write converges instead of failing.
-  defp mend(%{kind: kind, cols: cols}, :missing_row, user, _row) do
-    with {:ok, image} <- Images.put_profile_image(user, kind, desired(user, cols)),
+  # A parent that carries its own repair has one for both verdicts, and it is
+  # the same statement the request path writes: for a review cover that is
+  # `Vutuv.Images.sync_review_cover/1`, which upserts on `post_review_id` and
+  # re-mints the token only when the bytes it names changed — the same rule
+  # `remint_token/3` states below, decided in SQL because two fetches can reach
+  # it at once. Read off the source rather than matched on the parent schema,
+  # so a second such kind is a registry entry rather than another clause here.
+  defp mend(%{cols: %{sync: {module, fun}}}, verdict, parent, _row)
+       when verdict in [:missing_row, :mismatched_row] do
+    apply(module, fun, [parent])
+  end
+
+  defp mend(%{kind: kind, cols: %{pointer: _} = cols}, :missing_row, user, _row) do
+    with {:ok, image} <- Images.put_profile_image(user, kind, Images.column_attrs(kind, user)),
          do: point_at(user, cols, image.id)
   end
 
@@ -386,8 +406,8 @@ defmodule Vutuv.Images.Backfill do
   # only, because a token names the bytes: a row corrected back to a different
   # file must not keep a handle that named the other one, and a row whose
   # moderation state alone drifted must not lose the handle it has.
-  defp mend(%{cols: cols}, :mismatched_row, user, row) do
-    desired = desired(user, cols)
+  defp mend(%{kind: kind, cols: %{pointer: _} = cols}, :mismatched_row, user, row) do
+    desired = Images.column_attrs(kind, user)
 
     with {:ok, image} <-
            row
@@ -399,7 +419,8 @@ defmodule Vutuv.Images.Backfill do
 
   # The row is right and only the member row's pointer is not — the shape a
   # half-committed upload leaves behind.
-  defp mend(%{cols: cols}, :missing_pointer, user, row), do: point_at(user, cols, row.id)
+  defp mend(%{cols: %{pointer: _} = cols}, :missing_pointer, user, row),
+    do: point_at(user, cols, row.id)
 
   # A gallery picture has one repair for both verdicts, and it is the same
   # upsert the request path writes: `Vutuv.Images.mirror/2` keys on the token,
@@ -440,16 +461,18 @@ defmodule Vutuv.Images.Backfill do
 
   # A profile repair writes the row **and** the member row's pointer, so the two
   # move together or not at all — that half-committed pair is the very thing
-  # this backfill exists to mend. A gallery repair is one idempotent upsert, so
-  # a transaction around it would be a BEGIN and a COMMIT buying nothing.
-  defp attempt(%{cols: _}, fun) do
+  # this backfill exists to mend. Everything else (a gallery mirror, a review
+  # cover) is one idempotent upsert, and a transaction around it would be a
+  # BEGIN and a COMMIT buying nothing — so the pointer is what decides, not the
+  # shape.
+  defp attempt(%{cols: %{pointer: _}}, fun) do
     case Repo.transaction(fn -> or_rollback(fun.()) end) do
       {:ok, :ok} -> :ok
       {:error, reason} -> {:error, reason}
     end
   end
 
-  defp attempt(%{gallery: _}, fun), do: fun.()
+  defp attempt(_source, fun), do: fun.()
 
   defp or_rollback(:ok), do: :ok
   defp or_rollback({:error, reason}), do: Repo.rollback(reason)
@@ -485,8 +508,9 @@ defmodule Vutuv.Images.Backfill do
   # check's count.
   defp orphan_query(%{kind: kind, cols: cols}) do
     ownerless =
-      from(u in User,
-        where: u.id == parent_as(:image).user_id and is_nil(field(u, ^cols.file))
+      from(p in cols.schema,
+        where:
+          p.id == field(parent_as(:image), ^cols.owner) and is_nil(field(p, ^cols.copied.file))
       )
 
     from(i in Image,
@@ -536,6 +560,14 @@ defmodule Vutuv.Images.Backfill do
   # report every un-backfilled member twice and call the second reading a
   # missing file.
   defp file_verdict(_source, _picture, nil), do: :ok
+
+  # A column kind with a store of its own answers from the parent row already
+  # in hand: a review cover is served through its own proxy off the review's
+  # id, and the version segment is the fingerprinted name the `cover` column
+  # yields. No quarantine branch — this kind never had one, the proxy is what
+  # holds a cover back while the AI gate runs.
+  defp file_verdict(%{cols: %{store: store}}, parent, _row),
+    do: if(is_nil(store.stored_path(parent)), do: :missing_file, else: :ok)
 
   defp file_verdict(%{kind: kind, cols: cols}, user, row) do
     # The row is in hand, so hand it over as the preload `member_image/2` would

--- a/lib/vutuv/images/image.ex
+++ b/lib/vutuv/images/image.ex
@@ -26,6 +26,12 @@ defmodule Vutuv.Images.Image do
     belongs_to(:post, Vutuv.Posts.Post)
     belongs_to(:organization, Vutuv.Organizations.Organization)
 
+    # The review a fetched book cover belongs to (#2055). Unlike the three
+    # above this one is also the **join key**: a review's cover is columns on
+    # the review row with no token of its own, so there is nothing else to
+    # match the two sides on. Exactly one cover per review, by unique index.
+    belongs_to(:post_review, Vutuv.Posts.PostReview)
+
     # Who uploaded an organization image — **not** who owns it (#2053). The
     # page owns its logo, which is why `organization_images.user_id` is
     # `ON DELETE SET NULL` and this column copies that: a page keeps its

--- a/lib/vutuv/moderation/image_subjects.ex
+++ b/lib/vutuv/moderation/image_subjects.ex
@@ -517,17 +517,31 @@ defmodule Vutuv.Moderation.ImageSubjects do
   end
 
   def apply_approved(%ImageScan{kind: "review_cover"} = scan) do
-    flipped =
-      from(r in PostReview,
-        where:
-          r.id == ^scan.subject_id and r.cover == ^scan.fingerprint and
-            r.cover_moderation == "pending"
-      )
-      |> Repo.update_all(set: [cover_moderation: "approved"])
+    {:ok, released} =
+      Repo.transaction(fn ->
+        # `select: r` rather than a second statement: the flipped row is what
+        # the mirror copies and what the two announcements below address.
+        from(r in PostReview,
+          where:
+            r.id == ^scan.subject_id and r.cover == ^scan.fingerprint and
+              r.cover_moderation == "pending",
+          select: r
+        )
+        |> Repo.update_all(set: [cover_moderation: "approved"])
+        |> case do
+          {1, [review]} ->
+            # The mirror row (#2055) takes the same verdict in the same
+            # transaction as the flip it copies.
+            :ok = Images.sync_review_cover(review)
+            review
 
-    case flipped do
-      {1, _} ->
-        review = Repo.get!(PostReview, scan.subject_id)
+          _stale ->
+            nil
+        end
+      end)
+
+    case released do
+      %PostReview{} = review ->
         # The card upgrade was held back at fetch time; the cover is only
         # announced once it is released (no quarantine move — covers are
         # served through the authorizing proxy, which checks this state).
@@ -750,22 +764,33 @@ defmodule Vutuv.Moderation.ImageSubjects do
   end
 
   def apply_rejected(%ImageScan{kind: "review_cover"} = scan) do
-    cleared =
-      from(r in PostReview, where: r.id == ^scan.subject_id and r.cover == ^scan.fingerprint)
-      |> Repo.update_all(set: [cover: nil, cover_status: "failed", cover_moderation: nil])
+    {:ok, cleared} =
+      Repo.transaction(fn ->
+        from(r in PostReview,
+          where: r.id == ^scan.subject_id and r.cover == ^scan.fingerprint,
+          select: r
+        )
+        |> Repo.update_all(set: [cover: nil, cover_status: "failed", cover_moderation: nil])
+        |> case do
+          {1, [review]} ->
+            # The review keeps no file, so it keeps no row either (#2055) — in
+            # the same transaction, before any byte is deleted below.
+            :ok = Images.sync_review_cover(review)
+            review
+
+          _stale ->
+            nil
+        end
+      end)
 
     case cleared do
-      {1, _} ->
-        Vutuv.ReviewCover.delete_files(%PostReview{id: scan.subject_id})
+      %PostReview{post_id: post_id} = review ->
+        Vutuv.ReviewCover.delete_files(review)
         # The cover is settled (as gone), so a post held for it federates now.
-        case Repo.get(PostReview, scan.subject_id) do
-          %PostReview{post_id: post_id} -> Fediverse.images_settled(post_id)
-          nil -> :ok
-        end
-
+        Fediverse.images_settled(post_id)
         :ok
 
-      _ ->
+      nil ->
         :stale
     end
   end

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -625,12 +625,35 @@ defmodule Vutuv.Posts do
         end
 
         attach_images!(updated, image_ids)
+        sync_review_cover!(updated)
         updated
 
       {:error, changeset} ->
         Repo.rollback(changeset)
     end
   end
+
+  # An edit can only ever *take* a review's cover away: `PostReview`'s
+  # changeset clears `cover` when the ISBN changes or goes, and nothing on
+  # this path can set one — the cover is fetched off the request path
+  # afterwards. So the mirror row (#2055) follows here, inside the same
+  # transaction as the write that dropped the cover. `create_post/2` needs no
+  # such call: a review that has just been inserted cannot have a row yet.
+  #
+  # The cover columns are **read back** rather than taken off the struct in
+  # hand. A caller that preloaded the post before the cover was fetched holds
+  # `cover: nil`, and `change(cover: nil)` on such a struct records no change
+  # at all — so the review keeps its file in the database while the struct
+  # says otherwise, and syncing from the struct would drop the row of a
+  # picture that is still there.
+  defp sync_review_cover!(%Post{review: %PostReview{id: id}}) do
+    case Repo.get(PostReview, id) do
+      nil -> :ok
+      review -> :ok = Images.sync_review_cover(review)
+    end
+  end
+
+  defp sync_review_cover!(%Post{}), do: :ok
 
   @doc """
   Deletes a post including its image files, and tells open clients it is gone:
@@ -661,7 +684,7 @@ defmodule Vutuv.Posts do
         if post.screenshot, do: Screenshots.delete(post.screenshot)
         # Same for a book review's fetched cover files.
         if post.review, do: ReviewCovers.delete_files(post.review)
-        broadcast_post_deleted(post.id, deletion_recipients(post))
+        broadcast_post_deleted(post.id, post_audience(post))
         if parent_id, do: broadcast_reply_count(parent_id)
         # Deleting reported content settles its moderation case.
         Vutuv.Moderation.content_deleted(deleted)
@@ -7274,8 +7297,20 @@ defmodule Vutuv.Posts do
       nil ->
         :ok
 
-      %Post{user_id: author_id} ->
-        broadcast_to_followers(author_id, {event_name, %{post_id: post_id, author_id: author_id}})
+      %Post{} = post ->
+        # Through `post_audience/1`, the one function that answers "whose feed
+        # does this post reach", rather than the member query: a post published
+        # in an organization's name has **no member author**, and handing that
+        # nil to `follower_ids/1` raised (`where: x == ^nil` is not a silent
+        # no-op), so a page's link screenshot and its book cover both died on
+        # announcing themselves — the cover inside
+        # `Vutuv.Posts.ReviewCovers`' own rescue, which then wrote the review
+        # off as `failed`. Both consumers read `post_id` alone.
+        post
+        |> post_audience()
+        |> broadcast_each({event_name, %{post_id: post_id, author_id: post.user_id}})
+
+        :ok
     end
   end
 
@@ -7554,15 +7589,17 @@ defmodule Vutuv.Posts do
     Enum.each(recipient_ids, &Vutuv.Activity.broadcast(&1, event))
   end
 
-  # Whose open feed has to drop this entry. A member's post reaches them and
-  # their followers; an organization post reaches the people who follow the
-  # **page** (issue #1336) — it never sat in the publishers' own feeds, so
-  # there is nobody else to tell. Without this clause a nil author matched
-  # neither head and deleting an organization post raised (issue #1334).
-  defp deletion_recipients(%Post{organization_id: id}) when is_binary(id),
+  # Whose open feed this post reaches — what a deletion has to tell, and what
+  # an attachment that finished loading (a link screenshot, a book cover) has
+  # to tell too. A member's post reaches them and their followers; an
+  # organization post reaches the people who follow the **page** (issue #1336)
+  # — it never sat in the publishers' own feeds, so there is nobody else to
+  # tell. Without the first clause a nil author matched neither head and
+  # deleting an organization post raised (issue #1334).
+  defp post_audience(%Post{organization_id: id}) when is_binary(id),
     do: organization_follower_ids(id)
 
-  defp deletion_recipients(%Post{user_id: user_id}),
+  defp post_audience(%Post{user_id: user_id}),
     do: [user_id | follower_ids(user_id)]
 
   defp organization_follower_ids(organization_id) do

--- a/lib/vutuv/posts/review_covers.ex
+++ b/lib/vutuv/posts/review_covers.ex
@@ -18,12 +18,20 @@ defmodule Vutuv.Posts.ReviewCovers do
   AI-moderation gate like any upload: stored `pending`
   (`Vutuv.Moderation.ImageScans`), served through the authorizing proxy only
   once released, deleted on rejection (`Vutuv.Moderation.ImageSubjects`).
+
+  Since #2055 a stored cover is also a row in the shared `images` table, so a
+  copyright case has something to act on. The review row stays the truth and
+  nothing here reads the mirror; `Vutuv.Images.sync_review_cover/1` is the one
+  door, called wherever `cover` or `cover_moderation` changes — here, in
+  `Vutuv.Moderation.ImageSubjects`' two verdicts, and in `Vutuv.Posts` when an
+  edit drops the cover.
   """
 
   import Ecto.Query
 
   alias Vutuv.AudiobookLength
   alias Vutuv.BookMetadata
+  alias Vutuv.Images
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostReview
@@ -198,7 +206,7 @@ defmodule Vutuv.Posts.ReviewCovers do
   defp announce_stored(review, file) do
     moderation = ImageScans.initial_state()
 
-    case mark(review, cover: file, cover_status: "ready", cover_moderation: moderation) do
+    case store_cover(review, file, moderation) do
       :ok when moderation == "approved" ->
         # Open feeds/profiles re-render the card with the cover.
         Vutuv.Posts.broadcast_review_cover_ready(review.post_id)
@@ -215,6 +223,26 @@ defmodule Vutuv.Posts.ReviewCovers do
         ReviewCover.delete_files(review)
         :ok
     end
+  end
+
+  # The review row and its row in the shared `images` table, together or not
+  # at all (issue #2055). The files are already on disk by the time this runs,
+  # so writing them apart could leave a cover the copyright freeze cannot see
+  # — the same reason a profile upload writes its pair in one transaction.
+  # `sync_review_cover/1` is handed the review as it stands *after* the mark,
+  # which is the row this just wrote.
+  defp store_cover(%PostReview{} = review, file, moderation) do
+    set = [cover: file, cover_status: "ready", cover_moderation: moderation]
+
+    {:ok, outcome} =
+      Repo.transaction(fn ->
+        with :ok <- mark(review, set) do
+          :ok = Images.sync_review_cover(struct(review, set))
+          :ok
+        end
+      end)
+
+    outcome
   end
 
   # Atomically updates the review iff it still carries the fetched ISBN

--- a/lib/vutuv/release.ex
+++ b/lib/vutuv/release.ex
@@ -133,8 +133,9 @@ defmodule Vutuv.Release do
   Brings every picture uploaded before the shared `images` table into it, and
   corrects any row that disagrees with the picture's own columns (see
   `Vutuv.Images.Backfill`). Covers profile pictures and covers (#2013/#2014)
-  and the kinds that still keep a table of their own — a job-posting picture
-  since #2054, a post photo since #2052. Moves no file and changes no URL, so
+  and the kinds #2015 brought in — a job-posting picture since #2054, a post
+  photo since #2052, an organization image since #2053 and a book review's
+  cover since #2055. Moves no file and changes no URL, so
   it is safe while the app serves traffic and safe to run again after an
   interruption:
 
@@ -143,6 +144,8 @@ defmodule Vutuv.Release do
       bin/vutuv eval "Vutuv.Release.backfill_image_rows(only: \\"cover\\")"
       bin/vutuv eval "Vutuv.Release.backfill_image_rows(only: \\"job_posting_image\\")"
       bin/vutuv eval "Vutuv.Release.backfill_image_rows(only: \\"post_image\\")"
+      bin/vutuv eval "Vutuv.Release.backfill_image_rows(only: \\"organization_image\\")"
+      bin/vutuv eval "Vutuv.Release.backfill_image_rows(only: \\"review_cover\\")"
   """
   def backfill_image_rows(opts \\ []) do
     load_app()

--- a/lib/vutuv/uploaders/review_cover.ex
+++ b/lib/vutuv/uploaders/review_cover.ex
@@ -67,6 +67,14 @@ defmodule Vutuv.ReviewCover do
   end
 
   @doc """
+  Where this review's stored cover actually is on disk, or `nil` when the
+  `cover` column names a file that is not there — the twin of
+  `Vutuv.Images.stored_path/3` for a review, so a caller that only wants to
+  know whether the bytes exist does not have to name the version itself.
+  """
+  def stored_path(review), do: version_path(review, version_name(review))
+
+  @doc """
   The path nginx would resolve for X-Accel serving. The default install
   serves covers via `send_file` (`:post_image_serving`), like post images.
   """

--- a/priv/repo/migrations/20260907235913_add_review_cover_to_images.exs
+++ b/priv/repo/migrations/20260907235913_add_review_cover_to_images.exs
@@ -1,0 +1,55 @@
+defmodule Vutuv.Repo.Migrations.AddReviewCoverToImages do
+  use Ecto.Migration
+
+  # The last of the four kinds #2015 brings into the shared `images` table
+  # (issue #2055): the cover of a book review. Expand half — one nullable
+  # column, one partial index, one check constraint, and not a byte of the
+  # picture moves. N-1 safe: the release one step back neither reads nor
+  # writes any of it.
+  #
+  # **This kind is not the gallery shape.** A post photo, an organization
+  # image and a job-posting picture each carry a `token` of their own, so the
+  # mirror joins them on it. A review's cover is `cover` / `cover_status` /
+  # `cover_moderation` columns on `post_reviews` with no token and no table of
+  # its own, so this column *is* the join key as well as the parent — one
+  # cover per review, hence a unique index rather than the plain one the other
+  # three parents got.
+  #
+  # No column type question: `post_reviews.cover` and `cover_moderation` are
+  # varchar(255) and copy into `images.file` and `images.moderation`, which are
+  # varchar(255) too. `cover_status` deliberately stays behind — see
+  # `docs/architecture/images.md`; it is the *fetch* lifecycle, and there is no
+  # picture at all while it says none/pending/failed.
+  def change do
+    alter table(:images) do
+      # Cascades like `post_reviews.post_id` does from `posts`: deleting the
+      # post takes the review and its cover row with it in one statement.
+      add(:post_review_id, references(:post_reviews, type: :binary_id, on_delete: :delete_all))
+    end
+
+    # Partial, like the other three parents': every other kind's row is NULL
+    # here. Unique, unlike theirs: a review has exactly one cover, so this is
+    # the join key the mirror upserts on. It also serves the cascade's own
+    # `WHERE post_review_id = $1`, which Postgres can prove `IS NOT NULL` from.
+    create(
+      unique_index(:images, [:post_review_id],
+        where: "post_review_id IS NOT NULL",
+        name: :images_post_review_id_index
+      )
+    )
+
+    # The shape a comment cannot hold: `Vutuv.Images.sync_review_cover/1`
+    # writes through `insert_all`, so no changeset stands between a future
+    # author who "fills in" `user_id` and the `ON DELETE CASCADE` that would
+    # then delete a publisher's cover the day the reviewer closes their
+    # account. Nobody uploaded this picture — the review owns it, and the post
+    # under it need not have a member author at all (an organization's review
+    # post has `posts.user_id` NULL).
+    create(
+      constraint(:images, :images_review_kind_owned_by_review,
+        check:
+          "kind <> 'review_cover' OR (post_review_id IS NOT NULL AND user_id IS NULL)"
+      )
+    )
+  end
+end

--- a/test/support/image_helpers.ex
+++ b/test/support/image_helpers.ex
@@ -92,4 +92,13 @@ defmodule Vutuv.ImageHelpers do
 
   def mirror_row(kind, token) when is_binary(token),
     do: Repo.get_by(Image, token: token, kind: kind)
+
+  @doc """
+  The `images` row standing beside a book review's fetched cover (#2055), or
+  `nil`. Not `mirror_row/2`: a review's cover has no token of its own, so the
+  two sides are joined on `images.post_review_id` — the parent column, which
+  is also the key.
+  """
+  def review_cover_row(%{id: id}) when is_binary(id),
+    do: Repo.get_by(Image, post_review_id: id, kind: "review_cover")
 end

--- a/test/vutuv/images/backfill_test.exs
+++ b/test/vutuv/images/backfill_test.exs
@@ -20,12 +20,15 @@ defmodule Vutuv.Images.BackfillTest do
   alias Vutuv.Images.Backfill
   alias Vutuv.Images.Image, as: ImageRow
   alias Vutuv.Jobs.JobPostingImage
+  alias Vutuv.Posts.PostReview
   alias Vutuv.Repo
+  alias Vutuv.ReviewCover
   alias Vutuv.Uploads
   alias Vutuv.Uploads.Spec
 
   @kind "job_posting_image"
   @post_kind "post_image"
+  @review_kind "review_cover"
 
   setup do
     tmp =
@@ -79,6 +82,25 @@ defmodule Vutuv.Images.BackfillTest do
   end
 
   defp post_image_row(picture), do: Vutuv.ImageHelpers.mirror_row(@post_kind, picture)
+
+  # A book review whose cover was fetched before the row existed: the two
+  # columns on the review row and the one served version on disk. Not a
+  # gallery picture — there is no token and no table of its own, so the join
+  # is `images.post_review_id` and `mirror_row/2` cannot find it.
+  defp stored_review_cover(attrs \\ []) do
+    review = insert(:post_review, Keyword.merge([cover: "1a2b3c4d5e6f.jpg"], attrs))
+    dir = Uploads.disk_dir(Path.join("review_covers", review.id))
+    File.mkdir_p!(dir)
+    # Named through the uploader, so the fixture cannot outlive the convention.
+    File.write!(
+      Path.join(dir, ReviewCover.version_name(review) <> Spec.served_ext()),
+      "not really an avif"
+    )
+
+    review
+  end
+
+  defp review_cover_row(review), do: Vutuv.ImageHelpers.review_cover_row(review)
 
   defp jpeg_upload(name \\ "selfie.jpg") do
     src = Path.join(System.tmp_dir!(), "backfill_src_#{System.unique_integer([:positive])}.jpg")
@@ -462,6 +484,116 @@ defmodule Vutuv.Images.BackfillTest do
       Backfill.run(only: @post_kind)
 
       assert %{ok?: true} = Backfill.check(only: @post_kind)
+    end
+  end
+
+  # The fourth kind is the odd one (#2055): its truth is columns on the review
+  # row, so it walks the `%{cols: …}` half of this module — the same half the
+  # avatar walks — with a different parent, a different join column and no
+  # pointer at all.
+  describe "a column kind that is not a member: the review cover (issue #2055)" do
+    test "it is one of the kinds a bare run walks" do
+      assert @review_kind in Backfill.kinds()
+    end
+
+    test "one that predates the row arrives with a token nobody had to mint" do
+      review = stored_review_cover(cover_moderation: "approved")
+
+      assert %{@review_kind => tally} = Backfill.run(only: @review_kind)
+      assert tally.pictures == 1
+      assert tally.created == 1
+
+      assert %ImageRow{} = row = review_cover_row(review)
+      assert row.kind == @review_kind
+      assert row.post_review_id == review.id
+      assert row.file == review.cover
+      assert row.moderation == "approved"
+      # No member owner, and nothing to fill it from: the picture is a
+      # publisher's and the post under it may have no member author.
+      assert row.user_id == nil
+      assert is_binary(row.token)
+    end
+
+    test "running it again changes nothing" do
+      stored_review_cover()
+      Backfill.run(only: @review_kind)
+
+      assert %{@review_kind => tally} = Backfill.run(only: @review_kind)
+      assert tally.unchanged == 1
+      assert tally.created == 0
+      assert tally.corrected == 0
+    end
+
+    test "a row whose verdict drifted is corrected, and keeps its token" do
+      review = stored_review_cover(cover_moderation: "approved")
+      Backfill.run(only: @review_kind)
+      before = review_cover_row(review)
+
+      Repo.update_all(from(i in ImageRow, where: i.id == ^before.id),
+        set: [moderation: "pending"]
+      )
+
+      assert %{@review_kind => tally} = Backfill.run(only: @review_kind)
+      assert tally.corrected == 1
+
+      after_run = review_cover_row(review)
+      assert after_run.moderation == "approved"
+      # The bytes did not change, so the handle that names them must not.
+      assert after_run.token == before.token
+    end
+
+    test "a row naming other bytes is corrected with a fresh token" do
+      review = stored_review_cover()
+      Backfill.run(only: @review_kind)
+      before = review_cover_row(review)
+
+      Repo.update_all(from(i in ImageRow, where: i.id == ^before.id), set: [file: "older.jpg"])
+
+      assert %{@review_kind => tally} = Backfill.run(only: @review_kind)
+      assert tally.corrected == 1
+
+      after_run = review_cover_row(review)
+      assert after_run.file == review.cover
+      assert after_run.token != before.token
+    end
+
+    test "a row whose review lost its cover is dropped" do
+      review = stored_review_cover()
+      Backfill.run(only: @review_kind)
+      assert review_cover_row(review)
+
+      Repo.update_all(from(r in PostReview, where: r.id == ^review.id), set: [cover: nil])
+
+      assert %{@review_kind => tally} = Backfill.run(only: @review_kind)
+      assert tally.dropped == 1
+      assert review_cover_row(review) == nil
+    end
+
+    test "the check names the covers with no row, and says nothing about a pointer" do
+      review = stored_review_cover()
+
+      assert %{kinds: %{@review_kind => before}, ok?: false} = Backfill.check(only: @review_kind)
+      assert before.missing_row.count == 1
+      assert before.missing_row.sample == [review.id]
+      assert before.missing_file.count == 0
+      # A review row keeps no pointer back at the picture, so the report must
+      # not invite anybody to go looking for one.
+      refute Map.has_key?(before, :missing_pointer)
+
+      Backfill.run(only: @review_kind)
+
+      assert %{ok?: true} = Backfill.check(only: @review_kind)
+    end
+
+    test "a cover whose file is gone is named and never repaired away" do
+      review = stored_review_cover()
+      File.rm_rf!(Uploads.disk_dir(Path.join("review_covers", review.id)))
+
+      Backfill.run(only: @review_kind)
+
+      assert %{kinds: %{@review_kind => result}, ok?: false} = Backfill.check(only: @review_kind)
+      assert result.missing_file.count == 1
+      assert result.missing_row.count == 0
     end
   end
 

--- a/test/vutuv/images/review_covers_test.exs
+++ b/test/vutuv/images/review_covers_test.exs
@@ -1,0 +1,318 @@
+defmodule Vutuv.Images.ReviewCoversTest do
+  @moduledoc """
+  The last of the four kinds #2015 moves into the shared `images` table
+  (issue #2055): the cover of a book review is a row there beside the review
+  row it has always lived on, kept in step by every write, and nothing about
+  how it is stored or served has moved.
+
+  **It is not the shape the other three took.** A post photo, an organization
+  image and a job-posting picture each have a row of their own carrying a
+  `token`, so they join the mirror on that token. A review's cover is
+  `cover` / `cover_status` / `cover_moderation` *columns on the review row*
+  with no token and no table — the profile picture's shape — so it joins on a
+  parent column (`images.post_review_id`) and the token is minted here.
+
+  **And nobody uploaded it.** The cover is fetched from Open Library, so there
+  is no member who owns it: `images.user_id` means a member owner and cascades
+  on delete, and the reviewer is not the owner of a publisher's picture. The
+  post carrying the review may not even have a member author — an organization
+  publishes reviews too, and `posts.user_id` is NULL for those — so the owner
+  is the review, under a check constraint rather than a comment.
+
+  Not async: the fetch writes files, so the module holds the global
+  `:uploads_dir_prefix` down for its lifetime.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+  import Vutuv.WebPushHelpers, only: [put_config: 2]
+
+  alias Vutuv.Images
+  alias Vutuv.Images.Image, as: ImageRow
+  alias Vutuv.Moderation.ImageScan
+  alias Vutuv.Moderation.ImageSubjects
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+  alias Vutuv.Posts.PostReview
+  alias Vutuv.Posts.ReviewCovers
+  alias Vutuv.Repo
+  alias Vutuv.ReviewCover
+
+  @kind "review_cover"
+  @isbn "9783161484100"
+  @other_isbn "9780262033848"
+
+  defp review_attrs(isbn), do: %{kind: "book", identifier: isbn, title: "Refactoring"}
+
+  setup do
+    tmp =
+      Path.join(System.tmp_dir!(), "vutuv_review_covers_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmp)
+    put_config(:uploads_dir_prefix, tmp)
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    {:ok, tmp: tmp}
+  end
+
+  # Real JPEG bytes (synthesized via libvips), so the decode succeeds and a
+  # file really lands on disk — "the cover is stored" is a claim about bytes.
+  defp jpeg_bytes(color) do
+    {:ok, img} = Image.new(120, 180, color: color)
+    {:ok, bytes} = Image.write(img, :memory, suffix: ".jpg")
+    bytes
+  end
+
+  # Open Library answering with a cover, then the fetch the request path runs.
+  defp fetch!(review, color \\ [10, 120, 200]) do
+    Application.put_env(:vutuv, :book_covers_req_options,
+      plug: fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("image/jpeg")
+        |> Plug.Conn.resp(200, jpeg_bytes(color))
+      end
+    )
+
+    on_exit(fn -> Application.delete_env(:vutuv, :book_covers_req_options) end)
+
+    :ok = ReviewCovers.fetch(review)
+    Repo.get!(PostReview, review.id)
+  end
+
+  defp mirror(review), do: Vutuv.ImageHelpers.review_cover_row(review)
+
+  describe "the row beside the review row" do
+    test "a fetched cover writes one, column for column" do
+      review = insert(:post_review, cover_status: "pending")
+      stored = fetch!(review)
+
+      assert %ImageRow{} = row = mirror(stored)
+      assert row.kind == @kind
+      assert row.post_review_id == review.id
+      assert row.file == stored.cover
+      assert row.moderation == stored.cover_moderation
+      assert row.frozen_at == nil
+      # Minted here: the review row has no handle of its own to repeat.
+      assert is_binary(row.token) and row.token != ""
+    end
+
+    # The picture is a publisher's, fetched from a catalogue. `images.user_id`
+    # means a member *owner* and cascades on delete, so naming the reviewer
+    # there would arm a deletion on a picture that is not theirs.
+    test "the reviewer is not its owner" do
+      review = insert(:post_review, cover_status: "pending")
+
+      assert %ImageRow{user_id: nil} = mirror(fetch!(review))
+    end
+
+    # The case that decides the owner column: a page publishes a review, the
+    # post has NO member author at all (`posts.user_id` is NULL beside
+    # `organization_id`), and a row keyed on a member owner could not exist.
+    test "a review published in an organization's name gets its row too" do
+      put_config(:verify_organization_domains, true)
+      on_exit(fn -> Application.delete_env(:vutuv, :organizations_dns_resolver) end)
+
+      owner = insert(:activated_user)
+      organization = active_organization_for(owner)
+      {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+
+      {:ok, post} =
+        Posts.create_organization_post(organization, owner, %{
+          body: "Gelesen",
+          review: review_attrs(@isbn)
+        })
+
+      assert post.user_id == nil
+      stored = fetch!(post.review)
+
+      assert %ImageRow{user_id: nil, post_review_id: review_id} = mirror(stored)
+      assert review_id == post.review.id
+
+      # And the fetch really finished. Announcing the cover fans out to the
+      # author's followers, which for a page hangs off
+      # `followee_organization_id` — handing the nil author to the member
+      # query raised, `fetch/1`'s own rescue swallowed it, and the review was
+      # written off as `failed` with its picture already on disk.
+      assert stored.cover_status == "ready"
+    end
+
+    test "a re-fetch replaces the row and mints a fresh token" do
+      review = insert(:post_review, cover_status: "pending")
+      first = fetch!(review)
+      first_row = mirror(first)
+
+      second = fetch!(first, [200, 30, 30])
+      second_row = mirror(second)
+
+      assert second.cover != first.cover
+      assert second_row.id == first_row.id
+      assert second_row.file == second.cover
+      # A token names the bytes, so a report that named the old cover points
+      # at nothing rather than quietly at the new one.
+      assert second_row.token != first_row.token
+    end
+
+    test "the same bytes again keep the token they had" do
+      review = insert(:post_review, cover_status: "pending")
+      first = fetch!(review)
+      first_row = mirror(first)
+
+      second = fetch!(first)
+
+      assert second.cover == first.cover
+      assert mirror(second).token == first_row.token
+    end
+  end
+
+  describe "every path that touches the cover keeps the row in step" do
+    setup do
+      put_config(:moderate_images, true)
+      :ok
+    end
+
+    test "the AI gate's release reaches the row" do
+      review = insert(:post_review, cover_status: "pending")
+      stored = fetch!(review)
+
+      assert stored.cover_moderation == "pending"
+      assert mirror(stored).moderation == "pending"
+
+      scan = Repo.get_by!(ImageScan, kind: @kind, subject_id: review.id)
+      assert :ok = ImageSubjects.apply_approved(scan)
+
+      assert mirror(stored).moderation == "approved"
+      assert Repo.get!(PostReview, review.id).cover_moderation == "approved"
+    end
+
+    test "a rejected cover takes its row with it" do
+      review = insert(:post_review, cover_status: "pending")
+      stored = fetch!(review)
+      assert mirror(stored)
+
+      scan = Repo.get_by!(ImageScan, kind: @kind, subject_id: review.id)
+      assert :ok = ImageSubjects.apply_rejected(scan)
+
+      assert Repo.get!(PostReview, review.id).cover == nil
+      assert mirror(stored) == nil
+    end
+  end
+
+  describe "the row follows the review row" do
+    setup do
+      author = insert(:activated_user)
+
+      {:ok, post} =
+        Posts.create_post(author, %{body: "Gelesen", review: review_attrs(@isbn)})
+
+      stored = fetch!(post.review)
+      assert mirror(stored)
+
+      {:ok, post: post, stored: stored}
+    end
+
+    test "changing the reviewed ISBN drops the cover and its row", ctx do
+      # Re-read the way the editor does: the struct `create_post/2` handed
+      # back predates the fetch, and `change(cover: nil)` on a review that
+      # already reads nil records nothing at all.
+      post = Repo.preload(ctx.post, :review, force: true)
+
+      {:ok, updated} =
+        Posts.update_post(post, %{body: "Gelesen", review: review_attrs(@other_isbn)})
+
+      assert updated.review.cover == nil
+      assert mirror(ctx.stored) == nil
+    end
+
+    # The other half of that: an editor holding a stale review (its cover
+    # fetched after the page was loaded) must not take the row of a picture
+    # that is still there — the mirror follows the row, not the struct.
+    test "an edit that keeps the cover keeps its row", ctx do
+      row = mirror(ctx.stored)
+
+      {:ok, _updated} =
+        Posts.update_post(ctx.post, %{body: "Immer noch gelesen", review: review_attrs(@isbn)})
+
+      assert Repo.get!(PostReview, ctx.stored.id).cover == ctx.stored.cover
+      assert mirror(ctx.stored).id == row.id
+    end
+
+    test "deleting the post takes the row with it", ctx do
+      {:ok, _} = Posts.delete_post(ctx.post)
+
+      assert Repo.aggregate(from(i in ImageRow, where: i.kind == ^@kind), :count) == 0
+    end
+  end
+
+  # `mirror/2` and the sync below write through `insert_all`, so no changeset
+  # stands between a future author and the shape. The database holds it.
+  describe "the shape the database holds" do
+    test "a review cover with a member owner is refused" do
+      review = insert(:post_review)
+      user = insert(:activated_user)
+
+      assert_raise Ecto.ConstraintError, ~r/images_review_kind_owned_by_review/, fn ->
+        Repo.insert!(%ImageRow{
+          kind: @kind,
+          token: "t-#{System.unique_integer([:positive])}",
+          post_review_id: review.id,
+          user_id: user.id
+        })
+      end
+    end
+
+    test "a review cover naming no review is refused" do
+      assert_raise Ecto.ConstraintError, ~r/images_review_kind_owned_by_review/, fn ->
+        Repo.insert!(%ImageRow{
+          kind: @kind,
+          token: "t-#{System.unique_integer([:positive])}"
+        })
+      end
+    end
+
+    test "one review has at most one cover row" do
+      review = insert(:post_review)
+
+      Repo.insert!(%ImageRow{
+        kind: @kind,
+        token: "t-#{System.unique_integer([:positive])}",
+        post_review_id: review.id
+      })
+
+      assert_raise Ecto.ConstraintError, ~r/images_post_review_id_index/, fn ->
+        Repo.insert!(%ImageRow{
+          kind: @kind,
+          token: "t-#{System.unique_integer([:positive])}",
+          post_review_id: review.id
+        })
+      end
+    end
+  end
+
+  describe "nothing about the picture itself has moved" do
+    test "the URL and the file on disk are the ones they were" do
+      review = insert(:post_review, cover_status: "pending")
+      stored = fetch!(review)
+
+      version = ReviewCover.version_name(stored)
+      assert version == "cover-" <> Path.rootname(stored.cover)
+      assert ReviewCover.url(stored) == "/review_covers/#{stored.id}/#{version}.avif"
+      assert ReviewCover.version_path(stored, version)
+    end
+
+    # The expand half writes the row and reads nothing from it, so a report
+    # cannot name one of these pictures yet: the case's uphold would reach a
+    # freeze with no strategy for the kind and raise in front of the admin.
+    test "the takedown gate still refuses this kind" do
+      refute Images.takedown_ready?(%ImageRow{kind: @kind})
+
+      assert_raise ArgumentError, ~r/nothing here can take a picture of that kind/, fn ->
+        Images.freeze(%ImageRow{kind: @kind})
+      end
+    end
+
+    test "and it is served through its authorizing proxy, like the other three" do
+      assert Images.serving(@kind) == :proxy
+      assert @kind in Images.kinds()
+    end
+  end
+end

--- a/test/vutuv/images_test.exs
+++ b/test/vutuv/images_test.exs
@@ -21,6 +21,7 @@ defmodule Vutuv.ImagesTest do
   alias Vutuv.Moderation.ImageScan
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Moderation.ImageSubjects
+  alias Vutuv.Posts.PostReview
   alias Vutuv.Repo
 
   @safe {:ok, %{safe?: true, category: "safe"}}
@@ -280,22 +281,32 @@ defmodule Vutuv.ImagesTest do
     test "avatars and covers are served straight off disk" do
       assert Images.serving("avatar") == :static
       assert Images.serving("cover") == :static
-      assert Images.kinds() == ~w(avatar cover job_posting_image organization_image post_image)
+
+      assert Images.kinds() ==
+               ~w(avatar cover job_posting_image organization_image post_image review_cover)
     end
 
-    # Every gallery kind that has moved goes through an authorizing proxy, so
-    # the row is its off switch rather than the tree the bytes sit in.
-    test "the gallery kinds go through their proxy" do
+    # Every kind that has moved goes through an authorizing proxy, so the row
+    # is its off switch rather than the tree the bytes sit in.
+    test "the kinds #2015 brought go through their proxy" do
       assert Images.serving("job_posting_image") == :proxy
       assert Images.serving("organization_image") == :proxy
       assert Images.serving("post_image") == :proxy
+      assert Images.serving("review_cover") == :proxy
     end
 
-    # A review's cover is the last kind #2015 brings (#2055); until it arrives,
-    # asking about it is asking about a picture nobody could take offline.
+    # #2055 was the last of the four, so there is no un-moved kind left to
+    # point at here. The claim was never about a *pending* kind anyway: it is
+    # that a name nobody declared raises instead of inheriting a strategy, so
+    # the example is a name that is deliberately not a kind — and the second
+    # assertion is what keeps it that way, since the day somebody declares it
+    # this test would otherwise start proving nothing.
     test "an undeclared kind raises rather than inheriting a default" do
+      undeclared = "poster"
+      refute undeclared in Images.kinds()
+
       assert_raise ArgumentError, ~r/no serving strategy declared/, fn ->
-        Images.serving("review_cover")
+        Images.serving(undeclared)
       end
     end
   end
@@ -360,6 +371,52 @@ defmodule Vutuv.ImagesTest do
         assert Images.mirror_source(kind).fields -- ImageRow.__schema__(:fields) == [],
                "#{kind} names a column the images row does not have"
       end
+    end
+
+    # The review cover is in no mirror registry — it is columns on a parent
+    # row (#2055) — so the loop above cannot see it, and the whole review row
+    # is the wrong thing to compare against: fifteen of its seventeen columns
+    # describe the *review*, not its picture, and a drift test that listed
+    # them all would fire on every new review field and be rubber-stamped.
+    #
+    # What is worth pinning is narrower and exact: every `cover*` column of
+    # `post_reviews` is either copied into the row or excluded on purpose. A
+    # future `cover_source_url` or `cover_alt` then has to answer for itself
+    # before the release that drops these columns loses it.
+    # The **fetch** lifecycle (none → pending → ready/failed), not a fact about
+    # a stored picture: while it is anything but "ready" there is no cover at
+    # all, so the row's existence already says what a copy would. It stays on
+    # the review row when the other two go.
+    @cover_columns_kept [:cover_status]
+
+    test "every cover column of a review is copied or kept back on purpose" do
+      copied = Images.column_source("review_cover").copied
+
+      cover_columns =
+        PostReview.__schema__(:fields)
+        |> Enum.filter(&String.starts_with?(Atom.to_string(&1), "cover"))
+
+      assert Enum.sort(cover_columns) ==
+               Enum.sort(Map.values(copied) ++ @cover_columns_kept),
+             """
+             post_reviews' cover columns and the review cover's row have drifted.
+
+             columns: #{inspect(Enum.sort(cover_columns))}
+             copied:  #{inspect(Enum.sort(Map.values(copied)))}
+             kept:    #{inspect(@cover_columns_kept)}
+
+             Add the column to `Vutuv.Images`' `@column_sources` entry for
+             "review_cover" (and to `images` in a migration), or to
+             `@cover_columns_kept` here with the reason it belongs to the
+             review row alone.
+             """
+    end
+
+    test "and every copied name is a column of the images row too" do
+      copied = Map.keys(Images.column_source("review_cover").copied)
+
+      assert copied -- ImageRow.__schema__(:fields) == [],
+             "review_cover names a column the images row does not have"
     end
   end
 


### PR DESCRIPTION
A book review's fetched cover kept its own storage outside the shared `images` table, so a copyright freeze had nothing to act on.

It now has one, reconciled by `mix vutuv.images.backfill --only review_cover`. Last of #2015's four kinds and the only non-gallery one: a cover is columns on the review row with no token, so `images.post_review_id` is parent and join key. `user_id` stays empty under a check constraint — nobody uploaded a publisher's picture, and a page's review post has no member author.

Closes #2055

https://claude.ai/code/session_01UGPe7bHVS11M1W7fNehSku

<!-- closing-note #2055 -->
A review cover now has a row in the shared images table, so the copyright freeze has something to act on. Nothing reads it yet — no URL, no proxy and no byte moved. `cover_status` stays behind on purpose: it says whether a fetch is due, not whether a picture exists.

*An AI agent wrote this text in my name. I know that is problematic.*
