### PR TITLE
The takedown notices say what was reported and how it ended

### DIFF
--- a/docs/architecture/email.md
+++ b/docs/architecture/email.md
@@ -105,6 +105,24 @@ layout, dark mode, and blocks like the PIN box, CTA button and key/value panel).
 The two formats are paired by a drift test, so an email added with only one
 fails the build.
 
+**A body is written per locale, so a fact it needs must arrive as an assign —
+and a noun that inflects arrives as a whole sentence.** The two owner mails
+opened with "one of your posts was reported" for every content type, because the
+type was never handed to them: a member whose profile picture had been taken
+offline went looking through posts that were all still there (issue #2067).
+Naming the type is not a matter of dropping `content_type_label/1` into a frame,
+because German gives each kind its own gender and article (der Beitrag, das
+Bild, die Nachricht, die Seite, die Stellenanzeige) and a profile is not "one of
+your" anything — and a sentence built from translated fragments is exactly what
+this project forbids. So `VutuvWeb.ReportHTML.content_reported_sentence/1` is
+**one whole translatable sentence per type**, pre-rendered in the recipient's
+locale (`in_locale/2`, like the category labels beside it), and everything after
+it in the body says "the reported content", which has one gender in each locale.
+The same shape answers two more facts a body cannot derive: whether an account
+here is behind the report (`from_member`, or the mail invents a member for an
+anonymous outside notice) and what became of the content
+(`content_fate`) — see `moderation.md`.
+
 **Quoting somebody else's text.** A mail that carries what another person wrote
 has two blocks, and they are not interchangeable. `email_markdown/1` renders a
 member's own Markdown (an invitation note, a DM) with its links live.

--- a/docs/architecture/moderation.md
+++ b/docs/architecture/moderation.md
@@ -67,6 +67,24 @@ suspension → permanent deactivation; strikes expire after 12 months) or
 *abusive* strike the **reporter** on the same ladder — reporting-as-a-weapon is
 treated as bullying).
 
+Two things the ruling has to carry rather than assume. **The warning names the
+ground the case page named**: the owner of a copyright case is told outright
+that this is the law and not a house rule, and the warning that followed said
+their content broke the community guidelines and linked them, so the two letters
+about one case disagreed (issue #2067). `strike_ground/2` reads
+`copyright_case?/1` and hands the mail `:copyright` or `:community` — for the
+**owner** only, because a reporter's strike is for weaponising the report
+button, which is a house rule whatever the case underneath was about. And
+**what upholding does to the content is not one sentence**: the decision panel
+promised "the content stays hidden" on every case, which is true for a frozen
+post and false for the other three shapes an open case has, so
+`uphold_content_effect/2` answers `:deleted` (a picture, hidden or not),
+`:stays_hidden`, `:unhidden` (a profile or a page, where the consequence is the
+strike) or `:untouched` (a flagged case that never hid anything). Beside it,
+`pending_copyright_notice?/1` is what lets the picture caption tell the two
+reasons a copyright case has not hidden anything apart — the category, or an
+address nobody has confirmed yet.
+
 For a clear-cut spam or abuse account the case page also offers a decisive
 **remove** ruling (`Vutuv.Moderation.remove_owner/4`) that skips the warn-first
 ladder: **deactivate** stamps an internal `users.moderation_reason` (`"spam"`),
@@ -360,7 +378,7 @@ page and is keyed by **report id**, since looking a notice up by its nil
 reporter was a `KeyError` and a 500. `list_reporter_stats/0` is two grouped
 queries now — its inner join to `users` dropped every outside notice from the
 one screen whose job is showing who abuses the report button.
-`Notifier.reporters_case_closed/2` branches on the column rather than on a
+`Notifier.reporters_case_closed/1` branches on the column rather than on a
 preloaded `%User{}`, so an outside notice gets its own mail instead of raising
 in `deliver_to/2`, and `reject_case/3` marks an outside notice abusive without
 trying to strike an account that does not exist (the mark still costs that
@@ -385,9 +403,15 @@ there is one. This is what the Digital Services Act calls a statement of reasons
 
 `Moderation.owner_notice/1` is the one place all three read: it returns the
 deduplicated `categories` (most recent report first), the `category` to name
-where there is room for only one, the reporters' `notes`, and `copyright?`.
-The reporter is deliberately not in the map — a surface cannot leak what it
-was never handed. The three surfaces are
+where there is room for only one, the reporters' `notes`, `copyright?`, and
+`from_member?`. The reporter is deliberately not in the map — a surface cannot
+leak what it was never handed. `from_member?` is the one thing about them that
+does travel, and only because the alternative was a lie: both surfaces explained
+the automatic freeze as "a report from a **member** in good standing", which for
+an outside notice (issue #2009) names somebody who has no account here and
+points the owner at the wrong people (issue #2067). It says whether *any*
+effective report on the case has a user row, never which one, so a case a member
+and a stranger both reported keeps the member wording. The three surfaces are
 
 - the case page `/moderation/cases/:id`, which the controller hands the notice
   as `@notice`;
@@ -401,8 +425,25 @@ was never handed. The three surfaces are
   same function, so a member who reads the mail instead of opening the app is
   told the same thing.
 
-Two things the mail must not get wrong. **The options are the options that case
-actually has**, and `Moderation.owner_edit_offer/2` answers that as one value
+That third surface is **one row per case, rewritten in place**, so its time has
+to be the time of what the row currently *says*. It was the case's
+`inserted_at`, the moment the report arrived, so a ruling days later kept the
+row where it had always been, with the hour of the complaint on it, and the
+member was never told their content had come back (issue #2067). Every reader of
+the `moderation` kind in `Vutuv.Activity` — the ordering, the keyset cursor, the
+`max` and the unread count — now asks `coalesce(resolved_at, inserted_at)`
+through one macro, or the cursor and the ordering stop agreeing. It is the
+answer `report_outcome` gives one kind over: stamp the event, not the trigger.
+
+**The mail names what was actually reported**, which the body cannot derive from
+a per-locale template: `VutuvWeb.ReportHTML.content_reported_sentence/1` gives
+it one whole sentence per content type, pre-rendered in the recipient's language
+beside the category labels. It is a sentence rather than a noun in a frame
+because German inflects each kind differently — see `email.md` for why that is
+the shape and not a placeholder.
+
+Two more things the mail must not get wrong. **The options are the options that
+case actually has**, and `Moderation.owner_edit_offer/2` answers that as one value
 (`:immediate` / `:reviewed` / `:none`) rather than as two booleans each of the
 seven rendering places recombines: only a post has an editor behind the case
 page's button, so a reported message or job posting gets delete and dispute,
@@ -435,7 +476,7 @@ said nothing at all — so somebody who reported a post went back to the URL for
 days and eventually filed the same notice again. This is what the Digital
 Services Act asks for (Art. 16); the reporter-facing text never says so.
 
-`Notifier.reporters_case_closed/2` is the one place it happens, and all five
+`Notifier.reporters_case_closed/1` is the one place it happens, and all five
 ways a case can close call it: `uphold_case/2`, `reject_case/3`, the owner's
 delete (`content_deleted/1`), the owner's edit (`resolve_edited/2`) and the
 erasing `remove_owner/4`. A member gets an in-app entry **and** a mail, an
@@ -448,6 +489,21 @@ removed would be false. It says what happened to the *content* and never what
 happened to the account behind it: a warning, a suspension or nothing visible at
 all is between that member and us, the same asymmetry that keeps the reporter's
 name off the owner's case page.
+
+**What happened to the content is measured, not derived from the ending.**
+Because those four words cannot carry it, the upheld letter said only "we have
+taken the necessary steps" and told the one person it is addressed to nothing at
+all — a promise this issue made and did not keep (fixed in #2067).
+`Moderation.reported_content_fate/1` answers `:removed`, `:hidden` or `:visible`
+by **looking**, after the ruling has settled the content and before any delivery
+task is spawned: the row is gone, or it is frozen, or its owner is hidden and
+takes everything they own with them (`account_hidden?/1` — otherwise the account
+removal an admin has just carried out reads to the reporter as "still visible").
+It is read once per closing case and travels to both builders as `content_fate`,
+so a member and an outside notifier are told the same thing. On the one path
+that erases the case with its account, the fate is read while the content still
+exists, so it says "no longer visible" about content that is about to be
+deleted; that is the same trade the ordering there already makes.
 
 **Exactly once is a claim, not a convention.** One `UPDATE` both picks the
 reports that still owe their reporter a notice and stamps

--- a/docs/architecture/moderation.md
+++ b/docs/architecture/moderation.md
@@ -500,10 +500,28 @@ task is spawned: the row is gone, or it is frozen, or its owner is hidden and
 takes everything they own with them (`account_hidden?/1` — otherwise the account
 removal an admin has just carried out reads to the reporter as "still visible").
 It is read once per closing case and travels to both builders as `content_fate`,
-so a member and an outside notifier are told the same thing. On the one path
-that erases the case with its account, the fate is read while the content still
-exists, so it says "no longer visible" about content that is about to be
-deleted; that is the same trade the ordering there already makes.
+so a member and an outside notifier are told the same thing.
+
+**Two closing paths cannot be measured, and both said the friendly thing until
+they were fixed.** `remove_owner/4` on `:delete` has to tell the reporters
+*before* it erases the case, so a measurement there answers "still on vutuv"
+about an account that is gone a line later; it is the one caller that passes
+`fate: :removed` to `Notifier.reporters_case_closed/2`, stated by the call that
+makes it true. And **replacing** a flagged picture leaves the row standing with
+its id (issue #2035) and somebody else's bytes in it, so a measurement answers
+"still visible" — while the case, closed as `resolved_deleted`, put "was
+deleted" in the subject. That one is fixed at the source rather than in the
+body: a replacement is a **revision** (`Moderation.content_replaced/1`,
+`resolved_edited`), which also spends the owner's one self-service round on that
+picture, as it should.
+
+That second bug is what `Moderation.consistent_outcome?/2` now guards. The
+subject comes from the case status and the fate paragraph from a measurement —
+**two sources on purpose**, one saying who decided and what they did, the other
+what the content is now — and exactly two of the four endings make a claim
+about the content in their own subject, so each of those has exactly one fate
+that agrees with it. A path that closes a case without settling the content the
+way its status claims is a test failure now, not a mail.
 
 **Exactly once is a claim, not a convention.** One `UPDATE` both picks the
 reports that still owe their reporter a notice and stamps

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -2277,16 +2277,22 @@ defmodule Vutuv.Accounts do
       # A picture whose case only flagged it may be replaced (the guard above is
       # about the takedown hold, and a flagged case moved nothing), and such an
       # upload overwrites the very bytes that were reported. So the replacement
-      # settles the case the way the owner's own "remove it" does: left open, an
-      # admin's ruling — which for a picture is the one ruling that *deletes* —
-      # would land on whatever the member put there afterwards.
+      # settles the case: left open, an admin's ruling — which for a picture is
+      # the one ruling that *deletes* — would land on whatever the member put
+      # there afterwards.
+      #
+      # It settles as a **revision**, not as a deletion. The row keeps its id
+      # (issue #2035), so the reported bytes are gone while a picture the
+      # reporter can still see stands in their place; closing it the way the
+      # owner's own "remove it" does made their notice contradict itself — the
+      # subject said deleted and the body said still visible (issue #2067).
       #
       # But only a replacement. Uploading the same file again overwrites the
       # reported bytes with themselves, and settling on that was a way to make a
       # complaint vanish from the admin queue at no cost to the owner (issue
       # #2035). The fingerprint answers it, crop and all
       # (`Vutuv.Uploads.content_hash/2`).
-      if fingerprint != reported, do: Moderation.content_deleted(image)
+      if fingerprint != reported, do: Moderation.content_replaced(image)
       saved
     else
       _ ->

--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -38,6 +38,7 @@ defmodule Vutuv.Activity do
   """
   import Ecto.Query
   import Vutuv.Identity.Query, only: [join_party: 3, shown_party: 2]
+  import Vutuv.Moderation.Query, only: [case_event_at: 1]
 
   alias Vutuv.Accounts.HandleChangeNotification
   alias Vutuv.Accounts.User
@@ -342,7 +343,7 @@ defmodule Vutuv.Activity do
 
   defp moderation_max(user_id) do
     Vutuv.Moderation.owner_notified_cases_query(user_id)
-    |> select([c], %{ts: max(c.inserted_at)})
+    |> select([c], %{ts: max(case_event_at(c))})
   end
 
   defp image_rejected_max(user_id) do
@@ -1954,10 +1955,10 @@ defmodule Vutuv.Activity do
   defp moderation_items(user_id, limit, cursor) do
     rows =
       Vutuv.Moderation.owner_notified_cases_query(user_id)
-      |> order_by([c], desc: c.inserted_at, desc: c.id)
+      |> order_by([c], desc: case_event_at(c), desc: c.id)
       |> limit(^limit)
-      |> select([c], {c.id, c.inserted_at, c.status})
-      |> at_or_before(cursor)
+      |> select([c], {c.id, case_event_at(c), c.status})
+      |> at_or_before_case_event(cursor)
       |> Repo.all()
 
     # What was claimed, so the line can name it instead of saying only that
@@ -2026,6 +2027,16 @@ defmodule Vutuv.Activity do
       }
     end)
   end
+
+  # The keyset and unread twins of `case_event_at/1`: the same expression the
+  # ordering uses, or a page boundary and a badge land in the wrong place.
+  defp at_or_before_case_event(query, nil), do: query
+
+  defp at_or_before_case_event(query, %{at: at}),
+    do: where(query, [c], case_event_at(c) <= ^at)
+
+  defp since_case_event(query, nil), do: query
+  defp since_case_event(query, read_at), do: where(query, [c], case_event_at(c) > ^read_at)
 
   defp at_or_before_notified(query, nil), do: query
 
@@ -2477,10 +2488,13 @@ defmodule Vutuv.Activity do
     from(group in subquery(CvUpdates.count_query(user_id, read_at)), select: %{count: count()})
   end
 
+  # `since/2` compares `inserted_at`, which here is when the report arrived; the
+  # event is what the row says now, so this bounds on the same expression the
+  # items and the max do (issue #2067).
   defp count_moderation(user_id, read_at) do
     Vutuv.Moderation.owner_notified_cases_query(user_id)
     |> select([c], %{count: count()})
-    |> since(read_at)
+    |> since_case_event(read_at)
   end
 
   defp count_image_rejections(user_id, read_at) do

--- a/lib/vutuv/moderation.ex
+++ b/lib/vutuv/moderation.ex
@@ -1137,6 +1137,87 @@ defmodule Vutuv.Moderation do
   end
 
   @doc """
+  Whether a copyright notice was filed on this case but **counts for nothing
+  yet** — an outside notice whose address nobody has confirmed
+  (`Report.effective?/1`).
+
+  It exists because that state reads on the admin case page as its own
+  opposite: the picture is still on the profile, `copyright_case?/1` says no,
+  and the page then explained the picture with "only a copyright notice takes
+  one offline before a ruling" — on a case whose category is copyright. The
+  reason is the unconfirmed address, and only this predicate can tell the two
+  apart. Takes the case with its **plain** `:reports` preload, which is what
+  the two admin surfaces carry.
+  """
+  def pending_copyright_notice?(%Case{reports: reports} = case_record) when is_list(reports),
+    do: Enum.any?(reports, &Report.copyright?/1) and not copyright_case?(case_record)
+
+  def pending_copyright_notice?(%Case{} = case_record),
+    do: case_record |> Repo.preload(:reports) |> pending_copyright_notice?()
+
+  @doc """
+  What became of the reported content itself, for the notice its reporter is
+  owed (issues #2011/#2067): `:removed`, `:hidden` or `:visible`.
+
+  **Measured after the ruling settled the content**, never derived from the
+  case status — one `"upheld"` ends three different ways (a picture is purged,
+  a post stays frozen as evidence, a profile comes back with its owner on the
+  strike ladder), and the sweeping "we have taken the necessary steps" the mail
+  used to send instead is exactly the sentence that made the notice worthless.
+  Every caller runs after `settle_content_on_uphold/1` or `unfreeze_content/1`,
+  so what it reads is the answer.
+
+  A hidden owner hides everything they own, so a suspended or deactivated
+  account counts as `:hidden` even when the content row itself was never
+  frozen — otherwise the account removal an admin has just carried out would be
+  reported to the reporter as "still visible".
+  """
+  def reported_content_fate(%Case{} = case_record) do
+    case case_content(case_record) do
+      nil -> :removed
+      content -> if content_hidden?(case_record, content), do: :hidden, else: :visible
+    end
+  end
+
+  # A profile case's content *is* its owner (`owner_id/1` on a `%User{}` returns
+  # its own id), so reading the row a second time would be the same row —
+  # and `account_hidden?/1` already tests `frozen_at`.
+  defp content_hidden?(%Case{owner_id: id}, %User{id: id} = owner), do: account_hidden?(owner)
+
+  defp content_hidden?(%Case{}, %{frozen_at: %NaiveDateTime{}}), do: true
+
+  defp content_hidden?(%Case{owner_id: owner_id}, _content) do
+    case Repo.get(User, owner_id) do
+      nil -> true
+      owner -> account_hidden?(owner)
+    end
+  end
+
+  @doc """
+  What upholding this case would do to the content, for the admin about to
+  rule: `:deleted`, `:stays_hidden`, `:untouched` or `:unhidden`.
+
+  The decision panel promised "the content stays hidden" on every case, which
+  is true for a frozen post and false for the three other shapes an open case
+  has: a picture is deleted by the ruling whether or not it was ever hidden, a
+  flagged post was never hidden in the first place, and an upheld **profile**
+  case unfreezes the profile because the consequence there is the strike.
+
+  It is the *description* of what `settle_content_on_uphold/1` does, so the two
+  clause lists have to move together; content that is gone falls through to
+  `:untouched`, which is the honest answer for a ruling that no longer has
+  anything to act on.
+  """
+  def uphold_content_effect(%Case{content_type: "image"}, _content), do: :deleted
+
+  def uphold_content_effect(%Case{content_type: type}, %{frozen_at: %NaiveDateTime{}})
+      when type in ["user", "organization"],
+      do: :unhidden
+
+  def uphold_content_effect(%Case{}, %{frozen_at: %NaiveDateTime{}}), do: :stays_hidden
+  def uphold_content_effect(%Case{}, _content), do: :untouched
+
+  @doc """
   The statement of reasons the owner of hidden content is owed (issue #2010):
   what was claimed, in the words the reporters typed, and on what ground.
 
@@ -1145,6 +1226,14 @@ defmodule Vutuv.Moderation do
   ground is the law rather than the house rules. The reporter is deliberately
   not in the map — reports are anonymous, and a surface cannot leak what it
   was never handed.
+
+  `from_member?` is the one thing about the reporter the owner does get, and
+  only because the alternative was a lie: both owner surfaces explained the
+  automatic freeze as "a report from a **member** in good standing", which for
+  an outside notice (issue #2009) names somebody who does not exist and points
+  the owner at the wrong people. It says whether *any* effective report on this
+  case has an account here, never which one, so a case a member and a stranger
+  both reported keeps the member wording it has earned.
 
   All three surfaces that carry the notice (the case page, the owner's email
   and the in-app line) read it here, so they cannot drift apart.
@@ -1167,7 +1256,8 @@ defmodule Vutuv.Moderation do
       categories: categories,
       category: leading_category(categories),
       notes: ordered |> Enum.map(& &1.note) |> Enum.reject(&(&1 in [nil, ""])),
-      copyright?: Enum.any?(categories, &Report.copyright?/1)
+      copyright?: Enum.any?(categories, &Report.copyright?/1),
+      from_member?: Enum.any?(ordered, &is_binary(&1.reporter_id))
     }
   end
 
@@ -1495,20 +1585,36 @@ defmodule Vutuv.Moderation do
     |> Repo.insert!()
 
     log(case_record, admin, "strike_issued", %{"role" => role, "level" => level})
-    apply_ladder(user, level, now)
+    apply_ladder(user, level, now, case_record, role)
   end
 
-  defp apply_ladder(user, 1, _now) do
-    Notifier.strike_warning(user)
+  # What the warning names as the ground it rests on. The case page tells the
+  # owner of a copyright case outright that this is the law and not a house
+  # rule; the warning that followed cited the community guidelines and linked
+  # them, so the two letters about one case disagreed (issue #2067). Asked
+  # inside the level-1 clause, because it costs a query on a case struct that
+  # carries no reports and only the warning has a use for the answer — the two
+  # rungs above it are about a ladder, not about one case.
+  #
+  # Only the **owner** can be struck on a copyright ground. A reporter's strike
+  # is for weaponising the report button, which is a house rule whatever the
+  # case underneath it was about.
+  defp strike_ground(%Case{} = case_record, "owner"),
+    do: if(copyright_case?(case_record), do: :copyright, else: :community)
+
+  defp strike_ground(%Case{}, _role), do: :community
+
+  defp apply_ladder(user, 1, _now, case_record, role) do
+    Notifier.strike_warning(user, strike_ground(case_record, role))
   end
 
-  defp apply_ladder(user, 2, now) do
+  defp apply_ladder(user, 2, now, _case_record, _role) do
     until = NaiveDateTime.add(now, @suspension_days * 86_400)
     set_user_moderation!(user.id, suspended_until: until)
     Notifier.suspension(user, until)
   end
 
-  defp apply_ladder(user, _level, now) do
+  defp apply_ladder(user, _level, now, _case_record, _role) do
     set_user_moderation!(user.id, deactivated_at: now)
     Notifier.deactivation(user)
     # The third strike is permanent, so it federates like the admin's own

--- a/lib/vutuv/moderation.ex
+++ b/lib/vutuv/moderation.ex
@@ -929,6 +929,10 @@ defmodule Vutuv.Moderation do
   case without admin work.
   """
   def content_deleted(content) do
+    settle_case(content, "resolved_deleted", "content_deleted")
+  end
+
+  defp settle_case(content, status, action) do
     case open_case_for(content) do
       nil ->
         :ok
@@ -936,14 +940,31 @@ defmodule Vutuv.Moderation do
       case_record ->
         updated =
           update_case!(case_record, %{
-            status: "resolved_deleted",
+            status: status,
             resolved_at: NaiveDateTime.utc_now(:second)
           })
 
-        log(updated, nil, "content_deleted")
+        log(updated, nil, action)
         Notifier.reporters_case_closed(updated)
         :ok
     end
+  end
+
+  @doc """
+  Closes the open case (if any) because the owner **replaced** the reported
+  content with something else of their own.
+
+  Today only a picture can be replaced in place: since issue #2035 the row
+  keeps its id when new bytes arrive, so the reported bytes are gone while the
+  row — and a picture the reporter can still see — remains. That is a revision,
+  not a deletion, and calling `content_deleted/1` for it made the notice
+  contradict itself: the subject said the content had been deleted and the body
+  said it was still on vutuv (issue #2067). It also earns the owner's one
+  self-service round on that content (`previously_self_resolved?/1` reads
+  `"resolved_edited"`), which is right — they have used it.
+  """
+  def content_replaced(content) do
+    settle_case(content, "resolved_edited", "content_replaced")
   end
 
   @doc """
@@ -952,6 +973,24 @@ defmodule Vutuv.Moderation do
   outside this directory already talks to.
   """
   defdelegate reporter_outcome(status), to: Case
+
+  @doc """
+  Whether an ending and a measured fate can stand in the same notice.
+
+  Two of the four endings make a claim about the content in their own **subject
+  line** — "the content you reported was deleted", "…was revised" — so exactly
+  one fate agrees with each. The two admin rulings claim nothing about the
+  content there, so any fate reads honestly beside them.
+
+  It exists because the subject comes from the case status and the body's last
+  paragraph from a measurement, and those are two sources: a path that closes a
+  case without settling the content the way its status claims puts two
+  sentences about one case into one mail that disagree. That is not
+  hypothetical — replacing a flagged picture did exactly that.
+  """
+  def consistent_outcome?("removed", fate), do: fate == :removed
+  def consistent_outcome?("revised", fate), do: fate == :visible
+  def consistent_outcome?(_upheld_or_not, _fate), do: true
 
   @doc """
   The owner edited reported content while its case was still in their court:
@@ -1547,7 +1586,14 @@ defmodule Vutuv.Moderation do
         # and there would be nobody left to look up. Their mail stands; their
         # in-app entry is derived from the report row, so it goes with it —
         # the accepted price of a ruling that erases its own evidence.
-        Notifier.reporters_case_closed(updated)
+        #
+        # This is the one path that states its fate instead of measuring it,
+        # and the ordering above is exactly why: read now, the content is still
+        # there and answers `:visible` or `:hidden`, so the rights holder was
+        # told it is on vutuv seconds before it stopped being (issue #2067).
+        # It is stated by the call that makes it true on the next line, not by
+        # a caller guessing — everything this account owns goes with it.
+        Notifier.reporters_case_closed(updated, fate: :removed)
 
         # No case-side audit line: admin_delete_user erases the account and, with
         # it, this case and its events (owner FK on_delete: :delete_all), so any

--- a/lib/vutuv/moderation/notifier.ex
+++ b/lib/vutuv/moderation/notifier.ex
@@ -67,15 +67,21 @@ defmodule Vutuv.Moderation.Notifier do
 
   Who is left out — an unconfirmed outside notice, an abusive report — is
   `Report.awaiting_outcome/1`'s decision, spelled once there.
+
+  `:fate` overrides the measurement for the **one** caller that cannot be
+  measured: `remove_owner/4` on `:delete` has to tell the reporters before it
+  erases the case, so reading the content then answers "still here" about
+  something that is gone a line later. Every other path settles the content
+  first and lets `Moderation.reported_content_fate/1` look.
   """
-  def reporters_case_closed(%Case{} = case_record) do
-    deliver_outcomes(case_record, Case.reporter_outcome(case_record.status))
+  def reporters_case_closed(%Case{} = case_record, opts \\ []) do
+    deliver_outcomes(case_record, Case.reporter_outcome(case_record.status), opts[:fate])
   end
 
   # Still open: nothing to tell anybody, and nothing claimed.
-  defp deliver_outcomes(_case_record, nil), do: :ok
+  defp deliver_outcomes(_case_record, nil, _fate), do: :ok
 
-  defp deliver_outcomes(%Case{} = case_record, outcome) do
+  defp deliver_outcomes(%Case{} = case_record, outcome, stated_fate) do
     now = NaiveDateTime.utc_now(:second)
 
     {_count, reports} =
@@ -94,7 +100,7 @@ defmodule Vutuv.Moderation.Notifier do
       # have erased. Once per case rather than per reporter, and only once the
       # `UPDATE` above says somebody is actually owed a notice — a second close
       # or a retry claims no rows and must not pay for a lookup nothing reads.
-      fate = Moderation.reported_content_fate(case_record)
+      fate = stated_fate || Moderation.reported_content_fate(case_record)
       reporters = reporters_by_id(reports)
 
       for report <- reports, do: deliver_outcome(report, reporters, outcome, fate)

--- a/lib/vutuv/moderation/notifier.ex
+++ b/lib/vutuv/moderation/notifier.ex
@@ -87,9 +87,18 @@ defmodule Vutuv.Moderation.Notifier do
       )
       |> Repo.update_all(set: [outcome_notified_at: now, updated_at: now])
 
-    reporters = reporters_by_id(reports)
+    if reports != [] do
+      # What became of the content, read **here**: the ruling has already
+      # settled it (purged a picture, unfrozen a profile, left a post frozen)
+      # and the delivery tasks run later, on a row `remove_owner/4` may by then
+      # have erased. Once per case rather than per reporter, and only once the
+      # `UPDATE` above says somebody is actually owed a notice — a second close
+      # or a retry claims no rows and must not pay for a lookup nothing reads.
+      fate = Moderation.reported_content_fate(case_record)
+      reporters = reporters_by_id(reports)
 
-    for report <- reports, do: deliver_outcome(report, reporters, outcome)
+      for report <- reports, do: deliver_outcome(report, reporters, outcome, fate)
+    end
 
     :ok
   end
@@ -110,7 +119,7 @@ defmodule Vutuv.Moderation.Notifier do
 
   # A member reporter: the in-app entry (derived from the row this stamped, so
   # the push and the persisted line are the same event) plus the mail.
-  defp deliver_outcome(%Report{reporter_id: reporter_id} = report, reporters, outcome)
+  defp deliver_outcome(%Report{reporter_id: reporter_id} = report, reporters, outcome, fate)
        when is_binary(reporter_id) do
     Activity.notify(reporter_id, %{
       kind: "report_outcome",
@@ -125,20 +134,21 @@ defmodule Vutuv.Moderation.Notifier do
 
       reporter ->
         deliver_to(reporter, fn user, email ->
-          Emailer.moderation_outcome_email(user, email, outcome)
+          Emailer.moderation_outcome_email(user, email, outcome, fate)
         end)
     end
   end
 
   # An outside notifier (issue #2009): no account, so no in-app anything, and
   # the name and language ride the report row.
-  defp deliver_outcome(%Report{reporter_email: address} = report, _reporters, outcome)
+  defp deliver_outcome(%Report{reporter_email: address} = report, _reporters, outcome, fate)
        when is_binary(address) do
     notice = %{
       name: report.reporter_name,
       email: address,
       locale: report.reporter_locale,
-      outcome: outcome
+      outcome: outcome,
+      fate: fate
     }
 
     Emailer.deliver_async(fn ->
@@ -146,7 +156,7 @@ defmodule Vutuv.Moderation.Notifier do
     end)
   end
 
-  defp deliver_outcome(_report, _reporters, _outcome), do: :ok
+  defp deliver_outcome(_report, _reporters, _outcome, _fate), do: :ok
 
   @doc """
   The AI image scan rejected and deleted one of the member's images
@@ -172,9 +182,13 @@ defmodule Vutuv.Moderation.Notifier do
     end
   end
 
-  @doc "Strike 1: a formal warning."
-  def strike_warning(%User{} = user) do
-    deliver_to(user, &Emailer.moderation_warning_email/2)
+  @doc """
+  Strike 1: a formal warning, naming the ground the ruling rested on
+  (`:copyright` or `:community`) — the same ground the owner's case page named
+  when the content was first hidden (issue #2067).
+  """
+  def strike_warning(%User{} = user, ground) do
+    deliver_to(user, fn user, email -> Emailer.moderation_warning_email(user, email, ground) end)
   end
 
   @doc "Strike 2: a temporary suspension."

--- a/lib/vutuv/moderation/query.ex
+++ b/lib/vutuv/moderation/query.ex
@@ -4,7 +4,34 @@ defmodule Vutuv.Moderation.Query do
   twin of `Vutuv.Moderation.account_hidden?/1`. `Vutuv.Posts.scope_visible/2`
   and `Vutuv.Search` both build on it, so a future hidden state (or a changed
   suspension boundary) is one edit here plus the struct predicate.
+
+  It also holds `case_event_at/1`, the one expression for when a moderation case
+  last said something to its owner.
   """
+
+  @doc """
+  When this case last said something to its owner: the ruling if there is one,
+  otherwise the moment the report arrived.
+
+  The owner's notification list is **one row per case, rewritten in place**, so
+  its time has to be the time of what the row currently says. It was the case's
+  `inserted_at`, so a ruling days later kept the row where it had always been,
+  with the hour of the complaint on it, and the member was never told their
+  content had come back (issue #2067) — the answer `moderation_reports`'
+  `outcome_notified_at` gives one kind over: stamp the event, not the trigger.
+
+  It lives here rather than beside its readers because ordering, keyset cursor,
+  `max` and unread count must all ask the identical expression or the cursor and
+  the ordering stop agreeing. Use inside `order_by:` / `where:` / `select:` on a
+  `moderation_cases` binding after `import Vutuv.Moderation.Query`.
+
+  Deliberately **not** `coalesce(resolved_at, escalated_at, inserted_at)`: a
+  member disputing their own case escalates it, and a row rising to the top of
+  their notifications because of their own click is noise, not news.
+  """
+  defmacro case_event_at(c) do
+    quote do: coalesce(unquote(c).resolved_at, unquote(c).inserted_at)
+  end
 
   @doc """
   True when the account behind `user_id` (a column reference) is hidden:

--- a/lib/vutuv/notifications/emailer.ex
+++ b/lib/vutuv/notifications/emailer.ex
@@ -1011,15 +1011,30 @@ defmodule Vutuv.Notifications.Emailer do
   # template is picked by their locale, and the ambient one is the sender's.
   defp statement_of_reasons(user, case_record) do
     notice = Moderation.owner_notice(case_record)
+    locale = get_locale(user.locale)
 
-    labels =
-      in_locale(get_locale(user.locale), fn ->
-        Enum.map_join(notice.categories, ", ", &ReportHTML.category_label/1)
+    # Two sentences that cannot be assembled from parts, so each arrives whole.
+    # The **opening** names what was reported, and German gives each kind its
+    # own gender (der Beitrag, das Bild, die Nachricht, die Seite, die
+    # Stellenanzeige), so every one of them is one translatable sentence rather
+    # than a noun dropped into a frame — until this, a frozen profile picture
+    # was announced as a post and the member went looking through posts that
+    # were all still there (issue #2067). Everything after it says "the reported
+    # content", which is one gender in every locale. The **standing** sentence
+    # differs by one noun between a member's report and an outside notice, which
+    # is exactly why it is one string and not a branch in twelve templates.
+    {labels, intro, standing} =
+      in_locale(locale, fn ->
+        {Enum.map_join(notice.categories, ", ", &ReportHTML.category_label/1),
+         ReportHTML.content_reported_sentence(case_record.content_type),
+         ReportHTML.reporter_standing_sentence(notice.from_member?)}
       end)
 
     %{
       case_id: case_record.id,
       category_labels: labels,
+      content_intro: intro,
+      standing_sentence: standing,
       notes: notice.notes,
       copyright_case: notice.copyright?
     }
@@ -1040,15 +1055,22 @@ defmodule Vutuv.Notifications.Emailer do
   the statement of reasons (#2010), which tells the owner what was claimed and
   never who claimed it.
 
+  `fate` is what became of the content — `:removed`, `:hidden` or `:visible`,
+  measured by `Moderation.reported_content_fate/1` after the ruling settled it.
+  The four endings alone could not carry it: an upheld case purges a picture,
+  leaves a post frozen and puts a profile back, so the upheld letter said "we
+  have taken the necessary steps" and told the one person it is addressed to
+  nothing at all (issue #2067).
+
   `public_notice_outcome_email/1` is the same message for somebody with no
-  member row; both funnel into the one template through `outcome_assigns/2`.
+  member row; both funnel into the one template through `outcome_assigns/3`.
   """
-  def moderation_outcome_email(user, email, outcome) do
+  def moderation_outcome_email(user, email, outcome, fate) do
     locale = get_locale(user.locale)
 
     assigns =
       outcome
-      |> outcome_assigns(locale)
+      |> outcome_assigns(fate, locale)
       |> Map.put(:greeting, UserHelpers.email_greeting(user))
 
     build_email(user, email, "moderation_outcome", assigns, fn -> outcome_subject(outcome) end)
@@ -1064,8 +1086,12 @@ defmodule Vutuv.Notifications.Emailer do
 
   # The preheader is the subject: four endings would otherwise be spelled a
   # second time, per locale, inside three HEEx attributes.
-  defp outcome_assigns(outcome, locale) do
-    %{outcome: outcome, preheader: in_locale(locale, fn -> outcome_subject(outcome) end)}
+  defp outcome_assigns(outcome, fate, locale) do
+    %{
+      outcome: outcome,
+      content_fate: fate,
+      preheader: in_locale(locale, fn -> outcome_subject(outcome) end)
+    }
   end
 
   @doc """
@@ -1087,9 +1113,17 @@ defmodule Vutuv.Notifications.Emailer do
     |> with_appeal_reply_to()
   end
 
-  @doc "Strike 1: the formal warning."
-  def moderation_warning_email(user, email) do
-    build_email(user, email, "moderation_warning", %{}, fn ->
+  @doc """
+  Strike 1: the formal warning, on the ground the ruling rested on —
+  `:copyright` or `:community`.
+
+  It has to be told: the case page tells the owner of a copyright case outright
+  that this is a legal complaint and not a house rule, and this letter then
+  said their content broke the community guidelines and linked them, so the two
+  mails about one case named two different grounds (issue #2067).
+  """
+  def moderation_warning_email(user, email, ground) do
+    build_email(user, email, "moderation_warning", %{copyright_case: ground == :copyright}, fn ->
       gettext("A warning for your vutuv account")
     end)
   end
@@ -1189,7 +1223,7 @@ defmodule Vutuv.Notifications.Emailer do
       notice,
       "moderation_outcome",
       fn -> outcome_subject(notice.outcome) end,
-      &outcome_assigns(notice.outcome, &1)
+      &outcome_assigns(notice.outcome, notice.fate, &1)
     )
   end
 

--- a/lib/vutuv_web/controllers/moderation_case_controller.ex
+++ b/lib/vutuv_web/controllers/moderation_case_controller.ex
@@ -37,12 +37,24 @@ defmodule VutuvWeb.ModerationCaseController do
         # same statement of reasons the owner's email carries (issue #2010).
         notice: Moderation.owner_notice(case_record),
         edit_offer: Moderation.owner_edit_offer(case_record, content),
+        # What became of the content, for a settled case only — the same
+        # measured answer its reporter is mailed (issue #2067), so the two
+        # sides of one case cannot describe it differently.
+        content_fate: settled_content_fate(case_record),
         content: content
       )
     else
       _ -> ControllerHelpers.render_error(conn, 404)
     end
   end
+
+  # Only the two admin rulings: the owner's own delete and edit already say what
+  # became of the content, because they are what became of it.
+  defp settled_content_fate(%Case{status: status} = case_record)
+       when status in ~w(upheld rejected),
+       do: Moderation.reported_content_fate(case_record)
+
+  defp settled_content_fate(%Case{}), do: nil
 
   @doc """
   The reported picture itself, for the two case pages — the owner's and the

--- a/lib/vutuv_web/live/admin/moderation_case_live.ex
+++ b/lib/vutuv_web/live/admin/moderation_case_live.ex
@@ -234,17 +234,28 @@ defmodule VutuvWeb.Admin.ModerationCaseLive do
           <%!-- Whether the picture is still on the profile decides what the two
                 rulings do, and an admin has to know which case they are in:
                 only a copyright notice takes one offline before a ruling
-                (issue #2030). Read off the row's own column. --%>
+                (issue #2030). Read off the row's own column.
+
+                A copyright notice whose address nobody has confirmed hides
+                nothing either (`Report.effective?/1`), and the two-branch
+                version then explained a copyright case with "only a copyright
+                notice takes one offline" — telling the admin the opposite of
+                what the queue is waiting for (issue #2067). --%>
           <p class="mt-1 text-xs text-slate-600 dark:text-slate-400">
-            {if @content.frozen_at,
-              do:
-                gettext(
+            <%= cond do %>
+              <% @content.frozen_at -> %>
+                {gettext(
                   "Upholding the case deletes it, the private original included. Rejecting it puts every file back where it was."
-                ),
-              else:
-                gettext(
+                )}
+              <% Moderation.pending_copyright_notice?(@case) -> %>
+                {gettext(
+                  "This picture is still on the profile: the address behind the copyright notice is not confirmed yet, so nothing has been hidden. Upholding the case deletes it, the private original included."
+                )}
+              <% true -> %>
+                {gettext(
                   "This picture is still on the profile: only a copyright notice takes one offline before a ruling. Upholding the case deletes it, the private original included."
                 )}
+            <% end %>
           </p>
         </div>
 
@@ -370,10 +381,30 @@ defmodule VutuvWeb.Admin.ModerationCaseLive do
 
         <div class="mt-3 grid gap-4 md:grid-cols-2">
           <div class="rounded-lg border border-red-200 p-4 dark:border-red-900">
+            <%!-- What upholding does to the content is not one sentence: it
+                  deletes a picture, leaves a frozen post frozen, leaves a
+                  flagged one where it is, and puts a frozen profile back. The
+                  panel claimed "the content stays hidden" on all four
+                  (issue #2067). --%>
             <p class="text-sm text-slate-600 dark:text-slate-400">
-              {gettext(
-                "The report is justified. The content stays hidden and the owner gets a strike (warn, suspend, deactivate)."
-              )}
+              <%= case Moderation.uphold_content_effect(@case, @content) do %>
+                <% :deleted -> %>
+                  {gettext(
+                    "The report is justified. The reported picture is deleted, the private original included, and the owner gets a strike (warn, suspend, deactivate)."
+                  )}
+                <% :stays_hidden -> %>
+                  {gettext(
+                    "The report is justified. The content stays hidden and the owner gets a strike (warn, suspend, deactivate)."
+                  )}
+                <% :unhidden -> %>
+                  {gettext(
+                    "The report is justified. The content becomes visible again - the consequence here is the strike (warn, suspend, deactivate)."
+                  )}
+                <% :untouched -> %>
+                  {gettext(
+                    "The report is justified. The content is not hidden and upholding does not hide it; the owner gets a strike (warn, suspend, deactivate)."
+                  )}
+              <% end %>
             </p>
             <button type="button" class="button button--danger mt-3" id="uphold-case" phx-click="uphold">
               {gettext("Uphold the report")}

--- a/lib/vutuv_web/templates/email/moderation_frozen_de.text.eex
+++ b/lib/vutuv_web/templates/email/moderation_frozen_de.text.eex
@@ -1,9 +1,11 @@
 <%= email_greeting(@user) %>,
 
-einer Ihrer Beiträge auf vutuv wurde gemeldet. Kein Mensch hat ihn vorher
-angesehen: Die Meldung eines Mitglieds mit guter Bilanz verbirgt den
-gemeldeten Inhalt automatisch, sobald sie eintrifft. Genau das ist hier
-passiert; sehen können ihn jetzt nur noch Sie und unsere Admins.
+<%= email_wrapped_text(@content_intro) %>
+Kein Mensch hat den gemeldeten Inhalt vorher angesehen; sehen können ihn
+jetzt nur noch Sie und unsere Admins.
+
+<%= email_wrapped_text(@standing_sentence) %>
+Genau das ist hier passiert.
 
   Gemeldet als: <%= @category_labels %>
 <%= if @notes != [] do %>
@@ -36,7 +38,7 @@ Auf dieser Seite können Sie:
   * Den Inhalt bearbeiten. Unsere Admins sehen sich die Überarbeitung dann
     an; bis dahin bleibt er verborgen.
 <% end %>
-  * Ihn löschen. Damit ist die Meldung erledigt, ohne Rückfragen.
+  * Den Inhalt löschen. Damit ist die Meldung erledigt, ohne Rückfragen.
 
   * Uns mitteilen, dass Ihr Inhalt in Ordnung ist. Er bleibt dann
     verborgen, bis eine unserer Admins entschieden hat.

--- a/lib/vutuv_web/templates/email/moderation_frozen_en.text.eex
+++ b/lib/vutuv_web/templates/email/moderation_frozen_en.text.eex
@@ -1,9 +1,11 @@
 <%= email_greeting(@user) %>,
 
-someone reported one of your contributions on vutuv. No person looked at it
-first: a report from a member in good standing hides the reported content
-automatically, the moment it arrives. That is what happened here, and only
-you and our admins can see it now.
+<%= email_wrapped_text(@content_intro) %>
+No person looked at the reported content first, and only you and our admins
+can see it now.
+
+<%= email_wrapped_text(@standing_sentence) %>
+That is what happened here.
 
   Reported as: <%= @category_labels %>
 <%= if @notes != [] do %>
@@ -34,7 +36,7 @@ On that page you can:
   * Edit the content. One of our admins then looks at the revision, and it
     stays hidden until they have.
 <% end %>
-  * Delete it. That settles the report, no questions asked.
+  * Delete the content. That settles the report, no questions asked.
 
   * Tell us your content is fine. It stays hidden until one of our admins
     has ruled.

--- a/lib/vutuv_web/templates/email/moderation_frozen_it.text.eex
+++ b/lib/vutuv_web/templates/email/moderation_frozen_it.text.eex
@@ -1,9 +1,11 @@
 <%= email_greeting(@user) %>,
 
-qualcuno ha segnalato un Suo contributo su vutuv. Nessuna persona lo ha
-esaminato prima: la segnalazione di un membro affidabile nasconde il
-contenuto segnalato automaticamente, nel momento in cui arriva. È quello che
-è successo qui; ora possono vederlo solo Lei e i nostri amministratori.
+<%= email_wrapped_text(@content_intro) %>
+Nessuna persona ha esaminato prima il contenuto segnalato; ora possono
+vederlo solo Lei e i nostri amministratori.
+
+<%= email_wrapped_text(@standing_sentence) %>
+È quello che è successo qui.
 
   Segnalato come: <%= @category_labels %>
 <%= if @notes != [] do %>
@@ -34,7 +36,8 @@ Su quella pagina può:
   * Modificare il contenuto. I nostri amministratori esaminano poi la
     revisione; fino ad allora resta nascosto.
 <% end %>
-  * Eliminarlo. Così la segnalazione è chiusa, senza altre domande.
+  * Eliminare il contenuto. Così la segnalazione è chiusa, senza altre
+    domande.
 
   * Dirci che il Suo contenuto è a posto. Resta nascosto finché un
     amministratore non avrà deciso.

--- a/lib/vutuv_web/templates/email/moderation_outcome_de.text.eex
+++ b/lib/vutuv_web/templates/email/moderation_outcome_de.text.eex
@@ -3,23 +3,25 @@
 danke für Ihre Meldung. Der Fall ist abgeschlossen, und das ist dabei
 herausgekommen:
 <%= if @outcome == "removed" do %>
-Der Besitzer hat den gemeldeten Inhalt gelöscht. Auf vutuv ist er damit nicht
-mehr zu sehen.
+Der Besitzer hat den gemeldeten Inhalt gelöscht.
 <% end %><%= if @outcome == "revised" do %>
-Der Besitzer hat den gemeldeten Inhalt überarbeitet; er ist wieder sichtbar.
-Wenn Sie weiterhin der Meinung sind, dass er gegen unsere
-Community-Richtlinien verstößt, können Sie ihn erneut melden. Der Fall geht
-dann direkt an unsere Admins.
+Der Besitzer hat den gemeldeten Inhalt überarbeitet. Wenn Sie weiterhin der
+Meinung sind, dass er gegen unsere Community-Richtlinien verstößt, können Sie
+ihn erneut melden. Der Fall geht dann direkt an unsere Admins.
 <% end %><%= if @outcome == "upheld" do %>
 Ein Mensch aus unserem Team hat sich Ihre Meldung angesehen und ihr
-stattgegeben. Wir haben die nötigen Schritte unternommen. Was davon das Konto
-hinter dem Inhalt betrifft, sagen wir Ihnen nicht; das bleibt zwischen dieser
-Person und uns.
+stattgegeben. Was das für das Konto hinter dem Inhalt bedeutet, sagen wir
+Ihnen nicht; das bleibt zwischen dieser Person und uns.
 <% end %><%= if @outcome == "not_upheld" do %>
 Ein Mensch aus unserem Team hat sich Ihre Meldung angesehen und ihr nicht
-stattgegeben. Der gemeldete Inhalt bleibt deshalb, wo er ist. Das ist keine
-Aussage über Sie: Melden war richtig, auch wenn am Ende eine andere
-Entscheidung steht.
+stattgegeben. Das ist keine Aussage über Sie: Melden war richtig, auch wenn
+am Ende eine andere Entscheidung steht.
+<% end %><%= if @content_fate == :removed do %>
+Der gemeldete Inhalt ist gelöscht.
+<% end %><%= if @content_fate == :hidden do %>
+Der gemeldete Inhalt ist auf vutuv nicht mehr zu sehen.
+<% end %><%= if @content_fate == :visible do %>
+Der gemeldete Inhalt ist auf vutuv weiterhin zu sehen.
 <% end %>
 Von uns kommt zu diesem Fall nichts mehr.
 

--- a/lib/vutuv_web/templates/email/moderation_outcome_en.text.eex
+++ b/lib/vutuv_web/templates/email/moderation_outcome_en.text.eex
@@ -2,19 +2,24 @@
 
 thank you for your report. The case is closed, and this is how it ended:
 <%= if @outcome == "removed" do %>
-The owner deleted the content you reported. It is no longer on vutuv.
+The owner deleted the content you reported.
 <% end %><%= if @outcome == "revised" do %>
-The owner revised the content you reported, and it is visible again. If you
-still believe it breaks our community guidelines, you can report it once
-more; it will then go straight to our admins.
+The owner revised the content you reported. If you still believe it breaks
+our community guidelines, you can report it once more; it will then go
+straight to our admins.
 <% end %><%= if @outcome == "upheld" do %>
-Somebody on our team read your report and upheld it. We have taken the steps
-that follow from that. What any of them mean for the account behind the
-content stays between that person and us.
+Somebody on our team read your report and upheld it. What that means for the
+account behind the content stays between that person and us.
 <% end %><%= if @outcome == "not_upheld" do %>
-Somebody on our team read your report and did not uphold it. The content you
-reported stays where it is. That is not a judgement on you: reporting it was
-the right thing to do, even when the answer goes the other way.
+Somebody on our team read your report and did not uphold it. That is not a
+judgement on you: reporting it was the right thing to do, even when the
+answer goes the other way.
+<% end %><%= if @content_fate == :removed do %>
+The reported content has been deleted.
+<% end %><%= if @content_fate == :hidden do %>
+The reported content is no longer visible on vutuv.
+<% end %><%= if @content_fate == :visible do %>
+The reported content is still visible on vutuv.
 <% end %>
 You will not hear from us about this case again.
 

--- a/lib/vutuv_web/templates/email/moderation_outcome_it.text.eex
+++ b/lib/vutuv_web/templates/email/moderation_outcome_it.text.eex
@@ -2,21 +2,25 @@
 
 grazie per la Sua segnalazione. Il caso è chiuso, ed ecco com'è andata:
 <%= if @outcome == "removed" do %>
-Il proprietario ha cancellato il contenuto che ha segnalato. Su vutuv non è
-più visibile.
+Il proprietario ha cancellato il contenuto che ha segnalato.
 <% end %><%= if @outcome == "revised" do %>
-Il proprietario ha corretto il contenuto che ha segnalato, ed è di nuovo
-visibile. Se ritiene ancora che violi le nostre regole della community, può
-segnalarlo un'altra volta; andrà allora direttamente ai nostri
-amministratori.
+Il proprietario ha corretto il contenuto che ha segnalato. Se ritiene ancora
+che violi le nostre regole della community, può segnalarlo un'altra volta;
+andrà allora direttamente ai nostri amministratori.
 <% end %><%= if @outcome == "upheld" do %>
 Una persona del nostro team ha esaminato la Sua segnalazione e le ha dato
-ragione. Abbiamo preso i provvedimenti necessari. Che cosa significhino per
-l'account dietro al contenuto resta tra quella persona e noi.
+ragione. Che cosa significhi per l'account dietro al contenuto resta tra
+quella persona e noi.
 <% end %><%= if @outcome == "not_upheld" do %>
 Una persona del nostro team ha esaminato la Sua segnalazione e non le ha dato
-ragione. Il contenuto segnalato resta dov'è. Non è un giudizio su di Lei:
-segnalare è stato giusto, anche quando la decisione va in un'altra direzione.
+ragione. Non è un giudizio su di Lei: segnalare è stato giusto, anche quando
+la decisione va in un'altra direzione.
+<% end %><%= if @content_fate == :removed do %>
+Il contenuto segnalato è stato eliminato.
+<% end %><%= if @content_fate == :hidden do %>
+Il contenuto segnalato non è più visibile su vutuv.
+<% end %><%= if @content_fate == :visible do %>
+Il contenuto segnalato è ancora visibile su vutuv.
 <% end %>
 Non Le scriveremo più a proposito di questo caso.
 

--- a/lib/vutuv_web/templates/email/moderation_review_de.text.eex
+++ b/lib/vutuv_web/templates/email/moderation_review_de.text.eex
@@ -1,9 +1,10 @@
 <%= email_greeting(@user) %>,
 
-einer Ihrer Beiträge auf vutuv wurde gemeldet und ist verborgen, während
-unsere Admins den Fall prüfen. Kein Mensch hat ihn vorher angesehen: Die
-Meldung eines Mitglieds mit guter Bilanz verbirgt den gemeldeten Inhalt
-automatisch, sobald sie eintrifft.
+<%= email_wrapped_text(@content_intro) %>
+Bis unsere Admins den Fall geprüft haben, ist der gemeldete Inhalt
+verborgen; kein Mensch hat ihn vorher angesehen.
+
+<%= email_wrapped_text(@standing_sentence) %>
 
   Gemeldet als: <%= @category_labels %>
 <%= if @notes != [] do %>

--- a/lib/vutuv_web/templates/email/moderation_review_en.text.eex
+++ b/lib/vutuv_web/templates/email/moderation_review_en.text.eex
@@ -1,9 +1,10 @@
 <%= email_greeting(@user) %>,
 
-one of your contributions on vutuv was reported and is hidden while our
-admins review it. No person looked at it first: a report from a member in
-good standing hides the reported content automatically, the moment it
-arrives.
+<%= email_wrapped_text(@content_intro) %>
+The reported content stays hidden until our admins have looked at the case;
+no person looked at it first.
+
+<%= email_wrapped_text(@standing_sentence) %>
 
   Reported as: <%= @category_labels %>
 <%= if @notes != [] do %>

--- a/lib/vutuv_web/templates/email/moderation_review_it.text.eex
+++ b/lib/vutuv_web/templates/email/moderation_review_it.text.eex
@@ -1,9 +1,10 @@
 <%= email_greeting(@user) %>,
 
-un Suo contributo su vutuv è stato segnalato ed è nascosto mentre i nostri
-amministratori lo esaminano. Nessuna persona lo ha esaminato prima: la
-segnalazione di un membro affidabile nasconde il contenuto segnalato
-automaticamente, nel momento in cui arriva.
+<%= email_wrapped_text(@content_intro) %>
+Il contenuto segnalato resta nascosto finché i nostri amministratori non
+avranno esaminato il caso; nessuna persona lo ha esaminato prima.
+
+<%= email_wrapped_text(@standing_sentence) %>
 
   Segnalato come: <%= @category_labels %>
 <%= if @notes != [] do %>

--- a/lib/vutuv_web/templates/email/moderation_warning_de.text.eex
+++ b/lib/vutuv_web/templates/email/moderation_warning_de.text.eex
@@ -1,10 +1,13 @@
 <%= email_greeting(@user) %>,
 
-unsere Admins haben eine Meldung zu einem Ihrer Inhalte geprüft und
+<%= if @copyright_case do %>unsere Admins haben eine Meldung zu einem Ihrer Inhalte geprüft und ihr
+stattgegeben: Der Inhalt verletzt fremde Urheberrechte. Das ist eine
+rechtliche Frage, keine Hausregel.
+<% else %>unsere Admins haben eine Meldung zu einem Ihrer Inhalte geprüft und
 festgestellt, dass er gegen unsere Community-Richtlinien verstößt:
 
 <%= @url %>community
-
+<% end %>
 Dies ist eine formelle Verwarnung, die erste von drei Stufen. Ein
 zweiter bestätigter Verstoß sperrt Ihr Konto für eine Woche, ein
 dritter deaktiviert es endgültig. Verwarnungen verfallen nach zwölf

--- a/lib/vutuv_web/templates/email/moderation_warning_en.text.eex
+++ b/lib/vutuv_web/templates/email/moderation_warning_en.text.eex
@@ -1,10 +1,13 @@
 <%= email_greeting(@user) %>,
 
-our admins reviewed a report about content of yours and found that it
+<%= if @copyright_case do %>our admins reviewed a report about content of yours and upheld it: the
+content infringes somebody else's copyright. That is a legal question, not
+a house rule.
+<% else %>our admins reviewed a report about content of yours and found that it
 breaks our community guidelines:
 
 <%= @url %>community
-
+<% end %>
 This is a formal warning, the first of three steps. A second confirmed
 violation suspends your account for a week; a third deactivates it for
 good. Warnings expire after twelve months.

--- a/lib/vutuv_web/templates/email/moderation_warning_it.text.eex
+++ b/lib/vutuv_web/templates/email/moderation_warning_it.text.eex
@@ -1,10 +1,13 @@
 <%= email_greeting(@user) %>,
 
-i nostri amministratori hanno esaminato una segnalazione su un Suo contenuto e
+<%= if @copyright_case do %>i nostri amministratori hanno esaminato una segnalazione su un Suo contenuto e
+le hanno dato ragione: il contenuto viola il diritto d'autore altrui. È una
+questione legale, non una regola della casa.
+<% else %>i nostri amministratori hanno esaminato una segnalazione su un Suo contenuto e
 hanno rilevato che viola le nostre regole della community:
 
 <%= @url %>community
-
+<% end %>
 Questo è un avvertimento formale, il primo di tre passi. Una seconda violazione
 confermata sospende il Suo account per una settimana; una terza lo disattiva
 definitivamente. Gli avvertimenti decadono dopo dodici mesi.

--- a/lib/vutuv_web/templates/email_body/moderation_frozen_de.html.heex
+++ b/lib/vutuv_web/templates/email_body/moderation_frozen_de.html.heex
@@ -1,11 +1,10 @@
 <.email_layout preheader="Ihr Inhalt auf vutuv wurde gemeldet und ist verborgen" locale={@locale}>
   <.email_p>{email_greeting(@user)},</.email_p>
   <.email_p>
-    einer Ihrer Beiträge auf vutuv wurde gemeldet. Kein Mensch hat ihn vorher angesehen: Die
-    Meldung eines Mitglieds mit guter Bilanz verbirgt den gemeldeten Inhalt automatisch, sobald
-    sie eintrifft. Genau das ist hier passiert; sehen können ihn jetzt nur noch Sie und unsere
-    Admins.
+    {@content_intro} Kein Mensch hat den gemeldeten Inhalt vorher angesehen; sehen können ihn
+    jetzt nur noch Sie und unsere Admins.
   </.email_p>
+  <.email_p>{@standing_sentence} Genau das ist hier passiert.</.email_p>
   <.email_panel>
     <.email_row label="Gemeldet als">{@category_labels}</.email_row>
   </.email_panel>
@@ -38,7 +37,7 @@
       do:
         "Den Inhalt bearbeiten. Unsere Admins sehen sich die Überarbeitung dann an; bis dahin bleibt er verborgen."
     ),
-    "Ihn löschen. Damit ist die Meldung erledigt, ohne Rückfragen.",
+    "Den Inhalt löschen. Damit ist die Meldung erledigt, ohne Rückfragen.",
     "Uns mitteilen, dass Ihr Inhalt in Ordnung ist. Er bleibt dann verborgen, bis eine unserer Admins entschieden hat."
   ]} />
   <.email_signature locale={@locale} />

--- a/lib/vutuv_web/templates/email_body/moderation_frozen_en.html.heex
+++ b/lib/vutuv_web/templates/email_body/moderation_frozen_en.html.heex
@@ -1,10 +1,10 @@
 <.email_layout preheader="Your content on vutuv was reported and is hidden" locale={@locale}>
   <.email_p>{email_greeting(@user)},</.email_p>
   <.email_p>
-    someone reported one of your contributions on vutuv. No person looked at it first: a report
-    from a member in good standing hides the reported content automatically, the moment it
-    arrives. That is what happened here, and only you and our admins can see it now.
+    {@content_intro} No person looked at the reported content first, and only you and our admins
+    can see it now.
   </.email_p>
+  <.email_p>{@standing_sentence} That is what happened here.</.email_p>
   <.email_panel>
     <.email_row label="Reported as">{@category_labels}</.email_row>
   </.email_panel>
@@ -35,7 +35,7 @@
       do:
         "Edit the content. One of our admins then looks at the revision, and it stays hidden until they have."
     ),
-    "Delete it. That settles the report, no questions asked.",
+    "Delete the content. That settles the report, no questions asked.",
     "Tell us your content is fine. It stays hidden until one of our admins has ruled."
   ]} />
   <.email_signature locale={@locale} />

--- a/lib/vutuv_web/templates/email_body/moderation_frozen_it.html.heex
+++ b/lib/vutuv_web/templates/email_body/moderation_frozen_it.html.heex
@@ -1,11 +1,10 @@
 <.email_layout preheader="Un Suo contenuto su vutuv è stato segnalato ed è nascosto" locale={@locale}>
   <.email_p>{email_greeting(@user)},</.email_p>
   <.email_p>
-    qualcuno ha segnalato un Suo contributo su vutuv. Nessuna persona lo ha esaminato prima: la
-    segnalazione di un membro affidabile nasconde il contenuto segnalato automaticamente, nel
-    momento in cui arriva. È quello che è successo qui; ora possono vederlo solo Lei e i nostri
-    amministratori.
+    {@content_intro} Nessuna persona ha esaminato prima il contenuto segnalato; ora possono
+    vederlo solo Lei e i nostri amministratori.
   </.email_p>
+  <.email_p>{@standing_sentence} È quello che è successo qui.</.email_p>
   <.email_panel>
     <.email_row label="Segnalato come">{@category_labels}</.email_row>
   </.email_panel>
@@ -39,7 +38,7 @@
       do:
         "Modificare il contenuto. I nostri amministratori esaminano poi la revisione; fino ad allora resta nascosto."
     ),
-    "Eliminarlo. Così la segnalazione è chiusa, senza altre domande.",
+    "Eliminare il contenuto. Così la segnalazione è chiusa, senza altre domande.",
     "Dirci che il Suo contenuto è a posto. Resta nascosto finché un amministratore non avrà deciso."
   ]} />
   <.email_signature locale={@locale} />

--- a/lib/vutuv_web/templates/email_body/moderation_outcome_de.html.heex
+++ b/lib/vutuv_web/templates/email_body/moderation_outcome_de.html.heex
@@ -4,22 +4,29 @@
     danke für Ihre Meldung. Der Fall ist abgeschlossen, und das ist dabei herausgekommen:
   </.email_p>
   <.email_p :if={@outcome == "removed"}>
-    Der Besitzer hat den gemeldeten Inhalt gelöscht. Auf vutuv ist er damit nicht mehr zu sehen.
+    Der Besitzer hat den gemeldeten Inhalt gelöscht.
   </.email_p>
   <.email_p :if={@outcome == "revised"}>
-    Der Besitzer hat den gemeldeten Inhalt überarbeitet; er ist wieder sichtbar. Wenn Sie
-    weiterhin der Meinung sind, dass er gegen unsere Community-Richtlinien verstößt, können Sie
-    ihn erneut melden. Der Fall geht dann direkt an unsere Admins.
+    Der Besitzer hat den gemeldeten Inhalt überarbeitet. Wenn Sie weiterhin der Meinung sind, dass
+    er gegen unsere Community-Richtlinien verstößt, können Sie ihn erneut melden. Der Fall geht
+    dann direkt an unsere Admins.
   </.email_p>
   <.email_p :if={@outcome == "upheld"}>
-    Ein Mensch aus unserem Team hat sich Ihre Meldung angesehen und ihr stattgegeben. Wir haben
-    die nötigen Schritte unternommen. Was davon das Konto hinter dem Inhalt betrifft, sagen wir
-    Ihnen nicht; das bleibt zwischen dieser Person und uns.
+    Ein Mensch aus unserem Team hat sich Ihre Meldung angesehen und ihr stattgegeben. Was das für
+    das Konto hinter dem Inhalt bedeutet, sagen wir Ihnen nicht; das bleibt zwischen dieser Person
+    und uns.
   </.email_p>
   <.email_p :if={@outcome == "not_upheld"}>
-    Ein Mensch aus unserem Team hat sich Ihre Meldung angesehen und ihr nicht stattgegeben. Der
-    gemeldete Inhalt bleibt deshalb, wo er ist. Das ist keine Aussage über Sie: Melden war
-    richtig, auch wenn am Ende eine andere Entscheidung steht.
+    Ein Mensch aus unserem Team hat sich Ihre Meldung angesehen und ihr nicht stattgegeben. Das
+    ist keine Aussage über Sie: Melden war richtig, auch wenn am Ende eine andere Entscheidung
+    steht.
+  </.email_p>
+  <.email_p :if={@content_fate == :removed}>Der gemeldete Inhalt ist gelöscht.</.email_p>
+  <.email_p :if={@content_fate == :hidden}>
+    Der gemeldete Inhalt ist auf vutuv nicht mehr zu sehen.
+  </.email_p>
+  <.email_p :if={@content_fate == :visible}>
+    Der gemeldete Inhalt ist auf vutuv weiterhin zu sehen.
   </.email_p>
   <.email_p>Von uns kommt zu diesem Fall nichts mehr.</.email_p>
   <.email_signature locale={@locale} />

--- a/lib/vutuv_web/templates/email_body/moderation_outcome_en.html.heex
+++ b/lib/vutuv_web/templates/email_body/moderation_outcome_en.html.heex
@@ -1,23 +1,25 @@
 <.email_layout preheader={@preheader} locale={@locale}>
   <.email_p>{@greeting},</.email_p>
   <.email_p>thank you for your report. The case is closed, and this is how it ended:</.email_p>
-  <.email_p :if={@outcome == "removed"}>
-    The owner deleted the content you reported. It is no longer on vutuv.
-  </.email_p>
+  <.email_p :if={@outcome == "removed"}>The owner deleted the content you reported.</.email_p>
   <.email_p :if={@outcome == "revised"}>
-    The owner revised the content you reported, and it is visible again. If you still believe it
-    breaks our community guidelines, you can report it once more; it will then go straight to our
-    admins.
+    The owner revised the content you reported. If you still believe it breaks our community
+    guidelines, you can report it once more; it will then go straight to our admins.
   </.email_p>
   <.email_p :if={@outcome == "upheld"}>
-    Somebody on our team read your report and upheld it. We have taken the steps that follow from
-    that. What any of them mean for the account behind the content stays between that person and
-    us.
+    Somebody on our team read your report and upheld it. What that means for the account behind
+    the content stays between that person and us.
   </.email_p>
   <.email_p :if={@outcome == "not_upheld"}>
-    Somebody on our team read your report and did not uphold it. The content you reported stays
-    where it is. That is not a judgement on you: reporting it was the right thing to do, even when
-    the answer goes the other way.
+    Somebody on our team read your report and did not uphold it. That is not a judgement on you:
+    reporting it was the right thing to do, even when the answer goes the other way.
+  </.email_p>
+  <.email_p :if={@content_fate == :removed}>The reported content has been deleted.</.email_p>
+  <.email_p :if={@content_fate == :hidden}>
+    The reported content is no longer visible on vutuv.
+  </.email_p>
+  <.email_p :if={@content_fate == :visible}>
+    The reported content is still visible on vutuv.
   </.email_p>
   <.email_p>You will not hear from us about this case again.</.email_p>
   <.email_signature locale={@locale} />

--- a/lib/vutuv_web/templates/email_body/moderation_outcome_it.html.heex
+++ b/lib/vutuv_web/templates/email_body/moderation_outcome_it.html.heex
@@ -2,22 +2,28 @@
   <.email_p>{@greeting},</.email_p>
   <.email_p>grazie per la Sua segnalazione. Il caso è chiuso, ed ecco com'è andata:</.email_p>
   <.email_p :if={@outcome == "removed"}>
-    Il proprietario ha cancellato il contenuto che ha segnalato. Su vutuv non è più visibile.
+    Il proprietario ha cancellato il contenuto che ha segnalato.
   </.email_p>
   <.email_p :if={@outcome == "revised"}>
-    Il proprietario ha corretto il contenuto che ha segnalato, ed è di nuovo visibile. Se ritiene
-    ancora che violi le nostre regole della community, può segnalarlo un'altra volta; andrà allora
-    direttamente ai nostri amministratori.
+    Il proprietario ha corretto il contenuto che ha segnalato. Se ritiene ancora che violi le
+    nostre regole della community, può segnalarlo un'altra volta; andrà allora direttamente ai
+    nostri amministratori.
   </.email_p>
   <.email_p :if={@outcome == "upheld"}>
-    Una persona del nostro team ha esaminato la Sua segnalazione e le ha dato ragione. Abbiamo
-    preso i provvedimenti necessari. Che cosa significhino per l'account dietro al contenuto resta
-    tra quella persona e noi.
+    Una persona del nostro team ha esaminato la Sua segnalazione e le ha dato ragione. Che cosa
+    significhi per l'account dietro al contenuto resta tra quella persona e noi.
   </.email_p>
   <.email_p :if={@outcome == "not_upheld"}>
-    Una persona del nostro team ha esaminato la Sua segnalazione e non le ha dato ragione. Il
-    contenuto segnalato resta dov'è. Non è un giudizio su di Lei: segnalare è stato giusto, anche
-    quando la decisione va in un'altra direzione.
+    Una persona del nostro team ha esaminato la Sua segnalazione e non le ha dato ragione. Non è
+    un giudizio su di Lei: segnalare è stato giusto, anche quando la decisione va in un'altra
+    direzione.
+  </.email_p>
+  <.email_p :if={@content_fate == :removed}>Il contenuto segnalato è stato eliminato.</.email_p>
+  <.email_p :if={@content_fate == :hidden}>
+    Il contenuto segnalato non è più visibile su vutuv.
+  </.email_p>
+  <.email_p :if={@content_fate == :visible}>
+    Il contenuto segnalato è ancora visibile su vutuv.
   </.email_p>
   <.email_p>Non Le scriveremo più a proposito di questo caso.</.email_p>
   <.email_signature locale={@locale} />

--- a/lib/vutuv_web/templates/email_body/moderation_review_de.html.heex
+++ b/lib/vutuv_web/templates/email_body/moderation_review_de.html.heex
@@ -1,10 +1,10 @@
 <.email_layout preheader="Ihr Inhalt auf vutuv wird geprüft" locale={@locale}>
   <.email_p>{email_greeting(@user)},</.email_p>
   <.email_p>
-    einer Ihrer Beiträge auf vutuv wurde gemeldet und ist verborgen, während unsere Admins den
-    Fall prüfen. Kein Mensch hat ihn vorher angesehen: Die Meldung eines Mitglieds mit guter
-    Bilanz verbirgt den gemeldeten Inhalt automatisch, sobald sie eintrifft.
+    {@content_intro} Bis unsere Admins den Fall geprüft haben, ist der gemeldete Inhalt verborgen;
+    kein Mensch hat ihn vorher angesehen.
   </.email_p>
+  <.email_p>{@standing_sentence}</.email_p>
   <.email_panel>
     <.email_row label="Gemeldet als">{@category_labels}</.email_row>
   </.email_panel>

--- a/lib/vutuv_web/templates/email_body/moderation_review_en.html.heex
+++ b/lib/vutuv_web/templates/email_body/moderation_review_en.html.heex
@@ -1,10 +1,10 @@
 <.email_layout preheader="Your content on vutuv is under review" locale={@locale}>
   <.email_p>{email_greeting(@user)},</.email_p>
   <.email_p>
-    one of your contributions on vutuv was reported and is hidden while our admins review it. No
-    person looked at it first: a report from a member in good standing hides the reported content
-    automatically, the moment it arrives.
+    {@content_intro} The reported content stays hidden until our admins have looked at the case;
+    no person looked at it first.
   </.email_p>
+  <.email_p>{@standing_sentence}</.email_p>
   <.email_panel>
     <.email_row label="Reported as">{@category_labels}</.email_row>
   </.email_panel>

--- a/lib/vutuv_web/templates/email_body/moderation_review_it.html.heex
+++ b/lib/vutuv_web/templates/email_body/moderation_review_it.html.heex
@@ -1,10 +1,10 @@
 <.email_layout preheader="Un Suo contenuto su vutuv è in esame" locale={@locale}>
   <.email_p>{email_greeting(@user)},</.email_p>
   <.email_p>
-    un Suo contributo su vutuv è stato segnalato ed è nascosto mentre i nostri amministratori lo
-    esaminano. Nessuna persona lo ha esaminato prima: la segnalazione di un membro affidabile
-    nasconde il contenuto segnalato automaticamente, nel momento in cui arriva.
+    {@content_intro} Il contenuto segnalato resta nascosto finché i nostri amministratori non
+    avranno esaminato il caso; nessuna persona lo ha esaminato prima.
   </.email_p>
+  <.email_p>{@standing_sentence}</.email_p>
   <.email_panel>
     <.email_row label="Segnalato come">{@category_labels}</.email_row>
   </.email_panel>

--- a/lib/vutuv_web/templates/email_body/moderation_warning_de.html.heex
+++ b/lib/vutuv_web/templates/email_body/moderation_warning_de.html.heex
@@ -1,10 +1,16 @@
 <.email_layout preheader="Eine Verwarnung für Ihr vutuv-Konto" locale={@locale}>
   <.email_p>{email_greeting(@user)},</.email_p>
-  <.email_p>
+  <.email_p :if={@copyright_case}>
+    unsere Admins haben eine Meldung zu einem Ihrer Inhalte geprüft und ihr stattgegeben: Der
+    Inhalt verletzt fremde Urheberrechte. Das ist eine rechtliche Frage, keine Hausregel.
+  </.email_p>
+  <.email_p :if={!@copyright_case}>
     unsere Admins haben eine Meldung zu einem Ihrer Inhalte geprüft und festgestellt, dass er gegen
     unsere Community-Richtlinien verstößt:
   </.email_p>
-  <.email_button href={"#{@url}community"}>Unsere Community-Richtlinien</.email_button>
+  <.email_button :if={!@copyright_case} href={"#{@url}community"}>
+    Unsere Community-Richtlinien
+  </.email_button>
   <.email_p>
     Dies ist eine formelle Verwarnung, die erste von drei Stufen. Ein zweiter bestätigter Verstoß
     sperrt Ihr Konto für eine Woche, ein dritter deaktiviert es endgültig. Verwarnungen verfallen

--- a/lib/vutuv_web/templates/email_body/moderation_warning_en.html.heex
+++ b/lib/vutuv_web/templates/email_body/moderation_warning_en.html.heex
@@ -1,10 +1,16 @@
 <.email_layout preheader="A warning for your vutuv account" locale={@locale}>
   <.email_p>{email_greeting(@user)},</.email_p>
-  <.email_p>
+  <.email_p :if={@copyright_case}>
+    our admins reviewed a report about content of yours and upheld it: the content infringes
+    somebody else's copyright. That is a legal question, not a house rule.
+  </.email_p>
+  <.email_p :if={!@copyright_case}>
     our admins reviewed a report about content of yours and found that it breaks our community
     guidelines:
   </.email_p>
-  <.email_button href={"#{@url}community"}>Our community guidelines</.email_button>
+  <.email_button :if={!@copyright_case} href={"#{@url}community"}>
+    Our community guidelines
+  </.email_button>
   <.email_p>
     This is a formal warning, the first of three steps. A second confirmed violation suspends your
     account for a week; a third deactivates it for good. Warnings expire after twelve months.

--- a/lib/vutuv_web/templates/email_body/moderation_warning_it.html.heex
+++ b/lib/vutuv_web/templates/email_body/moderation_warning_it.html.heex
@@ -1,10 +1,17 @@
 <.email_layout preheader="Un avvertimento per il Suo account vutuv" locale={@locale}>
   <.email_p>{email_greeting(@user)},</.email_p>
-  <.email_p>
+  <.email_p :if={@copyright_case}>
+    i nostri amministratori hanno esaminato una segnalazione su un Suo contenuto e le hanno dato
+    ragione: il contenuto viola il diritto d'autore altrui. È una questione legale, non una regola
+    della casa.
+  </.email_p>
+  <.email_p :if={!@copyright_case}>
     i nostri amministratori hanno esaminato una segnalazione su un Suo contenuto e hanno rilevato
     che viola le nostre regole della community:
   </.email_p>
-  <.email_button href={"#{@url}community"}>Le nostre regole della community</.email_button>
+  <.email_button :if={!@copyright_case} href={"#{@url}community"}>
+    Le nostre regole della community
+  </.email_button>
   <.email_p>
     Questo è un avvertimento formale, il primo di tre passi. Una seconda violazione confermata
     sospende il Suo account per una settimana; una terza lo disattiva definitivamente. Gli

--- a/lib/vutuv_web/templates/moderation_case/show.html.heex
+++ b/lib/vutuv_web/templates/moderation_case/show.html.heex
@@ -7,15 +7,25 @@
     <p class="mt-2 flex items-start gap-2 rounded-lg bg-amber-50 p-3 text-sm font-medium text-amber-800 ring-1 ring-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:ring-amber-900">
       <span aria-hidden="true">⚑</span>
       {status_line(@case)}
+      <span :if={@content_fate}>{content_fate_line(@content_fate)}</span>
     </p>
 
-    <%!-- Nobody weighed this up: the freeze is what a report from a member in
+    <%!-- Nobody weighed this up: the freeze is what a report from a reporter in
           good standing does on arrival, and a member owed a statement of
-          reasons is owed that fact first. --%>
+          reasons is owed that fact first. The word "member" is only true when
+          one of the reports really came from an account here — an outside
+          notice (issue #2009) has nobody behind it to name, and saying it
+          anyway pointed the owner at the wrong people (issue #2067). --%>
     <p :if={@case.status in ~w(pending_owner escalated)} class="mt-3 text-sm text-slate-600 dark:text-slate-400">
-      {gettext(
-        "No person made this decision: a report from a member in good standing hides the reported content automatically, the moment it arrives."
-      )}
+      {if @notice.from_member?,
+        do:
+          gettext(
+            "No person made this decision: a report from a member in good standing hides the reported content automatically, the moment it arrives."
+          ),
+        else:
+          gettext(
+            "No person made this decision: a report from somebody with a good record hides the reported content automatically, the moment it arrives."
+          )}
     </p>
 
     <dl class="mt-4 space-y-3 text-sm">

--- a/lib/vutuv_web/views/admin/moderation_html.ex
+++ b/lib/vutuv_web/views/admin/moderation_html.ex
@@ -76,6 +76,7 @@ defmodule VutuvWeb.Admin.ModerationHTML do
   def event_label("owner_disputed"), do: gettext("Owner disputed the report")
   def event_label("content_edited"), do: gettext("Owner edited the content")
   def event_label("content_deleted"), do: gettext("Content deleted")
+  def event_label("content_replaced"), do: gettext("Owner replaced the content")
   def event_label("escalated_deadline"), do: gettext("Escalated - the 72h deadline passed")
   def event_label("upheld"), do: gettext("Report upheld")
   def event_label("rejected"), do: gettext("Report rejected")

--- a/lib/vutuv_web/views/moderation_case_html.ex
+++ b/lib/vutuv_web/views/moderation_case_html.ex
@@ -22,11 +22,24 @@ defmodule VutuvWeb.ModerationCaseHTML do
   def status_line(%Case{status: "resolved_edited"}),
     do: gettext("Settled: you revised the content and it is visible again.")
 
-  def status_line(%Case{status: "upheld"}),
-    do: gettext("An admin confirmed the report. The content stays hidden.")
+  # These two said what became of the content as well — "the content stays
+  # hidden", "the content is visible again" — and neither is a function of the
+  # status: an upheld picture case deletes, an upheld post stays frozen, an
+  # upheld profile comes back on the strike ladder (issue #2067). They name the
+  # ruling now; `content_fate_line/1` below is the sentence beside them, its own
+  # paragraph rather than a second half glued on, because two translated halves
+  # of one sentence is the shape this project forbids.
+  def status_line(%Case{status: "upheld"}), do: gettext("An admin confirmed the report.")
+  def status_line(%Case{status: "rejected"}), do: gettext("An admin dismissed the report.")
 
-  def status_line(%Case{status: "rejected"}),
-    do: gettext("An admin dismissed the report. The content is visible again.")
+  @doc """
+  What became of the content, for a settled case — the owner's half of what
+  `Moderation.reported_content_fate/1` tells the reporter, so the two sides of
+  one case cannot describe it differently.
+  """
+  def content_fate_line(:removed), do: gettext("The content is deleted.")
+  def content_fate_line(:hidden), do: gettext("The content stays hidden.")
+  def content_fate_line(:visible), do: gettext("The content is visible again.")
 
   @doc """
   The reported categories, human-readable. Takes the statement of reasons

--- a/lib/vutuv_web/views/report_html.ex
+++ b/lib/vutuv_web/views/report_html.ex
@@ -53,6 +53,65 @@ defmodule VutuvWeb.ReportHTML do
   def content_type_label("image"), do: pgettext("content type", "Picture")
   def content_type_label(other), do: other
 
+  @doc """
+  The opening sentence of the mail that tells a member their content was
+  reported — one whole sentence per content type, in the recipient's locale.
+
+  It is a sentence and not a noun in a frame, because German gives each kind
+  its own gender and its own article (der Beitrag, das Bild, die Nachricht, die
+  Seite, die Stellenanzeige) and a profile is not "one of your" anything. Both
+  owner mails opened with the post wording for every type until issue #2067, so
+  a member whose profile picture had been taken offline was told a post of
+  theirs was hidden and went looking through posts that were all still there.
+
+  It reads lower-case and ends in a full stop: it follows the greeting's comma,
+  which is how a German letter continues and how these templates are written.
+  Everything after it in the body says "the reported content", so this is the
+  only sentence the type reaches.
+  """
+  def content_reported_sentence("post"),
+    do: gettext("somebody reported one of your posts on vutuv.")
+
+  def content_reported_sentence("image"),
+    do: gettext("somebody reported one of your pictures on vutuv.")
+
+  def content_reported_sentence("message"),
+    do: gettext("somebody reported one of your private messages on vutuv.")
+
+  def content_reported_sentence("job_posting"),
+    do: gettext("somebody reported one of your job postings on vutuv.")
+
+  def content_reported_sentence("organization"),
+    do: gettext("somebody reported one of your pages on vutuv.")
+
+  def content_reported_sentence("user"),
+    do: gettext("somebody reported your profile on vutuv.")
+
+  def content_reported_sentence(_other),
+    do: gettext("somebody reported something of yours on vutuv.")
+
+  @doc """
+  Why the content is already hidden, for the owner mails: whoever reported it
+  had a clean record, and that is the whole decision.
+
+  Both mails said "a report from a **member** in good standing", which for an
+  outside notice (issue #2009) names somebody who has no account here and points
+  the owner at the wrong people (issue #2067). One sentence per shape, handed to
+  the six templates as an assign, because the difference is one noun and
+  branching it in each locale of each mail is twelve copies to keep in step.
+  """
+  def reporter_standing_sentence(true),
+    do:
+      gettext(
+        "A report from a member in good standing hides the reported content automatically, the moment it arrives."
+      )
+
+  def reporter_standing_sentence(_outside),
+    do:
+      gettext(
+        "A report from somebody with a good record hides the reported content automatically, the moment it arrives."
+      )
+
   @doc "Whether this content type's form carries the copyright notice at all."
   def copyright_offered?(content_type),
     do: Report.copyright_category() in Report.categories_for(content_type)

--- a/lib/vutuv_web/views/user_helpers.ex
+++ b/lib/vutuv_web/views/user_helpers.ex
@@ -1068,6 +1068,24 @@ defmodule VutuvWeb.UserHelpers do
   end
 
   @doc """
+  A sentence a `*.text.eex` body interpolates, folded to the same 72 columns the
+  hand-written prose around it keeps.
+
+  A text template is written at a fixed measure; a sentence that arrives as an
+  assign is one long line inside it, and the paragraph reads as ragged as the
+  wrap it broke. The quoter above already knows where to fold, so this is that
+  half of it without the `"> "` marker — the same width, so the two cannot drift.
+  """
+  def email_wrapped_text(nil), do: ""
+
+  def email_wrapped_text(text) when is_binary(text) do
+    text
+    |> split_lines()
+    |> Enum.flat_map(&wrap_line/1)
+    |> Enum.join("\n")
+  end
+
+  @doc """
   Splits a stranger's text wherever a *renderer* will start a new line.
 
   The rule is the effect, not a list of the spellings anyone happens to think

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -2855,7 +2855,7 @@ msgstr "Nur Text"
 msgid "This post is for the connections of %{name}"
 msgstr "Dieser Beitrag ist für die Vernetzungen von %{name}"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:126
+#: lib/vutuv_web/views/admin/moderation_html.ex:127
 #: lib/vutuv_web/views/user_html.ex:536
 #, elixir-autogen, elixir-format
 msgid "connection"
@@ -3628,7 +3628,7 @@ msgstr ""
 "Sie haben alle %{limit} Namensänderungen der letzten %{days} Tage "
 "aufgebraucht."
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:127
+#: lib/vutuv_web/views/admin/moderation_html.ex:128
 #, elixir-autogen, elixir-format
 msgid "%{count} follows"
 msgstr "%{count} Follows"
@@ -3665,7 +3665,7 @@ msgstr "Inhalt eingefroren"
 msgid "Decision"
 msgstr "Entscheidung"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:79
+#: lib/vutuv_web/views/admin/moderation_html.ex:80
 #, elixir-autogen, elixir-format
 msgid "Escalated - the 72h deadline passed"
 msgstr "Eskaliert - die 72h-Frist ist abgelaufen"
@@ -3722,12 +3722,12 @@ msgstr "Meldung eingegangen"
 msgid "Report protection"
 msgstr "Schutz nach Meldung"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:81
+#: lib/vutuv_web/views/admin/moderation_html.ex:82
 #, elixir-autogen, elixir-format
 msgid "Report rejected"
 msgstr "Meldung abgelehnt"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:80
+#: lib/vutuv_web/views/admin/moderation_html.ex:81
 #, elixir-autogen, elixir-format
 msgid "Report upheld"
 msgstr "Meldung bestätigt"
@@ -3764,7 +3764,7 @@ msgstr "Durch Bearbeitung erledigt"
 msgid "Settled by deletion"
 msgstr "Durch Löschung erledigt"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:83
+#: lib/vutuv_web/views/admin/moderation_html.ex:84
 #, elixir-autogen, elixir-format
 msgid "Strike issued"
 msgstr "Verwarnungspunkt vergeben"
@@ -3807,22 +3807,22 @@ msgstr ""
 "kein Kontakt in beide Richtungen. Stufen unsere Admins die Meldung als "
 "unbegründet ein, wird das rückgängig gemacht."
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:101
+#: lib/vutuv_web/views/admin/moderation_html.ex:102
 #, elixir-autogen, elixir-format
 msgid "for the owner"
 msgstr "für den Besitzer"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:102
+#: lib/vutuv_web/views/admin/moderation_html.ex:103
 #, elixir-autogen, elixir-format
 msgid "for the reporter"
 msgstr "für den Melder"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:106
+#: lib/vutuv_web/views/admin/moderation_html.ex:107
 #, elixir-autogen, elixir-format
 msgid "level %{level}, %{role}"
 msgstr "Stufe %{level}, %{role}"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:128
+#: lib/vutuv_web/views/admin/moderation_html.ex:129
 #, elixir-autogen, elixir-format
 msgid "messages"
 msgstr "Nachrichten"
@@ -3866,7 +3866,7 @@ msgstr ""
 msgid "Case %{id}, captured %{at} UTC"
 msgstr "Fall %{id}, aufgenommen %{at} UTC"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:84
+#: lib/vutuv_web/views/admin/moderation_html.ex:85
 #, elixir-autogen, elixir-format
 msgid "Evidence screenshot captured"
 msgstr "Beweis-Screenshot aufgenommen"
@@ -10223,7 +10223,7 @@ msgstr "Tags durchsuchen"
 msgid "name or slug"
 msgstr "Name oder Slug"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:121
+#: lib/vutuv_web/views/admin/moderation_html.ex:122
 #, elixir-autogen, elixir-format
 msgid "%{action} (%{reason})"
 msgstr "%{action} (%{reason})"
@@ -10246,7 +10246,7 @@ msgstr ""
 msgid "Account deleted."
 msgstr "Konto gelöscht."
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:82
+#: lib/vutuv_web/views/admin/moderation_html.ex:83
 #, elixir-autogen, elixir-format
 msgid "Account removed"
 msgstr "Konto entfernt"
@@ -10325,12 +10325,12 @@ msgstr ""
 "dieses Konto."
 
 #: lib/vutuv_web/views/admin/account_html.ex:78
-#: lib/vutuv_web/views/admin/moderation_html.ex:114
+#: lib/vutuv_web/views/admin/moderation_html.ex:115
 #, elixir-autogen, elixir-format
 msgid "deactivated"
 msgstr "deaktiviert"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:115
+#: lib/vutuv_web/views/admin/moderation_html.ex:116
 #, elixir-autogen, elixir-format
 msgid "deleted"
 msgstr "gelöscht"
@@ -24132,7 +24132,7 @@ msgstr "Noch ein Klick, dann geht Ihre Meldung an unsere Admins. Je nachdem, was
 msgid "Our admins see your name and address so they can come back to you. The owner of the reported content never does."
 msgstr "Unsere Admins sehen Ihren Namen und Ihre Adresse, um sich bei Ihnen melden zu können. Wem der gemeldete Inhalt gehört, erfährt beides nie."
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:86
+#: lib/vutuv_web/views/admin/moderation_html.ex:87
 #, elixir-autogen, elixir-format
 msgid "Outside reporter confirmed their address"
 msgstr "Externer Melder hat seine Adresse bestätigt"
@@ -24154,7 +24154,7 @@ msgstr "Meldung bestätigt"
 msgid "Report content on this site"
 msgstr "Inhalt auf dieser Seite melden"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:85
+#: lib/vutuv_web/views/admin/moderation_html.ex:86
 #, elixir-autogen, elixir-format
 msgid "Report filed from outside"
 msgstr "Meldung von außerhalb eingegangen"
@@ -24280,7 +24280,7 @@ msgstr "Profil"
 msgid "A confirmation link is good for one week. Yours has run out, so your report never reached our admins and nothing about the reported content changed."
 msgstr "Ein Bestätigungslink gilt eine Woche. Ihrer ist abgelaufen, deshalb hat Ihre Meldung unsere Admins nie erreicht und am gemeldeten Inhalt hat sich nichts geändert."
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:89
+#: lib/vutuv_web/views/admin/moderation_html.ex:90
 #, elixir-autogen, elixir-format
 msgid "Report dropped: the address was never confirmed"
 msgstr "Meldung verworfen: die Adresse wurde nie bestätigt"
@@ -24456,3 +24456,8 @@ msgstr "Der Inhalt ist wieder sichtbar."
 #, elixir-autogen, elixir-format
 msgid "The content stays hidden."
 msgstr "Der Inhalt bleibt verborgen."
+
+#: lib/vutuv_web/views/admin/moderation_html.ex:79
+#, elixir-autogen, elixir-format
+msgid "Owner replaced the content"
+msgstr "Besitzer hat den Inhalt ersetzt"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -15,8 +15,8 @@ msgstr "Language: de\n"
 msgid "About us"
 msgstr "Impressum"
 
-#: lib/vutuv_web/components/ui.ex:4871
-#: lib/vutuv_web/components/ui.ex:4876
+#: lib/vutuv_web/components/ui.ex:4883
+#: lib/vutuv_web/components/ui.ex:4888
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
 #: lib/vutuv_web/live/organization_live/domains.ex:287
@@ -38,7 +38,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1489
+#: lib/vutuv_web/templates/user/show.html.heex:1494
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -62,7 +62,7 @@ msgstr "Eine Adresse wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/text.ex:71
-#: lib/vutuv_web/components/ui.ex:5208
+#: lib/vutuv_web/components/ui.ex:5220
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -81,8 +81,8 @@ msgstr "Adressen"
 msgid "Already a member? Sign in here."
 msgstr "Schon ein Mitglied? Einloggen."
 
-#: lib/vutuv_web/components/ui.ex:4662
-#: lib/vutuv_web/components/ui.ex:4761
+#: lib/vutuv_web/components/ui.ex:4674
+#: lib/vutuv_web/components/ui.ex:4773
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -95,7 +95,7 @@ msgstr "Sind Sie sicher?"
 msgid "Avatar"
 msgstr "Avatar"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:410
+#: lib/vutuv_web/templates/user/edit.html.heex:416
 #, elixir-autogen
 msgid "Birthdate"
 msgstr "Geburtstag"
@@ -104,13 +104,13 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/agent_docs/markdown.ex:677
 #: lib/vutuv_web/agent_docs/text.ex:636
 #: lib/vutuv_web/agent_docs/text.ex:637
-#: lib/vutuv_web/templates/user/show.html.heex:1120
+#: lib/vutuv_web/templates/user/show.html.heex:1125
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Geburtstag"
 
 #: lib/vutuv_web/components/saved_search_components.ex:104
-#: lib/vutuv_web/components/ui.ex:4656
+#: lib/vutuv_web/components/ui.ex:4668
 #: lib/vutuv_web/components/video_components.ex:281
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
@@ -129,9 +129,9 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:53
-#: lib/vutuv_web/templates/user/edit.html.heex:133
-#: lib/vutuv_web/templates/user/edit.html.heex:466
-#: lib/vutuv_web/templates/user/edit.html.heex:511
+#: lib/vutuv_web/templates/user/edit.html.heex:137
+#: lib/vutuv_web/templates/user/edit.html.heex:472
+#: lib/vutuv_web/templates/user/edit.html.heex:517
 #: lib/vutuv_web/templates/username/confirm.html.heex:220
 #, elixir-autogen
 msgid "Cancel"
@@ -154,7 +154,7 @@ msgstr "Wählen Sie einen Typ aus"
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1158
+#: lib/vutuv_web/templates/user/show.html.heex:1163
 #, elixir-autogen
 msgid "Contact"
 msgstr "Kontakt"
@@ -163,8 +163,8 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:4223
-#: lib/vutuv_web/components/ui.ex:4763
+#: lib/vutuv_web/components/post_components.ex:4278
+#: lib/vutuv_web/components/ui.ex:4775
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:657
@@ -172,7 +172,7 @@ msgstr "%{name} konnte nicht zurückgefolgt werden."
 #: lib/vutuv_web/live/admin/user_delete_live.ex:167
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:28
 #: lib/vutuv_web/templates/dev_app/show.html.heex:135
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:117
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:127
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:70
 #, elixir-autogen
 msgid "Delete"
@@ -211,8 +211,8 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:4188
-#: lib/vutuv_web/components/ui.ex:4754
+#: lib/vutuv_web/components/post_components.ex:4243
+#: lib/vutuv_web/components/ui.ex:4766
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
@@ -224,8 +224,8 @@ msgstr "Download"
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:6
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:103
-#: lib/vutuv_web/templates/user/show.html.heex:1143
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:113
+#: lib/vutuv_web/templates/user/show.html.heex:1148
 #, elixir-autogen
 msgid "Edit"
 msgstr "Ändern"
@@ -286,11 +286,11 @@ msgstr "E-Mail-Adresse eingeben"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:5172
+#: lib/vutuv_web/components/ui.ex:5184
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:644
+#: lib/vutuv_web/templates/user/show.html.heex:649
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -307,7 +307,7 @@ msgid "Fax"
 msgstr "Fax"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:662
-#: lib/vutuv_web/templates/user/edit.html.heex:164
+#: lib/vutuv_web/templates/user/edit.html.heex:170
 #, elixir-autogen
 msgid "First Name"
 msgstr "Vorname"
@@ -333,7 +333,7 @@ msgstr "Follower"
 #: lib/vutuv_web/live/organization_live/show.ex:618
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:988
+#: lib/vutuv_web/templates/user/show.html.heex:993
 #: lib/vutuv_web/views/user_html.ex:640
 #, elixir-autogen
 msgid "Following"
@@ -341,7 +341,7 @@ msgstr "Folge ich"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:212
 #: lib/vutuv_web/templates/page/index.html.heex:121
-#: lib/vutuv_web/templates/user/edit.html.heex:201
+#: lib/vutuv_web/templates/user/edit.html.heex:207
 #: lib/vutuv_web/views/account_event_text.ex:219
 #, elixir-autogen
 msgid "Gender"
@@ -384,7 +384,7 @@ msgid "Language"
 msgstr "Sprache"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:664
-#: lib/vutuv_web/templates/user/edit.html.heex:169
+#: lib/vutuv_web/templates/user/edit.html.heex:175
 #, elixir-autogen
 msgid "Last Name"
 msgstr "Nachname"
@@ -451,7 +451,7 @@ msgid "Log in"
 msgstr "Einloggen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:663
-#: lib/vutuv_web/templates/user/edit.html.heex:174
+#: lib/vutuv_web/templates/user/edit.html.heex:180
 #, elixir-autogen
 msgid "Middle Name"
 msgstr "Zweiter Vorname"
@@ -488,7 +488,7 @@ msgid "New"
 msgstr "Neu"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:666
-#: lib/vutuv_web/templates/user/edit.html.heex:179
+#: lib/vutuv_web/templates/user/edit.html.heex:185
 #, elixir-autogen
 msgid "Nickname"
 msgstr "Spitzname"
@@ -569,7 +569,7 @@ msgid "Phone number updated successfully."
 msgstr "Telefonnummer wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:661
-#: lib/vutuv_web/templates/user/edit.html.heex:184
+#: lib/vutuv_web/templates/user/edit.html.heex:190
 #, elixir-autogen
 msgid "Prefix"
 msgstr "Titel"
@@ -615,7 +615,7 @@ msgstr "Provider"
 msgid "Public"
 msgstr "Öffentlich"
 
-#: lib/vutuv_web/components/ui.ex:4655
+#: lib/vutuv_web/components/ui.ex:4667
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2201
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -631,7 +631,7 @@ msgstr "Öffentlich"
 #: lib/vutuv_web/templates/settings/preferences.html.heex:362
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:61
-#: lib/vutuv_web/templates/user/edit.html.heex:461
+#: lib/vutuv_web/templates/user/edit.html.heex:467
 #: lib/vutuv_web/views/settings_html.ex:253
 #, elixir-autogen
 msgid "Save"
@@ -693,13 +693,13 @@ msgstr "Slug"
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1272
+#: lib/vutuv_web/templates/user/show.html.heex:1277
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1274
+#: lib/vutuv_web/templates/user/show.html.heex:1279
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr "Profil hinzufügen"
@@ -748,7 +748,7 @@ msgid "Submit a bugreport or a feature request."
 msgstr "Fehler auf der Seite melden."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:665
-#: lib/vutuv_web/templates/user/edit.html.heex:189
+#: lib/vutuv_web/templates/user/edit.html.heex:195
 #, elixir-autogen
 msgid "Suffix"
 msgstr "Namenszusatz"
@@ -792,7 +792,7 @@ msgstr "Profil aktualisiert."
 msgid "User verified successfully."
 msgstr "User wurde verifiziert."
 
-#: lib/vutuv_web/components/ui.ex:5168
+#: lib/vutuv_web/components/ui.ex:5180
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:832
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -852,14 +852,14 @@ msgstr "Benutzer"
 msgid "vCard"
 msgstr "vCard"
 
-#: lib/vutuv_web/components/ui.ex:4824
-#: lib/vutuv_web/templates/user/show.html.heex:982
-#: lib/vutuv_web/templates/user/show.html.heex:1005
+#: lib/vutuv_web/components/ui.ex:4836
+#: lib/vutuv_web/templates/user/show.html.heex:987
+#: lib/vutuv_web/templates/user/show.html.heex:1010
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
 
-#: lib/vutuv_web/components/ui.ex:5331
+#: lib/vutuv_web/components/ui.ex:5343
 #: lib/vutuv_web/controllers/settings_controller.ex:175
 #: lib/vutuv_web/live/job_posting_live/form.ex:818
 #: lib/vutuv_web/live/organization_live/edit.ex:339
@@ -1057,7 +1057,7 @@ msgstr "Diese Seite ist für Sie gesperrt."
 msgid "An error occurred"
 msgstr "Es gab einen Fehler."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1109
+#: lib/vutuv_web/templates/user/show.html.heex:1114
 #, elixir-autogen
 msgid "General Info"
 msgstr "Allgemeines"
@@ -1198,10 +1198,10 @@ msgstr "Alle Tag-Synonyme"
 msgid "All tag urls"
 msgstr "Alle Tag-URLs"
 
-#: lib/vutuv_web/components/post_components.ex:4838
+#: lib/vutuv_web/components/post_components.ex:4893
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:638
+#: lib/vutuv_web/templates/user/show.html.heex:643
 #, elixir-autogen
 msgid "All tags"
 msgstr "Alle Tags"
@@ -1373,7 +1373,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:584
 #: lib/vutuv_web/agent_docs/text.ex:850
-#: lib/vutuv_web/components/ui.ex:5193
+#: lib/vutuv_web/components/ui.ex:5205
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1400,7 +1400,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:28
 #: lib/vutuv_web/templates/tag/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:608
+#: lib/vutuv_web/templates/user/show.html.heex:613
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1675,7 +1675,7 @@ msgid "Delete my account"
 msgstr "Mein Konto löschen"
 
 #: lib/vutuv_web/controllers/user_controller.ex:149
-#: lib/vutuv_web/templates/user/show.html.heex:147
+#: lib/vutuv_web/templates/user/show.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Edit profile"
 msgstr "Profil bearbeiten"
@@ -1703,7 +1703,7 @@ msgstr "Empfehlen"
 #: lib/vutuv_web/live/organization_live/show.ex:616
 #: lib/vutuv_web/live/post_live/feed.ex:902
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
-#: lib/vutuv_web/templates/user/show.html.heex:1313
+#: lib/vutuv_web/templates/user/show.html.heex:1318
 #: lib/vutuv_web/views/user_html.ex:651
 #, elixir-autogen, elixir-format
 msgid "Follow"
@@ -1762,7 +1762,7 @@ msgid "Network"
 msgstr "Netzwerk"
 
 #: lib/vutuv_web/components/post_components.ex:485
-#: lib/vutuv_web/components/ui.ex:4873
+#: lib/vutuv_web/components/ui.ex:4885
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
@@ -1778,7 +1778,7 @@ msgid "Nothing new yet."
 msgstr "Noch nichts Neues."
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:5230
+#: lib/vutuv_web/components/ui.ex:5242
 #: lib/vutuv_web/controllers/page_controller.ex:214
 #: lib/vutuv_web/live/notification_live/index.ex:154
 #: lib/vutuv_web/live/notification_live/index.ex:440
@@ -1850,7 +1850,7 @@ msgstr "Zu viele Versuche. Bitte versuchen Sie es später erneut."
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:19
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
-#: lib/vutuv_web/templates/user/show.html.heex:222
+#: lib/vutuv_web/templates/user/show.html.heex:232
 #: lib/vutuv_web/views/user_html.ex:1100
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
@@ -1923,14 +1923,14 @@ msgstr "ist jetzt mit Ihnen vernetzt."
 msgid "started following you."
 msgstr "folgt Ihnen jetzt."
 
-#: lib/vutuv_web/components/ui.ex:4130
-#: lib/vutuv_web/components/ui.ex:4275
+#: lib/vutuv_web/components/ui.ex:4142
+#: lib/vutuv_web/components/ui.ex:4287
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr "Seitennavigation"
 
-#: lib/vutuv_web/components/ui.ex:4898
+#: lib/vutuv_web/components/ui.ex:4910
 #: lib/vutuv_web/live/organization_live/activity.ex:159
 #: lib/vutuv_web/live/organization_live/feed.ex:258
 #: lib/vutuv_web/live/organization_live/show.ex:787
@@ -1945,7 +1945,7 @@ msgstr ""
 "Die Adresse selbst kann nicht geändert werden. Um eine andere zu verwenden, "
 "legen Sie sie als neue E-Mail-Adresse an und löschen Sie diese hier."
 
-#: lib/vutuv_web/components/ui.ex:4665
+#: lib/vutuv_web/components/ui.ex:4677
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Eintrag löschen"
@@ -1990,12 +1990,12 @@ msgstr "Titelbild hinzufügen"
 msgid "Add cover photo"
 msgstr "Titelbild hinzufügen"
 
-#: lib/vutuv_web/components/ui.ex:3589
+#: lib/vutuv_web/components/ui.ex:3601
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr "April"
 
-#: lib/vutuv_web/components/ui.ex:3593
+#: lib/vutuv_web/components/ui.ex:3605
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr "August"
@@ -2011,7 +2011,7 @@ msgid "Change cover photo"
 msgstr "Titelbild ändern"
 
 #: lib/vutuv_web/controllers/report_controller.ex:173
-#: lib/vutuv_web/templates/user/edit.html.heex:96
+#: lib/vutuv_web/templates/user/edit.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
 msgstr "Titelbild"
@@ -2021,37 +2021,37 @@ msgstr "Titelbild"
 msgid "Cover photo of %{name}"
 msgstr "Titelbild von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:3597
+#: lib/vutuv_web/components/ui.ex:3609
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr "Dezember"
 
-#: lib/vutuv_web/components/ui.ex:3587
+#: lib/vutuv_web/components/ui.ex:3599
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr "Februar"
 
-#: lib/vutuv_web/components/ui.ex:3586
+#: lib/vutuv_web/components/ui.ex:3598
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr "Januar"
 
-#: lib/vutuv_web/components/ui.ex:3592
+#: lib/vutuv_web/components/ui.ex:3604
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr "Juli"
 
-#: lib/vutuv_web/components/ui.ex:3591
+#: lib/vutuv_web/components/ui.ex:3603
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr "Juni"
 
-#: lib/vutuv_web/components/ui.ex:3588
+#: lib/vutuv_web/components/ui.ex:3600
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr "März"
 
-#: lib/vutuv_web/components/ui.ex:3590
+#: lib/vutuv_web/components/ui.ex:3602
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr "Mai"
@@ -2066,23 +2066,23 @@ msgstr "Mitglied seit %{month} %{year}"
 msgid "Member since %{year}"
 msgstr "Mitglied seit %{year}"
 
-#: lib/vutuv_web/components/ui.ex:3596
+#: lib/vutuv_web/components/ui.ex:3608
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr "November"
 
-#: lib/vutuv_web/components/ui.ex:3595
+#: lib/vutuv_web/components/ui.ex:3607
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr "Oktober"
 
-#: lib/vutuv_web/components/ui.ex:3594
+#: lib/vutuv_web/components/ui.ex:3606
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr "September"
 
 #: lib/vutuv_web/templates/education/form_content.html.heex:32
-#: lib/vutuv_web/templates/user/edit.html.heex:257
+#: lib/vutuv_web/templates/user/edit.html.heex:263
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Markdown is supported: bold, italics, links and lists."
@@ -2115,7 +2115,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:4220
+#: lib/vutuv_web/components/post_components.ex:4275
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2160,8 +2160,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:4174
-#: lib/vutuv_web/components/post_components.ex:4176
+#: lib/vutuv_web/components/post_components.ex:4229
+#: lib/vutuv_web/components/post_components.ex:4231
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2227,13 +2227,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:4711
-#: lib/vutuv_web/components/post_components.ex:4715
+#: lib/vutuv_web/components/post_components.ex:4766
+#: lib/vutuv_web/components/post_components.ex:4770
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:4712
+#: lib/vutuv_web/components/post_components.ex:4767
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2311,7 +2311,7 @@ msgstr "Zu viele Dateien."
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
-#: lib/vutuv_web/components/ui.ex:5575
+#: lib/vutuv_web/components/ui.ex:5587
 #: lib/vutuv_web/live/shell_live.ex:1582
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2330,32 +2330,32 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:4171
+#: lib/vutuv_web/components/post_components.ex:4226
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:6337
+#: lib/vutuv_web/components/post_components.ex:6392
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:6341
+#: lib/vutuv_web/components/post_components.ex:6396
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:6339
+#: lib/vutuv_web/components/post_components.ex:6394
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:6340
+#: lib/vutuv_web/components/post_components.ex:6395
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
 
-#: lib/vutuv_web/components/ui.ex:3667
+#: lib/vutuv_web/components/ui.ex:3679
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
@@ -2384,7 +2384,7 @@ msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
 msgid "Posts by %{name}"
 msgstr "Beiträge von %{name}"
 
-#: lib/vutuv_web/templates/user/show.html.heex:598
+#: lib/vutuv_web/templates/user/show.html.heex:603
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr "Alle %{count} Beiträge ansehen"
@@ -2395,8 +2395,8 @@ msgid "All posts"
 msgstr "Alle Beiträge"
 
 #: lib/vutuv_web/components/post_components.ex:2178
-#: lib/vutuv_web/components/post_components.ex:6437
-#: lib/vutuv_web/components/ui.ex:4197
+#: lib/vutuv_web/components/post_components.ex:6492
+#: lib/vutuv_web/components/ui.ex:4209
 #: lib/vutuv_web/views/user_html.ex:484
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2414,8 +2414,8 @@ msgid "Bookmarks"
 msgstr "Lesezeichen"
 
 #: lib/vutuv_web/components/post_components.ex:2122
-#: lib/vutuv_web/components/post_components.ex:6678
-#: lib/vutuv_web/components/ui.ex:4183
+#: lib/vutuv_web/components/post_components.ex:6733
+#: lib/vutuv_web/components/ui.ex:4195
 #: lib/vutuv_web/notification_line.ex:317
 #: lib/vutuv_web/views/user_html.ex:494
 #, elixir-autogen, elixir-format
@@ -2423,7 +2423,7 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1263
-#: lib/vutuv_web/components/post_components.ex:6688
+#: lib/vutuv_web/components/post_components.ex:6743
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1590
@@ -2444,13 +2444,13 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:6425
+#: lib/vutuv_web/components/post_components.ex:6480
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
 #: lib/vutuv_web/components/post_components.ex:2177
-#: lib/vutuv_web/components/post_components.ex:6436
+#: lib/vutuv_web/components/post_components.ex:6491
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:484
 #, elixir-autogen, elixir-format
@@ -2458,26 +2458,26 @@ msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
 #: lib/vutuv_web/components/post_components.ex:2158
-#: lib/vutuv_web/components/post_components.ex:6421
+#: lib/vutuv_web/components/post_components.ex:6476
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:2696
-#: lib/vutuv_web/components/post_components.ex:5443
+#: lib/vutuv_web/components/post_components.ex:2751
+#: lib/vutuv_web/components/post_components.ex:5498
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
 #: lib/vutuv_web/components/post_components.ex:2157
-#: lib/vutuv_web/components/post_components.ex:6420
+#: lib/vutuv_web/components/post_components.ex:6475
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
 #: lib/vutuv_web/components/post_components.ex:2121
-#: lib/vutuv_web/components/post_components.ex:6677
+#: lib/vutuv_web/components/post_components.ex:6732
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:494
 #, elixir-autogen, elixir-format
@@ -2485,7 +2485,7 @@ msgid "Unlike"
 msgstr "Gefällt mir entfernen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:498
-#: lib/vutuv_web/components/post_components.ex:3182
+#: lib/vutuv_web/components/post_components.ex:3237
 #: lib/vutuv_web/components/ui.ex:3023
 #: lib/vutuv_web/components/ui.ex:3023
 #: lib/vutuv_web/components/ui.ex:3099
@@ -2505,7 +2505,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:6732
+#: lib/vutuv_web/components/post_components.ex:6787
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2517,8 +2517,8 @@ msgid "Replies"
 msgstr "Antworten"
 
 #: lib/vutuv_web/components/post_components.ex:2367
-#: lib/vutuv_web/components/post_components.ex:6715
-#: lib/vutuv_web/components/post_components.ex:6716
+#: lib/vutuv_web/components/post_components.ex:6770
+#: lib/vutuv_web/components/post_components.ex:6771
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:314
@@ -2526,7 +2526,7 @@ msgstr "Antworten"
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4130
+#: lib/vutuv_web/components/post_components.ex:4185
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2547,7 +2547,7 @@ msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beitr
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/components/post_components.ex:3648
+#: lib/vutuv_web/components/post_components.ex:3703
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2555,14 +2555,14 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4102
+#: lib/vutuv_web/components/post_components.ex:4157
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:4093
-#: lib/vutuv_web/components/post_components.ex:4122
-#: lib/vutuv_web/components/post_components.ex:4125
+#: lib/vutuv_web/components/post_components.ex:4148
+#: lib/vutuv_web/components/post_components.ex:4177
+#: lib/vutuv_web/components/post_components.ex:4180
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2730,51 +2730,51 @@ msgstr "Andere E-Mail-Adresse verwenden"
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:918
+#: lib/vutuv_web/templates/user/show.html.heex:923
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr "Link hinzufügen"
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1232
+#: lib/vutuv_web/templates/user/show.html.heex:1237
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Telefonnummer hinzufügen"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1491
+#: lib/vutuv_web/templates/user/show.html.heex:1496
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Adresse hinzufügen"
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1160
+#: lib/vutuv_web/templates/user/show.html.heex:1165
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "E-Mail-Adresse hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1111
+#: lib/vutuv_web/templates/user/show.html.heex:1116
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Persönliche Angaben hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:647
+#: lib/vutuv_web/templates/user/show.html.heex:652
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr "Berufserfahrung hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:495
+#: lib/vutuv_web/templates/user/show.html.heex:500
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr "Ersten Beitrag schreiben"
 
-#: lib/vutuv_web/components/ui.ex:4363
-#: lib/vutuv_web/components/ui.ex:4826
+#: lib/vutuv_web/components/ui.ex:4375
+#: lib/vutuv_web/components/ui.ex:4838
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:109
@@ -2782,7 +2782,7 @@ msgstr "Ersten Beitrag schreiben"
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
-#: lib/vutuv_web/templates/user/show.html.heex:638
+#: lib/vutuv_web/templates/user/show.html.heex:643
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr "Verwalten"
@@ -2810,7 +2810,7 @@ msgstr[1] "%{formatted} Vernetzungen"
 
 #: lib/vutuv_web/live/job_board_live.ex:458
 #: lib/vutuv_web/live/post_live/feed.ex:1018
-#: lib/vutuv_web/templates/user/card_list.html.heex:51
+#: lib/vutuv_web/templates/user/card_list.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
 msgid_plural "+%{formatted} more tags"
@@ -2863,7 +2863,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:6338
+#: lib/vutuv_web/components/post_components.ex:6393
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -2891,7 +2891,7 @@ msgid "Endorsement"
 msgstr "Empfehlung"
 
 #: lib/vutuv_web/notification_line.ex:312
-#: lib/vutuv_web/templates/user/show.html.heex:966
+#: lib/vutuv_web/templates/user/show.html.heex:971
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -2923,7 +2923,7 @@ msgstr[0] "%{formatted} Fall wartet auf eine Entscheidung."
 msgstr[1] "%{formatted} Fälle warten auf eine Entscheidung."
 
 #: lib/vutuv_web/live/admin/job_live.ex:335
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:290
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:301
 #: lib/vutuv_web/templates/moderation_evidence/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "(deleted account)"
@@ -2949,16 +2949,6 @@ msgstr "Eine Meldung zu Ihrem Inhalt wurde verworfen; er ist wieder sichtbar."
 #, elixir-autogen, elixir-format
 msgid "Abusive"
 msgstr "Missbräuchlich"
-
-#: lib/vutuv_web/views/moderation_case_html.ex:26
-#, elixir-autogen, elixir-format
-msgid "An admin confirmed the report. The content stays hidden."
-msgstr "Ein Admin hat die Meldung bestätigt. Der Inhalt bleibt verborgen."
-
-#: lib/vutuv_web/views/moderation_case_html.ex:29
-#, elixir-autogen, elixir-format
-msgid "An admin dismissed the report. The content is visible again."
-msgstr "Ein Admin hat die Meldung verworfen. Der Inhalt ist wieder sichtbar."
 
 #: lib/vutuv_web/templates/report/new.html.heex:123
 #, elixir-autogen, elixir-format
@@ -2988,7 +2978,7 @@ msgstr ""
 "einwöchige Sperre, dann die endgültige Deaktivierung. Verwarnungspunkte "
 "verfallen nach zwölf Monaten."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:276
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "Conversation context (the reported message last)"
 msgstr "Gesprächskontext (die gemeldete Nachricht zuletzt)"
@@ -3001,17 +2991,17 @@ msgstr ""
 "wiederholt unerwünschte Nachrichten führen zur Sperrung des Kontos, in "
 "öffentlichen Beiträgen genauso wie in privaten Nachrichten."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:268
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Current version (edited since the report)"
 msgstr "Aktuelle Version (seit der Meldung bearbeitet)"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:115
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Delete this content permanently?"
 msgstr "Diesen Inhalt endgültig löschen?"
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:106
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:117
 #, elixir-autogen, elixir-format
 msgid "Deleted. The report is settled, no further steps needed."
 msgstr ""
@@ -3022,7 +3012,7 @@ msgstr ""
 msgid "Escalated"
 msgstr "Eskaliert"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:100
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Fix it. An edited post is visible again immediately."
 msgstr "Korrigieren. Ein bearbeiteter Beitrag ist sofort wieder sichtbar."
@@ -3075,7 +3065,7 @@ msgstr "Moderationsfall"
 msgid "Moderation queue"
 msgstr "Moderations-Warteschlange"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:126
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "My content is fine"
 msgstr "Mein Inhalt ist in Ordnung"
@@ -3132,13 +3122,13 @@ msgstr "Nichts zu sehen, keiner Ihrer Inhalte ist derzeit gemeldet."
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1200
-#: lib/vutuv_web/templates/user/show.html.heex:1201
+#: lib/vutuv_web/templates/user/show.html.heex:1205
+#: lib/vutuv_web/templates/user/show.html.heex:1206
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:4069
+#: lib/vutuv_web/components/post_components.ex:4124
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3180,7 +3170,7 @@ msgstr "Besitzer"
 msgid "Please report honestly. Reporting to harm someone breaks our"
 msgstr "Melden Sie ehrlich. Wer meldet, um jemandem zu schaden, verstößt gegen unsere"
 
-#: lib/vutuv_web/components/ui.ex:5162
+#: lib/vutuv_web/components/ui.ex:5174
 #: lib/vutuv_web/live/shell_live.ex:1373
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3188,7 +3178,7 @@ msgstr "Melden Sie ehrlich. Wer meldet, um jemandem zu schaden, verstößt gegen
 msgid "Profile"
 msgstr "Profil"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:414
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "Reject the report"
 msgstr "Meldung ablehnen"
@@ -3199,16 +3189,16 @@ msgstr "Meldung ablehnen"
 msgid "Rejected"
 msgstr "Abgelehnt"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:109
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
 #: lib/vutuv_web/components/post_components.ex:1460
-#: lib/vutuv_web/components/post_components.ex:3202
-#: lib/vutuv_web/components/post_components.ex:4287
+#: lib/vutuv_web/components/post_components.ex:3257
+#: lib/vutuv_web/components/post_components.ex:4342
 #: lib/vutuv_web/live/organization_live/show.ex:661
-#: lib/vutuv_web/templates/user/show.html.heex:242
+#: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
 msgid "Report"
 msgstr "Melden"
@@ -3250,13 +3240,13 @@ msgid "Report upheld; the owner got a strike."
 msgstr "Meldung bestätigt; der Besitzer hat einen Verwarnungspunkt erhalten."
 
 #: lib/vutuv_web/live/admin/moderation_live.ex:55
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:23
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "Reported as"
 msgstr "Gemeldet als"
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:24
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:35
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:23
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:34
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Reported content"
@@ -3282,20 +3272,20 @@ msgstr "Melder"
 msgid "Reporter track records"
 msgstr "Melder-Bilanz"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:300
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:311
 #: lib/vutuv_web/live/admin/moderation_live.ex:57
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Reports"
 msgstr "Meldungen"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:133
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 "Meldungen sind anonym; wir verraten nie, wer gemeldet hat. Unsere Regeln:"
 
-#: lib/vutuv_web/components/ui.ex:4045
+#: lib/vutuv_web/components/ui.ex:4057
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3339,7 +3329,7 @@ msgstr "Etwas anderes"
 msgid "Spam or scam"
 msgstr "Spam oder Betrug"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:123
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Stand by it. It stays hidden until one of our admins has ruled."
 msgstr ""
@@ -3380,7 +3370,7 @@ msgstr "Beschreiben Sie es in der Notiz unten genauer."
 msgid "Thank you for your report. We take it from here."
 msgstr "Danke für Ihre Meldung. Wir übernehmen ab hier."
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:53
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "The content in question"
 msgstr "Der betreffende Inhalt"
@@ -3399,14 +3389,14 @@ msgid "The queue is empty - the self-service flow settled everything."
 msgstr ""
 "Die Warteschlange ist leer, der Selbstbedienungs-Ablauf hat alles erledigt."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:402
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:433
 #, elixir-autogen, elixir-format
 msgid "The report by @%{slug} was a deliberate weapon (strikes the reporter)"
 msgstr ""
 "Die Meldung von @%{slug} war eine gezielte Waffe (Verwarnungspunkt für den "
 "Melder)"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:374
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:396
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content stays hidden and the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
@@ -3425,7 +3415,7 @@ msgstr "Dieses Konto wurde deaktiviert."
 msgid "This account is suspended until %{date}."
 msgstr "Dieses Konto ist bis zum %{date} gesperrt."
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:121
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:132
 #, elixir-autogen, elixir-format
 msgid "This case is already settled."
 msgstr "Dieser Fall ist bereits erledigt."
@@ -3445,7 +3435,7 @@ msgstr "Vertrauenswürdig"
 msgid "Type"
 msgstr "Typ"
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:83
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:94
 #, elixir-autogen, elixir-format
 msgid "Understood. The content stays hidden until one of our admins has ruled."
 msgstr ""
@@ -3457,7 +3447,7 @@ msgstr ""
 msgid "Unwanted advertising, fraud or fake activity."
 msgstr "Unerwünschte Werbung, Betrug oder gefälschte Aktivität."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:379
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "Uphold the report"
 msgstr "Meldung bestätigen"
@@ -3523,7 +3513,7 @@ msgstr ""
 "Ihre Meldung ist anonym. Wenn sie plausibel ist, wird der Inhalt sofort "
 "verborgen und der Besitzer gebeten, ihn in Ordnung zu bringen."
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:135
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:145
 #: lib/vutuv_web/templates/public_report/new.html.heex:149
 #: lib/vutuv_web/templates/report/new.html.heex:162
 #, elixir-autogen, elixir-format
@@ -3548,17 +3538,17 @@ msgstr ""
 msgid "yes"
 msgstr "ja"
 
-#: lib/vutuv/notifications/emailer.ex:1093
+#: lib/vutuv/notifications/emailer.ex:1127
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr "Eine Verwarnung für Ihr vutuv-Konto"
 
-#: lib/vutuv/notifications/emailer.ex:1270
+#: lib/vutuv/notifications/emailer.ex:1304
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr "Moderation: %{count} Fälle warten"
 
-#: lib/vutuv/notifications/emailer.ex:1061
+#: lib/vutuv/notifications/emailer.ex:1083
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr "Der von Ihnen gemeldete Inhalt wurde überarbeitet"
@@ -3573,12 +3563,12 @@ msgstr "Ihr Inhalt auf vutuv wird geprüft"
 msgid "Your content on vutuv was reported and is hidden"
 msgstr "Ihr Inhalt auf vutuv wurde gemeldet und ist verborgen"
 
-#: lib/vutuv/notifications/emailer.ex:1107
+#: lib/vutuv/notifications/emailer.ex:1141
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr "Ihr vutuv-Konto wurde deaktiviert"
 
-#: lib/vutuv/notifications/emailer.ex:1100
+#: lib/vutuv/notifications/emailer.ex:1134
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr "Ihr vutuv-Konto ist gesperrt"
@@ -3643,14 +3633,14 @@ msgstr ""
 msgid "%{count} follows"
 msgstr "%{count} Follows"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:314
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "%{count} report so far"
 msgid_plural "%{count} reports so far"
 msgstr[0] "bisher %{count} Meldung"
 msgstr[1] "bisher %{count} Meldungen"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:314
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "%{rejected} rejected, %{abusive} abusive"
 msgstr "%{rejected} abgelehnt, %{abusive} missbräuchlich"
@@ -3670,7 +3660,7 @@ msgstr "Inhalt gelöscht"
 msgid "Content frozen"
 msgstr "Inhalt eingefroren"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:369
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "Decision"
 msgstr "Entscheidung"
@@ -3690,7 +3680,7 @@ msgstr "Eskaliert am %{date}"
 msgid "Evidence"
 msgstr "Beweismaterial"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:342
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr "Verlauf"
@@ -3747,7 +3737,7 @@ msgstr "Meldung bestätigt"
 msgid "Reported on %{date}"
 msgstr "Gemeldet am %{date}"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:331
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Reporter and owner are separated since this report (connection, follows, messages)."
 msgstr ""
@@ -3779,12 +3769,12 @@ msgstr "Durch Löschung erledigt"
 msgid "Strike issued"
 msgstr "Verwarnungspunkt vergeben"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:327
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "The protective separation from the owner was lifted on %{date}."
 msgstr "Die schützende Trennung vom Besitzer wurde am %{date} aufgehoben."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:390
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #, elixir-autogen, elixir-format
 msgid "The report is unfounded. The content becomes visible again, any protective separation is lifted, and the rejection counts against each reporter's trust."
 msgstr ""
@@ -3837,7 +3827,7 @@ msgstr "Stufe %{level}, %{role}"
 msgid "messages"
 msgstr "Nachrichten"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:345
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "No history recorded - this case predates the audit log."
 msgstr "Kein Verlauf aufgezeichnet - dieser Fall ist älter als das Protokoll."
@@ -3881,7 +3871,7 @@ msgstr "Fall %{id}, aufgenommen %{at} UTC"
 msgid "Evidence screenshot captured"
 msgstr "Beweis-Screenshot aufgenommen"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:257
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Evidence screenshot captured when the report was filed"
 msgstr "Beweis-Screenshot, aufgenommen beim Eingang der Meldung"
@@ -3891,7 +3881,7 @@ msgstr "Beweis-Screenshot, aufgenommen beim Eingang der Meldung"
 msgid "Moderation evidence - reported private message with context"
 msgstr "Moderations-Beweismaterial - gemeldete private Nachricht mit Kontext"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:252
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Screenshot at report time"
 msgstr "Screenshot zum Meldezeitpunkt"
@@ -3901,7 +3891,7 @@ msgstr "Screenshot zum Meldezeitpunkt"
 msgid "reported message"
 msgstr "gemeldete Nachricht"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:263
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
@@ -4429,12 +4419,12 @@ msgstr "Buchbar bis einschließlich %{last}."
 msgid "Bookings are open through %{last}. Next available day: %{day}"
 msgstr "Buchbar bis einschließlich %{last}. Nächster freier Tag: %{day}"
 
-#: lib/vutuv_web/components/ui.ex:3619
+#: lib/vutuv_web/components/ui.ex:3631
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr "Fr"
 
-#: lib/vutuv_web/components/ui.ex:3615
+#: lib/vutuv_web/components/ui.ex:3627
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr "Mo"
@@ -4446,27 +4436,27 @@ msgstr ""
 "Eine Anzeige pro Kalendertag: Wählen Sie einen freien Tag im Kalender; "
 "durchgestrichene Tage sind bereits vergeben."
 
-#: lib/vutuv_web/components/ui.ex:3620
+#: lib/vutuv_web/components/ui.ex:3632
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr "Sa"
 
-#: lib/vutuv_web/components/ui.ex:3621
+#: lib/vutuv_web/components/ui.ex:3633
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr "So"
 
-#: lib/vutuv_web/components/ui.ex:3618
+#: lib/vutuv_web/components/ui.ex:3630
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr "Do"
 
-#: lib/vutuv_web/components/ui.ex:3616
+#: lib/vutuv_web/components/ui.ex:3628
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr "Di"
 
-#: lib/vutuv_web/components/ui.ex:3617
+#: lib/vutuv_web/components/ui.ex:3629
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr "Mi"
@@ -4596,7 +4586,7 @@ msgid "Search for words in public posts."
 msgstr "Suchen Sie nach Wörtern in öffentlichen Beiträgen."
 
 #: lib/vutuv_web/templates/block/index.html.heex:36
-#: lib/vutuv_web/templates/user/show.html.heex:263
+#: lib/vutuv_web/templates/user/show.html.heex:268
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr "Blockieren"
@@ -4610,7 +4600,7 @@ msgstr ""
 "beide Richtungen unterbunden. Eine Aufhebung der Blockierung stellt das "
 "Entfernte nicht wieder her."
 
-#: lib/vutuv_web/components/ui.ex:5335
+#: lib/vutuv_web/components/ui.ex:5347
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4630,13 +4620,13 @@ msgstr ""
 "eine Aufhebung stellt sie nicht wieder her."
 
 #: lib/vutuv_web/templates/block/index.html.heex:74
-#: lib/vutuv_web/templates/user/show.html.heex:158
+#: lib/vutuv_web/templates/user/show.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr "Blockierung aufheben"
 
 #: lib/vutuv_web/templates/block/index.html.heex:72
-#: lib/vutuv_web/templates/user/show.html.heex:155
+#: lib/vutuv_web/templates/user/show.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Unblock @%{slug}?"
 msgstr "Blockierung von @%{slug} aufheben?"
@@ -4673,7 +4663,7 @@ msgstr "Mitglieder finden"
 #: lib/vutuv_web/live/organization_live/following.ex:313
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:988
+#: lib/vutuv_web/templates/user/show.html.heex:993
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folgt"
@@ -4795,7 +4785,7 @@ msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 
 #: lib/vutuv_web/live/job_board_live.ex:547
 #: lib/vutuv_web/live/tag_new_live.ex:47
-#: lib/vutuv_web/templates/user/show.html.heex:611
+#: lib/vutuv_web/templates/user/show.html.heex:616
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr "Tags hinzufügen"
@@ -5433,9 +5423,9 @@ msgstr "API-Token (%{date})"
 msgid "API documentation"
 msgstr "API-Dokumentation"
 
-#: lib/vutuv_web/components/ui.ex:5385
+#: lib/vutuv_web/components/ui.ex:5397
 #: lib/vutuv_web/controllers/settings_controller.ex:161
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:457
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:488
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
@@ -5517,10 +5507,10 @@ msgstr "Tastaturkürzel"
 msgid "Navigation"
 msgstr "Navigation"
 
-#: lib/vutuv_web/components/ui.ex:5482
-#: lib/vutuv_web/components/ui.ex:5487
-#: lib/vutuv_web/components/ui.ex:5566
-#: lib/vutuv_web/components/ui.ex:5630
+#: lib/vutuv_web/components/ui.ex:5494
+#: lib/vutuv_web/components/ui.ex:5499
+#: lib/vutuv_web/components/ui.ex:5578
+#: lib/vutuv_web/components/ui.ex:5642
 #: lib/vutuv_web/controllers/settings_controller.ex:68
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5554,17 +5544,17 @@ msgstr "Beitrag schreiben"
 msgid "Your profile"
 msgstr "Ihr Profil"
 
-#: lib/vutuv_web/templates/user/show.html.heex:408
+#: lib/vutuv_web/templates/user/show.html.heex:413
 #, elixir-autogen, elixir-format
 msgid "Complete your profile"
 msgstr "Profil vervollständigen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:430
+#: lib/vutuv_web/templates/user/show.html.heex:435
 #, elixir-autogen, elixir-format
 msgid "A few quick steps so people can find and recognize you."
 msgstr "Ein paar schnelle Schritte, damit andere Sie finden und erkennen."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1461
+#: lib/vutuv_web/live/user_profile_live.ex:1464
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr "Profilfoto hinzufügen"
@@ -5590,9 +5580,9 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:4365
-#: lib/vutuv_web/components/post_components.ex:4417
-#: lib/vutuv_web/components/post_components.ex:4959
+#: lib/vutuv_web/components/post_components.ex:4420
+#: lib/vutuv_web/components/post_components.ex:4472
+#: lib/vutuv_web/components/post_components.ex:5014
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/views/user_html.ex:131
 #, elixir-autogen, elixir-format
@@ -5633,12 +5623,12 @@ msgstr "Art der E-Mail"
 msgid "Type of email address"
 msgstr "Art der E-Mail-Adresse"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:236
+#: lib/vutuv_web/templates/user/edit.html.heex:242
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr "Über Sie"
 
-#: lib/vutuv_web/components/ui.ex:5355
+#: lib/vutuv_web/components/ui.ex:5367
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5660,7 +5650,7 @@ msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 "Laden Sie alles herunter, was vutuv über Sie speichert, als eine Datei."
 
-#: lib/vutuv_web/components/ui.ex:5200
+#: lib/vutuv_web/components/ui.ex:5212
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5695,7 +5685,7 @@ msgstr "Persönliche Tokens für die vutuv-API."
 msgid "Photos"
 msgstr "Fotos"
 
-#: lib/vutuv_web/components/ui.ex:5329
+#: lib/vutuv_web/components/ui.ex:5341
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -5717,7 +5707,7 @@ msgid "View"
 msgstr "Ansehen"
 
 #: lib/vutuv_web/templates/public_report/new.html.heex:92
-#: lib/vutuv_web/templates/user/edit.html.heex:161
+#: lib/vutuv_web/templates/user/edit.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Your name"
 msgstr "Ihr Name"
@@ -5777,18 +5767,18 @@ msgstr ""
 msgid "Current avatar"
 msgstr "Aktueller Avatar"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:107
-#: lib/vutuv_web/templates/user/edit.html.heex:114
+#: lib/vutuv_web/templates/user/edit.html.heex:111
+#: lib/vutuv_web/templates/user/edit.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Current cover photo"
 msgstr "Aktuelles Titelbild"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:185
+#: lib/vutuv_web/templates/user/edit.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "e.g. Dr. or Prof."
 msgstr "z. B. Dr. oder Prof."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:190
+#: lib/vutuv_web/templates/user/edit.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "e.g. Jr. or PhD"
 msgstr "z. B. jun. oder B.Sc."
@@ -5810,7 +5800,7 @@ msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/vutuv_web/components/ui.ex:5378
+#: lib/vutuv_web/components/ui.ex:5390
 #: lib/vutuv_web/controllers/settings_controller.ex:185
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -6018,21 +6008,21 @@ msgid "Sort"
 msgstr "Sortieren"
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3683
+#: lib/vutuv_web/components/ui.ex:3695
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "vor %{count} Tag"
 msgstr[1] "vor %{count} Tagen"
 
-#: lib/vutuv_web/components/ui.ex:3682
+#: lib/vutuv_web/components/ui.ex:3694
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "vor %{count} Stunde"
 msgstr[1] "vor %{count} Stunden"
 
-#: lib/vutuv_web/components/ui.ex:3681
+#: lib/vutuv_web/components/ui.ex:3693
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -6101,7 +6091,7 @@ msgstr ""
 "Das ist die erste Anmeldung, die wir von diesem Gerät oder Browser gesehen "
 "haben."
 
-#: lib/vutuv_web/components/ui.ex:3680
+#: lib/vutuv_web/components/ui.ex:3692
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "gerade eben"
@@ -6241,13 +6231,13 @@ msgstr "z. B. MacBook"
 msgid "or"
 msgstr "oder"
 
-#: lib/vutuv_web/live/user_profile_live.ex:1466
+#: lib/vutuv_web/live/user_profile_live.ex:1469
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr "Kurzbeschreibung hinzufügen"
 
 #: lib/vutuv_web/live/cv_live.ex:166
-#: lib/vutuv_web/templates/user/edit.html.heex:253
+#: lib/vutuv_web/templates/user/edit.html.heex:259
 #: lib/vutuv_web/views/account_event_text.ex:212
 #, elixir-autogen, elixir-format
 msgid "Tagline"
@@ -6256,14 +6246,14 @@ msgstr "Kurzbeschreibung"
 #: lib/vutuv_web/components/ui.ex:487
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:916
+#: lib/vutuv_web/templates/user/show.html.heex:921
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] "Link"
 msgstr[1] "Links"
 
-#: lib/vutuv_web/templates/user/show.html.heex:471
+#: lib/vutuv_web/templates/user/show.html.heex:476
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6271,36 +6261,36 @@ msgid_plural "Posts"
 msgstr[0] "Beitrag"
 msgstr[1] "Beiträge"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:63
-#: lib/vutuv_web/templates/user/edit.html.heex:144
+#: lib/vutuv_web/templates/user/edit.html.heex:67
+#: lib/vutuv_web/templates/user/edit.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1541
+#: lib/vutuv_web/templates/user/show.html.heex:1546
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Auch auf"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:51
-#: lib/vutuv_web/templates/user/edit.html.heex:131
+#: lib/vutuv_web/templates/user/edit.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Drag to move, use the slider to zoom. The framed area is what others see."
 msgstr ""
 "Zum Verschieben ziehen, zum Zoomen den Regler nutzen. Der umrahmte Bereich "
 "ist für andere sichtbar."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:68
+#: lib/vutuv_web/templates/user/edit.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "New avatar preview"
 msgstr "Vorschau des neuen Avatars"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:149
+#: lib/vutuv_web/templates/user/edit.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "New cover photo preview"
 msgstr "Vorschau des neuen Titelbilds"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:130
+#: lib/vutuv_web/templates/user/edit.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Position your cover photo"
 msgstr "Titelbild positionieren"
@@ -6311,20 +6301,20 @@ msgid "Position your photo"
 msgstr "Foto positionieren"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:52
-#: lib/vutuv_web/templates/user/edit.html.heex:132
+#: lib/vutuv_web/templates/user/edit.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Use photo"
 msgstr "Foto verwenden"
 
 #: lib/vutuv_web/live/post_live/composer.ex:1919
 #: lib/vutuv_web/templates/user/edit.html.heex:54
-#: lib/vutuv_web/templates/user/edit.html.heex:134
+#: lib/vutuv_web/templates/user/edit.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr "Zoom"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1126
-#: lib/vutuv_web/templates/user/show.html.heex:1136
+#: lib/vutuv_web/templates/user/show.html.heex:1131
+#: lib/vutuv_web/templates/user/show.html.heex:1141
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6366,12 +6356,12 @@ msgstr "Tagesbericht für %{day}"
 msgid "Jump to a day"
 msgstr "Zu einem Tag springen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1248
+#: lib/vutuv_web/templates/user/show.html.heex:1253
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr "E-Mails verwalten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1259
+#: lib/vutuv_web/templates/user/show.html.heex:1264
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr "Telefon verwalten"
@@ -6414,7 +6404,7 @@ msgstr "Vorheriger Tag"
 msgid "Reposts"
 msgstr "Reposts"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1257
+#: lib/vutuv_web/templates/user/show.html.heex:1262
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr "Alle Telefonnummern anzeigen"
@@ -6475,9 +6465,9 @@ msgstr "Anzuzeigende Kartendienste"
 msgid "Maps"
 msgstr "Karten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1531
-#: lib/vutuv_web/templates/user/show.html.heex:1535
-#: lib/vutuv_web/templates/user/show.html.heex:1547
+#: lib/vutuv_web/templates/user/show.html.heex:1536
+#: lib/vutuv_web/templates/user/show.html.heex:1540
+#: lib/vutuv_web/templates/user/show.html.heex:1552
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
@@ -6508,7 +6498,7 @@ msgstr "Empfohlen am"
 msgid "Members who endorsed %{name} for %{tag}"
 msgstr "Mitglieder, die %{name} für %{tag} empfohlen haben"
 
-#: lib/vutuv_web/templates/user_tag/endorsers.html.heex:78
+#: lib/vutuv_web/templates/user_tag/endorsers.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "No endorsements yet."
 msgstr "Noch keine Empfehlungen."
@@ -6833,16 +6823,16 @@ msgstr ""
 "Schalten Sie einen Schalter aus, geht der passende Opt-out auf den Seiten "
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
-#: lib/vutuv_web/components/post_components.ex:3129
-#: lib/vutuv_web/components/post_components.ex:4240
-#: lib/vutuv_web/components/post_components.ex:4254
+#: lib/vutuv_web/components/post_components.ex:3184
+#: lib/vutuv_web/components/post_components.ex:4295
+#: lib/vutuv_web/components/post_components.ex:4309
 #: lib/vutuv_web/components/ui.ex:3171
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:320
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
-#: lib/vutuv_web/templates/user/show.html.heex:235
+#: lib/vutuv_web/templates/user/show.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr "Stummschalten"
@@ -6863,7 +6853,7 @@ msgstr "Neue Nachrichten und neue Vernetzungen"
 msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
-#: lib/vutuv_web/components/post_components.ex:4240
+#: lib/vutuv_web/components/post_components.ex:4295
 #: lib/vutuv_web/components/ui.ex:3170
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6871,7 +6861,7 @@ msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:320
 #: lib/vutuv_web/templates/settings/filters.html.heex:111
 #: lib/vutuv_web/templates/settings/mutes.html.heex:60
-#: lib/vutuv_web/templates/user/show.html.heex:235
+#: lib/vutuv_web/templates/user/show.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "Unmute"
 msgstr "Stummschaltung aufheben"
@@ -7491,13 +7481,13 @@ msgstr "Ihre Mitglieder werden zu dieser hinzugefügt (Vereinigung)."
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr "Seite %{page} von %{pages}, %{total} gesamt"
 
-#: lib/vutuv_web/components/ui.ex:4139
+#: lib/vutuv_web/components/ui.ex:4151
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Zurück"
 
-#: lib/vutuv_web/components/ui.ex:4151
+#: lib/vutuv_web/components/ui.ex:4163
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7581,9 +7571,9 @@ msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:6588
+#: lib/vutuv_web/components/post_components.ex:6643
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
-#: lib/vutuv_web/live/shell_live.ex:1812
+#: lib/vutuv_web/live/shell_live.ex:1817
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
 msgstr "+%{count} weitere"
@@ -8304,7 +8294,7 @@ msgstr "PIN abgelaufen"
 msgid "PIN registered"
 msgstr "PIN-registriert"
 
-#: lib/vutuv_web/components/ui.ex:4142
+#: lib/vutuv_web/components/ui.ex:4154
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr "Seite %{page} von %{pages}"
@@ -8431,7 +8421,7 @@ msgstr[1] "%{count} Berufserfahrungen"
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:704
+#: lib/vutuv_web/templates/user/show.html.heex:709
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr "Ausbildung hinzufügen"
@@ -8443,7 +8433,7 @@ msgstr "Abschluss"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:5176
+#: lib/vutuv_web/components/ui.ex:5188
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8455,7 +8445,7 @@ msgstr "Abschluss"
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
-#: lib/vutuv_web/templates/user/show.html.heex:701
+#: lib/vutuv_web/templates/user/show.html.heex:706
 #: lib/vutuv_web/views/import_html.ex:70
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
@@ -8503,14 +8493,14 @@ msgstr ""
 " was Sie nicht übernehmen möchten. Einträge, die bereits in Ihrem Profil "
 "stehen, sind für Sie abgewählt."
 
-#: lib/vutuv_web/components/ui.ex:5366
+#: lib/vutuv_web/components/ui.ex:5378
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
 
 #: lib/vutuv_web/controllers/import_controller.ex:37
 #: lib/vutuv_web/controllers/import_controller.ex:128
-#: lib/vutuv_web/live/user_profile_live.ex:1477
+#: lib/vutuv_web/live/user_profile_live.ex:1480
 #: lib/vutuv_web/templates/import/new.html.heex:1
 #: lib/vutuv_web/templates/import/preview.html.heex:1
 #, elixir-autogen, elixir-format
@@ -8532,7 +8522,7 @@ msgstr "%{items} importiert."
 msgid "Nothing new to import."
 msgstr "Nichts Neues zu importieren."
 
-#: lib/vutuv_web/components/ui.ex:5204
+#: lib/vutuv_web/components/ui.ex:5216
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8629,7 +8619,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 
-#: lib/vutuv_web/components/ui.ex:4408
+#: lib/vutuv_web/components/ui.ex:4420
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8643,7 +8633,7 @@ msgid "Loading posts"
 msgstr "Beiträge werden geladen"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1395
+#: lib/vutuv_web/templates/user/show.html.heex:1400
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Social-Media-Beiträge"
@@ -8723,25 +8713,25 @@ msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 "Ziehen Sie Ihre ZIP-Datei hierher oder klicken Sie, um eine auszuwählen."
 
-#: lib/vutuv_web/components/ui.ex:5164
+#: lib/vutuv_web/components/ui.ex:5176
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr "Basisdaten & Fotos"
 
-#: lib/vutuv_web/components/ui.ex:5298
+#: lib/vutuv_web/components/ui.ex:5310
 #: lib/vutuv_web/controllers/settings_controller.ex:129
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Language & display"
 msgstr "Sprache & Anzeige"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:526
+#: lib/vutuv_web/templates/user/edit.html.heex:532
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
 
-#: lib/vutuv_web/components/ui.ex:5357
+#: lib/vutuv_web/components/ui.ex:5369
 #: lib/vutuv_web/controllers/settings_controller.ex:112
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8751,7 +8741,7 @@ msgstr "Weitere Profil-Bereiche"
 msgid "Sign-in & security"
 msgstr "Anmeldung & Sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:5370
+#: lib/vutuv_web/components/ui.ex:5382
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8982,7 +8972,7 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/agent_docs/text.ex:652
 #: lib/vutuv_web/components/organization_components.ex:276
 #: lib/vutuv_web/components/ui.ex:1783
-#: lib/vutuv_web/components/ui.ex:5347
+#: lib/vutuv_web/components/ui.ex:5359
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:366
 #: lib/vutuv_web/controllers/settings_controller.ex:433
@@ -8995,7 +8985,7 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1300
+#: lib/vutuv_web/templates/user/show.html.heex:1305
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr "Fediverse"
@@ -9149,7 +9139,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:5446
+#: lib/vutuv_web/components/post_components.ex:5501
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9270,7 +9260,7 @@ msgstr ""
 "LaTeX ist der Quelltext zum Setzen, und JSON Resume ist das offene Format "
 "von %{link}."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:266
+#: lib/vutuv_web/templates/user/edit.html.heex:272
 #, elixir-autogen, elixir-format
 msgid "characters"
 msgstr "Zeichen"
@@ -9427,7 +9417,7 @@ msgstr "A2 (Grundkenntnisse)"
 #: lib/vutuv_web/live/feed_languages_live.ex:317
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:766
+#: lib/vutuv_web/templates/user/show.html.heex:771
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr "Sprache hinzufügen"
@@ -9652,7 +9642,7 @@ msgstr "Sprache erfolgreich aktualisiert."
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:763
+#: lib/vutuv_web/templates/user/show.html.heex:768
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Sprachen"
@@ -9839,7 +9829,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
-#: lib/vutuv/accounts/user.ex:1271
+#: lib/vutuv/accounts/user.ex:1278
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9850,13 +9840,13 @@ msgstr "Auf Jobsuche"
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
-#: lib/vutuv/accounts/user.ex:1268
+#: lib/vutuv/accounts/user.ex:1275
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
 msgstr "Offen für Angebote"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:290
+#: lib/vutuv_web/templates/user/edit.html.heex:296
 #, elixir-autogen, elixir-format
 msgid "Shown as a badge next to your tagline so people can see whether you are open to opportunities."
 msgstr ""
@@ -9943,7 +9933,7 @@ msgstr[0] "%{count} Zertifikat oder Lizenz"
 msgstr[1] "%{count} Zertifikate oder Lizenzen"
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:870
+#: lib/vutuv_web/templates/user/show.html.heex:875
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
@@ -9976,7 +9966,7 @@ msgstr "Zertifikate"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:5180
+#: lib/vutuv_web/components/ui.ex:5192
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -9991,7 +9981,7 @@ msgstr "Zertifikate"
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:867
+#: lib/vutuv_web/templates/user/show.html.heex:872
 #: lib/vutuv_web/views/import_html.ex:71
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
@@ -10115,8 +10105,8 @@ msgstr "Bevorzugt"
 msgid "Preferred contact language"
 msgstr "Bevorzugte Kontaktsprache"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1222
-#: lib/vutuv_web/templates/user/show.html.heex:1223
+#: lib/vutuv_web/templates/user/show.html.heex:1227
+#: lib/vutuv_web/templates/user/show.html.heex:1228
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr "+%{code} ist die Ländervorwahl von %{region}"
@@ -10131,18 +10121,18 @@ msgstr "+%{code} ist die Ländervorwahl von %{region}"
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:439
-#: lib/vutuv_web/templates/user/edit.html.heex:514
+#: lib/vutuv_web/templates/user/edit.html.heex:445
+#: lib/vutuv_web/templates/user/edit.html.heex:520
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr "Geburtsdatum entfernen"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:502
+#: lib/vutuv_web/templates/user/edit.html.heex:508
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr "Geburtsdatum entfernen?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:505
+#: lib/vutuv_web/templates/user/edit.html.heex:511
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -10173,19 +10163,19 @@ msgstr "Keine Angabe"
 msgid "Permanent profile link"
 msgstr "Dauerhafter Profillink"
 
-#: lib/vutuv_web/templates/user/show.html.heex:419
-#: lib/vutuv_web/templates/user/show.html.heex:420
+#: lib/vutuv_web/templates/user/show.html.heex:424
+#: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr "Schließen"
 
-#: lib/vutuv_web/components/ui.ex:3796
+#: lib/vutuv_web/components/ui.ex:3808
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Kopiert"
 
-#: lib/vutuv_web/components/ui.ex:3795
-#: lib/vutuv_web/components/ui.ex:3803
+#: lib/vutuv_web/components/ui.ex:3807
+#: lib/vutuv_web/components/ui.ex:3815
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Kopieren"
@@ -10271,7 +10261,7 @@ msgstr "Konto wiederhergestellt. Das Mitglied kann sich wieder anmelden."
 msgid "Accounts removed as spam"
 msgstr "Als Spam entfernte Konten"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:424
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "Clear-cut spam or abuse?"
 msgstr "Eindeutiger Spam oder Missbrauch?"
@@ -10281,24 +10271,24 @@ msgstr "Eindeutiger Spam oder Missbrauch?"
 msgid "Could not restore this member."
 msgstr "Dieses Mitglied konnte nicht wiederhergestellt werden."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:439
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "Deactivate @%{slug} and mark the account as spam?"
 msgstr "@%{slug} deaktivieren und das Konto als Spam markieren?"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:442
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:473
 #, elixir-autogen, elixir-format
 msgid "Deactivate account"
 msgstr "Konto deaktivieren"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:451
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Permanently DELETE @%{slug} and everything they posted? This cannot be undone."
 msgstr ""
 "@%{slug} und alle Beiträge dauerhaft LÖSCHEN? Das kann nicht rückgängig "
 "gemacht werden."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:427
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:458
 #, elixir-autogen, elixir-format
 msgid "Remove the account outright, skipping the warning ladder. Deactivating marks it as spam and is reversible from the member browser; deleting is permanent."
 msgstr ""
@@ -10646,7 +10636,7 @@ msgstr[1] "%{formatted} Sterne"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:71
 #: lib/vutuv_web/agent_docs/text.ex:66
-#: lib/vutuv_web/templates/user/show.html.heex:1369
+#: lib/vutuv_web/templates/user/show.html.heex:1374
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Code"
@@ -11278,7 +11268,7 @@ msgstr "Versuche"
 msgid "Views"
 msgstr "Ansichten"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:299
+#: lib/vutuv_web/templates/user/edit.html.heex:305
 #, elixir-autogen, elixir-format
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
@@ -11287,19 +11277,19 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
-#: lib/vutuv/accounts/user.ex:1309
+#: lib/vutuv/accounts/user.ex:1316
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
-#: lib/vutuv/accounts/user.ex:1314
+#: lib/vutuv/accounts/user.ex:1321
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
-#: lib/vutuv/accounts/user.ex:1312
+#: lib/vutuv/accounts/user.ex:1319
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -11307,25 +11297,25 @@ msgid "Signed-in members only"
 msgstr "Nur angemeldete Mitglieder"
 
 #: lib/vutuv_web/components/welcome_components.ex:259
-#: lib/vutuv_web/templates/user/edit.html.heex:296
+#: lib/vutuv_web/templates/user/edit.html.heex:302
 #, elixir-autogen, elixir-format
 msgid "Who can see your availability?"
 msgstr "Wer kann Ihre Verfügbarkeit sehen?"
 
 #: lib/vutuv_web/components/welcome_components.ex:270
-#: lib/vutuv_web/templates/user/edit.html.heex:321
+#: lib/vutuv_web/templates/user/edit.html.heex:327
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr "Betrag"
 
 #: lib/vutuv_web/components/welcome_components.ex:278
 #: lib/vutuv_web/live/job_posting_live/form.ex:693
-#: lib/vutuv_web/templates/user/edit.html.heex:329
+#: lib/vutuv_web/templates/user/edit.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr "Währung"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:339
+#: lib/vutuv_web/templates/user/edit.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "Hidden by default, and it still does its job while hidden. \"Signed-in members only\" adds a quiet line to your profile for members; \"Everyone\" also shows it to logged-out visitors."
 msgstr ""
@@ -11334,12 +11324,12 @@ msgstr ""
 "Mitglieder; „Alle“ zeigt sie auch nicht angemeldeten Besuchern."
 
 #: lib/vutuv_web/components/welcome_components.ex:266
-#: lib/vutuv_web/templates/user/edit.html.heex:312
+#: lib/vutuv_web/templates/user/edit.html.heex:318
 #, elixir-autogen, elixir-format
 msgid "Minimum salary expectation"
 msgstr "Mindest-Gehaltsvorstellung"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:315
+#: lib/vutuv_web/templates/user/edit.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
@@ -11349,17 +11339,17 @@ msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:274
 #: lib/vutuv_web/live/job_posting_live/form.ex:700
-#: lib/vutuv_web/templates/user/edit.html.heex:325
+#: lib/vutuv_web/templates/user/edit.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "Per"
 msgstr "Pro"
 
-#: lib/vutuv_web/templates/user/show.html.heex:315
+#: lib/vutuv_web/templates/user/show.html.heex:320
 #, elixir-autogen, elixir-format
 msgid "Salary expectation from %{amount} %{currency} per %{period}"
 msgstr "Gehaltsvorstellung ab %{amount} %{currency} pro %{period}"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:336
+#: lib/vutuv_web/templates/user/edit.html.heex:342
 #, elixir-autogen, elixir-format
 msgid "Who can see your salary expectation?"
 msgstr "Wer kann Ihre Gehaltsvorstellung sehen?"
@@ -11428,7 +11418,7 @@ msgstr "Ein Mitglied ausschließen"
 msgid "Exclude an email domain"
 msgstr "Eine E-Mail-Domain ausschließen"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:387
+#: lib/vutuv_web/templates/user/edit.html.heex:393
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr "Vor bestimmten Personen verbergen"
@@ -11439,7 +11429,7 @@ msgstr "Vor bestimmten Personen verbergen"
 msgid "Job-search exclusion list"
 msgstr "Ausschlussliste für die Jobsuche"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:390
+#: lib/vutuv_web/templates/user/edit.html.heex:396
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
@@ -11448,7 +11438,7 @@ msgstr ""
 "Mitglieder oder E-Mail-Domains aus; sie sehen Ihre Verfügbarkeit und Ihre "
 "Gehaltsvorstellung dann nie, auch nicht bei „Alle“."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:398
+#: lib/vutuv_web/templates/user/edit.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -11599,12 +11589,12 @@ msgstr "Stellen Sie diese Datei bereit unter:"
 msgid "State / region (optional)"
 msgstr "Bundesland / Region (optional)"
 
-#: lib/vutuv_web/components/ui.ex:4495
+#: lib/vutuv_web/components/ui.ex:4507
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr "Dieser Dateityp ist nicht erlaubt."
 
-#: lib/vutuv_web/components/ui.ex:4497
+#: lib/vutuv_web/components/ui.ex:4509
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr "Der Upload ist fehlgeschlagen."
@@ -12324,7 +12314,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:462
-#: lib/vutuv_web/components/ui.ex:5374
+#: lib/vutuv_web/components/ui.ex:5386
 #: lib/vutuv_web/controllers/settings_controller.ex:222
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
@@ -12646,7 +12636,7 @@ msgstr "Hervorgehobene Tags passen zu Ihrem Profil."
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
 
-#: lib/vutuv/accounts/user.ex:1283
+#: lib/vutuv/accounts/user.ex:1290
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12765,7 +12755,7 @@ msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
 
-#: lib/vutuv/accounts/user.ex:1282
+#: lib/vutuv/accounts/user.ex:1289
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12847,7 +12837,7 @@ msgstr "Anzeige nicht gefunden."
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: lib/vutuv/accounts/user.ex:1284
+#: lib/vutuv/accounts/user.ex:1291
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:590
 #: lib/vutuv_web/agent_docs/markdown.ex:532
@@ -12984,7 +12974,7 @@ msgstr "Arbeitsort"
 msgid "You already have the maximum number of published postings."
 msgstr "Sie haben bereits die maximale Anzahl veröffentlichter Anzeigen."
 
-#: lib/vutuv/notifications/emailer.ex:1123
+#: lib/vutuv/notifications/emailer.ex:1157
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr "Ihre Stellenanzeige auf vutuv läuft bald ab"
@@ -13550,7 +13540,7 @@ msgstr "Suche speichern"
 msgid "Saved search deleted."
 msgstr "Gespeicherte Suche gelöscht."
 
-#: lib/vutuv_web/components/ui.ex:5283
+#: lib/vutuv_web/components/ui.ex:5295
 #: lib/vutuv_web/controllers/settings_controller.ex:629
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13570,7 +13560,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/components/post_components.ex:3607
+#: lib/vutuv_web/components/post_components.ex:3662
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -13825,7 +13815,7 @@ msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7
 msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 Tagen abgelehnt. Eine wachsende Warteschlange bedeutet meist, dass Ollama nicht erreichbar ist."
 
 #: lib/vutuv_web/templates/user/edit.html.heex:41
-#: lib/vutuv_web/templates/user/edit.html.heex:121
+#: lib/vutuv_web/templates/user/edit.html.heex:125
 #: lib/vutuv_web/templates/user/show.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Image awaiting review, visible only to you"
@@ -13842,7 +13832,7 @@ msgstr "Bildprüfung"
 msgid "No images waiting for the AI scan. %{formatted} rejected in the last 7 days."
 msgstr "Keine Bilder in der KI-Prüfung. %{formatted} in den letzten 7 Tagen abgelehnt."
 
-#: lib/vutuv_web/templates/user/show.html.heex:208
+#: lib/vutuv_web/templates/user/show.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Profile picture awaiting review, visible only to you"
 msgstr "Profilbild wird geprüft, nur für Sie sichtbar"
@@ -13872,36 +13862,36 @@ msgstr "Screenshot entfernt."
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
-#: lib/vutuv/accounts/user.ex:1327
+#: lib/vutuv/accounts/user.ex:1334
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
 msgstr "Nur das Alter, ohne das Datum"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:450
+#: lib/vutuv_web/templates/user/edit.html.heex:456
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
-#: lib/vutuv/accounts/user.ex:1330
+#: lib/vutuv/accounts/user.ex:1337
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
-#: lib/vutuv/accounts/user.ex:1333
+#: lib/vutuv/accounts/user.ex:1340
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
-#: lib/vutuv/accounts/user.ex:1324
+#: lib/vutuv/accounts/user.ex:1331
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
 msgstr "Vollständiges Datum und Alter"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:447
+#: lib/vutuv_web/templates/user/edit.html.heex:453
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr "Geburtstag anzeigen als"
@@ -14022,7 +14012,7 @@ msgstr ""
 "Personen tauchen in Ihren Vorschlägen auf. Einem Tag folgen Sie auf seiner "
 "Seite."
 
-#: lib/vutuv_web/components/ui.ex:5266
+#: lib/vutuv_web/components/ui.ex:5278
 #: lib/vutuv_web/controllers/settings_controller.ex:643
 #: lib/vutuv_web/live/post_live/feed.ex:710
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -14070,7 +14060,7 @@ msgstr "Signal und WhatsApp akzeptieren eine Telefonnummer oder einen Benutzerna
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1335
+#: lib/vutuv_web/templates/user/show.html.heex:1340
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr "Messenger hinzufügen"
@@ -14099,7 +14089,7 @@ msgstr "Messenger wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:63
-#: lib/vutuv_web/components/ui.ex:5223
+#: lib/vutuv_web/components/ui.ex:5235
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -14107,7 +14097,7 @@ msgstr "Messenger wurde geändert."
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1333
+#: lib/vutuv_web/templates/user/show.html.heex:1338
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr "Messenger"
@@ -14127,14 +14117,14 @@ msgstr "Messenger von %{name}"
 msgid "Select a messenger"
 msgstr "Messenger auswählen"
 
-#: lib/vutuv_web/components/ui.ex:4580
+#: lib/vutuv_web/components/ui.ex:4592
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] "Meinen Follower darüber informieren"
 msgstr[1] "Meine %{formatted} Follower darüber informieren"
 
-#: lib/vutuv_web/components/ui.ex:4590
+#: lib/vutuv_web/components/ui.ex:4602
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
@@ -14184,34 +14174,34 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:6134
+#: lib/vutuv_web/components/post_components.ex:6189
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:6091
+#: lib/vutuv_web/components/post_components.ex:6146
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:6135
+#: lib/vutuv_web/components/post_components.ex:6190
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:6137
+#: lib/vutuv_web/components/post_components.ex:6192
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:6133
+#: lib/vutuv_web/components/post_components.ex:6188
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:6090
+#: lib/vutuv_web/components/post_components.ex:6145
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14222,12 +14212,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:6132
+#: lib/vutuv_web/components/post_components.ex:6187
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:6136
+#: lib/vutuv_web/components/post_components.ex:6191
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14247,7 +14237,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:6173
+#: lib/vutuv_web/components/post_components.ex:6228
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14255,27 +14245,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:6203
+#: lib/vutuv_web/components/post_components.ex:6258
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:6204
+#: lib/vutuv_web/components/post_components.ex:6259
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:6202
+#: lib/vutuv_web/components/post_components.ex:6257
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:6162
+#: lib/vutuv_web/components/post_components.ex:6217
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:6209
+#: lib/vutuv_web/components/post_components.ex:6264
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14305,7 +14295,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5976
+#: lib/vutuv_web/components/post_components.ex:6031
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14348,7 +14338,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:5967
+#: lib/vutuv_web/components/post_components.ex:6022
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -14536,7 +14526,7 @@ msgid "Are you looking for a job?"
 msgstr "Suchen Sie eine Stelle?"
 
 #: lib/vutuv_web/components/welcome_components.ex:290
-#: lib/vutuv_web/templates/user/edit.html.heex:359
+#: lib/vutuv_web/templates/user/edit.html.heex:365
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr "Wie möchten Sie arbeiten?"
@@ -14553,12 +14543,12 @@ msgid "Preferred workplace"
 msgstr "Bevorzugte Arbeitsform"
 
 #: lib/vutuv_web/components/welcome_components.ex:249
-#: lib/vutuv_web/templates/user/edit.html.heex:287
+#: lib/vutuv_web/templates/user/edit.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "Availability"
 msgstr "Verfügbarkeit"
 
-#: lib/vutuv/notifications/emailer.ex:1085
+#: lib/vutuv/notifications/emailer.ex:1111
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Eine automatische Prüfung hat ein Bild aus Ihrem vutuv-Konto entfernt"
@@ -14711,14 +14701,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:3896
+#: lib/vutuv_web/components/post_components.ex:3951
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:3919
+#: lib/vutuv_web/components/post_components.ex:3974
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14745,7 +14735,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:6687
+#: lib/vutuv_web/components/post_components.ex:6742
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -14903,7 +14893,7 @@ msgstr "Blenden Sie Beiträge aus Ihrem Feed aus, die ein Tag tragen oder ein Wo
 msgid "Match whole words only (word/phrase)"
 msgstr "Nur ganze Wörter treffen (Wort/Phrase)"
 
-#: lib/vutuv_web/components/ui.ex:5237
+#: lib/vutuv_web/components/ui.ex:5249
 #: lib/vutuv_web/controllers/settings_controller.ex:773
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -15483,7 +15473,7 @@ msgstr "Anwendung bearbeiten"
 msgid "Book an ad"
 msgstr "Anzeige buchen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1042
+#: lib/vutuv_web/templates/user/show.html.heex:1047
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr "%{name} hat dieses Fediverse-Konto umgezogen. Folgen Sie stattdessen der neuen Adresse:"
@@ -15539,252 +15529,252 @@ msgstr "Ihr Server"
 msgid "moved to %{address}"
 msgstr "umgezogen nach %{address}"
 
-#: lib/vutuv_web/components/ui.ex:5165
+#: lib/vutuv_web/components/ui.ex:5177
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr "Name, Foto, Titelbild, Kurzbeschreibung"
 
-#: lib/vutuv_web/components/ui.ex:5170
+#: lib/vutuv_web/components/ui.ex:5182
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr "handle spitzname nutzername umbenennen slug profiladresse url erwähnung"
 
-#: lib/vutuv_web/components/ui.ex:5173
+#: lib/vutuv_web/components/ui.ex:5185
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr "Die Stationen in Ihrem Lebenslauf"
 
-#: lib/vutuv_web/components/ui.ex:5174
+#: lib/vutuv_web/components/ui.ex:5186
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr "lebenslauf cv karriere beruf arbeitgeber position stelle job firma"
 
-#: lib/vutuv_web/components/ui.ex:5177
+#: lib/vutuv_web/components/ui.ex:5189
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr "Schulen, Hochschulen, Abschlüsse"
 
-#: lib/vutuv_web/components/ui.ex:5178
+#: lib/vutuv_web/components/ui.ex:5190
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr "lebenslauf studium schule universität hochschule abschluss ausbildung"
 
-#: lib/vutuv_web/components/ui.ex:5181
+#: lib/vutuv_web/components/ui.ex:5193
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr "Nachweise, mit Belegdokumenten"
 
-#: lib/vutuv_web/components/ui.ex:5182
+#: lib/vutuv_web/components/ui.ex:5194
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr "zertifikat lizenz urkunde diplom nachweis beleg auszeichnung dokument"
 
-#: lib/vutuv_web/components/ui.ex:5189
+#: lib/vutuv_web/components/ui.ex:5201
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr "Sprachkenntnisse"
 
-#: lib/vutuv_web/components/ui.ex:5190
+#: lib/vutuv_web/components/ui.ex:5202
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr "Die Sprachen, die Sie sprechen"
 
-#: lib/vutuv_web/components/ui.ex:5191
+#: lib/vutuv_web/components/ui.ex:5203
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr "sprache sprachen sprechen fließend muttersprache verhandlungssicher"
 
-#: lib/vutuv_web/components/ui.ex:5194
+#: lib/vutuv_web/components/ui.ex:5206
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr "Die Themen, für die Sie bekannt sind"
 
-#: lib/vutuv_web/components/ui.ex:5195
+#: lib/vutuv_web/components/ui.ex:5207
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr "fähigkeit kenntnis thema stichwort schlagwort expertise empfehlung"
 
-#: lib/vutuv_web/components/ui.ex:5375
+#: lib/vutuv_web/components/ui.ex:5387
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr "Organisationsseiten, die Sie verwalten"
 
-#: lib/vutuv_web/components/ui.ex:5376
+#: lib/vutuv_web/components/ui.ex:5388
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr "firma unternehmen arbeitgeber betrieb organisation seite"
 
-#: lib/vutuv_web/components/ui.ex:5198
+#: lib/vutuv_web/components/ui.ex:5210
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr "Kontaktdaten"
 
-#: lib/vutuv_web/components/ui.ex:5201
+#: lib/vutuv_web/components/ui.ex:5213
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr "Wo wir Sie erreichen, und welche Adresse öffentlich ist"
 
-#: lib/vutuv_web/components/ui.ex:5202
+#: lib/vutuv_web/components/ui.ex:5214
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr "mail e-mail email adresse hauptadresse primär"
 
-#: lib/vutuv_web/components/ui.ex:5205
+#: lib/vutuv_web/components/ui.ex:5217
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr "Festnetz, Mobil, Fax"
 
-#: lib/vutuv_web/components/ui.ex:5206
+#: lib/vutuv_web/components/ui.ex:5218
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr "telefon handy mobil festnetz fax nummer rufnummer"
 
-#: lib/vutuv_web/components/ui.ex:5209
+#: lib/vutuv_web/components/ui.ex:5221
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr "Postanschriften auf Ihrem Profil"
 
-#: lib/vutuv_web/components/ui.ex:5210
+#: lib/vutuv_web/components/ui.ex:5222
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr "straße stadt ort postleitzahl plz land anschrift karte"
 
-#: lib/vutuv_web/components/ui.ex:5212
+#: lib/vutuv_web/components/ui.ex:5224
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr "Webseiten & Links"
 
-#: lib/vutuv_web/components/ui.ex:5213
+#: lib/vutuv_web/components/ui.ex:5225
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr "Ihre Homepage und weitere Links"
 
-#: lib/vutuv_web/components/ui.ex:5214
+#: lib/vutuv_web/components/ui.ex:5226
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr "url webseite website homepage blog link verifizieren bestätigen rel=me"
 
-#: lib/vutuv_web/components/ui.ex:5216
+#: lib/vutuv_web/components/ui.ex:5228
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr "Social-Media-Profile"
 
-#: lib/vutuv_web/components/ui.ex:5217
+#: lib/vutuv_web/components/ui.ex:5229
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr "Mastodon, Bluesky, GitHub und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:5219
+#: lib/vutuv_web/components/ui.ex:5231
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr "mastodon bluesky github gitlab codeberg linkedin x twitter instagram soziale netzwerke"
 
-#: lib/vutuv_web/components/ui.ex:5224
+#: lib/vutuv_web/components/ui.ex:5236
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr "Signal, Threema, Matrix und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:5225
+#: lib/vutuv_web/components/ui.ex:5237
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr "signal threema matrix xmpp telegram whatsapp chat messenger nachrichten"
 
-#: lib/vutuv_web/components/ui.ex:5228
+#: lib/vutuv_web/components/ui.ex:5240
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr "Mitteilungen & Feed"
 
-#: lib/vutuv_web/components/ui.ex:5231
+#: lib/vutuv_web/components/ui.ex:5243
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr "Welche E-Mails wir schicken, und was die Glocke meldet"
 
-#: lib/vutuv_web/components/ui.ex:5238
+#: lib/vutuv_web/components/ui.ex:5250
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr "Beiträge aus Ihrem Feed heraushalten"
 
-#: lib/vutuv_web/components/ui.ex:5239
+#: lib/vutuv_web/components/ui.ex:5251
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr "stummschalten ausblenden verbergen filter wort begriff tag feed blockieren"
 
-#: lib/vutuv_web/components/ui.ex:5267
+#: lib/vutuv_web/components/ui.ex:5279
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr "Themen, deren Beiträge in Ihrem Feed landen"
 
-#: lib/vutuv_web/components/ui.ex:5268
+#: lib/vutuv_web/components/ui.ex:5280
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr "tag thema abonnieren folgen feed"
 
-#: lib/vutuv_web/components/ui.ex:5284
+#: lib/vutuv_web/components/ui.ex:5296
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr "Job- und Personensuchen, die Ihnen neue Treffer mailen"
 
-#: lib/vutuv_web/components/ui.ex:5285
+#: lib/vutuv_web/components/ui.ex:5297
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr "job stelle stellenangebot suchauftrag suche alarm benachrichtigung merkliste"
 
-#: lib/vutuv_web/components/ui.ex:5332
+#: lib/vutuv_web/components/ui.ex:5344
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr "Suchmaschinen, KI, Online-Status"
 
-#: lib/vutuv_web/components/ui.ex:5333
+#: lib/vutuv_web/components/ui.ex:5345
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr "privatsphäre datenschutz google suchmaschine ki ai llm crawler noindex online punkt öffentlich sichtbar"
 
-#: lib/vutuv_web/components/ui.ex:5336
+#: lib/vutuv_web/components/ui.ex:5348
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr "Personen, die nicht mit Ihnen interagieren können"
 
-#: lib/vutuv_web/components/ui.ex:5337
+#: lib/vutuv_web/components/ui.ex:5349
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr "blockieren sperren bannen stummschalten melden missbrauch belästigung"
 
-#: lib/vutuv_web/components/ui.ex:5358
+#: lib/vutuv_web/components/ui.ex:5370
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr "Passkeys, angemeldete Geräte, Anmeldecodes"
 
-#: lib/vutuv_web/components/ui.ex:5359
+#: lib/vutuv_web/components/ui.ex:5371
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr "passwort kennwort anmelden abmelden login logout sitzung gerät passkey totp 2fa pin sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:5367
+#: lib/vutuv_web/components/ui.ex:5379
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr "Ihre Daten von LinkedIn übernehmen"
 
-#: lib/vutuv_web/components/ui.ex:5368
+#: lib/vutuv_web/components/ui.ex:5380
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr "linkedin hochladen zip übernehmen importieren umzug"
 
-#: lib/vutuv_web/components/ui.ex:5371
+#: lib/vutuv_web/components/ui.ex:5383
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr "Alles herunterladen, was wir über Sie speichern"
 
-#: lib/vutuv_web/components/ui.ex:5372
+#: lib/vutuv_web/components/ui.ex:5384
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr "herunterladen download dsgvo gdpr daten sicherung json lebenslauf auskunft"
 
-#: lib/vutuv_web/components/ui.ex:5386
+#: lib/vutuv_web/components/ui.ex:5398
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr "Ihr Konto und alles darauf entfernen"
 
-#: lib/vutuv_web/components/ui.ex:5387
+#: lib/vutuv_web/components/ui.ex:5399
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr "löschen entfernen schließen kündigen beenden verlassen"
@@ -15906,7 +15896,7 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:6633
+#: lib/vutuv_web/components/post_components.ex:6688
 #: lib/vutuv_web/live/notification_live/index.ex:1596
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -15914,7 +15904,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:6637
+#: lib/vutuv_web/components/post_components.ex:6692
 #: lib/vutuv_web/live/notification_live/index.ex:1590
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15922,7 +15912,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:6641
+#: lib/vutuv_web/components/post_components.ex:6696
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15930,7 +15920,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:6592
+#: lib/vutuv_web/components/post_components.ex:6647
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -15949,7 +15939,7 @@ msgid "Content warning"
 msgstr "Inhaltswarnung"
 
 #: lib/vutuv_web/components/post_components.ex:1581
-#: lib/vutuv_web/components/post_components.ex:2625
+#: lib/vutuv_web/components/post_components.ex:2680
 #: lib/vutuv_web/live/fediverse_account_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "From another network"
@@ -16028,7 +16018,7 @@ msgstr "Diese Antwort können Sie nicht entfernen."
 #: lib/vutuv_web/agent_docs/markdown.ex:1501
 #: lib/vutuv_web/components/post_components.ex:1496
 #: lib/vutuv_web/components/post_components.ex:1727
-#: lib/vutuv_web/components/post_components.ex:3465
+#: lib/vutuv_web/components/post_components.ex:3520
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -16261,7 +16251,7 @@ msgstr "API-Token erstellt"
 msgid "Access token revoked"
 msgstr "API-Token widerrufen"
 
-#: lib/vutuv_web/components/ui.ex:5361
+#: lib/vutuv_web/components/ui.ex:5373
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16606,7 +16596,7 @@ msgstr "Was sich an einem Konto geändert hat, wann, von wo und wie es bestätig
 msgid "What changed on your account, and exactly when."
 msgstr "Was sich an Ihrem Konto geändert hat, und wann genau."
 
-#: lib/vutuv_web/components/ui.ex:5362
+#: lib/vutuv_web/components/ui.ex:5374
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr "Was sich an Ihrem Konto geändert hat, und wann"
@@ -16642,7 +16632,7 @@ msgstr "durch den Betreiber"
 msgid "from a signed-in session"
 msgstr "aus einer angemeldeten Sitzung"
 
-#: lib/vutuv_web/components/ui.ex:5364
+#: lib/vutuv_web/components/ui.ex:5376
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr "protokoll verlauf historie chronik audit sicherheit war ich das wer hat wann geaendert geändert log"
@@ -16694,22 +16684,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:4081
+#: lib/vutuv_web/components/post_components.ex:4136
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:4207
+#: lib/vutuv_web/components/post_components.ex:4262
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:4215
+#: lib/vutuv_web/components/post_components.ex:4270
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:4201
+#: lib/vutuv_web/components/post_components.ex:4256
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -16738,19 +16728,19 @@ msgstr "angehefteter Beitrag"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:626
 #: lib/vutuv_web/agent_docs/text.ex:611
-#: lib/vutuv_web/templates/user/edit.html.heex:219
-#: lib/vutuv_web/templates/user/show.html.heex:286
+#: lib/vutuv_web/templates/user/edit.html.heex:225
+#: lib/vutuv_web/templates/user/show.html.heex:291
 #: lib/vutuv_web/views/account_event_text.ex:213
 #, elixir-autogen, elixir-format
 msgid "Name pronunciation"
 msgstr "Aussprache des Namens"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:223
+#: lib/vutuv_web/templates/user/edit.html.heex:229
 #, elixir-autogen, elixir-format
 msgid "e.g. [SHTEH-fahn VIN-ter-my-er]"
 msgstr "z. B. [SCHTEH-fan WIN-ter-mei-er]"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:226
+#: lib/vutuv_web/templates/user/edit.html.heex:232
 #, elixir-autogen, elixir-format
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
@@ -16838,17 +16828,17 @@ msgstr "Nächstes Foto"
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:3660
+#: lib/vutuv_web/components/post_components.ex:3715
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:5091
+#: lib/vutuv_web/components/post_components.ex:5146
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:5240
+#: lib/vutuv_web/components/post_components.ex:5295
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -16861,7 +16851,7 @@ msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1462
 #: lib/vutuv_web/agent_docs/text.ex:890
-#: lib/vutuv_web/components/post_components.ex:5322
+#: lib/vutuv_web/components/post_components.ex:5377
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
@@ -16887,7 +16877,7 @@ msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qual
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:3713
+#: lib/vutuv_web/components/post_components.ex:3768
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
@@ -16907,7 +16897,7 @@ msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen S
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/components/post_components.ex:3704
+#: lib/vutuv_web/components/post_components.ex:3759
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
@@ -16917,12 +16907,12 @@ msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht �
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/components/post_components.ex:3722
+#: lib/vutuv_web/components/post_components.ex:3777
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Diese Seite nimmt nicht am Fediverse teil."
 
-#: lib/vutuv_web/components/post_components.ex:3656
+#: lib/vutuv_web/components/post_components.ex:3711
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
@@ -16937,7 +16927,7 @@ msgstr "Wer diese Fotos weiterverwenden darf"
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:3717
+#: lib/vutuv_web/components/post_components.ex:3772
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
@@ -16947,7 +16937,7 @@ msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshal
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
 
-#: lib/vutuv_web/components/post_components.ex:3670
+#: lib/vutuv_web/components/post_components.ex:3725
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fediverse-Follower. Auf vutuv ist sie ebenfalls ein öffentlicher Beitrag."
@@ -17022,13 +17012,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1319
-#: lib/vutuv_web/components/post_components.ex:6630
+#: lib/vutuv_web/components/post_components.ex:6685
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1317
-#: lib/vutuv_web/components/post_components.ex:6627
+#: lib/vutuv_web/components/post_components.ex:6682
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17038,7 +17028,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:6514
+#: lib/vutuv_web/components/post_components.ex:6569
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17165,7 +17155,7 @@ msgstr "Ein Konto in einem anderen Netzwerk"
 msgid "Cancel request"
 msgstr "Anfrage zurückziehen"
 
-#: lib/vutuv_web/components/ui.ex:5348
+#: lib/vutuv_web/components/ui.ex:5360
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Konten auf Mastodon folgen, und von dort gefolgt werden"
@@ -17368,7 +17358,7 @@ msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, desh
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr "Ihr Konto ist derzeit gesperrt, deshalb geht nichts von Ihnen an andere Netzwerke und Sie können dort niemandem folgen. Das endet von selbst, sobald die Sperre abläuft."
 
-#: lib/vutuv_web/components/ui.ex:5350
+#: lib/vutuv_web/components/ui.ex:5362
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr "mastodon activitypub foederation federation follower folgen folge umzug migration entferntes konto"
@@ -17388,7 +17378,7 @@ msgstr "Von hier aus wird %{follows} Konten in anderen Netzwerken gefolgt, davon
 msgid "Cached posts"
 msgstr "Zwischengespeicherte Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:3224
+#: lib/vutuv_web/components/post_components.ex:3279
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Nur für die Follower dieses Kontos"
@@ -17398,7 +17388,7 @@ msgstr "Nur für die Follower dieses Kontos"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:3464
+#: lib/vutuv_web/components/post_components.ex:3519
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -17423,7 +17413,7 @@ msgstr "Von Mitgliedern entfernte Inhalte aus anderen Netzwerken"
 msgid "Hide"
 msgstr "Verbergen"
 
-#: lib/vutuv_web/components/post_components.ex:3405
+#: lib/vutuv_web/components/post_components.ex:3460
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Von der verfassenden Person als sensibel markiert"
@@ -17438,7 +17428,7 @@ msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwin
 msgid "Nobody has removed or reported anything yet."
 msgstr "Bisher hat niemand etwas entfernt oder gemeldet."
 
-#: lib/vutuv_web/components/post_components.ex:3197
+#: lib/vutuv_web/components/post_components.ex:3252
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr "Diesen Beitrag als unangemessen melden? Unsere Kopie wird sofort für alle auf diesem vutuv gelöscht."
@@ -17526,7 +17516,7 @@ msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, desh
 msgid "Your account move"
 msgstr "Ihr Kontoumzug"
 
-#: lib/vutuv_web/views/page_html.ex:28
+#: lib/vutuv_web/views/page_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "“LinkedIn is annoying. vutuv is not.”"
 msgstr "„LinkedIn nervt. vutuv nicht.“"
@@ -17538,27 +17528,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(ein Bild)"
 msgstr[1] "(%{count} Bilder)"
 
-#: lib/vutuv_web/components/post_components.ex:2798
+#: lib/vutuv_web/components/post_components.ex:2853
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr "Bild wird geprüft"
 
-#: lib/vutuv_web/components/post_components.ex:2831
+#: lib/vutuv_web/components/post_components.ex:2886
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Wieder verdecken"
 
-#: lib/vutuv_web/components/post_components.ex:2826
+#: lib/vutuv_web/components/post_components.ex:2881
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Heikles Motiv. Bild anzeigen."
 
-#: lib/vutuv_web/components/post_components.ex:3563
+#: lib/vutuv_web/components/post_components.ex:3618
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:3569
+#: lib/vutuv_web/components/post_components.ex:3624
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
@@ -17568,7 +17558,7 @@ msgstr "Diesen Beitrag gibt es hier nicht mehr."
 msgid "Back to the feed"
 msgstr "Zurück zum Feed"
 
-#: lib/vutuv_web/components/post_components.ex:3708
+#: lib/vutuv_web/components/post_components.ex:3763
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18245,7 +18235,7 @@ msgstr "Auf vutuv gibt es zu diesem Tag noch keine Beiträge."
 msgid "word in a post"
 msgstr "Wort in einem Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:3566
+#: lib/vutuv_web/components/post_components.ex:3621
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Diese Antwort gibt es hier nicht mehr."
@@ -18317,19 +18307,19 @@ msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:5616
+#: lib/vutuv_web/components/post_components.ex:5671
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5618
+#: lib/vutuv_web/components/post_components.ex:5673
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:5629
+#: lib/vutuv_web/components/post_components.ex:5684
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
@@ -18391,7 +18381,7 @@ msgstr "Für dieses Zeugnis läuft bereits eine Prüfung."
 #: lib/vutuv_web/controllers/job_reference_controller.ex:144
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:18
 #: lib/vutuv_web/templates/job_reference/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:804
+#: lib/vutuv_web/templates/user/show.html.heex:809
 #, elixir-autogen, elixir-format
 msgid "Add an employment reference"
 msgstr "Arbeitszeugnis hinzufügen"
@@ -18458,7 +18448,7 @@ msgstr "Arbeitszeugnis aktualisiert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:5184
+#: lib/vutuv_web/components/ui.ex:5196
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -18468,7 +18458,7 @@ msgstr "Arbeitszeugnis aktualisiert."
 #: lib/vutuv_web/templates/job_reference/new.html.heex:4
 #: lib/vutuv_web/templates/job_reference/show.html.heex:12
 #: lib/vutuv_web/templates/job_reference/view.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:801
+#: lib/vutuv_web/templates/user/show.html.heex:806
 #, elixir-autogen, elixir-format
 msgid "Employment references"
 msgstr "Arbeitszeugnisse"
@@ -18653,7 +18643,7 @@ msgstr "In der Warteschlange, Ihres ist als Nächstes dran."
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr "Sie haben den Text nach dieser Prüfung geändert. Sie beschreibt die frühere Fassung."
 
-#: lib/vutuv_web/components/ui.ex:5185
+#: lib/vutuv_web/components/ui.ex:5197
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr "Ihre Arbeitszeugnisse, privat bis Sie sie veröffentlichen"
@@ -18664,7 +18654,7 @@ msgstr "Ihre Arbeitszeugnisse, privat bis Sie sie veröffentlichen"
 msgid "Zwischenzeugnis"
 msgstr "Zwischenzeugnis"
 
-#: lib/vutuv_web/components/ui.ex:5187
+#: lib/vutuv_web/components/ui.ex:5199
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr "arbeitszeugnis zeugnis referenz beurteilung arbeitgeber bewertung prüfung"
@@ -18919,7 +18909,7 @@ msgstr "Datei hierher ziehen oder eine auswählen"
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr "PDF, JPG, PNG oder WebP, bis %{limit}"
 
-#: lib/vutuv_web/components/ui.ex:4481
+#: lib/vutuv_web/components/ui.ex:4493
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -19099,7 +19089,7 @@ msgstr "Ihr vutuv-Benutzername steht fest."
 msgid "by the lawyer Tom Braegelmann"
 msgstr "von Rechtsanwalt Tom Braegelmann"
 
-#: lib/vutuv_web/templates/user/show.html.heex:845
+#: lib/vutuv_web/templates/user/show.html.heex:850
 #, elixir-autogen, elixir-format
 msgid "Documents:"
 msgstr "Belegt:"
@@ -19227,17 +19217,17 @@ msgstr ""
 "Kommt keine PIN an? Ist die E-Mail-Adresse {email} korrekt? Haben Sie einmal "
 "in Ihren Spam-Ordner geschaut?"
 
-#: lib/vutuv/accounts/user.ex:1430
+#: lib/vutuv/accounts/user.ex:1437
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/vutuv/accounts/user.ex:1428
+#: lib/vutuv/accounts/user.ex:1435
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Weiblich"
 
-#: lib/vutuv/accounts/user.ex:1429
+#: lib/vutuv/accounts/user.ex:1436
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
@@ -19249,7 +19239,7 @@ msgstr ""
 "Anteile bezogen auf die %{answered} Mitglieder mit Angabe. %{unanswered} ohne "
 "Angabe."
 
-#: lib/vutuv_web/components/ui.ex:5166
+#: lib/vutuv_web/components/ui.ex:5178
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr "avatar profilbild portrait foto bild geburtstag geburtsdatum geschlecht über mich"
@@ -19345,7 +19335,7 @@ msgstr "Ebenfalls löschen"
 msgid "Always keep"
 msgstr "Immer behalten"
 
-#: lib/vutuv_web/components/ui.ex:5341
+#: lib/vutuv_web/components/ui.ex:5353
 #: lib/vutuv_web/controllers/settings_controller.ex:256
 #: lib/vutuv_web/controllers/settings_controller.ex:335
 #: lib/vutuv_web/controllers/settings_controller.ex:347
@@ -19442,7 +19432,7 @@ msgstr "Fotobeiträge behalten"
 msgid "Keep posts that did well"
 msgstr "Beiträge behalten, die gut liefen"
 
-#: lib/vutuv_web/components/ui.ex:5343
+#: lib/vutuv_web/components/ui.ex:5355
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr "Ihre Beiträge nach einer selbst gewählten Zeit auslaufen lassen"
@@ -19551,7 +19541,7 @@ msgstr "Sie können vorher alles herunterladen, was Sie hier haben:"
 msgid "Your rule"
 msgstr "Ihre Regel"
 
-#: lib/vutuv_web/components/ui.ex:5345
+#: lib/vutuv_web/components/ui.ex:5357
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr "löschen entfernen beiträge alter alt ablaufen verfallen automatisch aufräumen aufbewahrung"
@@ -19925,7 +19915,7 @@ msgstr "Suchen Sie so oft Sie möchten und nehmen Sie dazu, was gehört. Abkürz
 msgid "Start over"
 msgstr "Von vorn beginnen"
 
-#: lib/vutuv_web/components/post_components.ex:3596
+#: lib/vutuv_web/components/post_components.ex:3651
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr "Ein Herz oder ein Repost geht zurück in das Netzwerk, aus dem dieser Beitrag stammt. Ihr Konto nimmt derzeit nicht am Fediverse teil. Einschalten können Sie das in den {settings}."
@@ -20082,7 +20072,7 @@ msgstr[1] "%{formatted} neu"
 msgid "%{name} mentioned this page."
 msgstr "%{name} hat diese Seite erwähnt."
 
-#: lib/vutuv_web/templates/user/show.html.heex:184
+#: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
 msgid "%{name} follows"
 msgstr "%{name} folgt"
@@ -20092,7 +20082,7 @@ msgstr "%{name} folgt"
 msgid "Feed – %{name}"
 msgstr "Feed – %{name}"
 
-#: lib/vutuv_web/templates/user/show.html.heex:185
+#: lib/vutuv_web/templates/user/show.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "Follow as %{name}"
 msgstr "Als %{name} folgen"
@@ -20467,7 +20457,7 @@ msgstr "eine Adresse in einem anderen Netzwerk: vutuv bietet Ihnen an, ihr zu fo
 msgid "the address of a post out there: vutuv fetches it so you can answer it here"
 msgstr "die Adresse eines Beitrags dort draußen: vutuv holt ihn, damit Sie hier darauf antworten können"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:81
+#: lib/vutuv_web/templates/user/edit.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Fetch my picture from gravatar.com"
 msgstr "Mein Bild von gravatar.com holen"
@@ -20492,7 +20482,7 @@ msgstr "gravatar.com war nicht erreichbar. Bitte versuchen Sie es später noch e
 msgid "gravatar.com has no picture for your email address."
 msgstr "gravatar.com hat kein Bild zu Ihrer E-Mail-Adresse."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:84
+#: lib/vutuv_web/templates/user/edit.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "Only when you press this: we ask gravatar.com whether there is a picture for your email address, sending a hash of the address rather than the address itself. Nothing leaves this server otherwise."
 msgstr "Nur wenn Sie hier klicken: Wir fragen bei gravatar.com nach, ob es zu Ihrer E-Mail-Adresse ein Bild gibt, und übermitteln dafür einen Hashwert der Adresse, nicht die Adresse selbst. Sonst verlässt nichts diesen Server."
@@ -20812,27 +20802,27 @@ msgstr "Sprache"
 msgid "The language this post is written in"
 msgstr "Die Sprache, in der dieser Beitrag geschrieben ist"
 
-#: lib/vutuv_web/components/post_components.ex:5510
+#: lib/vutuv_web/components/post_components.ex:5565
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Original anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:5546
+#: lib/vutuv_web/components/post_components.ex:5601
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Übersetzen"
 
-#: lib/vutuv_web/components/post_components.ex:5555
+#: lib/vutuv_web/components/post_components.ex:5610
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Übersetzt"
 
-#: lib/vutuv_web/components/post_components.ex:5558
+#: lib/vutuv_web/components/post_components.ex:5613
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Übersetzt aus %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:5535
+#: lib/vutuv_web/components/post_components.ex:5590
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Wird übersetzt …"
@@ -20842,8 +20832,8 @@ msgstr "Wird übersetzt …"
 msgid "Feed language settings reset to the site defaults."
 msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
 
-#: lib/vutuv_web/components/post_components.ex:5525
-#: lib/vutuv_web/components/ui.ex:5259
+#: lib/vutuv_web/components/post_components.ex:5580
+#: lib/vutuv_web/components/ui.ex:5271
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -20971,32 +20961,32 @@ msgstr "Wir haben den Link in Ihrem Profil noch nicht gefunden. Bitte versuchen 
 msgid "Your username, or paste the address of your profile page."
 msgstr "Ihr Benutzername – oder fügen Sie die Adresse Ihrer Profilseite ein."
 
-#: lib/vutuv_web/components/post_components.ex:5288
+#: lib/vutuv_web/components/post_components.ex:5343
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] "Unsere KI prüft es gerade. Sobald die Prüfung durch ist, erscheint das Foto von selbst."
 msgstr[1] "Unsere KI prüft sie gerade, %{done} von %{total} sind durch. Sobald die letzte durch ist, erscheinen die Fotos von selbst."
 
-#: lib/vutuv_web/components/post_components.ex:5285
+#: lib/vutuv_web/components/post_components.ex:5340
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Ihr Beitrag ist veröffentlicht, das Foto noch nicht."
 
-#: lib/vutuv_web/components/post_components.ex:2852
-#: lib/vutuv_web/components/post_components.ex:4495
+#: lib/vutuv_web/components/post_components.ex:2907
+#: lib/vutuv_web/components/post_components.ex:4550
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
 msgstr[0] "Unsere KI sieht es sich an. Es erscheint hier von selbst, sobald sie durch ist."
 msgstr[1] "Unsere KI sieht sie sich an. Sie erscheinen hier von selbst, sobald sie durch ist."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:139
+#: lib/vutuv_web/templates/user/edit.html.heex:145
 #, elixir-autogen, elixir-format
 msgid "Recommended: %{width} × %{height} pixels (%{ratio})."
 msgstr "Empfohlen: %{width} × %{height} Pixel (%{ratio})."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:59
+#: lib/vutuv_web/templates/user/edit.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Empfohlen: quadratisch, mindestens %{width} × %{height} Pixel."
@@ -21054,7 +21044,7 @@ msgstr "Damit können Sie sich von einer Mastodon-kompatiblen App aus bei diesem
 msgid "Mastodon app access changed"
 msgstr "Mastodon-App-Zugriff geändert"
 
-#: lib/vutuv_web/components/ui.ex:5379
+#: lib/vutuv_web/components/ui.ex:5391
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr "Mastodon-Apps, verbundene Apps und Zugriffstoken"
@@ -21100,7 +21090,7 @@ msgstr "Wer etwas geschrieben hat, wird weiter festgehalten, das Team kann also 
 msgid "Your account is then %{handle}."
 msgstr "Dein Konto heißt dann %{handle}."
 
-#: lib/vutuv_web/components/ui.ex:5381
+#: lib/vutuv_web/components/ui.ex:5393
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr "api token oauth entwickler verbunden drittanbieter schnittstelle mastodon app handy telefon client ivory tusky ice cubes anmelden"
@@ -21135,7 +21125,7 @@ msgstr "Bekannte aus LinkedIn finden"
 msgid "Find your LinkedIn contacts"
 msgstr "Ihre LinkedIn-Kontakte finden"
 
-#: lib/vutuv_web/components/ui.ex:5275
+#: lib/vutuv_web/components/ui.ex:5287
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format
@@ -21243,7 +21233,7 @@ msgstr "Nach Namen suchen"
 msgid "See which of them are already on vutuv"
 msgstr "Sehen Sie, wer davon schon auf vutuv ist"
 
-#: lib/vutuv_web/components/ui.ex:5277
+#: lib/vutuv_web/components/ui.ex:5289
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr "Sehen, wer aus Ihren LinkedIn-Kontakten schon auf vutuv ist"
@@ -21315,7 +21305,7 @@ msgstr "Ihre Kontakte auf vutuv"
 msgid "Your export also lists your LinkedIn contacts."
 msgstr "Ihr Export enthält auch Ihre LinkedIn-Kontakte."
 
-#: lib/vutuv_web/components/ui.ex:5279
+#: lib/vutuv_web/components/ui.ex:5291
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr "linkedin kontakte verbindungen adressbuch bekannte kollegen finden folgen zip import netzwerk"
@@ -21497,7 +21487,7 @@ msgstr "Land suchen"
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr "Diese Seite folgt bereits so vielen Konten, wie hier erlaubt sind (%{max})."
 
-#: lib/vutuv_web/components/post_components.ex:3177
+#: lib/vutuv_web/components/post_components.ex:3232
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr "%{handle} nicht mehr folgen? Die Beiträge verschwinden aus Ihrem Feed."
@@ -21572,7 +21562,7 @@ msgstr "Wenn etwas eintrifft, während vutuv in einem Tab offen ist, den Sie ger
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr "Sie haben Browser-Benachrichtigungen eingeschaltet. Dieser Browser wurde noch nicht um Erlaubnis gebeten."
 
-#: lib/vutuv_web/components/ui.ex:5233
+#: lib/vutuv_web/components/ui.ex:5245
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr "e-mail email mail abbestellen abmelden newsletter glocke benachrichtigung weniger ruhe browser desktop popup push hinweis mitteilung"
@@ -21804,26 +21794,26 @@ msgstr "Wird in Ihrem Feed ausgeblendet."
 msgid "Shown in the language it was written in."
 msgstr "Wird in der Sprache gezeigt, in der es geschrieben wurde."
 
-#: lib/vutuv_web/components/ui.ex:5260
+#: lib/vutuv_web/components/ui.ex:5272
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr "Welche Sprachen Sie erreichen und was mit dem Rest geschieht"
 
-#: lib/vutuv_web/components/ui.ex:5262
+#: lib/vutuv_web/components/ui.ex:5274
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr ""
 "sprache übersetzen übersetzung deutsch englisch original ausblenden "
 "fremdsprache reihenfolge rang feed language translate"
 
-#: lib/vutuv_web/components/ui.ex:5300
+#: lib/vutuv_web/components/ui.ex:5312
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr ""
 "Anzeigesprache, Datumsformat und Zeitzone, Karten, wie Beiträge gekürzt "
 "werden"
 
-#: lib/vutuv_web/components/ui.ex:5304
+#: lib/vutuv_web/components/ui.ex:5316
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -21922,12 +21912,12 @@ msgstr ""
 msgid "That alternative name is no longer on record."
 msgstr "Dieser Zweitname ist nicht mehr vermerkt."
 
-#: lib/vutuv_web/views/page_html.ex:63
+#: lib/vutuv_web/views/page_html.ex:60
 #, elixir-autogen, elixir-format
 msgid "Fast."
 msgstr "Schnell."
 
-#: lib/vutuv_web/views/page_html.ex:64
+#: lib/vutuv_web/views/page_html.ex:61
 #, elixir-autogen, elixir-format
 msgid "No paid premium accounts."
 msgstr "Keine bezahlten Premium-Accounts."
@@ -22292,7 +22282,7 @@ msgid_plural "Show %{formatted} posts in the feed"
 msgstr[0] "%{formatted} Beitrag im Feed anzeigen"
 msgstr[1] "%{formatted} Beiträge im Feed anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2769
+#: lib/vutuv_web/components/post_components.ex:2824
 #, elixir-autogen, elixir-format
 msgid "Picture unavailable"
 msgstr "Bild nicht verfügbar"
@@ -22321,7 +22311,7 @@ msgstr ""
 "Ihre Organisationsseite wurde aktualisiert, aber dieses Bild konnte nicht als "
 "Logo verwendet werden. Bitte wählen Sie ein anderes."
 
-#: lib/vutuv_web/components/ui.ex:4487
+#: lib/vutuv_web/components/ui.ex:4499
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -22468,7 +22458,7 @@ msgid_plural "New (%{formatted}):"
 msgstr[0] "Neu:"
 msgstr[1] "Neu (%{formatted}):"
 
-#: lib/vutuv_web/components/post_components.ex:3332
+#: lib/vutuv_web/components/post_components.ex:3387
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr "Zitierter Beitrag"
@@ -22519,12 +22509,12 @@ msgstr "Bleibt das Account-Feld leer, gilt die Regel für alle; %{example} grenz
 msgid "Only these accounts (empty = all) …"
 msgstr "Nur diese Accounts (leer = alle) …"
 
-#: lib/vutuv_web/components/ui.ex:3530
+#: lib/vutuv_web/components/ui.ex:3542
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr "nur %{account}"
 
-#: lib/vutuv_web/components/post_components.ex:6973
+#: lib/vutuv_web/components/post_components.ex:7028
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -22761,7 +22751,7 @@ msgstr "Von diesem Beitrag bleibt nichts übrig."
 msgid "Replace with"
 msgstr "Ersetzen durch"
 
-#: lib/vutuv_web/components/ui.ex:5252
+#: lib/vutuv_web/components/ui.ex:5264
 #, elixir-autogen, elixir-format
 msgid "Rewrite what an account's posts say, for you alone"
 msgstr "Text in den Beiträgen eines Kontos umschreiben, nur für Sie"
@@ -22777,9 +22767,9 @@ msgid "Rules that rewrite the text of one account's posts before you read them: 
 msgstr "Regeln, die den Text der Beiträge eines Kontos umschreiben, bevor Sie ihn lesen: eine Fußzeile unter jedem Beitrag, eine Signatur, eine Wand aus Hashtags. Nur Sie sehen den Unterschied. Öffnen Sie das ⋯-Menü an einem Beitrag, um Regeln für dessen Autor zu schreiben."
 
 #: lib/vutuv_web/components/post_components.ex:1450
-#: lib/vutuv_web/components/post_components.ex:3190
-#: lib/vutuv_web/components/post_components.ex:4284
-#: lib/vutuv_web/components/ui.ex:5251
+#: lib/vutuv_web/components/post_components.ex:3245
+#: lib/vutuv_web/components/post_components.ex:4339
+#: lib/vutuv_web/components/ui.ex:5263
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
 #: lib/vutuv_web/live/post_rewrites_live.ex:264
@@ -22835,12 +22825,12 @@ msgstr "Ihre gespeicherten Regeln ändern diesen Beitrag von %{who} wie gezeigt.
 msgid "\\1 puts back what the first (…) group matched, \\0 the whole match."
 msgstr "\\1 setzt ein, was die erste (…)-Gruppe getroffen hat, \\0 den ganzen Treffer."
 
-#: lib/vutuv_web/components/ui.ex:5253
+#: lib/vutuv_web/components/ui.ex:5265
 #, elixir-autogen, elixir-format
 msgid "regex regular expression rewrite replace footer signature strip"
 msgstr "regex regulärer ausdruck umschreiben ersetzen fußzeile signatur entfernen suchen"
 
-#: lib/vutuv_web/components/ui.ex:5322
+#: lib/vutuv_web/components/ui.ex:5334
 #, elixir-autogen, elixir-format
 msgid "Smaller pictures and a plain composer on a slow connection"
 msgstr "Kleinere Bilder und ein einfacher Editor bei langsamer Verbindung"
@@ -22850,12 +22840,12 @@ msgstr "Kleinere Bilder und ein einfacher Editor bei langsamer Verbindung"
 msgid "That endorsement is not possible."
 msgstr "Diese Empfehlung ist nicht möglich."
 
-#: lib/vutuv_web/components/ui.ex:5324
+#: lib/vutuv_web/components/ui.ex:5336
 #, elixir-autogen, elixir-format
 msgid "bandwidth slow internet mobile data saving saver volume metered compression pictures images screenshots editor langsam daten sparen datensparmodus volumen schmalband komprimierung bilder"
 msgstr "bandbreite langsam internet mobil daten sparen datensparmodus volumen schmalband komprimierung bilder fotos screenshots editor bandwidth slow data saving"
 
-#: lib/vutuv_web/components/ui.ex:5296
+#: lib/vutuv_web/components/ui.ex:5308
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr "Darstellung"
@@ -22968,7 +22958,7 @@ msgstr "Dieses Video konnte nicht umgewandelt werden."
 #: lib/vutuv_web/agent_docs/markdown.ex:1417
 #: lib/vutuv_web/agent_docs/text.ex:899
 #: lib/vutuv_web/agent_docs/text.ex:900
-#: lib/vutuv_web/components/post_components.ex:2904
+#: lib/vutuv_web/components/post_components.ex:2959
 #: lib/vutuv_web/components/video_components.ex:127
 #: lib/vutuv_web/live/post_live/composer.ex:2458
 #, elixir-autogen, elixir-format
@@ -23031,7 +23021,7 @@ msgstr[1] "%{formatted} neue Follower"
 msgid "Last 30 days: %{parts}"
 msgstr "Letzte 30 Tage: %{parts}"
 
-#: lib/vutuv_web/components/post_components.ex:4847
+#: lib/vutuv_web/components/post_components.ex:4902
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -23335,7 +23325,7 @@ msgstr "Ein Fediverse-Konto, das hier mehreren Profilen folgt, zählt trotzdem a
 msgid "Accounts whose posts stay out of your feed, and accounts whose reposts do. This list is yours alone: it is never shared and nobody is told they are on it."
 msgstr "Konten, deren Beiträge nicht in Ihrem Feed erscheinen, und Konten, deren Reposts Sie ausgeblendet haben. Diese Liste gehört Ihnen allein: sie wird nie geteilt, und niemand erfährt, dass er darauf steht."
 
-#: lib/vutuv_web/components/ui.ex:5245
+#: lib/vutuv_web/components/ui.ex:5257
 #, elixir-autogen, elixir-format
 msgid "Accounts you have silenced, and whose reposts you hide"
 msgstr "Konten, die Sie stummgeschaltet haben, und deren Reposts Sie ausblenden"
@@ -23345,8 +23335,8 @@ msgstr "Konten, die Sie stummgeschaltet haben, und deren Reposts Sie ausblenden"
 msgid "Hidden. What they pass on stays out of your feed; their own posts do not."
 msgstr "Ausgeblendet. Was dieses Konto weiterreicht, erscheint nicht mehr in Ihrem Feed, die eigenen Beiträge schon."
 
-#: lib/vutuv_web/components/post_components.ex:3162
-#: lib/vutuv_web/components/post_components.ex:4278
+#: lib/vutuv_web/components/post_components.ex:3217
+#: lib/vutuv_web/components/post_components.ex:4333
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr "Reposts ausblenden"
@@ -23361,7 +23351,7 @@ msgstr "Suchen Sie stattdessen nach Wörtern, Wendungen oder Tags?"
 msgid "Mute everything"
 msgstr "Ganz stummschalten"
 
-#: lib/vutuv_web/components/ui.ex:5244
+#: lib/vutuv_web/components/ui.ex:5256
 #: lib/vutuv_web/controllers/settings_controller.ex:713
 #: lib/vutuv_web/templates/settings/mutes.html.heex:1
 #: lib/vutuv_web/templates/settings/mutes.html.heex:3
@@ -23405,7 +23395,7 @@ msgstr "Sie haben noch niemanden stummgeschaltet."
 msgid "You mute an account where you meet it: the ⋯ menu on any of its posts, or its own page. Muting works whether or not you follow them."
 msgstr "Stummschalten können Sie ein Konto dort, wo Sie ihm begegnen: im ⋯-Menü eines seiner Beiträge oder auf seiner eigenen Seite. Das geht auch bei Konten, denen Sie nicht folgen."
 
-#: lib/vutuv_web/components/ui.ex:5247
+#: lib/vutuv_web/components/ui.ex:5259
 #, elixir-autogen, elixir-format
 msgid "mute unmute hide account reposts boosts feed stumm stummschalten ausblenden konto"
 msgstr "stumm stummschalten stummschaltung ausblenden verbergen konto account reposts boosts feed"
@@ -23505,7 +23495,7 @@ msgstr "Die Länge Ihres Feeds folgt wieder der Voreinstellung."
 msgid "Feed settings saved."
 msgstr "Feed-Einstellungen gespeichert."
 
-#: lib/vutuv_web/components/ui.ex:5315
+#: lib/vutuv_web/components/ui.ex:5327
 #, elixir-autogen, elixir-format
 msgid "How many load at once, and how many “Load more” adds"
 msgstr "Wie viele auf einmal geladen werden und wie viele „Mehr laden“ ergänzt"
@@ -23515,7 +23505,7 @@ msgstr "Wie viele auf einmal geladen werden und wie viele „Mehr laden“ ergä
 msgid "How many posts your feed shows before the “Load more” button, and how many that button adds. More posts mean a longer wait for the page."
 msgstr "Wie viele Beiträge Ihr Feed vor dem Knopf „Mehr laden“ zeigt und wie viele dieser Knopf ergänzt. Mehr Beiträge bedeuten eine längere Wartezeit auf die Seite."
 
-#: lib/vutuv_web/components/ui.ex:5314
+#: lib/vutuv_web/components/ui.ex:5326
 #: lib/vutuv_web/controllers/settings_controller.ex:963
 #: lib/vutuv_web/templates/settings/feed.html.heex:12
 #, elixir-autogen, elixir-format
@@ -23538,18 +23528,18 @@ msgstr "Beiträge pro Seite"
 msgid "You can change this under the feed itself as well, right below the “Load more” button."
 msgstr "Sie können das auch direkt im Feed ändern, gleich unter „Mehr laden“."
 
-#: lib/vutuv_web/components/ui.ex:5317
+#: lib/vutuv_web/components/ui.ex:5329
 #, elixir-autogen, elixir-format
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr "feed länge seitengröße beiträge anzahl menge mehr laden scrollen blättern seite umfang page size posts number load more"
 
-#: lib/vutuv_web/components/post_components.ex:6964
-#: lib/vutuv_web/components/post_components.ex:6965
+#: lib/vutuv_web/components/post_components.ex:7019
+#: lib/vutuv_web/components/post_components.ex:7020
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr "Ein Wort oder eine Wortgruppe …"
 
-#: lib/vutuv_web/components/post_components.ex:6992
+#: lib/vutuv_web/components/post_components.ex:7047
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr "Für wen %{thing} ausgeblendet wird"
@@ -23566,7 +23556,7 @@ msgstr "Ausgeblendet"
 msgid "Hide something from your feed"
 msgstr "Etwas aus dem Feed ausblenden"
 
-#: lib/vutuv_web/components/post_components.ex:6912
+#: lib/vutuv_web/components/post_components.ex:6967
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr "Nicht mehr zeigen"
@@ -23581,22 +23571,22 @@ msgstr "Was hiervon getroffen wird, klappt im Feed auf eine Zeile zu."
 msgid "Words & tags"
 msgstr "Wörter & Tags"
 
-#: lib/vutuv_web/components/post_components.ex:6996
+#: lib/vutuv_web/components/post_components.ex:7051
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr "bei allen"
 
-#: lib/vutuv_web/components/post_components.ex:6999
+#: lib/vutuv_web/components/post_components.ex:7054
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr "nur %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:6968
+#: lib/vutuv_web/components/post_components.ex:7023
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr "dieses Wort"
 
-#: lib/vutuv_web/components/post_components.ex:7009
+#: lib/vutuv_web/components/post_components.ex:7064
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "nur %{server}"
@@ -23648,7 +23638,7 @@ msgstr "Diese Website ist gerade offline."
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr "Die Website läuft, nur diese Adresse gibt es hier nicht. Wahrscheinlich ist der Link alt oder enthält einen Tippfehler."
 
-#: lib/vutuv_web/components/post_components.ex:6319
+#: lib/vutuv_web/components/post_components.ex:6374
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr "Screenshot vergrößern"
@@ -23668,7 +23658,7 @@ msgstr "Schalten Sie ihn für Ihr Konto ein, dann können Sie %{app} gleich hier
 msgid "Turn on for my account"
 msgstr "Für mein Konto einschalten"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:97
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."
 msgstr "Korrigieren. Einer unserer Admins sieht sich die Änderung dann an; bis dahin bleibt der Beitrag verborgen."
@@ -23703,7 +23693,7 @@ msgstr "Nutzt einen Text, ein Foto oder ein Video ohne Erlaubnis des Rechteinhab
 msgid "Which work is it, and where can the original be seen? (required)"
 msgstr "Um welches Werk geht es, und wo ist das Original zu sehen? (erforderlich)"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:45
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Copyright law. This complaint says the work is not yours to publish, which is a legal question rather than a house rule."
 msgstr "Das Urheberrecht. Diese Beschwerde besagt, dass das Werk nicht Ihres ist, um es zu veröffentlichen, und das ist eine Rechtsfrage, keine Hausregel."
@@ -23713,27 +23703,27 @@ msgstr "Das Urheberrecht. Diese Beschwerde besagt, dass das Werk nicht Ihres ist
 msgid "Hidden automatically after a report: %{reason}. The case page says what you can do."
 msgstr "Nach einer Meldung automatisch verborgen: %{reason}. Auf der Fallseite steht, was Sie tun können."
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:16
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "No person made this decision: a report from a member in good standing hides the reported content automatically, the moment it arrives."
 msgstr "Diese Entscheidung hat kein Mensch getroffen: Die Meldung eines Mitglieds mit guter Bilanz verbirgt den gemeldeten Inhalt automatisch, sobald sie eintrifft."
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:79
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Nobody else can see it right now. You have 72 hours to settle this yourself; after that our admins decide. Here is what you can do:"
 msgstr "Niemand sonst kann ihn gerade sehen. Sie haben 72 Stunden, um das selbst zu klären; danach entscheiden unsere Admins. Das können Sie tun:"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:48
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Our community guidelines, which everything on vutuv has to keep to."
 msgstr "Unsere Verhaltensregeln, an die sich alles auf vutuv halten muss."
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:41
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "The ground"
 msgstr "Grundlage"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:28
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "What the report says"
 msgstr "Was in der Meldung steht"
@@ -23748,8 +23738,8 @@ msgstr "Ihr Inhalt wurde nach einer Meldung automatisch verborgen. Auf der Falls
 msgid "Hidden. What other people pass on of them stays out of your feed; their own posts do not."
 msgstr "Ausgeblendet. Was andere von diesem Konto weiterreichen, erscheint nicht mehr in Ihrem Feed, die eigenen Beiträge schon."
 
-#: lib/vutuv_web/components/post_components.ex:3148
-#: lib/vutuv_web/components/post_components.ex:4266
+#: lib/vutuv_web/components/post_components.ex:3203
+#: lib/vutuv_web/components/post_components.ex:4321
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr "Ausblenden, wenn andere reposten"
@@ -23793,14 +23783,14 @@ msgstr ""
 "Per PIN aus der Mail, Passkey, Authenticator-App oder einer gedruckten "
 "Codeliste."
 
-#: lib/vutuv_web/views/page_html.ex:160
+#: lib/vutuv_web/views/page_html.ex:157
 #, elixir-autogen, elixir-format
 msgid "Curious? Have a look at a real profile: {profile}. With or without a vutuv account of your own."
 msgstr ""
 "Neugierig? Schauen Sie sich einmal ein echtes Profil an: {profile}. Mit oder "
 "ohne eigenen vutuv-Account."
 
-#: lib/vutuv_web/views/page_html.ex:156
+#: lib/vutuv_web/views/page_html.ex:153
 #, elixir-autogen, elixir-format
 msgid "Curious? Have a look at the profile of vutuv founder Stefan Wintermeyer: {profile}. With or without a vutuv account of your own."
 msgstr ""
@@ -23957,7 +23947,7 @@ msgstr ""
 "Anmeldung und später mit einem Schalter in den Einstellungen. Wir sind da "
 "nicht dogmatisch: jeder, wie er will."
 
-#: lib/vutuv_web/live/shell_live.ex:1806
+#: lib/vutuv_web/live/shell_live.ex:1811
 #, elixir-autogen, elixir-format
 msgid "All notifications"
 msgstr "Alle Mitteilungen"
@@ -23977,12 +23967,12 @@ msgstr "Weder Ihr Profilbild noch Ihr Titelbild wurde ersetzt: Eine Meldung dazu
 msgid "Profile picture"
 msgstr "Profilbild"
 
-#: lib/vutuv_web/templates/user/show.html.heex:260
+#: lib/vutuv_web/templates/user/show.html.heex:265
 #, elixir-autogen, elixir-format
 msgid "Report the cover photo"
 msgstr "Titelbild melden"
 
-#: lib/vutuv_web/templates/user/show.html.heex:253
+#: lib/vutuv_web/templates/user/show.html.heex:258
 #, elixir-autogen, elixir-format
 msgid "Report the profile picture"
 msgstr "Profilbild melden"
@@ -23992,7 +23982,7 @@ msgstr "Profilbild melden"
 msgid "The reported picture"
 msgstr "Das gemeldete Bild"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:241
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "Upholding the case deletes it, the private original included. Rejecting it puts every file back where it was."
 msgstr "Wird der Meldung stattgegeben, wird es gelöscht, auch das private Original. Wird sie abgelehnt, liegt jede Datei wieder an ihrem Platz."
@@ -24007,7 +23997,7 @@ msgstr "Ihr Titelbild wurde nicht ersetzt: Eine Meldung dazu ist noch offen. Öf
 msgid "Your profile picture was not replaced: a report about it is still open. Open the case to remove the picture or to say that it is yours."
 msgstr "Ihr Profilbild wurde nicht ersetzt: Eine Meldung dazu ist noch offen. Öffnen Sie den Fall, um das Bild zu entfernen oder zu sagen, dass es Ihres ist."
 
-#: lib/vutuv_web/components/post_components.ex:2471
+#: lib/vutuv_web/components/post_components.ex:2476
 #, elixir-autogen, elixir-format
 msgid "Fetching the answers from the servers that hold them…"
 msgstr "Die Antworten werden von den Servern geholt, auf denen sie liegen …"
@@ -24022,7 +24012,7 @@ msgstr "Nicht jede Antwort ließ sich holen. Der Rest steht auf dem Ursprungsser
 msgid "Nothing here we are allowed to show you."
 msgstr "Hier ist nichts, was wir Ihnen zeigen dürfen."
 
-#: lib/vutuv_web/components/post_components.ex:2490
+#: lib/vutuv_web/components/post_components.ex:2495
 #, elixir-autogen, elixir-format
 msgid "Show more answers"
 msgstr "Weitere Antworten anzeigen"
@@ -24064,7 +24054,7 @@ msgstr ""
 "Danke für Ihre Meldung. Unsere Moderatoren wurden benachrichtigt und prüfen "
 "dieses Bild."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:245
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:255
 #, elixir-autogen, elixir-format
 msgid "This picture is still on the profile: only a copyright notice takes one offline before a ruling. Upholding the case deletes it, the private original included."
 msgstr ""
@@ -24122,7 +24112,7 @@ msgstr "Ich versichere nach bestem Wissen, dass meine Angaben zutreffen und dass
 msgid "Is content published here yours, or does it break the law? You can tell us without an account."
 msgstr "Gehört ein hier veröffentlichter Inhalt Ihnen, oder verstößt er gegen das Gesetz? Sie können uns das ohne Konto mitteilen."
 
-#: lib/vutuv/notifications/emailer.ex:1250
+#: lib/vutuv/notifications/emailer.ex:1284
 #, elixir-autogen, elixir-format
 msgid "Moderation: something was reported"
 msgstr "Moderation: Ein Inhalt wurde gemeldet"
@@ -24147,7 +24137,7 @@ msgstr "Unsere Admins sehen Ihren Namen und Ihre Adresse, um sich bei Ihnen meld
 msgid "Outside reporter confirmed their address"
 msgstr "Externer Melder hat seine Adresse bestätigt"
 
-#: lib/vutuv/notifications/emailer.ex:1166
+#: lib/vutuv/notifications/emailer.ex:1200
 #: lib/vutuv_web/templates/public_report/sent.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Please confirm your report"
@@ -24194,7 +24184,7 @@ msgstr "Diese Adresse gehört nicht zu dieser Seite. Wir können nur bei Inhalte
 msgid "The post, picture, video, profile, page or job posting you are reporting. Copy it out of your browser's address bar."
 msgstr "Der Beitrag, das Bild, das Video, das Profil, die Seite oder die Stellenanzeige, die Sie melden. Kopieren Sie die Adresse aus der Adresszeile Ihres Browsers."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:407
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "The report by %{email} was a deliberate weapon (that address loses our trust)"
 msgstr "Die Meldung von %{email} war eine gezielte Waffe (diese Adresse verliert unser Vertrauen)"
@@ -24342,7 +24332,7 @@ msgstr "Ein Mensch hat Ihre Meldung gelesen und ihr stattgegeben. Danke dafür."
 msgid "Report decision"
 msgstr "Entscheidung über Ihre Meldung"
 
-#: lib/vutuv/notifications/emailer.ex:1060
+#: lib/vutuv/notifications/emailer.ex:1082
 #, elixir-autogen, elixir-format
 msgid "The content you reported was deleted"
 msgstr "Der von Ihnen gemeldete Inhalt wurde gelöscht"
@@ -24357,17 +24347,112 @@ msgstr "Der von Ihnen gemeldete Inhalt wurde gelöscht; der Fall ist abgeschloss
 msgid "The owner revised the content you reported; it is visible again."
 msgstr "Der Besitzer hat den von Ihnen gemeldeten Inhalt überarbeitet; er ist wieder sichtbar."
 
-#: lib/vutuv/notifications/emailer.ex:1063
+#: lib/vutuv/notifications/emailer.ex:1085
 #, elixir-autogen, elixir-format
 msgid "Your report was not upheld"
 msgstr "Wir konnten Ihrer Meldung nicht stattgeben"
 
-#: lib/vutuv/notifications/emailer.ex:1062
+#: lib/vutuv/notifications/emailer.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Your report was upheld"
 msgstr "Wir haben Ihrer Meldung stattgegeben"
 
-#: lib/vutuv_web/views/page_html.ex:62
+#: lib/vutuv_web/views/page_html.ex:59
 #, elixir-autogen, elixir-format
 msgid "Easy LinkedIn profile import."
 msgstr "Einfacher LinkedIn-Profil-Import."
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:26
+#, elixir-autogen, elixir-format
+msgid "No person made this decision: a report from somebody with a good record hides the reported content automatically, the moment it arrives."
+msgstr "Diese Entscheidung hat kein Mensch getroffen: Die Meldung einer Person mit guter Bilanz verbirgt den gemeldeten Inhalt automatisch, sobald sie eintrifft."
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:400
+#, elixir-autogen, elixir-format
+msgid "The report is justified. The content becomes visible again - the consequence here is the strike (warn, suspend, deactivate)."
+msgstr "Die Meldung ist berechtigt. Der Inhalt wird wieder sichtbar; die Folge ist hier der Verwarnungspunkt (verwarnen, sperren, deaktivieren)."
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:404
+#, elixir-autogen, elixir-format
+msgid "The report is justified. The content is not hidden and upholding does not hide it; the owner gets a strike (warn, suspend, deactivate)."
+msgstr "Die Meldung ist berechtigt. Der Inhalt ist nicht verborgen und wird es dadurch auch nicht; der Besitzer erhält einen Verwarnungspunkt (verwarnen, sperren, deaktivieren)."
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:392
+#, elixir-autogen, elixir-format
+msgid "The report is justified. The reported picture is deleted, the private original included, and the owner gets a strike (warn, suspend, deactivate)."
+msgstr "Die Meldung ist berechtigt. Das gemeldete Bild wird gelöscht, auch das private Original, und der Besitzer erhält einen Verwarnungspunkt (verwarnen, sperren, deaktivieren)."
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:251
+#, elixir-autogen, elixir-format
+msgid "This picture is still on the profile: the address behind the copyright notice is not confirmed yet, so nothing has been hidden. Upholding the case deletes it, the private original included."
+msgstr "Dieses Bild ist weiterhin im Profil zu sehen: Die Adresse hinter der Urheberrechtsmeldung ist noch nicht bestätigt, deshalb ist nichts verborgen. Wird der Meldung stattgegeben, wird es gelöscht, auch das private Original."
+
+#: lib/vutuv_web/views/report_html.ex:82
+#, elixir-autogen, elixir-format
+msgid "somebody reported one of your job postings on vutuv."
+msgstr "eine Ihrer Stellenanzeigen auf vutuv wurde gemeldet."
+
+#: lib/vutuv_web/views/report_html.ex:85
+#, elixir-autogen, elixir-format
+msgid "somebody reported one of your pages on vutuv."
+msgstr "eine Ihrer Seiten auf vutuv wurde gemeldet."
+
+#: lib/vutuv_web/views/report_html.ex:76
+#, elixir-autogen, elixir-format
+msgid "somebody reported one of your pictures on vutuv."
+msgstr "eines Ihrer Bilder auf vutuv wurde gemeldet."
+
+#: lib/vutuv_web/views/report_html.ex:73
+#, elixir-autogen, elixir-format
+msgid "somebody reported one of your posts on vutuv."
+msgstr "einer Ihrer Beiträge auf vutuv wurde gemeldet."
+
+#: lib/vutuv_web/views/report_html.ex:79
+#, elixir-autogen, elixir-format
+msgid "somebody reported one of your private messages on vutuv."
+msgstr "eine Ihrer privaten Nachrichten auf vutuv wurde gemeldet."
+
+#: lib/vutuv_web/views/report_html.ex:91
+#, elixir-autogen, elixir-format
+msgid "somebody reported something of yours on vutuv."
+msgstr "etwas von Ihnen auf vutuv wurde gemeldet."
+
+#: lib/vutuv_web/views/report_html.ex:88
+#, elixir-autogen, elixir-format
+msgid "somebody reported your profile on vutuv."
+msgstr "Ihr Profil auf vutuv wurde gemeldet."
+
+#: lib/vutuv_web/views/report_html.ex:105
+#, elixir-autogen, elixir-format
+msgid "A report from a member in good standing hides the reported content automatically, the moment it arrives."
+msgstr "Die Meldung eines Mitglieds mit guter Bilanz verbirgt den gemeldeten Inhalt automatisch, sobald sie eintrifft."
+
+#: lib/vutuv_web/views/report_html.ex:111
+#, elixir-autogen, elixir-format
+msgid "A report from somebody with a good record hides the reported content automatically, the moment it arrives."
+msgstr "Die Meldung einer Person mit guter Bilanz verbirgt den gemeldeten Inhalt automatisch, sobald sie eintrifft."
+
+#: lib/vutuv_web/views/moderation_case_html.ex:32
+#, elixir-autogen, elixir-format
+msgid "An admin confirmed the report."
+msgstr "Ein Admin hat die Meldung bestätigt."
+
+#: lib/vutuv_web/views/moderation_case_html.ex:33
+#, elixir-autogen, elixir-format
+msgid "An admin dismissed the report."
+msgstr "Ein Admin hat die Meldung verworfen."
+
+#: lib/vutuv_web/views/moderation_case_html.ex:40
+#, elixir-autogen, elixir-format
+msgid "The content is deleted."
+msgstr "Der Inhalt ist gelöscht."
+
+#: lib/vutuv_web/views/moderation_case_html.ex:42
+#, elixir-autogen, elixir-format
+msgid "The content is visible again."
+msgstr "Der Inhalt ist wieder sichtbar."
+
+#: lib/vutuv_web/views/moderation_case_html.ex:41
+#, elixir-autogen, elixir-format
+msgid "The content stays hidden."
+msgstr "Der Inhalt bleibt verborgen."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -2811,7 +2811,7 @@ msgstr ""
 msgid "This post is for the connections of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:126
+#: lib/vutuv_web/views/admin/moderation_html.ex:127
 #: lib/vutuv_web/views/user_html.ex:536
 #, elixir-autogen, elixir-format
 msgid "connection"
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "You have used all %{limit} username changes of the last %{days} days."
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:127
+#: lib/vutuv_web/views/admin/moderation_html.ex:128
 #, elixir-autogen, elixir-format
 msgid "%{count} follows"
 msgstr ""
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Decision"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:79
+#: lib/vutuv_web/views/admin/moderation_html.ex:80
 #, elixir-autogen, elixir-format
 msgid "Escalated - the 72h deadline passed"
 msgstr ""
@@ -3626,12 +3626,12 @@ msgstr ""
 msgid "Report protection"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:81
+#: lib/vutuv_web/views/admin/moderation_html.ex:82
 #, elixir-autogen, elixir-format
 msgid "Report rejected"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:80
+#: lib/vutuv_web/views/admin/moderation_html.ex:81
 #, elixir-autogen, elixir-format
 msgid "Report upheld"
 msgstr ""
@@ -3666,7 +3666,7 @@ msgstr ""
 msgid "Settled by deletion"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:83
+#: lib/vutuv_web/views/admin/moderation_html.ex:84
 #, elixir-autogen, elixir-format
 msgid "Strike issued"
 msgstr ""
@@ -3701,22 +3701,22 @@ msgstr ""
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:101
+#: lib/vutuv_web/views/admin/moderation_html.ex:102
 #, elixir-autogen, elixir-format
 msgid "for the owner"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:102
+#: lib/vutuv_web/views/admin/moderation_html.ex:103
 #, elixir-autogen, elixir-format
 msgid "for the reporter"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:106
+#: lib/vutuv_web/views/admin/moderation_html.ex:107
 #, elixir-autogen, elixir-format
 msgid "level %{level}, %{role}"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:128
+#: lib/vutuv_web/views/admin/moderation_html.ex:129
 #, elixir-autogen, elixir-format
 msgid "messages"
 msgstr ""
@@ -3751,7 +3751,7 @@ msgstr ""
 msgid "Case %{id}, captured %{at} UTC"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:84
+#: lib/vutuv_web/views/admin/moderation_html.ex:85
 #, elixir-autogen, elixir-format
 msgid "Evidence screenshot captured"
 msgstr ""
@@ -9760,7 +9760,7 @@ msgstr ""
 msgid "name or slug"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:121
+#: lib/vutuv_web/views/admin/moderation_html.ex:122
 #, elixir-autogen, elixir-format
 msgid "%{action} (%{reason})"
 msgstr ""
@@ -9781,7 +9781,7 @@ msgstr ""
 msgid "Account deleted."
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:82
+#: lib/vutuv_web/views/admin/moderation_html.ex:83
 #, elixir-autogen, elixir-format
 msgid "Account removed"
 msgstr ""
@@ -9852,12 +9852,12 @@ msgid "Thank you for your report. Our moderators have been notified and will rev
 msgstr ""
 
 #: lib/vutuv_web/views/admin/account_html.ex:78
-#: lib/vutuv_web/views/admin/moderation_html.ex:114
+#: lib/vutuv_web/views/admin/moderation_html.ex:115
 #, elixir-autogen, elixir-format
 msgid "deactivated"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:115
+#: lib/vutuv_web/views/admin/moderation_html.ex:116
 #, elixir-autogen, elixir-format
 msgid "deleted"
 msgstr ""
@@ -23299,7 +23299,7 @@ msgstr ""
 msgid "Our admins see your name and address so they can come back to you. The owner of the reported content never does."
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:86
+#: lib/vutuv_web/views/admin/moderation_html.ex:87
 #, elixir-autogen, elixir-format
 msgid "Outside reporter confirmed their address"
 msgstr ""
@@ -23321,7 +23321,7 @@ msgstr ""
 msgid "Report content on this site"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:85
+#: lib/vutuv_web/views/admin/moderation_html.ex:86
 #, elixir-autogen, elixir-format
 msgid "Report filed from outside"
 msgstr ""
@@ -23447,7 +23447,7 @@ msgstr ""
 msgid "A confirmation link is good for one week. Yours has run out, so your report never reached our admins and nothing about the reported content changed."
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:89
+#: lib/vutuv_web/views/admin/moderation_html.ex:90
 #, elixir-autogen, elixir-format
 msgid "Report dropped: the address was never confirmed"
 msgstr ""
@@ -23622,4 +23622,9 @@ msgstr ""
 #: lib/vutuv_web/views/moderation_case_html.ex:41
 #, elixir-autogen, elixir-format
 msgid "The content stays hidden."
+msgstr ""
+
+#: lib/vutuv_web/views/admin/moderation_html.ex:79
+#, elixir-autogen, elixir-format
+msgid "Owner replaced the content"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -17,8 +17,8 @@ msgstr ""
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4871
-#: lib/vutuv_web/components/ui.ex:4876
+#: lib/vutuv_web/components/ui.ex:4883
+#: lib/vutuv_web/components/ui.ex:4888
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
 #: lib/vutuv_web/live/organization_live/domains.ex:287
@@ -40,7 +40,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1489
+#: lib/vutuv_web/templates/user/show.html.heex:1494
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -64,7 +64,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/text.ex:71
-#: lib/vutuv_web/components/ui.ex:5208
+#: lib/vutuv_web/components/ui.ex:5220
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -83,8 +83,8 @@ msgstr ""
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4662
-#: lib/vutuv_web/components/ui.ex:4761
+#: lib/vutuv_web/components/ui.ex:4674
+#: lib/vutuv_web/components/ui.ex:4773
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Avatar"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:410
+#: lib/vutuv_web/templates/user/edit.html.heex:416
 #, elixir-autogen
 msgid "Birthdate"
 msgstr ""
@@ -106,13 +106,13 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:677
 #: lib/vutuv_web/agent_docs/text.ex:636
 #: lib/vutuv_web/agent_docs/text.ex:637
-#: lib/vutuv_web/templates/user/show.html.heex:1120
+#: lib/vutuv_web/templates/user/show.html.heex:1125
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:104
-#: lib/vutuv_web/components/ui.ex:4656
+#: lib/vutuv_web/components/ui.ex:4668
 #: lib/vutuv_web/components/video_components.ex:281
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
@@ -131,9 +131,9 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:53
-#: lib/vutuv_web/templates/user/edit.html.heex:133
-#: lib/vutuv_web/templates/user/edit.html.heex:466
-#: lib/vutuv_web/templates/user/edit.html.heex:511
+#: lib/vutuv_web/templates/user/edit.html.heex:137
+#: lib/vutuv_web/templates/user/edit.html.heex:472
+#: lib/vutuv_web/templates/user/edit.html.heex:517
 #: lib/vutuv_web/templates/username/confirm.html.heex:220
 #, elixir-autogen
 msgid "Cancel"
@@ -154,7 +154,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1158
+#: lib/vutuv_web/templates/user/show.html.heex:1163
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -163,8 +163,8 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4223
-#: lib/vutuv_web/components/ui.ex:4763
+#: lib/vutuv_web/components/post_components.ex:4278
+#: lib/vutuv_web/components/ui.ex:4775
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:657
@@ -172,7 +172,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:167
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:28
 #: lib/vutuv_web/templates/dev_app/show.html.heex:135
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:117
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:127
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:70
 #, elixir-autogen
 msgid "Delete"
@@ -211,8 +211,8 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4188
-#: lib/vutuv_web/components/ui.ex:4754
+#: lib/vutuv_web/components/post_components.ex:4243
+#: lib/vutuv_web/components/ui.ex:4766
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
@@ -224,8 +224,8 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:6
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:103
-#: lib/vutuv_web/templates/user/show.html.heex:1143
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:113
+#: lib/vutuv_web/templates/user/show.html.heex:1148
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -286,11 +286,11 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:5172
+#: lib/vutuv_web/components/ui.ex:5184
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:644
+#: lib/vutuv_web/templates/user/show.html.heex:649
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -307,7 +307,7 @@ msgid "Fax"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:662
-#: lib/vutuv_web/templates/user/edit.html.heex:164
+#: lib/vutuv_web/templates/user/edit.html.heex:170
 #, elixir-autogen
 msgid "First Name"
 msgstr ""
@@ -333,7 +333,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/show.ex:618
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:988
+#: lib/vutuv_web/templates/user/show.html.heex:993
 #: lib/vutuv_web/views/user_html.ex:640
 #, elixir-autogen
 msgid "Following"
@@ -341,7 +341,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:212
 #: lib/vutuv_web/templates/page/index.html.heex:121
-#: lib/vutuv_web/templates/user/edit.html.heex:201
+#: lib/vutuv_web/templates/user/edit.html.heex:207
 #: lib/vutuv_web/views/account_event_text.ex:219
 #, elixir-autogen
 msgid "Gender"
@@ -384,7 +384,7 @@ msgid "Language"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:664
-#: lib/vutuv_web/templates/user/edit.html.heex:169
+#: lib/vutuv_web/templates/user/edit.html.heex:175
 #, elixir-autogen
 msgid "Last Name"
 msgstr ""
@@ -451,7 +451,7 @@ msgid "Log in"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:663
-#: lib/vutuv_web/templates/user/edit.html.heex:174
+#: lib/vutuv_web/templates/user/edit.html.heex:180
 #, elixir-autogen
 msgid "Middle Name"
 msgstr ""
@@ -488,7 +488,7 @@ msgid "New"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:666
-#: lib/vutuv_web/templates/user/edit.html.heex:179
+#: lib/vutuv_web/templates/user/edit.html.heex:185
 #, elixir-autogen
 msgid "Nickname"
 msgstr ""
@@ -569,7 +569,7 @@ msgid "Phone number updated successfully."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:661
-#: lib/vutuv_web/templates/user/edit.html.heex:184
+#: lib/vutuv_web/templates/user/edit.html.heex:190
 #, elixir-autogen
 msgid "Prefix"
 msgstr ""
@@ -615,7 +615,7 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4655
+#: lib/vutuv_web/components/ui.ex:4667
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2201
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -631,7 +631,7 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/preferences.html.heex:362
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:61
-#: lib/vutuv_web/templates/user/edit.html.heex:461
+#: lib/vutuv_web/templates/user/edit.html.heex:467
 #: lib/vutuv_web/views/settings_html.ex:253
 #, elixir-autogen
 msgid "Save"
@@ -693,13 +693,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1272
+#: lib/vutuv_web/templates/user/show.html.heex:1277
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1274
+#: lib/vutuv_web/templates/user/show.html.heex:1279
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -748,7 +748,7 @@ msgid "Submit a bugreport or a feature request."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:665
-#: lib/vutuv_web/templates/user/edit.html.heex:189
+#: lib/vutuv_web/templates/user/edit.html.heex:195
 #, elixir-autogen
 msgid "Suffix"
 msgstr ""
@@ -790,7 +790,7 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5168
+#: lib/vutuv_web/components/ui.ex:5180
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:832
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -850,14 +850,14 @@ msgstr ""
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4824
-#: lib/vutuv_web/templates/user/show.html.heex:982
-#: lib/vutuv_web/templates/user/show.html.heex:1005
+#: lib/vutuv_web/components/ui.ex:4836
+#: lib/vutuv_web/templates/user/show.html.heex:987
+#: lib/vutuv_web/templates/user/show.html.heex:1010
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5331
+#: lib/vutuv_web/components/ui.ex:5343
 #: lib/vutuv_web/controllers/settings_controller.ex:175
 #: lib/vutuv_web/live/job_posting_live/form.ex:818
 #: lib/vutuv_web/live/organization_live/edit.ex:339
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1109
+#: lib/vutuv_web/templates/user/show.html.heex:1114
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1179,10 +1179,10 @@ msgstr ""
 msgid "All tag urls"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4838
+#: lib/vutuv_web/components/post_components.ex:4893
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:638
+#: lib/vutuv_web/templates/user/show.html.heex:643
 #, elixir-autogen
 msgid "All tags"
 msgstr ""
@@ -1351,7 +1351,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:584
 #: lib/vutuv_web/agent_docs/text.ex:850
-#: lib/vutuv_web/components/ui.ex:5193
+#: lib/vutuv_web/components/ui.ex:5205
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1378,7 +1378,7 @@ msgstr ""
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:28
 #: lib/vutuv_web/templates/tag/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:608
+#: lib/vutuv_web/templates/user/show.html.heex:613
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1648,7 +1648,7 @@ msgid "Delete my account"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_controller.ex:149
-#: lib/vutuv_web/templates/user/show.html.heex:147
+#: lib/vutuv_web/templates/user/show.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Edit profile"
 msgstr ""
@@ -1676,7 +1676,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/show.ex:616
 #: lib/vutuv_web/live/post_live/feed.ex:902
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
-#: lib/vutuv_web/templates/user/show.html.heex:1313
+#: lib/vutuv_web/templates/user/show.html.heex:1318
 #: lib/vutuv_web/views/user_html.ex:651
 #, elixir-autogen, elixir-format
 msgid "Follow"
@@ -1732,7 +1732,7 @@ msgid "Network"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:485
-#: lib/vutuv_web/components/ui.ex:4873
+#: lib/vutuv_web/components/ui.ex:4885
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
@@ -1748,7 +1748,7 @@ msgid "Nothing new yet."
 msgstr ""
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:5230
+#: lib/vutuv_web/components/ui.ex:5242
 #: lib/vutuv_web/controllers/page_controller.ex:214
 #: lib/vutuv_web/live/notification_live/index.ex:154
 #: lib/vutuv_web/live/notification_live/index.ex:440
@@ -1820,7 +1820,7 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:19
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
-#: lib/vutuv_web/templates/user/show.html.heex:222
+#: lib/vutuv_web/templates/user/show.html.heex:232
 #: lib/vutuv_web/views/user_html.ex:1100
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
@@ -1887,14 +1887,14 @@ msgstr ""
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4130
-#: lib/vutuv_web/components/ui.ex:4275
+#: lib/vutuv_web/components/ui.ex:4142
+#: lib/vutuv_web/components/ui.ex:4287
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4898
+#: lib/vutuv_web/components/ui.ex:4910
 #: lib/vutuv_web/live/organization_live/activity.ex:159
 #: lib/vutuv_web/live/organization_live/feed.ex:258
 #: lib/vutuv_web/live/organization_live/show.ex:787
@@ -1907,7 +1907,7 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4665
+#: lib/vutuv_web/components/ui.ex:4677
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
@@ -1952,12 +1952,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3589
+#: lib/vutuv_web/components/ui.ex:3601
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3593
+#: lib/vutuv_web/components/ui.ex:3605
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -1973,7 +1973,7 @@ msgid "Change cover photo"
 msgstr ""
 
 #: lib/vutuv_web/controllers/report_controller.ex:173
-#: lib/vutuv_web/templates/user/edit.html.heex:96
+#: lib/vutuv_web/templates/user/edit.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
 msgstr ""
@@ -1983,37 +1983,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3597
+#: lib/vutuv_web/components/ui.ex:3609
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3587
+#: lib/vutuv_web/components/ui.ex:3599
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3586
+#: lib/vutuv_web/components/ui.ex:3598
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3592
+#: lib/vutuv_web/components/ui.ex:3604
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3591
+#: lib/vutuv_web/components/ui.ex:3603
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3588
+#: lib/vutuv_web/components/ui.ex:3600
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3590
+#: lib/vutuv_web/components/ui.ex:3602
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2028,23 +2028,23 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3596
+#: lib/vutuv_web/components/ui.ex:3608
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3595
+#: lib/vutuv_web/components/ui.ex:3607
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3594
+#: lib/vutuv_web/components/ui.ex:3606
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
 
 #: lib/vutuv_web/templates/education/form_content.html.heex:32
-#: lib/vutuv_web/templates/user/edit.html.heex:257
+#: lib/vutuv_web/templates/user/edit.html.heex:263
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Markdown is supported: bold, italics, links and lists."
@@ -2077,7 +2077,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4220
+#: lib/vutuv_web/components/post_components.ex:4275
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2122,8 +2122,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4174
-#: lib/vutuv_web/components/post_components.ex:4176
+#: lib/vutuv_web/components/post_components.ex:4229
+#: lib/vutuv_web/components/post_components.ex:4231
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2187,13 +2187,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4711
-#: lib/vutuv_web/components/post_components.ex:4715
+#: lib/vutuv_web/components/post_components.ex:4766
+#: lib/vutuv_web/components/post_components.ex:4770
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4712
+#: lib/vutuv_web/components/post_components.ex:4767
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5575
+#: lib/vutuv_web/components/ui.ex:5587
 #: lib/vutuv_web/live/shell_live.ex:1582
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2288,32 +2288,32 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4171
+#: lib/vutuv_web/components/post_components.ex:4226
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6337
+#: lib/vutuv_web/components/post_components.ex:6392
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6341
+#: lib/vutuv_web/components/post_components.ex:6396
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6339
+#: lib/vutuv_web/components/post_components.ex:6394
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6340
+#: lib/vutuv_web/components/post_components.ex:6395
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3667
+#: lib/vutuv_web/components/ui.ex:3679
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
@@ -2342,7 +2342,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:598
+#: lib/vutuv_web/templates/user/show.html.heex:603
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2353,8 +2353,8 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2178
-#: lib/vutuv_web/components/post_components.ex:6437
-#: lib/vutuv_web/components/ui.ex:4197
+#: lib/vutuv_web/components/post_components.ex:6492
+#: lib/vutuv_web/components/ui.ex:4209
 #: lib/vutuv_web/views/user_html.ex:484
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2372,8 +2372,8 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2122
-#: lib/vutuv_web/components/post_components.ex:6678
-#: lib/vutuv_web/components/ui.ex:4183
+#: lib/vutuv_web/components/post_components.ex:6733
+#: lib/vutuv_web/components/ui.ex:4195
 #: lib/vutuv_web/notification_line.ex:317
 #: lib/vutuv_web/views/user_html.ex:494
 #, elixir-autogen, elixir-format
@@ -2381,7 +2381,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1263
-#: lib/vutuv_web/components/post_components.ex:6688
+#: lib/vutuv_web/components/post_components.ex:6743
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1590
@@ -2402,13 +2402,13 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6425
+#: lib/vutuv_web/components/post_components.ex:6480
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2177
-#: lib/vutuv_web/components/post_components.ex:6436
+#: lib/vutuv_web/components/post_components.ex:6491
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:484
 #, elixir-autogen, elixir-format
@@ -2416,26 +2416,26 @@ msgid "Remove bookmark"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2158
-#: lib/vutuv_web/components/post_components.ex:6421
+#: lib/vutuv_web/components/post_components.ex:6476
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2696
-#: lib/vutuv_web/components/post_components.ex:5443
+#: lib/vutuv_web/components/post_components.ex:2751
+#: lib/vutuv_web/components/post_components.ex:5498
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2157
-#: lib/vutuv_web/components/post_components.ex:6420
+#: lib/vutuv_web/components/post_components.ex:6475
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2121
-#: lib/vutuv_web/components/post_components.ex:6677
+#: lib/vutuv_web/components/post_components.ex:6732
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:494
 #, elixir-autogen, elixir-format
@@ -2443,7 +2443,7 @@ msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:498
-#: lib/vutuv_web/components/post_components.ex:3182
+#: lib/vutuv_web/components/post_components.ex:3237
 #: lib/vutuv_web/components/ui.ex:3023
 #: lib/vutuv_web/components/ui.ex:3023
 #: lib/vutuv_web/components/ui.ex:3099
@@ -2463,7 +2463,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6732
+#: lib/vutuv_web/components/post_components.ex:6787
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2475,8 +2475,8 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2367
-#: lib/vutuv_web/components/post_components.ex:6715
-#: lib/vutuv_web/components/post_components.ex:6716
+#: lib/vutuv_web/components/post_components.ex:6770
+#: lib/vutuv_web/components/post_components.ex:6771
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:314
@@ -2484,7 +2484,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4130
+#: lib/vutuv_web/components/post_components.ex:4185
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2505,7 +2505,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3648
+#: lib/vutuv_web/components/post_components.ex:3703
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2513,14 +2513,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4102
+#: lib/vutuv_web/components/post_components.ex:4157
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4093
-#: lib/vutuv_web/components/post_components.ex:4122
-#: lib/vutuv_web/components/post_components.ex:4125
+#: lib/vutuv_web/components/post_components.ex:4148
+#: lib/vutuv_web/components/post_components.ex:4177
+#: lib/vutuv_web/components/post_components.ex:4180
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2686,51 +2686,51 @@ msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:918
+#: lib/vutuv_web/templates/user/show.html.heex:923
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1232
+#: lib/vutuv_web/templates/user/show.html.heex:1237
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1491
+#: lib/vutuv_web/templates/user/show.html.heex:1496
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1160
+#: lib/vutuv_web/templates/user/show.html.heex:1165
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1111
+#: lib/vutuv_web/templates/user/show.html.heex:1116
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:647
+#: lib/vutuv_web/templates/user/show.html.heex:652
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:495
+#: lib/vutuv_web/templates/user/show.html.heex:500
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4363
-#: lib/vutuv_web/components/ui.ex:4826
+#: lib/vutuv_web/components/ui.ex:4375
+#: lib/vutuv_web/components/ui.ex:4838
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:109
@@ -2738,7 +2738,7 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
-#: lib/vutuv_web/templates/user/show.html.heex:638
+#: lib/vutuv_web/templates/user/show.html.heex:643
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
@@ -2766,7 +2766,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/live/job_board_live.ex:458
 #: lib/vutuv_web/live/post_live/feed.ex:1018
-#: lib/vutuv_web/templates/user/card_list.html.heex:51
+#: lib/vutuv_web/templates/user/card_list.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
 msgid_plural "+%{formatted} more tags"
@@ -2819,7 +2819,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6338
+#: lib/vutuv_web/components/post_components.ex:6393
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2847,7 +2847,7 @@ msgid "Endorsement"
 msgstr ""
 
 #: lib/vutuv_web/notification_line.ex:312
-#: lib/vutuv_web/templates/user/show.html.heex:966
+#: lib/vutuv_web/templates/user/show.html.heex:971
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -2879,7 +2879,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:335
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:290
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:301
 #: lib/vutuv_web/templates/moderation_evidence/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "(deleted account)"
@@ -2904,16 +2904,6 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:28
 #, elixir-autogen, elixir-format
 msgid "Abusive"
-msgstr ""
-
-#: lib/vutuv_web/views/moderation_case_html.ex:26
-#, elixir-autogen, elixir-format
-msgid "An admin confirmed the report. The content stays hidden."
-msgstr ""
-
-#: lib/vutuv_web/views/moderation_case_html.ex:29
-#, elixir-autogen, elixir-format
-msgid "An admin dismissed the report. The content is visible again."
 msgstr ""
 
 #: lib/vutuv_web/templates/report/new.html.heex:123
@@ -2941,7 +2931,7 @@ msgstr ""
 msgid "Confirmed violations follow three steps: a warning, then a one-week suspension, then permanent deactivation. Strikes expire after twelve months."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:276
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "Conversation context (the reported message last)"
 msgstr ""
@@ -2951,17 +2941,17 @@ msgstr ""
 msgid "Criticize ideas, never people. Demeaning, threatening or repeatedly unwanted messages get accounts suspended - in public posts and in private messages alike."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:268
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Current version (edited since the report)"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:115
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Delete this content permanently?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:106
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:117
 #, elixir-autogen, elixir-format
 msgid "Deleted. The report is settled, no further steps needed."
 msgstr ""
@@ -2971,7 +2961,7 @@ msgstr ""
 msgid "Escalated"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:100
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Fix it. An edited post is visible again immediately."
 msgstr ""
@@ -3022,7 +3012,7 @@ msgstr ""
 msgid "Moderation queue"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:126
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "My content is fine"
 msgstr ""
@@ -3072,13 +3062,13 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1200
-#: lib/vutuv_web/templates/user/show.html.heex:1201
+#: lib/vutuv_web/templates/user/show.html.heex:1205
+#: lib/vutuv_web/templates/user/show.html.heex:1206
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4069
+#: lib/vutuv_web/components/post_components.ex:4124
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3118,7 +3108,7 @@ msgstr ""
 msgid "Please report honestly. Reporting to harm someone breaks our"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5162
+#: lib/vutuv_web/components/ui.ex:5174
 #: lib/vutuv_web/live/shell_live.ex:1373
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3126,7 +3116,7 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:414
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "Reject the report"
 msgstr ""
@@ -3137,16 +3127,16 @@ msgstr ""
 msgid "Rejected"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:109
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1460
-#: lib/vutuv_web/components/post_components.ex:3202
-#: lib/vutuv_web/components/post_components.ex:4287
+#: lib/vutuv_web/components/post_components.ex:3257
+#: lib/vutuv_web/components/post_components.ex:4342
 #: lib/vutuv_web/live/organization_live/show.ex:661
-#: lib/vutuv_web/templates/user/show.html.heex:242
+#: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
 msgid "Report"
 msgstr ""
@@ -3188,13 +3178,13 @@ msgid "Report upheld; the owner got a strike."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_live.ex:55
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:23
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "Reported as"
 msgstr ""
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:24
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:35
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:23
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:34
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Reported content"
@@ -3218,19 +3208,19 @@ msgstr ""
 msgid "Reporter track records"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:300
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:311
 #: lib/vutuv_web/live/admin/moderation_live.ex:57
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Reports"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:133
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4045
+#: lib/vutuv_web/components/ui.ex:4057
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3269,7 +3259,7 @@ msgstr ""
 msgid "Spam or scam"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:123
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Stand by it. It stays hidden until one of our admins has ruled."
 msgstr ""
@@ -3308,7 +3298,7 @@ msgstr ""
 msgid "Thank you for your report. We take it from here."
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:53
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "The content in question"
 msgstr ""
@@ -3323,12 +3313,12 @@ msgstr ""
 msgid "The queue is empty - the self-service flow settled everything."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:402
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:433
 #, elixir-autogen, elixir-format
 msgid "The report by @%{slug} was a deliberate weapon (strikes the reporter)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:374
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:396
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content stays hidden and the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
@@ -3345,7 +3335,7 @@ msgstr ""
 msgid "This account is suspended until %{date}."
 msgstr ""
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:121
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:132
 #, elixir-autogen, elixir-format
 msgid "This case is already settled."
 msgstr ""
@@ -3365,7 +3355,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:83
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:94
 #, elixir-autogen, elixir-format
 msgid "Understood. The content stays hidden until one of our admins has ruled."
 msgstr ""
@@ -3375,7 +3365,7 @@ msgstr ""
 msgid "Unwanted advertising, fraud or fake activity."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:379
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "Uphold the report"
 msgstr ""
@@ -3436,7 +3426,7 @@ msgstr ""
 msgid "Your report is anonymous. If it checks out, the content is hidden right away and the owner is asked to fix it."
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:135
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:145
 #: lib/vutuv_web/templates/public_report/new.html.heex:149
 #: lib/vutuv_web/templates/report/new.html.heex:162
 #, elixir-autogen, elixir-format
@@ -3458,17 +3448,17 @@ msgstr ""
 msgid "yes"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1093
+#: lib/vutuv/notifications/emailer.ex:1127
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1270
+#: lib/vutuv/notifications/emailer.ex:1304
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1061
+#: lib/vutuv/notifications/emailer.ex:1083
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr ""
@@ -3483,12 +3473,12 @@ msgstr ""
 msgid "Your content on vutuv was reported and is hidden"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1107
+#: lib/vutuv/notifications/emailer.ex:1141
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1100
+#: lib/vutuv/notifications/emailer.ex:1134
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr ""
@@ -3549,14 +3539,14 @@ msgstr ""
 msgid "%{count} follows"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:314
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "%{count} report so far"
 msgid_plural "%{count} reports so far"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:314
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "%{rejected} rejected, %{abusive} abusive"
 msgstr ""
@@ -3576,7 +3566,7 @@ msgstr ""
 msgid "Content frozen"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:369
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "Decision"
 msgstr ""
@@ -3596,7 +3586,7 @@ msgstr ""
 msgid "Evidence"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:342
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr ""
@@ -3651,7 +3641,7 @@ msgstr ""
 msgid "Reported on %{date}"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:331
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Reporter and owner are separated since this report (connection, follows, messages)."
 msgstr ""
@@ -3681,12 +3671,12 @@ msgstr ""
 msgid "Strike issued"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:327
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "The protective separation from the owner was lifted on %{date}."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:390
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #, elixir-autogen, elixir-format
 msgid "The report is unfounded. The content becomes visible again, any protective separation is lifted, and the rejection counts against each reporter's trust."
 msgstr ""
@@ -3731,7 +3721,7 @@ msgstr ""
 msgid "messages"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:345
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "No history recorded - this case predates the audit log."
 msgstr ""
@@ -3766,7 +3756,7 @@ msgstr ""
 msgid "Evidence screenshot captured"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:257
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Evidence screenshot captured when the report was filed"
 msgstr ""
@@ -3776,7 +3766,7 @@ msgstr ""
 msgid "Moderation evidence - reported private message with context"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:252
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Screenshot at report time"
 msgstr ""
@@ -3786,7 +3776,7 @@ msgstr ""
 msgid "reported message"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:263
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
@@ -4292,12 +4282,12 @@ msgstr ""
 msgid "Bookings are open through %{last}. Next available day: %{day}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3619
+#: lib/vutuv_web/components/ui.ex:3631
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3615
+#: lib/vutuv_web/components/ui.ex:3627
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr ""
@@ -4307,27 +4297,27 @@ msgstr ""
 msgid "One ad per calendar day: pick a free day in the calendar; struck-through days are already booked."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3620
+#: lib/vutuv_web/components/ui.ex:3632
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3621
+#: lib/vutuv_web/components/ui.ex:3633
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3618
+#: lib/vutuv_web/components/ui.ex:3630
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3616
+#: lib/vutuv_web/components/ui.ex:3628
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3617
+#: lib/vutuv_web/components/ui.ex:3629
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr ""
@@ -4449,7 +4439,7 @@ msgid "Search for words in public posts."
 msgstr ""
 
 #: lib/vutuv_web/templates/block/index.html.heex:36
-#: lib/vutuv_web/templates/user/show.html.heex:263
+#: lib/vutuv_web/templates/user/show.html.heex:268
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr ""
@@ -4459,7 +4449,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5335
+#: lib/vutuv_web/components/ui.ex:5347
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4474,13 +4464,13 @@ msgid "Blocked members cannot follow you, connect with you, message you, or repl
 msgstr ""
 
 #: lib/vutuv_web/templates/block/index.html.heex:74
-#: lib/vutuv_web/templates/user/show.html.heex:158
+#: lib/vutuv_web/templates/user/show.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr ""
 
 #: lib/vutuv_web/templates/block/index.html.heex:72
-#: lib/vutuv_web/templates/user/show.html.heex:155
+#: lib/vutuv_web/templates/user/show.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Unblock @%{slug}?"
 msgstr ""
@@ -4515,7 +4505,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:313
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:988
+#: lib/vutuv_web/templates/user/show.html.heex:993
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4633,7 +4623,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:547
 #: lib/vutuv_web/live/tag_new_live.ex:47
-#: lib/vutuv_web/templates/user/show.html.heex:611
+#: lib/vutuv_web/templates/user/show.html.heex:616
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
@@ -5226,9 +5216,9 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5385
+#: lib/vutuv_web/components/ui.ex:5397
 #: lib/vutuv_web/controllers/settings_controller.ex:161
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:457
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:488
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
@@ -5305,10 +5295,10 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5482
-#: lib/vutuv_web/components/ui.ex:5487
-#: lib/vutuv_web/components/ui.ex:5566
-#: lib/vutuv_web/components/ui.ex:5630
+#: lib/vutuv_web/components/ui.ex:5494
+#: lib/vutuv_web/components/ui.ex:5499
+#: lib/vutuv_web/components/ui.ex:5578
+#: lib/vutuv_web/components/ui.ex:5642
 #: lib/vutuv_web/controllers/settings_controller.ex:68
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5342,17 +5332,17 @@ msgstr ""
 msgid "Your profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:408
+#: lib/vutuv_web/templates/user/show.html.heex:413
 #, elixir-autogen, elixir-format
 msgid "Complete your profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:430
+#: lib/vutuv_web/templates/user/show.html.heex:435
 #, elixir-autogen, elixir-format
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1461
+#: lib/vutuv_web/live/user_profile_live.ex:1464
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5378,9 +5368,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4365
-#: lib/vutuv_web/components/post_components.ex:4417
-#: lib/vutuv_web/components/post_components.ex:4959
+#: lib/vutuv_web/components/post_components.ex:4420
+#: lib/vutuv_web/components/post_components.ex:4472
+#: lib/vutuv_web/components/post_components.ex:5014
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/views/user_html.ex:131
 #, elixir-autogen, elixir-format
@@ -5421,12 +5411,12 @@ msgstr ""
 msgid "Type of email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:236
+#: lib/vutuv_web/templates/user/edit.html.heex:242
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5355
+#: lib/vutuv_web/components/ui.ex:5367
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5447,7 +5437,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5200
+#: lib/vutuv_web/components/ui.ex:5212
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5482,7 +5472,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5329
+#: lib/vutuv_web/components/ui.ex:5341
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -5504,7 +5494,7 @@ msgid "View"
 msgstr ""
 
 #: lib/vutuv_web/templates/public_report/new.html.heex:92
-#: lib/vutuv_web/templates/user/edit.html.heex:161
+#: lib/vutuv_web/templates/user/edit.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Your name"
 msgstr ""
@@ -5562,18 +5552,18 @@ msgstr ""
 msgid "Current avatar"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:107
-#: lib/vutuv_web/templates/user/edit.html.heex:114
+#: lib/vutuv_web/templates/user/edit.html.heex:111
+#: lib/vutuv_web/templates/user/edit.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Current cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:185
+#: lib/vutuv_web/templates/user/edit.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "e.g. Dr. or Prof."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:190
+#: lib/vutuv_web/templates/user/edit.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "e.g. Jr. or PhD"
 msgstr ""
@@ -5595,7 +5585,7 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5378
+#: lib/vutuv_web/components/ui.ex:5390
 #: lib/vutuv_web/controllers/settings_controller.ex:185
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5799,21 +5789,21 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3683
+#: lib/vutuv_web/components/ui.ex:3695
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3682
+#: lib/vutuv_web/components/ui.ex:3694
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3681
+#: lib/vutuv_web/components/ui.ex:3693
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -5880,7 +5870,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3680
+#: lib/vutuv_web/components/ui.ex:3692
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -6010,13 +6000,13 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1466
+#: lib/vutuv_web/live/user_profile_live.ex:1469
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:166
-#: lib/vutuv_web/templates/user/edit.html.heex:253
+#: lib/vutuv_web/templates/user/edit.html.heex:259
 #: lib/vutuv_web/views/account_event_text.ex:212
 #, elixir-autogen, elixir-format
 msgid "Tagline"
@@ -6025,14 +6015,14 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:487
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:916
+#: lib/vutuv_web/templates/user/show.html.heex:921
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:471
+#: lib/vutuv_web/templates/user/show.html.heex:476
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6040,34 +6030,34 @@ msgid_plural "Posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:63
-#: lib/vutuv_web/templates/user/edit.html.heex:144
+#: lib/vutuv_web/templates/user/edit.html.heex:67
+#: lib/vutuv_web/templates/user/edit.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1541
+#: lib/vutuv_web/templates/user/show.html.heex:1546
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:51
-#: lib/vutuv_web/templates/user/edit.html.heex:131
+#: lib/vutuv_web/templates/user/edit.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Drag to move, use the slider to zoom. The framed area is what others see."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:68
+#: lib/vutuv_web/templates/user/edit.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "New avatar preview"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:149
+#: lib/vutuv_web/templates/user/edit.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "New cover photo preview"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:130
+#: lib/vutuv_web/templates/user/edit.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Position your cover photo"
 msgstr ""
@@ -6078,20 +6068,20 @@ msgid "Position your photo"
 msgstr ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:52
-#: lib/vutuv_web/templates/user/edit.html.heex:132
+#: lib/vutuv_web/templates/user/edit.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Use photo"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/composer.ex:1919
 #: lib/vutuv_web/templates/user/edit.html.heex:54
-#: lib/vutuv_web/templates/user/edit.html.heex:134
+#: lib/vutuv_web/templates/user/edit.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1126
-#: lib/vutuv_web/templates/user/show.html.heex:1136
+#: lib/vutuv_web/templates/user/show.html.heex:1131
+#: lib/vutuv_web/templates/user/show.html.heex:1141
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6131,12 +6121,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1248
+#: lib/vutuv_web/templates/user/show.html.heex:1253
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1259
+#: lib/vutuv_web/templates/user/show.html.heex:1264
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6179,7 +6169,7 @@ msgstr ""
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1257
+#: lib/vutuv_web/templates/user/show.html.heex:1262
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6238,9 +6228,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1531
-#: lib/vutuv_web/templates/user/show.html.heex:1535
-#: lib/vutuv_web/templates/user/show.html.heex:1547
+#: lib/vutuv_web/templates/user/show.html.heex:1536
+#: lib/vutuv_web/templates/user/show.html.heex:1540
+#: lib/vutuv_web/templates/user/show.html.heex:1552
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6267,7 +6257,7 @@ msgstr ""
 msgid "Members who endorsed %{name} for %{tag}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user_tag/endorsers.html.heex:78
+#: lib/vutuv_web/templates/user_tag/endorsers.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "No endorsements yet."
 msgstr ""
@@ -6567,16 +6557,16 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3129
-#: lib/vutuv_web/components/post_components.ex:4240
-#: lib/vutuv_web/components/post_components.ex:4254
+#: lib/vutuv_web/components/post_components.ex:3184
+#: lib/vutuv_web/components/post_components.ex:4295
+#: lib/vutuv_web/components/post_components.ex:4309
 #: lib/vutuv_web/components/ui.ex:3171
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:320
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
-#: lib/vutuv_web/templates/user/show.html.heex:235
+#: lib/vutuv_web/templates/user/show.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr ""
@@ -6597,7 +6587,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4240
+#: lib/vutuv_web/components/post_components.ex:4295
 #: lib/vutuv_web/components/ui.ex:3170
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6605,7 +6595,7 @@ msgstr ""
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:320
 #: lib/vutuv_web/templates/settings/filters.html.heex:111
 #: lib/vutuv_web/templates/settings/mutes.html.heex:60
-#: lib/vutuv_web/templates/user/show.html.heex:235
+#: lib/vutuv_web/templates/user/show.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "Unmute"
 msgstr ""
@@ -7202,13 +7192,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4139
+#: lib/vutuv_web/components/ui.ex:4151
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4151
+#: lib/vutuv_web/components/ui.ex:4163
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7290,9 +7280,9 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:6588
+#: lib/vutuv_web/components/post_components.ex:6643
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
-#: lib/vutuv_web/live/shell_live.ex:1812
+#: lib/vutuv_web/live/shell_live.ex:1817
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
 msgstr ""
@@ -7960,7 +7950,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4142
+#: lib/vutuv_web/components/ui.ex:4154
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8078,7 +8068,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:704
+#: lib/vutuv_web/templates/user/show.html.heex:709
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8090,7 +8080,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:5176
+#: lib/vutuv_web/components/ui.ex:5188
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8102,7 +8092,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
-#: lib/vutuv_web/templates/user/show.html.heex:701
+#: lib/vutuv_web/templates/user/show.html.heex:706
 #: lib/vutuv_web/views/import_html.ex:70
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
@@ -8145,14 +8135,14 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5366
+#: lib/vutuv_web/components/ui.ex:5378
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
 #: lib/vutuv_web/controllers/import_controller.ex:37
 #: lib/vutuv_web/controllers/import_controller.ex:128
-#: lib/vutuv_web/live/user_profile_live.ex:1477
+#: lib/vutuv_web/live/user_profile_live.ex:1480
 #: lib/vutuv_web/templates/import/new.html.heex:1
 #: lib/vutuv_web/templates/import/preview.html.heex:1
 #, elixir-autogen, elixir-format
@@ -8174,7 +8164,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5204
+#: lib/vutuv_web/components/ui.ex:5216
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8268,7 +8258,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4408
+#: lib/vutuv_web/components/ui.ex:4420
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8282,7 +8272,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1395
+#: lib/vutuv_web/templates/user/show.html.heex:1400
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8343,25 +8333,25 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5164
+#: lib/vutuv_web/components/ui.ex:5176
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5298
+#: lib/vutuv_web/components/ui.ex:5310
 #: lib/vutuv_web/controllers/settings_controller.ex:129
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Language & display"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:526
+#: lib/vutuv_web/templates/user/edit.html.heex:532
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5357
+#: lib/vutuv_web/components/ui.ex:5369
 #: lib/vutuv_web/controllers/settings_controller.ex:112
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8371,7 +8361,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5370
+#: lib/vutuv_web/components/ui.ex:5382
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8577,7 +8567,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:652
 #: lib/vutuv_web/components/organization_components.ex:276
 #: lib/vutuv_web/components/ui.ex:1783
-#: lib/vutuv_web/components/ui.ex:5347
+#: lib/vutuv_web/components/ui.ex:5359
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:366
 #: lib/vutuv_web/controllers/settings_controller.ex:433
@@ -8590,7 +8580,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1300
+#: lib/vutuv_web/templates/user/show.html.heex:1305
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8732,7 +8722,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5446
+#: lib/vutuv_web/components/post_components.ex:5501
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -8834,7 +8824,7 @@ msgstr ""
 msgid "For a PDF, open the print view and choose \"Save as PDF\" in your browser's print dialog. Word and OpenDocument are editable; LaTeX is the typesetting source; JSON Resume is the open %{link} format."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:266
+#: lib/vutuv_web/templates/user/edit.html.heex:272
 #, elixir-autogen, elixir-format
 msgid "characters"
 msgstr ""
@@ -8983,7 +8973,7 @@ msgstr ""
 #: lib/vutuv_web/live/feed_languages_live.ex:317
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:766
+#: lib/vutuv_web/templates/user/show.html.heex:771
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9208,7 +9198,7 @@ msgstr ""
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:763
+#: lib/vutuv_web/templates/user/show.html.heex:768
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -9395,7 +9385,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1271
+#: lib/vutuv/accounts/user.ex:1278
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9406,13 +9396,13 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1268
+#: lib/vutuv/accounts/user.ex:1275
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:290
+#: lib/vutuv_web/templates/user/edit.html.heex:296
 #, elixir-autogen, elixir-format
 msgid "Shown as a badge next to your tagline so people can see whether you are open to opportunities."
 msgstr ""
@@ -9488,7 +9478,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:870
+#: lib/vutuv_web/templates/user/show.html.heex:875
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
@@ -9521,7 +9511,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:5180
+#: lib/vutuv_web/components/ui.ex:5192
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -9536,7 +9526,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:867
+#: lib/vutuv_web/templates/user/show.html.heex:872
 #: lib/vutuv_web/views/import_html.ex:71
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
@@ -9655,8 +9645,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1222
-#: lib/vutuv_web/templates/user/show.html.heex:1223
+#: lib/vutuv_web/templates/user/show.html.heex:1227
+#: lib/vutuv_web/templates/user/show.html.heex:1228
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -9671,18 +9661,18 @@ msgstr ""
 msgid "Date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:439
-#: lib/vutuv_web/templates/user/edit.html.heex:514
+#: lib/vutuv_web/templates/user/edit.html.heex:445
+#: lib/vutuv_web/templates/user/edit.html.heex:520
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:502
+#: lib/vutuv_web/templates/user/edit.html.heex:508
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:505
+#: lib/vutuv_web/templates/user/edit.html.heex:511
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -9711,19 +9701,19 @@ msgstr ""
 msgid "Permanent profile link"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:419
-#: lib/vutuv_web/templates/user/show.html.heex:420
+#: lib/vutuv_web/templates/user/show.html.heex:424
+#: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3796
+#: lib/vutuv_web/components/ui.ex:3808
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3795
-#: lib/vutuv_web/components/ui.ex:3803
+#: lib/vutuv_web/components/ui.ex:3807
+#: lib/vutuv_web/components/ui.ex:3815
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -9806,7 +9796,7 @@ msgstr ""
 msgid "Accounts removed as spam"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:424
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "Clear-cut spam or abuse?"
 msgstr ""
@@ -9816,22 +9806,22 @@ msgstr ""
 msgid "Could not restore this member."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:439
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "Deactivate @%{slug} and mark the account as spam?"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:442
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:473
 #, elixir-autogen, elixir-format
 msgid "Deactivate account"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:451
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Permanently DELETE @%{slug} and everything they posted? This cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:427
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:458
 #, elixir-autogen, elixir-format
 msgid "Remove the account outright, skipping the warning ladder. Deactivating marks it as spam and is reversible from the member browser; deleting is permanent."
 msgstr ""
@@ -10143,7 +10133,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:71
 #: lib/vutuv_web/agent_docs/text.ex:66
-#: lib/vutuv_web/templates/user/show.html.heex:1369
+#: lib/vutuv_web/templates/user/show.html.heex:1374
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10718,24 +10708,24 @@ msgstr ""
 msgid "Views"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:299
+#: lib/vutuv_web/templates/user/edit.html.heex:305
 #, elixir-autogen, elixir-format
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1309
+#: lib/vutuv/accounts/user.ex:1316
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1314
+#: lib/vutuv/accounts/user.ex:1321
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1312
+#: lib/vutuv/accounts/user.ex:1319
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -10743,53 +10733,53 @@ msgid "Signed-in members only"
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:259
-#: lib/vutuv_web/templates/user/edit.html.heex:296
+#: lib/vutuv_web/templates/user/edit.html.heex:302
 #, elixir-autogen, elixir-format
 msgid "Who can see your availability?"
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:270
-#: lib/vutuv_web/templates/user/edit.html.heex:321
+#: lib/vutuv_web/templates/user/edit.html.heex:327
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:278
 #: lib/vutuv_web/live/job_posting_live/form.ex:693
-#: lib/vutuv_web/templates/user/edit.html.heex:329
+#: lib/vutuv_web/templates/user/edit.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:339
+#: lib/vutuv_web/templates/user/edit.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "Hidden by default, and it still does its job while hidden. \"Signed-in members only\" adds a quiet line to your profile for members; \"Everyone\" also shows it to logged-out visitors."
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:266
-#: lib/vutuv_web/templates/user/edit.html.heex:312
+#: lib/vutuv_web/templates/user/edit.html.heex:318
 #, elixir-autogen, elixir-format
 msgid "Minimum salary expectation"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:315
+#: lib/vutuv_web/templates/user/edit.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:274
 #: lib/vutuv_web/live/job_posting_live/form.ex:700
-#: lib/vutuv_web/templates/user/edit.html.heex:325
+#: lib/vutuv_web/templates/user/edit.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "Per"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:315
+#: lib/vutuv_web/templates/user/show.html.heex:320
 #, elixir-autogen, elixir-format
 msgid "Salary expectation from %{amount} %{currency} per %{period}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:336
+#: lib/vutuv_web/templates/user/edit.html.heex:342
 #, elixir-autogen, elixir-format
 msgid "Who can see your salary expectation?"
 msgstr ""
@@ -10858,7 +10848,7 @@ msgstr ""
 msgid "Exclude an email domain"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:387
+#: lib/vutuv_web/templates/user/edit.html.heex:393
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr ""
@@ -10869,12 +10859,12 @@ msgstr ""
 msgid "Job-search exclusion list"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:390
+#: lib/vutuv_web/templates/user/edit.html.heex:396
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:398
+#: lib/vutuv_web/templates/user/edit.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -11017,12 +11007,12 @@ msgstr ""
 msgid "State / region (optional)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4495
+#: lib/vutuv_web/components/ui.ex:4507
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4497
+#: lib/vutuv_web/components/ui.ex:4509
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr ""
@@ -11705,7 +11695,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:462
-#: lib/vutuv_web/components/ui.ex:5374
+#: lib/vutuv_web/components/ui.ex:5386
 #: lib/vutuv_web/controllers/settings_controller.ex:222
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
@@ -12014,7 +12004,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1283
+#: lib/vutuv/accounts/user.ex:1290
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12133,7 +12123,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1282
+#: lib/vutuv/accounts/user.ex:1289
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12215,7 +12205,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1284
+#: lib/vutuv/accounts/user.ex:1291
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:590
 #: lib/vutuv_web/agent_docs/markdown.ex:532
@@ -12352,7 +12342,7 @@ msgstr ""
 msgid "You already have the maximum number of published postings."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1123
+#: lib/vutuv/notifications/emailer.ex:1157
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr ""
@@ -12913,7 +12903,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5283
+#: lib/vutuv_web/components/ui.ex:5295
 #: lib/vutuv_web/controllers/settings_controller.ex:629
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -12932,7 +12922,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3607
+#: lib/vutuv_web/components/post_components.ex:3662
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -13179,7 +13169,7 @@ msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7
 msgstr ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:41
-#: lib/vutuv_web/templates/user/edit.html.heex:121
+#: lib/vutuv_web/templates/user/edit.html.heex:125
 #: lib/vutuv_web/templates/user/show.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Image awaiting review, visible only to you"
@@ -13196,7 +13186,7 @@ msgstr ""
 msgid "No images waiting for the AI scan. %{formatted} rejected in the last 7 days."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:208
+#: lib/vutuv_web/templates/user/show.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Profile picture awaiting review, visible only to you"
 msgstr ""
@@ -13226,36 +13216,36 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1327
+#: lib/vutuv/accounts/user.ex:1334
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:450
+#: lib/vutuv_web/templates/user/edit.html.heex:456
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1330
+#: lib/vutuv/accounts/user.ex:1337
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1333
+#: lib/vutuv/accounts/user.ex:1340
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1324
+#: lib/vutuv/accounts/user.ex:1331
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:447
+#: lib/vutuv_web/templates/user/edit.html.heex:453
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr ""
@@ -13371,7 +13361,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5266
+#: lib/vutuv_web/components/ui.ex:5278
 #: lib/vutuv_web/controllers/settings_controller.ex:643
 #: lib/vutuv_web/live/post_live/feed.ex:710
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13417,7 +13407,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1335
+#: lib/vutuv_web/templates/user/show.html.heex:1340
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13446,7 +13436,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:63
-#: lib/vutuv_web/components/ui.ex:5223
+#: lib/vutuv_web/components/ui.ex:5235
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13454,7 +13444,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1333
+#: lib/vutuv_web/templates/user/show.html.heex:1338
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13474,14 +13464,14 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4580
+#: lib/vutuv_web/components/ui.ex:4592
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:4590
+#: lib/vutuv_web/components/ui.ex:4602
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
@@ -13531,34 +13521,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6134
+#: lib/vutuv_web/components/post_components.ex:6189
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:6091
+#: lib/vutuv_web/components/post_components.ex:6146
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6135
+#: lib/vutuv_web/components/post_components.ex:6190
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6137
+#: lib/vutuv_web/components/post_components.ex:6192
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6133
+#: lib/vutuv_web/components/post_components.ex:6188
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:6090
+#: lib/vutuv_web/components/post_components.ex:6145
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13569,12 +13559,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6132
+#: lib/vutuv_web/components/post_components.ex:6187
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6136
+#: lib/vutuv_web/components/post_components.ex:6191
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13594,7 +13584,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6173
+#: lib/vutuv_web/components/post_components.ex:6228
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13602,27 +13592,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6203
+#: lib/vutuv_web/components/post_components.ex:6258
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6204
+#: lib/vutuv_web/components/post_components.ex:6259
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6202
+#: lib/vutuv_web/components/post_components.ex:6257
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6162
+#: lib/vutuv_web/components/post_components.ex:6217
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6209
+#: lib/vutuv_web/components/post_components.ex:6264
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13652,7 +13642,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5976
+#: lib/vutuv_web/components/post_components.ex:6031
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13695,7 +13685,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5967
+#: lib/vutuv_web/components/post_components.ex:6022
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -13877,7 +13867,7 @@ msgid "Are you looking for a job?"
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:290
-#: lib/vutuv_web/templates/user/edit.html.heex:359
+#: lib/vutuv_web/templates/user/edit.html.heex:365
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr ""
@@ -13894,12 +13884,12 @@ msgid "Preferred workplace"
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:249
-#: lib/vutuv_web/templates/user/edit.html.heex:287
+#: lib/vutuv_web/templates/user/edit.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1085
+#: lib/vutuv/notifications/emailer.ex:1111
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
@@ -14042,14 +14032,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3896
+#: lib/vutuv_web/components/post_components.ex:3951
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3919
+#: lib/vutuv_web/components/post_components.ex:3974
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14076,7 +14066,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6687
+#: lib/vutuv_web/components/post_components.ex:6742
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14234,7 +14224,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5237
+#: lib/vutuv_web/components/ui.ex:5249
 #: lib/vutuv_web/controllers/settings_controller.ex:773
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -14812,7 +14802,7 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1042
+#: lib/vutuv_web/templates/user/show.html.heex:1047
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
@@ -14868,252 +14858,252 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5165
+#: lib/vutuv_web/components/ui.ex:5177
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5170
+#: lib/vutuv_web/components/ui.ex:5182
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5173
+#: lib/vutuv_web/components/ui.ex:5185
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5174
+#: lib/vutuv_web/components/ui.ex:5186
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5177
+#: lib/vutuv_web/components/ui.ex:5189
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5178
+#: lib/vutuv_web/components/ui.ex:5190
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5181
+#: lib/vutuv_web/components/ui.ex:5193
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5182
+#: lib/vutuv_web/components/ui.ex:5194
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5189
+#: lib/vutuv_web/components/ui.ex:5201
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5190
+#: lib/vutuv_web/components/ui.ex:5202
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5191
+#: lib/vutuv_web/components/ui.ex:5203
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5194
+#: lib/vutuv_web/components/ui.ex:5206
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5195
+#: lib/vutuv_web/components/ui.ex:5207
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5375
+#: lib/vutuv_web/components/ui.ex:5387
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5376
+#: lib/vutuv_web/components/ui.ex:5388
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5198
+#: lib/vutuv_web/components/ui.ex:5210
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5201
+#: lib/vutuv_web/components/ui.ex:5213
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5202
+#: lib/vutuv_web/components/ui.ex:5214
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5205
+#: lib/vutuv_web/components/ui.ex:5217
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5206
+#: lib/vutuv_web/components/ui.ex:5218
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5209
+#: lib/vutuv_web/components/ui.ex:5221
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5210
+#: lib/vutuv_web/components/ui.ex:5222
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5212
+#: lib/vutuv_web/components/ui.ex:5224
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5213
+#: lib/vutuv_web/components/ui.ex:5225
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5214
+#: lib/vutuv_web/components/ui.ex:5226
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5216
+#: lib/vutuv_web/components/ui.ex:5228
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5217
+#: lib/vutuv_web/components/ui.ex:5229
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5219
+#: lib/vutuv_web/components/ui.ex:5231
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5224
+#: lib/vutuv_web/components/ui.ex:5236
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5225
+#: lib/vutuv_web/components/ui.ex:5237
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5228
+#: lib/vutuv_web/components/ui.ex:5240
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5231
+#: lib/vutuv_web/components/ui.ex:5243
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5238
+#: lib/vutuv_web/components/ui.ex:5250
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5239
+#: lib/vutuv_web/components/ui.ex:5251
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5267
+#: lib/vutuv_web/components/ui.ex:5279
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5268
+#: lib/vutuv_web/components/ui.ex:5280
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5284
+#: lib/vutuv_web/components/ui.ex:5296
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5285
+#: lib/vutuv_web/components/ui.ex:5297
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5332
+#: lib/vutuv_web/components/ui.ex:5344
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5333
+#: lib/vutuv_web/components/ui.ex:5345
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5336
+#: lib/vutuv_web/components/ui.ex:5348
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5337
+#: lib/vutuv_web/components/ui.ex:5349
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5358
+#: lib/vutuv_web/components/ui.ex:5370
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5359
+#: lib/vutuv_web/components/ui.ex:5371
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5367
+#: lib/vutuv_web/components/ui.ex:5379
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5368
+#: lib/vutuv_web/components/ui.ex:5380
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5371
+#: lib/vutuv_web/components/ui.ex:5383
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5372
+#: lib/vutuv_web/components/ui.ex:5384
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5386
+#: lib/vutuv_web/components/ui.ex:5398
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5387
+#: lib/vutuv_web/components/ui.ex:5399
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15221,7 +15211,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6633
+#: lib/vutuv_web/components/post_components.ex:6688
 #: lib/vutuv_web/live/notification_live/index.ex:1596
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -15229,7 +15219,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6637
+#: lib/vutuv_web/components/post_components.ex:6692
 #: lib/vutuv_web/live/notification_live/index.ex:1590
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15237,7 +15227,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6641
+#: lib/vutuv_web/components/post_components.ex:6696
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15245,7 +15235,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:6592
+#: lib/vutuv_web/components/post_components.ex:6647
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15264,7 +15254,7 @@ msgid "Content warning"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1581
-#: lib/vutuv_web/components/post_components.ex:2625
+#: lib/vutuv_web/components/post_components.ex:2680
 #: lib/vutuv_web/live/fediverse_account_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "From another network"
@@ -15343,7 +15333,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1501
 #: lib/vutuv_web/components/post_components.ex:1496
 #: lib/vutuv_web/components/post_components.ex:1727
-#: lib/vutuv_web/components/post_components.ex:3465
+#: lib/vutuv_web/components/post_components.ex:3520
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -15572,7 +15562,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5361
+#: lib/vutuv_web/components/ui.ex:5373
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -15917,7 +15907,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5362
+#: lib/vutuv_web/components/ui.ex:5374
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -15953,7 +15943,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5364
+#: lib/vutuv_web/components/ui.ex:5376
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16005,22 +15995,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4081
+#: lib/vutuv_web/components/post_components.ex:4136
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4207
+#: lib/vutuv_web/components/post_components.ex:4262
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4215
+#: lib/vutuv_web/components/post_components.ex:4270
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4201
+#: lib/vutuv_web/components/post_components.ex:4256
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16047,19 +16037,19 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:626
 #: lib/vutuv_web/agent_docs/text.ex:611
-#: lib/vutuv_web/templates/user/edit.html.heex:219
-#: lib/vutuv_web/templates/user/show.html.heex:286
+#: lib/vutuv_web/templates/user/edit.html.heex:225
+#: lib/vutuv_web/templates/user/show.html.heex:291
 #: lib/vutuv_web/views/account_event_text.ex:213
 #, elixir-autogen, elixir-format
 msgid "Name pronunciation"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:223
+#: lib/vutuv_web/templates/user/edit.html.heex:229
 #, elixir-autogen, elixir-format
 msgid "e.g. [SHTEH-fahn VIN-ter-my-er]"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:226
+#: lib/vutuv_web/templates/user/edit.html.heex:232
 #, elixir-autogen, elixir-format
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
@@ -16143,17 +16133,17 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3660
+#: lib/vutuv_web/components/post_components.ex:3715
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5091
+#: lib/vutuv_web/components/post_components.ex:5146
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5240
+#: lib/vutuv_web/components/post_components.ex:5295
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16166,7 +16156,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1462
 #: lib/vutuv_web/agent_docs/text.ex:890
-#: lib/vutuv_web/components/post_components.ex:5322
+#: lib/vutuv_web/components/post_components.ex:5377
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
@@ -16192,7 +16182,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3713
+#: lib/vutuv_web/components/post_components.ex:3768
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16212,7 +16202,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3704
+#: lib/vutuv_web/components/post_components.ex:3759
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16222,12 +16212,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3722
+#: lib/vutuv_web/components/post_components.ex:3777
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3656
+#: lib/vutuv_web/components/post_components.ex:3711
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16242,7 +16232,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3717
+#: lib/vutuv_web/components/post_components.ex:3772
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16252,7 +16242,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3670
+#: lib/vutuv_web/components/post_components.ex:3725
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16327,13 +16317,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1319
-#: lib/vutuv_web/components/post_components.ex:6630
+#: lib/vutuv_web/components/post_components.ex:6685
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1317
-#: lib/vutuv_web/components/post_components.ex:6627
+#: lib/vutuv_web/components/post_components.ex:6682
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16343,7 +16333,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6514
+#: lib/vutuv_web/components/post_components.ex:6569
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -16461,7 +16451,7 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5348
+#: lib/vutuv_web/components/ui.ex:5360
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
@@ -16664,7 +16654,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5350
+#: lib/vutuv_web/components/ui.ex:5362
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -16684,7 +16674,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3224
+#: lib/vutuv_web/components/post_components.ex:3279
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16694,7 +16684,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3464
+#: lib/vutuv_web/components/post_components.ex:3519
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16719,7 +16709,7 @@ msgstr ""
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3405
+#: lib/vutuv_web/components/post_components.ex:3460
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr ""
@@ -16734,7 +16724,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3197
+#: lib/vutuv_web/components/post_components.ex:3252
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -16822,7 +16812,7 @@ msgstr ""
 msgid "Your account move"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:28
+#: lib/vutuv_web/views/page_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "“LinkedIn is annoying. vutuv is not.”"
 msgstr ""
@@ -16834,27 +16824,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2798
+#: lib/vutuv_web/components/post_components.ex:2853
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2831
+#: lib/vutuv_web/components/post_components.ex:2886
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2826
+#: lib/vutuv_web/components/post_components.ex:2881
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3563
+#: lib/vutuv_web/components/post_components.ex:3618
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3569
+#: lib/vutuv_web/components/post_components.ex:3624
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr ""
@@ -16864,7 +16854,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3708
+#: lib/vutuv_web/components/post_components.ex:3763
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17525,7 +17515,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3566
+#: lib/vutuv_web/components/post_components.ex:3621
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -17597,19 +17587,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5616
+#: lib/vutuv_web/components/post_components.ex:5671
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5618
+#: lib/vutuv_web/components/post_components.ex:5673
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5629
+#: lib/vutuv_web/components/post_components.ex:5684
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -17669,7 +17659,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/job_reference_controller.ex:144
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:18
 #: lib/vutuv_web/templates/job_reference/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:804
+#: lib/vutuv_web/templates/user/show.html.heex:809
 #, elixir-autogen, elixir-format
 msgid "Add an employment reference"
 msgstr ""
@@ -17736,7 +17726,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:5184
+#: lib/vutuv_web/components/ui.ex:5196
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -17746,7 +17736,7 @@ msgstr ""
 #: lib/vutuv_web/templates/job_reference/new.html.heex:4
 #: lib/vutuv_web/templates/job_reference/show.html.heex:12
 #: lib/vutuv_web/templates/job_reference/view.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:801
+#: lib/vutuv_web/templates/user/show.html.heex:806
 #, elixir-autogen, elixir-format
 msgid "Employment references"
 msgstr ""
@@ -17931,7 +17921,7 @@ msgstr ""
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5185
+#: lib/vutuv_web/components/ui.ex:5197
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
@@ -17942,7 +17932,7 @@ msgstr ""
 msgid "Zwischenzeugnis"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5187
+#: lib/vutuv_web/components/ui.ex:5199
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -18197,7 +18187,7 @@ msgstr ""
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4481
+#: lib/vutuv_web/components/ui.ex:4493
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -18377,7 +18367,7 @@ msgstr ""
 msgid "by the lawyer Tom Braegelmann"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:845
+#: lib/vutuv_web/templates/user/show.html.heex:850
 #, elixir-autogen, elixir-format
 msgid "Documents:"
 msgstr ""
@@ -18493,17 +18483,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1430
+#: lib/vutuv/accounts/user.ex:1437
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1428
+#: lib/vutuv/accounts/user.ex:1435
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1429
+#: lib/vutuv/accounts/user.ex:1436
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -18513,7 +18503,7 @@ msgstr ""
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5166
+#: lib/vutuv_web/components/ui.ex:5178
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
@@ -18609,7 +18599,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5341
+#: lib/vutuv_web/components/ui.ex:5353
 #: lib/vutuv_web/controllers/settings_controller.ex:256
 #: lib/vutuv_web/controllers/settings_controller.ex:335
 #: lib/vutuv_web/controllers/settings_controller.ex:347
@@ -18706,7 +18696,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5343
+#: lib/vutuv_web/components/ui.ex:5355
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -18815,7 +18805,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5345
+#: lib/vutuv_web/components/ui.ex:5357
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -19189,7 +19179,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3596
+#: lib/vutuv_web/components/post_components.ex:3651
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -19346,7 +19336,7 @@ msgstr[1] ""
 msgid "%{name} mentioned this page."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:184
+#: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
 msgid "%{name} follows"
 msgstr ""
@@ -19356,7 +19346,7 @@ msgstr ""
 msgid "Feed – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:185
+#: lib/vutuv_web/templates/user/show.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "Follow as %{name}"
 msgstr ""
@@ -19729,7 +19719,7 @@ msgstr ""
 msgid "the address of a post out there: vutuv fetches it so you can answer it here"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:81
+#: lib/vutuv_web/templates/user/edit.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Fetch my picture from gravatar.com"
 msgstr ""
@@ -19754,7 +19744,7 @@ msgstr ""
 msgid "gravatar.com has no picture for your email address."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:84
+#: lib/vutuv_web/templates/user/edit.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "Only when you press this: we ask gravatar.com whether there is a picture for your email address, sending a hash of the address rather than the address itself. Nothing leaves this server otherwise."
 msgstr ""
@@ -20057,27 +20047,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5510
+#: lib/vutuv_web/components/post_components.ex:5565
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5546
+#: lib/vutuv_web/components/post_components.ex:5601
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5555
+#: lib/vutuv_web/components/post_components.ex:5610
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5558
+#: lib/vutuv_web/components/post_components.ex:5613
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5535
+#: lib/vutuv_web/components/post_components.ex:5590
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20087,8 +20077,8 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5525
-#: lib/vutuv_web/components/ui.ex:5259
+#: lib/vutuv_web/components/post_components.ex:5580
+#: lib/vutuv_web/components/ui.ex:5271
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -20216,32 +20206,32 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5288
+#: lib/vutuv_web/components/post_components.ex:5343
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5285
+#: lib/vutuv_web/components/post_components.ex:5340
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2852
-#: lib/vutuv_web/components/post_components.ex:4495
+#: lib/vutuv_web/components/post_components.ex:2907
+#: lib/vutuv_web/components/post_components.ex:4550
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:139
+#: lib/vutuv_web/templates/user/edit.html.heex:145
 #, elixir-autogen, elixir-format
 msgid "Recommended: %{width} × %{height} pixels (%{ratio})."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:59
+#: lib/vutuv_web/templates/user/edit.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
@@ -20299,7 +20289,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5379
+#: lib/vutuv_web/components/ui.ex:5391
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
@@ -20345,7 +20335,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5381
+#: lib/vutuv_web/components/ui.ex:5393
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -20380,7 +20370,7 @@ msgstr ""
 msgid "Find your LinkedIn contacts"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5275
+#: lib/vutuv_web/components/ui.ex:5287
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format
@@ -20488,7 +20478,7 @@ msgstr ""
 msgid "See which of them are already on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5277
+#: lib/vutuv_web/components/ui.ex:5289
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr ""
@@ -20560,7 +20550,7 @@ msgstr ""
 msgid "Your export also lists your LinkedIn contacts."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5279
+#: lib/vutuv_web/components/ui.ex:5291
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr ""
@@ -20742,7 +20732,7 @@ msgstr ""
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3177
+#: lib/vutuv_web/components/post_components.ex:3232
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
@@ -20817,7 +20807,7 @@ msgstr ""
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5233
+#: lib/vutuv_web/components/ui.ex:5245
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
@@ -21038,22 +21028,22 @@ msgstr ""
 msgid "Shown in the language it was written in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5260
+#: lib/vutuv_web/components/ui.ex:5272
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5262
+#: lib/vutuv_web/components/ui.ex:5274
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5300
+#: lib/vutuv_web/components/ui.ex:5312
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5304
+#: lib/vutuv_web/components/ui.ex:5316
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -21141,12 +21131,12 @@ msgstr ""
 msgid "That alternative name is no longer on record."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:63
+#: lib/vutuv_web/views/page_html.ex:60
 #, elixir-autogen, elixir-format
 msgid "Fast."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:64
+#: lib/vutuv_web/views/page_html.ex:61
 #, elixir-autogen, elixir-format
 msgid "No paid premium accounts."
 msgstr ""
@@ -21511,7 +21501,7 @@ msgid_plural "Show %{formatted} posts in the feed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2769
+#: lib/vutuv_web/components/post_components.ex:2824
 #, elixir-autogen, elixir-format
 msgid "Picture unavailable"
 msgstr ""
@@ -21536,7 +21526,7 @@ msgstr ""
 msgid "Your organization page was updated, but that picture could not be used as a logo. Please pick another one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4487
+#: lib/vutuv_web/components/ui.ex:4499
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -21683,7 +21673,7 @@ msgid_plural "New (%{formatted}):"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3332
+#: lib/vutuv_web/components/post_components.ex:3387
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr ""
@@ -21734,12 +21724,12 @@ msgstr ""
 msgid "Only these accounts (empty = all) …"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3530
+#: lib/vutuv_web/components/ui.ex:3542
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6973
+#: lib/vutuv_web/components/post_components.ex:7028
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -21976,7 +21966,7 @@ msgstr ""
 msgid "Replace with"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5252
+#: lib/vutuv_web/components/ui.ex:5264
 #, elixir-autogen, elixir-format
 msgid "Rewrite what an account's posts say, for you alone"
 msgstr ""
@@ -21992,9 +21982,9 @@ msgid "Rules that rewrite the text of one account's posts before you read them: 
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1450
-#: lib/vutuv_web/components/post_components.ex:3190
-#: lib/vutuv_web/components/post_components.ex:4284
-#: lib/vutuv_web/components/ui.ex:5251
+#: lib/vutuv_web/components/post_components.ex:3245
+#: lib/vutuv_web/components/post_components.ex:4339
+#: lib/vutuv_web/components/ui.ex:5263
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
 #: lib/vutuv_web/live/post_rewrites_live.ex:264
@@ -22050,12 +22040,12 @@ msgstr ""
 msgid "\\1 puts back what the first (…) group matched, \\0 the whole match."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5253
+#: lib/vutuv_web/components/ui.ex:5265
 #, elixir-autogen, elixir-format
 msgid "regex regular expression rewrite replace footer signature strip"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5322
+#: lib/vutuv_web/components/ui.ex:5334
 #, elixir-autogen, elixir-format
 msgid "Smaller pictures and a plain composer on a slow connection"
 msgstr ""
@@ -22065,12 +22055,12 @@ msgstr ""
 msgid "That endorsement is not possible."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5324
+#: lib/vutuv_web/components/ui.ex:5336
 #, elixir-autogen, elixir-format
 msgid "bandwidth slow internet mobile data saving saver volume metered compression pictures images screenshots editor langsam daten sparen datensparmodus volumen schmalband komprimierung bilder"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5296
+#: lib/vutuv_web/components/ui.ex:5308
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr ""
@@ -22183,7 +22173,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1417
 #: lib/vutuv_web/agent_docs/text.ex:899
 #: lib/vutuv_web/agent_docs/text.ex:900
-#: lib/vutuv_web/components/post_components.ex:2904
+#: lib/vutuv_web/components/post_components.ex:2959
 #: lib/vutuv_web/components/video_components.ex:127
 #: lib/vutuv_web/live/post_live/composer.ex:2458
 #, elixir-autogen, elixir-format
@@ -22246,7 +22236,7 @@ msgstr[1] ""
 msgid "Last 30 days: %{parts}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4847
+#: lib/vutuv_web/components/post_components.ex:4902
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -22550,7 +22540,7 @@ msgstr ""
 msgid "Accounts whose posts stay out of your feed, and accounts whose reposts do. This list is yours alone: it is never shared and nobody is told they are on it."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5245
+#: lib/vutuv_web/components/ui.ex:5257
 #, elixir-autogen, elixir-format
 msgid "Accounts you have silenced, and whose reposts you hide"
 msgstr ""
@@ -22560,8 +22550,8 @@ msgstr ""
 msgid "Hidden. What they pass on stays out of your feed; their own posts do not."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3162
-#: lib/vutuv_web/components/post_components.ex:4278
+#: lib/vutuv_web/components/post_components.ex:3217
+#: lib/vutuv_web/components/post_components.ex:4333
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr ""
@@ -22576,7 +22566,7 @@ msgstr ""
 msgid "Mute everything"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5244
+#: lib/vutuv_web/components/ui.ex:5256
 #: lib/vutuv_web/controllers/settings_controller.ex:713
 #: lib/vutuv_web/templates/settings/mutes.html.heex:1
 #: lib/vutuv_web/templates/settings/mutes.html.heex:3
@@ -22620,7 +22610,7 @@ msgstr ""
 msgid "You mute an account where you meet it: the ⋯ menu on any of its posts, or its own page. Muting works whether or not you follow them."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5247
+#: lib/vutuv_web/components/ui.ex:5259
 #, elixir-autogen, elixir-format
 msgid "mute unmute hide account reposts boosts feed stumm stummschalten ausblenden konto"
 msgstr ""
@@ -22720,7 +22710,7 @@ msgstr ""
 msgid "Feed settings saved."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5315
+#: lib/vutuv_web/components/ui.ex:5327
 #, elixir-autogen, elixir-format
 msgid "How many load at once, and how many “Load more” adds"
 msgstr ""
@@ -22730,7 +22720,7 @@ msgstr ""
 msgid "How many posts your feed shows before the “Load more” button, and how many that button adds. More posts mean a longer wait for the page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5314
+#: lib/vutuv_web/components/ui.ex:5326
 #: lib/vutuv_web/controllers/settings_controller.ex:963
 #: lib/vutuv_web/templates/settings/feed.html.heex:12
 #, elixir-autogen, elixir-format
@@ -22753,18 +22743,18 @@ msgstr ""
 msgid "You can change this under the feed itself as well, right below the “Load more” button."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5317
+#: lib/vutuv_web/components/ui.ex:5329
 #, elixir-autogen, elixir-format
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6964
-#: lib/vutuv_web/components/post_components.ex:6965
+#: lib/vutuv_web/components/post_components.ex:7019
+#: lib/vutuv_web/components/post_components.ex:7020
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6992
+#: lib/vutuv_web/components/post_components.ex:7047
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr ""
@@ -22781,7 +22771,7 @@ msgstr ""
 msgid "Hide something from your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6912
+#: lib/vutuv_web/components/post_components.ex:6967
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr ""
@@ -22796,22 +22786,22 @@ msgstr ""
 msgid "Words & tags"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6996
+#: lib/vutuv_web/components/post_components.ex:7051
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6999
+#: lib/vutuv_web/components/post_components.ex:7054
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6968
+#: lib/vutuv_web/components/post_components.ex:7023
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7009
+#: lib/vutuv_web/components/post_components.ex:7064
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr ""
@@ -22863,7 +22853,7 @@ msgstr ""
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6319
+#: lib/vutuv_web/components/post_components.ex:6374
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr ""
@@ -22883,7 +22873,7 @@ msgstr ""
 msgid "Turn on for my account"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:97
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."
 msgstr ""
@@ -22918,7 +22908,7 @@ msgstr ""
 msgid "Which work is it, and where can the original be seen? (required)"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:45
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Copyright law. This complaint says the work is not yours to publish, which is a legal question rather than a house rule."
 msgstr ""
@@ -22928,27 +22918,27 @@ msgstr ""
 msgid "Hidden automatically after a report: %{reason}. The case page says what you can do."
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:16
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "No person made this decision: a report from a member in good standing hides the reported content automatically, the moment it arrives."
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:79
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Nobody else can see it right now. You have 72 hours to settle this yourself; after that our admins decide. Here is what you can do:"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:48
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Our community guidelines, which everything on vutuv has to keep to."
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:41
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "The ground"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:28
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "What the report says"
 msgstr ""
@@ -22963,8 +22953,8 @@ msgstr ""
 msgid "Hidden. What other people pass on of them stays out of your feed; their own posts do not."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3148
-#: lib/vutuv_web/components/post_components.ex:4266
+#: lib/vutuv_web/components/post_components.ex:3203
+#: lib/vutuv_web/components/post_components.ex:4321
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr ""
@@ -22999,12 +22989,12 @@ msgstr ""
 msgid "By emailed PIN, passkey, authenticator app or a printed list of codes."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:160
+#: lib/vutuv_web/views/page_html.ex:157
 #, elixir-autogen, elixir-format
 msgid "Curious? Have a look at a real profile: {profile}. With or without a vutuv account of your own."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:156
+#: lib/vutuv_web/views/page_html.ex:153
 #, elixir-autogen, elixir-format
 msgid "Curious? Have a look at the profile of vutuv founder Stefan Wintermeyer: {profile}. With or without a vutuv account of your own."
 msgstr ""
@@ -23134,7 +23124,7 @@ msgstr ""
 msgid "vutuv is part of the Fediverse, the union of independent networks that Mastodon belongs to as well. Whether your posts take part is your choice at sign-up, and one switch in the settings later. We are not religious about it: each to their own."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1806
+#: lib/vutuv_web/live/shell_live.ex:1811
 #, elixir-autogen, elixir-format
 msgid "All notifications"
 msgstr ""
@@ -23154,12 +23144,12 @@ msgstr ""
 msgid "Profile picture"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:260
+#: lib/vutuv_web/templates/user/show.html.heex:265
 #, elixir-autogen, elixir-format
 msgid "Report the cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:253
+#: lib/vutuv_web/templates/user/show.html.heex:258
 #, elixir-autogen, elixir-format
 msgid "Report the profile picture"
 msgstr ""
@@ -23169,7 +23159,7 @@ msgstr ""
 msgid "The reported picture"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:241
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "Upholding the case deletes it, the private original included. Rejecting it puts every file back where it was."
 msgstr ""
@@ -23184,7 +23174,7 @@ msgstr ""
 msgid "Your profile picture was not replaced: a report about it is still open. Open the case to remove the picture or to say that it is yours."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2471
+#: lib/vutuv_web/components/post_components.ex:2476
 #, elixir-autogen, elixir-format
 msgid "Fetching the answers from the servers that hold them…"
 msgstr ""
@@ -23199,7 +23189,7 @@ msgstr ""
 msgid "Nothing here we are allowed to show you."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2490
+#: lib/vutuv_web/components/post_components.ex:2495
 #, elixir-autogen, elixir-format
 msgid "Show more answers"
 msgstr ""
@@ -23237,7 +23227,7 @@ msgstr ""
 msgid "Thank you for your report. Our moderators have been notified and will review this picture."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:245
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:255
 #, elixir-autogen, elixir-format
 msgid "This picture is still on the profile: only a copyright notice takes one offline before a ruling. Upholding the case deletes it, the private original included."
 msgstr ""
@@ -23289,7 +23279,7 @@ msgstr ""
 msgid "Is content published here yours, or does it break the law? You can tell us without an account."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1250
+#: lib/vutuv/notifications/emailer.ex:1284
 #, elixir-autogen, elixir-format
 msgid "Moderation: something was reported"
 msgstr ""
@@ -23314,7 +23304,7 @@ msgstr ""
 msgid "Outside reporter confirmed their address"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1166
+#: lib/vutuv/notifications/emailer.ex:1200
 #: lib/vutuv_web/templates/public_report/sent.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Please confirm your report"
@@ -23361,7 +23351,7 @@ msgstr ""
 msgid "The post, picture, video, profile, page or job posting you are reporting. Copy it out of your browser's address bar."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:407
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "The report by %{email} was a deliberate weapon (that address loses our trust)"
 msgstr ""
@@ -23509,7 +23499,7 @@ msgstr ""
 msgid "Report decision"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1060
+#: lib/vutuv/notifications/emailer.ex:1082
 #, elixir-autogen, elixir-format
 msgid "The content you reported was deleted"
 msgstr ""
@@ -23524,17 +23514,112 @@ msgstr ""
 msgid "The owner revised the content you reported; it is visible again."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1063
+#: lib/vutuv/notifications/emailer.ex:1085
 #, elixir-autogen, elixir-format
 msgid "Your report was not upheld"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1062
+#: lib/vutuv/notifications/emailer.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Your report was upheld"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:62
+#: lib/vutuv_web/views/page_html.ex:59
 #, elixir-autogen, elixir-format
 msgid "Easy LinkedIn profile import."
+msgstr ""
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:26
+#, elixir-autogen, elixir-format
+msgid "No person made this decision: a report from somebody with a good record hides the reported content automatically, the moment it arrives."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:400
+#, elixir-autogen, elixir-format
+msgid "The report is justified. The content becomes visible again - the consequence here is the strike (warn, suspend, deactivate)."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:404
+#, elixir-autogen, elixir-format
+msgid "The report is justified. The content is not hidden and upholding does not hide it; the owner gets a strike (warn, suspend, deactivate)."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:392
+#, elixir-autogen, elixir-format
+msgid "The report is justified. The reported picture is deleted, the private original included, and the owner gets a strike (warn, suspend, deactivate)."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:251
+#, elixir-autogen, elixir-format
+msgid "This picture is still on the profile: the address behind the copyright notice is not confirmed yet, so nothing has been hidden. Upholding the case deletes it, the private original included."
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:82
+#, elixir-autogen, elixir-format
+msgid "somebody reported one of your job postings on vutuv."
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:85
+#, elixir-autogen, elixir-format
+msgid "somebody reported one of your pages on vutuv."
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:76
+#, elixir-autogen, elixir-format
+msgid "somebody reported one of your pictures on vutuv."
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:73
+#, elixir-autogen, elixir-format
+msgid "somebody reported one of your posts on vutuv."
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:79
+#, elixir-autogen, elixir-format
+msgid "somebody reported one of your private messages on vutuv."
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:91
+#, elixir-autogen, elixir-format
+msgid "somebody reported something of yours on vutuv."
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:88
+#, elixir-autogen, elixir-format
+msgid "somebody reported your profile on vutuv."
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:105
+#, elixir-autogen, elixir-format
+msgid "A report from a member in good standing hides the reported content automatically, the moment it arrives."
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:111
+#, elixir-autogen, elixir-format
+msgid "A report from somebody with a good record hides the reported content automatically, the moment it arrives."
+msgstr ""
+
+#: lib/vutuv_web/views/moderation_case_html.ex:32
+#, elixir-autogen, elixir-format
+msgid "An admin confirmed the report."
+msgstr ""
+
+#: lib/vutuv_web/views/moderation_case_html.ex:33
+#, elixir-autogen, elixir-format
+msgid "An admin dismissed the report."
+msgstr ""
+
+#: lib/vutuv_web/views/moderation_case_html.ex:40
+#, elixir-autogen, elixir-format
+msgid "The content is deleted."
+msgstr ""
+
+#: lib/vutuv_web/views/moderation_case_html.ex:42
+#, elixir-autogen, elixir-format
+msgid "The content is visible again."
+msgstr ""
+
+#: lib/vutuv_web/views/moderation_case_html.ex:41
+#, elixir-autogen, elixir-format
+msgid "The content stays hidden."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -2809,7 +2809,7 @@ msgstr ""
 msgid "This post is for the connections of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:126
+#: lib/vutuv_web/views/admin/moderation_html.ex:127
 #: lib/vutuv_web/views/user_html.ex:536
 #, elixir-autogen, elixir-format
 msgid "connection"
@@ -3532,7 +3532,7 @@ msgstr ""
 msgid "You have used all %{limit} username changes of the last %{days} days."
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:127
+#: lib/vutuv_web/views/admin/moderation_html.ex:128
 #, elixir-autogen, elixir-format
 msgid "%{count} follows"
 msgstr ""
@@ -3569,7 +3569,7 @@ msgstr ""
 msgid "Decision"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:79
+#: lib/vutuv_web/views/admin/moderation_html.ex:80
 #, elixir-autogen, elixir-format
 msgid "Escalated - the 72h deadline passed"
 msgstr ""
@@ -3624,12 +3624,12 @@ msgstr ""
 msgid "Report protection"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:81
+#: lib/vutuv_web/views/admin/moderation_html.ex:82
 #, elixir-autogen, elixir-format
 msgid "Report rejected"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:80
+#: lib/vutuv_web/views/admin/moderation_html.ex:81
 #, elixir-autogen, elixir-format
 msgid "Report upheld"
 msgstr ""
@@ -3664,7 +3664,7 @@ msgstr ""
 msgid "Settled by deletion"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:83
+#: lib/vutuv_web/views/admin/moderation_html.ex:84
 #, elixir-autogen, elixir-format
 msgid "Strike issued"
 msgstr ""
@@ -3699,22 +3699,22 @@ msgstr ""
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:101
+#: lib/vutuv_web/views/admin/moderation_html.ex:102
 #, elixir-autogen, elixir-format
 msgid "for the owner"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:102
+#: lib/vutuv_web/views/admin/moderation_html.ex:103
 #, elixir-autogen, elixir-format
 msgid "for the reporter"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:106
+#: lib/vutuv_web/views/admin/moderation_html.ex:107
 #, elixir-autogen, elixir-format
 msgid "level %{level}, %{role}"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:128
+#: lib/vutuv_web/views/admin/moderation_html.ex:129
 #, elixir-autogen, elixir-format
 msgid "messages"
 msgstr ""
@@ -3749,7 +3749,7 @@ msgstr ""
 msgid "Case %{id}, captured %{at} UTC"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:84
+#: lib/vutuv_web/views/admin/moderation_html.ex:85
 #, elixir-autogen, elixir-format
 msgid "Evidence screenshot captured"
 msgstr ""
@@ -9758,7 +9758,7 @@ msgstr ""
 msgid "name or slug"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:121
+#: lib/vutuv_web/views/admin/moderation_html.ex:122
 #, elixir-autogen, elixir-format
 msgid "%{action} (%{reason})"
 msgstr ""
@@ -9779,7 +9779,7 @@ msgstr ""
 msgid "Account deleted."
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:82
+#: lib/vutuv_web/views/admin/moderation_html.ex:83
 #, elixir-autogen, elixir-format
 msgid "Account removed"
 msgstr ""
@@ -9850,12 +9850,12 @@ msgid "Thank you for your report. Our moderators have been notified and will rev
 msgstr ""
 
 #: lib/vutuv_web/views/admin/account_html.ex:78
-#: lib/vutuv_web/views/admin/moderation_html.ex:114
+#: lib/vutuv_web/views/admin/moderation_html.ex:115
 #, elixir-autogen, elixir-format
 msgid "deactivated"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:115
+#: lib/vutuv_web/views/admin/moderation_html.ex:116
 #, elixir-autogen, elixir-format
 msgid "deleted"
 msgstr ""
@@ -23297,7 +23297,7 @@ msgstr ""
 msgid "Our admins see your name and address so they can come back to you. The owner of the reported content never does."
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:86
+#: lib/vutuv_web/views/admin/moderation_html.ex:87
 #, elixir-autogen, elixir-format
 msgid "Outside reporter confirmed their address"
 msgstr ""
@@ -23319,7 +23319,7 @@ msgstr ""
 msgid "Report content on this site"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:85
+#: lib/vutuv_web/views/admin/moderation_html.ex:86
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report filed from outside"
 msgstr ""
@@ -23445,7 +23445,7 @@ msgstr ""
 msgid "A confirmation link is good for one week. Yours has run out, so your report never reached our admins and nothing about the reported content changed."
 msgstr ""
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:89
+#: lib/vutuv_web/views/admin/moderation_html.ex:90
 #, elixir-autogen, elixir-format
 msgid "Report dropped: the address was never confirmed"
 msgstr ""
@@ -23620,4 +23620,9 @@ msgstr ""
 #: lib/vutuv_web/views/moderation_case_html.ex:41
 #, elixir-autogen, elixir-format
 msgid "The content stays hidden."
+msgstr ""
+
+#: lib/vutuv_web/views/admin/moderation_html.ex:79
+#, elixir-autogen, elixir-format
+msgid "Owner replaced the content"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -15,8 +15,8 @@ msgstr "Language: en\n"
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4871
-#: lib/vutuv_web/components/ui.ex:4876
+#: lib/vutuv_web/components/ui.ex:4883
+#: lib/vutuv_web/components/ui.ex:4888
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
 #: lib/vutuv_web/live/organization_live/domains.ex:287
@@ -38,7 +38,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1489
+#: lib/vutuv_web/templates/user/show.html.heex:1494
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -62,7 +62,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/text.ex:71
-#: lib/vutuv_web/components/ui.ex:5208
+#: lib/vutuv_web/components/ui.ex:5220
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -81,8 +81,8 @@ msgstr ""
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4662
-#: lib/vutuv_web/components/ui.ex:4761
+#: lib/vutuv_web/components/ui.ex:4674
+#: lib/vutuv_web/components/ui.ex:4773
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -95,7 +95,7 @@ msgstr ""
 msgid "Avatar"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:410
+#: lib/vutuv_web/templates/user/edit.html.heex:416
 #, elixir-autogen
 msgid "Birthdate"
 msgstr ""
@@ -104,13 +104,13 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:677
 #: lib/vutuv_web/agent_docs/text.ex:636
 #: lib/vutuv_web/agent_docs/text.ex:637
-#: lib/vutuv_web/templates/user/show.html.heex:1120
+#: lib/vutuv_web/templates/user/show.html.heex:1125
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:104
-#: lib/vutuv_web/components/ui.ex:4656
+#: lib/vutuv_web/components/ui.ex:4668
 #: lib/vutuv_web/components/video_components.ex:281
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
@@ -129,9 +129,9 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:53
-#: lib/vutuv_web/templates/user/edit.html.heex:133
-#: lib/vutuv_web/templates/user/edit.html.heex:466
-#: lib/vutuv_web/templates/user/edit.html.heex:511
+#: lib/vutuv_web/templates/user/edit.html.heex:137
+#: lib/vutuv_web/templates/user/edit.html.heex:472
+#: lib/vutuv_web/templates/user/edit.html.heex:517
 #: lib/vutuv_web/templates/username/confirm.html.heex:220
 #, elixir-autogen
 msgid "Cancel"
@@ -152,7 +152,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1158
+#: lib/vutuv_web/templates/user/show.html.heex:1163
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -161,8 +161,8 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4223
-#: lib/vutuv_web/components/ui.ex:4763
+#: lib/vutuv_web/components/post_components.ex:4278
+#: lib/vutuv_web/components/ui.ex:4775
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:657
@@ -170,7 +170,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:167
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:28
 #: lib/vutuv_web/templates/dev_app/show.html.heex:135
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:117
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:127
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:70
 #, elixir-autogen
 msgid "Delete"
@@ -209,8 +209,8 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4188
-#: lib/vutuv_web/components/ui.ex:4754
+#: lib/vutuv_web/components/post_components.ex:4243
+#: lib/vutuv_web/components/ui.ex:4766
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
@@ -222,8 +222,8 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:6
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:103
-#: lib/vutuv_web/templates/user/show.html.heex:1143
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:113
+#: lib/vutuv_web/templates/user/show.html.heex:1148
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -284,11 +284,11 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:5172
+#: lib/vutuv_web/components/ui.ex:5184
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:644
+#: lib/vutuv_web/templates/user/show.html.heex:649
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -305,7 +305,7 @@ msgid "Fax"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:662
-#: lib/vutuv_web/templates/user/edit.html.heex:164
+#: lib/vutuv_web/templates/user/edit.html.heex:170
 #, elixir-autogen
 msgid "First Name"
 msgstr ""
@@ -331,7 +331,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/show.ex:618
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:988
+#: lib/vutuv_web/templates/user/show.html.heex:993
 #: lib/vutuv_web/views/user_html.ex:640
 #, elixir-autogen
 msgid "Following"
@@ -339,7 +339,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:212
 #: lib/vutuv_web/templates/page/index.html.heex:121
-#: lib/vutuv_web/templates/user/edit.html.heex:201
+#: lib/vutuv_web/templates/user/edit.html.heex:207
 #: lib/vutuv_web/views/account_event_text.ex:219
 #, elixir-autogen
 msgid "Gender"
@@ -382,7 +382,7 @@ msgid "Language"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:664
-#: lib/vutuv_web/templates/user/edit.html.heex:169
+#: lib/vutuv_web/templates/user/edit.html.heex:175
 #, elixir-autogen
 msgid "Last Name"
 msgstr ""
@@ -449,7 +449,7 @@ msgid "Log in"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:663
-#: lib/vutuv_web/templates/user/edit.html.heex:174
+#: lib/vutuv_web/templates/user/edit.html.heex:180
 #, elixir-autogen
 msgid "Middle Name"
 msgstr ""
@@ -486,7 +486,7 @@ msgid "New"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:666
-#: lib/vutuv_web/templates/user/edit.html.heex:179
+#: lib/vutuv_web/templates/user/edit.html.heex:185
 #, elixir-autogen
 msgid "Nickname"
 msgstr ""
@@ -567,7 +567,7 @@ msgid "Phone number updated successfully."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:661
-#: lib/vutuv_web/templates/user/edit.html.heex:184
+#: lib/vutuv_web/templates/user/edit.html.heex:190
 #, elixir-autogen
 msgid "Prefix"
 msgstr ""
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4655
+#: lib/vutuv_web/components/ui.ex:4667
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2201
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -629,7 +629,7 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/preferences.html.heex:362
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:61
-#: lib/vutuv_web/templates/user/edit.html.heex:461
+#: lib/vutuv_web/templates/user/edit.html.heex:467
 #: lib/vutuv_web/views/settings_html.ex:253
 #, elixir-autogen
 msgid "Save"
@@ -691,13 +691,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1272
+#: lib/vutuv_web/templates/user/show.html.heex:1277
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1274
+#: lib/vutuv_web/templates/user/show.html.heex:1279
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -746,7 +746,7 @@ msgid "Submit a bugreport or a feature request."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:665
-#: lib/vutuv_web/templates/user/edit.html.heex:189
+#: lib/vutuv_web/templates/user/edit.html.heex:195
 #, elixir-autogen
 msgid "Suffix"
 msgstr ""
@@ -788,7 +788,7 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5168
+#: lib/vutuv_web/components/ui.ex:5180
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:832
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -848,14 +848,14 @@ msgstr ""
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4824
-#: lib/vutuv_web/templates/user/show.html.heex:982
-#: lib/vutuv_web/templates/user/show.html.heex:1005
+#: lib/vutuv_web/components/ui.ex:4836
+#: lib/vutuv_web/templates/user/show.html.heex:987
+#: lib/vutuv_web/templates/user/show.html.heex:1010
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5331
+#: lib/vutuv_web/components/ui.ex:5343
 #: lib/vutuv_web/controllers/settings_controller.ex:175
 #: lib/vutuv_web/live/job_posting_live/form.ex:818
 #: lib/vutuv_web/live/organization_live/edit.ex:339
@@ -1036,7 +1036,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1109
+#: lib/vutuv_web/templates/user/show.html.heex:1114
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1177,10 +1177,10 @@ msgstr ""
 msgid "All tag urls"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4838
+#: lib/vutuv_web/components/post_components.ex:4893
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:638
+#: lib/vutuv_web/templates/user/show.html.heex:643
 #, elixir-autogen
 msgid "All tags"
 msgstr ""
@@ -1349,7 +1349,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:584
 #: lib/vutuv_web/agent_docs/text.ex:850
-#: lib/vutuv_web/components/ui.ex:5193
+#: lib/vutuv_web/components/ui.ex:5205
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1376,7 +1376,7 @@ msgstr ""
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:28
 #: lib/vutuv_web/templates/tag/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:608
+#: lib/vutuv_web/templates/user/show.html.heex:613
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1646,7 +1646,7 @@ msgid "Delete my account"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_controller.ex:149
-#: lib/vutuv_web/templates/user/show.html.heex:147
+#: lib/vutuv_web/templates/user/show.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Edit profile"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/show.ex:616
 #: lib/vutuv_web/live/post_live/feed.ex:902
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
-#: lib/vutuv_web/templates/user/show.html.heex:1313
+#: lib/vutuv_web/templates/user/show.html.heex:1318
 #: lib/vutuv_web/views/user_html.ex:651
 #, elixir-autogen, elixir-format
 msgid "Follow"
@@ -1730,7 +1730,7 @@ msgid "Network"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:485
-#: lib/vutuv_web/components/ui.ex:4873
+#: lib/vutuv_web/components/ui.ex:4885
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
@@ -1746,7 +1746,7 @@ msgid "Nothing new yet."
 msgstr ""
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:5230
+#: lib/vutuv_web/components/ui.ex:5242
 #: lib/vutuv_web/controllers/page_controller.ex:214
 #: lib/vutuv_web/live/notification_live/index.ex:154
 #: lib/vutuv_web/live/notification_live/index.ex:440
@@ -1818,7 +1818,7 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:19
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
-#: lib/vutuv_web/templates/user/show.html.heex:222
+#: lib/vutuv_web/templates/user/show.html.heex:232
 #: lib/vutuv_web/views/user_html.ex:1100
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
@@ -1885,14 +1885,14 @@ msgstr ""
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4130
-#: lib/vutuv_web/components/ui.ex:4275
+#: lib/vutuv_web/components/ui.ex:4142
+#: lib/vutuv_web/components/ui.ex:4287
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4898
+#: lib/vutuv_web/components/ui.ex:4910
 #: lib/vutuv_web/live/organization_live/activity.ex:159
 #: lib/vutuv_web/live/organization_live/feed.ex:258
 #: lib/vutuv_web/live/organization_live/show.ex:787
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4665
+#: lib/vutuv_web/components/ui.ex:4677
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
@@ -1950,12 +1950,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3589
+#: lib/vutuv_web/components/ui.ex:3601
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3593
+#: lib/vutuv_web/components/ui.ex:3605
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -1971,7 +1971,7 @@ msgid "Change cover photo"
 msgstr ""
 
 #: lib/vutuv_web/controllers/report_controller.ex:173
-#: lib/vutuv_web/templates/user/edit.html.heex:96
+#: lib/vutuv_web/templates/user/edit.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
 msgstr ""
@@ -1981,37 +1981,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3597
+#: lib/vutuv_web/components/ui.ex:3609
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3587
+#: lib/vutuv_web/components/ui.ex:3599
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3586
+#: lib/vutuv_web/components/ui.ex:3598
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3592
+#: lib/vutuv_web/components/ui.ex:3604
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3591
+#: lib/vutuv_web/components/ui.ex:3603
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3588
+#: lib/vutuv_web/components/ui.ex:3600
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3590
+#: lib/vutuv_web/components/ui.ex:3602
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2026,23 +2026,23 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3596
+#: lib/vutuv_web/components/ui.ex:3608
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3595
+#: lib/vutuv_web/components/ui.ex:3607
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3594
+#: lib/vutuv_web/components/ui.ex:3606
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
 
 #: lib/vutuv_web/templates/education/form_content.html.heex:32
-#: lib/vutuv_web/templates/user/edit.html.heex:257
+#: lib/vutuv_web/templates/user/edit.html.heex:263
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Markdown is supported: bold, italics, links and lists."
@@ -2075,7 +2075,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4220
+#: lib/vutuv_web/components/post_components.ex:4275
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2120,8 +2120,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4174
-#: lib/vutuv_web/components/post_components.ex:4176
+#: lib/vutuv_web/components/post_components.ex:4229
+#: lib/vutuv_web/components/post_components.ex:4231
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2185,13 +2185,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4711
-#: lib/vutuv_web/components/post_components.ex:4715
+#: lib/vutuv_web/components/post_components.ex:4766
+#: lib/vutuv_web/components/post_components.ex:4770
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4712
+#: lib/vutuv_web/components/post_components.ex:4767
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2267,7 +2267,7 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5575
+#: lib/vutuv_web/components/ui.ex:5587
 #: lib/vutuv_web/live/shell_live.ex:1582
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2286,32 +2286,32 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4171
+#: lib/vutuv_web/components/post_components.ex:4226
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6337
+#: lib/vutuv_web/components/post_components.ex:6392
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6341
+#: lib/vutuv_web/components/post_components.ex:6396
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6339
+#: lib/vutuv_web/components/post_components.ex:6394
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6340
+#: lib/vutuv_web/components/post_components.ex:6395
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3667
+#: lib/vutuv_web/components/ui.ex:3679
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
@@ -2340,7 +2340,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:598
+#: lib/vutuv_web/templates/user/show.html.heex:603
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2351,8 +2351,8 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2178
-#: lib/vutuv_web/components/post_components.ex:6437
-#: lib/vutuv_web/components/ui.ex:4197
+#: lib/vutuv_web/components/post_components.ex:6492
+#: lib/vutuv_web/components/ui.ex:4209
 #: lib/vutuv_web/views/user_html.ex:484
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2370,8 +2370,8 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2122
-#: lib/vutuv_web/components/post_components.ex:6678
-#: lib/vutuv_web/components/ui.ex:4183
+#: lib/vutuv_web/components/post_components.ex:6733
+#: lib/vutuv_web/components/ui.ex:4195
 #: lib/vutuv_web/notification_line.ex:317
 #: lib/vutuv_web/views/user_html.ex:494
 #, elixir-autogen, elixir-format
@@ -2379,7 +2379,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1263
-#: lib/vutuv_web/components/post_components.ex:6688
+#: lib/vutuv_web/components/post_components.ex:6743
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1590
@@ -2400,13 +2400,13 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6425
+#: lib/vutuv_web/components/post_components.ex:6480
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2177
-#: lib/vutuv_web/components/post_components.ex:6436
+#: lib/vutuv_web/components/post_components.ex:6491
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:484
 #, elixir-autogen, elixir-format
@@ -2414,26 +2414,26 @@ msgid "Remove bookmark"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2158
-#: lib/vutuv_web/components/post_components.ex:6421
+#: lib/vutuv_web/components/post_components.ex:6476
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2696
-#: lib/vutuv_web/components/post_components.ex:5443
+#: lib/vutuv_web/components/post_components.ex:2751
+#: lib/vutuv_web/components/post_components.ex:5498
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2157
-#: lib/vutuv_web/components/post_components.ex:6420
+#: lib/vutuv_web/components/post_components.ex:6475
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2121
-#: lib/vutuv_web/components/post_components.ex:6677
+#: lib/vutuv_web/components/post_components.ex:6732
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:494
 #, elixir-autogen, elixir-format
@@ -2441,7 +2441,7 @@ msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:498
-#: lib/vutuv_web/components/post_components.ex:3182
+#: lib/vutuv_web/components/post_components.ex:3237
 #: lib/vutuv_web/components/ui.ex:3023
 #: lib/vutuv_web/components/ui.ex:3023
 #: lib/vutuv_web/components/ui.ex:3099
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6732
+#: lib/vutuv_web/components/post_components.ex:6787
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2473,8 +2473,8 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2367
-#: lib/vutuv_web/components/post_components.ex:6715
-#: lib/vutuv_web/components/post_components.ex:6716
+#: lib/vutuv_web/components/post_components.ex:6770
+#: lib/vutuv_web/components/post_components.ex:6771
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:314
@@ -2482,7 +2482,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4130
+#: lib/vutuv_web/components/post_components.ex:4185
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2503,7 +2503,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3648
+#: lib/vutuv_web/components/post_components.ex:3703
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2511,14 +2511,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4102
+#: lib/vutuv_web/components/post_components.ex:4157
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4093
-#: lib/vutuv_web/components/post_components.ex:4122
-#: lib/vutuv_web/components/post_components.ex:4125
+#: lib/vutuv_web/components/post_components.ex:4148
+#: lib/vutuv_web/components/post_components.ex:4177
+#: lib/vutuv_web/components/post_components.ex:4180
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2684,51 +2684,51 @@ msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:918
+#: lib/vutuv_web/templates/user/show.html.heex:923
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1232
+#: lib/vutuv_web/templates/user/show.html.heex:1237
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1491
+#: lib/vutuv_web/templates/user/show.html.heex:1496
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1160
+#: lib/vutuv_web/templates/user/show.html.heex:1165
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1111
+#: lib/vutuv_web/templates/user/show.html.heex:1116
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:647
+#: lib/vutuv_web/templates/user/show.html.heex:652
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:495
+#: lib/vutuv_web/templates/user/show.html.heex:500
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4363
-#: lib/vutuv_web/components/ui.ex:4826
+#: lib/vutuv_web/components/ui.ex:4375
+#: lib/vutuv_web/components/ui.ex:4838
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:109
@@ -2736,7 +2736,7 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
-#: lib/vutuv_web/templates/user/show.html.heex:638
+#: lib/vutuv_web/templates/user/show.html.heex:643
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
@@ -2764,7 +2764,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/live/job_board_live.ex:458
 #: lib/vutuv_web/live/post_live/feed.ex:1018
-#: lib/vutuv_web/templates/user/card_list.html.heex:51
+#: lib/vutuv_web/templates/user/card_list.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
 msgid_plural "+%{formatted} more tags"
@@ -2817,7 +2817,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6338
+#: lib/vutuv_web/components/post_components.ex:6393
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2845,7 +2845,7 @@ msgid "Endorsement"
 msgstr ""
 
 #: lib/vutuv_web/notification_line.ex:312
-#: lib/vutuv_web/templates/user/show.html.heex:966
+#: lib/vutuv_web/templates/user/show.html.heex:971
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -2877,7 +2877,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:335
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:290
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:301
 #: lib/vutuv_web/templates/moderation_evidence/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "(deleted account)"
@@ -2902,16 +2902,6 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:28
 #, elixir-autogen, elixir-format
 msgid "Abusive"
-msgstr ""
-
-#: lib/vutuv_web/views/moderation_case_html.ex:26
-#, elixir-autogen, elixir-format
-msgid "An admin confirmed the report. The content stays hidden."
-msgstr ""
-
-#: lib/vutuv_web/views/moderation_case_html.ex:29
-#, elixir-autogen, elixir-format
-msgid "An admin dismissed the report. The content is visible again."
 msgstr ""
 
 #: lib/vutuv_web/templates/report/new.html.heex:123
@@ -2939,7 +2929,7 @@ msgstr ""
 msgid "Confirmed violations follow three steps: a warning, then a one-week suspension, then permanent deactivation. Strikes expire after twelve months."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:276
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "Conversation context (the reported message last)"
 msgstr ""
@@ -2949,17 +2939,17 @@ msgstr ""
 msgid "Criticize ideas, never people. Demeaning, threatening or repeatedly unwanted messages get accounts suspended - in public posts and in private messages alike."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:268
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Current version (edited since the report)"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:115
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Delete this content permanently?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:106
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:117
 #, elixir-autogen, elixir-format
 msgid "Deleted. The report is settled, no further steps needed."
 msgstr ""
@@ -2969,7 +2959,7 @@ msgstr ""
 msgid "Escalated"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:100
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Fix it. An edited post is visible again immediately."
 msgstr ""
@@ -3020,7 +3010,7 @@ msgstr ""
 msgid "Moderation queue"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:126
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "My content is fine"
 msgstr ""
@@ -3070,13 +3060,13 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1200
-#: lib/vutuv_web/templates/user/show.html.heex:1201
+#: lib/vutuv_web/templates/user/show.html.heex:1205
+#: lib/vutuv_web/templates/user/show.html.heex:1206
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4069
+#: lib/vutuv_web/components/post_components.ex:4124
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3116,7 +3106,7 @@ msgstr ""
 msgid "Please report honestly. Reporting to harm someone breaks our"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5162
+#: lib/vutuv_web/components/ui.ex:5174
 #: lib/vutuv_web/live/shell_live.ex:1373
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3124,7 +3114,7 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:414
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "Reject the report"
 msgstr ""
@@ -3135,16 +3125,16 @@ msgstr ""
 msgid "Rejected"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:109
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1460
-#: lib/vutuv_web/components/post_components.ex:3202
-#: lib/vutuv_web/components/post_components.ex:4287
+#: lib/vutuv_web/components/post_components.ex:3257
+#: lib/vutuv_web/components/post_components.ex:4342
 #: lib/vutuv_web/live/organization_live/show.ex:661
-#: lib/vutuv_web/templates/user/show.html.heex:242
+#: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
 msgid "Report"
 msgstr ""
@@ -3186,13 +3176,13 @@ msgid "Report upheld; the owner got a strike."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_live.ex:55
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:23
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "Reported as"
 msgstr ""
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:24
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:35
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:23
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:34
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Reported content"
@@ -3216,19 +3206,19 @@ msgstr ""
 msgid "Reporter track records"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:300
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:311
 #: lib/vutuv_web/live/admin/moderation_live.ex:57
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Reports"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:133
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4045
+#: lib/vutuv_web/components/ui.ex:4057
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3267,7 +3257,7 @@ msgstr ""
 msgid "Spam or scam"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:123
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Stand by it. It stays hidden until one of our admins has ruled."
 msgstr ""
@@ -3306,7 +3296,7 @@ msgstr ""
 msgid "Thank you for your report. We take it from here."
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:53
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "The content in question"
 msgstr ""
@@ -3321,12 +3311,12 @@ msgstr ""
 msgid "The queue is empty - the self-service flow settled everything."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:402
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:433
 #, elixir-autogen, elixir-format
 msgid "The report by @%{slug} was a deliberate weapon (strikes the reporter)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:374
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:396
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content stays hidden and the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
@@ -3343,7 +3333,7 @@ msgstr ""
 msgid "This account is suspended until %{date}."
 msgstr ""
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:121
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:132
 #, elixir-autogen, elixir-format
 msgid "This case is already settled."
 msgstr ""
@@ -3363,7 +3353,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:83
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:94
 #, elixir-autogen, elixir-format
 msgid "Understood. The content stays hidden until one of our admins has ruled."
 msgstr ""
@@ -3373,7 +3363,7 @@ msgstr ""
 msgid "Unwanted advertising, fraud or fake activity."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:379
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "Uphold the report"
 msgstr ""
@@ -3434,7 +3424,7 @@ msgstr ""
 msgid "Your report is anonymous. If it checks out, the content is hidden right away and the owner is asked to fix it."
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:135
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:145
 #: lib/vutuv_web/templates/public_report/new.html.heex:149
 #: lib/vutuv_web/templates/report/new.html.heex:162
 #, elixir-autogen, elixir-format
@@ -3456,17 +3446,17 @@ msgstr ""
 msgid "yes"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1093
+#: lib/vutuv/notifications/emailer.ex:1127
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1270
+#: lib/vutuv/notifications/emailer.ex:1304
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1061
+#: lib/vutuv/notifications/emailer.ex:1083
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr ""
@@ -3481,12 +3471,12 @@ msgstr ""
 msgid "Your content on vutuv was reported and is hidden"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1107
+#: lib/vutuv/notifications/emailer.ex:1141
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1100
+#: lib/vutuv/notifications/emailer.ex:1134
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr ""
@@ -3547,14 +3537,14 @@ msgstr ""
 msgid "%{count} follows"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:314
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "%{count} report so far"
 msgid_plural "%{count} reports so far"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:314
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "%{rejected} rejected, %{abusive} abusive"
 msgstr ""
@@ -3574,7 +3564,7 @@ msgstr ""
 msgid "Content frozen"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:369
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "Decision"
 msgstr ""
@@ -3594,7 +3584,7 @@ msgstr ""
 msgid "Evidence"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:342
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr ""
@@ -3649,7 +3639,7 @@ msgstr ""
 msgid "Reported on %{date}"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:331
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Reporter and owner are separated since this report (connection, follows, messages)."
 msgstr ""
@@ -3679,12 +3669,12 @@ msgstr ""
 msgid "Strike issued"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:327
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "The protective separation from the owner was lifted on %{date}."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:390
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #, elixir-autogen, elixir-format
 msgid "The report is unfounded. The content becomes visible again, any protective separation is lifted, and the rejection counts against each reporter's trust."
 msgstr ""
@@ -3729,7 +3719,7 @@ msgstr ""
 msgid "messages"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:345
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "No history recorded - this case predates the audit log."
 msgstr ""
@@ -3764,7 +3754,7 @@ msgstr ""
 msgid "Evidence screenshot captured"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:257
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Evidence screenshot captured when the report was filed"
 msgstr ""
@@ -3774,7 +3764,7 @@ msgstr ""
 msgid "Moderation evidence - reported private message with context"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:252
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Screenshot at report time"
 msgstr ""
@@ -3784,7 +3774,7 @@ msgstr ""
 msgid "reported message"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:263
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
@@ -4290,12 +4280,12 @@ msgstr ""
 msgid "Bookings are open through %{last}. Next available day: %{day}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3619
+#: lib/vutuv_web/components/ui.ex:3631
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3615
+#: lib/vutuv_web/components/ui.ex:3627
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr ""
@@ -4305,27 +4295,27 @@ msgstr ""
 msgid "One ad per calendar day: pick a free day in the calendar; struck-through days are already booked."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3620
+#: lib/vutuv_web/components/ui.ex:3632
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3621
+#: lib/vutuv_web/components/ui.ex:3633
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3618
+#: lib/vutuv_web/components/ui.ex:3630
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3616
+#: lib/vutuv_web/components/ui.ex:3628
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3617
+#: lib/vutuv_web/components/ui.ex:3629
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr ""
@@ -4447,7 +4437,7 @@ msgid "Search for words in public posts."
 msgstr ""
 
 #: lib/vutuv_web/templates/block/index.html.heex:36
-#: lib/vutuv_web/templates/user/show.html.heex:263
+#: lib/vutuv_web/templates/user/show.html.heex:268
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr ""
@@ -4457,7 +4447,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5335
+#: lib/vutuv_web/components/ui.ex:5347
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4472,13 +4462,13 @@ msgid "Blocked members cannot follow you, connect with you, message you, or repl
 msgstr ""
 
 #: lib/vutuv_web/templates/block/index.html.heex:74
-#: lib/vutuv_web/templates/user/show.html.heex:158
+#: lib/vutuv_web/templates/user/show.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr ""
 
 #: lib/vutuv_web/templates/block/index.html.heex:72
-#: lib/vutuv_web/templates/user/show.html.heex:155
+#: lib/vutuv_web/templates/user/show.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Unblock @%{slug}?"
 msgstr ""
@@ -4513,7 +4503,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:313
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:988
+#: lib/vutuv_web/templates/user/show.html.heex:993
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4631,7 +4621,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:547
 #: lib/vutuv_web/live/tag_new_live.ex:47
-#: lib/vutuv_web/templates/user/show.html.heex:611
+#: lib/vutuv_web/templates/user/show.html.heex:616
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
@@ -5224,9 +5214,9 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5385
+#: lib/vutuv_web/components/ui.ex:5397
 #: lib/vutuv_web/controllers/settings_controller.ex:161
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:457
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:488
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
@@ -5303,10 +5293,10 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5482
-#: lib/vutuv_web/components/ui.ex:5487
-#: lib/vutuv_web/components/ui.ex:5566
-#: lib/vutuv_web/components/ui.ex:5630
+#: lib/vutuv_web/components/ui.ex:5494
+#: lib/vutuv_web/components/ui.ex:5499
+#: lib/vutuv_web/components/ui.ex:5578
+#: lib/vutuv_web/components/ui.ex:5642
 #: lib/vutuv_web/controllers/settings_controller.ex:68
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5340,17 +5330,17 @@ msgstr ""
 msgid "Your profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:408
+#: lib/vutuv_web/templates/user/show.html.heex:413
 #, elixir-autogen, elixir-format
 msgid "Complete your profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:430
+#: lib/vutuv_web/templates/user/show.html.heex:435
 #, elixir-autogen, elixir-format
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1461
+#: lib/vutuv_web/live/user_profile_live.ex:1464
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5376,9 +5366,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4365
-#: lib/vutuv_web/components/post_components.ex:4417
-#: lib/vutuv_web/components/post_components.ex:4959
+#: lib/vutuv_web/components/post_components.ex:4420
+#: lib/vutuv_web/components/post_components.ex:4472
+#: lib/vutuv_web/components/post_components.ex:5014
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/views/user_html.ex:131
 #, elixir-autogen, elixir-format
@@ -5419,12 +5409,12 @@ msgstr ""
 msgid "Type of email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:236
+#: lib/vutuv_web/templates/user/edit.html.heex:242
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5355
+#: lib/vutuv_web/components/ui.ex:5367
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5445,7 +5435,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5200
+#: lib/vutuv_web/components/ui.ex:5212
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5480,7 +5470,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5329
+#: lib/vutuv_web/components/ui.ex:5341
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -5502,7 +5492,7 @@ msgid "View"
 msgstr ""
 
 #: lib/vutuv_web/templates/public_report/new.html.heex:92
-#: lib/vutuv_web/templates/user/edit.html.heex:161
+#: lib/vutuv_web/templates/user/edit.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Your name"
 msgstr ""
@@ -5560,18 +5550,18 @@ msgstr ""
 msgid "Current avatar"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:107
-#: lib/vutuv_web/templates/user/edit.html.heex:114
+#: lib/vutuv_web/templates/user/edit.html.heex:111
+#: lib/vutuv_web/templates/user/edit.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Current cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:185
+#: lib/vutuv_web/templates/user/edit.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "e.g. Dr. or Prof."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:190
+#: lib/vutuv_web/templates/user/edit.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "e.g. Jr. or PhD"
 msgstr ""
@@ -5593,7 +5583,7 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5378
+#: lib/vutuv_web/components/ui.ex:5390
 #: lib/vutuv_web/controllers/settings_controller.ex:185
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5797,21 +5787,21 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3683
+#: lib/vutuv_web/components/ui.ex:3695
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3682
+#: lib/vutuv_web/components/ui.ex:3694
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3681
+#: lib/vutuv_web/components/ui.ex:3693
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -5878,7 +5868,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3680
+#: lib/vutuv_web/components/ui.ex:3692
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -6008,13 +5998,13 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1466
+#: lib/vutuv_web/live/user_profile_live.ex:1469
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:166
-#: lib/vutuv_web/templates/user/edit.html.heex:253
+#: lib/vutuv_web/templates/user/edit.html.heex:259
 #: lib/vutuv_web/views/account_event_text.ex:212
 #, elixir-autogen, elixir-format
 msgid "Tagline"
@@ -6023,14 +6013,14 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:487
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:916
+#: lib/vutuv_web/templates/user/show.html.heex:921
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:471
+#: lib/vutuv_web/templates/user/show.html.heex:476
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6038,34 +6028,34 @@ msgid_plural "Posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:63
-#: lib/vutuv_web/templates/user/edit.html.heex:144
+#: lib/vutuv_web/templates/user/edit.html.heex:67
+#: lib/vutuv_web/templates/user/edit.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1541
+#: lib/vutuv_web/templates/user/show.html.heex:1546
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:51
-#: lib/vutuv_web/templates/user/edit.html.heex:131
+#: lib/vutuv_web/templates/user/edit.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Drag to move, use the slider to zoom. The framed area is what others see."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:68
+#: lib/vutuv_web/templates/user/edit.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "New avatar preview"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:149
+#: lib/vutuv_web/templates/user/edit.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "New cover photo preview"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:130
+#: lib/vutuv_web/templates/user/edit.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Position your cover photo"
 msgstr ""
@@ -6076,20 +6066,20 @@ msgid "Position your photo"
 msgstr ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:52
-#: lib/vutuv_web/templates/user/edit.html.heex:132
+#: lib/vutuv_web/templates/user/edit.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Use photo"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/composer.ex:1919
 #: lib/vutuv_web/templates/user/edit.html.heex:54
-#: lib/vutuv_web/templates/user/edit.html.heex:134
+#: lib/vutuv_web/templates/user/edit.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1126
-#: lib/vutuv_web/templates/user/show.html.heex:1136
+#: lib/vutuv_web/templates/user/show.html.heex:1131
+#: lib/vutuv_web/templates/user/show.html.heex:1141
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6129,12 +6119,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1248
+#: lib/vutuv_web/templates/user/show.html.heex:1253
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1259
+#: lib/vutuv_web/templates/user/show.html.heex:1264
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6177,7 +6167,7 @@ msgstr ""
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1257
+#: lib/vutuv_web/templates/user/show.html.heex:1262
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6236,9 +6226,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1531
-#: lib/vutuv_web/templates/user/show.html.heex:1535
-#: lib/vutuv_web/templates/user/show.html.heex:1547
+#: lib/vutuv_web/templates/user/show.html.heex:1536
+#: lib/vutuv_web/templates/user/show.html.heex:1540
+#: lib/vutuv_web/templates/user/show.html.heex:1552
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6265,7 +6255,7 @@ msgstr ""
 msgid "Members who endorsed %{name} for %{tag}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user_tag/endorsers.html.heex:78
+#: lib/vutuv_web/templates/user_tag/endorsers.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "No endorsements yet."
 msgstr ""
@@ -6565,16 +6555,16 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3129
-#: lib/vutuv_web/components/post_components.ex:4240
-#: lib/vutuv_web/components/post_components.ex:4254
+#: lib/vutuv_web/components/post_components.ex:3184
+#: lib/vutuv_web/components/post_components.ex:4295
+#: lib/vutuv_web/components/post_components.ex:4309
 #: lib/vutuv_web/components/ui.ex:3171
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:320
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
-#: lib/vutuv_web/templates/user/show.html.heex:235
+#: lib/vutuv_web/templates/user/show.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr ""
@@ -6595,7 +6585,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4240
+#: lib/vutuv_web/components/post_components.ex:4295
 #: lib/vutuv_web/components/ui.ex:3170
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6603,7 +6593,7 @@ msgstr ""
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:320
 #: lib/vutuv_web/templates/settings/filters.html.heex:111
 #: lib/vutuv_web/templates/settings/mutes.html.heex:60
-#: lib/vutuv_web/templates/user/show.html.heex:235
+#: lib/vutuv_web/templates/user/show.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "Unmute"
 msgstr ""
@@ -7200,13 +7190,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4139
+#: lib/vutuv_web/components/ui.ex:4151
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4151
+#: lib/vutuv_web/components/ui.ex:4163
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7288,9 +7278,9 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:6588
+#: lib/vutuv_web/components/post_components.ex:6643
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
-#: lib/vutuv_web/live/shell_live.ex:1812
+#: lib/vutuv_web/live/shell_live.ex:1817
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
 msgstr ""
@@ -7958,7 +7948,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4142
+#: lib/vutuv_web/components/ui.ex:4154
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8076,7 +8066,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:704
+#: lib/vutuv_web/templates/user/show.html.heex:709
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8088,7 +8078,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:5176
+#: lib/vutuv_web/components/ui.ex:5188
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8100,7 +8090,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
-#: lib/vutuv_web/templates/user/show.html.heex:701
+#: lib/vutuv_web/templates/user/show.html.heex:706
 #: lib/vutuv_web/views/import_html.ex:70
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
@@ -8143,14 +8133,14 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5366
+#: lib/vutuv_web/components/ui.ex:5378
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
 #: lib/vutuv_web/controllers/import_controller.ex:37
 #: lib/vutuv_web/controllers/import_controller.ex:128
-#: lib/vutuv_web/live/user_profile_live.ex:1477
+#: lib/vutuv_web/live/user_profile_live.ex:1480
 #: lib/vutuv_web/templates/import/new.html.heex:1
 #: lib/vutuv_web/templates/import/preview.html.heex:1
 #, elixir-autogen, elixir-format
@@ -8172,7 +8162,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5204
+#: lib/vutuv_web/components/ui.ex:5216
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8266,7 +8256,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4408
+#: lib/vutuv_web/components/ui.ex:4420
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8280,7 +8270,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1395
+#: lib/vutuv_web/templates/user/show.html.heex:1400
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8341,25 +8331,25 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5164
+#: lib/vutuv_web/components/ui.ex:5176
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5298
+#: lib/vutuv_web/components/ui.ex:5310
 #: lib/vutuv_web/controllers/settings_controller.ex:129
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Language & display"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:526
+#: lib/vutuv_web/templates/user/edit.html.heex:532
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5357
+#: lib/vutuv_web/components/ui.ex:5369
 #: lib/vutuv_web/controllers/settings_controller.ex:112
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8369,7 +8359,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5370
+#: lib/vutuv_web/components/ui.ex:5382
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8575,7 +8565,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:652
 #: lib/vutuv_web/components/organization_components.ex:276
 #: lib/vutuv_web/components/ui.ex:1783
-#: lib/vutuv_web/components/ui.ex:5347
+#: lib/vutuv_web/components/ui.ex:5359
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:366
 #: lib/vutuv_web/controllers/settings_controller.ex:433
@@ -8588,7 +8578,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1300
+#: lib/vutuv_web/templates/user/show.html.heex:1305
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8730,7 +8720,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5446
+#: lib/vutuv_web/components/post_components.ex:5501
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -8832,7 +8822,7 @@ msgstr ""
 msgid "For a PDF, open the print view and choose \"Save as PDF\" in your browser's print dialog. Word and OpenDocument are editable; LaTeX is the typesetting source; JSON Resume is the open %{link} format."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:266
+#: lib/vutuv_web/templates/user/edit.html.heex:272
 #, elixir-autogen, elixir-format
 msgid "characters"
 msgstr ""
@@ -8981,7 +8971,7 @@ msgstr ""
 #: lib/vutuv_web/live/feed_languages_live.ex:317
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:766
+#: lib/vutuv_web/templates/user/show.html.heex:771
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9206,7 +9196,7 @@ msgstr ""
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:763
+#: lib/vutuv_web/templates/user/show.html.heex:768
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -9393,7 +9383,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1271
+#: lib/vutuv/accounts/user.ex:1278
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9404,13 +9394,13 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1268
+#: lib/vutuv/accounts/user.ex:1275
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:290
+#: lib/vutuv_web/templates/user/edit.html.heex:296
 #, elixir-autogen, elixir-format
 msgid "Shown as a badge next to your tagline so people can see whether you are open to opportunities."
 msgstr ""
@@ -9486,7 +9476,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:870
+#: lib/vutuv_web/templates/user/show.html.heex:875
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
@@ -9519,7 +9509,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:5180
+#: lib/vutuv_web/components/ui.ex:5192
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -9534,7 +9524,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:867
+#: lib/vutuv_web/templates/user/show.html.heex:872
 #: lib/vutuv_web/views/import_html.ex:71
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
@@ -9653,8 +9643,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1222
-#: lib/vutuv_web/templates/user/show.html.heex:1223
+#: lib/vutuv_web/templates/user/show.html.heex:1227
+#: lib/vutuv_web/templates/user/show.html.heex:1228
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -9669,18 +9659,18 @@ msgstr ""
 msgid "Date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:439
-#: lib/vutuv_web/templates/user/edit.html.heex:514
+#: lib/vutuv_web/templates/user/edit.html.heex:445
+#: lib/vutuv_web/templates/user/edit.html.heex:520
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:502
+#: lib/vutuv_web/templates/user/edit.html.heex:508
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:505
+#: lib/vutuv_web/templates/user/edit.html.heex:511
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -9709,19 +9699,19 @@ msgstr ""
 msgid "Permanent profile link"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:419
-#: lib/vutuv_web/templates/user/show.html.heex:420
+#: lib/vutuv_web/templates/user/show.html.heex:424
+#: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3796
+#: lib/vutuv_web/components/ui.ex:3808
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3795
-#: lib/vutuv_web/components/ui.ex:3803
+#: lib/vutuv_web/components/ui.ex:3807
+#: lib/vutuv_web/components/ui.ex:3815
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -9804,7 +9794,7 @@ msgstr ""
 msgid "Accounts removed as spam"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:424
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "Clear-cut spam or abuse?"
 msgstr ""
@@ -9814,22 +9804,22 @@ msgstr ""
 msgid "Could not restore this member."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:439
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "Deactivate @%{slug} and mark the account as spam?"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:442
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:473
 #, elixir-autogen, elixir-format
 msgid "Deactivate account"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:451
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Permanently DELETE @%{slug} and everything they posted? This cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:427
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:458
 #, elixir-autogen, elixir-format
 msgid "Remove the account outright, skipping the warning ladder. Deactivating marks it as spam and is reversible from the member browser; deleting is permanent."
 msgstr ""
@@ -10141,7 +10131,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:71
 #: lib/vutuv_web/agent_docs/text.ex:66
-#: lib/vutuv_web/templates/user/show.html.heex:1369
+#: lib/vutuv_web/templates/user/show.html.heex:1374
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10716,24 +10706,24 @@ msgstr ""
 msgid "Views"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:299
+#: lib/vutuv_web/templates/user/edit.html.heex:305
 #, elixir-autogen, elixir-format
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1309
+#: lib/vutuv/accounts/user.ex:1316
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1314
+#: lib/vutuv/accounts/user.ex:1321
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1312
+#: lib/vutuv/accounts/user.ex:1319
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -10741,53 +10731,53 @@ msgid "Signed-in members only"
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:259
-#: lib/vutuv_web/templates/user/edit.html.heex:296
+#: lib/vutuv_web/templates/user/edit.html.heex:302
 #, elixir-autogen, elixir-format
 msgid "Who can see your availability?"
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:270
-#: lib/vutuv_web/templates/user/edit.html.heex:321
+#: lib/vutuv_web/templates/user/edit.html.heex:327
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:278
 #: lib/vutuv_web/live/job_posting_live/form.ex:693
-#: lib/vutuv_web/templates/user/edit.html.heex:329
+#: lib/vutuv_web/templates/user/edit.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:339
+#: lib/vutuv_web/templates/user/edit.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "Hidden by default, and it still does its job while hidden. \"Signed-in members only\" adds a quiet line to your profile for members; \"Everyone\" also shows it to logged-out visitors."
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:266
-#: lib/vutuv_web/templates/user/edit.html.heex:312
+#: lib/vutuv_web/templates/user/edit.html.heex:318
 #, elixir-autogen, elixir-format
 msgid "Minimum salary expectation"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:315
+#: lib/vutuv_web/templates/user/edit.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:274
 #: lib/vutuv_web/live/job_posting_live/form.ex:700
-#: lib/vutuv_web/templates/user/edit.html.heex:325
+#: lib/vutuv_web/templates/user/edit.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "Per"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:315
+#: lib/vutuv_web/templates/user/show.html.heex:320
 #, elixir-autogen, elixir-format
 msgid "Salary expectation from %{amount} %{currency} per %{period}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:336
+#: lib/vutuv_web/templates/user/edit.html.heex:342
 #, elixir-autogen, elixir-format
 msgid "Who can see your salary expectation?"
 msgstr ""
@@ -10856,7 +10846,7 @@ msgstr ""
 msgid "Exclude an email domain"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:387
+#: lib/vutuv_web/templates/user/edit.html.heex:393
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr ""
@@ -10867,12 +10857,12 @@ msgstr ""
 msgid "Job-search exclusion list"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:390
+#: lib/vutuv_web/templates/user/edit.html.heex:396
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:398
+#: lib/vutuv_web/templates/user/edit.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -11015,12 +11005,12 @@ msgstr ""
 msgid "State / region (optional)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4495
+#: lib/vutuv_web/components/ui.ex:4507
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4497
+#: lib/vutuv_web/components/ui.ex:4509
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr ""
@@ -11703,7 +11693,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:462
-#: lib/vutuv_web/components/ui.ex:5374
+#: lib/vutuv_web/components/ui.ex:5386
 #: lib/vutuv_web/controllers/settings_controller.ex:222
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
@@ -12012,7 +12002,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1283
+#: lib/vutuv/accounts/user.ex:1290
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12131,7 +12121,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1282
+#: lib/vutuv/accounts/user.ex:1289
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12213,7 +12203,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1284
+#: lib/vutuv/accounts/user.ex:1291
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:590
 #: lib/vutuv_web/agent_docs/markdown.ex:532
@@ -12350,7 +12340,7 @@ msgstr ""
 msgid "You already have the maximum number of published postings."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1123
+#: lib/vutuv/notifications/emailer.ex:1157
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr ""
@@ -12911,7 +12901,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5283
+#: lib/vutuv_web/components/ui.ex:5295
 #: lib/vutuv_web/controllers/settings_controller.ex:629
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -12930,7 +12920,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3607
+#: lib/vutuv_web/components/post_components.ex:3662
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -13177,7 +13167,7 @@ msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7
 msgstr ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:41
-#: lib/vutuv_web/templates/user/edit.html.heex:121
+#: lib/vutuv_web/templates/user/edit.html.heex:125
 #: lib/vutuv_web/templates/user/show.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Image awaiting review, visible only to you"
@@ -13194,7 +13184,7 @@ msgstr ""
 msgid "No images waiting for the AI scan. %{formatted} rejected in the last 7 days."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:208
+#: lib/vutuv_web/templates/user/show.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Profile picture awaiting review, visible only to you"
 msgstr ""
@@ -13224,36 +13214,36 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1327
+#: lib/vutuv/accounts/user.ex:1334
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:450
+#: lib/vutuv_web/templates/user/edit.html.heex:456
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1330
+#: lib/vutuv/accounts/user.ex:1337
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1333
+#: lib/vutuv/accounts/user.ex:1340
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1324
+#: lib/vutuv/accounts/user.ex:1331
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:447
+#: lib/vutuv_web/templates/user/edit.html.heex:453
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr ""
@@ -13369,7 +13359,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5266
+#: lib/vutuv_web/components/ui.ex:5278
 #: lib/vutuv_web/controllers/settings_controller.ex:643
 #: lib/vutuv_web/live/post_live/feed.ex:710
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13415,7 +13405,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1335
+#: lib/vutuv_web/templates/user/show.html.heex:1340
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13444,7 +13434,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:63
-#: lib/vutuv_web/components/ui.ex:5223
+#: lib/vutuv_web/components/ui.ex:5235
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13452,7 +13442,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1333
+#: lib/vutuv_web/templates/user/show.html.heex:1338
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13472,14 +13462,14 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4580
+#: lib/vutuv_web/components/ui.ex:4592
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:4590
+#: lib/vutuv_web/components/ui.ex:4602
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
@@ -13529,34 +13519,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6134
+#: lib/vutuv_web/components/post_components.ex:6189
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:6091
+#: lib/vutuv_web/components/post_components.ex:6146
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6135
+#: lib/vutuv_web/components/post_components.ex:6190
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6137
+#: lib/vutuv_web/components/post_components.ex:6192
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6133
+#: lib/vutuv_web/components/post_components.ex:6188
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:6090
+#: lib/vutuv_web/components/post_components.ex:6145
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13567,12 +13557,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6132
+#: lib/vutuv_web/components/post_components.ex:6187
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6136
+#: lib/vutuv_web/components/post_components.ex:6191
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13592,7 +13582,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6173
+#: lib/vutuv_web/components/post_components.ex:6228
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13600,27 +13590,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6203
+#: lib/vutuv_web/components/post_components.ex:6258
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6204
+#: lib/vutuv_web/components/post_components.ex:6259
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6202
+#: lib/vutuv_web/components/post_components.ex:6257
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6162
+#: lib/vutuv_web/components/post_components.ex:6217
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6209
+#: lib/vutuv_web/components/post_components.ex:6264
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13650,7 +13640,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5976
+#: lib/vutuv_web/components/post_components.ex:6031
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13693,7 +13683,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5967
+#: lib/vutuv_web/components/post_components.ex:6022
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -13875,7 +13865,7 @@ msgid "Are you looking for a job?"
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:290
-#: lib/vutuv_web/templates/user/edit.html.heex:359
+#: lib/vutuv_web/templates/user/edit.html.heex:365
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr ""
@@ -13892,12 +13882,12 @@ msgid "Preferred workplace"
 msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:249
-#: lib/vutuv_web/templates/user/edit.html.heex:287
+#: lib/vutuv_web/templates/user/edit.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1085
+#: lib/vutuv/notifications/emailer.ex:1111
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
@@ -14040,14 +14030,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3896
+#: lib/vutuv_web/components/post_components.ex:3951
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3919
+#: lib/vutuv_web/components/post_components.ex:3974
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14074,7 +14064,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6687
+#: lib/vutuv_web/components/post_components.ex:6742
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14232,7 +14222,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5237
+#: lib/vutuv_web/components/ui.ex:5249
 #: lib/vutuv_web/controllers/settings_controller.ex:773
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -14810,7 +14800,7 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1042
+#: lib/vutuv_web/templates/user/show.html.heex:1047
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
@@ -14866,252 +14856,252 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5165
+#: lib/vutuv_web/components/ui.ex:5177
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5170
+#: lib/vutuv_web/components/ui.ex:5182
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5173
+#: lib/vutuv_web/components/ui.ex:5185
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5174
+#: lib/vutuv_web/components/ui.ex:5186
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5177
+#: lib/vutuv_web/components/ui.ex:5189
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5178
+#: lib/vutuv_web/components/ui.ex:5190
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5181
+#: lib/vutuv_web/components/ui.ex:5193
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5182
+#: lib/vutuv_web/components/ui.ex:5194
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5189
+#: lib/vutuv_web/components/ui.ex:5201
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5190
+#: lib/vutuv_web/components/ui.ex:5202
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5191
+#: lib/vutuv_web/components/ui.ex:5203
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5194
+#: lib/vutuv_web/components/ui.ex:5206
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5195
+#: lib/vutuv_web/components/ui.ex:5207
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5375
+#: lib/vutuv_web/components/ui.ex:5387
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5376
+#: lib/vutuv_web/components/ui.ex:5388
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5198
+#: lib/vutuv_web/components/ui.ex:5210
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5201
+#: lib/vutuv_web/components/ui.ex:5213
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5202
+#: lib/vutuv_web/components/ui.ex:5214
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5205
+#: lib/vutuv_web/components/ui.ex:5217
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5206
+#: lib/vutuv_web/components/ui.ex:5218
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5209
+#: lib/vutuv_web/components/ui.ex:5221
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5210
+#: lib/vutuv_web/components/ui.ex:5222
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5212
+#: lib/vutuv_web/components/ui.ex:5224
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5213
+#: lib/vutuv_web/components/ui.ex:5225
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5214
+#: lib/vutuv_web/components/ui.ex:5226
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5216
+#: lib/vutuv_web/components/ui.ex:5228
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5217
+#: lib/vutuv_web/components/ui.ex:5229
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5219
+#: lib/vutuv_web/components/ui.ex:5231
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5224
+#: lib/vutuv_web/components/ui.ex:5236
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5225
+#: lib/vutuv_web/components/ui.ex:5237
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5228
+#: lib/vutuv_web/components/ui.ex:5240
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5231
+#: lib/vutuv_web/components/ui.ex:5243
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5238
+#: lib/vutuv_web/components/ui.ex:5250
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5239
+#: lib/vutuv_web/components/ui.ex:5251
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5267
+#: lib/vutuv_web/components/ui.ex:5279
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5268
+#: lib/vutuv_web/components/ui.ex:5280
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5284
+#: lib/vutuv_web/components/ui.ex:5296
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5285
+#: lib/vutuv_web/components/ui.ex:5297
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5332
+#: lib/vutuv_web/components/ui.ex:5344
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5333
+#: lib/vutuv_web/components/ui.ex:5345
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5336
+#: lib/vutuv_web/components/ui.ex:5348
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5337
+#: lib/vutuv_web/components/ui.ex:5349
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5358
+#: lib/vutuv_web/components/ui.ex:5370
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5359
+#: lib/vutuv_web/components/ui.ex:5371
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5367
+#: lib/vutuv_web/components/ui.ex:5379
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5368
+#: lib/vutuv_web/components/ui.ex:5380
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5371
+#: lib/vutuv_web/components/ui.ex:5383
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5372
+#: lib/vutuv_web/components/ui.ex:5384
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5386
+#: lib/vutuv_web/components/ui.ex:5398
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5387
+#: lib/vutuv_web/components/ui.ex:5399
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15219,7 +15209,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6633
+#: lib/vutuv_web/components/post_components.ex:6688
 #: lib/vutuv_web/live/notification_live/index.ex:1596
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
@@ -15227,7 +15217,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6637
+#: lib/vutuv_web/components/post_components.ex:6692
 #: lib/vutuv_web/live/notification_live/index.ex:1590
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -15235,7 +15225,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:6641
+#: lib/vutuv_web/components/post_components.ex:6696
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15243,7 +15233,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:6592
+#: lib/vutuv_web/components/post_components.ex:6647
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15262,7 +15252,7 @@ msgid "Content warning"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1581
-#: lib/vutuv_web/components/post_components.ex:2625
+#: lib/vutuv_web/components/post_components.ex:2680
 #: lib/vutuv_web/live/fediverse_account_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "From another network"
@@ -15341,7 +15331,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1501
 #: lib/vutuv_web/components/post_components.ex:1496
 #: lib/vutuv_web/components/post_components.ex:1727
-#: lib/vutuv_web/components/post_components.ex:3465
+#: lib/vutuv_web/components/post_components.ex:3520
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -15570,7 +15560,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5361
+#: lib/vutuv_web/components/ui.ex:5373
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -15915,7 +15905,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5362
+#: lib/vutuv_web/components/ui.ex:5374
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -15951,7 +15941,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5364
+#: lib/vutuv_web/components/ui.ex:5376
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16003,22 +15993,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4081
+#: lib/vutuv_web/components/post_components.ex:4136
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4207
+#: lib/vutuv_web/components/post_components.ex:4262
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4215
+#: lib/vutuv_web/components/post_components.ex:4270
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4201
+#: lib/vutuv_web/components/post_components.ex:4256
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16045,19 +16035,19 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:626
 #: lib/vutuv_web/agent_docs/text.ex:611
-#: lib/vutuv_web/templates/user/edit.html.heex:219
-#: lib/vutuv_web/templates/user/show.html.heex:286
+#: lib/vutuv_web/templates/user/edit.html.heex:225
+#: lib/vutuv_web/templates/user/show.html.heex:291
 #: lib/vutuv_web/views/account_event_text.ex:213
 #, elixir-autogen, elixir-format
 msgid "Name pronunciation"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:223
+#: lib/vutuv_web/templates/user/edit.html.heex:229
 #, elixir-autogen, elixir-format
 msgid "e.g. [SHTEH-fahn VIN-ter-my-er]"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:226
+#: lib/vutuv_web/templates/user/edit.html.heex:232
 #, elixir-autogen, elixir-format
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
@@ -16141,17 +16131,17 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3660
+#: lib/vutuv_web/components/post_components.ex:3715
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5091
+#: lib/vutuv_web/components/post_components.ex:5146
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5240
+#: lib/vutuv_web/components/post_components.ex:5295
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16164,7 +16154,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1462
 #: lib/vutuv_web/agent_docs/text.ex:890
-#: lib/vutuv_web/components/post_components.ex:5322
+#: lib/vutuv_web/components/post_components.ex:5377
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
@@ -16190,7 +16180,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3713
+#: lib/vutuv_web/components/post_components.ex:3768
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16210,7 +16200,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3704
+#: lib/vutuv_web/components/post_components.ex:3759
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16220,12 +16210,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3722
+#: lib/vutuv_web/components/post_components.ex:3777
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3656
+#: lib/vutuv_web/components/post_components.ex:3711
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16240,7 +16230,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3717
+#: lib/vutuv_web/components/post_components.ex:3772
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16250,7 +16240,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3670
+#: lib/vutuv_web/components/post_components.ex:3725
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16325,13 +16315,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1319
-#: lib/vutuv_web/components/post_components.ex:6630
+#: lib/vutuv_web/components/post_components.ex:6685
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1317
-#: lib/vutuv_web/components/post_components.ex:6627
+#: lib/vutuv_web/components/post_components.ex:6682
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16341,7 +16331,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6514
+#: lib/vutuv_web/components/post_components.ex:6569
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -16459,7 +16449,7 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5348
+#: lib/vutuv_web/components/ui.ex:5360
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
@@ -16662,7 +16652,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5350
+#: lib/vutuv_web/components/ui.ex:5362
 #, elixir-autogen, elixir-format, fuzzy
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -16682,7 +16672,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3224
+#: lib/vutuv_web/components/post_components.ex:3279
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16692,7 +16682,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3464
+#: lib/vutuv_web/components/post_components.ex:3519
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16717,7 +16707,7 @@ msgstr ""
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3405
+#: lib/vutuv_web/components/post_components.ex:3460
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marked as sensitive by its author"
 msgstr ""
@@ -16732,7 +16722,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3197
+#: lib/vutuv_web/components/post_components.ex:3252
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -16820,7 +16810,7 @@ msgstr ""
 msgid "Your account move"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:28
+#: lib/vutuv_web/views/page_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "“LinkedIn is annoying. vutuv is not.”"
 msgstr ""
@@ -16832,27 +16822,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2798
+#: lib/vutuv_web/components/post_components.ex:2853
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2831
+#: lib/vutuv_web/components/post_components.ex:2886
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2826
+#: lib/vutuv_web/components/post_components.ex:2881
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3563
+#: lib/vutuv_web/components/post_components.ex:3618
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3569
+#: lib/vutuv_web/components/post_components.ex:3624
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is not here any more."
 msgstr ""
@@ -16862,7 +16852,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3708
+#: lib/vutuv_web/components/post_components.ex:3763
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17523,7 +17513,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3566
+#: lib/vutuv_web/components/post_components.ex:3621
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -17595,19 +17585,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5616
+#: lib/vutuv_web/components/post_components.ex:5671
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5618
+#: lib/vutuv_web/components/post_components.ex:5673
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5629
+#: lib/vutuv_web/components/post_components.ex:5684
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -17667,7 +17657,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/job_reference_controller.ex:144
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:18
 #: lib/vutuv_web/templates/job_reference/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:804
+#: lib/vutuv_web/templates/user/show.html.heex:809
 #, elixir-autogen, elixir-format
 msgid "Add an employment reference"
 msgstr ""
@@ -17734,7 +17724,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:5184
+#: lib/vutuv_web/components/ui.ex:5196
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -17744,7 +17734,7 @@ msgstr ""
 #: lib/vutuv_web/templates/job_reference/new.html.heex:4
 #: lib/vutuv_web/templates/job_reference/show.html.heex:12
 #: lib/vutuv_web/templates/job_reference/view.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:801
+#: lib/vutuv_web/templates/user/show.html.heex:806
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employment references"
 msgstr ""
@@ -17929,7 +17919,7 @@ msgstr ""
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5185
+#: lib/vutuv_web/components/ui.ex:5197
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
@@ -17940,7 +17930,7 @@ msgstr ""
 msgid "Zwischenzeugnis"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5187
+#: lib/vutuv_web/components/ui.ex:5199
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -18195,7 +18185,7 @@ msgstr ""
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4481
+#: lib/vutuv_web/components/ui.ex:4493
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -18375,7 +18365,7 @@ msgstr ""
 msgid "by the lawyer Tom Braegelmann"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:845
+#: lib/vutuv_web/templates/user/show.html.heex:850
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Documents:"
 msgstr ""
@@ -18491,17 +18481,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1430
+#: lib/vutuv/accounts/user.ex:1437
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1428
+#: lib/vutuv/accounts/user.ex:1435
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1429
+#: lib/vutuv/accounts/user.ex:1436
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -18511,7 +18501,7 @@ msgstr ""
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5166
+#: lib/vutuv_web/components/ui.ex:5178
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
@@ -18607,7 +18597,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5341
+#: lib/vutuv_web/components/ui.ex:5353
 #: lib/vutuv_web/controllers/settings_controller.ex:256
 #: lib/vutuv_web/controllers/settings_controller.ex:335
 #: lib/vutuv_web/controllers/settings_controller.ex:347
@@ -18704,7 +18694,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5343
+#: lib/vutuv_web/components/ui.ex:5355
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -18813,7 +18803,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5345
+#: lib/vutuv_web/components/ui.ex:5357
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -19187,7 +19177,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3596
+#: lib/vutuv_web/components/post_components.ex:3651
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -19344,7 +19334,7 @@ msgstr[1] ""
 msgid "%{name} mentioned this page."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:184
+#: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{name} follows"
 msgstr ""
@@ -19354,7 +19344,7 @@ msgstr ""
 msgid "Feed – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:185
+#: lib/vutuv_web/templates/user/show.html.heex:195
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow as %{name}"
 msgstr ""
@@ -19727,7 +19717,7 @@ msgstr ""
 msgid "the address of a post out there: vutuv fetches it so you can answer it here"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:81
+#: lib/vutuv_web/templates/user/edit.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Fetch my picture from gravatar.com"
 msgstr ""
@@ -19752,7 +19742,7 @@ msgstr ""
 msgid "gravatar.com has no picture for your email address."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:84
+#: lib/vutuv_web/templates/user/edit.html.heex:88
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Only when you press this: we ask gravatar.com whether there is a picture for your email address, sending a hash of the address rather than the address itself. Nothing leaves this server otherwise."
 msgstr ""
@@ -20055,27 +20045,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5510
+#: lib/vutuv_web/components/post_components.ex:5565
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5546
+#: lib/vutuv_web/components/post_components.ex:5601
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5555
+#: lib/vutuv_web/components/post_components.ex:5610
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5558
+#: lib/vutuv_web/components/post_components.ex:5613
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5535
+#: lib/vutuv_web/components/post_components.ex:5590
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20085,8 +20075,8 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5525
-#: lib/vutuv_web/components/ui.ex:5259
+#: lib/vutuv_web/components/post_components.ex:5580
+#: lib/vutuv_web/components/ui.ex:5271
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -20214,32 +20204,32 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5288
+#: lib/vutuv_web/components/post_components.ex:5343
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5285
+#: lib/vutuv_web/components/post_components.ex:5340
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2852
-#: lib/vutuv_web/components/post_components.ex:4495
+#: lib/vutuv_web/components/post_components.ex:2907
+#: lib/vutuv_web/components/post_components.ex:4550
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:139
+#: lib/vutuv_web/templates/user/edit.html.heex:145
 #, elixir-autogen, elixir-format
 msgid "Recommended: %{width} × %{height} pixels (%{ratio})."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:59
+#: lib/vutuv_web/templates/user/edit.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
@@ -20297,7 +20287,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5379
+#: lib/vutuv_web/components/ui.ex:5391
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
@@ -20343,7 +20333,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5381
+#: lib/vutuv_web/components/ui.ex:5393
 #, elixir-autogen, elixir-format, fuzzy
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -20378,7 +20368,7 @@ msgstr ""
 msgid "Find your LinkedIn contacts"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5275
+#: lib/vutuv_web/components/ui.ex:5287
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format, fuzzy
@@ -20486,7 +20476,7 @@ msgstr ""
 msgid "See which of them are already on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5277
+#: lib/vutuv_web/components/ui.ex:5289
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr ""
@@ -20558,7 +20548,7 @@ msgstr ""
 msgid "Your export also lists your LinkedIn contacts."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5279
+#: lib/vutuv_web/components/ui.ex:5291
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr ""
@@ -20740,7 +20730,7 @@ msgstr ""
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3177
+#: lib/vutuv_web/components/post_components.ex:3232
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
@@ -20815,7 +20805,7 @@ msgstr ""
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5233
+#: lib/vutuv_web/components/ui.ex:5245
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
@@ -21036,22 +21026,22 @@ msgstr ""
 msgid "Shown in the language it was written in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5260
+#: lib/vutuv_web/components/ui.ex:5272
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5262
+#: lib/vutuv_web/components/ui.ex:5274
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5300
+#: lib/vutuv_web/components/ui.ex:5312
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5304
+#: lib/vutuv_web/components/ui.ex:5316
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -21139,12 +21129,12 @@ msgstr ""
 msgid "That alternative name is no longer on record."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:63
+#: lib/vutuv_web/views/page_html.ex:60
 #, elixir-autogen, elixir-format
 msgid "Fast."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:64
+#: lib/vutuv_web/views/page_html.ex:61
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No paid premium accounts."
 msgstr ""
@@ -21509,7 +21499,7 @@ msgid_plural "Show %{formatted} posts in the feed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2769
+#: lib/vutuv_web/components/post_components.ex:2824
 #, elixir-autogen, elixir-format
 msgid "Picture unavailable"
 msgstr "Picture unavailable"
@@ -21534,7 +21524,7 @@ msgstr ""
 msgid "Your organization page was updated, but that picture could not be used as a logo. Please pick another one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4487
+#: lib/vutuv_web/components/ui.ex:4499
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -21681,7 +21671,7 @@ msgid_plural "New (%{formatted}):"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3332
+#: lib/vutuv_web/components/post_components.ex:3387
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Quoted post"
 msgstr ""
@@ -21732,12 +21722,12 @@ msgstr ""
 msgid "Only these accounts (empty = all) …"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3530
+#: lib/vutuv_web/components/ui.ex:3542
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6973
+#: lib/vutuv_web/components/post_components.ex:7028
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -21974,7 +21964,7 @@ msgstr ""
 msgid "Replace with"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5252
+#: lib/vutuv_web/components/ui.ex:5264
 #, elixir-autogen, elixir-format
 msgid "Rewrite what an account's posts say, for you alone"
 msgstr ""
@@ -21990,9 +21980,9 @@ msgid "Rules that rewrite the text of one account's posts before you read them: 
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1450
-#: lib/vutuv_web/components/post_components.ex:3190
-#: lib/vutuv_web/components/post_components.ex:4284
-#: lib/vutuv_web/components/ui.ex:5251
+#: lib/vutuv_web/components/post_components.ex:3245
+#: lib/vutuv_web/components/post_components.ex:4339
+#: lib/vutuv_web/components/ui.ex:5263
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
 #: lib/vutuv_web/live/post_rewrites_live.ex:264
@@ -22048,12 +22038,12 @@ msgstr ""
 msgid "\\1 puts back what the first (…) group matched, \\0 the whole match."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5253
+#: lib/vutuv_web/components/ui.ex:5265
 #, elixir-autogen, elixir-format
 msgid "regex regular expression rewrite replace footer signature strip"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5322
+#: lib/vutuv_web/components/ui.ex:5334
 #, elixir-autogen, elixir-format
 msgid "Smaller pictures and a plain composer on a slow connection"
 msgstr ""
@@ -22063,12 +22053,12 @@ msgstr ""
 msgid "That endorsement is not possible."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5324
+#: lib/vutuv_web/components/ui.ex:5336
 #, elixir-autogen, elixir-format
 msgid "bandwidth slow internet mobile data saving saver volume metered compression pictures images screenshots editor langsam daten sparen datensparmodus volumen schmalband komprimierung bilder"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5296
+#: lib/vutuv_web/components/ui.ex:5308
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr ""
@@ -22181,7 +22171,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1417
 #: lib/vutuv_web/agent_docs/text.ex:899
 #: lib/vutuv_web/agent_docs/text.ex:900
-#: lib/vutuv_web/components/post_components.ex:2904
+#: lib/vutuv_web/components/post_components.ex:2959
 #: lib/vutuv_web/components/video_components.ex:127
 #: lib/vutuv_web/live/post_live/composer.ex:2458
 #, elixir-autogen, elixir-format
@@ -22244,7 +22234,7 @@ msgstr[1] ""
 msgid "Last 30 days: %{parts}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4847
+#: lib/vutuv_web/components/post_components.ex:4902
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Less"
@@ -22548,7 +22538,7 @@ msgstr ""
 msgid "Accounts whose posts stay out of your feed, and accounts whose reposts do. This list is yours alone: it is never shared and nobody is told they are on it."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5245
+#: lib/vutuv_web/components/ui.ex:5257
 #, elixir-autogen, elixir-format
 msgid "Accounts you have silenced, and whose reposts you hide"
 msgstr ""
@@ -22558,8 +22548,8 @@ msgstr ""
 msgid "Hidden. What they pass on stays out of your feed; their own posts do not."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3162
-#: lib/vutuv_web/components/post_components.ex:4278
+#: lib/vutuv_web/components/post_components.ex:3217
+#: lib/vutuv_web/components/post_components.ex:4333
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr ""
@@ -22574,7 +22564,7 @@ msgstr ""
 msgid "Mute everything"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5244
+#: lib/vutuv_web/components/ui.ex:5256
 #: lib/vutuv_web/controllers/settings_controller.ex:713
 #: lib/vutuv_web/templates/settings/mutes.html.heex:1
 #: lib/vutuv_web/templates/settings/mutes.html.heex:3
@@ -22618,7 +22608,7 @@ msgstr ""
 msgid "You mute an account where you meet it: the ⋯ menu on any of its posts, or its own page. Muting works whether or not you follow them."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5247
+#: lib/vutuv_web/components/ui.ex:5259
 #, elixir-autogen, elixir-format
 msgid "mute unmute hide account reposts boosts feed stumm stummschalten ausblenden konto"
 msgstr ""
@@ -22718,7 +22708,7 @@ msgstr ""
 msgid "Feed settings saved."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5315
+#: lib/vutuv_web/components/ui.ex:5327
 #, elixir-autogen, elixir-format
 msgid "How many load at once, and how many “Load more” adds"
 msgstr ""
@@ -22728,7 +22718,7 @@ msgstr ""
 msgid "How many posts your feed shows before the “Load more” button, and how many that button adds. More posts mean a longer wait for the page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5314
+#: lib/vutuv_web/components/ui.ex:5326
 #: lib/vutuv_web/controllers/settings_controller.ex:963
 #: lib/vutuv_web/templates/settings/feed.html.heex:12
 #, elixir-autogen, elixir-format
@@ -22751,18 +22741,18 @@ msgstr ""
 msgid "You can change this under the feed itself as well, right below the “Load more” button."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5317
+#: lib/vutuv_web/components/ui.ex:5329
 #, elixir-autogen, elixir-format
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6964
-#: lib/vutuv_web/components/post_components.ex:6965
+#: lib/vutuv_web/components/post_components.ex:7019
+#: lib/vutuv_web/components/post_components.ex:7020
 #, elixir-autogen, elixir-format, fuzzy
 msgid "A word or phrase …"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6992
+#: lib/vutuv_web/components/post_components.ex:7047
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr ""
@@ -22779,7 +22769,7 @@ msgstr ""
 msgid "Hide something from your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6912
+#: lib/vutuv_web/components/post_components.ex:6967
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr ""
@@ -22794,22 +22784,22 @@ msgstr ""
 msgid "Words & tags"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6996
+#: lib/vutuv_web/components/post_components.ex:7051
 #, elixir-autogen, elixir-format, fuzzy
 msgid "everyone"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6999
+#: lib/vutuv_web/components/post_components.ex:7054
 #, elixir-autogen, elixir-format, fuzzy
 msgid "only %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6968
+#: lib/vutuv_web/components/post_components.ex:7023
 #, elixir-autogen, elixir-format, fuzzy
 msgid "this word"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:7009
+#: lib/vutuv_web/components/post_components.ex:7064
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "only %{server}"
@@ -22861,7 +22851,7 @@ msgstr ""
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6319
+#: lib/vutuv_web/components/post_components.ex:6374
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr ""
@@ -22881,7 +22871,7 @@ msgstr ""
 msgid "Turn on for my account"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:97
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."
 msgstr ""
@@ -22916,7 +22906,7 @@ msgstr ""
 msgid "Which work is it, and where can the original be seen? (required)"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:45
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Copyright law. This complaint says the work is not yours to publish, which is a legal question rather than a house rule."
 msgstr ""
@@ -22926,27 +22916,27 @@ msgstr ""
 msgid "Hidden automatically after a report: %{reason}. The case page says what you can do."
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:16
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "No person made this decision: a report from a member in good standing hides the reported content automatically, the moment it arrives."
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:79
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Nobody else can see it right now. You have 72 hours to settle this yourself; after that our admins decide. Here is what you can do:"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:48
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Our community guidelines, which everything on vutuv has to keep to."
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:41
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "The ground"
 msgstr ""
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:28
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "What the report says"
 msgstr ""
@@ -22961,8 +22951,8 @@ msgstr ""
 msgid "Hidden. What other people pass on of them stays out of your feed; their own posts do not."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3148
-#: lib/vutuv_web/components/post_components.ex:4266
+#: lib/vutuv_web/components/post_components.ex:3203
+#: lib/vutuv_web/components/post_components.ex:4321
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr ""
@@ -22997,12 +22987,12 @@ msgstr ""
 msgid "By emailed PIN, passkey, authenticator app or a printed list of codes."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:160
+#: lib/vutuv_web/views/page_html.ex:157
 #, elixir-autogen, elixir-format
 msgid "Curious? Have a look at a real profile: {profile}. With or without a vutuv account of your own."
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:156
+#: lib/vutuv_web/views/page_html.ex:153
 #, elixir-autogen, elixir-format
 msgid "Curious? Have a look at the profile of vutuv founder Stefan Wintermeyer: {profile}. With or without a vutuv account of your own."
 msgstr ""
@@ -23132,7 +23122,7 @@ msgstr ""
 msgid "vutuv is part of the Fediverse, the union of independent networks that Mastodon belongs to as well. Whether your posts take part is your choice at sign-up, and one switch in the settings later. We are not religious about it: each to their own."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1806
+#: lib/vutuv_web/live/shell_live.ex:1811
 #, elixir-autogen, elixir-format
 msgid "All notifications"
 msgstr ""
@@ -23152,12 +23142,12 @@ msgstr ""
 msgid "Profile picture"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:260
+#: lib/vutuv_web/templates/user/show.html.heex:265
 #, elixir-autogen, elixir-format
 msgid "Report the cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:253
+#: lib/vutuv_web/templates/user/show.html.heex:258
 #, elixir-autogen, elixir-format
 msgid "Report the profile picture"
 msgstr ""
@@ -23167,7 +23157,7 @@ msgstr ""
 msgid "The reported picture"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:241
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "Upholding the case deletes it, the private original included. Rejecting it puts every file back where it was."
 msgstr ""
@@ -23182,7 +23172,7 @@ msgstr ""
 msgid "Your profile picture was not replaced: a report about it is still open. Open the case to remove the picture or to say that it is yours."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2471
+#: lib/vutuv_web/components/post_components.ex:2476
 #, elixir-autogen, elixir-format
 msgid "Fetching the answers from the servers that hold them…"
 msgstr ""
@@ -23197,7 +23187,7 @@ msgstr ""
 msgid "Nothing here we are allowed to show you."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2490
+#: lib/vutuv_web/components/post_components.ex:2495
 #, elixir-autogen, elixir-format
 msgid "Show more answers"
 msgstr ""
@@ -23235,7 +23225,7 @@ msgstr ""
 msgid "Thank you for your report. Our moderators have been notified and will review this picture."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:245
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:255
 #, elixir-autogen, elixir-format
 msgid "This picture is still on the profile: only a copyright notice takes one offline before a ruling. Upholding the case deletes it, the private original included."
 msgstr ""
@@ -23287,7 +23277,7 @@ msgstr ""
 msgid "Is content published here yours, or does it break the law? You can tell us without an account."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1250
+#: lib/vutuv/notifications/emailer.ex:1284
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Moderation: something was reported"
 msgstr ""
@@ -23312,7 +23302,7 @@ msgstr ""
 msgid "Outside reporter confirmed their address"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1166
+#: lib/vutuv/notifications/emailer.ex:1200
 #: lib/vutuv_web/templates/public_report/sent.html.heex:4
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Please confirm your report"
@@ -23359,7 +23349,7 @@ msgstr ""
 msgid "The post, picture, video, profile, page or job posting you are reporting. Copy it out of your browser's address bar."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:407
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "The report by %{email} was a deliberate weapon (that address loses our trust)"
 msgstr ""
@@ -23507,7 +23497,7 @@ msgstr ""
 msgid "Report decision"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1060
+#: lib/vutuv/notifications/emailer.ex:1082
 #, elixir-autogen, elixir-format
 msgid "The content you reported was deleted"
 msgstr ""
@@ -23522,17 +23512,112 @@ msgstr ""
 msgid "The owner revised the content you reported; it is visible again."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1063
+#: lib/vutuv/notifications/emailer.ex:1085
 #, elixir-autogen, elixir-format
 msgid "Your report was not upheld"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1062
+#: lib/vutuv/notifications/emailer.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Your report was upheld"
 msgstr ""
 
-#: lib/vutuv_web/views/page_html.ex:62
+#: lib/vutuv_web/views/page_html.ex:59
 #, elixir-autogen, elixir-format
 msgid "Easy LinkedIn profile import."
+msgstr ""
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:26
+#, elixir-autogen, elixir-format
+msgid "No person made this decision: a report from somebody with a good record hides the reported content automatically, the moment it arrives."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:400
+#, elixir-autogen, elixir-format
+msgid "The report is justified. The content becomes visible again - the consequence here is the strike (warn, suspend, deactivate)."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:404
+#, elixir-autogen, elixir-format
+msgid "The report is justified. The content is not hidden and upholding does not hide it; the owner gets a strike (warn, suspend, deactivate)."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:392
+#, elixir-autogen, elixir-format
+msgid "The report is justified. The reported picture is deleted, the private original included, and the owner gets a strike (warn, suspend, deactivate)."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:251
+#, elixir-autogen, elixir-format
+msgid "This picture is still on the profile: the address behind the copyright notice is not confirmed yet, so nothing has been hidden. Upholding the case deletes it, the private original included."
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:82
+#, elixir-autogen, elixir-format
+msgid "somebody reported one of your job postings on vutuv."
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:85
+#, elixir-autogen, elixir-format
+msgid "somebody reported one of your pages on vutuv."
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:76
+#, elixir-autogen, elixir-format
+msgid "somebody reported one of your pictures on vutuv."
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:73
+#, elixir-autogen, elixir-format
+msgid "somebody reported one of your posts on vutuv."
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:79
+#, elixir-autogen, elixir-format
+msgid "somebody reported one of your private messages on vutuv."
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:91
+#, elixir-autogen, elixir-format
+msgid "somebody reported something of yours on vutuv."
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:88
+#, elixir-autogen, elixir-format
+msgid "somebody reported your profile on vutuv."
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:105
+#, elixir-autogen, elixir-format
+msgid "A report from a member in good standing hides the reported content automatically, the moment it arrives."
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:111
+#, elixir-autogen, elixir-format
+msgid "A report from somebody with a good record hides the reported content automatically, the moment it arrives."
+msgstr ""
+
+#: lib/vutuv_web/views/moderation_case_html.ex:32
+#, elixir-autogen, elixir-format
+msgid "An admin confirmed the report."
+msgstr ""
+
+#: lib/vutuv_web/views/moderation_case_html.ex:33
+#, elixir-autogen, elixir-format
+msgid "An admin dismissed the report."
+msgstr ""
+
+#: lib/vutuv_web/views/moderation_case_html.ex:40
+#, elixir-autogen, elixir-format
+msgid "The content is deleted."
+msgstr ""
+
+#: lib/vutuv_web/views/moderation_case_html.ex:42
+#, elixir-autogen, elixir-format
+msgid "The content is visible again."
+msgstr ""
+
+#: lib/vutuv_web/views/moderation_case_html.ex:41
+#, elixir-autogen, elixir-format
+msgid "The content stays hidden."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -17,8 +17,8 @@ msgstr ""
 msgid "About us"
 msgstr "Note legali"
 
-#: lib/vutuv_web/components/ui.ex:4871
-#: lib/vutuv_web/components/ui.ex:4876
+#: lib/vutuv_web/components/ui.ex:4883
+#: lib/vutuv_web/components/ui.ex:4888
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:729
 #: lib/vutuv_web/live/organization_live/domains.ex:287
@@ -40,7 +40,7 @@ msgstr "Aggiungi"
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1489
+#: lib/vutuv_web/templates/user/show.html.heex:1494
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -64,7 +64,7 @@ msgstr "Indirizzo aggiornato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/text.ex:71
-#: lib/vutuv_web/components/ui.ex:5208
+#: lib/vutuv_web/components/ui.ex:5220
 #: lib/vutuv_web/controllers/address_controller.ex:22
 #: lib/vutuv_web/controllers/address_controller.ex:37
 #: lib/vutuv_web/controllers/address_controller.ex:84
@@ -83,8 +83,8 @@ msgstr "Indirizzi"
 msgid "Already a member? Sign in here."
 msgstr "È già iscritto? Acceda qui."
 
-#: lib/vutuv_web/components/ui.ex:4662
-#: lib/vutuv_web/components/ui.ex:4761
+#: lib/vutuv_web/components/ui.ex:4674
+#: lib/vutuv_web/components/ui.ex:4773
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:841
@@ -97,7 +97,7 @@ msgstr "Confermi?"
 msgid "Avatar"
 msgstr "Immagine del profilo"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:410
+#: lib/vutuv_web/templates/user/edit.html.heex:416
 #, elixir-autogen
 msgid "Birthdate"
 msgstr "Data di nascita"
@@ -106,13 +106,13 @@ msgstr "Data di nascita"
 #: lib/vutuv_web/agent_docs/markdown.ex:677
 #: lib/vutuv_web/agent_docs/text.ex:636
 #: lib/vutuv_web/agent_docs/text.ex:637
-#: lib/vutuv_web/templates/user/show.html.heex:1120
+#: lib/vutuv_web/templates/user/show.html.heex:1125
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Compleanno"
 
 #: lib/vutuv_web/components/saved_search_components.ex:104
-#: lib/vutuv_web/components/ui.ex:4656
+#: lib/vutuv_web/components/ui.ex:4668
 #: lib/vutuv_web/components/video_components.ex:281
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:210
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1133
@@ -131,9 +131,9 @@ msgstr "Compleanno"
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:53
-#: lib/vutuv_web/templates/user/edit.html.heex:133
-#: lib/vutuv_web/templates/user/edit.html.heex:466
-#: lib/vutuv_web/templates/user/edit.html.heex:511
+#: lib/vutuv_web/templates/user/edit.html.heex:137
+#: lib/vutuv_web/templates/user/edit.html.heex:472
+#: lib/vutuv_web/templates/user/edit.html.heex:517
 #: lib/vutuv_web/templates/username/confirm.html.heex:220
 #, elixir-autogen
 msgid "Cancel"
@@ -154,7 +154,7 @@ msgstr "Selezioni una voce"
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1158
+#: lib/vutuv_web/templates/user/show.html.heex:1163
 #, elixir-autogen
 msgid "Contact"
 msgstr "Contatto"
@@ -163,8 +163,8 @@ msgstr "Contatto"
 msgid "Couldn't follow back to %{name}."
 msgstr "Non è stato possibile ricambiare il follow a %{name}."
 
-#: lib/vutuv_web/components/post_components.ex:4223
-#: lib/vutuv_web/components/ui.ex:4763
+#: lib/vutuv_web/components/post_components.ex:4278
+#: lib/vutuv_web/components/ui.ex:4775
 #: lib/vutuv_web/live/admin/job_live.ex:486
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:621
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:657
@@ -172,7 +172,7 @@ msgstr "Non è stato possibile ricambiare il follow a %{name}."
 #: lib/vutuv_web/live/admin/user_delete_live.ex:167
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:28
 #: lib/vutuv_web/templates/dev_app/show.html.heex:135
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:117
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:127
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:70
 #, elixir-autogen
 msgid "Delete"
@@ -211,8 +211,8 @@ msgstr "Disattiva"
 msgid "Download"
 msgstr "Scarica"
 
-#: lib/vutuv_web/components/post_components.ex:4188
-#: lib/vutuv_web/components/ui.ex:4754
+#: lib/vutuv_web/components/post_components.ex:4243
+#: lib/vutuv_web/components/ui.ex:4766
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:649
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:150
@@ -224,8 +224,8 @@ msgstr "Scarica"
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:6
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:103
-#: lib/vutuv_web/templates/user/show.html.heex:1143
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:113
+#: lib/vutuv_web/templates/user/show.html.heex:1148
 #, elixir-autogen
 msgid "Edit"
 msgstr "Modifica"
@@ -286,11 +286,11 @@ msgstr "Inserisca il Suo indirizzo e-mail"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:5172
+#: lib/vutuv_web/components/ui.ex:5184
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:644
+#: lib/vutuv_web/templates/user/show.html.heex:649
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -307,7 +307,7 @@ msgid "Fax"
 msgstr "Fax"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:662
-#: lib/vutuv_web/templates/user/edit.html.heex:164
+#: lib/vutuv_web/templates/user/edit.html.heex:170
 #, elixir-autogen
 msgid "First Name"
 msgstr "Nome"
@@ -333,7 +333,7 @@ msgstr "Follower"
 #: lib/vutuv_web/live/organization_live/show.ex:618
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:988
+#: lib/vutuv_web/templates/user/show.html.heex:993
 #: lib/vutuv_web/views/user_html.ex:640
 #, elixir-autogen
 msgid "Following"
@@ -341,7 +341,7 @@ msgstr "Seguiti"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:212
 #: lib/vutuv_web/templates/page/index.html.heex:121
-#: lib/vutuv_web/templates/user/edit.html.heex:201
+#: lib/vutuv_web/templates/user/edit.html.heex:207
 #: lib/vutuv_web/views/account_event_text.ex:219
 #, elixir-autogen
 msgid "Gender"
@@ -386,7 +386,7 @@ msgid "Language"
 msgstr "Lingua"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:664
-#: lib/vutuv_web/templates/user/edit.html.heex:169
+#: lib/vutuv_web/templates/user/edit.html.heex:175
 #, elixir-autogen
 msgid "Last Name"
 msgstr "Cognome"
@@ -453,7 +453,7 @@ msgid "Log in"
 msgstr "Accedi"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:663
-#: lib/vutuv_web/templates/user/edit.html.heex:174
+#: lib/vutuv_web/templates/user/edit.html.heex:180
 #, elixir-autogen
 msgid "Middle Name"
 msgstr "Secondo nome"
@@ -490,7 +490,7 @@ msgid "New"
 msgstr "Nuovo"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:666
-#: lib/vutuv_web/templates/user/edit.html.heex:179
+#: lib/vutuv_web/templates/user/edit.html.heex:185
 #, elixir-autogen
 msgid "Nickname"
 msgstr "Soprannome"
@@ -571,7 +571,7 @@ msgid "Phone number updated successfully."
 msgstr "Numero di telefono aggiornato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:661
-#: lib/vutuv_web/templates/user/edit.html.heex:184
+#: lib/vutuv_web/templates/user/edit.html.heex:190
 #, elixir-autogen
 msgid "Prefix"
 msgstr "Prefisso"
@@ -617,7 +617,7 @@ msgstr "Piattaforma"
 msgid "Public"
 msgstr "Pubblico"
 
-#: lib/vutuv_web/components/ui.ex:4655
+#: lib/vutuv_web/components/ui.ex:4667
 #: lib/vutuv_web/live/organization_live/edit.ex:376
 #: lib/vutuv_web/live/post_live/composer.ex:2201
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -633,7 +633,7 @@ msgstr "Pubblico"
 #: lib/vutuv_web/templates/settings/preferences.html.heex:362
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:61
-#: lib/vutuv_web/templates/user/edit.html.heex:461
+#: lib/vutuv_web/templates/user/edit.html.heex:467
 #: lib/vutuv_web/views/settings_html.ex:253
 #, elixir-autogen
 msgid "Save"
@@ -695,13 +695,13 @@ msgstr "Slug"
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1272
+#: lib/vutuv_web/templates/user/show.html.heex:1277
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profili"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1274
+#: lib/vutuv_web/templates/user/show.html.heex:1279
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr "Aggiungi un profilo"
@@ -750,7 +750,7 @@ msgid "Submit a bugreport or a feature request."
 msgstr "Segnali un problema o proponga una funzione."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:665
-#: lib/vutuv_web/templates/user/edit.html.heex:189
+#: lib/vutuv_web/templates/user/edit.html.heex:195
 #, elixir-autogen
 msgid "Suffix"
 msgstr "Suffisso"
@@ -792,7 +792,7 @@ msgstr "Utente aggiornato."
 msgid "User verified successfully."
 msgstr "Utente verificato."
 
-#: lib/vutuv_web/components/ui.ex:5168
+#: lib/vutuv_web/components/ui.ex:5180
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:832
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -852,14 +852,14 @@ msgstr "Utenti"
 msgid "vCard"
 msgstr "vCard"
 
-#: lib/vutuv_web/components/ui.ex:4824
-#: lib/vutuv_web/templates/user/show.html.heex:982
-#: lib/vutuv_web/templates/user/show.html.heex:1005
+#: lib/vutuv_web/components/ui.ex:4836
+#: lib/vutuv_web/templates/user/show.html.heex:987
+#: lib/vutuv_web/templates/user/show.html.heex:1010
 #, elixir-autogen
 msgid "View All"
 msgstr "Mostra tutti"
 
-#: lib/vutuv_web/components/ui.ex:5331
+#: lib/vutuv_web/components/ui.ex:5343
 #: lib/vutuv_web/controllers/settings_controller.ex:175
 #: lib/vutuv_web/live/job_posting_live/form.ex:818
 #: lib/vutuv_web/live/organization_live/edit.ex:339
@@ -1058,7 +1058,7 @@ msgstr "Non ha i permessi per vedere questa pagina."
 msgid "An error occurred"
 msgstr "Si è verificato un errore"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1109
+#: lib/vutuv_web/templates/user/show.html.heex:1114
 #, elixir-autogen
 msgid "General Info"
 msgstr "Informazioni generali"
@@ -1200,10 +1200,10 @@ msgstr "Tutti i sinonimi dei tag"
 msgid "All tag urls"
 msgstr "Tutti gli URL dei tag"
 
-#: lib/vutuv_web/components/post_components.ex:4838
+#: lib/vutuv_web/components/post_components.ex:4893
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:638
+#: lib/vutuv_web/templates/user/show.html.heex:643
 #, elixir-autogen
 msgid "All tags"
 msgstr "Tutti i tag"
@@ -1374,7 +1374,7 @@ msgstr "URL dei tag"
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:584
 #: lib/vutuv_web/agent_docs/text.ex:850
-#: lib/vutuv_web/components/ui.ex:5193
+#: lib/vutuv_web/components/ui.ex:5205
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1401,7 +1401,7 @@ msgstr "URL dei tag"
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:28
 #: lib/vutuv_web/templates/tag/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:608
+#: lib/vutuv_web/templates/user/show.html.heex:613
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1676,7 +1676,7 @@ msgid "Delete my account"
 msgstr "Elimina il mio account"
 
 #: lib/vutuv_web/controllers/user_controller.ex:149
-#: lib/vutuv_web/templates/user/show.html.heex:147
+#: lib/vutuv_web/templates/user/show.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Edit profile"
 msgstr "Modifica profilo"
@@ -1704,7 +1704,7 @@ msgstr "Conferma"
 #: lib/vutuv_web/live/organization_live/show.ex:616
 #: lib/vutuv_web/live/post_live/feed.ex:902
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
-#: lib/vutuv_web/templates/user/show.html.heex:1313
+#: lib/vutuv_web/templates/user/show.html.heex:1318
 #: lib/vutuv_web/views/user_html.ex:651
 #, elixir-autogen, elixir-format
 msgid "Follow"
@@ -1762,7 +1762,7 @@ msgid "Network"
 msgstr "Rete"
 
 #: lib/vutuv_web/components/post_components.ex:485
-#: lib/vutuv_web/components/ui.ex:4873
+#: lib/vutuv_web/components/ui.ex:4885
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:804
@@ -1778,7 +1778,7 @@ msgid "Nothing new yet."
 msgstr "Ancora nessuna novità."
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:5230
+#: lib/vutuv_web/components/ui.ex:5242
 #: lib/vutuv_web/controllers/page_controller.ex:214
 #: lib/vutuv_web/live/notification_live/index.ex:154
 #: lib/vutuv_web/live/notification_live/index.ex:440
@@ -1850,7 +1850,7 @@ msgstr "Troppi tentativi. Riprovi più tardi."
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:19
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
-#: lib/vutuv_web/templates/user/show.html.heex:222
+#: lib/vutuv_web/templates/user/show.html.heex:232
 #: lib/vutuv_web/views/user_html.ex:1100
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
@@ -1923,14 +1923,14 @@ msgstr "ora è collegato con Lei."
 msgid "started following you."
 msgstr "ha iniziato a seguirla."
 
-#: lib/vutuv_web/components/ui.ex:4130
-#: lib/vutuv_web/components/ui.ex:4275
+#: lib/vutuv_web/components/ui.ex:4142
+#: lib/vutuv_web/components/ui.ex:4287
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr "Paginazione"
 
-#: lib/vutuv_web/components/ui.ex:4898
+#: lib/vutuv_web/components/ui.ex:4910
 #: lib/vutuv_web/live/organization_live/activity.ex:159
 #: lib/vutuv_web/live/organization_live/feed.ex:258
 #: lib/vutuv_web/live/organization_live/show.ex:787
@@ -1945,7 +1945,7 @@ msgstr ""
 "L'indirizzo non può essere modificato. Per usarne un altro, lo aggiunga come"
 " nuovo indirizzo e-mail ed elimini questo."
 
-#: lib/vutuv_web/components/ui.ex:4665
+#: lib/vutuv_web/components/ui.ex:4677
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Elimina voce"
@@ -1990,12 +1990,12 @@ msgstr "Aggiungi un'immagine di copertina"
 msgid "Add cover photo"
 msgstr "Aggiungi immagine di copertina"
 
-#: lib/vutuv_web/components/ui.ex:3589
+#: lib/vutuv_web/components/ui.ex:3601
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr "Aprile"
 
-#: lib/vutuv_web/components/ui.ex:3593
+#: lib/vutuv_web/components/ui.ex:3605
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr "Agosto"
@@ -2011,7 +2011,7 @@ msgid "Change cover photo"
 msgstr "Cambia immagine di copertina"
 
 #: lib/vutuv_web/controllers/report_controller.ex:173
-#: lib/vutuv_web/templates/user/edit.html.heex:96
+#: lib/vutuv_web/templates/user/edit.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
 msgstr "Immagine di copertina"
@@ -2021,37 +2021,37 @@ msgstr "Immagine di copertina"
 msgid "Cover photo of %{name}"
 msgstr "Immagine di copertina di %{name}"
 
-#: lib/vutuv_web/components/ui.ex:3597
+#: lib/vutuv_web/components/ui.ex:3609
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr "Dicembre"
 
-#: lib/vutuv_web/components/ui.ex:3587
+#: lib/vutuv_web/components/ui.ex:3599
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr "Febbraio"
 
-#: lib/vutuv_web/components/ui.ex:3586
+#: lib/vutuv_web/components/ui.ex:3598
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr "Gennaio"
 
-#: lib/vutuv_web/components/ui.ex:3592
+#: lib/vutuv_web/components/ui.ex:3604
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr "Luglio"
 
-#: lib/vutuv_web/components/ui.ex:3591
+#: lib/vutuv_web/components/ui.ex:3603
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr "Giugno"
 
-#: lib/vutuv_web/components/ui.ex:3588
+#: lib/vutuv_web/components/ui.ex:3600
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr "Marzo"
 
-#: lib/vutuv_web/components/ui.ex:3590
+#: lib/vutuv_web/components/ui.ex:3602
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr "Maggio"
@@ -2066,23 +2066,23 @@ msgstr "Membro da %{month} %{year}"
 msgid "Member since %{year}"
 msgstr "Membro dal %{year}"
 
-#: lib/vutuv_web/components/ui.ex:3596
+#: lib/vutuv_web/components/ui.ex:3608
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr "Novembre"
 
-#: lib/vutuv_web/components/ui.ex:3595
+#: lib/vutuv_web/components/ui.ex:3607
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr "Ottobre"
 
-#: lib/vutuv_web/components/ui.ex:3594
+#: lib/vutuv_web/components/ui.ex:3606
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr "Settembre"
 
 #: lib/vutuv_web/templates/education/form_content.html.heex:32
-#: lib/vutuv_web/templates/user/edit.html.heex:257
+#: lib/vutuv_web/templates/user/edit.html.heex:263
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Markdown is supported: bold, italics, links and lists."
@@ -2117,7 +2117,7 @@ msgstr "Annulla il caricamento"
 msgid "Delete post"
 msgstr "Elimina il post"
 
-#: lib/vutuv_web/components/post_components.ex:4220
+#: lib/vutuv_web/components/post_components.ex:4275
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2162,8 +2162,8 @@ msgstr "Nascondi a una persona specifica…"
 msgid "Hide this post from…"
 msgstr "Nascondi questo post a…"
 
-#: lib/vutuv_web/components/post_components.ex:4174
-#: lib/vutuv_web/components/post_components.ex:4176
+#: lib/vutuv_web/components/post_components.ex:4229
+#: lib/vutuv_web/components/post_components.ex:4231
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Pubblico limitato"
@@ -2229,13 +2229,13 @@ msgstr "Post eliminato."
 msgid "Posts"
 msgstr "Post"
 
-#: lib/vutuv_web/components/post_components.ex:4711
-#: lib/vutuv_web/components/post_components.ex:4715
+#: lib/vutuv_web/components/post_components.ex:4766
+#: lib/vutuv_web/components/post_components.ex:4770
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Leggi tutto"
 
-#: lib/vutuv_web/components/post_components.ex:4712
+#: lib/vutuv_web/components/post_components.ex:4767
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:146
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:236
@@ -2313,7 +2313,7 @@ msgstr "Troppi file."
 msgid "Upload failed."
 msgstr "Caricamento non riuscito."
 
-#: lib/vutuv_web/components/ui.ex:5575
+#: lib/vutuv_web/components/ui.ex:5587
 #: lib/vutuv_web/live/shell_live.ex:1582
 #: lib/vutuv_web/templates/post/index.html.heex:32
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2332,32 +2332,32 @@ msgstr "Che c'è di nuovo?"
 msgid "What's new? Markdown is supported."
 msgstr "Che c'è di nuovo? Markdown è supportato."
 
-#: lib/vutuv_web/components/post_components.ex:4171
+#: lib/vutuv_web/components/post_components.ex:4226
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "modificato"
 
-#: lib/vutuv_web/components/post_components.ex:6337
+#: lib/vutuv_web/components/post_components.ex:6392
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "tutti gli altri"
 
-#: lib/vutuv_web/components/post_components.ex:6341
+#: lib/vutuv_web/components/post_components.ex:6396
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "visitatori non connessi"
 
-#: lib/vutuv_web/components/post_components.ex:6339
+#: lib/vutuv_web/components/post_components.ex:6394
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "persone che non La seguono"
 
-#: lib/vutuv_web/components/post_components.ex:6340
+#: lib/vutuv_web/components/post_components.ex:6395
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "persone che non segue"
 
-#: lib/vutuv_web/components/ui.ex:3667
+#: lib/vutuv_web/components/ui.ex:3679
 #: lib/vutuv_web/views/post_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "unknown"
@@ -2386,7 +2386,7 @@ msgstr "Tipo di file non supportato (ammessi: %{types})."
 msgid "Posts by %{name}"
 msgstr "Post di %{name}"
 
-#: lib/vutuv_web/templates/user/show.html.heex:598
+#: lib/vutuv_web/templates/user/show.html.heex:603
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr "Vedi tutti i %{count} post"
@@ -2397,8 +2397,8 @@ msgid "All posts"
 msgstr "Tutti i post"
 
 #: lib/vutuv_web/components/post_components.ex:2178
-#: lib/vutuv_web/components/post_components.ex:6437
-#: lib/vutuv_web/components/ui.ex:4197
+#: lib/vutuv_web/components/post_components.ex:6492
+#: lib/vutuv_web/components/ui.ex:4209
 #: lib/vutuv_web/views/user_html.ex:484
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2416,8 +2416,8 @@ msgid "Bookmarks"
 msgstr "Salvati"
 
 #: lib/vutuv_web/components/post_components.ex:2122
-#: lib/vutuv_web/components/post_components.ex:6678
-#: lib/vutuv_web/components/ui.ex:4183
+#: lib/vutuv_web/components/post_components.ex:6733
+#: lib/vutuv_web/components/ui.ex:4195
 #: lib/vutuv_web/notification_line.ex:317
 #: lib/vutuv_web/views/user_html.ex:494
 #, elixir-autogen, elixir-format
@@ -2425,7 +2425,7 @@ msgid "Like"
 msgstr "Mi piace"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1263
-#: lib/vutuv_web/components/post_components.ex:6688
+#: lib/vutuv_web/components/post_components.ex:6743
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:526
 #: lib/vutuv_web/live/shell_live.ex:1590
@@ -2446,13 +2446,13 @@ msgstr "Qui non c'è ancora nulla. I post che salva compaiono qui."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Qui non c'è ancora nulla. I post a cui mette Mi piace compaiono qui."
 
-#: lib/vutuv_web/components/post_components.ex:6425
+#: lib/vutuv_web/components/post_components.ex:6480
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Solo i post pubblici possono essere ripubblicati."
 
 #: lib/vutuv_web/components/post_components.ex:2177
-#: lib/vutuv_web/components/post_components.ex:6436
+#: lib/vutuv_web/components/post_components.ex:6491
 #: lib/vutuv_web/live/post_live/saved.ex:822
 #: lib/vutuv_web/views/user_html.ex:484
 #, elixir-autogen, elixir-format
@@ -2460,26 +2460,26 @@ msgid "Remove bookmark"
 msgstr "Rimuovi dai salvati"
 
 #: lib/vutuv_web/components/post_components.ex:2158
-#: lib/vutuv_web/components/post_components.ex:6421
+#: lib/vutuv_web/components/post_components.ex:6476
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:168
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Ripubblica"
 
-#: lib/vutuv_web/components/post_components.ex:2696
-#: lib/vutuv_web/components/post_components.ex:5443
+#: lib/vutuv_web/components/post_components.ex:2751
+#: lib/vutuv_web/components/post_components.ex:5498
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Ripubblicato da %{name}"
 
 #: lib/vutuv_web/components/post_components.ex:2157
-#: lib/vutuv_web/components/post_components.ex:6420
+#: lib/vutuv_web/components/post_components.ex:6475
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Annulla la ripubblicazione"
 
 #: lib/vutuv_web/components/post_components.ex:2121
-#: lib/vutuv_web/components/post_components.ex:6677
+#: lib/vutuv_web/components/post_components.ex:6732
 #: lib/vutuv_web/live/post_live/saved.ex:821
 #: lib/vutuv_web/views/user_html.ex:494
 #, elixir-autogen, elixir-format
@@ -2487,7 +2487,7 @@ msgid "Unlike"
 msgstr "Togli Mi piace"
 
 #: lib/vutuv_web/components/fediverse_components.ex:498
-#: lib/vutuv_web/components/post_components.ex:3182
+#: lib/vutuv_web/components/post_components.ex:3237
 #: lib/vutuv_web/components/ui.ex:3023
 #: lib/vutuv_web/components/ui.ex:3023
 #: lib/vutuv_web/components/ui.ex:3099
@@ -2507,7 +2507,7 @@ msgstr "Non seguire più"
 msgid "Welcome to vutuv!"
 msgstr "Benvenuto su vutuv."
 
-#: lib/vutuv_web/components/post_components.ex:6732
+#: lib/vutuv_web/components/post_components.ex:6787
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Solo ai post pubblici si può rispondere."
@@ -2519,8 +2519,8 @@ msgid "Replies"
 msgstr "Risposte"
 
 #: lib/vutuv_web/components/post_components.ex:2367
-#: lib/vutuv_web/components/post_components.ex:6715
-#: lib/vutuv_web/components/post_components.ex:6716
+#: lib/vutuv_web/components/post_components.ex:6770
+#: lib/vutuv_web/components/post_components.ex:6771
 #: lib/vutuv_web/live/notification_live/index.ex:993
 #: lib/vutuv_web/live/post_live/reply.ex:49
 #: lib/vutuv_web/notification_line.ex:314
@@ -2528,7 +2528,7 @@ msgstr "Risposte"
 msgid "Reply"
 msgstr "Rispondi"
 
-#: lib/vutuv_web/components/post_components.ex:4130
+#: lib/vutuv_web/components/post_components.ex:4185
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Risposta a un post eliminato"
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr "ha risposto al Suo post."
 
-#: lib/vutuv_web/components/post_components.ex:3648
+#: lib/vutuv_web/components/post_components.ex:3703
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:63
 #: lib/vutuv_web/live/post_live/remote_reply.ex:61
 #: lib/vutuv_web/live/post_live/reply.ex:63
@@ -2562,14 +2562,14 @@ msgstr "ha risposto al Suo post."
 msgid "Reply to %{handle}"
 msgstr "Rispondi a %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:4102
+#: lib/vutuv_web/components/post_components.ex:4157
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Risposta a un post di %{handle} ora eliminato"
 
-#: lib/vutuv_web/components/post_components.ex:4093
-#: lib/vutuv_web/components/post_components.ex:4122
-#: lib/vutuv_web/components/post_components.ex:4125
+#: lib/vutuv_web/components/post_components.ex:4148
+#: lib/vutuv_web/components/post_components.ex:4177
+#: lib/vutuv_web/components/post_components.ex:4180
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "In risposta a %{handle}"
@@ -2737,51 +2737,51 @@ msgstr "Usa un altro indirizzo e-mail"
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:918
+#: lib/vutuv_web/templates/user/show.html.heex:923
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr "Aggiungi un link"
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1232
+#: lib/vutuv_web/templates/user/show.html.heex:1237
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Aggiungi un numero di telefono"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1491
+#: lib/vutuv_web/templates/user/show.html.heex:1496
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Aggiungi un indirizzo"
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1160
+#: lib/vutuv_web/templates/user/show.html.heex:1165
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "Aggiungi un indirizzo e-mail"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1111
+#: lib/vutuv_web/templates/user/show.html.heex:1116
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Aggiungi i dati personali"
 
-#: lib/vutuv_web/templates/user/show.html.heex:647
+#: lib/vutuv_web/templates/user/show.html.heex:652
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr "Aggiungi un'esperienza lavorativa"
 
-#: lib/vutuv_web/templates/user/show.html.heex:495
+#: lib/vutuv_web/templates/user/show.html.heex:500
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr "Scriva il Suo primo post"
 
-#: lib/vutuv_web/components/ui.ex:4363
-#: lib/vutuv_web/components/ui.ex:4826
+#: lib/vutuv_web/components/ui.ex:4375
+#: lib/vutuv_web/components/ui.ex:4838
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:109
@@ -2789,7 +2789,7 @@ msgstr "Scriva il Suo primo post"
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
-#: lib/vutuv_web/templates/user/show.html.heex:638
+#: lib/vutuv_web/templates/user/show.html.heex:643
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr "Gestisci"
@@ -2817,7 +2817,7 @@ msgstr[1] "%{formatted} collegamenti"
 
 #: lib/vutuv_web/live/job_board_live.ex:458
 #: lib/vutuv_web/live/post_live/feed.ex:1018
-#: lib/vutuv_web/templates/user/card_list.html.heex:51
+#: lib/vutuv_web/templates/user/card_list.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
 msgid_plural "+%{formatted} more tags"
@@ -2870,7 +2870,7 @@ msgid_plural "connections"
 msgstr[0] "collegamento"
 msgstr[1] "collegamenti"
 
-#: lib/vutuv_web/components/post_components.ex:6338
+#: lib/vutuv_web/components/post_components.ex:6393
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "persone che non sono Suoi collegamenti"
@@ -2898,7 +2898,7 @@ msgid "Endorsement"
 msgstr "Conferma"
 
 #: lib/vutuv_web/notification_line.ex:312
-#: lib/vutuv_web/templates/user/show.html.heex:966
+#: lib/vutuv_web/templates/user/show.html.heex:971
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -2930,7 +2930,7 @@ msgstr[0] "%{formatted} caso attende una decisione."
 msgstr[1] "%{formatted} casi attendono una decisione."
 
 #: lib/vutuv_web/live/admin/job_live.ex:335
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:290
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:301
 #: lib/vutuv_web/templates/moderation_evidence/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "(deleted account)"
@@ -2958,20 +2958,6 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Abusive"
 msgstr "Offensivo"
-
-#: lib/vutuv_web/views/moderation_case_html.ex:26
-#, elixir-autogen, elixir-format
-msgid "An admin confirmed the report. The content stays hidden."
-msgstr ""
-"Un amministratore ha confermato la segnalazione. Il contenuto resta "
-"nascosto."
-
-#: lib/vutuv_web/views/moderation_case_html.ex:29
-#, elixir-autogen, elixir-format
-msgid "An admin dismissed the report. The content is visible again."
-msgstr ""
-"Un amministratore ha respinto la segnalazione. Il contenuto è di nuovo "
-"visibile."
 
 #: lib/vutuv_web/templates/report/new.html.heex:123
 #, elixir-autogen, elixir-format
@@ -3001,7 +2987,7 @@ msgstr ""
 "sospensione di una settimana, poi la disattivazione definitiva. I richiami "
 "decadono dopo dodici mesi."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:276
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "Conversation context (the reported message last)"
 msgstr "Contesto della conversazione (il messaggio segnalato per ultimo)"
@@ -3014,17 +3000,17 @@ msgstr ""
 "ripetutamente indesiderati portano alla sospensione dell'account, tanto nei "
 "post pubblici quanto nei messaggi privati."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:268
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Current version (edited since the report)"
 msgstr "Versione attuale (modificata dopo la segnalazione)"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:115
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Delete this content permanently?"
 msgstr "Eliminare definitivamente questo contenuto?"
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:106
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:117
 #, elixir-autogen, elixir-format
 msgid "Deleted. The report is settled, no further steps needed."
 msgstr "Eliminato. La segnalazione è chiusa, non serve altro."
@@ -3034,7 +3020,7 @@ msgstr "Eliminato. La segnalazione è chiusa, non serve altro."
 msgid "Escalated"
 msgstr "Inoltrato"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:100
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Fix it. An edited post is visible again immediately."
 msgstr "Lo corregga. Un post modificato torna subito visibile."
@@ -3087,7 +3073,7 @@ msgstr "Caso di moderazione"
 msgid "Moderation queue"
 msgstr "Coda di moderazione"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:126
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "My content is fine"
 msgstr "Il mio contenuto è a posto"
@@ -3142,13 +3128,13 @@ msgstr "Qui non c'è nulla: al momento nessun Suo contenuto è segnalato."
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nudità, violenza o altri contenuti che non hanno posto su vutuv."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1200
-#: lib/vutuv_web/templates/user/show.html.heex:1201
+#: lib/vutuv_web/templates/user/show.html.heex:1205
+#: lib/vutuv_web/templates/user/show.html.heex:1206
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr "Visibile solo a Lei"
 
-#: lib/vutuv_web/components/post_components.ex:4069
+#: lib/vutuv_web/components/post_components.ex:4124
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solo Lei può vedere questo post finché la segnalazione è in corso."
@@ -3191,7 +3177,7 @@ msgid "Please report honestly. Reporting to harm someone breaks our"
 msgstr "Segnali in modo onesto. Chi segnala per danneggiare qualcuno viola le nostre"
 "Segnali in buona fede. Segnalare per danneggiare qualcuno viola le nostre"
 
-#: lib/vutuv_web/components/ui.ex:5162
+#: lib/vutuv_web/components/ui.ex:5174
 #: lib/vutuv_web/live/shell_live.ex:1373
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3199,7 +3185,7 @@ msgstr "Segnali in modo onesto. Chi segnala per danneggiare qualcuno viola le no
 msgid "Profile"
 msgstr "Profilo"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:414
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "Reject the report"
 msgstr "Respingi la segnalazione"
@@ -3210,16 +3196,16 @@ msgstr "Respingi la segnalazione"
 msgid "Rejected"
 msgstr "Respinta"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:109
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Lo rimuova. La segnalazione si chiude, senza altre domande."
 
 #: lib/vutuv_web/components/post_components.ex:1460
-#: lib/vutuv_web/components/post_components.ex:3202
-#: lib/vutuv_web/components/post_components.ex:4287
+#: lib/vutuv_web/components/post_components.ex:3257
+#: lib/vutuv_web/components/post_components.ex:4342
 #: lib/vutuv_web/live/organization_live/show.ex:661
-#: lib/vutuv_web/templates/user/show.html.heex:242
+#: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
 msgid "Report"
 msgstr "Segnala"
@@ -3261,13 +3247,13 @@ msgid "Report upheld; the owner got a strike."
 msgstr "Segnalazione accolta; il proprietario ha ricevuto un richiamo."
 
 #: lib/vutuv_web/live/admin/moderation_live.ex:55
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:23
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "Reported as"
 msgstr "Segnalato come"
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:24
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:35
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:23
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:34
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Reported content"
@@ -3293,21 +3279,21 @@ msgstr "Segnalante"
 msgid "Reporter track records"
 msgstr "Storico dei segnalanti"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:300
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:311
 #: lib/vutuv_web/live/admin/moderation_live.ex:57
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Reports"
 msgstr "Segnalazioni"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:133
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 "Le segnalazioni sono anonime; non diciamo mai chi ha segnalato. Le nostre "
 "regole:"
 
-#: lib/vutuv_web/components/ui.ex:4045
+#: lib/vutuv_web/components/ui.ex:4057
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:784
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3350,7 +3336,7 @@ msgstr "Altro"
 msgid "Spam or scam"
 msgstr "Spam o truffa"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:123
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Stand by it. It stays hidden until one of our admins has ruled."
 msgstr ""
@@ -3391,7 +3377,7 @@ msgstr "Ci dica di più nella nota qui sotto."
 msgid "Thank you for your report. We take it from here."
 msgstr "Grazie per la segnalazione. Ce ne occupiamo noi."
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:53
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "The content in question"
 msgstr "Il contenuto in questione"
@@ -3409,14 +3395,14 @@ msgstr ""
 msgid "The queue is empty - the self-service flow settled everything."
 msgstr "La coda è vuota: la procedura autonoma ha risolto tutto."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:402
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:433
 #, elixir-autogen, elixir-format
 msgid "The report by @%{slug} was a deliberate weapon (strikes the reporter)"
 msgstr ""
 "La segnalazione di @%{slug} è stata un'arma deliberata (richiamo al "
 "segnalante)"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:374
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:396
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content stays hidden and the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
@@ -3435,7 +3421,7 @@ msgstr "Questo account è stato disattivato."
 msgid "This account is suspended until %{date}."
 msgstr "Questo account è sospeso fino al %{date}."
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:121
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:132
 #, elixir-autogen, elixir-format
 msgid "This case is already settled."
 msgstr "Questo caso è già chiuso."
@@ -3455,7 +3441,7 @@ msgstr "Affidabile"
 msgid "Type"
 msgstr "Tipo"
 
-#: lib/vutuv_web/controllers/moderation_case_controller.ex:83
+#: lib/vutuv_web/controllers/moderation_case_controller.ex:94
 #, elixir-autogen, elixir-format
 msgid "Understood. The content stays hidden until one of our admins has ruled."
 msgstr ""
@@ -3467,7 +3453,7 @@ msgstr ""
 msgid "Unwanted advertising, fraud or fake activity."
 msgstr "Pubblicità indesiderata, frode o attività falsa."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:379
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "Uphold the report"
 msgstr "Accogli la segnalazione"
@@ -3533,7 +3519,7 @@ msgstr ""
 "La Sua segnalazione è anonima. Se risulta fondata, il contenuto viene "
 "nascosto subito e al proprietario viene chiesto di correggerlo."
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:135
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:145
 #: lib/vutuv_web/templates/public_report/new.html.heex:149
 #: lib/vutuv_web/templates/report/new.html.heex:162
 #, elixir-autogen, elixir-format
@@ -3558,17 +3544,17 @@ msgstr ""
 msgid "yes"
 msgstr "sì"
 
-#: lib/vutuv/notifications/emailer.ex:1093
+#: lib/vutuv/notifications/emailer.ex:1127
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr "Un avvertimento per il Suo account vutuv"
 
-#: lib/vutuv/notifications/emailer.ex:1270
+#: lib/vutuv/notifications/emailer.ex:1304
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr "Moderazione: %{count} casi in attesa"
 
-#: lib/vutuv/notifications/emailer.ex:1061
+#: lib/vutuv/notifications/emailer.ex:1083
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr "Il contenuto che ha segnalato è stato corretto"
@@ -3583,12 +3569,12 @@ msgstr "Un Suo contenuto su vutuv è in esame"
 msgid "Your content on vutuv was reported and is hidden"
 msgstr "Un Suo contenuto su vutuv è stato segnalato ed è nascosto"
 
-#: lib/vutuv/notifications/emailer.ex:1107
+#: lib/vutuv/notifications/emailer.ex:1141
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr "Il Suo account vutuv è stato disattivato"
 
-#: lib/vutuv/notifications/emailer.ex:1100
+#: lib/vutuv/notifications/emailer.ex:1134
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr "Il Suo account vutuv è sospeso"
@@ -3652,14 +3638,14 @@ msgstr ""
 msgid "%{count} follows"
 msgstr "%{count} follow"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:314
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "%{count} report so far"
 msgid_plural "%{count} reports so far"
 msgstr[0] "%{count} segnalazione finora"
 msgstr[1] "%{count} segnalazioni finora"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:314
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "%{rejected} rejected, %{abusive} abusive"
 msgstr "%{rejected} respinte, %{abusive} abusive"
@@ -3679,7 +3665,7 @@ msgstr "Contenuto eliminato"
 msgid "Content frozen"
 msgstr "Contenuto bloccato"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:369
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "Decision"
 msgstr "Decisione"
@@ -3699,7 +3685,7 @@ msgstr "Inoltrato il %{date}"
 msgid "Evidence"
 msgstr "Prove"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:342
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr "Cronologia"
@@ -3756,7 +3742,7 @@ msgstr "Segnalazione accolta"
 msgid "Reported on %{date}"
 msgstr "Segnalato il %{date}"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:331
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Reporter and owner are separated since this report (connection, follows, messages)."
 msgstr ""
@@ -3788,13 +3774,13 @@ msgstr "Chiuso con l'eliminazione"
 msgid "Strike issued"
 msgstr "Richiamo assegnato"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:327
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "The protective separation from the owner was lifted on %{date}."
 msgstr ""
 "La separazione protettiva dal proprietario è stata revocata il %{date}."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:390
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #, elixir-autogen, elixir-format
 msgid "The report is unfounded. The content becomes visible again, any protective separation is lifted, and the rejection counts against each reporter's trust."
 msgstr ""
@@ -3847,7 +3833,7 @@ msgstr "livello %{level}, %{role}"
 msgid "messages"
 msgstr "messaggi"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:345
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "No history recorded - this case predates the audit log."
 msgstr ""
@@ -3893,7 +3879,7 @@ msgstr "Caso %{id}, acquisito il %{at} UTC"
 msgid "Evidence screenshot captured"
 msgstr "Screenshot di prova acquisito"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:257
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Evidence screenshot captured when the report was filed"
 msgstr "Screenshot di prova acquisito al momento della segnalazione"
@@ -3903,7 +3889,7 @@ msgstr "Screenshot di prova acquisito al momento della segnalazione"
 msgid "Moderation evidence - reported private message with context"
 msgstr "Prova di moderazione: messaggio privato segnalato con il contesto"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:252
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Screenshot at report time"
 msgstr "Screenshot al momento della segnalazione"
@@ -3913,7 +3899,7 @@ msgstr "Screenshot al momento della segnalazione"
 msgid "reported message"
 msgstr "messaggio segnalato"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:263
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Scorra dentro il riquadro, o prema per aprire l'immagine intera."
@@ -4445,12 +4431,12 @@ msgstr ""
 "Le prenotazioni sono aperte fino al %{last}. Prossimo giorno disponibile: "
 "%{day}"
 
-#: lib/vutuv_web/components/ui.ex:3619
+#: lib/vutuv_web/components/ui.ex:3631
 #, elixir-autogen, elixir-format
 msgid "Fr"
 msgstr "Ve"
 
-#: lib/vutuv_web/components/ui.ex:3615
+#: lib/vutuv_web/components/ui.ex:3627
 #, elixir-autogen, elixir-format
 msgid "Mo"
 msgstr "Lu"
@@ -4462,27 +4448,27 @@ msgstr ""
 "Una pubblicità al giorno: scelga un giorno libero nel calendario; i giorni "
 "barrati sono già prenotati."
 
-#: lib/vutuv_web/components/ui.ex:3620
+#: lib/vutuv_web/components/ui.ex:3632
 #, elixir-autogen, elixir-format
 msgid "Sa"
 msgstr "Sa"
 
-#: lib/vutuv_web/components/ui.ex:3621
+#: lib/vutuv_web/components/ui.ex:3633
 #, elixir-autogen, elixir-format
 msgid "Su"
 msgstr "Do"
 
-#: lib/vutuv_web/components/ui.ex:3618
+#: lib/vutuv_web/components/ui.ex:3630
 #, elixir-autogen, elixir-format
 msgid "Th"
 msgstr "Gi"
 
-#: lib/vutuv_web/components/ui.ex:3616
+#: lib/vutuv_web/components/ui.ex:3628
 #, elixir-autogen, elixir-format
 msgid "Tu"
 msgstr "Ma"
 
-#: lib/vutuv_web/components/ui.ex:3617
+#: lib/vutuv_web/components/ui.ex:3629
 #, elixir-autogen, elixir-format
 msgid "We"
 msgstr "Me"
@@ -4612,7 +4598,7 @@ msgid "Search for words in public posts."
 msgstr "Cerchi parole nei post pubblici."
 
 #: lib/vutuv_web/templates/block/index.html.heex:36
-#: lib/vutuv_web/templates/user/show.html.heex:263
+#: lib/vutuv_web/templates/user/show.html.heex:268
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr "Blocca"
@@ -4625,7 +4611,7 @@ msgstr ""
 " la vostra conversazione e impedisce ogni interazione in entrambe le "
 "direzioni. Sbloccare non ripristina ciò che è stato rimosso."
 
-#: lib/vutuv_web/components/ui.ex:5335
+#: lib/vutuv_web/components/ui.ex:5347
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4643,13 +4629,13 @@ msgstr ""
 " rimosso ogni follow e collegamento tra voi; sbloccare non li ripristina."
 
 #: lib/vutuv_web/templates/block/index.html.heex:74
-#: lib/vutuv_web/templates/user/show.html.heex:158
+#: lib/vutuv_web/templates/user/show.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr "Sblocca"
 
 #: lib/vutuv_web/templates/block/index.html.heex:72
-#: lib/vutuv_web/templates/user/show.html.heex:155
+#: lib/vutuv_web/templates/user/show.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Unblock @%{slug}?"
 msgstr "Sbloccare @%{slug}?"
@@ -4686,7 +4672,7 @@ msgstr "Trova membri"
 #: lib/vutuv_web/live/organization_live/following.ex:313
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:988
+#: lib/vutuv_web/templates/user/show.html.heex:993
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Segue"
@@ -4804,7 +4790,7 @@ msgstr "cerca solo nel nome (cognome: per il cognome)"
 
 #: lib/vutuv_web/live/job_board_live.ex:547
 #: lib/vutuv_web/live/tag_new_live.ex:47
-#: lib/vutuv_web/templates/user/show.html.heex:611
+#: lib/vutuv_web/templates/user/show.html.heex:616
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr "Aggiungi un tag"
@@ -5433,9 +5419,9 @@ msgstr "Token API (%{date})"
 msgid "API documentation"
 msgstr "Documentazione dell'API"
 
-#: lib/vutuv_web/components/ui.ex:5385
+#: lib/vutuv_web/components/ui.ex:5397
 #: lib/vutuv_web/controllers/settings_controller.ex:161
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:457
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:488
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
@@ -5516,10 +5502,10 @@ msgstr "Scorciatoie da tastiera"
 msgid "Navigation"
 msgstr "Navigazione"
 
-#: lib/vutuv_web/components/ui.ex:5482
-#: lib/vutuv_web/components/ui.ex:5487
-#: lib/vutuv_web/components/ui.ex:5566
-#: lib/vutuv_web/components/ui.ex:5630
+#: lib/vutuv_web/components/ui.ex:5494
+#: lib/vutuv_web/components/ui.ex:5499
+#: lib/vutuv_web/components/ui.ex:5578
+#: lib/vutuv_web/components/ui.ex:5642
 #: lib/vutuv_web/controllers/settings_controller.ex:68
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5553,17 +5539,17 @@ msgstr "Scrivi un nuovo post"
 msgid "Your profile"
 msgstr "Il Suo profilo"
 
-#: lib/vutuv_web/templates/user/show.html.heex:408
+#: lib/vutuv_web/templates/user/show.html.heex:413
 #, elixir-autogen, elixir-format
 msgid "Complete your profile"
 msgstr "Completi il Suo profilo"
 
-#: lib/vutuv_web/templates/user/show.html.heex:430
+#: lib/vutuv_web/templates/user/show.html.heex:435
 #, elixir-autogen, elixir-format
 msgid "A few quick steps so people can find and recognize you."
 msgstr "Pochi passaggi veloci perché le persone La trovino e La riconoscano."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1461
+#: lib/vutuv_web/live/user_profile_live.ex:1464
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr "Aggiungi una foto del profilo"
@@ -5589,9 +5575,9 @@ msgstr "Navigazione principale"
 msgid "Footer navigation"
 msgstr "Navigazione a piè di pagina"
 
-#: lib/vutuv_web/components/post_components.ex:4365
-#: lib/vutuv_web/components/post_components.ex:4417
-#: lib/vutuv_web/components/post_components.ex:4959
+#: lib/vutuv_web/components/post_components.ex:4420
+#: lib/vutuv_web/components/post_components.ex:4472
+#: lib/vutuv_web/components/post_components.ex:5014
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/views/user_html.ex:131
 #, elixir-autogen, elixir-format
@@ -5632,12 +5618,12 @@ msgstr "Tipo di indirizzo e-mail"
 msgid "Type of email address"
 msgstr "Tipo di indirizzo e-mail"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:236
+#: lib/vutuv_web/templates/user/edit.html.heex:242
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr "Su di Lei"
 
-#: lib/vutuv_web/components/ui.ex:5355
+#: lib/vutuv_web/components/ui.ex:5367
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:262
@@ -5658,7 +5644,7 @@ msgstr "Modifica"
 msgid "Download everything vutuv stores about you, as one file."
 msgstr "Scarichi in un unico file tutto ciò che vutuv conserva su di Lei."
 
-#: lib/vutuv_web/components/ui.ex:5200
+#: lib/vutuv_web/components/ui.ex:5212
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5693,7 +5679,7 @@ msgstr "Token personali per l'API di vutuv."
 msgid "Photos"
 msgstr "Foto"
 
-#: lib/vutuv_web/components/ui.ex:5329
+#: lib/vutuv_web/components/ui.ex:5341
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -5715,7 +5701,7 @@ msgid "View"
 msgstr "Vedi"
 
 #: lib/vutuv_web/templates/public_report/new.html.heex:92
-#: lib/vutuv_web/templates/user/edit.html.heex:161
+#: lib/vutuv_web/templates/user/edit.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Your name"
 msgstr "Il Suo nome"
@@ -5775,18 +5761,18 @@ msgstr ""
 msgid "Current avatar"
 msgstr "Immagine del profilo attuale"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:107
-#: lib/vutuv_web/templates/user/edit.html.heex:114
+#: lib/vutuv_web/templates/user/edit.html.heex:111
+#: lib/vutuv_web/templates/user/edit.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Current cover photo"
 msgstr "Immagine di copertina attuale"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:185
+#: lib/vutuv_web/templates/user/edit.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "e.g. Dr. or Prof."
 msgstr "ad esempio Dott. o Prof."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:190
+#: lib/vutuv_web/templates/user/edit.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "e.g. Jr. or PhD"
 msgstr "ad esempio Jr. o PhD"
@@ -5808,7 +5794,7 @@ msgstr "@%{slug} ha iniziato a seguirla su vutuv"
 msgid "Apps"
 msgstr "App"
 
-#: lib/vutuv_web/components/ui.ex:5378
+#: lib/vutuv_web/components/ui.ex:5390
 #: lib/vutuv_web/controllers/settings_controller.ex:185
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -6015,21 +6001,21 @@ msgid "Sort"
 msgstr "Ordina"
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/components/ui.ex:3683
+#: lib/vutuv_web/components/ui.ex:3695
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "%{count} giorno fa"
 msgstr[1] "%{count} giorni fa"
 
-#: lib/vutuv_web/components/ui.ex:3682
+#: lib/vutuv_web/components/ui.ex:3694
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "%{count} ora fa"
 msgstr[1] "%{count} ore fa"
 
-#: lib/vutuv_web/components/ui.ex:3681
+#: lib/vutuv_web/components/ui.ex:3693
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -6096,7 +6082,7 @@ msgstr "Questo dispositivo"
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr "È il primo accesso che vediamo da questo dispositivo o browser."
 
-#: lib/vutuv_web/components/ui.ex:3680
+#: lib/vutuv_web/components/ui.ex:3692
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "adesso"
@@ -6233,13 +6219,13 @@ msgstr "ad esempio MacBook"
 msgid "or"
 msgstr "oppure"
 
-#: lib/vutuv_web/live/user_profile_live.ex:1466
+#: lib/vutuv_web/live/user_profile_live.ex:1469
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr "Aggiungi una descrizione breve"
 
 #: lib/vutuv_web/live/cv_live.ex:166
-#: lib/vutuv_web/templates/user/edit.html.heex:253
+#: lib/vutuv_web/templates/user/edit.html.heex:259
 #: lib/vutuv_web/views/account_event_text.ex:212
 #, elixir-autogen, elixir-format
 msgid "Tagline"
@@ -6248,14 +6234,14 @@ msgstr "Descrizione breve"
 #: lib/vutuv_web/components/ui.ex:487
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:916
+#: lib/vutuv_web/templates/user/show.html.heex:921
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] "Link"
 msgstr[1] "Link"
 
-#: lib/vutuv_web/templates/user/show.html.heex:471
+#: lib/vutuv_web/templates/user/show.html.heex:476
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6263,36 +6249,36 @@ msgid_plural "Posts"
 msgstr[0] "post"
 msgstr[1] "post"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:63
-#: lib/vutuv_web/templates/user/edit.html.heex:144
+#: lib/vutuv_web/templates/user/edit.html.heex:67
+#: lib/vutuv_web/templates/user/edit.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Dopo aver scelto un file può spostarlo e ingrandirlo."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1541
+#: lib/vutuv_web/templates/user/show.html.heex:1546
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Anche su"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:51
-#: lib/vutuv_web/templates/user/edit.html.heex:131
+#: lib/vutuv_web/templates/user/edit.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Drag to move, use the slider to zoom. The framed area is what others see."
 msgstr ""
 "Trascini per spostare, usi il cursore per ingrandire. L'area nel riquadro è "
 "quella che vedono gli altri."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:68
+#: lib/vutuv_web/templates/user/edit.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "New avatar preview"
 msgstr "Anteprima della nuova immagine del profilo"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:149
+#: lib/vutuv_web/templates/user/edit.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "New cover photo preview"
 msgstr "Anteprima della nuova immagine di copertina"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:130
+#: lib/vutuv_web/templates/user/edit.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Position your cover photo"
 msgstr "Posizioni la Sua immagine di copertina"
@@ -6303,20 +6289,20 @@ msgid "Position your photo"
 msgstr "Posizioni la Sua foto"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:52
-#: lib/vutuv_web/templates/user/edit.html.heex:132
+#: lib/vutuv_web/templates/user/edit.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Use photo"
 msgstr "Usa questa foto"
 
 #: lib/vutuv_web/live/post_live/composer.ex:1919
 #: lib/vutuv_web/templates/user/edit.html.heex:54
-#: lib/vutuv_web/templates/user/edit.html.heex:134
+#: lib/vutuv_web/templates/user/edit.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr "Ingrandimento"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1126
-#: lib/vutuv_web/templates/user/show.html.heex:1136
+#: lib/vutuv_web/templates/user/show.html.heex:1131
+#: lib/vutuv_web/templates/user/show.html.heex:1141
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6358,12 +6344,12 @@ msgstr "Rapporto giornaliero del %{day}"
 msgid "Jump to a day"
 msgstr "Vai a un giorno"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1248
+#: lib/vutuv_web/templates/user/show.html.heex:1253
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr "Gestisci gli indirizzi e-mail"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1259
+#: lib/vutuv_web/templates/user/show.html.heex:1264
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr "Gestisci i numeri di telefono"
@@ -6406,7 +6392,7 @@ msgstr "Giorno precedente"
 msgid "Reposts"
 msgstr "Ripubblicazioni"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1257
+#: lib/vutuv_web/templates/user/show.html.heex:1262
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr "Vedi tutti i numeri di telefono"
@@ -6467,9 +6453,9 @@ msgstr "Servizi di mappe da mostrare"
 msgid "Maps"
 msgstr "Mappe"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1531
-#: lib/vutuv_web/templates/user/show.html.heex:1535
-#: lib/vutuv_web/templates/user/show.html.heex:1547
+#: lib/vutuv_web/templates/user/show.html.heex:1536
+#: lib/vutuv_web/templates/user/show.html.heex:1540
+#: lib/vutuv_web/templates/user/show.html.heex:1552
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "Apri in %{name}"
@@ -6500,7 +6486,7 @@ msgstr "Confermato"
 msgid "Members who endorsed %{name} for %{tag}"
 msgstr "Membri che hanno confermato %{name} per %{tag}"
 
-#: lib/vutuv_web/templates/user_tag/endorsers.html.heex:78
+#: lib/vutuv_web/templates/user_tag/endorsers.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "No endorsements yet."
 msgstr "Ancora nessuna conferma."
@@ -6827,16 +6813,16 @@ msgstr ""
 "Se disattiva un'opzione, la relativa esclusione viaggia con le pagine e le "
 "risposte che La riguardano. Con entrambe disattivate, ad esempio:"
 
-#: lib/vutuv_web/components/post_components.ex:3129
-#: lib/vutuv_web/components/post_components.ex:4240
-#: lib/vutuv_web/components/post_components.ex:4254
+#: lib/vutuv_web/components/post_components.ex:3184
+#: lib/vutuv_web/components/post_components.ex:4295
+#: lib/vutuv_web/components/post_components.ex:4309
 #: lib/vutuv_web/components/ui.ex:3171
 #: lib/vutuv_web/live/fediverse_account_live.ex:437
 #: lib/vutuv_web/live/organization_live/following.ex:385
 #: lib/vutuv_web/live/organization_live/following.ex:469
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:320
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
-#: lib/vutuv_web/templates/user/show.html.heex:235
+#: lib/vutuv_web/templates/user/show.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr "Silenzia"
@@ -6857,7 +6843,7 @@ msgstr "Nuovi messaggi e nuovi collegamenti"
 msgid "Remove this connection? You will stop following them."
 msgstr "Rimuovere questo collegamento? Smetterà di seguire questa persona."
 
-#: lib/vutuv_web/components/post_components.ex:4240
+#: lib/vutuv_web/components/post_components.ex:4295
 #: lib/vutuv_web/components/ui.ex:3170
 #: lib/vutuv_web/live/fediverse_account_live.ex:435
 #: lib/vutuv_web/live/organization_live/following.ex:385
@@ -6865,7 +6851,7 @@ msgstr "Rimuovere questo collegamento? Smetterà di seguire questa persona."
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:320
 #: lib/vutuv_web/templates/settings/filters.html.heex:111
 #: lib/vutuv_web/templates/settings/mutes.html.heex:60
-#: lib/vutuv_web/templates/user/show.html.heex:235
+#: lib/vutuv_web/templates/user/show.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "Unmute"
 msgstr "Riattiva"
@@ -7484,13 +7470,13 @@ msgstr "I loro membri vengono aggiunti a questo (unione)."
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr "pagina %{page} di %{pages}, %{total} in totale"
 
-#: lib/vutuv_web/components/ui.ex:4139
+#: lib/vutuv_web/components/ui.ex:4151
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Precedente"
 
-#: lib/vutuv_web/components/ui.ex:4151
+#: lib/vutuv_web/components/ui.ex:4163
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7574,9 +7560,9 @@ msgid "applies to the whole list, not just this page"
 msgstr "vale per l'intero elenco, non solo per questa pagina"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:6588
+#: lib/vutuv_web/components/post_components.ex:6643
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:980
-#: lib/vutuv_web/live/shell_live.ex:1812
+#: lib/vutuv_web/live/shell_live.ex:1817
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
 msgstr "+%{count} altri"
@@ -8295,7 +8281,7 @@ msgstr "PIN scaduto"
 msgid "PIN registered"
 msgstr "Registrato con PIN"
 
-#: lib/vutuv_web/components/ui.ex:4142
+#: lib/vutuv_web/components/ui.ex:4154
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr "Pagina %{page} di %{pages}"
@@ -8422,7 +8408,7 @@ msgstr[1] "%{count} esperienze lavorative"
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:704
+#: lib/vutuv_web/templates/user/show.html.heex:709
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr "Aggiungi una formazione"
@@ -8434,7 +8420,7 @@ msgstr "Titolo di studio"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:5176
+#: lib/vutuv_web/components/ui.ex:5188
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8446,7 +8432,7 @@ msgstr "Titolo di studio"
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
-#: lib/vutuv_web/templates/user/show.html.heex:701
+#: lib/vutuv_web/templates/user/show.html.heex:706
 #: lib/vutuv_web/views/import_html.ex:70
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
@@ -8493,14 +8479,14 @@ msgstr ""
 "Ecco cosa abbiamo trovato nella Sua esportazione. Tolga la spunta a ciò che "
 "non desidera. Le voci già presenti sul Suo profilo sono già senza spunta."
 
-#: lib/vutuv_web/components/ui.ex:5366
+#: lib/vutuv_web/components/ui.ex:5378
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importa"
 
 #: lib/vutuv_web/controllers/import_controller.ex:37
 #: lib/vutuv_web/controllers/import_controller.ex:128
-#: lib/vutuv_web/live/user_profile_live.ex:1477
+#: lib/vutuv_web/live/user_profile_live.ex:1480
 #: lib/vutuv_web/templates/import/new.html.heex:1
 #: lib/vutuv_web/templates/import/preview.html.heex:1
 #, elixir-autogen, elixir-format
@@ -8522,7 +8508,7 @@ msgstr "Importati: %{items}."
 msgid "Nothing new to import."
 msgstr "Nulla di nuovo da importare."
 
-#: lib/vutuv_web/components/ui.ex:5204
+#: lib/vutuv_web/components/ui.ex:5216
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8618,7 +8604,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Troppe importazioni. Riprovi tra poco."
 
-#: lib/vutuv_web/components/ui.ex:4408
+#: lib/vutuv_web/components/ui.ex:4420
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8632,7 +8618,7 @@ msgid "Loading posts"
 msgstr "Caricamento dei post"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1395
+#: lib/vutuv_web/templates/user/show.html.heex:1400
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Post dai social media"
@@ -8708,25 +8694,25 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr "Trascini qui il Suo file ZIP, oppure prema per sceglierne uno."
 
-#: lib/vutuv_web/components/ui.ex:5164
+#: lib/vutuv_web/components/ui.ex:5176
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr "Dati di base e foto"
 
-#: lib/vutuv_web/components/ui.ex:5298
+#: lib/vutuv_web/components/ui.ex:5310
 #: lib/vutuv_web/controllers/settings_controller.ex:129
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Language & display"
 msgstr "Lingua e visualizzazione"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:526
+#: lib/vutuv_web/templates/user/edit.html.heex:532
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr "Altre sezioni del profilo"
 
-#: lib/vutuv_web/components/ui.ex:5357
+#: lib/vutuv_web/components/ui.ex:5369
 #: lib/vutuv_web/controllers/settings_controller.ex:112
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8736,7 +8722,7 @@ msgstr "Altre sezioni del profilo"
 msgid "Sign-in & security"
 msgstr "Accesso e sicurezza"
 
-#: lib/vutuv_web/components/ui.ex:5370
+#: lib/vutuv_web/components/ui.ex:5382
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8961,7 +8947,7 @@ msgstr "La scriva in Amministrazione › Pagine legali"
 #: lib/vutuv_web/agent_docs/text.ex:652
 #: lib/vutuv_web/components/organization_components.ex:276
 #: lib/vutuv_web/components/ui.ex:1783
-#: lib/vutuv_web/components/ui.ex:5347
+#: lib/vutuv_web/components/ui.ex:5359
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:366
 #: lib/vutuv_web/controllers/settings_controller.ex:433
@@ -8974,7 +8960,7 @@ msgstr "La scriva in Amministrazione › Pagine legali"
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1300
+#: lib/vutuv_web/templates/user/show.html.heex:1305
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr "Fediverso"
@@ -9125,7 +9111,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Download del CV"
 
-#: lib/vutuv_web/components/post_components.ex:5446
+#: lib/vutuv_web/components/post_components.ex:5501
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9242,7 +9228,7 @@ msgstr ""
 "finestra di stampa del browser. Word e OpenDocument sono modificabili; LaTeX"
 " è il sorgente di impaginazione; JSON Resume è il formato aperto %{link}."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:266
+#: lib/vutuv_web/templates/user/edit.html.heex:272
 #, elixir-autogen, elixir-format
 msgid "characters"
 msgstr "caratteri"
@@ -9400,7 +9386,7 @@ msgstr "A2 (Elementare)"
 #: lib/vutuv_web/live/feed_languages_live.ex:317
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:766
+#: lib/vutuv_web/templates/user/show.html.heex:771
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr "Aggiungi una lingua"
@@ -9625,7 +9611,7 @@ msgstr "Lingua aggiornata."
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:763
+#: lib/vutuv_web/templates/user/show.html.heex:768
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Lingue"
@@ -9812,7 +9798,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Situazione lavorativa"
 
-#: lib/vutuv/accounts/user.ex:1271
+#: lib/vutuv/accounts/user.ex:1278
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9823,13 +9809,13 @@ msgstr "In cerca di lavoro"
 msgid "Not open to work"
 msgstr "Non in cerca di lavoro"
 
-#: lib/vutuv/accounts/user.ex:1268
+#: lib/vutuv/accounts/user.ex:1275
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
 msgstr "Aperto a proposte"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:290
+#: lib/vutuv_web/templates/user/edit.html.heex:296
 #, elixir-autogen, elixir-format
 msgid "Shown as a badge next to your tagline so people can see whether you are open to opportunities."
 msgstr ""
@@ -9915,7 +9901,7 @@ msgstr[0] "%{count} certificato o abilitazione"
 msgstr[1] "%{count} certificati o abilitazioni"
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:870
+#: lib/vutuv_web/templates/user/show.html.heex:875
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr "Aggiungi un certificato o un'abilitazione"
@@ -9948,7 +9934,7 @@ msgstr "Certificati"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:5180
+#: lib/vutuv_web/components/ui.ex:5192
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -9963,7 +9949,7 @@ msgstr "Certificati"
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:867
+#: lib/vutuv_web/templates/user/show.html.heex:872
 #: lib/vutuv_web/views/import_html.ex:71
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
@@ -10087,8 +10073,8 @@ msgstr "Preferita"
 msgid "Preferred contact language"
 msgstr "Lingua di contatto preferita"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1222
-#: lib/vutuv_web/templates/user/show.html.heex:1223
+#: lib/vutuv_web/templates/user/show.html.heex:1227
+#: lib/vutuv_web/templates/user/show.html.heex:1228
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr "+%{code} è il prefisso telefonico di %{region}"
@@ -10103,18 +10089,18 @@ msgstr "+%{code} è il prefisso telefonico di %{region}"
 msgid "Date of birth"
 msgstr "Data di nascita"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:439
-#: lib/vutuv_web/templates/user/edit.html.heex:514
+#: lib/vutuv_web/templates/user/edit.html.heex:445
+#: lib/vutuv_web/templates/user/edit.html.heex:520
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr "Rimuovi la data di nascita"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:502
+#: lib/vutuv_web/templates/user/edit.html.heex:508
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr "Rimuovere la Sua data di nascita?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:505
+#: lib/vutuv_web/templates/user/edit.html.heex:511
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -10145,19 +10131,19 @@ msgstr "Preferisco non dirlo"
 msgid "Permanent profile link"
 msgstr "Link permanente al profilo"
 
-#: lib/vutuv_web/templates/user/show.html.heex:419
-#: lib/vutuv_web/templates/user/show.html.heex:420
+#: lib/vutuv_web/templates/user/show.html.heex:424
+#: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr "Chiudi"
 
-#: lib/vutuv_web/components/ui.ex:3796
+#: lib/vutuv_web/components/ui.ex:3808
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Copiato"
 
-#: lib/vutuv_web/components/ui.ex:3795
-#: lib/vutuv_web/components/ui.ex:3803
+#: lib/vutuv_web/components/ui.ex:3807
+#: lib/vutuv_web/components/ui.ex:3815
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Copia"
@@ -10242,7 +10228,7 @@ msgstr "Account ripristinato. Il membro può accedere di nuovo."
 msgid "Accounts removed as spam"
 msgstr "Account rimossi come spam"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:424
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "Clear-cut spam or abuse?"
 msgstr "Spam o abuso lampante?"
@@ -10252,24 +10238,24 @@ msgstr "Spam o abuso lampante?"
 msgid "Could not restore this member."
 msgstr "Non è stato possibile ripristinare questo membro."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:439
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "Deactivate @%{slug} and mark the account as spam?"
 msgstr "Disattivare @%{slug} e contrassegnare l'account come spam?"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:442
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:473
 #, elixir-autogen, elixir-format
 msgid "Deactivate account"
 msgstr "Disattiva l'account"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:451
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Permanently DELETE @%{slug} and everything they posted? This cannot be undone."
 msgstr ""
 "ELIMINARE definitivamente @%{slug} e tutto ciò che ha pubblicato? "
 "L'operazione non si può annullare."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:427
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:458
 #, elixir-autogen, elixir-format
 msgid "Remove the account outright, skipping the warning ladder. Deactivating marks it as spam and is reversible from the member browser; deleting is permanent."
 msgstr ""
@@ -10616,7 +10602,7 @@ msgstr[1] "%{formatted} stelle"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:71
 #: lib/vutuv_web/agent_docs/text.ex:66
-#: lib/vutuv_web/templates/user/show.html.heex:1369
+#: lib/vutuv_web/templates/user/show.html.heex:1374
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Codice"
@@ -11249,7 +11235,7 @@ msgstr "Tentativi"
 msgid "Views"
 msgstr "Visualizzazioni"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:299
+#: lib/vutuv_web/templates/user/edit.html.heex:305
 #, elixir-autogen, elixir-format
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
@@ -11257,19 +11243,19 @@ msgstr ""
 "Sua disponibilità ma non può garantirla, perché chiunque può creare un "
 "account. Scelga \"Nessuno\" per conservare lo stato senza mostrarlo."
 
-#: lib/vutuv/accounts/user.ex:1309
+#: lib/vutuv/accounts/user.ex:1316
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Tutti, compresi i visitatori non connessi"
 
-#: lib/vutuv/accounts/user.ex:1314
+#: lib/vutuv/accounts/user.ex:1321
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Nessuno"
 
-#: lib/vutuv/accounts/user.ex:1312
+#: lib/vutuv/accounts/user.ex:1319
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:823
 #, elixir-autogen, elixir-format
@@ -11277,25 +11263,25 @@ msgid "Signed-in members only"
 msgstr "Solo i membri connessi"
 
 #: lib/vutuv_web/components/welcome_components.ex:259
-#: lib/vutuv_web/templates/user/edit.html.heex:296
+#: lib/vutuv_web/templates/user/edit.html.heex:302
 #, elixir-autogen, elixir-format
 msgid "Who can see your availability?"
 msgstr "Chi può vedere la Sua disponibilità?"
 
 #: lib/vutuv_web/components/welcome_components.ex:270
-#: lib/vutuv_web/templates/user/edit.html.heex:321
+#: lib/vutuv_web/templates/user/edit.html.heex:327
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr "Importo"
 
 #: lib/vutuv_web/components/welcome_components.ex:278
 #: lib/vutuv_web/live/job_posting_live/form.ex:693
-#: lib/vutuv_web/templates/user/edit.html.heex:329
+#: lib/vutuv_web/templates/user/edit.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr "Valuta"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:339
+#: lib/vutuv_web/templates/user/edit.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "Hidden by default, and it still does its job while hidden. \"Signed-in members only\" adds a quiet line to your profile for members; \"Everyone\" also shows it to logged-out visitors."
 msgstr ""
@@ -11304,12 +11290,12 @@ msgstr ""
 "membri; \"Tutti\" la mostra anche ai visitatori non connessi."
 
 #: lib/vutuv_web/components/welcome_components.ex:266
-#: lib/vutuv_web/templates/user/edit.html.heex:312
+#: lib/vutuv_web/templates/user/edit.html.heex:318
 #, elixir-autogen, elixir-format
 msgid "Minimum salary expectation"
 msgstr "Retribuzione minima desiderata"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:315
+#: lib/vutuv_web/templates/user/edit.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
@@ -11319,18 +11305,18 @@ msgstr ""
 
 #: lib/vutuv_web/components/welcome_components.ex:274
 #: lib/vutuv_web/live/job_posting_live/form.ex:700
-#: lib/vutuv_web/templates/user/edit.html.heex:325
+#: lib/vutuv_web/templates/user/edit.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "Per"
 msgstr "Per"
 
-#: lib/vutuv_web/templates/user/show.html.heex:315
+#: lib/vutuv_web/templates/user/show.html.heex:320
 #, elixir-autogen, elixir-format
 msgid "Salary expectation from %{amount} %{currency} per %{period}"
 msgstr ""
 "Retribuzione desiderata a partire da %{amount} %{currency} per %{period}"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:336
+#: lib/vutuv_web/templates/user/edit.html.heex:342
 #, elixir-autogen, elixir-format
 msgid "Who can see your salary expectation?"
 msgstr "Chi può vedere la Sua retribuzione desiderata?"
@@ -11399,7 +11385,7 @@ msgstr "Escludi un membro"
 msgid "Exclude an email domain"
 msgstr "Escludi un dominio e-mail"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:387
+#: lib/vutuv_web/templates/user/edit.html.heex:393
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr "Nascondi a persone specifiche"
@@ -11410,7 +11396,7 @@ msgstr "Nascondi a persone specifiche"
 msgid "Job-search exclusion list"
 msgstr "Elenco di esclusioni per la ricerca di lavoro"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:390
+#: lib/vutuv_web/templates/user/edit.html.heex:396
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
@@ -11419,7 +11405,7 @@ msgstr ""
 "specifici: non vedranno mai la Sua disponibilità né la Sua retribuzione "
 "desiderata, nemmeno con l'impostazione \"Tutti\"."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:398
+#: lib/vutuv_web/templates/user/edit.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -11571,12 +11557,12 @@ msgstr "Pubblichi questo file all'indirizzo:"
 msgid "State / region (optional)"
 msgstr "Provincia / regione (facoltativo)"
 
-#: lib/vutuv_web/components/ui.ex:4495
+#: lib/vutuv_web/components/ui.ex:4507
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr "Questo tipo di file non è ammesso."
 
-#: lib/vutuv_web/components/ui.ex:4497
+#: lib/vutuv_web/components/ui.ex:4509
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr "Il caricamento non è riuscito."
@@ -12310,7 +12296,7 @@ msgstr "Organizzazione sbloccata."
 #: lib/vutuv_web/agent_docs/markdown.ex:493
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:462
-#: lib/vutuv_web/components/ui.ex:5374
+#: lib/vutuv_web/components/ui.ex:5386
 #: lib/vutuv_web/controllers/settings_controller.ex:222
 #: lib/vutuv_web/live/organization_live/index.ex:32
 #: lib/vutuv_web/live/organization_live/index.ex:62
@@ -12635,7 +12621,7 @@ msgstr "I tag evidenziati corrispondono al Suo profilo."
 msgid "How to apply"
 msgstr "Come candidarsi"
 
-#: lib/vutuv/accounts/user.ex:1283
+#: lib/vutuv/accounts/user.ex:1290
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12757,7 +12743,7 @@ msgstr ""
 "Offri i formati leggibili dalle macchine (.md/.txt/.json/.xml) agli agenti "
 "IA."
 
-#: lib/vutuv/accounts/user.ex:1282
+#: lib/vutuv/accounts/user.ex:1289
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12841,7 +12827,7 @@ msgstr "Annuncio non trovato."
 msgid "Publish"
 msgstr "Pubblica"
 
-#: lib/vutuv/accounts/user.ex:1284
+#: lib/vutuv/accounts/user.ex:1291
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:590
 #: lib/vutuv_web/agent_docs/markdown.ex:532
@@ -12983,7 +12969,7 @@ msgstr "Modalità di lavoro"
 msgid "You already have the maximum number of published postings."
 msgstr "Ha già raggiunto il numero massimo di annunci pubblicati."
 
-#: lib/vutuv/notifications/emailer.ex:1123
+#: lib/vutuv/notifications/emailer.ex:1157
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr "Il Suo annuncio di lavoro su vutuv scade a breve"
@@ -13586,7 +13572,7 @@ msgstr "Salva la ricerca"
 msgid "Saved search deleted."
 msgstr "Ricerca salvata eliminata."
 
-#: lib/vutuv_web/components/ui.ex:5283
+#: lib/vutuv_web/components/ui.ex:5295
 #: lib/vutuv_web/controllers/settings_controller.ex:629
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13606,7 +13592,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "Interrompere gli avvisi via e-mail per la Sua ricerca salvata \"%{label}\"?"
 
-#: lib/vutuv_web/components/post_components.ex:3607
+#: lib/vutuv_web/components/post_components.ex:3662
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:788
 #: lib/vutuv_web/controllers/settings_controller.ex:806
@@ -13885,7 +13871,7 @@ msgstr ""
 "raggiungibile."
 
 #: lib/vutuv_web/templates/user/edit.html.heex:41
-#: lib/vutuv_web/templates/user/edit.html.heex:121
+#: lib/vutuv_web/templates/user/edit.html.heex:125
 #: lib/vutuv_web/templates/user/show.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Image awaiting review, visible only to you"
@@ -13904,7 +13890,7 @@ msgstr ""
 "Nessuna immagine in attesa dell'analisi IA. %{formatted} rifiutate negli "
 "ultimi 7 giorni."
 
-#: lib/vutuv_web/templates/user/show.html.heex:208
+#: lib/vutuv_web/templates/user/show.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Profile picture awaiting review, visible only to you"
 msgstr "Immagine del profilo in attesa di esame, visibile solo a Lei"
@@ -13937,13 +13923,13 @@ msgstr ""
 "Se è venuto male (ad esempio con un avviso sui cookie che copre la pagina), "
 "può rimuoverlo."
 
-#: lib/vutuv/accounts/user.ex:1327
+#: lib/vutuv/accounts/user.ex:1334
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
 msgstr "Solo l'età, senza la data"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:450
+#: lib/vutuv_web/templates/user/edit.html.heex:456
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
@@ -13951,25 +13937,25 @@ msgstr ""
 "la data esatta, \"Giorno e mese\" nasconde l'anno (e la Sua età) e \"Non "
 "mostrare\" lo conserva ma lo tiene fuori dal profilo."
 
-#: lib/vutuv/accounts/user.ex:1330
+#: lib/vutuv/accounts/user.ex:1337
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Giorno e mese, senza l'anno"
 
-#: lib/vutuv/accounts/user.ex:1333
+#: lib/vutuv/accounts/user.ex:1340
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Non mostrare il mio compleanno"
 
-#: lib/vutuv/accounts/user.ex:1324
+#: lib/vutuv/accounts/user.ex:1331
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
 msgstr "Data completa ed età"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:447
+#: lib/vutuv_web/templates/user/edit.html.heex:453
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr "Mostra il mio compleanno come"
@@ -14101,7 +14087,7 @@ msgstr ""
 "persone note per quel tag compaiono tra i Suoi suggerimenti. Segua un tag "
 "dalla sua pagina."
 
-#: lib/vutuv_web/components/ui.ex:5266
+#: lib/vutuv_web/components/ui.ex:5278
 #: lib/vutuv_web/controllers/settings_controller.ex:643
 #: lib/vutuv_web/live/post_live/feed.ex:710
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -14152,7 +14138,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1335
+#: lib/vutuv_web/templates/user/show.html.heex:1340
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr "Aggiungi un messenger"
@@ -14181,7 +14167,7 @@ msgstr "Messenger aggiornato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:63
-#: lib/vutuv_web/components/ui.ex:5223
+#: lib/vutuv_web/components/ui.ex:5235
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -14189,7 +14175,7 @@ msgstr "Messenger aggiornato."
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1333
+#: lib/vutuv_web/templates/user/show.html.heex:1338
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr "Messenger"
@@ -14209,14 +14195,14 @@ msgstr "Messenger di %{name}"
 msgid "Select a messenger"
 msgstr "Selezioni un messenger"
 
-#: lib/vutuv_web/components/ui.ex:4580
+#: lib/vutuv_web/components/ui.ex:4592
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] "Avvisa il mio follower"
 msgstr[1] "Avvisa i miei %{formatted} follower"
 
-#: lib/vutuv_web/components/ui.ex:4590
+#: lib/vutuv_web/components/ui.ex:4602
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
@@ -14271,34 +14257,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr "ha aggiunto %{count} nuove voci al proprio CV:"
 
-#: lib/vutuv_web/components/post_components.ex:6134
+#: lib/vutuv_web/components/post_components.ex:6189
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Audiolibro"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:6091
+#: lib/vutuv_web/components/post_components.ex:6146
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Recensione di un libro"
 
-#: lib/vutuv_web/components/post_components.ex:6135
+#: lib/vutuv_web/components/post_components.ex:6190
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Cinema"
 
-#: lib/vutuv_web/components/post_components.ex:6137
+#: lib/vutuv_web/components/post_components.ex:6192
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:6133
+#: lib/vutuv_web/components/post_components.ex:6188
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1352
-#: lib/vutuv_web/components/post_components.ex:6090
+#: lib/vutuv_web/components/post_components.ex:6145
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Recensione di un film"
@@ -14309,12 +14295,12 @@ msgstr "Recensione di un film"
 msgid "Look up"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:6132
+#: lib/vutuv_web/components/post_components.ex:6187
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Libro cartaceo"
 
-#: lib/vutuv_web/components/post_components.ex:6136
+#: lib/vutuv_web/components/post_components.ex:6191
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14334,7 +14320,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Anno"
 
-#: lib/vutuv_web/components/post_components.ex:6173
+#: lib/vutuv_web/components/post_components.ex:6228
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14342,27 +14328,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} pagina"
 msgstr[1] "%{formatted} pagine"
 
-#: lib/vutuv_web/components/post_components.ex:6203
+#: lib/vutuv_web/components/post_components.ex:6258
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} h"
 
-#: lib/vutuv_web/components/post_components.ex:6204
+#: lib/vutuv_web/components/post_components.ex:6259
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} h %{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:6202
+#: lib/vutuv_web/components/post_components.ex:6257
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:6162
+#: lib/vutuv_web/components/post_components.ex:6217
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(edizione cartacea)"
 
-#: lib/vutuv_web/components/post_components.ex:6209
+#: lib/vutuv_web/components/post_components.ex:6264
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "circa %{duration}"
@@ -14394,7 +14380,7 @@ msgstr "Con certificazione:"
 msgid "With qualification: %{name}"
 msgstr "Con certificazione: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5976
+#: lib/vutuv_web/components/post_components.ex:6031
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Editore:"
@@ -14437,7 +14423,7 @@ msgstr "ora La seguono."
 msgid "endorsed you for %{tags}."
 msgstr "L'ha confermata per %{tags}."
 
-#: lib/vutuv_web/components/post_components.ex:5967
+#: lib/vutuv_web/components/post_components.ex:6022
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "di:"
@@ -14628,7 +14614,7 @@ msgid "Are you looking for a job?"
 msgstr "È in cerca di lavoro?"
 
 #: lib/vutuv_web/components/welcome_components.ex:290
-#: lib/vutuv_web/templates/user/edit.html.heex:359
+#: lib/vutuv_web/templates/user/edit.html.heex:365
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr "Come vuole lavorare?"
@@ -14645,12 +14631,12 @@ msgid "Preferred workplace"
 msgstr "Modalità di lavoro preferita"
 
 #: lib/vutuv_web/components/welcome_components.ex:249
-#: lib/vutuv_web/templates/user/edit.html.heex:287
+#: lib/vutuv_web/templates/user/edit.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "Availability"
 msgstr "Disponibilità"
 
-#: lib/vutuv/notifications/emailer.ex:1085
+#: lib/vutuv/notifications/emailer.ex:1111
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Un controllo automatico ha rimosso un'immagine dal Suo account vutuv"
@@ -14814,14 +14800,14 @@ msgstr "Cerchi un account da bloccare"
 msgid "See all frozen accounts"
 msgstr "Vedi tutti gli account bloccati"
 
-#: lib/vutuv_web/components/post_components.ex:3896
+#: lib/vutuv_web/components/post_components.ex:3951
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "Mostra %{formatted} post precedente"
 msgstr[1] "Mostra %{formatted} post precedenti"
 
-#: lib/vutuv_web/components/post_components.ex:3919
+#: lib/vutuv_web/components/post_components.ex:3974
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14850,7 +14836,7 @@ msgstr ""
 "Digiti un nome, un @handle o un indirizzo e-mail per trovare un account da "
 "bloccare."
 
-#: lib/vutuv_web/components/post_components.ex:6687
+#: lib/vutuv_web/components/post_components.ex:6742
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Non può mettere Mi piace al Suo stesso post."
@@ -15029,7 +15015,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr "Corrispondenza solo su parole intere (parola o frase)"
 
-#: lib/vutuv_web/components/ui.ex:5237
+#: lib/vutuv_web/components/ui.ex:5249
 #: lib/vutuv_web/controllers/settings_controller.ex:773
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -15667,7 +15653,7 @@ msgstr "Modifica l'applicazione"
 msgid "Book an ad"
 msgstr "Prenoti una pubblicità"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1042
+#: lib/vutuv_web/templates/user/show.html.heex:1047
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
@@ -15734,259 +15720,259 @@ msgstr "Il Suo server"
 msgid "moved to %{address}"
 msgstr "spostato a %{address}"
 
-#: lib/vutuv_web/components/ui.ex:5165
+#: lib/vutuv_web/components/ui.ex:5177
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr "Nome, foto, immagine di copertina, descrizione breve"
 
-#: lib/vutuv_web/components/ui.ex:5170
+#: lib/vutuv_web/components/ui.ex:5182
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr "handle soprannome rinomina slug profilo indirizzo url menzione"
 
-#: lib/vutuv_web/components/ui.ex:5173
+#: lib/vutuv_web/components/ui.ex:5185
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr "Gli impieghi e i ruoli nel Suo CV"
 
-#: lib/vutuv_web/components/ui.ex:5174
+#: lib/vutuv_web/components/ui.ex:5186
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr "cv curriculum carriera datore di lavoro posizione qualifica azienda"
 
-#: lib/vutuv_web/components/ui.ex:5177
+#: lib/vutuv_web/components/ui.ex:5189
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr "Scuole, università, titoli di studio"
 
-#: lib/vutuv_web/components/ui.ex:5178
+#: lib/vutuv_web/components/ui.ex:5190
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr "cv curriculum studio studi scuola università laurea titolo"
 
-#: lib/vutuv_web/components/ui.ex:5181
+#: lib/vutuv_web/components/ui.ex:5193
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr "Credenziali, con documenti di prova"
 
-#: lib/vutuv_web/components/ui.ex:5182
+#: lib/vutuv_web/components/ui.ex:5194
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 "certificato abilitazione diploma credenziale riconoscimento prova documento"
 
-#: lib/vutuv_web/components/ui.ex:5189
+#: lib/vutuv_web/components/ui.ex:5201
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr "Competenze linguistiche"
 
-#: lib/vutuv_web/components/ui.ex:5190
+#: lib/vutuv_web/components/ui.ex:5202
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr "Le lingue che parla"
 
-#: lib/vutuv_web/components/ui.ex:5191
+#: lib/vutuv_web/components/ui.ex:5203
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr "lingua parlare parlata fluente madrelingua"
 
-#: lib/vutuv_web/components/ui.ex:5194
+#: lib/vutuv_web/components/ui.ex:5206
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr "Gli argomenti per cui è conosciuto"
 
-#: lib/vutuv_web/components/ui.ex:5195
+#: lib/vutuv_web/components/ui.ex:5207
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr "competenza argomento parola chiave esperienza conferma"
 
-#: lib/vutuv_web/components/ui.ex:5375
+#: lib/vutuv_web/components/ui.ex:5387
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr "Pagine aziendali che gestisce"
 
-#: lib/vutuv_web/components/ui.ex:5376
+#: lib/vutuv_web/components/ui.ex:5388
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr "azienda datore di lavoro impresa attività organizzazione pagina"
 
-#: lib/vutuv_web/components/ui.ex:5198
+#: lib/vutuv_web/components/ui.ex:5210
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr "Recapiti"
 
-#: lib/vutuv_web/components/ui.ex:5201
+#: lib/vutuv_web/components/ui.ex:5213
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr "Dove La raggiungiamo, e quale indirizzo è pubblico"
 
-#: lib/vutuv_web/components/ui.ex:5202
+#: lib/vutuv_web/components/ui.ex:5214
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr "posta e-mail indirizzo principale"
 
-#: lib/vutuv_web/components/ui.ex:5205
+#: lib/vutuv_web/components/ui.ex:5217
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr "Fisso, cellulare, fax"
 
-#: lib/vutuv_web/components/ui.ex:5206
+#: lib/vutuv_web/components/ui.ex:5218
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr "telefono cellulare fax numero"
 
-#: lib/vutuv_web/components/ui.ex:5209
+#: lib/vutuv_web/components/ui.ex:5221
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr "Indirizzi postali sul Suo profilo"
 
-#: lib/vutuv_web/components/ui.ex:5210
+#: lib/vutuv_web/components/ui.ex:5222
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr "via città cap paese posta mappa"
 
-#: lib/vutuv_web/components/ui.ex:5212
+#: lib/vutuv_web/components/ui.ex:5224
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr "Siti web e link"
 
-#: lib/vutuv_web/components/ui.ex:5213
+#: lib/vutuv_web/components/ui.ex:5225
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr "Il Suo sito e gli altri link"
 
-#: lib/vutuv_web/components/ui.ex:5214
+#: lib/vutuv_web/components/ui.ex:5226
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr "url sito web homepage blog link verifica rel=me"
 
-#: lib/vutuv_web/components/ui.ex:5216
+#: lib/vutuv_web/components/ui.ex:5228
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr "Profili sui social"
 
-#: lib/vutuv_web/components/ui.ex:5217
+#: lib/vutuv_web/components/ui.ex:5229
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr "Mastodon, Bluesky, GitHub e gli altri"
 
-#: lib/vutuv_web/components/ui.ex:5219
+#: lib/vutuv_web/components/ui.ex:5231
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 
-#: lib/vutuv_web/components/ui.ex:5224
+#: lib/vutuv_web/components/ui.ex:5236
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr "Signal, Threema, Matrix e gli altri"
 
-#: lib/vutuv_web/components/ui.ex:5225
+#: lib/vutuv_web/components/ui.ex:5237
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr "signal threema matrix xmpp telegram whatsapp chat messenger"
 
-#: lib/vutuv_web/components/ui.ex:5228
+#: lib/vutuv_web/components/ui.ex:5240
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr "Notifiche e feed"
 
-#: lib/vutuv_web/components/ui.ex:5231
+#: lib/vutuv_web/components/ui.ex:5243
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr "Quali e-mail inviamo, e cosa Le dice la campanella"
 
-#: lib/vutuv_web/components/ui.ex:5238
+#: lib/vutuv_web/components/ui.ex:5250
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr "Tenga dei post fuori dal Suo feed"
 
-#: lib/vutuv_web/components/ui.ex:5239
+#: lib/vutuv_web/components/ui.ex:5251
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr "silenzia blocca nascondi filtro parola chiave parola tag feed"
 
-#: lib/vutuv_web/components/ui.ex:5267
+#: lib/vutuv_web/components/ui.ex:5279
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr "Argomenti i cui post arrivano nel Suo feed"
 
-#: lib/vutuv_web/components/ui.ex:5268
+#: lib/vutuv_web/components/ui.ex:5280
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr "tag argomento iscriviti segui feed"
 
-#: lib/vutuv_web/components/ui.ex:5284
+#: lib/vutuv_web/components/ui.ex:5296
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 "Ricerche di lavoro e di persone che Le inviano per e-mail le nuove "
 "corrispondenze"
 
-#: lib/vutuv_web/components/ui.ex:5285
+#: lib/vutuv_web/components/ui.ex:5297
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr "lavoro avviso ricerca agente osservati"
 
-#: lib/vutuv_web/components/ui.ex:5332
+#: lib/vutuv_web/components/ui.ex:5344
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr "Motori di ricerca, IA, stato online"
 
-#: lib/vutuv_web/components/ui.ex:5333
+#: lib/vutuv_web/components/ui.ex:5345
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 "privacy google motore di ricerca ia llm crawler noindex online pallino "
 "pubblico"
 
-#: lib/vutuv_web/components/ui.ex:5336
+#: lib/vutuv_web/components/ui.ex:5348
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr "Persone che non possono interagire con Lei"
 
-#: lib/vutuv_web/components/ui.ex:5337
+#: lib/vutuv_web/components/ui.ex:5349
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr "blocca bandisci silenzia segnala abuso molestie stalker"
 
-#: lib/vutuv_web/components/ui.ex:5358
+#: lib/vutuv_web/components/ui.ex:5370
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr "Passkey, dispositivi connessi, codici di accesso"
 
-#: lib/vutuv_web/components/ui.ex:5359
+#: lib/vutuv_web/components/ui.ex:5371
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 "password accesso entrare uscire sessione dispositivo passkey totp 2fa pin"
 
-#: lib/vutuv_web/components/ui.ex:5367
+#: lib/vutuv_web/components/ui.ex:5379
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr "Porti i Suoi dati da LinkedIn"
 
-#: lib/vutuv_web/components/ui.ex:5368
+#: lib/vutuv_web/components/ui.ex:5380
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr "linkedin caricamento zip migrazione trasferimento"
 
-#: lib/vutuv_web/components/ui.ex:5371
+#: lib/vutuv_web/components/ui.ex:5383
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr "Scarichi tutto ciò che conserviamo su di Lei"
 
-#: lib/vutuv_web/components/ui.ex:5372
+#: lib/vutuv_web/components/ui.ex:5384
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr "download gdpr rgpd dati backup json cv"
 
-#: lib/vutuv_web/components/ui.ex:5386
+#: lib/vutuv_web/components/ui.ex:5398
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr "Rimuova il Suo account e tutto ciò che contiene"
 
-#: lib/vutuv_web/components/ui.ex:5387
+#: lib/vutuv_web/components/ui.ex:5399
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr "elimina rimuovi chiudi esci cancella abbandona"
@@ -16116,7 +16102,7 @@ msgstr ""
 " vedere dove va a finire. Modificare o eliminare un post su vutuv è solo una"
 " richiesta rivolta a quei server, e non tutti la rispettano."
 
-#: lib/vutuv_web/components/post_components.ex:6633
+#: lib/vutuv_web/components/post_components.ex:6688
 #: lib/vutuv_web/live/notification_live/index.ex:1596
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
@@ -16124,7 +16110,7 @@ msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} risposta"
 msgstr[1] "%{formatted} risposte"
 
-#: lib/vutuv_web/components/post_components.ex:6637
+#: lib/vutuv_web/components/post_components.ex:6692
 #: lib/vutuv_web/live/notification_live/index.ex:1590
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
@@ -16132,7 +16118,7 @@ msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Mi piace"
 msgstr[1] "%{formatted} Mi piace"
 
-#: lib/vutuv_web/components/post_components.ex:6641
+#: lib/vutuv_web/components/post_components.ex:6696
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16140,7 +16126,7 @@ msgstr[0] "%{formatted} ripubblicazione"
 msgstr[1] "%{formatted} ripubblicazioni"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1301
-#: lib/vutuv_web/components/post_components.ex:6592
+#: lib/vutuv_web/components/post_components.ex:6647
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Già conteggiate nei numeri qui sopra."
@@ -16164,7 +16150,7 @@ msgid "Content warning"
 msgstr "Avviso sul contenuto"
 
 #: lib/vutuv_web/components/post_components.ex:1581
-#: lib/vutuv_web/components/post_components.ex:2625
+#: lib/vutuv_web/components/post_components.ex:2680
 #: lib/vutuv_web/live/fediverse_account_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "From another network"
@@ -16244,7 +16230,7 @@ msgstr "Questa risposta non spetta a Lei rimuoverla."
 #: lib/vutuv_web/agent_docs/markdown.ex:1501
 #: lib/vutuv_web/components/post_components.ex:1496
 #: lib/vutuv_web/components/post_components.ex:1727
-#: lib/vutuv_web/components/post_components.ex:3465
+#: lib/vutuv_web/components/post_components.ex:3520
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "View the original"
@@ -16486,7 +16472,7 @@ msgstr "Token di accesso creato"
 msgid "Access token revoked"
 msgstr "Token di accesso revocato"
 
-#: lib/vutuv_web/components/ui.ex:5361
+#: lib/vutuv_web/components/ui.ex:5373
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16845,7 +16831,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr "Cosa è cambiato sul Suo account, ed esattamente quando."
 
-#: lib/vutuv_web/components/ui.ex:5362
+#: lib/vutuv_web/components/ui.ex:5374
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr "Cosa è cambiato sul Suo account, e quando"
@@ -16881,7 +16867,7 @@ msgstr "da chi gestisce il sito"
 msgid "from a signed-in session"
 msgstr "da una sessione connessa"
 
-#: lib/vutuv_web/components/ui.ex:5364
+#: lib/vutuv_web/components/ui.ex:5376
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16938,22 +16924,22 @@ msgstr ""
 msgid "device or detail"
 msgstr "dispositivo o dettaglio"
 
-#: lib/vutuv_web/components/post_components.ex:4081
+#: lib/vutuv_web/components/post_components.ex:4136
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Post fissato"
 
-#: lib/vutuv_web/components/post_components.ex:4207
+#: lib/vutuv_web/components/post_components.ex:4262
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "Fissa sul profilo"
 
-#: lib/vutuv_web/components/post_components.ex:4215
+#: lib/vutuv_web/components/post_components.ex:4270
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Togli dal profilo"
 
-#: lib/vutuv_web/components/post_components.ex:4201
+#: lib/vutuv_web/components/post_components.ex:4256
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16983,19 +16969,19 @@ msgstr "post fissato"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:626
 #: lib/vutuv_web/agent_docs/text.ex:611
-#: lib/vutuv_web/templates/user/edit.html.heex:219
-#: lib/vutuv_web/templates/user/show.html.heex:286
+#: lib/vutuv_web/templates/user/edit.html.heex:225
+#: lib/vutuv_web/templates/user/show.html.heex:291
 #: lib/vutuv_web/views/account_event_text.ex:213
 #, elixir-autogen, elixir-format
 msgid "Name pronunciation"
 msgstr "Pronuncia del nome"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:223
+#: lib/vutuv_web/templates/user/edit.html.heex:229
 #, elixir-autogen, elixir-format
 msgid "e.g. [SHTEH-fahn VIN-ter-my-er]"
 msgstr "ad esempio [STÈ-fan VÌN-ter-mai-er]"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:226
+#: lib/vutuv_web/templates/user/edit.html.heex:232
 #, elixir-autogen, elixir-format
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
@@ -17085,17 +17071,17 @@ msgstr "Foto successiva"
 msgid "No image description yet"
 msgstr "Ancora nessuna descrizione dell'immagine"
 
-#: lib/vutuv_web/components/post_components.ex:3660
+#: lib/vutuv_web/components/post_components.ex:3715
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Apri le impostazioni del Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:5091
+#: lib/vutuv_web/components/post_components.ex:5146
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} di %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:5240
+#: lib/vutuv_web/components/post_components.ex:5295
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "La foto è in fase di controllo"
@@ -17108,7 +17094,7 @@ msgstr "Opzioni della foto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1462
 #: lib/vutuv_web/agent_docs/text.ex:890
-#: lib/vutuv_web/components/post_components.ex:5322
+#: lib/vutuv_web/components/post_components.ex:5377
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Foto:"
@@ -17136,7 +17122,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr "Mostra le impostazioni della fotocamera"
 
-#: lib/vutuv_web/components/post_components.ex:3713
+#: lib/vutuv_web/components/post_components.ex:3768
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -17162,7 +17148,7 @@ msgstr ""
 "Questa foto porta con sé il luogo in cui è stata scattata. Chiunque scarichi"
 " il file esatto può leggerlo."
 
-#: lib/vutuv_web/components/post_components.ex:3704
+#: lib/vutuv_web/components/post_components.ex:3759
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -17177,12 +17163,12 @@ msgstr ""
 "inviare le Sue parole a quella rete, cosa che vutuv fa solo per i membri che"
 " hanno attivato la partecipazione al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:3722
+#: lib/vutuv_web/components/post_components.ex:3777
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Questo sito non partecipa al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:3656
+#: lib/vutuv_web/components/post_components.ex:3711
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Attivi la partecipazione al Fediverso per rispondere"
@@ -17198,7 +17184,7 @@ msgid "You have sent a lot of answers to other networks in the past hour. Please
 msgstr ""
 "Nell'ultima ora ha inviato molte risposte ad altre reti. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:3717
+#: lib/vutuv_web/components/post_components.ex:3772
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -17212,7 +17198,7 @@ msgstr ""
 "Al momento le Sue impostazioni del Fediverso non consentono di inviare una "
 "risposta."
 
-#: lib/vutuv_web/components/post_components.ex:3670
+#: lib/vutuv_web/components/post_components.ex:3725
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -17295,13 +17281,13 @@ msgstr[1] ""
 "il file esatto lo rivela."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1319
-#: lib/vutuv_web/components/post_components.ex:6630
+#: lib/vutuv_web/components/post_components.ex:6685
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "A %{handle} è piaciuto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1317
-#: lib/vutuv_web/components/post_components.ex:6627
+#: lib/vutuv_web/components/post_components.ex:6682
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} lo ha condiviso"
@@ -17311,7 +17297,7 @@ msgstr "%{handle} lo ha condiviso"
 msgid "Fediverse reactions"
 msgstr "Reazioni dal Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:6514
+#: lib/vutuv_web/components/post_components.ex:6569
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Da altre reti"
@@ -17438,7 +17424,7 @@ msgstr "Un account su un'altra rete"
 msgid "Cancel request"
 msgstr "Annulla la richiesta"
 
-#: lib/vutuv_web/components/ui.ex:5348
+#: lib/vutuv_web/components/ui.ex:5360
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Segua account su Mastodon, e si faccia seguire da lì"
@@ -17674,7 +17660,7 @@ msgstr ""
 "reti e non può seguire nessuno lì. La sospensione decade da sé quando "
 "termina."
 
-#: lib/vutuv_web/components/ui.ex:5350
+#: lib/vutuv_web/components/ui.ex:5362
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -17698,7 +17684,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr "Post in cache"
 
-#: lib/vutuv_web/components/post_components.ex:3224
+#: lib/vutuv_web/components/post_components.ex:3279
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Solo per i follower di questo account"
@@ -17708,7 +17694,7 @@ msgstr "Solo per i follower di questo account"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Grazie. La nostra copia è stata eliminata subito."
 
-#: lib/vutuv_web/components/post_components.ex:3464
+#: lib/vutuv_web/components/post_components.ex:3519
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Vota sull'originale"
@@ -17739,7 +17725,7 @@ msgstr "Contenuti da altre reti rimossi dai membri"
 msgid "Hide"
 msgstr "Nascondi"
 
-#: lib/vutuv_web/components/post_components.ex:3405
+#: lib/vutuv_web/components/post_components.ex:3460
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Contrassegnato come sensibile dal suo autore"
@@ -17754,7 +17740,7 @@ msgstr "Silenziato. Continua a seguirlo; i suoi post spariscono dal Suo feed."
 msgid "Nobody has removed or reported anything yet."
 msgstr "Nessuno ha ancora rimosso o segnalato nulla."
 
-#: lib/vutuv_web/components/post_components.ex:3197
+#: lib/vutuv_web/components/post_components.ex:3252
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17857,7 +17843,7 @@ msgstr ""
 msgid "Your account move"
 msgstr "Lo spostamento del Suo account"
 
-#: lib/vutuv_web/views/page_html.ex:28
+#: lib/vutuv_web/views/page_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "“LinkedIn is annoying. vutuv is not.”"
 msgstr "“LinkedIn è fastidioso. vutuv no.”"
@@ -17869,27 +17855,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(un'immagine)"
 msgstr[1] "(%{count} immagini)"
 
-#: lib/vutuv_web/components/post_components.ex:2798
+#: lib/vutuv_web/components/post_components.ex:2853
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr "L'immagine è in fase di controllo"
 
-#: lib/vutuv_web/components/post_components.ex:2831
+#: lib/vutuv_web/components/post_components.ex:2886
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Coprila di nuovo"
 
-#: lib/vutuv_web/components/post_components.ex:2826
+#: lib/vutuv_web/components/post_components.ex:2881
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Contenuto sensibile. Mostra l'immagine."
 
-#: lib/vutuv_web/components/post_components.ex:3563
+#: lib/vutuv_web/components/post_components.ex:3618
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Sono molti Mi piace in un'ora. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:3569
+#: lib/vutuv_web/components/post_components.ex:3624
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Quel post non è più qui."
@@ -17899,7 +17885,7 @@ msgstr "Quel post non è più qui."
 msgid "Back to the feed"
 msgstr "Torna al feed"
 
-#: lib/vutuv_web/components/post_components.ex:3708
+#: lib/vutuv_web/components/post_components.ex:3763
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18631,7 +18617,7 @@ msgstr "Nessun post su vutuv porta ancora questo tag."
 msgid "word in a post"
 msgstr "parola in un post"
 
-#: lib/vutuv_web/components/post_components.ex:3566
+#: lib/vutuv_web/components/post_components.ex:3621
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Quella risposta non è più qui."
@@ -18709,19 +18695,19 @@ msgstr ""
 msgid "Liked by"
 msgstr "Piace a"
 
-#: lib/vutuv_web/components/post_components.ex:5616
+#: lib/vutuv_web/components/post_components.ex:5671
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Piace a %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:5618
+#: lib/vutuv_web/components/post_components.ex:5673
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Piace a %{name} e a %{formatted} altro"
 msgstr[1] "Piace a %{name} e ad altri %{formatted}"
 
-#: lib/vutuv_web/components/post_components.ex:5629
+#: lib/vutuv_web/components/post_components.ex:5684
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18787,7 +18773,7 @@ msgstr "Per questo attestato è già in corso un'analisi."
 #: lib/vutuv_web/controllers/job_reference_controller.ex:144
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:18
 #: lib/vutuv_web/templates/job_reference/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:804
+#: lib/vutuv_web/templates/user/show.html.heex:809
 #, elixir-autogen, elixir-format
 msgid "Add an employment reference"
 msgstr "Aggiungi un attestato di lavoro"
@@ -18857,7 +18843,7 @@ msgstr "Attestato di lavoro aggiornato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:5184
+#: lib/vutuv_web/components/ui.ex:5196
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -18867,7 +18853,7 @@ msgstr "Attestato di lavoro aggiornato."
 #: lib/vutuv_web/templates/job_reference/new.html.heex:4
 #: lib/vutuv_web/templates/job_reference/show.html.heex:12
 #: lib/vutuv_web/templates/job_reference/view.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:801
+#: lib/vutuv_web/templates/user/show.html.heex:806
 #, elixir-autogen, elixir-format
 msgid "Employment references"
 msgstr "Attestati di lavoro"
@@ -19061,7 +19047,7 @@ msgstr ""
 "Ha modificato il testo dopo questa analisi. L'analisi descrive la versione "
 "precedente."
 
-#: lib/vutuv_web/components/ui.ex:5185
+#: lib/vutuv_web/components/ui.ex:5197
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr "I Suoi Arbeitszeugnisse, privati finché non li pubblica"
@@ -19072,7 +19058,7 @@ msgstr "I Suoi Arbeitszeugnisse, privati finché non li pubblica"
 msgid "Zwischenzeugnis"
 msgstr "Zwischenzeugnis"
 
-#: lib/vutuv_web/components/ui.ex:5187
+#: lib/vutuv_web/components/ui.ex:5199
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -19348,7 +19334,7 @@ msgstr "Trascini qui il file, oppure ne scelga uno"
 msgid "PDF, JPG, PNG or WebP, up to %{limit}"
 msgstr "PDF, JPG, PNG o WebP, fino a %{limit}"
 
-#: lib/vutuv_web/components/ui.ex:4481
+#: lib/vutuv_web/components/ui.ex:4493
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "That file is larger than %{limit}. Please upload a smaller one."
@@ -19548,7 +19534,7 @@ msgstr "Il Suo nome utente vutuv è pronto."
 msgid "by the lawyer Tom Braegelmann"
 msgstr "dall'avvocato Tom Braegelmann"
 
-#: lib/vutuv_web/templates/user/show.html.heex:845
+#: lib/vutuv_web/templates/user/show.html.heex:850
 #, elixir-autogen, elixir-format
 msgid "Documents:"
 msgstr "Documenti:"
@@ -19680,17 +19666,17 @@ msgstr ""
 "Il PIN non arriva? L'indirizzo e-mail {email} è corretto? Ha controllato la "
 "cartella dello spam?"
 
-#: lib/vutuv/accounts/user.ex:1430
+#: lib/vutuv/accounts/user.ex:1437
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Non binario"
 
-#: lib/vutuv/accounts/user.ex:1428
+#: lib/vutuv/accounts/user.ex:1435
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Femminile"
 
-#: lib/vutuv/accounts/user.ex:1429
+#: lib/vutuv/accounts/user.ex:1436
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Maschile"
@@ -19702,7 +19688,7 @@ msgstr ""
 "Le percentuali si riferiscono ai %{answered} membri che hanno risposto. "
 "%{unanswered} non hanno risposto."
 
-#: lib/vutuv_web/components/ui.ex:5166
+#: lib/vutuv_web/components/ui.ex:5178
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr "immagine profilo ritratto foto compleanno genere su di me"
@@ -19804,7 +19790,7 @@ msgstr "Elimina anche"
 msgid "Always keep"
 msgstr "Conserva sempre"
 
-#: lib/vutuv_web/components/ui.ex:5341
+#: lib/vutuv_web/components/ui.ex:5353
 #: lib/vutuv_web/controllers/settings_controller.ex:256
 #: lib/vutuv_web/controllers/settings_controller.ex:335
 #: lib/vutuv_web/controllers/settings_controller.ex:347
@@ -19914,7 +19900,7 @@ msgstr "Conserva i post con foto"
 msgid "Keep posts that did well"
 msgstr "Conserva i post andati bene"
 
-#: lib/vutuv_web/components/ui.ex:5343
+#: lib/vutuv_web/components/ui.ex:5355
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr "Lasci scadere i Suoi post dopo un tempo che decide Lei"
@@ -20038,7 +20024,7 @@ msgstr "Prima può scaricare tutto ciò che ha qui:"
 msgid "Your rule"
 msgstr "La Sua regola"
 
-#: lib/vutuv_web/components/ui.ex:5345
+#: lib/vutuv_web/components/ui.ex:5357
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -20450,7 +20436,7 @@ msgstr ""
 msgid "Start over"
 msgstr "Ricomincia"
 
-#: lib/vutuv_web/components/post_components.ex:3596
+#: lib/vutuv_web/components/post_components.ex:3651
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -20618,7 +20604,7 @@ msgstr[1] "%{formatted} nuovi"
 msgid "%{name} mentioned this page."
 msgstr "%{name} ha menzionato questa pagina."
 
-#: lib/vutuv_web/templates/user/show.html.heex:184
+#: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
 msgid "%{name} follows"
 msgstr "%{name} segue"
@@ -20628,7 +20614,7 @@ msgstr "%{name} segue"
 msgid "Feed – %{name}"
 msgstr "Feed – %{name}"
 
-#: lib/vutuv_web/templates/user/show.html.heex:185
+#: lib/vutuv_web/templates/user/show.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "Follow as %{name}"
 msgstr "Segui come %{name}"
@@ -21057,7 +21043,7 @@ msgstr ""
 "l'indirizzo di un post là fuori: vutuv lo scarica così può rispondergli da "
 "qui"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:81
+#: lib/vutuv_web/templates/user/edit.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Fetch my picture from gravatar.com"
 msgstr "Prendi la mia immagine da gravatar.com"
@@ -21082,7 +21068,7 @@ msgstr "Non è stato possibile raggiungere gravatar.com. Riprovi più tardi."
 msgid "gravatar.com has no picture for your email address."
 msgstr "gravatar.com non ha alcuna immagine per il Suo indirizzo e-mail."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:84
+#: lib/vutuv_web/templates/user/edit.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "Only when you press this: we ask gravatar.com whether there is a picture for your email address, sending a hash of the address rather than the address itself. Nothing leaves this server otherwise."
 msgstr ""
@@ -21412,27 +21398,27 @@ msgstr "Lingua"
 msgid "The language this post is written in"
 msgstr "La lingua in cui è scritto questo post"
 
-#: lib/vutuv_web/components/post_components.ex:5510
+#: lib/vutuv_web/components/post_components.ex:5565
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Mostra l'originale"
 
-#: lib/vutuv_web/components/post_components.ex:5546
+#: lib/vutuv_web/components/post_components.ex:5601
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Traduci"
 
-#: lib/vutuv_web/components/post_components.ex:5555
+#: lib/vutuv_web/components/post_components.ex:5610
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Tradotto"
 
-#: lib/vutuv_web/components/post_components.ex:5558
+#: lib/vutuv_web/components/post_components.ex:5613
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Tradotto da %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:5535
+#: lib/vutuv_web/components/post_components.ex:5590
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Traduzione in corso…"
@@ -21443,8 +21429,8 @@ msgid "Feed language settings reset to the site defaults."
 msgstr ""
 "Impostazioni delle lingue del feed riportate ai valori predefiniti del sito."
 
-#: lib/vutuv_web/components/post_components.ex:5525
-#: lib/vutuv_web/components/ui.ex:5259
+#: lib/vutuv_web/components/post_components.ex:5580
+#: lib/vutuv_web/components/ui.ex:5271
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
 #: lib/vutuv_web/templates/settings/preferences.html.heex:187
@@ -21586,7 +21572,7 @@ msgid "Your username, or paste the address of your profile page."
 msgstr ""
 "Il Suo nome utente, oppure incolli l'indirizzo della Sua pagina di profilo."
 
-#: lib/vutuv_web/components/post_components.ex:5288
+#: lib/vutuv_web/components/post_components.ex:5343
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
@@ -21597,13 +21583,13 @@ msgstr[1] ""
 "La nostra IA le sta ancora controllando, %{done} su %{total} fatte. Appena "
 "avrà finito con l'ultima, le foto compariranno da sé."
 
-#: lib/vutuv_web/components/post_components.ex:5285
+#: lib/vutuv_web/components/post_components.ex:5340
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Il Suo post è pubblicato, la foto non c'è ancora."
 
-#: lib/vutuv_web/components/post_components.ex:2852
-#: lib/vutuv_web/components/post_components.ex:4495
+#: lib/vutuv_web/components/post_components.ex:2907
+#: lib/vutuv_web/components/post_components.ex:4550
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -21612,12 +21598,12 @@ msgstr[0] ""
 msgstr[1] ""
 "La nostra IA le sta esaminando. Compariranno qui da sé quando avrà finito."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:139
+#: lib/vutuv_web/templates/user/edit.html.heex:145
 #, elixir-autogen, elixir-format
 msgid "Recommended: %{width} × %{height} pixels (%{ratio})."
 msgstr "Consigliato: %{width} × %{height} pixel (%{ratio})."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:59
+#: lib/vutuv_web/templates/user/edit.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Consigliato: quadrata, almeno %{width} × %{height} pixel."
@@ -21686,7 +21672,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr "Accesso delle app Mastodon modificato"
 
-#: lib/vutuv_web/components/ui.ex:5379
+#: lib/vutuv_web/components/ui.ex:5391
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr "App Mastodon, app collegate e token di accesso"
@@ -21742,7 +21728,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr "Il Suo account è allora %{handle}."
 
-#: lib/vutuv_web/components/ui.ex:5381
+#: lib/vutuv_web/components/ui.ex:5393
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -21779,7 +21765,7 @@ msgstr "Trovi le persone che conosce da LinkedIn"
 msgid "Find your LinkedIn contacts"
 msgstr "Trovi i Suoi contatti LinkedIn"
 
-#: lib/vutuv_web/components/ui.ex:5275
+#: lib/vutuv_web/components/ui.ex:5287
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format
@@ -21893,7 +21879,7 @@ msgstr "Cerchi per nome"
 msgid "See which of them are already on vutuv"
 msgstr "Veda quali di loro sono già su vutuv"
 
-#: lib/vutuv_web/components/ui.ex:5277
+#: lib/vutuv_web/components/ui.ex:5289
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr "Veda quali dei Suoi contatti LinkedIn sono già su vutuv"
@@ -21977,7 +21963,7 @@ msgstr "I Suoi contatti su vutuv"
 msgid "Your export also lists your LinkedIn contacts."
 msgstr "La Sua esportazione elenca anche i Suoi contatti LinkedIn."
 
-#: lib/vutuv_web/components/ui.ex:5279
+#: lib/vutuv_web/components/ui.ex:5291
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr ""
@@ -22176,7 +22162,7 @@ msgstr ""
 "Questa pagina sta seguendo il numero massimo di account che consentiamo "
 "(%{max})."
 
-#: lib/vutuv_web/components/post_components.ex:3177
+#: lib/vutuv_web/components/post_components.ex:3232
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr "Smettere di seguire %{handle}? I suoi post spariscono dal Suo feed."
@@ -22263,7 +22249,7 @@ msgstr ""
 "Ha attivato le notifiche del browser. A questo browser non è ancora stato "
 "chiesto il permesso."
 
-#: lib/vutuv_web/components/ui.ex:5233
+#: lib/vutuv_web/components/ui.ex:5245
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
@@ -22497,22 +22483,22 @@ msgstr "Vengono nascosti dal Suo feed."
 msgid "Shown in the language it was written in."
 msgstr "Vengono mostrati nella lingua in cui sono stati scritti."
 
-#: lib/vutuv_web/components/ui.ex:5260
+#: lib/vutuv_web/components/ui.ex:5272
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr "Quali lingue arrivano fino a Lei e cosa succede al resto"
 
-#: lib/vutuv_web/components/ui.ex:5262
+#: lib/vutuv_web/components/ui.ex:5274
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr "lingua tradurre traduzione italiano tedesco inglese originale nascondere lingua straniera ordine priorità feed language translate sprache"
 
-#: lib/vutuv_web/components/ui.ex:5300
+#: lib/vutuv_web/components/ui.ex:5312
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr "Lingua dell'interfaccia, formato della data e fuso orario, mappe, come vengono accorciati i post"
 
-#: lib/vutuv_web/components/ui.ex:5304
+#: lib/vutuv_web/components/ui.ex:5316
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr "italiano tedesco inglese lingua mappa carattere lunghezza sillabazione fuso orario timezone utc data ora orologio 24 ore formato della data"
@@ -22606,12 +22592,12 @@ msgstr ""
 msgid "That alternative name is no longer on record."
 msgstr "Quel nome alternativo non risulta più registrato."
 
-#: lib/vutuv_web/views/page_html.ex:63
+#: lib/vutuv_web/views/page_html.ex:60
 #, elixir-autogen, elixir-format
 msgid "Fast."
 msgstr "Veloce."
 
-#: lib/vutuv_web/views/page_html.ex:64
+#: lib/vutuv_web/views/page_html.ex:61
 #, elixir-autogen, elixir-format
 msgid "No paid premium accounts."
 msgstr "Nessun account premium a pagamento."
@@ -22976,7 +22962,7 @@ msgid_plural "Show %{formatted} posts in the feed"
 msgstr[0] "Mostra %{formatted} post nel feed"
 msgstr[1] "Mostra %{formatted} post nel feed"
 
-#: lib/vutuv_web/components/post_components.ex:2769
+#: lib/vutuv_web/components/post_components.ex:2824
 #, elixir-autogen, elixir-format
 msgid "Picture unavailable"
 msgstr "Immagine non disponibile"
@@ -23005,7 +22991,7 @@ msgstr ""
 "La pagina della Sua organizzazione è stata aggiornata, ma non è stato "
 "possibile usare quell'immagine come logo. Ne scelga un'altra."
 
-#: lib/vutuv_web/components/ui.ex:4487
+#: lib/vutuv_web/components/ui.ex:4499
 #, elixir-autogen, elixir-format
 msgid "You can upload one file at a time."
 msgid_plural "You can upload at most %{count} files at a time."
@@ -23152,7 +23138,7 @@ msgid_plural "New (%{formatted}):"
 msgstr[0] "Nuovo:"
 msgstr[1] "Nuovi (%{formatted}):"
 
-#: lib/vutuv_web/components/post_components.ex:3332
+#: lib/vutuv_web/components/post_components.ex:3387
 #, elixir-autogen, elixir-format
 msgid "Quoted post"
 msgstr "Post citato"
@@ -23203,12 +23189,12 @@ msgstr "Lascia vuoto il campo degli account e la regola vale per tutti; %{exampl
 msgid "Only these accounts (empty = all) …"
 msgstr "Solo questi account (vuoto = tutti) …"
 
-#: lib/vutuv_web/components/ui.ex:3530
+#: lib/vutuv_web/components/ui.ex:3542
 #, elixir-autogen, elixir-format
 msgid "only %{account}"
 msgstr "solo %{account}"
 
-#: lib/vutuv_web/components/post_components.ex:6973
+#: lib/vutuv_web/components/post_components.ex:7028
 #: lib/vutuv_web/live/post_live/filter_band.ex:290
 #: lib/vutuv_web/live/post_live/filter_band.ex:379
 #, elixir-autogen, elixir-format
@@ -23445,7 +23431,7 @@ msgstr "Di questo post non resta nulla."
 msgid "Replace with"
 msgstr "Sostituisci con"
 
-#: lib/vutuv_web/components/ui.ex:5252
+#: lib/vutuv_web/components/ui.ex:5264
 #, elixir-autogen, elixir-format
 msgid "Rewrite what an account's posts say, for you alone"
 msgstr "Riscrivere il testo dei post di un account, solo per Lei"
@@ -23461,9 +23447,9 @@ msgid "Rules that rewrite the text of one account's posts before you read them: 
 msgstr "Regole che riscrivono il testo dei post di un account prima che Lei li legga: un piè di pagina sotto ogni post, una firma, un muro di hashtag. Solo Lei vede la differenza. Apra il menu ⋯ di un post per scrivere regole per il suo autore."
 
 #: lib/vutuv_web/components/post_components.ex:1450
-#: lib/vutuv_web/components/post_components.ex:3190
-#: lib/vutuv_web/components/post_components.ex:4284
-#: lib/vutuv_web/components/ui.ex:5251
+#: lib/vutuv_web/components/post_components.ex:3245
+#: lib/vutuv_web/components/post_components.ex:4339
+#: lib/vutuv_web/components/ui.ex:5263
 #: lib/vutuv_web/live/post_rewrites_live.ex:76
 #: lib/vutuv_web/live/post_rewrites_live.ex:262
 #: lib/vutuv_web/live/post_rewrites_live.ex:264
@@ -23519,12 +23505,12 @@ msgstr "Le Sue regole salvate modificano questo post di %{who} come mostrato."
 msgid "\\1 puts back what the first (…) group matched, \\0 the whole match."
 msgstr "\\1 reinserisce ciò che ha trovato il primo gruppo (…), \\0 l'intera corrispondenza."
 
-#: lib/vutuv_web/components/ui.ex:5253
+#: lib/vutuv_web/components/ui.ex:5265
 #, elixir-autogen, elixir-format
 msgid "regex regular expression rewrite replace footer signature strip"
 msgstr "regex espressione regolare riscrivere sostituire piè di pagina firma rimuovere cerca"
 
-#: lib/vutuv_web/components/ui.ex:5322
+#: lib/vutuv_web/components/ui.ex:5334
 #, elixir-autogen, elixir-format
 msgid "Smaller pictures and a plain composer on a slow connection"
 msgstr "Immagini più piccole e un editor semplice con una connessione lenta"
@@ -23534,12 +23520,12 @@ msgstr "Immagini più piccole e un editor semplice con una connessione lenta"
 msgid "That endorsement is not possible."
 msgstr "Questa conferma non è possibile."
 
-#: lib/vutuv_web/components/ui.ex:5324
+#: lib/vutuv_web/components/ui.ex:5336
 #, elixir-autogen, elixir-format
 msgid "bandwidth slow internet mobile data saving saver volume metered compression pictures images screenshots editor langsam daten sparen datensparmodus volumen schmalband komprimierung bilder"
 msgstr "banda lento internet mobile risparmio dati volume compressione immagini foto screenshot editor bandwidth slow data saving"
 
-#: lib/vutuv_web/components/ui.ex:5296
+#: lib/vutuv_web/components/ui.ex:5308
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr "Aspetto"
@@ -23652,7 +23638,7 @@ msgstr "Questo video non può essere convertito."
 #: lib/vutuv_web/agent_docs/markdown.ex:1417
 #: lib/vutuv_web/agent_docs/text.ex:899
 #: lib/vutuv_web/agent_docs/text.ex:900
-#: lib/vutuv_web/components/post_components.ex:2904
+#: lib/vutuv_web/components/post_components.ex:2959
 #: lib/vutuv_web/components/video_components.ex:127
 #: lib/vutuv_web/live/post_live/composer.ex:2458
 #, elixir-autogen, elixir-format
@@ -23715,7 +23701,7 @@ msgstr[1] "%{formatted} follower"
 msgid "Last 30 days: %{parts}"
 msgstr "Ultimi 30 giorni"
 
-#: lib/vutuv_web/components/post_components.ex:4847
+#: lib/vutuv_web/components/post_components.ex:4902
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Less"
@@ -24019,7 +24005,7 @@ msgstr ""
 msgid "Accounts whose posts stay out of your feed, and accounts whose reposts do. This list is yours alone: it is never shared and nobody is told they are on it."
 msgstr "Account i cui post non compaiono nel Suo feed e account di cui ha nascosto le ripubblicazioni. Questo elenco è solo Suo: non viene mai condiviso e nessuno viene informato di farne parte."
 
-#: lib/vutuv_web/components/ui.ex:5245
+#: lib/vutuv_web/components/ui.ex:5257
 #, elixir-autogen, elixir-format
 msgid "Accounts you have silenced, and whose reposts you hide"
 msgstr "Account che ha silenziato e account di cui nasconde le ripubblicazioni"
@@ -24029,8 +24015,8 @@ msgstr "Account che ha silenziato e account di cui nasconde le ripubblicazioni"
 msgid "Hidden. What they pass on stays out of your feed; their own posts do not."
 msgstr "Nascosto. Ciò che questo account ripubblica non compare più nel Suo feed, i suoi post sì."
 
-#: lib/vutuv_web/components/post_components.ex:3162
-#: lib/vutuv_web/components/post_components.ex:4278
+#: lib/vutuv_web/components/post_components.ex:3217
+#: lib/vutuv_web/components/post_components.ex:4333
 #, elixir-autogen, elixir-format
 msgid "Hide reposts"
 msgstr "Nascondi le ripubblicazioni"
@@ -24045,7 +24031,7 @@ msgstr "Cerca invece parole, frasi o tag?"
 msgid "Mute everything"
 msgstr "Silenzia tutto"
 
-#: lib/vutuv_web/components/ui.ex:5244
+#: lib/vutuv_web/components/ui.ex:5256
 #: lib/vutuv_web/controllers/settings_controller.ex:713
 #: lib/vutuv_web/templates/settings/mutes.html.heex:1
 #: lib/vutuv_web/templates/settings/mutes.html.heex:3
@@ -24089,7 +24075,7 @@ msgstr "Non ha ancora silenziato nessuno."
 msgid "You mute an account where you meet it: the ⋯ menu on any of its posts, or its own page. Muting works whether or not you follow them."
 msgstr "Può silenziare un account dove lo incontra: nel menu ⋯ di uno dei suoi post oppure sulla sua pagina. Funziona anche con gli account che non segue."
 
-#: lib/vutuv_web/components/ui.ex:5247
+#: lib/vutuv_web/components/ui.ex:5259
 #, elixir-autogen, elixir-format
 msgid "mute unmute hide account reposts boosts feed stumm stummschalten ausblenden konto"
 msgstr "silenzia silenziare nascondere account ripubblicazioni boost feed"
@@ -24189,7 +24175,7 @@ msgstr ""
 msgid "Feed settings saved."
 msgstr "Impostazioni del feed salvate."
 
-#: lib/vutuv_web/components/ui.ex:5315
+#: lib/vutuv_web/components/ui.ex:5327
 #, elixir-autogen, elixir-format
 msgid "How many load at once, and how many “Load more” adds"
 msgstr ""
@@ -24199,7 +24185,7 @@ msgstr ""
 msgid "How many posts your feed shows before the “Load more” button, and how many that button adds. More posts mean a longer wait for the page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5314
+#: lib/vutuv_web/components/ui.ex:5326
 #: lib/vutuv_web/controllers/settings_controller.ex:963
 #: lib/vutuv_web/templates/settings/feed.html.heex:12
 #, elixir-autogen, elixir-format
@@ -24222,18 +24208,18 @@ msgstr "Post per pagina"
 msgid "You can change this under the feed itself as well, right below the “Load more” button."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:5317
+#: lib/vutuv_web/components/ui.ex:5329
 #, elixir-autogen, elixir-format
 msgid "feed length page size posts number amount load more scroll paging seite länge anzahl beiträge nachladen mehr laden umfang"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:6964
-#: lib/vutuv_web/components/post_components.ex:6965
+#: lib/vutuv_web/components/post_components.ex:7019
+#: lib/vutuv_web/components/post_components.ex:7020
 #, elixir-autogen, elixir-format
 msgid "A word or phrase …"
 msgstr "Una parola o un'espressione …"
 
-#: lib/vutuv_web/components/post_components.ex:6992
+#: lib/vutuv_web/components/post_components.ex:7047
 #, elixir-autogen, elixir-format
 msgid "For whom %{thing} is hidden"
 msgstr "Per chi %{thing} viene nascosto"
@@ -24250,7 +24236,7 @@ msgstr "Nascosti"
 msgid "Hide something from your feed"
 msgstr "Nascondi qualcosa dal tuo feed"
 
-#: lib/vutuv_web/components/post_components.ex:6912
+#: lib/vutuv_web/components/post_components.ex:6967
 #, elixir-autogen, elixir-format
 msgid "Stop showing"
 msgstr "Non mostrare più"
@@ -24265,22 +24251,22 @@ msgstr "Ciò che corrisponde viene ridotto a una riga nel tuo feed."
 msgid "Words & tags"
 msgstr "Parole e tag"
 
-#: lib/vutuv_web/components/post_components.ex:6996
+#: lib/vutuv_web/components/post_components.ex:7051
 #, elixir-autogen, elixir-format
 msgid "everyone"
 msgstr "per tutti"
 
-#: lib/vutuv_web/components/post_components.ex:6999
+#: lib/vutuv_web/components/post_components.ex:7054
 #, elixir-autogen, elixir-format
 msgid "only %{handle}"
 msgstr "solo %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:6968
+#: lib/vutuv_web/components/post_components.ex:7023
 #, elixir-autogen, elixir-format
 msgid "this word"
 msgstr "questa parola"
 
-#: lib/vutuv_web/components/post_components.ex:7009
+#: lib/vutuv_web/components/post_components.ex:7064
 #, elixir-autogen, elixir-format
 msgid "only %{server}"
 msgstr "solo %{server}"
@@ -24332,7 +24318,7 @@ msgstr "Questo sito è offline in questo momento."
 msgid "The site itself is running, this address just is not one of ours. The link is probably old, or it carries a typo."
 msgstr "Il sito funziona, è questo indirizzo a non essere uno dei nostri. Probabilmente il link è vecchio oppure contiene un errore di battitura."
 
-#: lib/vutuv_web/components/post_components.ex:6319
+#: lib/vutuv_web/components/post_components.ex:6374
 #, elixir-autogen, elixir-format
 msgid "Show this screenshot larger"
 msgstr "Ingrandisci lo screenshot"
@@ -24352,7 +24338,7 @@ msgstr "Attivalo per il tuo account e potrai collegare %{app} direttamente da qu
 msgid "Turn on for my account"
 msgstr "Attiva per il mio account"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:97
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."
 msgstr "Correggilo. Uno dei nostri amministratori esaminerà poi la modifica; fino ad allora il contributo resta nascosto."
@@ -24387,7 +24373,7 @@ msgstr "Usa un testo, una foto o un video senza il permesso del titolare dei dir
 msgid "Which work is it, and where can the original be seen? (required)"
 msgstr "Di quale opera si tratta e dove si può vedere l'originale? (obbligatorio)"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:45
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Copyright law. This complaint says the work is not yours to publish, which is a legal question rather than a house rule."
 msgstr "Il diritto d'autore. Questa contestazione sostiene che l'opera non è Sua da pubblicare, e questa è una questione giuridica, non una regola della casa."
@@ -24397,27 +24383,27 @@ msgstr "Il diritto d'autore. Questa contestazione sostiene che l'opera non è Su
 msgid "Hidden automatically after a report: %{reason}. The case page says what you can do."
 msgstr "Nascosto automaticamente dopo una segnalazione: %{reason}. Nella pagina del caso trova cosa può fare."
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:16
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "No person made this decision: a report from a member in good standing hides the reported content automatically, the moment it arrives."
 msgstr "Questa decisione non l'ha presa nessuna persona: la segnalazione di un membro affidabile nasconde il contenuto segnalato automaticamente, nel momento in cui arriva."
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:79
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Nobody else can see it right now. You have 72 hours to settle this yourself; after that our admins decide. Here is what you can do:"
 msgstr "Nessun altro può vederlo in questo momento. Ha 72 ore per risolvere da solo; dopo decidono i nostri amministratori. Ecco cosa può fare:"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:48
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Our community guidelines, which everything on vutuv has to keep to."
 msgstr "Le nostre regole della comunità, a cui tutto su vutuv deve attenersi."
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:41
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "The ground"
 msgstr "Il fondamento"
 
-#: lib/vutuv_web/templates/moderation_case/show.html.heex:28
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "What the report says"
 msgstr "Cosa dice la segnalazione"
@@ -24432,8 +24418,8 @@ msgstr "Il Suo contenuto è stato nascosto automaticamente dopo una segnalazione
 msgid "Hidden. What other people pass on of them stays out of your feed; their own posts do not."
 msgstr "Nascosto. Ciò che altri ripubblicano di questo account non compare più nel Suo feed, i suoi post sì."
 
-#: lib/vutuv_web/components/post_components.ex:3148
-#: lib/vutuv_web/components/post_components.ex:4266
+#: lib/vutuv_web/components/post_components.ex:3203
+#: lib/vutuv_web/components/post_components.ex:4321
 #, elixir-autogen, elixir-format
 msgid "Hide when others repost them"
 msgstr "Nascondi quando altri lo ripubblicano"
@@ -24476,14 +24462,14 @@ msgstr ""
 "Con un PIN via e-mail, passkey, app di autenticazione o una lista di codici "
 "stampata."
 
-#: lib/vutuv_web/views/page_html.ex:160
+#: lib/vutuv_web/views/page_html.ex:157
 #, elixir-autogen, elixir-format
 msgid "Curious? Have a look at a real profile: {profile}. With or without a vutuv account of your own."
 msgstr ""
 "Curioso? Dia un'occhiata a un profilo vero: {profile}. Con o senza un account"
 " vutuv."
 
-#: lib/vutuv_web/views/page_html.ex:156
+#: lib/vutuv_web/views/page_html.ex:153
 #, elixir-autogen, elixir-format
 msgid "Curious? Have a look at the profile of vutuv founder Stefan Wintermeyer: {profile}. With or without a vutuv account of your own."
 msgstr ""
@@ -24639,7 +24625,7 @@ msgstr ""
 " più tardi con un interruttore nelle impostazioni. Non ne facciamo una "
 "religione: ognuno come vuole."
 
-#: lib/vutuv_web/live/shell_live.ex:1806
+#: lib/vutuv_web/live/shell_live.ex:1811
 #, elixir-autogen, elixir-format
 msgid "All notifications"
 msgstr "Tutte le notifiche"
@@ -24659,12 +24645,12 @@ msgstr "Né la tua immagine del profilo né quella di copertina sono state sosti
 msgid "Profile picture"
 msgstr "Immagine del profilo"
 
-#: lib/vutuv_web/templates/user/show.html.heex:260
+#: lib/vutuv_web/templates/user/show.html.heex:265
 #, elixir-autogen, elixir-format
 msgid "Report the cover photo"
 msgstr "Segnala l'immagine di copertina"
 
-#: lib/vutuv_web/templates/user/show.html.heex:253
+#: lib/vutuv_web/templates/user/show.html.heex:258
 #, elixir-autogen, elixir-format
 msgid "Report the profile picture"
 msgstr "Segnala l'immagine del profilo"
@@ -24674,7 +24660,7 @@ msgstr "Segnala l'immagine del profilo"
 msgid "The reported picture"
 msgstr "L'immagine segnalata"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:241
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "Upholding the case deletes it, the private original included. Rejecting it puts every file back where it was."
 msgstr "Se il caso viene accolto, l'immagine viene eliminata, originale privato compreso. Se viene respinto, ogni file torna al suo posto."
@@ -24689,7 +24675,7 @@ msgstr "La tua immagine di copertina non è stata sostituita: una segnalazione �
 msgid "Your profile picture was not replaced: a report about it is still open. Open the case to remove the picture or to say that it is yours."
 msgstr "La tua immagine del profilo non è stata sostituita: una segnalazione è ancora aperta. Apri il caso per rimuovere l'immagine o per dire che è tua."
 
-#: lib/vutuv_web/components/post_components.ex:2471
+#: lib/vutuv_web/components/post_components.ex:2476
 #, elixir-autogen, elixir-format
 msgid "Fetching the answers from the servers that hold them…"
 msgstr "Le risposte vengono recuperate dai server che le ospitano…"
@@ -24704,7 +24690,7 @@ msgstr "Non è stato possibile recuperare tutte le risposte. Le altre sono sul s
 msgid "Nothing here we are allowed to show you."
 msgstr "Qui non c'è nulla che possiamo mostrarti."
 
-#: lib/vutuv_web/components/post_components.ex:2490
+#: lib/vutuv_web/components/post_components.ex:2495
 #, elixir-autogen, elixir-format
 msgid "Show more answers"
 msgstr "Mostra altre risposte"
@@ -24747,7 +24733,7 @@ msgstr ""
 "Grazie per la segnalazione. I nostri moderatori sono stati avvisati ed "
 "esamineranno questa immagine."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:245
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:255
 #, elixir-autogen, elixir-format
 msgid "This picture is still on the profile: only a copyright notice takes one offline before a ruling. Upholding the case deletes it, the private original included."
 msgstr ""
@@ -24805,7 +24791,7 @@ msgstr "Dichiaro in buona fede che quanto descrivo qui è vero e che questo util
 msgid "Is content published here yours, or does it break the law? You can tell us without an account."
 msgstr "Un contenuto pubblicato qui è Suo, oppure viola la legge? Può segnalarcelo senza un account."
 
-#: lib/vutuv/notifications/emailer.ex:1250
+#: lib/vutuv/notifications/emailer.ex:1284
 #, elixir-autogen, elixir-format
 msgid "Moderation: something was reported"
 msgstr "Moderazione: un contenuto è stato segnalato"
@@ -24830,7 +24816,7 @@ msgstr "I nostri amministratori vedono il Suo nome e il Suo indirizzo per poterL
 msgid "Outside reporter confirmed their address"
 msgstr "Il segnalante esterno ha confermato il proprio indirizzo"
 
-#: lib/vutuv/notifications/emailer.ex:1166
+#: lib/vutuv/notifications/emailer.ex:1200
 #: lib/vutuv_web/templates/public_report/sent.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Please confirm your report"
@@ -24877,7 +24863,7 @@ msgstr "Questo indirizzo non appartiene a questo sito. Possiamo intervenire solo
 msgid "The post, picture, video, profile, page or job posting you are reporting. Copy it out of your browser's address bar."
 msgstr "Il post, l'immagine, il video, il profilo, la pagina o l'annuncio di lavoro che sta segnalando. Copi l'indirizzo dalla barra del Suo browser."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:407
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "The report by %{email} was a deliberate weapon (that address loses our trust)"
 msgstr "La segnalazione di %{email} era un'arma deliberata (quell'indirizzo perde la nostra fiducia)"
@@ -25025,7 +25011,7 @@ msgstr "Una persona ha letto la Sua segnalazione e le ha dato ragione. Grazie."
 msgid "Report decision"
 msgstr "Decisione sulla segnalazione"
 
-#: lib/vutuv/notifications/emailer.ex:1060
+#: lib/vutuv/notifications/emailer.ex:1082
 #, elixir-autogen, elixir-format
 msgid "The content you reported was deleted"
 msgstr "Il contenuto che ha segnalato è stato cancellato"
@@ -25040,17 +25026,112 @@ msgstr "Il contenuto che ha segnalato è stato cancellato; il caso è chiuso."
 msgid "The owner revised the content you reported; it is visible again."
 msgstr "Il proprietario ha corretto il contenuto che ha segnalato; è di nuovo visibile."
 
-#: lib/vutuv/notifications/emailer.ex:1063
+#: lib/vutuv/notifications/emailer.ex:1085
 #, elixir-autogen, elixir-format
 msgid "Your report was not upheld"
 msgstr "Non abbiamo dato ragione alla Sua segnalazione"
 
-#: lib/vutuv/notifications/emailer.ex:1062
+#: lib/vutuv/notifications/emailer.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Your report was upheld"
 msgstr "Abbiamo dato ragione alla Sua segnalazione"
 
-#: lib/vutuv_web/views/page_html.ex:62
+#: lib/vutuv_web/views/page_html.ex:59
 #, elixir-autogen, elixir-format
 msgid "Easy LinkedIn profile import."
 msgstr "Importazione del profilo LinkedIn semplice."
+
+#: lib/vutuv_web/templates/moderation_case/show.html.heex:26
+#, elixir-autogen, elixir-format
+msgid "No person made this decision: a report from somebody with a good record hides the reported content automatically, the moment it arrives."
+msgstr "Questa decisione non l'ha presa nessuna persona: la segnalazione di una persona affidabile nasconde il contenuto segnalato automaticamente, nel momento in cui arriva."
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:400
+#, elixir-autogen, elixir-format
+msgid "The report is justified. The content becomes visible again - the consequence here is the strike (warn, suspend, deactivate)."
+msgstr "La segnalazione è fondata. Il contenuto torna visibile; qui la conseguenza è il richiamo (avvertimento, sospensione, disattivazione)."
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:404
+#, elixir-autogen, elixir-format
+msgid "The report is justified. The content is not hidden and upholding does not hide it; the owner gets a strike (warn, suspend, deactivate)."
+msgstr "La segnalazione è fondata. Il contenuto non è nascosto e accogliere il caso non lo nasconde; il proprietario riceve un richiamo (avvertimento, sospensione, disattivazione)."
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:392
+#, elixir-autogen, elixir-format
+msgid "The report is justified. The reported picture is deleted, the private original included, and the owner gets a strike (warn, suspend, deactivate)."
+msgstr "La segnalazione è fondata. L'immagine segnalata viene eliminata, originale privato compreso, e il proprietario riceve un richiamo (avvertimento, sospensione, disattivazione)."
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:251
+#, elixir-autogen, elixir-format
+msgid "This picture is still on the profile: the address behind the copyright notice is not confirmed yet, so nothing has been hidden. Upholding the case deletes it, the private original included."
+msgstr "L'immagine è ancora sul profilo: l'indirizzo dietro la segnalazione per violazione del diritto d'autore non è ancora confermato, quindi non è stato nascosto nulla. Se il caso viene accolto, l'immagine viene eliminata, originale privato compreso."
+
+#: lib/vutuv_web/views/report_html.ex:82
+#, elixir-autogen, elixir-format
+msgid "somebody reported one of your job postings on vutuv."
+msgstr "qualcuno ha segnalato un Suo annuncio di lavoro su vutuv."
+
+#: lib/vutuv_web/views/report_html.ex:85
+#, elixir-autogen, elixir-format
+msgid "somebody reported one of your pages on vutuv."
+msgstr "qualcuno ha segnalato una Sua pagina su vutuv."
+
+#: lib/vutuv_web/views/report_html.ex:76
+#, elixir-autogen, elixir-format
+msgid "somebody reported one of your pictures on vutuv."
+msgstr "qualcuno ha segnalato una Sua immagine su vutuv."
+
+#: lib/vutuv_web/views/report_html.ex:73
+#, elixir-autogen, elixir-format
+msgid "somebody reported one of your posts on vutuv."
+msgstr "qualcuno ha segnalato un Suo contributo su vutuv."
+
+#: lib/vutuv_web/views/report_html.ex:79
+#, elixir-autogen, elixir-format
+msgid "somebody reported one of your private messages on vutuv."
+msgstr "qualcuno ha segnalato un Suo messaggio privato su vutuv."
+
+#: lib/vutuv_web/views/report_html.ex:91
+#, elixir-autogen, elixir-format
+msgid "somebody reported something of yours on vutuv."
+msgstr "qualcuno ha segnalato un Suo contenuto su vutuv."
+
+#: lib/vutuv_web/views/report_html.ex:88
+#, elixir-autogen, elixir-format
+msgid "somebody reported your profile on vutuv."
+msgstr "qualcuno ha segnalato il Suo profilo su vutuv."
+
+#: lib/vutuv_web/views/report_html.ex:105
+#, elixir-autogen, elixir-format
+msgid "A report from a member in good standing hides the reported content automatically, the moment it arrives."
+msgstr "La segnalazione di un membro affidabile nasconde il contenuto segnalato automaticamente, nel momento in cui arriva."
+
+#: lib/vutuv_web/views/report_html.ex:111
+#, elixir-autogen, elixir-format
+msgid "A report from somebody with a good record hides the reported content automatically, the moment it arrives."
+msgstr "La segnalazione di una persona affidabile nasconde il contenuto segnalato automaticamente, nel momento in cui arriva."
+
+#: lib/vutuv_web/views/moderation_case_html.ex:32
+#, elixir-autogen, elixir-format
+msgid "An admin confirmed the report."
+msgstr "Un amministratore ha confermato la segnalazione."
+
+#: lib/vutuv_web/views/moderation_case_html.ex:33
+#, elixir-autogen, elixir-format
+msgid "An admin dismissed the report."
+msgstr "Un amministratore ha respinto la segnalazione."
+
+#: lib/vutuv_web/views/moderation_case_html.ex:40
+#, elixir-autogen, elixir-format
+msgid "The content is deleted."
+msgstr "Il contenuto è stato eliminato."
+
+#: lib/vutuv_web/views/moderation_case_html.ex:42
+#, elixir-autogen, elixir-format
+msgid "The content is visible again."
+msgstr "Il contenuto è di nuovo visibile."
+
+#: lib/vutuv_web/views/moderation_case_html.ex:41
+#, elixir-autogen, elixir-format
+msgid "The content stays hidden."
+msgstr "Il contenuto resta nascosto."

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -2862,7 +2862,7 @@ msgstr "Solo testo"
 msgid "This post is for the connections of %{name}"
 msgstr "Questo post è per i collegamenti di %{name}"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:126
+#: lib/vutuv_web/views/admin/moderation_html.ex:127
 #: lib/vutuv_web/views/user_html.ex:536
 #, elixir-autogen, elixir-format
 msgid "connection"
@@ -3633,7 +3633,7 @@ msgstr ""
 "Ha esaurito tutte le %{limit} modifiche del nome utente degli ultimi %{days}"
 " giorni."
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:127
+#: lib/vutuv_web/views/admin/moderation_html.ex:128
 #, elixir-autogen, elixir-format
 msgid "%{count} follows"
 msgstr "%{count} follow"
@@ -3670,7 +3670,7 @@ msgstr "Contenuto bloccato"
 msgid "Decision"
 msgstr "Decisione"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:79
+#: lib/vutuv_web/views/admin/moderation_html.ex:80
 #, elixir-autogen, elixir-format
 msgid "Escalated - the 72h deadline passed"
 msgstr "Inoltrato: sono passate le 72 ore"
@@ -3727,12 +3727,12 @@ msgstr "Segnalazione inviata"
 msgid "Report protection"
 msgstr "Protezione dopo la segnalazione"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:81
+#: lib/vutuv_web/views/admin/moderation_html.ex:82
 #, elixir-autogen, elixir-format
 msgid "Report rejected"
 msgstr "Segnalazione respinta"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:80
+#: lib/vutuv_web/views/admin/moderation_html.ex:81
 #, elixir-autogen, elixir-format
 msgid "Report upheld"
 msgstr "Segnalazione accolta"
@@ -3769,7 +3769,7 @@ msgstr "Chiuso con una modifica"
 msgid "Settled by deletion"
 msgstr "Chiuso con l'eliminazione"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:83
+#: lib/vutuv_web/views/admin/moderation_html.ex:84
 #, elixir-autogen, elixir-format
 msgid "Strike issued"
 msgstr "Richiamo assegnato"
@@ -3813,22 +3813,22 @@ msgstr ""
 "contatto in nessuna delle due direzioni. Se i nostri amministratori "
 "riterranno la segnalazione infondata, la sospensione verrà annullata."
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:101
+#: lib/vutuv_web/views/admin/moderation_html.ex:102
 #, elixir-autogen, elixir-format
 msgid "for the owner"
 msgstr "per il proprietario"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:102
+#: lib/vutuv_web/views/admin/moderation_html.ex:103
 #, elixir-autogen, elixir-format
 msgid "for the reporter"
 msgstr "per il segnalante"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:106
+#: lib/vutuv_web/views/admin/moderation_html.ex:107
 #, elixir-autogen, elixir-format
 msgid "level %{level}, %{role}"
 msgstr "livello %{level}, %{role}"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:128
+#: lib/vutuv_web/views/admin/moderation_html.ex:129
 #, elixir-autogen, elixir-format
 msgid "messages"
 msgstr "messaggi"
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Case %{id}, captured %{at} UTC"
 msgstr "Caso %{id}, acquisito il %{at} UTC"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:84
+#: lib/vutuv_web/views/admin/moderation_html.ex:85
 #, elixir-autogen, elixir-format
 msgid "Evidence screenshot captured"
 msgstr "Screenshot di prova acquisito"
@@ -10190,7 +10190,7 @@ msgstr "Cerchi i tag"
 msgid "name or slug"
 msgstr "nome o slug"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:121
+#: lib/vutuv_web/views/admin/moderation_html.ex:122
 #, elixir-autogen, elixir-format
 msgid "%{action} (%{reason})"
 msgstr "%{action} (%{reason})"
@@ -10213,7 +10213,7 @@ msgstr ""
 msgid "Account deleted."
 msgstr "Account eliminato."
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:82
+#: lib/vutuv_web/views/admin/moderation_html.ex:83
 #, elixir-autogen, elixir-format
 msgid "Account removed"
 msgstr "Account rimosso"
@@ -10291,12 +10291,12 @@ msgstr ""
 "esamineranno questo account."
 
 #: lib/vutuv_web/views/admin/account_html.ex:78
-#: lib/vutuv_web/views/admin/moderation_html.ex:114
+#: lib/vutuv_web/views/admin/moderation_html.ex:115
 #, elixir-autogen, elixir-format
 msgid "deactivated"
 msgstr "disattivato"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:115
+#: lib/vutuv_web/views/admin/moderation_html.ex:116
 #, elixir-autogen, elixir-format
 msgid "deleted"
 msgstr "eliminato"
@@ -24811,7 +24811,7 @@ msgstr "Ancora un clic e la Sua segnalazione arriva ai nostri amministratori. A 
 msgid "Our admins see your name and address so they can come back to you. The owner of the reported content never does."
 msgstr "I nostri amministratori vedono il Suo nome e il Suo indirizzo per poterLa ricontattare. Chi ha pubblicato il contenuto segnalato non li vede mai."
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:86
+#: lib/vutuv_web/views/admin/moderation_html.ex:87
 #, elixir-autogen, elixir-format
 msgid "Outside reporter confirmed their address"
 msgstr "Il segnalante esterno ha confermato il proprio indirizzo"
@@ -24833,7 +24833,7 @@ msgstr "Segnalazione confermata"
 msgid "Report content on this site"
 msgstr "Segnalare un contenuto di questo sito"
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:85
+#: lib/vutuv_web/views/admin/moderation_html.ex:86
 #, elixir-autogen, elixir-format
 msgid "Report filed from outside"
 msgstr "Segnalazione ricevuta dall'esterno"
@@ -24959,7 +24959,7 @@ msgstr "Profilo"
 msgid "A confirmation link is good for one week. Yours has run out, so your report never reached our admins and nothing about the reported content changed."
 msgstr "Un link di conferma vale una settimana. Il Suo è scaduto, quindi la Sua segnalazione non è mai arrivata ai nostri amministratori e nulla è cambiato per il contenuto segnalato."
 
-#: lib/vutuv_web/views/admin/moderation_html.ex:89
+#: lib/vutuv_web/views/admin/moderation_html.ex:90
 #, elixir-autogen, elixir-format
 msgid "Report dropped: the address was never confirmed"
 msgstr "Segnalazione scartata: l'indirizzo non è mai stato confermato"
@@ -25135,3 +25135,8 @@ msgstr "Il contenuto è di nuovo visibile."
 #, elixir-autogen, elixir-format
 msgid "The content stays hidden."
 msgstr "Il contenuto resta nascosto."
+
+#: lib/vutuv_web/views/admin/moderation_html.ex:79
+#, elixir-autogen, elixir-format
+msgid "Owner replaced the content"
+msgstr "Il proprietario ha sostituito il contenuto"

--- a/test/vutuv/moderation_image_takedown_test.exs
+++ b/test/vutuv/moderation_image_takedown_test.exs
@@ -309,8 +309,11 @@ defmodule Vutuv.ModerationImageTakedownTest do
 
       # And the case is settled with them: the reported bytes are gone, so
       # leaving it open would point an admin's ruling at a picture nobody
-      # reported.
-      assert Repo.get!(Moderation.Case, case_record.id).status == "resolved_deleted"
+      # reported. As a **revision**, not a deletion (issue #2067): the row keeps
+      # its id and a picture the reporter can still see stands in its place, so
+      # closing it as `resolved_deleted` put "was deleted" in their notice's
+      # subject and "still visible" in its body.
+      assert Repo.get!(Moderation.Case, case_record.id).status == "resolved_edited"
     end
 
     # Issue #2035: the settle above is earned by the bytes changing, not by an
@@ -349,7 +352,7 @@ defmodule Vutuv.ModerationImageTakedownTest do
         })
 
       assert cropped.avatar_fingerprint != owner.avatar_fingerprint
-      assert Repo.get!(Moderation.Case, case_record.id).status == "resolved_deleted"
+      assert Repo.get!(Moderation.Case, case_record.id).status == "resolved_edited"
     end
   end
 

--- a/test/vutuv/moderation_notice_wording_test.exs
+++ b/test/vutuv/moderation_notice_wording_test.exs
@@ -1,0 +1,385 @@
+defmodule Vutuv.ModerationNoticeWordingTest do
+  @moduledoc """
+  What the takedown chain actually says, checked against the German render a
+  real visitor gets (issue #2067).
+
+  Every claim here was read by a person in a browser before it was written
+  down, and each one was a sentence that was simply not true: a frozen profile
+  picture announced as a post, a member invented behind an anonymous notice,
+  the house rules cited for a copyright ruling, a reporter told only that "the
+  necessary steps" were taken, an admin told a picture is visible because no
+  copyright notice was filed on a copyright case, and a decision that arrives
+  in the owner's notification list stamped with the hour the report came in.
+
+  Not async: several tests flip `:uploads_dir_prefix` for a real picture.
+  """
+
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.WebPushHelpers, only: [put_config: 2]
+
+  alias Vutuv.{Accounts, Activity, Moderation}
+  alias Vutuv.Moderation.{Case, Notifier, Report}
+  alias Vutuv.Notifications.Emailer
+
+  @note "Das Foto ist meins, das Original steht auf example.com/hafen.jpg"
+
+  setup do
+    owner = insert(:activated_user, locale: "de")
+    insert(:email, user: owner, value: "eigner@example.com")
+    admin = insert(:activated_user, admin?: true)
+    insert(:email, user: admin)
+
+    {:ok, owner: owner, admin: admin}
+  end
+
+  defp member_reporter do
+    reporter = insert(:activated_user)
+    insert(:email, user: reporter)
+    reporter
+  end
+
+  defp uploads_dir do
+    tmp =
+      Path.join(System.tmp_dir!(), "vutuv_notice_wording_#{System.unique_integer([:positive])}")
+
+    put_config(:uploads_dir_prefix, tmp)
+    on_exit(fn -> File.rm_rf(tmp) end)
+    tmp
+  end
+
+  defp jpeg_upload do
+    src = Path.join(System.tmp_dir!(), "notice_src_#{System.unique_integer([:positive])}.jpg")
+    {:ok, img} = Image.new(120, 90, color: [10, 120, 200])
+    {:ok, _} = Image.write(img, src)
+    on_exit(fn -> File.rm(src) end)
+    %Plug.Upload{filename: "selfie.jpg", path: src, content_type: "image/jpeg"}
+  end
+
+  # The member's avatar as its own reportable row (issue #2012).
+  defp avatar_image(owner) do
+    uploads_dir()
+    {:ok, owner} = Accounts.update_user(owner, %{avatar: jpeg_upload()})
+    {owner, Vutuv.Images.member_image(owner, "avatar")}
+  end
+
+  defp copyright_notice(attrs \\ %{}) do
+    Map.merge(
+      %{"category" => "copyright", "note" => @note, "good_faith?" => "true"},
+      attrs
+    )
+  end
+
+  defp outside_notice(attrs \\ %{}) do
+    copyright_notice(
+      Map.merge(
+        %{"reporter_name" => "Rita Holder", "reporter_email" => "rita@example.com"},
+        attrs
+      )
+    )
+  end
+
+  defp mail(fragment) do
+    Enum.find(flush_emails(), &(&1.subject =~ fragment)) ||
+      flunk("no email whose subject matches #{inspect(fragment)}")
+  end
+
+  # Both halves of one mail, whitespace flattened. The HTML body wraps a
+  # sentence over several source lines, so a raw `=~` on a sentence only ever
+  # matches the text half — which is how a wrong HTML body would slip past.
+  defp bodies(email), do: Enum.map([email.text_body, email.html_body], &flatten/1)
+
+  defp flatten(body), do: body |> String.replace(~r/\s+/u, " ") |> String.trim()
+
+  # Move a case's arrival into the past, so a ruling now is a different moment.
+  defp backdate!(%Case{id: id}, seconds) do
+    then = NaiveDateTime.add(NaiveDateTime.utc_now(:second), -seconds)
+
+    Repo.update_all(
+      from(c in Case, where: c.id == ^id),
+      set: [inserted_at: then, owner_deadline_at: then, updated_at: then]
+    )
+  end
+
+  describe "the mail names what was actually reported (1)" do
+    test "a frozen profile picture is a picture, never a post", %{owner: owner} do
+      {_owner, image} = avatar_image(owner)
+      reporter = member_reporter()
+
+      {:ok, %Case{status: "pending_owner"}} =
+        Moderation.report_content(reporter, image, copyright_notice())
+
+      for body <- bodies(mail("gemeldet")) do
+        assert body =~ "eines Ihrer Bilder auf vutuv wurde gemeldet"
+        refute body =~ "Beiträge"
+        refute body =~ "Beitrag"
+      end
+    end
+
+    test "a reported post still reads as a post", %{owner: owner} do
+      post = insert(:post, user: owner)
+      reporter = member_reporter()
+
+      {:ok, %Case{status: "pending_owner"}} =
+        Moderation.report_content(reporter, post, %{"category" => "bullying"})
+
+      for body <- bodies(mail("gemeldet")) do
+        assert body =~ "einer Ihrer Beiträge auf vutuv wurde gemeldet"
+      end
+    end
+
+    test "a reported private message reads as a message", %{owner: owner} do
+      reporter = member_reporter()
+      conversation = insert_conversation_between(owner, reporter)
+      message = insert(:message, conversation: conversation, sender: owner)
+
+      {:ok, %Case{}} = Moderation.report_content(reporter, message, %{"category" => "bullying"})
+
+      for body <- bodies(mail("gemeldet")) do
+        assert body =~ "eine Ihrer privaten Nachrichten auf vutuv wurde gemeldet"
+      end
+    end
+  end
+
+  describe "an anonymous notice does not invent a member (2)" do
+    test "the frozen mail says a person, not a member", %{owner: owner} do
+      {_owner, image} = avatar_image(owner)
+
+      {:ok, _case, _report, token} = Moderation.file_public_notice(image, outside_notice(), "de")
+      flush_emails()
+      {:ok, :confirmed, _report} = Moderation.confirm_public_notice(token)
+
+      for body <- bodies(mail("gemeldet")) do
+        assert body =~ "Die Meldung einer Person mit guter Bilanz"
+        refute body =~ "Mitglied"
+      end
+    end
+
+    test "a member's report keeps the member wording", %{owner: owner} do
+      post = insert(:post, user: owner)
+      reporter = member_reporter()
+
+      {:ok, %Case{}} = Moderation.report_content(reporter, post, %{"category" => "bullying"})
+
+      for body <- bodies(mail("gemeldet")) do
+        assert body =~ "Die Meldung eines Mitglieds mit guter Bilanz"
+      end
+    end
+
+    test "the notice map says which of the two it was", %{owner: owner} do
+      post = insert(:post, user: owner)
+      reporter = member_reporter()
+      {:ok, case_record} = Moderation.report_content(reporter, post, %{"category" => "bullying"})
+      assert Moderation.owner_notice(case_record).from_member?
+
+      {_owner, image} = avatar_image(owner)
+      {:ok, _case, _report, token} = Moderation.file_public_notice(image, outside_notice(), "de")
+      {:ok, :confirmed, report} = Moderation.confirm_public_notice(token)
+      refute Moderation.owner_notice(Repo.get!(Case, report.case_id)).from_member?
+    end
+  end
+
+  describe "the strike names the ground the case page named (3)" do
+    test "an upheld copyright case does not cite the house rules", %{
+      owner: owner,
+      admin: admin
+    } do
+      post = insert(:post, user: owner)
+      reporter = member_reporter()
+
+      {:ok, case_record} = Moderation.report_content(reporter, post, copyright_notice())
+      flush_emails()
+      {:ok, _} = Moderation.uphold_case(case_record, admin)
+
+      for body <- bodies(mail("Verwarnung")) do
+        assert body =~ "Urheberrecht"
+        refute body =~ "Community-Richtlinien"
+      end
+    end
+
+    test "an upheld house-rule case still cites the house rules", %{owner: owner, admin: admin} do
+      post = insert(:post, user: owner)
+      reporter = member_reporter()
+
+      {:ok, case_record} = Moderation.report_content(reporter, post, %{"category" => "bullying"})
+      flush_emails()
+      {:ok, _} = Moderation.uphold_case(case_record, admin)
+
+      for body <- bodies(mail("Verwarnung")) do
+        assert body =~ "Community-Richtlinien"
+      end
+    end
+  end
+
+  describe "the reporter hears what happened to the content (4)" do
+    test "an upheld picture case says the picture is gone", %{owner: owner, admin: admin} do
+      {_owner, image} = avatar_image(owner)
+      reporter = insert(:activated_user, locale: "de")
+      insert(:email, user: reporter, value: "melder@example.com")
+
+      {:ok, case_record} = Moderation.report_content(reporter, image, copyright_notice())
+      flush_emails()
+      {:ok, _} = Moderation.uphold_case(case_record, admin)
+
+      for body <- bodies(mail("Meldung")) do
+        assert body =~ "Der gemeldete Inhalt ist gelöscht."
+        refute body =~ "Wir haben die nötigen Schritte unternommen."
+      end
+    end
+
+    test "an upheld post case says it is not visible any more", %{owner: owner, admin: admin} do
+      post = insert(:post, user: owner)
+      reporter = insert(:activated_user, locale: "de")
+      insert(:email, user: reporter, value: "melder@example.com")
+
+      {:ok, case_record} = Moderation.report_content(reporter, post, %{"category" => "bullying"})
+      flush_emails()
+      {:ok, _} = Moderation.uphold_case(case_record, admin)
+
+      for body <- bodies(mail("Meldung")) do
+        assert body =~ "Der gemeldete Inhalt ist auf vutuv nicht mehr zu sehen."
+      end
+    end
+
+    test "a rejected case says the content is still there", %{owner: owner, admin: admin} do
+      post = insert(:post, user: owner)
+      reporter = insert(:activated_user, locale: "de")
+      insert(:email, user: reporter, value: "melder@example.com")
+
+      {:ok, case_record} = Moderation.report_content(reporter, post, %{"category" => "bullying"})
+      flush_emails()
+      {:ok, _} = Moderation.reject_case(case_record, admin)
+
+      for body <- bodies(mail("Meldung")) do
+        assert body =~ "Der gemeldete Inhalt ist auf vutuv weiterhin zu sehen."
+      end
+    end
+
+    test "the outside notifier is told the same thing", %{owner: owner, admin: admin} do
+      {_owner, image} = avatar_image(owner)
+
+      {:ok, _case, report, token} = Moderation.file_public_notice(image, outside_notice(), "de")
+      {:ok, :confirmed, _report} = Moderation.confirm_public_notice(token)
+      flush_emails()
+
+      {:ok, _} = Moderation.uphold_case(Repo.get!(Case, report.case_id), admin)
+
+      email = mail("Meldung")
+      assert Enum.any?(email.to, fn {_name, address} -> address == "rita@example.com" end)
+
+      for body <- bodies(email) do
+        assert body =~ "Der gemeldete Inhalt ist gelöscht."
+      end
+    end
+
+    test "the fate is measured after the ruling settled the content", %{
+      owner: owner,
+      admin: admin
+    } do
+      {_owner, image} = avatar_image(owner)
+      reporter = member_reporter()
+      {:ok, case_record} = Moderation.report_content(reporter, image, copyright_notice())
+
+      assert Moderation.reported_content_fate(case_record) == :hidden
+      {:ok, upheld} = Moderation.uphold_case(case_record, admin)
+      assert Moderation.reported_content_fate(upheld) == :removed
+    end
+  end
+
+  describe "the admin panel says why the picture is still there (5)" do
+    test "an unconfirmed copyright notice is the reason, not the category", %{owner: owner} do
+      {_owner, image} = avatar_image(owner)
+      {:ok, case_record, _report, _token} = Moderation.file_public_notice(image, outside_notice())
+
+      case_record = Repo.preload(case_record, :reports)
+      assert Moderation.pending_copyright_notice?(case_record)
+      refute Moderation.copyright_case?(case_record)
+    end
+
+    test "upholding an unfrozen picture case deletes rather than hides", %{owner: owner} do
+      {_owner, image} = avatar_image(owner)
+      reporter = member_reporter()
+
+      {:ok, case_record} = Moderation.report_content(reporter, image, %{"category" => "family"})
+      assert case_record.status == "flagged"
+
+      assert Moderation.uphold_content_effect(case_record, Repo.reload!(image)) == :deleted
+    end
+
+    test "a frozen post case stays hidden, an unfrozen one does not", %{owner: owner} do
+      post = insert(:post, user: owner)
+      reporter = member_reporter()
+      {:ok, case_record} = Moderation.report_content(reporter, post, %{"category" => "bullying"})
+
+      assert Moderation.uphold_content_effect(case_record, Repo.reload!(post)) == :stays_hidden
+
+      other = insert(:post, user: owner)
+      open = %Case{content_type: "post", content_id: other.id, status: "flagged"}
+      assert Moderation.uphold_content_effect(open, other) == :untouched
+    end
+  end
+
+  describe "the ruling rises in the owner's notifications (6)" do
+    test "the entry is stamped with the decision, not with the report", %{
+      owner: owner,
+      admin: admin
+    } do
+      post = insert(:post, user: owner)
+      reporter = member_reporter()
+      {:ok, case_record} = Moderation.report_content(reporter, post, %{"category" => "bullying"})
+
+      # The report arrived two days ago; the ruling is now.
+      backdate!(case_record, 2 * 86_400)
+
+      {:ok, rejected} = Moderation.reject_case(Repo.get!(Case, case_record.id), admin)
+
+      %{entries: entries} = Activity.notifications_page(owner.id)
+      entry = Enum.find(entries, &(&1.kind == "moderation")) || flunk("no moderation entry")
+
+      assert NaiveDateTime.compare(entry.at, rejected.resolved_at) == :eq
+    end
+
+    test "a decision after the member last read is unread", %{owner: owner, admin: admin} do
+      post = insert(:post, user: owner)
+      reporter = member_reporter()
+      {:ok, case_record} = Moderation.report_content(reporter, post, %{"category" => "bullying"})
+
+      backdate!(case_record, 2 * 86_400)
+
+      # The member read their notifications the day after the report and a day
+      # before the ruling: the freeze is old news, the ruling is not.
+      read_at = NaiveDateTime.add(NaiveDateTime.utc_now(:second), -86_400)
+      owner = Repo.update!(Ecto.Changeset.change(owner, notifications_read_at: read_at))
+      assert Activity.unread_notification_count(owner) == 0
+
+      {:ok, _} = Moderation.reject_case(Repo.get!(Case, case_record.id), admin)
+
+      assert Activity.unread_notification_count(owner) == 1
+    end
+
+    # The row is one per case, rewritten in place, and `Activity.dismiss_ref/1`
+    # reads its `source_id` back out of the rendered id — so retiming the row
+    # must not retag it. Nothing else in the suite acknowledges a moderation
+    # row, so a changed id would have gone out silently: the click would settle
+    # nothing and the badge would stand.
+    test "the member can still tick the row off, and the badge drops", %{
+      owner: owner,
+      admin: admin
+    } do
+      post = insert(:post, user: owner)
+      reporter = member_reporter()
+      {:ok, case_record} = Moderation.report_content(reporter, post, %{"category" => "bullying"})
+      {:ok, _} = Moderation.reject_case(Repo.get!(Case, case_record.id), admin)
+
+      %{entries: entries} = Activity.notifications_page(owner.id)
+      entry = Enum.find(entries, &(&1.kind == "moderation")) || flunk("no moderation entry")
+
+      assert Activity.unread_notification_count(owner) == 1
+      assert %{kind: kind, source_id: source_id} = Activity.dismiss_ref(entry)
+      assert source_id == case_record.id
+
+      Activity.mark_notification_seen(owner.id, kind, source_id)
+      assert Activity.unread_notification_count(owner) == 0
+    end
+  end
+end

--- a/test/vutuv/moderation_notice_wording_test.exs
+++ b/test/vutuv/moderation_notice_wording_test.exs
@@ -39,6 +39,33 @@ defmodule Vutuv.ModerationNoticeWordingTest do
     reporter
   end
 
+  defp de_reporter do
+    reporter = insert(:activated_user, locale: "de")
+    insert(:email, user: reporter, value: "melder@example.com")
+    reporter
+  end
+
+  # One closing path, checked the way a reader meets it: the sentence about the
+  # content, and that it does not contradict the subject its ending produced.
+  defp assert_notice(address, outcome, fate_sentence) do
+    email = mail_to(address)
+
+    for body <- bodies(email) do
+      assert body =~ fate_sentence,
+             "the notice does not say #{inspect(fate_sentence)}"
+    end
+
+    fate =
+      case fate_sentence do
+        "Der gemeldete Inhalt ist gelöscht." -> :removed
+        "Der gemeldete Inhalt ist auf vutuv nicht mehr zu sehen." -> :hidden
+        "Der gemeldete Inhalt ist auf vutuv weiterhin zu sehen." -> :visible
+      end
+
+    assert Moderation.consistent_outcome?(outcome, fate),
+           "the subject for #{outcome} and the body's #{inspect(fate)} disagree"
+  end
+
   defp uploads_dir do
     tmp =
       Path.join(System.tmp_dir!(), "vutuv_notice_wording_#{System.unique_integer([:positive])}")
@@ -48,9 +75,11 @@ defmodule Vutuv.ModerationNoticeWordingTest do
     tmp
   end
 
-  defp jpeg_upload do
+  # The colour is the fingerprint: a replacement only settles a case when the
+  # bytes really differ (issue #2035).
+  defp jpeg_upload(color \\ [10, 120, 200]) do
     src = Path.join(System.tmp_dir!(), "notice_src_#{System.unique_integer([:positive])}.jpg")
-    {:ok, img} = Image.new(120, 90, color: [10, 120, 200])
+    {:ok, img} = Image.new(120, 90, color: color)
     {:ok, _} = Image.write(img, src)
     on_exit(fn -> File.rm(src) end)
     %Plug.Upload{filename: "selfie.jpg", path: src, content_type: "image/jpeg"}
@@ -82,6 +111,16 @@ defmodule Vutuv.ModerationNoticeWordingTest do
   defp mail(fragment) do
     Enum.find(flush_emails(), &(&1.subject =~ fragment)) ||
       flunk("no email whose subject matches #{inspect(fragment)}")
+  end
+
+  # By recipient, not by subject: the four outcome subjects have no word in
+  # common (a deleted content's subject never says "Meldung"), and picking the
+  # mail by what it is expected to say would hide the very disagreement these
+  # tests are about.
+  defp mail_to(address) do
+    Enum.find(flush_emails(), fn email ->
+      Enum.any?(email.to, fn {_name, to} -> to == address end)
+    end) || flunk("no email addressed to #{address}")
   end
 
   # Both halves of one mail, whitespace flattened. The HTML body wraps a
@@ -283,6 +322,156 @@ defmodule Vutuv.ModerationNoticeWordingTest do
       assert Moderation.reported_content_fate(case_record) == :hidden
       {:ok, upheld} = Moderation.uphold_case(case_record, admin)
       assert Moderation.reported_content_fate(upheld) == :removed
+    end
+  end
+
+  # The two paths that close a case where the content cannot simply be looked
+  # at afterwards: one erases the row that would answer, the other leaves a row
+  # standing whose bytes are somebody else's. Measuring blind said the friendly
+  # thing on both, which is worse than the silence they had before (issue
+  # #2067, first repair round).
+  describe "a closing path whose content cannot be measured afterwards" do
+    test "deleting the account tells the notifier the content is gone", %{
+      owner: owner,
+      admin: admin
+    } do
+      post = insert(:post, user: owner)
+
+      {:ok, _case, report, token} = Moderation.file_public_notice(post, outside_notice(), "de")
+      {:ok, :confirmed, _report} = Moderation.confirm_public_notice(token)
+      flush_emails()
+
+      {:ok, :deleted} =
+        Moderation.remove_owner(Repo.get!(Case, report.case_id), admin, :delete, "spam")
+
+      for body <- bodies(mail_to("rita@example.com")) do
+        refute body =~ "weiterhin zu sehen",
+               "the account and its post are being deleted, and the rights holder is told " <>
+                 "the content is still on vutuv"
+
+        refute body =~ "nicht mehr zu sehen",
+               "the account and its post are being deleted, and the rights holder is told " <>
+                 "only that the content is hidden"
+
+        assert body =~ "Der gemeldete Inhalt ist gelöscht."
+      end
+    end
+
+    test "replacing a flagged picture reads as revised, not as deleted", %{owner: owner} do
+      {owner, image} = avatar_image(owner)
+      reporter = insert(:activated_user, locale: "de")
+      insert(:email, user: reporter, value: "melder@example.com")
+
+      # A house-rule report on a picture only flags it (issue #2030), so the
+      # owner may still replace it — and since #2035 the row keeps its id.
+      {:ok, %Case{status: "flagged"}} =
+        Moderation.report_content(reporter, image, %{"category" => "family"})
+
+      flush_emails()
+      {:ok, _owner} = Accounts.update_user(owner, %{avatar: jpeg_upload([220, 40, 40])})
+
+      email = mail_to("melder@example.com")
+
+      refute email.subject =~ "gelöscht",
+             "the reported picture was replaced, not deleted, and the subject says deleted"
+
+      for body <- bodies(email) do
+        refute body =~ "Der Besitzer hat den gemeldeten Inhalt gelöscht.",
+               "the reported picture was replaced, not deleted"
+
+        assert body =~ "Der Besitzer hat den gemeldeten Inhalt überarbeitet."
+        assert body =~ "Der gemeldete Inhalt ist auf vutuv weiterhin zu sehen."
+      end
+    end
+
+    # The four closing paths the two describes above do not reach, so all nine
+    # are walked rather than sampled — which is how these two got through:
+    # coverage that follows the states somebody thought of stops at the states
+    # somebody thought of.
+    test "the owner deleting the reported content says it is deleted", %{owner: owner} do
+      post = insert(:post, user: owner)
+      reporter = de_reporter()
+      {:ok, case_record} = Moderation.report_content(reporter, post, %{"category" => "bullying"})
+      flush_emails()
+
+      :ok = Moderation.delete_reported_content(case_record, owner)
+
+      assert_notice("melder@example.com", "removed", "Der gemeldete Inhalt ist gelöscht.")
+    end
+
+    test "the owner editing a reported post says it is visible", %{owner: owner} do
+      post = insert(:post, user: owner)
+      reporter = de_reporter()
+      {:ok, _case} = Moderation.report_content(reporter, post, %{"category" => "bullying"})
+      flush_emails()
+
+      :ok = Moderation.content_edited(Repo.reload!(post))
+
+      assert_notice(
+        "melder@example.com",
+        "revised",
+        "Der gemeldete Inhalt ist auf vutuv weiterhin zu sehen."
+      )
+    end
+
+    test "an upheld profile case says the profile is back", %{owner: owner, admin: admin} do
+      reporter = de_reporter()
+      second = member_reporter()
+
+      {:ok, _case} = Moderation.report_content(reporter, owner, %{"category" => "bullying"})
+      {:ok, case_record} = Moderation.report_content(second, owner, %{"category" => "bullying"})
+      assert case_record.status == "escalated"
+      flush_emails()
+
+      {:ok, _} = Moderation.uphold_case(case_record, admin)
+
+      assert_notice(
+        "melder@example.com",
+        "upheld",
+        "Der gemeldete Inhalt ist auf vutuv weiterhin zu sehen."
+      )
+    end
+
+    test "deactivating the account says the content is not visible", %{
+      owner: owner,
+      admin: admin
+    } do
+      post = insert(:post, user: owner)
+      reporter = de_reporter()
+      {:ok, case_record} = Moderation.report_content(reporter, post, %{"category" => "bullying"})
+      flush_emails()
+
+      {:ok, _} = Moderation.remove_owner(case_record, admin, :deactivate, "spam")
+
+      assert_notice(
+        "melder@example.com",
+        "upheld",
+        "Der gemeldete Inhalt ist auf vutuv nicht mehr zu sehen."
+      )
+    end
+
+    # The invariant that would have caught both above, so a tenth path cannot
+    # ship the contradiction: only two of the four endings make a claim about
+    # the content in their own subject, and each has exactly one fate that
+    # agrees with it.
+    test "no closing path lets the subject and the fate disagree" do
+      for {status, fate} <- [
+            {"resolved_deleted", :removed},
+            {"resolved_edited", :visible}
+          ] do
+        assert Moderation.consistent_outcome?(Case.reporter_outcome(status), fate),
+               "#{status} must end in #{inspect(fate)}"
+      end
+
+      refute Moderation.consistent_outcome?("removed", :visible)
+      refute Moderation.consistent_outcome?("removed", :hidden)
+      refute Moderation.consistent_outcome?("revised", :removed)
+
+      # The two admin rulings claim nothing about the content in their subject,
+      # so every fate is honest beside them.
+      for outcome <- ["upheld", "not_upheld"], fate <- [:removed, :hidden, :visible] do
+        assert Moderation.consistent_outcome?(outcome, fate)
+      end
     end
   end
 

--- a/test/vutuv/moderation_statement_of_reasons_test.exs
+++ b/test/vutuv/moderation_statement_of_reasons_test.exs
@@ -244,7 +244,7 @@ defmodule Vutuv.ModerationStatementOfReasonsTest do
 
       assert squish(email.text_body) =~ "Leave me alone."
       refute squish(email.text_body) =~ "Edit the content"
-      assert squish(email.text_body) =~ "Delete it"
+      assert squish(email.text_body) =~ "Delete the content"
     end
   end
 

--- a/test/vutuv/notifications/emailer_test.exs
+++ b/test/vutuv/notifications/emailer_test.exs
@@ -501,7 +501,9 @@ defmodule Vutuv.Notifications.EmailerTest do
       user = insert(:user, locale: "en")
 
       # A moderation mail that does not invite a reply.
-      assert Emailer.moderation_warning_email(user, "warned@example.com").reply_to == nil
+      assert Emailer.moderation_warning_email(user, "warned@example.com", :community).reply_to ==
+               nil
+
       # A plain transactional mail.
       assert Emailer.login_email(@pin, "login@example.com", user).reply_to == nil
     end
@@ -696,7 +698,7 @@ defmodule Vutuv.Notifications.EmailerTest do
 
     test "a moderation email has the shared HTML chrome" do
       user = insert(:user, locale: "en")
-      html = Emailer.moderation_warning_email(user, "warned@example.com").html_body
+      html = Emailer.moderation_warning_email(user, "warned@example.com", :community).html_body
 
       assert html =~ "vutuv"
       assert html =~ "Wintermeyer Consulting"

--- a/test/vutuv/notifications/mail_class_test.exs
+++ b/test/vutuv/notifications/mail_class_test.exs
@@ -119,7 +119,7 @@ defmodule Vutuv.Notifications.MailClassTest do
     end
 
     test "a dead address stops transactional mail", %{user: user} do
-      assert Emailer.moderation_warning_email(user, "dead@example.com")
+      assert Emailer.moderation_warning_email(user, "dead@example.com", :community)
              |> Emailer.deliver() == :suppressed
     end
 
@@ -317,10 +317,10 @@ defmodule Vutuv.Notifications.MailClassTest do
     do: Emailer.moderation_review_email(user(), @address, moderation_case())
 
   defp build_mail(:moderation_outcome_email),
-    do: Emailer.moderation_outcome_email(user(), @address, "upheld")
+    do: Emailer.moderation_outcome_email(user(), @address, "upheld", :hidden)
 
   defp build_mail(:moderation_warning_email),
-    do: Emailer.moderation_warning_email(user(), @address)
+    do: Emailer.moderation_warning_email(user(), @address, :community)
 
   defp build_mail(:moderation_suspension_email),
     do: Emailer.moderation_suspension_email(user(), @address, ~N[2026-09-01 00:00:00])
@@ -363,7 +363,8 @@ defmodule Vutuv.Notifications.MailClassTest do
       name: "Rita Holder",
       email: @address,
       locale: "de",
-      outcome: "not_upheld"
+      outcome: "not_upheld",
+      fate: :visible
     })
   end
 

--- a/test/vutuv_web/live/admin/moderation_picture_wording_test.exs
+++ b/test/vutuv_web/live/admin/moderation_picture_wording_test.exs
@@ -1,0 +1,118 @@
+defmodule VutuvWeb.Admin.ModerationPictureWordingTest do
+  @moduledoc """
+  What the two case pages say about a reported picture, rendered (issue #2067).
+
+  The three sentences here are decided by helpers in `Vutuv.Moderation` and
+  covered as helpers in `Vutuv.ModerationNoticeWordingTest`; what only a render
+  can show is that the page picks the right one — and each of them was picked
+  wrongly by a page that had no way to ask. The owner's page explained an
+  anonymous notice as a member's report; the admin's page explained a picture
+  that a copyright case had not hidden with "only a copyright notice takes one
+  offline before a ruling", and offered a ruling that "the content stays hidden"
+  on a picture that is not hidden and that upholding deletes.
+
+  German, because that is the language the report was written in
+  (`Accept-Language: de-DE,de`) and because a fuzzy-filled msgid fails no build.
+
+  Not async: flips the global `:uploads_dir_prefix` for a real picture.
+  """
+
+  use VutuvWeb.ConnCase, async: false
+
+  import Vutuv.WebPushHelpers, only: [put_config: 2]
+
+  alias Vutuv.{Accounts, Images, Moderation}
+
+  setup %{conn: conn} do
+    tmp =
+      Path.join(System.tmp_dir!(), "vutuv_picture_wording_#{System.unique_integer([:positive])}")
+
+    put_config(:uploads_dir_prefix, tmp)
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    {admin_conn, _admin} = create_and_login_admin(conn)
+    {owner_conn, owner} = create_and_login_user(conn)
+    {:ok, owner} = Accounts.update_user(owner, %{avatar: jpeg_upload()})
+
+    {:ok,
+     conn: admin_conn,
+     owner_conn: owner_conn,
+     owner: owner,
+     image: Images.member_image(owner, "avatar")}
+  end
+
+  defp jpeg_upload do
+    src = Path.join(System.tmp_dir!(), "wording_src_#{System.unique_integer([:positive])}.jpg")
+    {:ok, img} = Image.new(120, 90, color: [200, 40, 40])
+    {:ok, _} = Image.write(img, src)
+    on_exit(fn -> File.rm(src) end)
+    %Plug.Upload{filename: "selfie.jpg", path: src, content_type: "image/jpeg"}
+  end
+
+  # `recycle/1` first: the login already sent a response on this conn, and a
+  # header cannot be put on a sent one.
+  defp german(conn),
+    do: conn |> recycle() |> put_req_header("accept-language", "de-DE,de;q=0.9")
+
+  defp outside_notice!(content) do
+    {:ok, case_record, _report, token} =
+      Moderation.file_public_notice(content, %{
+        "category" => "copyright",
+        "note" => "Das Foto ist meins.",
+        "good_faith?" => "true",
+        "reporter_name" => "Rita Holder",
+        "reporter_email" => "rita@example.com"
+      })
+
+    {case_record, token}
+  end
+
+  describe "the admin case page on a picture nothing has hidden" do
+    test "names the unconfirmed address, not the category", %{conn: conn, image: image} do
+      {case_record, _token} = outside_notice!(image)
+
+      html =
+        conn |> german() |> get(~p"/admin/moderation/#{case_record.id}") |> html_response(200)
+
+      assert html =~ "Die Adresse hinter der Urheberrechtsmeldung ist noch nicht bestätigt"
+      refute html =~ "Nur eine Meldung wegen Urheberrechts nimmt ein Bild"
+    end
+
+    test "says the ruling deletes rather than hides", %{conn: conn, image: image} do
+      {case_record, _token} = outside_notice!(image)
+
+      html =
+        conn |> german() |> get(~p"/admin/moderation/#{case_record.id}") |> html_response(200)
+
+      assert html =~ "Das gemeldete Bild wird gelöscht, auch das private Original"
+      refute html =~ "Der Inhalt bleibt verborgen und der Besitzer erhält"
+    end
+  end
+
+  describe "the owner's case page" do
+    test "does not invent a member behind an anonymous notice", %{
+      owner_conn: conn,
+      image: image
+    } do
+      {case_record, token} = outside_notice!(image)
+      {:ok, :confirmed, _report} = Moderation.confirm_public_notice(token)
+
+      html =
+        conn |> german() |> get(~p"/moderation/cases/#{case_record.id}") |> html_response(200)
+
+      assert html =~ "Die Meldung einer Person mit guter Bilanz"
+      refute html =~ "Die Meldung eines Mitglieds mit guter Bilanz"
+    end
+
+    test "keeps the member wording for a member's report", %{owner_conn: conn, owner: owner} do
+      reporter = insert_activated_user()
+      post = insert(:post, user: owner)
+      {:ok, case_record} = Moderation.report_content(reporter, post, %{"category" => "bullying"})
+
+      html =
+        conn |> german() |> get(~p"/moderation/cases/#{case_record.id}") |> html_response(200)
+
+      assert html =~ "Die Meldung eines Mitglieds mit guter Bilanz"
+    end
+  end
+end


### PR DESCRIPTION
A member whose profile picture was taken offline was told one of their *posts* was hidden, and went looking through posts that were all still there. The same mail named a "member" behind a notice filed by somebody with no account. The warning after an upheld copyright case cited the house rules, on a case whose own page said this was the law. And the person who reported it was told only that we had "taken the necessary steps".

Each sentence now comes from a fact rather than a template: one whole translated opening per content type (German gender cannot be filled into a placeholder), `from_member?` on `Moderation.owner_notice/1`, `strike_ground/2` for the warning, and a measured `reported_content_fate/1` for the decision notice. Three more from the same walkthrough: the admin case page explains a still-visible picture by the unconfirmed address, says per case what upholding does, and the owner's notification carries the ruling's time so a restoration rises.

Where: `Vutuv.Moderation`, `Vutuv.Moderation.Notifier`, the `moderation_*` mail templates, `/moderation/cases/:id`, `/admin/moderation/:id`.

Closes #2067

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01UGPe7bHVS11M1W7fNehSku

<!-- closing-note #2067 -->
The four sentences a member and a rights holder actually read are true now: the mail names a picture as a picture, does not invent a member behind an anonymous notice, the warning after a copyright ruling names copyright law rather than the house rules, and the reporter is told whether the content is deleted, no longer visible, or still there — measured after the ruling settled it, not derived from the four case endings, because one "upheld" purges a picture, leaves a post frozen and puts a profile back. I folded in the two smaller findings on the same pages, and left the suspension and deactivation letters citing the community guidelines: those rungs are about a ladder spanning several cases, not about the one ground this fix could name.

*An AI agent wrote this text in my name. I know that is problematic.*
