### PR TITLE
The outbox stops counting a post a takedown hid, and three loose ends beside it

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -912,6 +912,17 @@ None of this is a guarantee. Remote deletion is advisory by protocol and always
 will be, so the UI never claims a copy is gone — but every takedown now at least
 asks.
 
+**A frozen post is out of the count as well as out of the collections**
+(issue #2069). `Vutuv.Fediverse.public_post_count/1` and its page twin
+`organization_public_post_count/1` are what the count-only `outbox` reports, and
+they filtered a member's audience denials and nothing else — so an author whose
+only post a takedown had hidden still answered `"totalItems": 1` to every server
+that asked, while the note itself 404ed. It is the one number about a hidden
+post that still left the building: the neighbouring `featured_posts/1` already
+serves the anonymous public view, and NodeInfo's `localPosts` counts through
+`Posts.scope_visible/2`, so the outbox was the one surface that disagreed with
+the rest. Both counts now exclude `posts.frozen_at`.
+
 ## Leaving: 410 Gone, and saying so first
 
 Switching the opt-in off used to make every actor endpoint answer `404`, which

--- a/docs/architecture/moderation.md
+++ b/docs/architecture/moderation.md
@@ -39,13 +39,24 @@ things follow from that.
 
 **It is only accepted complete.** `Report.changeset/3` requires the note (which
 work, where the original can be seen) and a good-faith declaration whenever the
-category is `copyright`. The declaration is a **virtual** field, not a column:
-the changeset refuses the category without it, so a stored copyright report *is*
-the record that it was made, and a column would be a second copy free to drift.
-The check sits in the changeset rather than in the controller, so the Mastodon
-report API cannot file half a notice either (it has no field for the
-declaration, so it cannot file one at all — a client sending that category gets
-a 422).
+category is `copyright`. The check sits in the changeset rather than in the
+controller, so the Mastodon report API cannot file half a notice either (it has
+no field for the declaration, so it cannot file one at all — a client sending
+that category gets a 422).
+
+**And the declaration is kept** (issue #2069). It was a virtual field only, on
+the argument that a stored copyright report *is* the record that it was made —
+which stopped being true the moment the public form (#2009) began demanding the
+same declaration of **every** category, so the category answers a different
+question than "was this declared?". It is now `moderation_reports.good_faith_declared_at`,
+stamped by `Report.changeset/4` wherever the box was ticked (not only where it
+was demanded), so the column has one meaning on every report however it was
+filed. A timestamp rather than a boolean, like every other fact this table
+records about a report; nil means no declaration on file, and rows filed before
+the column existed stay nil rather than being backfilled into evidence nobody
+recorded. The admin case page shows it beside the report's category chip
+("in gutem Glauben erklärt"), which is the surface a rights holder's notice has
+to be readable on.
 
 **It is in the admin queue from the moment it is filed.** The trust ladder is
 untouched — a trusted reporter still freezes the content and still leaves the
@@ -150,6 +161,15 @@ Every case carries an **audit log** (`moderation_events`: reports, freezes,
 severances, owner self-service, escalations, rulings, strikes, `owner_removed`)
 rendered as the History timeline on the admin case page, and the urgent admin
 email names the profile, category and reporter's note instead of just a link.
+
+**Every instant on that page is one an admin can read.** The header printed the
+report time and the owner's 72h deadline as bare `Calendar.strftime` stamps in
+universal time, two hours behind the same moments in the History timeline
+directly beneath — which renders through `<.local_time>` like everything else in
+the app — so an admin reading a deadline off the header was two hours wrong, in
+the direction that makes them act too late (issue #2069). All three header
+stamps are `<.local_time>` now: the admin's own zone when they have set one,
+their browser's otherwise, in their date shape.
 
 ## A picture is reportable on its own (issue #2012)
 
@@ -515,13 +535,37 @@ body: a replacement is a **revision** (`Moderation.content_replaced/1`,
 `resolved_edited`), which also spends the owner's one self-service round on that
 picture, as it should.
 
-That second bug is what `Moderation.consistent_outcome?/2` now guards. The
-subject comes from the case status and the fate paragraph from a measurement —
-**two sources on purpose**, one saying who decided and what they did, the other
-what the content is now — and exactly two of the four endings make a claim
-about the content in their own subject, so each of those has exactly one fate
-that agrees with it. A path that closes a case without settling the content the
-way its status claims is a test failure now, not a mail.
+That second bug is what `Moderation.consistent_outcome?/2` guards. The subject
+comes from the case status and the fate paragraph from a measurement — **two
+sources on purpose**, one saying who decided and what they did, the other what
+the content is now — and exactly two of the four endings make a claim about the
+content in their own subject, so each of those has exactly one fate that agrees
+with it.
+
+**It is asked in `Notifier.deliver_or_refuse/4`, where the letter's two halves
+meet** (issue #2071). For its first weeks it was called from a test alone, and
+that test handed it the fate it expected rather than the one the system produced
+— so it compared a sentence with itself and would have passed whatever the code
+did. A tenth closing path proved it: a caller reaching for the public
+`content_deleted/1` on content that is merely frozen closes the case
+`resolved_deleted`, whose subject says the content was deleted, over a measured
+fate of `:hidden`. When the guard fires **nothing is sent** — a letter that
+contradicts itself is worse for its reader than none, and this one is a legal
+notice — and the claim the stamping `UPDATE` staked is **handed back**, because
+leaving `outcome_notified_at` set would record that these reporters were told,
+which is false. `Logger.error` names the case, its status, both halves and how
+many reporters are owed. The regression test walks that tenth path through the
+public API rather than asserting on the predicate, so it sees what the system
+produced.
+
+**What that guard is not.** Nothing re-drives the un-claimed rows:
+`Report.awaiting_outcome/1` has one reader, no sweeper wakes it, and a closed
+case cannot re-enter `settle_case/3` — so a fired guard is permanent silence for
+that reporter, traded against a letter that lies. The wrong *ending* is also
+still written: the status, its `resolved_at`, the History entry and (on
+`resolved_edited`) the owner's spent self-service round all stand. The deeper
+fix is to refuse the contradicting ending in the close path itself, where the
+letter would then never have two halves to disagree about.
 
 **Exactly once is a claim, not a convention.** One `UPDATE` both picks the
 reports that still owe their reporter a notice and stamps

--- a/docs/architecture/moderation.md
+++ b/docs/architecture/moderation.md
@@ -558,14 +558,33 @@ many reporters are owed. The regression test walks that tenth path through the
 public API rather than asserting on the predicate, so it sees what the system
 produced.
 
-**What that guard is not.** Nothing re-drives the un-claimed rows:
-`Report.awaiting_outcome/1` has one reader, no sweeper wakes it, and a closed
-case cannot re-enter `settle_case/3` — so a fired guard is permanent silence for
-that reporter, traded against a letter that lies. The wrong *ending* is also
-still written: the status, its `resolved_at`, the History entry and (on
-`resolved_edited`) the owner's spent self-service round all stand. The deeper
-fix is to refuse the contradicting ending in the close path itself, where the
-letter would then never have two halves to disagree about.
+**It belongs at the mail, and moving it into the close path would be worse.**
+The two sources are answering different questions — the status says what
+somebody *did*, the fate says how the content *stands* — so the close path has
+nothing to repair. A guard there could only refuse the *close*, which turns a
+wording bug into a failed member action on content they have already changed.
+The remedy for a fired guard is always a source change in whichever caller
+picked the wrong status, which is exactly what #2067 was, twice: `resolved_edited`
+for a replaced picture, and `fate: :removed` stated by the account deletion.
+Detecting it earlier would not change that.
+
+**Refusing is right; refusing for ever is not.** An operator reading a log is
+not a recovery plan, and the record already exists — `Report.awaiting_outcome/1`
+still says these reporters are owed a notice. What is missing is anything that
+comes back to such a row, which is **#2073**. Until then a fired guard is
+silence for that reporter, and the wrong *ending* still stands too: the status,
+its `resolved_at`, the History entry and, on `resolved_edited`, the owner's
+spent self-service round.
+
+**A guard here is a refusal to speak, so it must name the contradiction and not
+a hair more.** `"revised"` rules out only `:removed`: the subject says the owner
+rewrote the content, and the sole fate calling that a lie is one saying the
+content is gone. Demanding `:visible` instead looked tighter and refused a true
+letter on a live path — `account_hidden?/1` counts `frozen_at` and
+`unreachable_at`, neither of which blocks signing in, so an owner hidden by an
+**unrelated** case can still edit or replace reported content and close
+`resolved_edited` over a measured `:hidden`. Two true sentences, one refused
+notice, and that reporter heard nothing at all (caught in review on PR #2072).
 
 **Exactly once is a claim, not a convention.** One `UPDATE` both picks the
 reports that still owe their reporter a notice and stamps

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -85,7 +85,6 @@ defmodule Vutuv.Fediverse do
   alias Vutuv.Pages
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
-  alias Vutuv.Posts.PostDenial
   alias Vutuv.Posts.PostRemoteReply
   alias Vutuv.Posts.Screenshots
   alias Vutuv.RateLimiter
@@ -967,27 +966,45 @@ defmodule Vutuv.Fediverse do
     )
   end
 
-  @doc "How many public posts the member has (the outbox totalItems)."
+  @doc """
+  How many public posts the member has (the outbox totalItems).
+
+  `Posts.scope_visible/2` with the **anonymous** viewer, which is the SQL twin
+  of the `visible_to?(post, nil)` gate deciding whether the note itself is
+  served — so the count and the notes it counts answer one question, by
+  mechanism rather than by two spellings that happen to agree (issue #2069).
+
+  They did not agree. This filtered audience denials and nothing else, so an
+  author whose only post a takedown had frozen still told every server that
+  asked `"totalItems": 1` while the note 404ed: the one number about a hidden
+  post that still left the building, with `featured_posts/1` right below it
+  already serving the anonymous view. Spelling the missing half by hand would
+  have left the same trap for the next rule, and one was already sitting in
+  it — `federated?/1` does not test `unreachable_at`, so an opted-in member
+  whose address has died keeps their outbox served while every note 404s, and
+  only `scope_visible/2` (through `Moderation.account_hidden?/1`) knows it.
+
+  Costs the correlated `account_hidden` subplan `Posts` documents. An outbox
+  fetch is an occasional request from another server, not a feed render.
+  """
   def public_post_count(%User{id: user_id}) do
-    Repo.aggregate(
-      from(p in Post,
-        as: :post,
-        where: p.user_id == ^user_id,
-        where: not exists(from(d in PostDenial, where: d.post_id == parent_as(:post).id))
-      ),
-      :count
-    )
+    from(p in Post, where: p.user_id == ^user_id)
+    |> Posts.scope_visible(nil)
+    |> Repo.aggregate(:count)
   end
 
   @doc """
   How many posts a **page** has published (issue #1334) — what its `outbox`
   collection reports.
 
-  No denial check, unlike the member twin: an organization post carries no
-  audience by construction, so every one of them is public.
+  `Posts.count_organization_posts/2` owns the question ("how many of this
+  page's posts may this viewer see") and the Mastodon API's `statuses_count`
+  already asks it; the anonymous viewer is the outbox's. That is also where the
+  freeze belongs: this counted every row, frozen ones included, until
+  issue #2069.
   """
-  def organization_public_post_count(%Organization{id: id}),
-    do: Repo.aggregate(from(p in Post, where: p.organization_id == ^id), :count)
+  def organization_public_post_count(%Organization{} = organization),
+    do: Posts.count_organization_posts(organization, nil)
 
   @doc """
   What the `featured` collection holds (issue #1110): the member's pinned post

--- a/lib/vutuv/moderation.ex
+++ b/lib/vutuv/moderation.ex
@@ -978,18 +978,31 @@ defmodule Vutuv.Moderation do
   Whether an ending and a measured fate can stand in the same notice.
 
   Two of the four endings make a claim about the content in their own **subject
-  line** — "the content you reported was deleted", "…was revised" — so exactly
-  one fate agrees with each. The two admin rulings claim nothing about the
-  content there, so any fate reads honestly beside them.
+  line** — "the content you reported was deleted", "…was revised" — so a fate
+  that denies that claim cannot ride beneath it. The two admin rulings claim
+  nothing about the content there, so any fate reads honestly beside them.
 
   It exists because the subject comes from the case status and the body's last
   paragraph from a measurement, and those are two sources: a path that closes a
   case without settling the content the way its status claims puts two
   sentences about one case into one mail that disagree. That is not
   hypothetical — replacing a flagged picture did exactly that.
+
+  **"Revised" rules out only `:removed`, not everything but `:visible`.** The
+  subject says the owner rewrote the content, and the only fate that calls that
+  a lie is one saying the content is gone. `:hidden` beside it is two true
+  sentences, and it is a state a live path reaches: `account_hidden?/1` counts
+  `frozen_at` and `unreachable_at`, neither of which blocks signing in, so an
+  owner hidden by an **unrelated** case can still edit or replace their reported
+  content — closing `resolved_edited` over a measured `:hidden`. Demanding
+  `:visible` there refused a notice that was owed and true, and left that
+  reporter with nothing at all (issue #2071). Watch this against
+  `Notifier.deliver_or_refuse/4`: a guard here is a refusal to *speak*, so
+  making it stricter than the contradiction it names costs a reporter their
+  answer.
   """
   def consistent_outcome?("removed", fate), do: fate == :removed
-  def consistent_outcome?("revised", fate), do: fate == :visible
+  def consistent_outcome?("revised", fate), do: fate != :removed
   def consistent_outcome?(_upheld_or_not, _fate), do: true
 
   @doc """

--- a/lib/vutuv/moderation/notifier.ex
+++ b/lib/vutuv/moderation/notifier.ex
@@ -16,6 +16,8 @@ defmodule Vutuv.Moderation.Notifier do
 
   import Ecto.Query
 
+  require Logger
+
   alias Vutuv.{Accounts, Activity, Moderation, Repo}
   alias Vutuv.Accounts.User
   alias Vutuv.Moderation.{Case, Report}
@@ -73,6 +75,12 @@ defmodule Vutuv.Moderation.Notifier do
   erases the case, so reading the content then answers "still here" about
   something that is gone a line later. Every other path settles the content
   first and lets `Moderation.reported_content_fate/1` look.
+
+  The subject and the closing paragraph come from those two different sources,
+  so before anything is sent `Moderation.consistent_outcome?/2` is asked
+  whether they can stand in one letter (issue #2071). If they cannot, nothing
+  goes out, the claim is given back so no row falsely reads as answered, and
+  the log says so — see `refuse_contradicting_notice/4`.
   """
   def reporters_case_closed(%Case{} = case_record, opts \\ []) do
     deliver_outcomes(case_record, Case.reporter_outcome(case_record.status), opts[:fate])
@@ -93,20 +101,57 @@ defmodule Vutuv.Moderation.Notifier do
       )
       |> Repo.update_all(set: [outcome_notified_at: now, updated_at: now])
 
-    if reports != [] do
-      # What became of the content, read **here**: the ruling has already
-      # settled it (purged a picture, unfrozen a profile, left a post frozen)
-      # and the delivery tasks run later, on a row `remove_owner/4` may by then
-      # have erased. Once per case rather than per reporter, and only once the
-      # `UPDATE` above says somebody is actually owed a notice — a second close
-      # or a retry claims no rows and must not pay for a lookup nothing reads.
-      fate = stated_fate || Moderation.reported_content_fate(case_record)
+    if reports != [], do: deliver_or_refuse(case_record, reports, outcome, stated_fate)
+
+    :ok
+  end
+
+  # What became of the content, read **here**: the ruling has already settled it
+  # (purged a picture, unfrozen a profile, left a post frozen) and the delivery
+  # tasks run later, on a row `remove_owner/4` may by then have erased. Once per
+  # case rather than per reporter, and only once the `UPDATE` above says
+  # somebody is actually owed a notice — a second close or a retry claims no
+  # rows and must not pay for a lookup nothing reads.
+  defp deliver_or_refuse(%Case{} = case_record, reports, outcome, stated_fate) do
+    fate = stated_fate || Moderation.reported_content_fate(case_record)
+
+    if Moderation.consistent_outcome?(outcome, fate) do
       reporters = reporters_by_id(reports)
 
       for report <- reports, do: deliver_outcome(report, reporters, outcome, fate)
+    else
+      refuse_contradicting_notice(case_record, reports, outcome, fate)
     end
+  end
 
-    :ok
+  # The letter's two halves meet here, so this is where the rule against them
+  # contradicting each other is asked (issue #2071). It had existed since #2067
+  # and only tests ever called it — with the fate they expected rather than the
+  # one the system produced, so it compared a sentence with itself.
+  #
+  # What it does when it fires is two decisions. **No mail**: a subject saying
+  # the content was deleted over a paragraph saying it is merely hidden is
+  # worse for the person reading it than silence, and this is a legal notice.
+  # **The claim goes back**: leaving `outcome_notified_at` stamped would record
+  # in the database that these reporters were told, which is false, and
+  # `Report.awaiting_outcome/1` is what any later answer has to read. Be clear
+  # about what that does and does not buy — nothing re-drives it. That query
+  # has one reader (`deliver_outcomes/3`), no sweeper wakes it, and a closed
+  # case cannot re-enter `settle_case/3`, so in practice a fired guard is
+  # permanent silence for that reporter. The row stays honest and the log is
+  # what an operator acts on; the deeper fix is to refuse the contradicting
+  # *ending* rather than the letter, in the close path itself.
+  defp refuse_contradicting_notice(%Case{} = case_record, reports, outcome, fate) do
+    ids = Enum.map(reports, & &1.id)
+
+    Repo.update_all(from(r in Report, where: r.id in ^ids), set: [outcome_notified_at: nil])
+
+    Logger.error(
+      "moderation: no decision notice sent for case #{case_record.id} " <>
+        "(status #{case_record.status}) - the ending #{inspect(outcome)} and the content's " <>
+        "measured fate #{inspect(fate)} contradict each other " <>
+        "(Vutuv.Moderation.consistent_outcome?/2). #{length(ids)} reporter(s) still owed one."
+    )
   end
 
   # One query for every member reporter on the case, not one per report: a

--- a/lib/vutuv/moderation/notifier.ex
+++ b/lib/vutuv/moderation/notifier.ex
@@ -134,13 +134,21 @@ defmodule Vutuv.Moderation.Notifier do
   # worse for the person reading it than silence, and this is a legal notice.
   # **The claim goes back**: leaving `outcome_notified_at` stamped would record
   # in the database that these reporters were told, which is false, and
-  # `Report.awaiting_outcome/1` is what any later answer has to read. Be clear
-  # about what that does and does not buy — nothing re-drives it. That query
-  # has one reader (`deliver_outcomes/3`), no sweeper wakes it, and a closed
-  # case cannot re-enter `settle_case/3`, so in practice a fired guard is
-  # permanent silence for that reporter. The row stays honest and the log is
-  # what an operator acts on; the deeper fix is to refuse the contradicting
-  # *ending* rather than the letter, in the close path itself.
+  # `Report.awaiting_outcome/1` is what any later answer has to read. Nothing
+  # re-drives it yet, so until issue #2073 a fired guard is silence for that
+  # reporter; the row stays honest and the log is what an operator acts on.
+  #
+  # It stays here rather than moving into the close path. The status says what
+  # somebody *did* and the fate how the content *stands*, so closing cannot be
+  # repaired: a guard there could only refuse the close, turning a wording bug
+  # into a failed member action on content they have already changed. The
+  # remedy is always a source change in the caller that picked the wrong
+  # status, which is what #2067 was, twice.
+  #
+  # And because refusing is refusing to *speak*, the predicate must name the
+  # contradiction and nothing more — see `Moderation.consistent_outcome?/2`,
+  # which refused a true letter for as long as it read "revised" as demanding
+  # `:visible`.
   defp refuse_contradicting_notice(%Case{} = case_record, reports, outcome, fate) do
     ids = Enum.map(reports, & &1.id)
 

--- a/lib/vutuv/moderation/report.ex
+++ b/lib/vutuv/moderation/report.ex
@@ -26,10 +26,26 @@ defmodule Vutuv.Moderation.Report do
     field(:category, :string)
     field(:note, :string)
     field(:abusive?, :boolean, default: false)
-    # Deliberately not stored: the changeset refuses the copyright category
-    # without it, so a stored copyright report IS the record that the
-    # declaration was made.
+    # What the form binds to. The stored half is the column below.
     field(:good_faith?, :boolean, virtual: true, default: false)
+
+    # When the notifier declared that the use is licensed neither by the rights
+    # holder nor by law. Stored since issue #2069, because the declaration is
+    # part of what makes a notice a notice (DSA Art. 16(2)(d)) and was until
+    # then validated and dropped — nothing on the case, in the queue or
+    # anywhere else recorded that it had been made. The category cannot stand
+    # in for it: the public form demands the same declaration for **every**
+    # category (issue #2009), so "this is a copyright report" answers a
+    # different question.
+    #
+    # A timestamp rather than a boolean, though it can only ever hold this
+    # row's own `inserted_at`: the fact has exactly two states, made and not on
+    # file, because the changeset refuses a report that needed the declaration
+    # and did not carry one — there is no "declined". A nullable boolean would
+    # spell those two states with three, and nothing would ever write the
+    # third. Nil on a report filed before the column existed, and deliberately
+    # not backfilled: it would be invented evidence.
+    field(:good_faith_declared_at, :naive_datetime)
 
     belongs_to(:case, Vutuv.Moderation.Case)
     # Nullable since issue #2009: a rights holder without an account files
@@ -168,7 +184,18 @@ defmodule Vutuv.Moderation.Report do
     |> validate_inclusion(:category, categories_for(content_type), message: pick_one)
     |> validate_length(:note, max: @max_note_length, message: "Your note is too long.")
     |> validate_full_notice(Keyword.get(opts, :full_notice?, false))
+    |> record_good_faith()
     |> unique_constraint([:case_id, :reporter_id])
+  end
+
+  # The declaration as a stored fact rather than a passing validation
+  # (issue #2069). Stamped whenever it was ticked, not only where it was
+  # demanded, so the column answers one question — "was this declared?" — for
+  # every report, however it was filed.
+  defp record_good_faith(changeset) do
+    if get_field(changeset, :good_faith?),
+      do: put_change(changeset, :good_faith_declared_at, NaiveDateTime.utc_now(:second)),
+      else: changeset
   end
 
   @doc """

--- a/lib/vutuv_web/live/admin/moderation_case_live.ex
+++ b/lib/vutuv_web/live/admin/moderation_case_live.ex
@@ -25,8 +25,21 @@ defmodule VutuvWeb.Admin.ModerationCaseLive do
       reporter_identity: 1
     ]
 
-  alias Vutuv.{Chat, Moderation}
+  alias Vutuv.{Chat, Moderation, ViewerClock}
   alias Vutuv.Moderation.Case
+
+  # The two chips a report line wears — its category, and the declaration it was
+  # filed with (issue #2069). One recipe so the pair cannot drift apart into two
+  # shapes on one row; the tint is all that differs.
+  defp report_chip_class(tone) do
+    [
+      "inline-flex items-center rounded-lg px-2 py-0.5 text-xs font-medium",
+      case tone do
+        :brand -> "bg-brand-50 text-brand-700 dark:bg-brand-800/60 dark:text-brand-100"
+        :slate -> "bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-200"
+      end
+    ]
+  end
 
   @impl true
   def mount(%{"id" => id}, _session, socket) do
@@ -171,20 +184,21 @@ defmodule VutuvWeb.Admin.ModerationCaseLive do
                 {status_badge(@case)}
               </span>
             </p>
+            <%!-- Bare `Calendar.strftime` stamps in UTC until issue #2069, two
+                  hours behind the same three moments in the history further
+                  down this very page — and an admin reads the owner's deadline
+                  off here, not out of the log. `<.local_time>` is the one
+                  rendering of an instant a person reads: the admin's own zone
+                  when they picked one, their browser's otherwise. --%>
             <p class="mt-1 text-slate-600 dark:text-slate-400">
-              {gettext("Reported on %{date}",
-                date: Calendar.strftime(@case.inserted_at, "%Y-%m-%d %H:%M")
-              )}
+              {gettext("Reported")}: <.local_time at={@case.inserted_at} id="case-reported-at" />
             </p>
             <p :if={@case.owner_deadline_at} class="text-slate-600 dark:text-slate-400">
-              {gettext("Owner deadline: %{date}",
-                date: Calendar.strftime(@case.owner_deadline_at, "%Y-%m-%d %H:%M")
-              )}
+              {gettext("Owner deadline")}:
+              <.local_time at={@case.owner_deadline_at} id="case-deadline-at" />
             </p>
             <p :if={@case.escalated_at} class="text-slate-600 dark:text-slate-400">
-              {gettext("Escalated on %{date}",
-                date: Calendar.strftime(@case.escalated_at, "%Y-%m-%d %H:%M")
-              )}
+              {gettext("Escalated")}: <.local_time at={@case.escalated_at} id="case-escalated-at" />
             </p>
           </div>
         </div>
@@ -313,8 +327,13 @@ defmodule VutuvWeb.Admin.ModerationCaseLive do
         <ul class="mt-3 space-y-3">
           <li :for={report <- @case.reports} class="text-sm">
             <p>
-              <span class="inline-flex items-center rounded-lg bg-brand-50 px-2 py-0.5 text-xs font-medium text-brand-700 dark:bg-brand-800/60 dark:text-brand-100">
-                {category_label(report.category)}
+              <span class={report_chip_class(:brand)}>{category_label(report.category)}</span>
+              <%!-- The declaration the notice was only accepted with, which no
+                    surface could show until issue #2069. Absent on a report
+                    filed before the column existed, which is honest: it was
+                    never recorded. --%>
+              <span :if={report.good_faith_declared_at} class={report_chip_class(:slate)}>
+                {gettext("declared in good faith")}
               </span>
               <%!-- Who filed it: a member's @handle, or an outside notifier's
                     name and address, which is what an admin needs to write
@@ -335,8 +354,14 @@ defmodule VutuvWeb.Admin.ModerationCaseLive do
             <% severance = @severance_by_reporter[report.reporter_id] %>
             <p :if={severance} class="mt-1 text-xs text-slate-600 dark:text-slate-400">
               <%= if severance.restored_at do %>
+                <%!-- The date in the admin's own clock, not UTC: this line sits
+                      between a header and a History timeline that both read in
+                      it, and near midnight a bare stamp names the wrong day.
+                      `ViewerClock.format/2` rather than `<.local_time>`
+                      because the stamp is inside the sentence — splitting it
+                      into a label would cost the sentence its grammar. --%>
                 {gettext("The protective separation from the owner was lifted on %{date}.",
-                  date: Calendar.strftime(severance.restored_at, "%Y-%m-%d")
+                  date: ViewerClock.format(severance.restored_at, :date)
                 )}
               <% else %>
                 {gettext(

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -2923,13 +2923,13 @@ msgstr[0] "%{formatted} Fall wartet auf eine Entscheidung."
 msgstr[1] "%{formatted} Fälle warten auf eine Entscheidung."
 
 #: lib/vutuv_web/live/admin/job_live.ex:335
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:301
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:302
 #: lib/vutuv_web/templates/moderation_evidence/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "(deleted account)"
 msgstr "(gelöschtes Konto)"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:220
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:221
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "(no text)"
@@ -2978,7 +2978,7 @@ msgstr ""
 "einwöchige Sperre, dann die endgültige Deaktivierung. Verwarnungspunkte "
 "verfallen nach zwölf Monaten."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:287
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "Conversation context (the reported message last)"
 msgstr "Gesprächskontext (die gemeldete Nachricht zuletzt)"
@@ -2991,7 +2991,7 @@ msgstr ""
 "wiederholt unerwünschte Nachrichten führen zur Sperrung des Kontos, in "
 "öffentlichen Beiträgen genauso wie in privaten Nachrichten."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:279
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Current version (edited since the report)"
 msgstr "Aktuelle Version (seit der Meldung bearbeitet)"
@@ -3007,6 +3007,7 @@ msgid "Deleted. The report is settled, no further steps needed."
 msgstr ""
 "Gelöscht. Die Meldung ist damit erledigt, weitere Schritte sind nicht nötig."
 
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:188
 #: lib/vutuv_web/views/admin/moderation_html.ex:9
 #, elixir-autogen, elixir-format
 msgid "Escalated"
@@ -3178,7 +3179,7 @@ msgstr "Melden Sie ehrlich. Wer meldet, um jemandem zu schaden, verstößt gegen
 msgid "Profile"
 msgstr "Profil"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:445
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:458
 #, elixir-autogen, elixir-format
 msgid "Reject the report"
 msgstr "Meldung ablehnen"
@@ -3272,7 +3273,7 @@ msgstr "Melder"
 msgid "Reporter track records"
 msgstr "Melder-Bilanz"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:311
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:312
 #: lib/vutuv_web/live/admin/moderation_live.ex:57
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3389,14 +3390,14 @@ msgid "The queue is empty - the self-service flow settled everything."
 msgstr ""
 "Die Warteschlange ist leer, der Selbstbedienungs-Ablauf hat alles erledigt."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:433
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:446
 #, elixir-autogen, elixir-format
 msgid "The report by @%{slug} was a deliberate weapon (strikes the reporter)"
 msgstr ""
 "Die Meldung von @%{slug} war eine gezielte Waffe (Verwarnungspunkt für den "
 "Melder)"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:396
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content stays hidden and the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
@@ -3447,7 +3448,7 @@ msgstr ""
 msgid "Unwanted advertising, fraud or fake activity."
 msgstr "Unerwünschte Werbung, Betrug oder gefälschte Aktivität."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:410
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:423
 #, elixir-autogen, elixir-format
 msgid "Uphold the report"
 msgstr "Meldung bestätigen"
@@ -3633,14 +3634,14 @@ msgstr ""
 msgid "%{count} follows"
 msgstr "%{count} Follows"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:325
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "%{count} report so far"
 msgid_plural "%{count} reports so far"
 msgstr[0] "bisher %{count} Meldung"
 msgstr[1] "bisher %{count} Meldungen"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:325
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "%{rejected} rejected, %{abusive} abusive"
 msgstr "%{rejected} abgelehnt, %{abusive} missbräuchlich"
@@ -3660,7 +3661,7 @@ msgstr "Inhalt gelöscht"
 msgid "Content frozen"
 msgstr "Inhalt eingefroren"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:380
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "Decision"
 msgstr "Entscheidung"
@@ -3670,22 +3671,17 @@ msgstr "Entscheidung"
 msgid "Escalated - the 72h deadline passed"
 msgstr "Eskaliert - die 72h-Frist ist abgelaufen"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:185
-#, elixir-autogen, elixir-format
-msgid "Escalated on %{date}"
-msgstr "Eskaliert am %{date}"
-
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:195
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "Evidence"
 msgstr "Beweismaterial"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:353
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr "Verlauf"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:205
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Open the profile"
 msgstr "Profil öffnen"
@@ -3696,11 +3692,6 @@ msgid "Our admins found your report unfounded; the paused connection between you
 msgstr ""
 "Unsere Admins haben Ihre Meldung als unbegründet eingestuft; die pausierte "
 "Vernetzung zwischen Ihnen beiden ist wiederhergestellt."
-
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:180
-#, elixir-autogen, elixir-format
-msgid "Owner deadline: %{date}"
-msgstr "Frist des Besitzers: %{date}"
 
 #: lib/vutuv_web/views/admin/moderation_html.ex:76
 #, elixir-autogen, elixir-format
@@ -3732,12 +3723,7 @@ msgstr "Meldung abgelehnt"
 msgid "Report upheld"
 msgstr "Meldung bestätigt"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:175
-#, elixir-autogen, elixir-format
-msgid "Reported on %{date}"
-msgstr "Gemeldet am %{date}"
-
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:342
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Reporter and owner are separated since this report (connection, follows, messages)."
 msgstr ""
@@ -3769,12 +3755,12 @@ msgstr "Durch Löschung erledigt"
 msgid "Strike issued"
 msgstr "Verwarnungspunkt vergeben"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "The protective separation from the owner was lifted on %{date}."
 msgstr "Die schützende Trennung vom Besitzer wurde am %{date} aufgehoben."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:421
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:434
 #, elixir-autogen, elixir-format
 msgid "The report is unfounded. The content becomes visible again, any protective separation is lifted, and the rejection counts against each reporter's trust."
 msgstr ""
@@ -3782,7 +3768,7 @@ msgstr ""
 "schützende Trennung wird aufgehoben und die Ablehnung zählt gegen die "
 "Vertrauenswürdigkeit jedes Melders."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:199
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "The whole profile was reported. Judge the profile itself - the snapshot below only preserves the name at report time."
 msgstr ""
@@ -3827,7 +3813,7 @@ msgstr "Stufe %{level}, %{role}"
 msgid "messages"
 msgstr "Nachrichten"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:356
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "No history recorded - this case predates the audit log."
 msgstr "Kein Verlauf aufgezeichnet - dieser Fall ist älter als das Protokoll."
@@ -3871,7 +3857,7 @@ msgstr "Fall %{id}, aufgenommen %{at} UTC"
 msgid "Evidence screenshot captured"
 msgstr "Beweis-Screenshot aufgenommen"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:268
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "Evidence screenshot captured when the report was filed"
 msgstr "Beweis-Screenshot, aufgenommen beim Eingang der Meldung"
@@ -3881,7 +3867,7 @@ msgstr "Beweis-Screenshot, aufgenommen beim Eingang der Meldung"
 msgid "Moderation evidence - reported private message with context"
 msgstr "Moderations-Beweismaterial - gemeldete private Nachricht mit Kontext"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:263
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Screenshot at report time"
 msgstr "Screenshot zum Meldezeitpunkt"
@@ -3891,7 +3877,7 @@ msgstr "Screenshot zum Meldezeitpunkt"
 msgid "reported message"
 msgstr "gemeldete Nachricht"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:274
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:275
 #, elixir-autogen, elixir-format
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
@@ -5425,7 +5411,7 @@ msgstr "API-Dokumentation"
 
 #: lib/vutuv_web/components/ui.ex:5397
 #: lib/vutuv_web/controllers/settings_controller.ex:161
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:488
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:501
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
@@ -10261,7 +10247,7 @@ msgstr "Konto wiederhergestellt. Das Mitglied kann sich wieder anmelden."
 msgid "Accounts removed as spam"
 msgstr "Als Spam entfernte Konten"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:455
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "Clear-cut spam or abuse?"
 msgstr "Eindeutiger Spam oder Missbrauch?"
@@ -10271,24 +10257,24 @@ msgstr "Eindeutiger Spam oder Missbrauch?"
 msgid "Could not restore this member."
 msgstr "Dieses Mitglied konnte nicht wiederhergestellt werden."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:470
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Deactivate @%{slug} and mark the account as spam?"
 msgstr "@%{slug} deaktivieren und das Konto als Spam markieren?"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:473
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:486
 #, elixir-autogen, elixir-format
 msgid "Deactivate account"
 msgstr "Konto deaktivieren"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:482
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:495
 #, elixir-autogen, elixir-format
 msgid "Permanently DELETE @%{slug} and everything they posted? This cannot be undone."
 msgstr ""
 "@%{slug} und alle Beiträge dauerhaft LÖSCHEN? Das kann nicht rückgängig "
 "gemacht werden."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:458
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "Remove the account outright, skipping the warning ladder. Deactivating marks it as spam and is reversible from the member browser; deleting is permanent."
 msgstr ""
@@ -13377,7 +13363,7 @@ msgstr "Job-Übersicht öffnen"
 msgid "Open reports"
 msgstr "Offene Meldungen"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:215
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:216
 #, elixir-autogen, elixir-format
 msgid "Open the job posting"
 msgstr "Stellenanzeige öffnen"
@@ -23977,12 +23963,12 @@ msgstr "Titelbild melden"
 msgid "Report the profile picture"
 msgstr "Profilbild melden"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:228
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "The reported picture"
 msgstr "Das gemeldete Bild"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:247
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Upholding the case deletes it, the private original included. Rejecting it puts every file back where it was."
 msgstr "Wird der Meldung stattgegeben, wird es gelöscht, auch das private Original. Wird sie abgelehnt, liegt jede Datei wieder an ihrem Platz."
@@ -24054,7 +24040,7 @@ msgstr ""
 "Danke für Ihre Meldung. Unsere Moderatoren wurden benachrichtigt und prüfen "
 "dieses Bild."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:255
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "This picture is still on the profile: only a copyright notice takes one offline before a ruling. Upholding the case deletes it, the private original included."
 msgstr ""
@@ -24184,7 +24170,7 @@ msgstr "Diese Adresse gehört nicht zu dieser Seite. Wir können nur bei Inhalte
 msgid "The post, picture, video, profile, page or job posting you are reporting. Copy it out of your browser's address bar."
 msgstr "Der Beitrag, das Bild, das Video, das Profil, die Seite oder die Stellenanzeige, die Sie melden. Kopieren Sie die Adresse aus der Adresszeile Ihres Browsers."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:438
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:451
 #, elixir-autogen, elixir-format
 msgid "The report by %{email} was a deliberate weapon (that address loses our trust)"
 msgstr "Die Meldung von %{email} war eine gezielte Waffe (diese Adresse verliert unser Vertrauen)"
@@ -24367,22 +24353,22 @@ msgstr "Einfacher LinkedIn-Profil-Import."
 msgid "No person made this decision: a report from somebody with a good record hides the reported content automatically, the moment it arrives."
 msgstr "Diese Entscheidung hat kein Mensch getroffen: Die Meldung einer Person mit guter Bilanz verbirgt den gemeldeten Inhalt automatisch, sobald sie eintrifft."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:400
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content becomes visible again - the consequence here is the strike (warn, suspend, deactivate)."
 msgstr "Die Meldung ist berechtigt. Der Inhalt wird wieder sichtbar; die Folge ist hier der Verwarnungspunkt (verwarnen, sperren, deaktivieren)."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:404
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content is not hidden and upholding does not hide it; the owner gets a strike (warn, suspend, deactivate)."
 msgstr "Die Meldung ist berechtigt. Der Inhalt ist nicht verborgen und wird es dadurch auch nicht; der Besitzer erhält einen Verwarnungspunkt (verwarnen, sperren, deaktivieren)."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:392
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:405
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The reported picture is deleted, the private original included, and the owner gets a strike (warn, suspend, deactivate)."
 msgstr "Die Meldung ist berechtigt. Das gemeldete Bild wird gelöscht, auch das private Original, und der Besitzer erhält einen Verwarnungspunkt (verwarnen, sperren, deaktivieren)."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:251
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "This picture is still on the profile: the address behind the copyright notice is not confirmed yet, so nothing has been hidden. Upholding the case deletes it, the private original included."
 msgstr "Dieses Bild ist weiterhin im Profil zu sehen: Die Adresse hinter der Urheberrechtsmeldung ist noch nicht bestätigt, deshalb ist nichts verborgen. Wird der Meldung stattgegeben, wird es gelöscht, auch das private Original."
@@ -24461,3 +24447,18 @@ msgstr "Der Inhalt bleibt verborgen."
 #, elixir-autogen, elixir-format
 msgid "Owner replaced the content"
 msgstr "Besitzer hat den Inhalt ersetzt"
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:184
+#, elixir-autogen, elixir-format
+msgid "Owner deadline"
+msgstr "Frist des Besitzers"
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:181
+#, elixir-autogen, elixir-format
+msgid "Reported"
+msgstr "Gemeldet"
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:330
+#, elixir-autogen, elixir-format
+msgid "declared in good faith"
+msgstr "in gutem Glauben erklärt"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -2879,13 +2879,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:335
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:301
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:302
 #: lib/vutuv_web/templates/moderation_evidence/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "(deleted account)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:220
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:221
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "(no text)"
@@ -2931,7 +2931,7 @@ msgstr ""
 msgid "Confirmed violations follow three steps: a warning, then a one-week suspension, then permanent deactivation. Strikes expire after twelve months."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:287
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "Conversation context (the reported message last)"
 msgstr ""
@@ -2941,7 +2941,7 @@ msgstr ""
 msgid "Criticize ideas, never people. Demeaning, threatening or repeatedly unwanted messages get accounts suspended - in public posts and in private messages alike."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:279
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Current version (edited since the report)"
 msgstr ""
@@ -2956,6 +2956,7 @@ msgstr ""
 msgid "Deleted. The report is settled, no further steps needed."
 msgstr ""
 
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:188
 #: lib/vutuv_web/views/admin/moderation_html.ex:9
 #, elixir-autogen, elixir-format
 msgid "Escalated"
@@ -3116,7 +3117,7 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:445
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:458
 #, elixir-autogen, elixir-format
 msgid "Reject the report"
 msgstr ""
@@ -3208,7 +3209,7 @@ msgstr ""
 msgid "Reporter track records"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:311
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:312
 #: lib/vutuv_web/live/admin/moderation_live.ex:57
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3313,12 +3314,12 @@ msgstr ""
 msgid "The queue is empty - the self-service flow settled everything."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:433
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:446
 #, elixir-autogen, elixir-format
 msgid "The report by @%{slug} was a deliberate weapon (strikes the reporter)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:396
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content stays hidden and the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
@@ -3365,7 +3366,7 @@ msgstr ""
 msgid "Unwanted advertising, fraud or fake activity."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:410
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:423
 #, elixir-autogen, elixir-format
 msgid "Uphold the report"
 msgstr ""
@@ -3539,14 +3540,14 @@ msgstr ""
 msgid "%{count} follows"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:325
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "%{count} report so far"
 msgid_plural "%{count} reports so far"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:325
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "%{rejected} rejected, %{abusive} abusive"
 msgstr ""
@@ -3566,7 +3567,7 @@ msgstr ""
 msgid "Content frozen"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:380
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "Decision"
 msgstr ""
@@ -3576,22 +3577,17 @@ msgstr ""
 msgid "Escalated - the 72h deadline passed"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:185
-#, elixir-autogen, elixir-format
-msgid "Escalated on %{date}"
-msgstr ""
-
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:195
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "Evidence"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:353
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:205
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Open the profile"
 msgstr ""
@@ -3599,11 +3595,6 @@ msgstr ""
 #: lib/vutuv_web/notification_line.ex:173
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
-msgstr ""
-
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:180
-#, elixir-autogen, elixir-format
-msgid "Owner deadline: %{date}"
 msgstr ""
 
 #: lib/vutuv_web/views/admin/moderation_html.ex:76
@@ -3636,12 +3627,7 @@ msgstr ""
 msgid "Report upheld"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:175
-#, elixir-autogen, elixir-format
-msgid "Reported on %{date}"
-msgstr ""
-
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:342
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Reporter and owner are separated since this report (connection, follows, messages)."
 msgstr ""
@@ -3671,17 +3657,17 @@ msgstr ""
 msgid "Strike issued"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "The protective separation from the owner was lifted on %{date}."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:421
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:434
 #, elixir-autogen, elixir-format
 msgid "The report is unfounded. The content becomes visible again, any protective separation is lifted, and the rejection counts against each reporter's trust."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:199
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "The whole profile was reported. Judge the profile itself - the snapshot below only preserves the name at report time."
 msgstr ""
@@ -3721,7 +3707,7 @@ msgstr ""
 msgid "messages"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:356
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "No history recorded - this case predates the audit log."
 msgstr ""
@@ -3756,7 +3742,7 @@ msgstr ""
 msgid "Evidence screenshot captured"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:268
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "Evidence screenshot captured when the report was filed"
 msgstr ""
@@ -3766,7 +3752,7 @@ msgstr ""
 msgid "Moderation evidence - reported private message with context"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:263
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Screenshot at report time"
 msgstr ""
@@ -3776,7 +3762,7 @@ msgstr ""
 msgid "reported message"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:274
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:275
 #, elixir-autogen, elixir-format
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
@@ -5218,7 +5204,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5397
 #: lib/vutuv_web/controllers/settings_controller.ex:161
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:488
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:501
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
@@ -9796,7 +9782,7 @@ msgstr ""
 msgid "Accounts removed as spam"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:455
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "Clear-cut spam or abuse?"
 msgstr ""
@@ -9806,22 +9792,22 @@ msgstr ""
 msgid "Could not restore this member."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:470
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Deactivate @%{slug} and mark the account as spam?"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:473
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:486
 #, elixir-autogen, elixir-format
 msgid "Deactivate account"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:482
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:495
 #, elixir-autogen, elixir-format
 msgid "Permanently DELETE @%{slug} and everything they posted? This cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:458
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "Remove the account outright, skipping the warning ladder. Deactivating marks it as spam and is reversible from the member browser; deleting is permanent."
 msgstr ""
@@ -12745,7 +12731,7 @@ msgstr ""
 msgid "Open reports"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:215
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:216
 #, elixir-autogen, elixir-format
 msgid "Open the job posting"
 msgstr ""
@@ -23154,12 +23140,12 @@ msgstr ""
 msgid "Report the profile picture"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:228
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "The reported picture"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:247
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Upholding the case deletes it, the private original included. Rejecting it puts every file back where it was."
 msgstr ""
@@ -23227,7 +23213,7 @@ msgstr ""
 msgid "Thank you for your report. Our moderators have been notified and will review this picture."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:255
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "This picture is still on the profile: only a copyright notice takes one offline before a ruling. Upholding the case deletes it, the private original included."
 msgstr ""
@@ -23351,7 +23337,7 @@ msgstr ""
 msgid "The post, picture, video, profile, page or job posting you are reporting. Copy it out of your browser's address bar."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:438
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:451
 #, elixir-autogen, elixir-format
 msgid "The report by %{email} was a deliberate weapon (that address loses our trust)"
 msgstr ""
@@ -23534,22 +23520,22 @@ msgstr ""
 msgid "No person made this decision: a report from somebody with a good record hides the reported content automatically, the moment it arrives."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:400
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content becomes visible again - the consequence here is the strike (warn, suspend, deactivate)."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:404
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content is not hidden and upholding does not hide it; the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:392
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:405
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The reported picture is deleted, the private original included, and the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:251
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "This picture is still on the profile: the address behind the copyright notice is not confirmed yet, so nothing has been hidden. Upholding the case deletes it, the private original included."
 msgstr ""
@@ -23627,4 +23613,19 @@ msgstr ""
 #: lib/vutuv_web/views/admin/moderation_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "Owner replaced the content"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:184
+#, elixir-autogen, elixir-format
+msgid "Owner deadline"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:181
+#, elixir-autogen, elixir-format
+msgid "Reported"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:330
+#, elixir-autogen, elixir-format
+msgid "declared in good faith"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -2877,13 +2877,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:335
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:301
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:302
 #: lib/vutuv_web/templates/moderation_evidence/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "(deleted account)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:220
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:221
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "(no text)"
@@ -2929,7 +2929,7 @@ msgstr ""
 msgid "Confirmed violations follow three steps: a warning, then a one-week suspension, then permanent deactivation. Strikes expire after twelve months."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:287
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "Conversation context (the reported message last)"
 msgstr ""
@@ -2939,7 +2939,7 @@ msgstr ""
 msgid "Criticize ideas, never people. Demeaning, threatening or repeatedly unwanted messages get accounts suspended - in public posts and in private messages alike."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:279
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Current version (edited since the report)"
 msgstr ""
@@ -2954,6 +2954,7 @@ msgstr ""
 msgid "Deleted. The report is settled, no further steps needed."
 msgstr ""
 
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:188
 #: lib/vutuv_web/views/admin/moderation_html.ex:9
 #, elixir-autogen, elixir-format
 msgid "Escalated"
@@ -3114,7 +3115,7 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:445
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:458
 #, elixir-autogen, elixir-format
 msgid "Reject the report"
 msgstr ""
@@ -3206,7 +3207,7 @@ msgstr ""
 msgid "Reporter track records"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:311
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:312
 #: lib/vutuv_web/live/admin/moderation_live.ex:57
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3311,12 +3312,12 @@ msgstr ""
 msgid "The queue is empty - the self-service flow settled everything."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:433
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:446
 #, elixir-autogen, elixir-format
 msgid "The report by @%{slug} was a deliberate weapon (strikes the reporter)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:396
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content stays hidden and the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
@@ -3363,7 +3364,7 @@ msgstr ""
 msgid "Unwanted advertising, fraud or fake activity."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:410
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:423
 #, elixir-autogen, elixir-format
 msgid "Uphold the report"
 msgstr ""
@@ -3537,14 +3538,14 @@ msgstr ""
 msgid "%{count} follows"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:325
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "%{count} report so far"
 msgid_plural "%{count} reports so far"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:325
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "%{rejected} rejected, %{abusive} abusive"
 msgstr ""
@@ -3564,7 +3565,7 @@ msgstr ""
 msgid "Content frozen"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:380
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "Decision"
 msgstr ""
@@ -3574,22 +3575,17 @@ msgstr ""
 msgid "Escalated - the 72h deadline passed"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:185
-#, elixir-autogen, elixir-format
-msgid "Escalated on %{date}"
-msgstr ""
-
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:195
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "Evidence"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:353
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:205
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Open the profile"
 msgstr ""
@@ -3597,11 +3593,6 @@ msgstr ""
 #: lib/vutuv_web/notification_line.ex:173
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
-msgstr ""
-
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:180
-#, elixir-autogen, elixir-format
-msgid "Owner deadline: %{date}"
 msgstr ""
 
 #: lib/vutuv_web/views/admin/moderation_html.ex:76
@@ -3634,12 +3625,7 @@ msgstr ""
 msgid "Report upheld"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:175
-#, elixir-autogen, elixir-format
-msgid "Reported on %{date}"
-msgstr ""
-
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:342
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Reporter and owner are separated since this report (connection, follows, messages)."
 msgstr ""
@@ -3669,17 +3655,17 @@ msgstr ""
 msgid "Strike issued"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "The protective separation from the owner was lifted on %{date}."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:421
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:434
 #, elixir-autogen, elixir-format
 msgid "The report is unfounded. The content becomes visible again, any protective separation is lifted, and the rejection counts against each reporter's trust."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:199
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "The whole profile was reported. Judge the profile itself - the snapshot below only preserves the name at report time."
 msgstr ""
@@ -3719,7 +3705,7 @@ msgstr ""
 msgid "messages"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:356
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "No history recorded - this case predates the audit log."
 msgstr ""
@@ -3754,7 +3740,7 @@ msgstr ""
 msgid "Evidence screenshot captured"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:268
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "Evidence screenshot captured when the report was filed"
 msgstr ""
@@ -3764,7 +3750,7 @@ msgstr ""
 msgid "Moderation evidence - reported private message with context"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:263
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Screenshot at report time"
 msgstr ""
@@ -3774,7 +3760,7 @@ msgstr ""
 msgid "reported message"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:274
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:275
 #, elixir-autogen, elixir-format
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
@@ -5216,7 +5202,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5397
 #: lib/vutuv_web/controllers/settings_controller.ex:161
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:488
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:501
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
@@ -9794,7 +9780,7 @@ msgstr ""
 msgid "Accounts removed as spam"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:455
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "Clear-cut spam or abuse?"
 msgstr ""
@@ -9804,22 +9790,22 @@ msgstr ""
 msgid "Could not restore this member."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:470
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Deactivate @%{slug} and mark the account as spam?"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:473
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:486
 #, elixir-autogen, elixir-format
 msgid "Deactivate account"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:482
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:495
 #, elixir-autogen, elixir-format
 msgid "Permanently DELETE @%{slug} and everything they posted? This cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:458
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "Remove the account outright, skipping the warning ladder. Deactivating marks it as spam and is reversible from the member browser; deleting is permanent."
 msgstr ""
@@ -12743,7 +12729,7 @@ msgstr ""
 msgid "Open reports"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:215
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:216
 #, elixir-autogen, elixir-format
 msgid "Open the job posting"
 msgstr ""
@@ -23152,12 +23138,12 @@ msgstr ""
 msgid "Report the profile picture"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:228
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "The reported picture"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:247
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Upholding the case deletes it, the private original included. Rejecting it puts every file back where it was."
 msgstr ""
@@ -23225,7 +23211,7 @@ msgstr ""
 msgid "Thank you for your report. Our moderators have been notified and will review this picture."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:255
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "This picture is still on the profile: only a copyright notice takes one offline before a ruling. Upholding the case deletes it, the private original included."
 msgstr ""
@@ -23349,7 +23335,7 @@ msgstr ""
 msgid "The post, picture, video, profile, page or job posting you are reporting. Copy it out of your browser's address bar."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:438
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:451
 #, elixir-autogen, elixir-format
 msgid "The report by %{email} was a deliberate weapon (that address loses our trust)"
 msgstr ""
@@ -23532,22 +23518,22 @@ msgstr ""
 msgid "No person made this decision: a report from somebody with a good record hides the reported content automatically, the moment it arrives."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:400
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content becomes visible again - the consequence here is the strike (warn, suspend, deactivate)."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:404
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content is not hidden and upholding does not hide it; the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:392
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:405
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The reported picture is deleted, the private original included, and the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:251
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "This picture is still on the profile: the address behind the copyright notice is not confirmed yet, so nothing has been hidden. Upholding the case deletes it, the private original included."
 msgstr ""
@@ -23625,4 +23611,19 @@ msgstr ""
 #: lib/vutuv_web/views/admin/moderation_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "Owner replaced the content"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:184
+#, elixir-autogen, elixir-format
+msgid "Owner deadline"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:181
+#, elixir-autogen, elixir-format
+msgid "Reported"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:330
+#, elixir-autogen, elixir-format
+msgid "declared in good faith"
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -2930,13 +2930,13 @@ msgstr[0] "%{formatted} caso attende una decisione."
 msgstr[1] "%{formatted} casi attendono una decisione."
 
 #: lib/vutuv_web/live/admin/job_live.ex:335
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:301
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:302
 #: lib/vutuv_web/templates/moderation_evidence/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "(deleted account)"
 msgstr "(account eliminato)"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:220
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:221
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "(no text)"
@@ -2987,7 +2987,7 @@ msgstr ""
 "sospensione di una settimana, poi la disattivazione definitiva. I richiami "
 "decadono dopo dodici mesi."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:287
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "Conversation context (the reported message last)"
 msgstr "Contesto della conversazione (il messaggio segnalato per ultimo)"
@@ -3000,7 +3000,7 @@ msgstr ""
 "ripetutamente indesiderati portano alla sospensione dell'account, tanto nei "
 "post pubblici quanto nei messaggi privati."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:279
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Current version (edited since the report)"
 msgstr "Versione attuale (modificata dopo la segnalazione)"
@@ -3015,6 +3015,7 @@ msgstr "Eliminare definitivamente questo contenuto?"
 msgid "Deleted. The report is settled, no further steps needed."
 msgstr "Eliminato. La segnalazione è chiusa, non serve altro."
 
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:188
 #: lib/vutuv_web/views/admin/moderation_html.ex:9
 #, elixir-autogen, elixir-format
 msgid "Escalated"
@@ -3185,7 +3186,7 @@ msgstr "Segnali in modo onesto. Chi segnala per danneggiare qualcuno viola le no
 msgid "Profile"
 msgstr "Profilo"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:445
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:458
 #, elixir-autogen, elixir-format
 msgid "Reject the report"
 msgstr "Respingi la segnalazione"
@@ -3279,7 +3280,7 @@ msgstr "Segnalante"
 msgid "Reporter track records"
 msgstr "Storico dei segnalanti"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:311
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:312
 #: lib/vutuv_web/live/admin/moderation_live.ex:57
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3395,14 +3396,14 @@ msgstr ""
 msgid "The queue is empty - the self-service flow settled everything."
 msgstr "La coda è vuota: la procedura autonoma ha risolto tutto."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:433
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:446
 #, elixir-autogen, elixir-format
 msgid "The report by @%{slug} was a deliberate weapon (strikes the reporter)"
 msgstr ""
 "La segnalazione di @%{slug} è stata un'arma deliberata (richiamo al "
 "segnalante)"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:396
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content stays hidden and the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
@@ -3453,7 +3454,7 @@ msgstr ""
 msgid "Unwanted advertising, fraud or fake activity."
 msgstr "Pubblicità indesiderata, frode o attività falsa."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:410
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:423
 #, elixir-autogen, elixir-format
 msgid "Uphold the report"
 msgstr "Accogli la segnalazione"
@@ -3638,14 +3639,14 @@ msgstr ""
 msgid "%{count} follows"
 msgstr "%{count} follow"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:325
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "%{count} report so far"
 msgid_plural "%{count} reports so far"
 msgstr[0] "%{count} segnalazione finora"
 msgstr[1] "%{count} segnalazioni finora"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:325
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "%{rejected} rejected, %{abusive} abusive"
 msgstr "%{rejected} respinte, %{abusive} abusive"
@@ -3665,7 +3666,7 @@ msgstr "Contenuto eliminato"
 msgid "Content frozen"
 msgstr "Contenuto bloccato"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:380
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "Decision"
 msgstr "Decisione"
@@ -3675,22 +3676,17 @@ msgstr "Decisione"
 msgid "Escalated - the 72h deadline passed"
 msgstr "Inoltrato: sono passate le 72 ore"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:185
-#, elixir-autogen, elixir-format
-msgid "Escalated on %{date}"
-msgstr "Inoltrato il %{date}"
-
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:195
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "Evidence"
 msgstr "Prove"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:353
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr "Cronologia"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:205
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Open the profile"
 msgstr "Apri il profilo"
@@ -3701,11 +3697,6 @@ msgid "Our admins found your report unfounded; the paused connection between you
 msgstr ""
 "I nostri amministratori hanno ritenuto infondata la Sua segnalazione; il "
 "collegamento sospeso tra voi due è ripristinato."
-
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:180
-#, elixir-autogen, elixir-format
-msgid "Owner deadline: %{date}"
-msgstr "Termine per il proprietario: %{date}"
 
 #: lib/vutuv_web/views/admin/moderation_html.ex:76
 #, elixir-autogen, elixir-format
@@ -3737,12 +3728,7 @@ msgstr "Segnalazione respinta"
 msgid "Report upheld"
 msgstr "Segnalazione accolta"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:175
-#, elixir-autogen, elixir-format
-msgid "Reported on %{date}"
-msgstr "Segnalato il %{date}"
-
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:342
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Reporter and owner are separated since this report (connection, follows, messages)."
 msgstr ""
@@ -3774,13 +3760,13 @@ msgstr "Chiuso con l'eliminazione"
 msgid "Strike issued"
 msgstr "Richiamo assegnato"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "The protective separation from the owner was lifted on %{date}."
 msgstr ""
 "La separazione protettiva dal proprietario è stata revocata il %{date}."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:421
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:434
 #, elixir-autogen, elixir-format
 msgid "The report is unfounded. The content becomes visible again, any protective separation is lifted, and the rejection counts against each reporter's trust."
 msgstr ""
@@ -3788,7 +3774,7 @@ msgstr ""
 "protettiva viene revocata e il respingimento pesa sull'affidabilità di "
 "ciascun segnalante."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:199
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "The whole profile was reported. Judge the profile itself - the snapshot below only preserves the name at report time."
 msgstr ""
@@ -3833,7 +3819,7 @@ msgstr "livello %{level}, %{role}"
 msgid "messages"
 msgstr "messaggi"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:356
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "No history recorded - this case predates the audit log."
 msgstr ""
@@ -3879,7 +3865,7 @@ msgstr "Caso %{id}, acquisito il %{at} UTC"
 msgid "Evidence screenshot captured"
 msgstr "Screenshot di prova acquisito"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:268
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "Evidence screenshot captured when the report was filed"
 msgstr "Screenshot di prova acquisito al momento della segnalazione"
@@ -3889,7 +3875,7 @@ msgstr "Screenshot di prova acquisito al momento della segnalazione"
 msgid "Moderation evidence - reported private message with context"
 msgstr "Prova di moderazione: messaggio privato segnalato con il contesto"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:263
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Screenshot at report time"
 msgstr "Screenshot al momento della segnalazione"
@@ -3899,7 +3885,7 @@ msgstr "Screenshot al momento della segnalazione"
 msgid "reported message"
 msgstr "messaggio segnalato"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:274
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:275
 #, elixir-autogen, elixir-format
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Scorra dentro il riquadro, o prema per aprire l'immagine intera."
@@ -5421,7 +5407,7 @@ msgstr "Documentazione dell'API"
 
 #: lib/vutuv_web/components/ui.ex:5397
 #: lib/vutuv_web/controllers/settings_controller.ex:161
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:488
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:501
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
@@ -10228,7 +10214,7 @@ msgstr "Account ripristinato. Il membro può accedere di nuovo."
 msgid "Accounts removed as spam"
 msgstr "Account rimossi come spam"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:455
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "Clear-cut spam or abuse?"
 msgstr "Spam o abuso lampante?"
@@ -10238,24 +10224,24 @@ msgstr "Spam o abuso lampante?"
 msgid "Could not restore this member."
 msgstr "Non è stato possibile ripristinare questo membro."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:470
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Deactivate @%{slug} and mark the account as spam?"
 msgstr "Disattivare @%{slug} e contrassegnare l'account come spam?"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:473
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:486
 #, elixir-autogen, elixir-format
 msgid "Deactivate account"
 msgstr "Disattiva l'account"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:482
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:495
 #, elixir-autogen, elixir-format
 msgid "Permanently DELETE @%{slug} and everything they posted? This cannot be undone."
 msgstr ""
 "ELIMINARE definitivamente @%{slug} e tutto ciò che ha pubblicato? "
 "L'operazione non si può annullare."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:458
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "Remove the account outright, skipping the warning ladder. Deactivating marks it as spam and is reversible from the member browser; deleting is permanent."
 msgstr ""
@@ -13410,7 +13396,7 @@ msgstr "Apri la supervisione degli annunci"
 msgid "Open reports"
 msgstr "Segnalazioni aperte"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:215
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:216
 #, elixir-autogen, elixir-format
 msgid "Open the job posting"
 msgstr "Apri l'annuncio di lavoro"
@@ -24655,12 +24641,12 @@ msgstr "Segnala l'immagine di copertina"
 msgid "Report the profile picture"
 msgstr "Segnala l'immagine del profilo"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:228
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "The reported picture"
 msgstr "L'immagine segnalata"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:247
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Upholding the case deletes it, the private original included. Rejecting it puts every file back where it was."
 msgstr "Se il caso viene accolto, l'immagine viene eliminata, originale privato compreso. Se viene respinto, ogni file torna al suo posto."
@@ -24733,7 +24719,7 @@ msgstr ""
 "Grazie per la segnalazione. I nostri moderatori sono stati avvisati ed "
 "esamineranno questa immagine."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:255
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "This picture is still on the profile: only a copyright notice takes one offline before a ruling. Upholding the case deletes it, the private original included."
 msgstr ""
@@ -24863,7 +24849,7 @@ msgstr "Questo indirizzo non appartiene a questo sito. Possiamo intervenire solo
 msgid "The post, picture, video, profile, page or job posting you are reporting. Copy it out of your browser's address bar."
 msgstr "Il post, l'immagine, il video, il profilo, la pagina o l'annuncio di lavoro che sta segnalando. Copi l'indirizzo dalla barra del Suo browser."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:438
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:451
 #, elixir-autogen, elixir-format
 msgid "The report by %{email} was a deliberate weapon (that address loses our trust)"
 msgstr "La segnalazione di %{email} era un'arma deliberata (quell'indirizzo perde la nostra fiducia)"
@@ -25046,22 +25032,22 @@ msgstr "Importazione del profilo LinkedIn semplice."
 msgid "No person made this decision: a report from somebody with a good record hides the reported content automatically, the moment it arrives."
 msgstr "Questa decisione non l'ha presa nessuna persona: la segnalazione di una persona affidabile nasconde il contenuto segnalato automaticamente, nel momento in cui arriva."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:400
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content becomes visible again - the consequence here is the strike (warn, suspend, deactivate)."
 msgstr "La segnalazione è fondata. Il contenuto torna visibile; qui la conseguenza è il richiamo (avvertimento, sospensione, disattivazione)."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:404
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content is not hidden and upholding does not hide it; the owner gets a strike (warn, suspend, deactivate)."
 msgstr "La segnalazione è fondata. Il contenuto non è nascosto e accogliere il caso non lo nasconde; il proprietario riceve un richiamo (avvertimento, sospensione, disattivazione)."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:392
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:405
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The reported picture is deleted, the private original included, and the owner gets a strike (warn, suspend, deactivate)."
 msgstr "La segnalazione è fondata. L'immagine segnalata viene eliminata, originale privato compreso, e il proprietario riceve un richiamo (avvertimento, sospensione, disattivazione)."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:251
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "This picture is still on the profile: the address behind the copyright notice is not confirmed yet, so nothing has been hidden. Upholding the case deletes it, the private original included."
 msgstr "L'immagine è ancora sul profilo: l'indirizzo dietro la segnalazione per violazione del diritto d'autore non è ancora confermato, quindi non è stato nascosto nulla. Se il caso viene accolto, l'immagine viene eliminata, originale privato compreso."
@@ -25140,3 +25126,18 @@ msgstr "Il contenuto resta nascosto."
 #, elixir-autogen, elixir-format
 msgid "Owner replaced the content"
 msgstr "Il proprietario ha sostituito il contenuto"
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:184
+#, elixir-autogen, elixir-format
+msgid "Owner deadline"
+msgstr "Termine per il proprietario"
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:181
+#, elixir-autogen, elixir-format
+msgid "Reported"
+msgstr "Segnalato"
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:330
+#, elixir-autogen, elixir-format
+msgid "declared in good faith"
+msgstr "dichiarato in buona fede"

--- a/priv/repo/migrations/20260908042345_record_good_faith_declaration.exs
+++ b/priv/repo/migrations/20260908042345_record_good_faith_declaration.exs
@@ -1,0 +1,18 @@
+defmodule Vutuv.Repo.Migrations.RecordGoodFaithDeclaration do
+  use Ecto.Migration
+
+  # One plain nullable column, so the currently deployed release keeps working
+  # untouched (N-1): it neither writes nor reads it.
+  #
+  # A timestamp rather than a boolean, like every other fact this table records
+  # about a report (`confirmed_at`, `outcome_notified_at`): the declaration is
+  # an act, and nil means "no declaration on file" rather than "declined". Rows
+  # filed before this stay nil on purpose — the declaration was demanded of
+  # them, but it was never recorded, and writing one in now would invent
+  # evidence. See `Vutuv.Moderation.Report` (issue #2069).
+  def change do
+    alter table(:moderation_reports) do
+      add(:good_faith_declared_at, :naive_datetime)
+    end
+  end
+end

--- a/test/vutuv/moderation_copyright_test.exs
+++ b/test/vutuv/moderation_copyright_test.exs
@@ -84,8 +84,25 @@ defmodule Vutuv.ModerationCopyrightTest do
     test "neither is demanded of the other categories", %{owner: owner, reporter: reporter} do
       post = insert(:post, user: owner)
 
-      assert {:ok, %Case{}} =
+      assert {:ok, %Case{} = case_record} =
                Moderation.report_content(reporter, post, %{"category" => "spam"})
+
+      # And nothing is recorded where nothing was declared (issue #2069).
+      assert Repo.get_by!(Report, case_id: case_record.id).good_faith_declared_at == nil
+    end
+
+    # The declaration is part of what makes a notice a notice, so it is kept
+    # rather than validated and dropped (issue #2069). The category cannot
+    # stand in for it: the public form demands the same declaration of every
+    # category, so "this is a copyright report" answers a different question.
+    test "keeps the declaration that was made", %{owner: owner, reporter: reporter} do
+      post = insert(:post, user: owner)
+
+      assert {:ok, %Case{} = case_record} =
+               Moderation.report_content(reporter, post, complete_notice())
+
+      assert %NaiveDateTime{} =
+               Repo.get_by!(Report, case_id: case_record.id).good_faith_declared_at
     end
   end
 

--- a/test/vutuv/moderation_notice_wording_test.exs
+++ b/test/vutuv/moderation_notice_wording_test.exs
@@ -446,8 +446,8 @@ defmodule Vutuv.ModerationNoticeWordingTest do
 
     # The invariant that would have caught both above, so a tenth path cannot
     # ship the contradiction: only two of the four endings make a claim about
-    # the content in their own subject, and each has exactly one fate that
-    # agrees with it.
+    # the content in their own subject, and a fate that denies that claim
+    # cannot ride beneath it.
     test "no closing path lets the subject and the fate disagree" do
       for {status, fate} <- [
             {"resolved_deleted", :removed},
@@ -461,11 +461,49 @@ defmodule Vutuv.ModerationNoticeWordingTest do
       refute Moderation.consistent_outcome?("removed", :hidden)
       refute Moderation.consistent_outcome?("revised", :removed)
 
+      # "Revised" rules out only `:removed`. A rewritten piece of content that
+      # is hidden because its OWNER is hidden makes two true sentences, and the
+      # test below walks that path for real — this pin is what stops the
+      # predicate from quietly tightening back to `== :visible`.
+      assert Moderation.consistent_outcome?("revised", :hidden)
+
       # The two admin rulings claim nothing about the content in their subject,
       # so every fate is honest beside them.
       for outcome <- ["upheld", "not_upheld"], fate <- [:removed, :hidden, :visible] do
         assert Moderation.consistent_outcome?(outcome, fate)
       end
+    end
+
+    # The guard's own failure mode, and the one the reviewer of PR #2072 found:
+    # a refusal to speak is as wrong as a lie when the letter would have been
+    # true. `account_hidden?/1` counts `frozen_at` and `unreachable_at`, and
+    # neither blocks signing in, so an owner hidden by an unrelated case still
+    # edits their reported post — `resolved_edited` over a measured `:hidden`.
+    test "an owner hidden by another case still gets their reporter answered", %{owner: owner} do
+      post = insert(:post, user: owner)
+      reporter = de_reporter()
+      {:ok, case_record} = Moderation.report_content(reporter, post, %{"category" => "bullying"})
+
+      # Hidden by something else entirely: a deliverability freeze, which does
+      # not stop them logging in and rewriting the post.
+      Repo.update_all(
+        from(u in Vutuv.Accounts.User, where: u.id == ^owner.id),
+        set: [unreachable_at: NaiveDateTime.utc_now(:second)]
+      )
+
+      flush_emails()
+
+      :ok = Moderation.content_edited(Repo.reload!(post))
+
+      assert Moderation.reported_content_fate(Repo.reload!(case_record)) == :hidden
+
+      assert_notice(
+        "melder@example.com",
+        "Der gemeldete Inhalt ist auf vutuv nicht mehr zu sehen."
+      )
+
+      refute Repo.exists?(Report.awaiting_outcome(case_record.id)),
+             "the reporter was answered, so nothing is still owed"
     end
 
     # The tenth path, and the reason the invariant above proved nothing: it

--- a/test/vutuv/moderation_notice_wording_test.exs
+++ b/test/vutuv/moderation_notice_wording_test.exs
@@ -16,11 +16,11 @@ defmodule Vutuv.ModerationNoticeWordingTest do
 
   use Vutuv.DataCase, async: false
 
+  import ExUnit.CaptureLog, only: [capture_log: 1]
   import Vutuv.WebPushHelpers, only: [put_config: 2]
 
   alias Vutuv.{Accounts, Activity, Moderation}
-  alias Vutuv.Moderation.{Case, Notifier, Report}
-  alias Vutuv.Notifications.Emailer
+  alias Vutuv.Moderation.{Case, Report}
 
   @note "Das Foto ist meins, das Original steht auf example.com/hafen.jpg"
 
@@ -45,25 +45,22 @@ defmodule Vutuv.ModerationNoticeWordingTest do
     reporter
   end
 
-  # One closing path, checked the way a reader meets it: the sentence about the
-  # content, and that it does not contradict the subject its ending produced.
-  defp assert_notice(address, outcome, fate_sentence) do
-    email = mail_to(address)
-
-    for body <- bodies(email) do
+  # One closing path, checked the way a reader meets it: the sentence the notice
+  # makes about the content.
+  #
+  # It used to end by mapping that sentence back to a fate and asserting
+  # `consistent_outcome?/2` on it — two literals from the call site compared
+  # with each other, which is the "compares a sentence with itself" shape
+  # issue #2071 is about. Since `deliver_or_refuse/4` now refuses to send a
+  # contradicting pair at all, a notice that arrives is consistent by
+  # construction and the assertion could no longer fail. What it claimed to
+  # cover is covered for real below, twice: the exhaustive table over the
+  # predicate, and the tenth path driven through the public API.
+  defp assert_notice(address, fate_sentence) do
+    for body <- bodies(mail_to(address)) do
       assert body =~ fate_sentence,
              "the notice does not say #{inspect(fate_sentence)}"
     end
-
-    fate =
-      case fate_sentence do
-        "Der gemeldete Inhalt ist gelöscht." -> :removed
-        "Der gemeldete Inhalt ist auf vutuv nicht mehr zu sehen." -> :hidden
-        "Der gemeldete Inhalt ist auf vutuv weiterhin zu sehen." -> :visible
-      end
-
-    assert Moderation.consistent_outcome?(outcome, fate),
-           "the subject for #{outcome} and the body's #{inspect(fate)} disagree"
   end
 
   defp uploads_dir do
@@ -396,7 +393,7 @@ defmodule Vutuv.ModerationNoticeWordingTest do
 
       :ok = Moderation.delete_reported_content(case_record, owner)
 
-      assert_notice("melder@example.com", "removed", "Der gemeldete Inhalt ist gelöscht.")
+      assert_notice("melder@example.com", "Der gemeldete Inhalt ist gelöscht.")
     end
 
     test "the owner editing a reported post says it is visible", %{owner: owner} do
@@ -409,7 +406,6 @@ defmodule Vutuv.ModerationNoticeWordingTest do
 
       assert_notice(
         "melder@example.com",
-        "revised",
         "Der gemeldete Inhalt ist auf vutuv weiterhin zu sehen."
       )
     end
@@ -427,7 +423,6 @@ defmodule Vutuv.ModerationNoticeWordingTest do
 
       assert_notice(
         "melder@example.com",
-        "upheld",
         "Der gemeldete Inhalt ist auf vutuv weiterhin zu sehen."
       )
     end
@@ -445,7 +440,6 @@ defmodule Vutuv.ModerationNoticeWordingTest do
 
       assert_notice(
         "melder@example.com",
-        "upheld",
         "Der gemeldete Inhalt ist auf vutuv nicht mehr zu sehen."
       )
     end
@@ -472,6 +466,33 @@ defmodule Vutuv.ModerationNoticeWordingTest do
       for outcome <- ["upheld", "not_upheld"], fate <- [:removed, :hidden, :visible] do
         assert Moderation.consistent_outcome?(outcome, fate)
       end
+    end
+
+    # The tenth path, and the reason the invariant above proved nothing: it
+    # hands `consistent_outcome?/2` the fate it expects, so it compares a
+    # sentence with itself. Here the *system* produces both halves — a caller
+    # reaching for the public `content_deleted/1` on a post that is merely
+    # frozen, which is the closing path a reviewer wrote and watched send
+    # "…wurde gelöscht" over "…nicht mehr zu sehen" (issue #2071).
+    test "a contradicting ending sends no notice, loudly", %{owner: owner} do
+      post = insert(:post, user: owner)
+      reporter = de_reporter()
+
+      {:ok, case_record} = Moderation.report_content(reporter, post, %{"category" => "bullying"})
+      assert Repo.reload!(post).frozen_at
+      flush_emails()
+
+      log = capture_log(fn -> :ok = Moderation.content_deleted(post) end)
+
+      assert log =~ "consistent_outcome?"
+      assert log =~ case_record.id
+
+      assert flush_emails() == [],
+             "a notice went out whose subject and body disagree about the content"
+
+      # And not silently: the claim is handed back, so the reports still owe
+      # their reporter a notice rather than being stamped as answered.
+      assert Repo.exists?(Report.awaiting_outcome(case_record.id))
     end
   end
 

--- a/test/vutuv_web/controllers/fediverse_controller_test.exs
+++ b/test/vutuv_web/controllers/fediverse_controller_test.exs
@@ -25,6 +25,15 @@ defmodule VutuvWeb.FediverseControllerTest do
 
   defp host, do: VutuvWeb.Endpoint.host()
 
+  defp outbox_total(conn, user) do
+    conn
+    |> recycle()
+    |> get("/#{user.username}/actor/outbox")
+    |> Map.fetch!(:resp_body)
+    |> Jason.decode!()
+    |> Map.fetch!("totalItems")
+  end
+
   defp stub_remote_actor(pub_pem, extra \\ %{}) do
     doc =
       Jason.encode!(
@@ -305,6 +314,50 @@ defmodule VutuvWeb.FediverseControllerTest do
         conn |> recycle() |> get("/#{user.username}/actor/outbox") |> Map.fetch!(:resp_body)
 
       assert Jason.decode!(outbox)["type"] == "OrderedCollection"
+    end
+
+    # The count is what a hidden post still told other servers while its own
+    # note 404ed (issue #2069). Driven through the real takedown rather than a
+    # hand-set column, because the seam that disagreed is Moderation's freeze
+    # against this count.
+    test "the outbox stops counting a post a takedown froze (#2069)", %{conn: conn} do
+      user = federated_user()
+      post = insert(:post, user: user)
+
+      assert outbox_total(conn, user) == 1
+
+      reporter = insert(:activated_user)
+      insert(:email, user: reporter)
+
+      {:ok, _case} =
+        Vutuv.Moderation.report_content(reporter, post, %{
+          "category" => "copyright",
+          "note" => "Der Text ist meiner, das Original steht auf example.com/text.",
+          "good_faith?" => "true"
+        })
+
+      assert Repo.reload!(post).frozen_at
+      assert outbox_total(conn, user) == 0
+    end
+
+    # The trap one column over, and the reason the count goes through
+    # `Posts.scope_visible/2` rather than naming the freeze by hand:
+    # `federated?/1` does not test `unreachable_at`, so a member whose address
+    # has died keeps their outbox served while every note 404s.
+    test "nor a post whose author's account is hidden (#2069)", %{conn: conn} do
+      user = federated_user()
+      insert(:post, user: user)
+
+      assert outbox_total(conn, user) == 1
+
+      user
+      |> Ecto.Changeset.change(%{unreachable_at: NaiveDateTime.utc_now(:second)})
+      |> Repo.update!()
+
+      assert Fediverse.federated?(Repo.reload!(user)),
+             "the outbox is still served, which is what makes the count reachable"
+
+      assert outbox_total(conn, user) == 0
     end
 
     test "advertises the following collection, count-only and accepted-only (#1160)", %{

--- a/test/vutuv_web/live/admin/moderation_case_header_test.exs
+++ b/test/vutuv_web/live/admin/moderation_case_header_test.exs
@@ -1,0 +1,107 @@
+defmodule VutuvWeb.Admin.ModerationCaseHeaderTest do
+  @moduledoc """
+  The two things an admin reads off the top of a case page that were not true
+  (issue #2069).
+
+  The header printed the report time and the owner's deadline as bare machine
+  stamps in universal time, two hours behind the same moment in the history
+  directly beneath it — an admin reading a deadline off the header was two
+  hours wrong, in the wrong direction. And the good-faith declaration a
+  copyright notice is only accepted with was validated and thrown away, so
+  nothing on the page said it had been made.
+
+  German (`Accept-Language: de-DE,de`), because that is the language the queue
+  is worked in and because a fuzzy-filled msgid fails no build. The admin here
+  carries their own time zone, which is what makes the server text final and
+  this assertion deterministic rather than a browser's job.
+  """
+
+  use VutuvWeb.ConnCase, async: true
+
+  alias Vutuv.Moderation
+  alias Vutuv.Moderation.Case
+
+  # A summer instant, so Berlin is two hours ahead of the stamp in the database
+  # — the exact gap the issue reports.
+  @reported_at ~N[2026-07-15 01:24:00]
+  @deadline_at ~N[2026-07-18 01:26:00]
+
+  setup %{conn: conn} do
+    {admin_conn, admin} = create_and_login_admin(conn)
+
+    admin
+    |> Ecto.Changeset.change(%{time_zone: "Europe/Berlin", date_region: "DE"})
+    |> Repo.update!()
+
+    owner = insert(:activated_user)
+    insert(:email, user: owner)
+    reporter = insert(:activated_user)
+    insert(:email, user: reporter)
+
+    {:ok, conn: admin_conn, owner: owner, reporter: reporter}
+  end
+
+  # `recycle/1` first: the login already sent a response on this conn, and a
+  # header cannot be put on a sent one.
+  defp german(conn),
+    do: conn |> recycle() |> put_req_header("accept-language", "de-DE,de;q=0.9")
+
+  defp copyright_case!(%{owner: owner, reporter: reporter}) do
+    post = insert(:post, user: owner)
+
+    {:ok, %Case{} = case_record} =
+      Moderation.report_content(reporter, post, %{
+        "category" => "copyright",
+        "note" => "Der Text ist meiner, das Original steht auf example.com/text.",
+        "good_faith?" => "true"
+      })
+
+    case_record
+  end
+
+  defp pin_clock!(%Case{id: id}) do
+    Repo.update_all(
+      from(c in Case, where: c.id == ^id),
+      set: [inserted_at: @reported_at, owner_deadline_at: @deadline_at]
+    )
+  end
+
+  defp show(conn, %Case{id: id}),
+    do: conn |> german() |> get(~p"/admin/moderation/#{id}") |> html_response(200)
+
+  describe "the header clock" do
+    test "reads in the admin's own zone, like the history beneath it", context do
+      case_record = copyright_case!(context)
+      pin_clock!(case_record)
+
+      html = show(context.conn, case_record)
+
+      assert html =~ "15.07.2026 03:24"
+      assert html =~ "18.07.2026 03:26"
+
+      # The stamp as it sits in the database is what an admin was reading, and
+      # it must not be the visible text any more.
+      refute html =~ "2026-07-15 01:24"
+      refute html =~ "2026-07-18 01:26"
+
+      # The `<time datetime>` half is what gets an admin who never set a zone
+      # their browser's, instead of a bare UTC stamp.
+      assert html =~ ~s(datetime="2026-07-15T01:24:00Z")
+    end
+  end
+
+  describe "the good-faith declaration" do
+    test "is on the case, not only in the changeset", context do
+      case_record = copyright_case!(context)
+
+      assert show(context.conn, case_record) =~ "in gutem Glauben erklärt"
+    end
+
+    test "is absent where none was made", %{owner: owner, reporter: reporter, conn: conn} do
+      post = insert(:post, user: owner)
+      {:ok, case_record} = Moderation.report_content(reporter, post, %{"category" => "spam"})
+
+      refute show(conn, case_record) =~ "in gutem Glauben erklärt"
+    end
+  end
+end

--- a/test/vutuv_web/live/admin/moderation_case_header_test.exs
+++ b/test/vutuv_web/live/admin/moderation_case_header_test.exs
@@ -70,6 +70,25 @@ defmodule VutuvWeb.Admin.ModerationCaseHeaderTest do
     do: conn |> german() |> get(~p"/admin/moderation/#{id}") |> html_response(200)
 
   describe "the header clock" do
+    # Both labels are new msgids, and `gettext.extract --merge` fuzzy-filled
+    # this exact pair: "Reported" came back as "Melder" (the reporter, the
+    # other party entirely) and "Owner deadline" still carried the retired
+    # `%{date}`. A short label is the likeliest to be fuzzy-matched and the
+    # least likely to be noticed, so both are pinned by name — a timestamp
+    # assertion beside them would stay green through either mistranslation.
+    test "names both stamps in German", context do
+      case_record = copyright_case!(context)
+      pin_clock!(case_record)
+
+      html = show(context.conn, case_record)
+
+      assert html =~ "Gemeldet:"
+      assert html =~ "Frist des Besitzers:"
+
+      refute html =~ "Melder:"
+      refute html =~ "%{date}"
+    end
+
     test "reads in the admin's own zone, like the history beneath it", context do
       case_record = copyright_case!(context)
       pin_clock!(case_record)

--- a/test/vutuv_web/organization_fediverse_actor_web_test.exs
+++ b/test/vutuv_web/organization_fediverse_actor_web_test.exs
@@ -203,4 +203,28 @@ defmodule VutuvWeb.OrganizationFediverseActorWebTest do
     # least be a route, not a 404 from the router.
     assert json["inbox"] =~ "/organizations/#{page.slug}/actor/inbox"
   end
+
+  # The member twin of this is in `VutuvWeb.FediverseControllerTest`; a page's
+  # posts are frozen through the very same `posts.frozen_at` column, so the
+  # count had the very same hole (issue #2069).
+  test "the outbox stops counting a post a takedown froze (#2069)", %{conn: conn} do
+    page = federating_page()
+    post = insert(:post, user: nil, organization: page)
+
+    total = fn ->
+      conn
+      |> ap()
+      |> get(~p"/organizations/#{page.slug}/actor/outbox")
+      |> json_response(200)
+      |> Map.fetch!("totalItems")
+    end
+
+    assert total.() == 1
+
+    post
+    |> Ecto.Changeset.change(%{frozen_at: NaiveDateTime.utc_now(:second)})
+    |> Repo.update!()
+
+    assert total.() == 0
+  end
 end


### PR DESCRIPTION
An author whose only post a takedown had frozen still answered `"totalItems": 1`
to every server that asked, while the note itself 404ed. Three smaller things the
same check turned up ride along.

- **Outbox count** (`Vutuv.Fediverse.public_post_count/1`, and its page twin)
  goes through `Posts.scope_visible/2` now, the SQL twin of the gate deciding
  whether the note is served. That also covers an unreachable author.
- **The good-faith declaration** was validated and dropped. It is a column now
  (additive migration) and a chip on the admin case page.
- **That page's header** printed bare UTC stamps, two hours off the history
  beneath it. Every instant on it reads `<.local_time>` now.
- **`Moderation.consistent_outcome?/2`** was asked only by a test that fed it the
  expected answer. `Notifier.deliver_or_refuse/4` asks it now: a contradicting
  letter is refused and logged, not sent.

Smoke-tested in German in a browser, and against the real outbox.

Closes #2069
Closes #2071

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01UGPe7bHVS11M1W7fNehSku

<!-- closing-note #2069 -->
Three separate corrections, all shipped. The outbox count now routes through the
same visibility scope the note itself is served by, which also closes the
unreachable-author case you did not name; the good-faith declaration became a
nullable timestamp column and a chip beside the report's category; and the case
header's three stamps read in the admin's own clock, as does the severance line
one card below that I found on the way.

*An AI agent wrote this text in my name. I know that is problematic.*

<!-- closing-note #2071 -->
The guard is asked in `Notifier.deliver_or_refuse/4` now, where the subject and
the fate paragraph meet. When it fires nothing is sent and the claim on
`outcome_notified_at` is handed back, so no row falsely reads as answered, and
the log names the case and both halves. Review caught the guard being stricter
than the contradiction it names: "revised" rules out only `:removed`, so an
owner hidden by an unrelated case editing their post had a true letter refused.
Nothing re-drives an un-claimed row yet, which is #2073.

*An AI agent wrote this text in my name. I know that is problematic.*

