### PR TITLE
The report form tells a rights holder the truth about their link

### DIFF
--- a/docs/architecture/moderation.md
+++ b/docs/architecture/moderation.md
@@ -56,7 +56,12 @@ records about a report; nil means no declaration on file, and rows filed before
 the column existed stay nil rather than being backfilled into evidence nobody
 recorded. The admin case page shows it beside the report's category chip
 ("in gutem Glauben erklärt"), which is the surface a rights holder's notice has
-to be readable on.
+to be readable on. **And both forms word it identically** (issue #2068): the
+public one used to add "that my statements are correct" and the member one did
+not, which is two promises behind one column. It is one function component now,
+`ReportHTML.good_faith_declaration/1`, beside `honest_reporting_note/1` — the
+same channel `category_label/1` already travels, so the two forms cannot drift
+apart again rather than being watched for drift.
 
 **It is in the admin queue from the moment it is filed.** The trust ladder is
 untouched — a trusted reporter still freezes the content and still leaves the
@@ -127,7 +132,10 @@ brigaders' reports abusive).
 Suspended/deactivated accounts cannot log in and disappear from feeds, profiles
 and search.
 
-House rules live at `/community`.
+House rules live at `/community`, and the rule about publishing only what you
+hold the rights to links `/system/report` from the sentence that invites a
+rights holder to use it — that word was plain text until issue #2068, with the
+only way to the form sitting in the footer's Legal group.
 
 **Reporting someone also separates the two accounts on the spot** (before any
 second report or admin ruling): connection and follows are removed and the 1:1
@@ -302,9 +310,10 @@ demands the last three (`Report.outside_changeset/3`). A member is identified by
 their account and answerable through it; a stranger is answerable only through
 what they wrote and the address they confirmed.
 
-**Nothing happens on the submit.** `Moderation.file_public_notice/2` opens (or
-joins) the case as `flagged` — in front of an admin, with the content left
-exactly where it is — and mails a receipt carrying a confirmation link
+**The case is in front of an admin from the submit; nothing is hidden until
+the confirmation.** `Moderation.file_public_notice/2` opens (or joins) the case
+as `flagged`, which is a queue status, and mails a receipt carrying a
+confirmation link
 (`Emailer.public_notice_receipt_email/1`). The freeze, the owner's notice and
 the urgent admin mail all wait for `confirm_public_notice/1`, which runs the
 ordinary decision the trust ladder would have made at file time. The link is
@@ -352,6 +361,26 @@ the three addresses a profile picture has (`/avatars/<user id>/…`,
 visitor can already see resolves**, so the form is not an oracle for frozen,
 deleted, restricted or members-only content — "we could not find that page" is
 the honest answer for a typo and for a hidden post alike.
+
+**A miss has three shapes and the notifier is told which** (issue #2068).
+Answering "we could not find that page" about `/impressum` — an address that is
+perfectly correct — sends a rights holder off to re-check a link that was right
+all along, in the first minute of the one complaint that carries real
+liability. So `resolve/1` answers `:foreign_host` (another server), then
+`:not_reportable` (a page of the **site**: the Impressum, the house rules, the
+member directory), and only then `:not_found`. Two questions decide the middle
+one and both are asked without reading a row, which is what keeps the
+anti-oracle rule intact. **Is the first path segment a reserved slug?** A
+handle can never be one, so `from_segments/1` answers `:no_content_shape`
+rather than letting its two greedy handle clauses read `/system/members/w` as
+"the member `system`, missing" — that misreading is why every site page deeper
+than one segment sat in the typo bucket. **And does the router put a fixed
+address there?** `route_info/4` (asked about `Endpoint.host/0`, since
+`local_path/1` has already ruled the address ours) matching a route whose
+**first** segment is literal means a page of this installation;
+`/system/members/:letter` and `/system/posts/:year/:month` qualify, while
+`/:slug` does not — so a reserved word nobody routed, `/stefan`, is a name
+still to be claimed and keeps the answer a typo gets.
 
 Four things bound what a stranger can cause. The form is rate limited per client
 IP **and per mailbox** (`VutuvWeb.RateLimit.check_public_notice/2`, 5 an hour

--- a/lib/vutuv/moderation/content_url.ex
+++ b/lib/vutuv/moderation/content_url.ex
@@ -22,11 +22,16 @@ defmodule Vutuv.Moderation.ContentUrl do
   unauthenticated, so answering "that URL exists" for anything else would make
   it an oracle for frozen, deleted, restricted and members-only content —
   something the same visitor cannot learn by fetching the URL. Everything else
-  comes back `{:error, :not_found}`, which is the same answer a typo gets.
+  comes back `{:error, :not_found}`, which is the same answer a typo gets — one
+  exception, `{:error, :not_reportable}` for a page of the site itself, is
+  decided by the router alone and reads no row, so it can tell nobody anything
+  (issue #2068).
   """
 
   import Ecto.Query
 
+  alias Phoenix.Router, as: PhoenixRouter
+  alias Vutuv.Accounts.ReservedSlugs
   alias Vutuv.Accounts.User
   alias Vutuv.Fediverse
   alias Vutuv.Images
@@ -37,19 +42,28 @@ defmodule Vutuv.Moderation.ContentUrl do
   alias Vutuv.Repo
   alias Vutuv.UUIDv7
   alias Vutuv.Videos
+  alias VutuvWeb.Endpoint
+  alias VutuvWeb.Router
+
+  @reserved ReservedSlugs.list()
 
   @doc """
   Resolves `url` to the content row it names.
 
-  `{:ok, content}` for a reportable, publicly visible row; `{:error,
-  :foreign_host}` when the address belongs to another server (worth its own
-  message: the notifier has to be told we can only act on what is here);
-  `{:error, :not_found}` for anything else.
+  `{:ok, content}` for a reportable, publicly visible row, and three misses a
+  notifier has to be able to tell apart (issue #2068):
+
+  * `{:error, :foreign_host}` — the address belongs to another server, so we
+    can only say we do not host it.
+  * `{:error, :not_reportable}` — one of **our own pages**, which is a correct
+    address carrying nobody's content.
+  * `{:error, :not_found}` — everything else, and only here is "we could not
+    find it" true.
   """
   def resolve(url) when is_binary(url) do
     case url |> String.trim() |> with_scheme() |> Fediverse.local_path() do
       nil -> {:error, :foreign_host}
-      segments -> found(from_segments(segments))
+      segments -> found(from_segments(segments), segments)
     end
   end
 
@@ -64,13 +78,43 @@ defmodule Vutuv.Moderation.ContentUrl do
     if url =~ ~r{^https?://}i, do: url, else: "https://" <> url
   end
 
-  defp found(nil), do: {:error, :not_found}
-  defp found(content), do: {:ok, content}
+  # `nil` is "I know this shape and there is nothing there" — a typo, a deleted
+  # post, a hidden one — and stays the miss. `:no_content_shape` is "this is
+  # not an address content lives at", which is the only case allowed to ask
+  # whether the site itself has a page there.
+  defp found(:no_content_shape, segments), do: site_page(segments)
+  defp found(nil, _segments), do: {:error, :not_found}
+  defp found(content, _segments), do: {:ok, content}
+
+  # The address names no member's and no page's content, so the last question
+  # is whether it is a page of the **site** — the Impressum, the house rules,
+  # the member directory. The router answers it, and the discriminator is the
+  # matched route's **first** segment: a literal one is a fixed address of this
+  # installation, a dynamic one is where a handle stands (so a reserved word
+  # nobody routed, `/stefan`, keeps the answer a typo gets). Nothing here reads
+  # the database, so no address can learn anything from it that fetching the
+  # URL would not already tell. `Endpoint.host/0` rather than the pasted host:
+  # `local_path/1` has already ruled the address ours, `www.` and all.
+  defp site_page(segments) do
+    case PhoenixRouter.route_info(Router, "GET", segments, Endpoint.host()) do
+      %{route: route} ->
+        if fixed_address?(route), do: {:error, :not_reportable}, else: {:error, :not_found}
+
+      :error ->
+        {:error, :not_found}
+    end
+  end
+
+  defp fixed_address?(route) do
+    case String.split(route, "/", trim: true) do
+      [first | _] -> not String.starts_with?(first, [":", "*"])
+      [] -> true
+    end
+  end
 
   # A member's post and a page's post. Both by id: the handle or the slug in
   # front of it is only how the URL was spelled on the day it was copied.
   defp from_segments(["organizations", _slug, "posts", id]), do: visible_post(id)
-  defp from_segments([_handle, "posts", id]), do: visible_post(id)
 
   # The authorizing media proxies. Right-clicking a photo or a video in a post
   # copies one of these, and what is reportable is the post that carries it —
@@ -81,18 +125,30 @@ defmodule Vutuv.Moderation.ContentUrl do
   defp from_segments(["post_videos", token, _file]),
     do: post_of(Videos.get_video_by_token(token))
 
-  # A profile picture or cover, by the three addresses one has. The served
-  # files sit in an id-scoped public tree (`/avatars/<user id>/…`), which is
-  # what a "copy image address" hands over; `/<handle>/avatar.jpg` is the
-  # scraper-friendly JPEG a link preview shows.
+  # A profile picture or cover, by two of the three addresses one has. The
+  # served files sit in an id-scoped public tree (`/avatars/<user id>/…`),
+  # which is what a "copy image address" hands over; the third spelling,
+  # `/<handle>/avatar.jpg`, is below the reserved-word clause because its first
+  # segment is a handle.
   defp from_segments(["avatars", user_id | _rest]), do: visible_image(user_id, "avatar")
   defp from_segments(["covers", user_id | _rest]), do: visible_image(user_id, "cover")
-  defp from_segments([handle, "avatar.jpg"]), do: visible_image(visible_user(handle), "avatar")
 
   defp from_segments(["organizations", slug]),
     do: ok_or_nil(Organizations.fetch_visible_organization(slug, nil))
 
   defp from_segments(["jobs", slug]), do: ok_or_nil(Jobs.fetch_visible_job_posting(slug, nil))
+
+  # A reserved word is never a handle — keeping the URL root claimable is the
+  # whole purpose of that list, and `reserved_slugs_router_test.exs` keeps it in
+  # step with the router. So the clauses below, which all read their first
+  # segment as somebody's handle, must not claim these paths: `/system/members/w`
+  # read as "the member `system`, missing" is what put every site page deeper
+  # than one segment into the typo bucket (issue #2068). Placed after the
+  # content shapes above, which start with a reserved word themselves.
+  defp from_segments([first | _]) when first in @reserved, do: :no_content_shape
+
+  defp from_segments([handle, "avatar.jpg"]), do: visible_image(visible_user(handle), "avatar")
+  defp from_segments([_handle, "posts", id]), do: visible_post(id)
 
   # A bare handle is a member's profile, or — since members and pages share one
   # handle namespace — a page that claimed that root word. The two live in two
@@ -106,7 +162,8 @@ defmodule Vutuv.Moderation.ContentUrl do
   # that member, which is the reportable thing there.
   defp from_segments([handle | _rest]), do: visible_user(handle)
 
-  defp from_segments(_segments), do: nil
+  # The site root, which is a page of ours like any other.
+  defp from_segments([]), do: :no_content_shape
 
   defp ok_or_nil({:ok, record}), do: record
   defp ok_or_nil(_), do: nil

--- a/lib/vutuv_web/controllers/public_report_controller.ex
+++ b/lib/vutuv_web/controllers/public_report_controller.ex
@@ -30,7 +30,11 @@ defmodule VutuvWeb.PublicReportController do
     an earlier notice already froze cannot be reported again, and answers the
     same way. That is the right end of the trade — it is off the site and its
     case is with the admins — but it is why a second rights holder is told
-    "not found" rather than "already reported".
+    "not found" rather than "already reported". What it does say apart is one
+    of **our own pages** (`/impressum`, the house rules, the member
+    directory): a correct address carrying nobody's content, which the router
+    can answer without telling anybody anything a visitor cannot fetch for
+    themselves.
   * **The confirmation is a POST**, not the GET the link lands on. A link
     scanner in a corporate mail gateway follows every URL in an email, and a
     GET that fires a takedown would hand the confirmation to whoever's software
@@ -127,6 +131,18 @@ defmodule VutuvWeb.PublicReportController do
       {:error, :foreign_host} ->
         error(conn, params, url, [
           gettext("That address is not on this site. We can only act on content published here.")
+        ])
+
+      # A correct address that names one of our own pages. Told apart from the
+      # miss below on purpose (issue #2068): "we could not find that page"
+      # about `/impressum` sends a rights holder off to re-check a link that
+      # was right all along, in the first minute of the one complaint that
+      # carries real liability.
+      {:error, :not_reportable} ->
+        error(conn, params, url, [
+          gettext(
+            "That address is one of our own pages, not content somebody published here, so there is nothing on it we could act on. Please paste the address of the post, picture, video, profile or job posting itself."
+          )
         ])
 
       {:error, :not_found} ->

--- a/lib/vutuv_web/live/admin/moderation_case_live.ex
+++ b/lib/vutuv_web/live/admin/moderation_case_live.ex
@@ -348,8 +348,12 @@ defmodule VutuvWeb.Admin.ModerationCaseLive do
                 )}
               </span>
             </p>
+            <%!-- The quotation marks are the translation's, like everywhere
+                  else in the app: hardcoded here, they opened German and
+                  closed ASCII on a page that renders in three languages
+                  (issue #2068). --%>
             <p :if={report.note not in [nil, ""]} class="mt-1 text-slate-600 dark:text-slate-400">
-              „{report.note}"
+              {gettext("“%{note}”", note: report.note)}
             </p>
             <% severance = @severance_by_reporter[report.reporter_id] %>
             <p :if={severance} class="mt-1 text-xs text-slate-600 dark:text-slate-400">

--- a/lib/vutuv_web/templates/page/community.html.heex
+++ b/lib/vutuv_web/templates/page/community.html.heex
@@ -42,10 +42,18 @@
         <dt class="font-semibold text-slate-900 dark:text-white">
           {gettext("Publish only what you hold the rights to")}
         </dt>
+        <%!-- "here" was plain text, so the one paragraph that invites a rights
+              holder to report sent them looking for the form (issue #2068).
+              The marker carries the link where each language wants it. --%>
+        <% {rights_pre, rights_post} =
+          split_marker(
+            gettext(
+              "Texts, photos and videos belong to whoever made them. Post your own work, or work you have permission to use. A rights holder can report content here without an account, through {form}; such a complaint is decided by one of our admins, and an edit does not settle it."
+            ),
+            "{form}"
+          ) %>
         <dd class="mt-1 text-sm text-slate-600 dark:text-slate-400">
-          {gettext(
-            "Texts, photos and videos belong to whoever made them. Post your own work, or work you have permission to use. A rights holder can report content here, and such a complaint is decided by one of our admins - an edit does not settle it."
-          )}
+          {rights_pre}<a href={~p"/system/report"} class={link_class()}>{gettext("the report form")}</a>{rights_post}
         </dd>
       </div>
       <div>

--- a/lib/vutuv_web/templates/public_report/new.html.heex
+++ b/lib/vutuv_web/templates/public_report/new.html.heex
@@ -10,7 +10,7 @@
     </p>
     <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">
       {gettext(
-        "We will send you an email with a confirmation link. Nothing happens until you follow it - your report reaches our admins, and the reported content stays exactly where it is."
+        "We will send you an email with a confirmation link. Your report is in front of our admins right away; until you follow that link nothing about the reported content changes."
       )}
     </p>
 
@@ -121,34 +121,14 @@
         )}
       </p>
 
-      <label
+      <ReportHTML.good_faith_declaration
         id="notice-good-faith"
-        class="mt-5 flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200 p-3 dark:border-slate-700"
-      >
-        <input
-          type="checkbox"
-          name="report[good_faith?]"
-          value="true"
-          checked={@report.good_faith?}
-          required
-          class="mt-1 accent-brand-600"
-        />
-        <span class="text-sm text-slate-600 dark:text-slate-400">
-          {gettext(
-            "I declare in good faith that what I describe here is true and that this use is authorized neither by the rights holder nor by law."
-          )}
-        </span>
-      </label>
+        class="mt-5 flex"
+        checked={@report.good_faith?}
+        required
+      />
 
-      <p class="mt-3 text-xs text-slate-600 dark:text-slate-400">
-        {gettext("Please report honestly. Reporting to harm someone breaks our")}
-        <a
-          href={~p"/community"}
-          class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
-        >
-          {gettext("community guidelines")}
-        </a>.
-      </p>
+      <ReportHTML.honest_reporting_note />
 
       <div class="mt-6 flex items-center justify-end">
         <.button type="submit">{gettext("Send report")}</.button>

--- a/lib/vutuv_web/templates/public_report/sent.html.heex
+++ b/lib/vutuv_web/templates/public_report/sent.html.heex
@@ -7,8 +7,11 @@
       {gettext("We have sent an email to %{email}.", email: @email)}
     </p>
     <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">
+      <%!-- The case is `flagged` from the submit, which is a queue status, so
+            the admins have it before anybody clicks anything — the receipt
+            mail said so and this page said the opposite (issue #2068). --%>
       {gettext(
-        "Follow the link in it and your report goes to our admins. Until then nothing about the reported content changes."
+        "Your report is already with our admins. Follow the link in that email to confirm your address; until you do, nothing about the reported content changes."
       )}
     </p>
     <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">

--- a/lib/vutuv_web/templates/report/new.html.heex
+++ b/lib/vutuv_web/templates/report/new.html.heex
@@ -137,31 +137,14 @@
         >{@report.note}</textarea>
       </label>
 
-      <label
+      <.good_faith_declaration
         :if={copyright_offered?(@content_type)}
         id="report-good-faith"
-        class="mt-4 hidden cursor-pointer items-start gap-3 rounded-lg border border-slate-200 p-3 group-has-[.report-copyright-choice:checked]:flex dark:border-slate-700"
-      >
-        <input
-          type="checkbox"
-          name="report[good_faith?]"
-          value="true"
-          checked={@report.good_faith?}
-          class="mt-1 accent-brand-600"
-        />
-        <span class="text-sm text-slate-600 dark:text-slate-400">
-          {gettext(
-            "I declare in good faith that this use is authorized neither by the rights holder nor by law."
-          )}
-        </span>
-      </label>
+        class="mt-4 hidden group-has-[.report-copyright-choice:checked]:flex"
+        checked={@report.good_faith?}
+      />
 
-      <p class="mt-3 text-xs text-slate-600 dark:text-slate-400">
-        {gettext("Please report honestly. Reporting to harm someone breaks our")}
-        <a href={~p"/community"} class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300">
-          {gettext("community guidelines")}
-        </a>.
-      </p>
+      <.honest_reporting_note />
 
       <div class="mt-6 flex items-center justify-end gap-3">
         <a

--- a/lib/vutuv_web/views/public_report_html.ex
+++ b/lib/vutuv_web/views/public_report_html.ex
@@ -2,12 +2,17 @@ defmodule VutuvWeb.PublicReportHTML do
   @moduledoc false
   use VutuvWeb, :html
 
+  alias VutuvWeb.ReportHTML
+
   embed_templates("../templates/public_report/*")
 
   @doc """
   The category labels and hints are the in-app form's, so the two forms cannot
-  describe the same complaint differently.
+  describe the same complaint differently. The two sentences they also share —
+  the good-faith declaration and the house-rules line — come from the same
+  module as `<ReportHTML.good_faith_declaration>` and
+  `<ReportHTML.honest_reporting_note>`.
   """
-  defdelegate category_label(category), to: VutuvWeb.ReportHTML
-  defdelegate category_hint(category), to: VutuvWeb.ReportHTML
+  defdelegate category_label(category), to: ReportHTML
+  defdelegate category_hint(category), to: ReportHTML
 end

--- a/lib/vutuv_web/views/report_html.ex
+++ b/lib/vutuv_web/views/report_html.ex
@@ -3,8 +3,75 @@ defmodule VutuvWeb.ReportHTML do
   use VutuvWeb, :html
 
   alias Vutuv.Moderation.Report
+  alias VutuvWeb.PageHTML
 
   embed_templates("../templates/report/*")
+
+  @doc """
+  The good-faith declaration, on both report forms.
+
+  One home rather than two copies of the sentence: a single column records that
+  it was made (`good_faith_declared_at`, issue #2069), so it may not mean two
+  things depending on which form filed it — and it did, until issue #2068. The
+  member form reveals it by CSS when the copyright category is picked and does
+  not demand it for the others, hence `class` and `required`.
+  """
+  attr(:id, :string, required: true)
+  attr(:class, :string, default: "")
+  attr(:checked, :boolean, default: false)
+  attr(:required, :boolean, default: false)
+
+  def good_faith_declaration(assigns) do
+    ~H"""
+    <label
+      id={@id}
+      class={[
+        "cursor-pointer items-start gap-3 rounded-lg border border-slate-200 p-3 dark:border-slate-700",
+        @class
+      ]}
+    >
+      <input
+        type="checkbox"
+        name="report[good_faith?]"
+        value="true"
+        checked={@checked}
+        required={@required}
+        class="mt-1 accent-brand-600"
+      />
+      <span class="text-sm text-slate-600 dark:text-slate-400">
+        {gettext(
+          "I declare in good faith that what I describe here is true and that this use is authorized neither by the rights holder nor by law."
+        )}
+      </span>
+    </label>
+    """
+  end
+
+  @doc """
+  The line under both report forms that links the house rules.
+
+  The link is a `{guidelines}` marker inside the sentence rather than a label
+  glued to its end, so German and English can each place it — and so the full
+  stop cannot pick up the template's indentation and render a space away from
+  the word ("Community-Richtlinien .", issue #2068).
+  """
+  def honest_reporting_note(assigns) do
+    {pre, post} =
+      split_marker(
+        gettext("Please report honestly. Reporting to harm someone breaks our {guidelines}."),
+        "{guidelines}"
+      )
+
+    assigns = assign(assigns, pre: pre, post: post)
+
+    ~H"""
+    <p class="mt-3 text-xs text-slate-600 dark:text-slate-400">
+      {@pre}<a href={~p"/community"} class={PageHTML.link_class()}>{gettext(
+        "community guidelines"
+      )}</a>{@post}
+    </p>
+    """
+  end
 
   @doc """
   The human name of a report category, in the viewer's locale — the single

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -123,7 +123,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:113
-#: lib/vutuv_web/templates/report/new.html.heex:172
+#: lib/vutuv_web/templates/report/new.html.heex:155
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:255
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
@@ -1146,7 +1146,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
 #: lib/vutuv_web/live/admin/job_live.ex:199
 #: lib/vutuv_web/live/admin/member_badges.ex:22
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:131
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:144
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:127
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
@@ -2908,7 +2908,7 @@ msgstr "Willkommen bei vutuv, %{name}!"
 msgid "liked your post."
 msgstr "gefällt Ihr Beitrag."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:158
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:171
 #, elixir-autogen, elixir-format
 msgid "%{count} active strike"
 msgid_plural "%{count} active strikes"
@@ -2923,13 +2923,13 @@ msgstr[0] "%{formatted} Fall wartet auf eine Entscheidung."
 msgstr[1] "%{formatted} Fälle warten auf eine Entscheidung."
 
 #: lib/vutuv_web/live/admin/job_live.ex:335
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:302
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:315
 #: lib/vutuv_web/templates/moderation_evidence/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "(deleted account)"
 msgstr "(gelöschtes Konto)"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:221
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:234
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "(no text)"
@@ -2955,7 +2955,7 @@ msgstr "Missbräuchlich"
 msgid "Anything our admins should know? (optional)"
 msgstr "Gibt es etwas, das unsere Admins wissen sollten? (optional)"
 
-#: lib/vutuv_web/views/report_html.ex:14
+#: lib/vutuv_web/views/report_html.ex:81
 #, elixir-autogen, elixir-format
 msgid "Bullying or harassment"
 msgstr "Mobbing oder Belästigung"
@@ -2970,7 +2970,7 @@ msgstr "Mobbing oder Belästigung"
 msgid "Community guidelines"
 msgstr "Community-Richtlinien"
 
-#: lib/vutuv_web/templates/page/community.html.heex:78
+#: lib/vutuv_web/templates/page/community.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Confirmed violations follow three steps: a warning, then a one-week suspension, then permanent deactivation. Strikes expire after twelve months."
 msgstr ""
@@ -2978,7 +2978,7 @@ msgstr ""
 "einwöchige Sperre, dann die endgültige Deaktivierung. Verwarnungspunkte "
 "verfallen nach zwölf Monaten."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:288
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "Conversation context (the reported message last)"
 msgstr "Gesprächskontext (die gemeldete Nachricht zuletzt)"
@@ -2991,7 +2991,7 @@ msgstr ""
 "wiederholt unerwünschte Nachrichten führen zur Sperrung des Kontos, in "
 "öffentlichen Beiträgen genauso wie in privaten Nachrichten."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:280
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "Current version (edited since the report)"
 msgstr "Aktuelle Version (seit der Meldung bearbeitet)"
@@ -3007,7 +3007,7 @@ msgid "Deleted. The report is settled, no further steps needed."
 msgstr ""
 "Gelöscht. Die Meldung ist damit erledigt, weitere Schritte sind nicht nötig."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:188
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:201
 #: lib/vutuv_web/views/admin/moderation_html.ex:9
 #, elixir-autogen, elixir-format
 msgid "Escalated"
@@ -3045,7 +3045,7 @@ msgstr "Verborgen: gemeldet, wird geprüft"
 msgid "Keep it family-friendly"
 msgstr "Familienfreundlich bleiben"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:132
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:145
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
 #: lib/vutuv_web/notification_line.ex:322
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
@@ -3054,8 +3054,8 @@ msgstr "Familienfreundlich bleiben"
 msgid "Moderation"
 msgstr "Moderation"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:43
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:129
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:56
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "Moderation case"
 msgstr "Moderationsfall"
@@ -3108,7 +3108,7 @@ msgstr ""
 "Keine unerwünschte Werbung, keine Fake-Profile, kein Betrug, keine "
 "Klickköder."
 
-#: lib/vutuv_web/views/report_html.ex:13
+#: lib/vutuv_web/views/report_html.ex:80
 #, elixir-autogen, elixir-format
 msgid "Not family-friendly"
 msgstr "Nicht familienfreundlich"
@@ -3118,7 +3118,7 @@ msgstr "Nicht familienfreundlich"
 msgid "Nothing here - none of your content is currently reported."
 msgstr "Nichts zu sehen, keiner Ihrer Inhalte ist derzeit gemeldet."
 
-#: lib/vutuv_web/views/report_html.ex:25
+#: lib/vutuv_web/views/report_html.ex:92
 #, elixir-autogen, elixir-format
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
@@ -3165,12 +3165,6 @@ msgstr "Eröffnet"
 msgid "Owner"
 msgstr "Besitzer"
 
-#: lib/vutuv_web/templates/public_report/new.html.heex:144
-#: lib/vutuv_web/templates/report/new.html.heex:160
-#, elixir-autogen, elixir-format
-msgid "Please report honestly. Reporting to harm someone breaks our"
-msgstr "Melden Sie ehrlich. Wer meldet, um jemandem zu schaden, verstößt gegen unsere"
-
 #: lib/vutuv_web/components/ui.ex:5174
 #: lib/vutuv_web/live/shell_live.ex:1373
 #: lib/vutuv_web/templates/import/new.html.heex:16
@@ -3179,7 +3173,7 @@ msgstr "Melden Sie ehrlich. Wer meldet, um jemandem zu schaden, verstößt gegen
 msgid "Profile"
 msgstr "Profil"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:458
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "Reject the report"
 msgstr "Meldung ablehnen"
@@ -3204,7 +3198,7 @@ msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 msgid "Report"
 msgstr "Melden"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:239
+#: lib/vutuv_web/controllers/public_report_controller.ex:255
 #: lib/vutuv_web/controllers/report_controller.ex:54
 #: lib/vutuv_web/templates/layout/app.html.heex:131
 #: lib/vutuv_web/templates/page/legal.html.heex:42
@@ -3212,13 +3206,13 @@ msgstr "Melden"
 msgid "Report content"
 msgstr "Inhalt melden"
 
-#: lib/vutuv_web/templates/page/community.html.heex:53
+#: lib/vutuv_web/templates/page/community.html.heex:61
 #, elixir-autogen, elixir-format
 msgid "Report honestly"
 msgstr "Ehrlich melden"
 
 #: lib/vutuv_web/controllers/admin/moderation_controller.ex:55
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:59
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:72
 #, elixir-autogen, elixir-format
 msgid "Report rejected; the content is visible again."
 msgstr "Meldung abgelehnt; der Inhalt ist wieder sichtbar."
@@ -3235,7 +3229,7 @@ msgid "Report this message"
 msgstr "Diese Nachricht melden"
 
 #: lib/vutuv_web/controllers/admin/moderation_controller.ex:39
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:51
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Report upheld; the owner got a strike."
 msgstr "Meldung bestätigt; der Besitzer hat einen Verwarnungspunkt erhalten."
@@ -3253,7 +3247,7 @@ msgstr "Gemeldet als"
 msgid "Reported content"
 msgstr "Gemeldete Inhalte"
 
-#: lib/vutuv_web/templates/page/community.html.heex:68
+#: lib/vutuv_web/templates/page/community.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Reported content is hidden right away while the report is handled. Nobody is publicly marked."
 msgstr ""
@@ -3273,7 +3267,7 @@ msgstr "Melder"
 msgid "Reporter track records"
 msgstr "Melder-Bilanz"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:312
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:325
 #: lib/vutuv_web/live/admin/moderation_live.ex:57
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3294,7 +3288,7 @@ msgstr ""
 msgid "Review"
 msgstr "Ansehen"
 
-#: lib/vutuv_web/templates/page/community.html.heex:56
+#: lib/vutuv_web/templates/page/community.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "See something that breaks these rules? Report it - every post, message and profile has a report option, and reports are anonymous. But reporting is not a weapon: deliberately false reports count as bullying and earn the reporter the same strikes."
 msgstr ""
@@ -3304,8 +3298,8 @@ msgstr ""
 "Meldungen gelten als Mobbing und bringen dem Melder dieselben "
 "Verwarnungspunkte ein."
 
-#: lib/vutuv_web/templates/public_report/new.html.heex:154
-#: lib/vutuv_web/templates/report/new.html.heex:174
+#: lib/vutuv_web/templates/public_report/new.html.heex:134
+#: lib/vutuv_web/templates/report/new.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Send report"
 msgstr "Meldung absenden"
@@ -3320,12 +3314,12 @@ msgstr "Erledigt: Der Inhalt wurde gelöscht."
 msgid "Settled: you revised the content and it is visible again."
 msgstr "Erledigt: Sie haben den Inhalt überarbeitet, er ist wieder sichtbar."
 
-#: lib/vutuv_web/views/report_html.ex:21
+#: lib/vutuv_web/views/report_html.ex:88
 #, elixir-autogen, elixir-format
 msgid "Something else"
 msgstr "Etwas anderes"
 
-#: lib/vutuv_web/views/report_html.ex:15
+#: lib/vutuv_web/views/report_html.ex:82
 #, elixir-autogen, elixir-format
 msgid "Spam or scam"
 msgstr "Spam oder Betrug"
@@ -3356,12 +3350,12 @@ msgstr ""
 msgid "Status"
 msgstr "Status"
 
-#: lib/vutuv_web/views/report_html.ex:27
+#: lib/vutuv_web/views/report_html.ex:94
 #, elixir-autogen, elixir-format
 msgid "Targets, demeans or threatens a person."
 msgstr "Zielt auf eine Person, würdigt sie herab oder bedroht sie."
 
-#: lib/vutuv_web/views/report_html.ex:36
+#: lib/vutuv_web/views/report_html.ex:103
 #, elixir-autogen, elixir-format
 msgid "Tell us more in the note below."
 msgstr "Beschreiben Sie es in der Notiz unten genauer."
@@ -3376,7 +3370,7 @@ msgstr "Danke für Ihre Meldung. Wir übernehmen ab hier."
 msgid "The content in question"
 msgstr "Der betreffende Inhalt"
 
-#: lib/vutuv_web/templates/page/community.html.heex:73
+#: lib/vutuv_web/templates/page/community.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "The owner is notified and can delete the content, fix it (it becomes visible again immediately) or stand by it - then our admins decide."
 msgstr ""
@@ -3390,14 +3384,14 @@ msgid "The queue is empty - the self-service flow settled everything."
 msgstr ""
 "Die Warteschlange ist leer, der Selbstbedienungs-Ablauf hat alles erledigt."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:446
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "The report by @%{slug} was a deliberate weapon (strikes the reporter)"
 msgstr ""
 "Die Meldung von @%{slug} war eine gezielte Waffe (Verwarnungspunkt für den "
 "Melder)"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:409
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content stays hidden and the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
@@ -3443,12 +3437,12 @@ msgstr ""
 "Verstanden. Der Inhalt bleibt verborgen, bis einer unserer Admins "
 "entschieden hat."
 
-#: lib/vutuv_web/views/report_html.ex:28
+#: lib/vutuv_web/views/report_html.ex:95
 #, elixir-autogen, elixir-format
 msgid "Unwanted advertising, fraud or fake activity."
 msgstr "Unerwünschte Werbung, Betrug oder gefälschte Aktivität."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:423
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "Uphold the report"
 msgstr "Meldung bestätigen"
@@ -3458,7 +3452,7 @@ msgstr "Meldung bestätigen"
 msgid "Visible. Our admins will take a look."
 msgstr "Sichtbar. Unsere Admins schauen sich den Fall an."
 
-#: lib/vutuv_web/templates/page/community.html.heex:64
+#: lib/vutuv_web/templates/page/community.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "What happens after a report"
 msgstr "Was nach einer Meldung passiert"
@@ -3515,8 +3509,7 @@ msgstr ""
 "verborgen und der Besitzer gebeten, ihn in Ordnung zu bringen."
 
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:145
-#: lib/vutuv_web/templates/public_report/new.html.heex:149
-#: lib/vutuv_web/templates/report/new.html.heex:162
+#: lib/vutuv_web/views/report_html.ex:69
 #, elixir-autogen, elixir-format
 msgid "community guidelines"
 msgstr "Community-Richtlinien"
@@ -3634,19 +3627,19 @@ msgstr ""
 msgid "%{count} follows"
 msgstr "%{count} Follows"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "%{count} report so far"
 msgid_plural "%{count} reports so far"
 msgstr[0] "bisher %{count} Meldung"
 msgstr[1] "bisher %{count} Meldungen"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "%{rejected} rejected, %{abusive} abusive"
 msgstr "%{rejected} abgelehnt, %{abusive} missbräuchlich"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:133
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Case"
 msgstr "Fall"
@@ -3661,7 +3654,7 @@ msgstr "Inhalt gelöscht"
 msgid "Content frozen"
 msgstr "Inhalt eingefroren"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:393
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "Decision"
 msgstr "Entscheidung"
@@ -3671,17 +3664,17 @@ msgstr "Entscheidung"
 msgid "Escalated - the 72h deadline passed"
 msgstr "Eskaliert - die 72h-Frist ist abgelaufen"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:196
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Evidence"
 msgstr "Beweismaterial"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:366
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr "Verlauf"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:206
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:219
 #, elixir-autogen, elixir-format
 msgid "Open the profile"
 msgstr "Profil öffnen"
@@ -3723,7 +3716,7 @@ msgstr "Meldung abgelehnt"
 msgid "Report upheld"
 msgstr "Meldung bestätigt"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:355
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:371
 #, elixir-autogen, elixir-format
 msgid "Reporter and owner are separated since this report (connection, follows, messages)."
 msgstr ""
@@ -3755,12 +3748,12 @@ msgstr "Durch Löschung erledigt"
 msgid "Strike issued"
 msgstr "Verwarnungspunkt vergeben"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:351
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "The protective separation from the owner was lifted on %{date}."
 msgstr "Die schützende Trennung vom Besitzer wurde am %{date} aufgehoben."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:434
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:450
 #, elixir-autogen, elixir-format
 msgid "The report is unfounded. The content becomes visible again, any protective separation is lifted, and the rejection counts against each reporter's trust."
 msgstr ""
@@ -3768,7 +3761,7 @@ msgstr ""
 "schützende Trennung wird aufgehoben und die Ablehnung zählt gegen die "
 "Vertrauenswürdigkeit jedes Melders."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:200
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "The whole profile was reported. Judge the profile itself - the snapshot below only preserves the name at report time."
 msgstr ""
@@ -3813,7 +3806,7 @@ msgstr "Stufe %{level}, %{role}"
 msgid "messages"
 msgstr "Nachrichten"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:369
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "No history recorded - this case predates the audit log."
 msgstr "Kein Verlauf aufgezeichnet - dieser Fall ist älter als das Protokoll."
@@ -3857,7 +3850,7 @@ msgstr "Fall %{id}, aufgenommen %{at} UTC"
 msgid "Evidence screenshot captured"
 msgstr "Beweis-Screenshot aufgenommen"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:269
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Evidence screenshot captured when the report was filed"
 msgstr "Beweis-Screenshot, aufgenommen beim Eingang der Meldung"
@@ -3867,7 +3860,7 @@ msgstr "Beweis-Screenshot, aufgenommen beim Eingang der Meldung"
 msgid "Moderation evidence - reported private message with context"
 msgstr "Moderations-Beweismaterial - gemeldete private Nachricht mit Kontext"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:264
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "Screenshot at report time"
 msgstr "Screenshot zum Meldezeitpunkt"
@@ -3877,7 +3870,7 @@ msgstr "Screenshot zum Meldezeitpunkt"
 msgid "reported message"
 msgstr "gemeldete Nachricht"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:275
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
@@ -5411,7 +5404,7 @@ msgstr "API-Dokumentation"
 
 #: lib/vutuv_web/components/ui.ex:5397
 #: lib/vutuv_web/controllers/settings_controller.ex:161
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:501
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:517
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
@@ -5437,7 +5430,7 @@ msgid "The ad could not be approved."
 msgstr "Die Anzeige konnte nicht genehmigt werden."
 
 #: lib/vutuv_web/controllers/admin/moderation_controller.ex:106
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:90
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "This case has already been resolved."
 msgstr "Dieser Fall ist bereits erledigt."
@@ -7854,7 +7847,7 @@ msgstr "Dieses Konto existiert nicht mehr."
 msgid "That address no longer exists."
 msgstr "Diese Adresse existiert nicht mehr."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:37
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:50
 #, elixir-autogen, elixir-format
 msgid "This case no longer exists."
 msgstr "Dieser Fall existiert nicht mehr."
@@ -10219,7 +10212,7 @@ msgstr "%{action} (%{reason})"
 msgid "Account deactivated and marked as spam."
 msgstr "Konto deaktiviert und als Spam markiert."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:69
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:82
 #, elixir-autogen, elixir-format
 msgid "Account deactivated and marked as spam. Restore it from the member browser if this was wrong."
 msgstr ""
@@ -10227,7 +10220,7 @@ msgstr ""
 "wiederherstellen, falls das falsch war."
 
 #: lib/vutuv_web/controllers/admin/moderation_controller.ex:89
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:77
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Account deleted."
 msgstr "Konto gelöscht."
@@ -10247,7 +10240,7 @@ msgstr "Konto wiederhergestellt. Das Mitglied kann sich wieder anmelden."
 msgid "Accounts removed as spam"
 msgstr "Als Spam entfernte Konten"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:468
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Clear-cut spam or abuse?"
 msgstr "Eindeutiger Spam oder Missbrauch?"
@@ -10257,24 +10250,24 @@ msgstr "Eindeutiger Spam oder Missbrauch?"
 msgid "Could not restore this member."
 msgstr "Dieses Mitglied konnte nicht wiederhergestellt werden."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:483
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "Deactivate @%{slug} and mark the account as spam?"
 msgstr "@%{slug} deaktivieren und das Konto als Spam markieren?"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:486
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "Deactivate account"
 msgstr "Konto deaktivieren"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:495
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "Permanently DELETE @%{slug} and everything they posted? This cannot be undone."
 msgstr ""
 "@%{slug} und alle Beiträge dauerhaft LÖSCHEN? Das kann nicht rückgängig "
 "gemacht werden."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:471
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:487
 #, elixir-autogen, elixir-format
 msgid "Remove the account outright, skipping the warning ladder. Deactivating marks it as spam and is reversible from the member browser; deleting is permanent."
 msgstr ""
@@ -12476,7 +12469,7 @@ msgstr "Behörde / Öffentlich"
 msgid "%{views} views · %{clicks} apply clicks"
 msgstr "%{views} Aufrufe · %{clicks} Bewerbungsklicks"
 
-#: lib/vutuv_web/views/report_html.ex:31
+#: lib/vutuv_web/views/report_html.ex:98
 #, elixir-autogen, elixir-format
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr "Eine gefälschte, irreführende oder diskriminierende Stellenanzeige."
@@ -12690,7 +12683,7 @@ msgstr "Anbieter:in anschreiben"
 msgid "Mini-job"
 msgstr "Minijob"
 
-#: lib/vutuv_web/views/report_html.ex:16
+#: lib/vutuv_web/views/report_html.ex:83
 #, elixir-autogen, elixir-format
 msgid "Misleading job posting"
 msgstr "Irreführende Stellenanzeige"
@@ -13363,7 +13356,7 @@ msgstr "Job-Übersicht öffnen"
 msgid "Open reports"
 msgstr "Offene Meldungen"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:216
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Open the job posting"
 msgstr "Stellenanzeige öffnen"
@@ -23649,27 +23642,17 @@ msgstr "Für mein Konto einschalten"
 msgid "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."
 msgstr "Korrigieren. Einer unserer Admins sieht sich die Änderung dann an; bis dahin bleibt der Beitrag verborgen."
 
-#: lib/vutuv_web/templates/report/new.html.heex:153
-#, elixir-autogen, elixir-format
-msgid "I declare in good faith that this use is authorized neither by the rights holder nor by law."
-msgstr "Ich versichere nach bestem Wissen, dass diese Nutzung weder vom Rechteinhaber noch vom Gesetz gedeckt ist."
-
 #: lib/vutuv_web/templates/page/community.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Publish only what you hold the rights to"
 msgstr "Veröffentlichen Sie nur, wozu Sie die Rechte haben"
 
-#: lib/vutuv_web/views/report_html.ex:34
+#: lib/vutuv_web/views/report_html.ex:101
 #, elixir-autogen, elixir-format
 msgid "Tell us which work it is and where the original can be seen."
 msgstr "Sagen Sie uns, um welches Werk es geht und wo das Original zu sehen ist."
 
-#: lib/vutuv_web/templates/page/community.html.heex:46
-#, elixir-autogen, elixir-format
-msgid "Texts, photos and videos belong to whoever made them. Post your own work, or work you have permission to use. A rights holder can report content here, and such a complaint is decided by one of our admins - an edit does not settle it."
-msgstr "Texte, Fotos und Videos gehören denen, die sie gemacht haben. Veröffentlichen Sie eigene Werke oder solche, für die Sie die Erlaubnis haben. Rechteinhaber können Inhalte hier melden; über eine solche Meldung entscheidet einer unserer Admins - eine Korrektur erledigt sie nicht."
-
-#: lib/vutuv_web/views/report_html.ex:19
+#: lib/vutuv_web/views/report_html.ex:86
 #, elixir-autogen, elixir-format
 msgid "Uses a text, photo or video without the rights holder's permission"
 msgstr "Nutzt einen Text, ein Foto oder ein Video ohne Erlaubnis des Rechteinhabers"
@@ -23963,12 +23946,12 @@ msgstr "Titelbild melden"
 msgid "Report the profile picture"
 msgstr "Profilbild melden"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:229
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "The reported picture"
 msgstr "Das gemeldete Bild"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:248
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Upholding the case deletes it, the private original included. Rejecting it puts every file back where it was."
 msgstr "Wird der Meldung stattgegeben, wird es gelöscht, auch das private Original. Wird sie abgelehnt, liegt jede Datei wieder an ihrem Platz."
@@ -24040,7 +24023,7 @@ msgstr ""
 "Danke für Ihre Meldung. Unsere Moderatoren wurden benachrichtigt und prüfen "
 "dieses Bild."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:256
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "This picture is still on the profile: only a copyright notice takes one offline before a ruling. Upholding the case deletes it, the private original included."
 msgstr ""
@@ -24071,24 +24054,19 @@ msgstr "Adresse der Seite"
 msgid "Confirm the report"
 msgstr "Meldung bestätigen"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:87
-#: lib/vutuv_web/controllers/public_report_controller.ex:107
+#: lib/vutuv_web/controllers/public_report_controller.ex:91
+#: lib/vutuv_web/controllers/public_report_controller.ex:111
 #: lib/vutuv_web/templates/public_report/confirm.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Confirm your report"
 msgstr "Bestätigen Sie Ihre Meldung"
-
-#: lib/vutuv_web/templates/public_report/sent.html.heex:10
-#, elixir-autogen, elixir-format
-msgid "Follow the link in it and your report goes to our admins. Until then nothing about the reported content changes."
-msgstr "Folgen Sie dem Link darin, dann geht Ihre Meldung an unsere Admins. Bis dahin ändert sich am gemeldeten Inhalt nichts."
 
 #: lib/vutuv_web/templates/public_report/new.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "For a copyright claim: which work it is, and where the original can be seen."
 msgstr "Bei einer Urheberrechtsbeschwerde: um welches Werk es geht und wo das Original zu sehen ist."
 
-#: lib/vutuv_web/templates/public_report/new.html.heex:137
+#: lib/vutuv_web/views/report_html.ex:42
 #, elixir-autogen, elixir-format
 msgid "I declare in good faith that what I describe here is true and that this use is authorized neither by the rights holder nor by law."
 msgstr "Ich versichere nach bestem Wissen, dass meine Angaben zutreffen und dass diese Nutzung weder vom Rechteinhaber noch vom Gesetz gedeckt ist."
@@ -24103,7 +24081,7 @@ msgstr "Gehört ein hier veröffentlichter Inhalt Ihnen, oder verstößt er gege
 msgid "Moderation: something was reported"
 msgstr "Moderation: Ein Inhalt wurde gemeldet"
 
-#: lib/vutuv_web/templates/public_report/sent.html.heex:15
+#: lib/vutuv_web/templates/public_report/sent.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "No email? Please check your spam folder."
 msgstr "Keine E-Mail bekommen? Bitte sehen Sie in Ihrem Spam-Ordner nach."
@@ -24129,8 +24107,8 @@ msgstr "Externer Melder hat seine Adresse bestätigt"
 msgid "Please confirm your report"
 msgstr "Bitte bestätigen Sie Ihre Meldung"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:84
-#: lib/vutuv_web/controllers/public_report_controller.ex:112
+#: lib/vutuv_web/controllers/public_report_controller.ex:88
+#: lib/vutuv_web/controllers/public_report_controller.ex:116
 #, elixir-autogen, elixir-format
 msgid "Report confirmed"
 msgstr "Meldung bestätigt"
@@ -24145,7 +24123,7 @@ msgstr "Inhalt auf dieser Seite melden"
 msgid "Report filed from outside"
 msgstr "Meldung von außerhalb eingegangen"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:155
+#: lib/vutuv_web/controllers/public_report_controller.ex:171
 #, elixir-autogen, elixir-format
 msgid "Report sent"
 msgstr "Meldung abgeschickt"
@@ -24160,7 +24138,7 @@ msgstr "Inhalte auf dieser Seite melden"
 msgid "Thank you - your report is with our admins"
 msgstr "Danke, Ihre Meldung liegt bei unseren Admins"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:129
+#: lib/vutuv_web/controllers/public_report_controller.ex:133
 #, elixir-autogen, elixir-format
 msgid "That address is not on this site. We can only act on content published here."
 msgstr "Diese Adresse gehört nicht zu dieser Seite. Wir können nur bei Inhalten tätig werden, die hier veröffentlicht sind."
@@ -24170,12 +24148,12 @@ msgstr "Diese Adresse gehört nicht zu dieser Seite. Wir können nur bei Inhalte
 msgid "The post, picture, video, profile, page or job posting you are reporting. Copy it out of your browser's address bar."
 msgstr "Der Beitrag, das Bild, das Video, das Profil, die Seite oder die Stellenanzeige, die Sie melden. Kopieren Sie die Adresse aus der Adresszeile Ihres Browsers."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:451
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "The report by %{email} was a deliberate weapon (that address loses our trust)"
 msgstr "Die Meldung von %{email} war eine gezielte Waffe (diese Adresse verliert unser Vertrauen)"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:216
+#: lib/vutuv_web/controllers/public_report_controller.ex:232
 #, elixir-autogen, elixir-format
 msgid "We could not find that page. Please check the address."
 msgstr "Wir konnten diese Seite nicht finden. Bitte prüfen Sie die Adresse."
@@ -24185,17 +24163,12 @@ msgstr "Wir konnten diese Seite nicht finden. Bitte prüfen Sie die Adresse."
 msgid "We have sent an email to %{email}."
 msgstr "Wir haben eine E-Mail an %{email} geschickt."
 
-#: lib/vutuv_web/templates/public_report/new.html.heex:12
-#, elixir-autogen, elixir-format
-msgid "We will send you an email with a confirmation link. Nothing happens until you follow it - your report reaches our admins, and the reported content stays exactly where it is."
-msgstr "Wir schicken Ihnen eine E-Mail mit einem Bestätigungslink. Erst wenn Sie ihm folgen, geht Ihre Meldung an unsere Admins; bis dahin bleibt der gemeldete Inhalt genau dort, wo er ist."
-
 #: lib/vutuv_web/templates/public_report/new.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "What is wrong with it?"
 msgstr "Was stimmt damit nicht?"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:160
+#: lib/vutuv_web/controllers/public_report_controller.ex:176
 #, elixir-autogen, elixir-format
 msgid "You already sent us this report. Please use the confirmation link in the email we sent you."
 msgstr "Diese Meldung haben Sie uns bereits geschickt. Bitte nutzen Sie den Bestätigungslink aus unserer E-Mail."
@@ -24210,7 +24183,7 @@ msgstr "Sie brauchen kein Konto. Sagen Sie uns, um welche Seite es geht und was 
 msgid "You do not need to do anything else."
 msgstr "Mehr müssen Sie nicht tun."
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:68
+#: lib/vutuv_web/controllers/public_report_controller.ex:72
 #, elixir-autogen, elixir-format
 msgid "You have sent us a lot of reports just now. Please try again later."
 msgstr "Sie haben uns gerade sehr viele Meldungen geschickt. Bitte versuchen Sie es später noch einmal."
@@ -24225,37 +24198,37 @@ msgstr "Ihre E-Mail-Adresse"
 msgid "address not confirmed"
 msgstr "Adresse nicht bestätigt"
 
-#: lib/vutuv_web/views/report_html.ex:52
+#: lib/vutuv_web/views/report_html.ex:119
 #, elixir-autogen, elixir-format
 msgctxt "content type"
 msgid "Job posting"
 msgstr "Stellenanzeige"
 
-#: lib/vutuv_web/views/report_html.ex:51
+#: lib/vutuv_web/views/report_html.ex:118
 #, elixir-autogen, elixir-format
 msgctxt "content type"
 msgid "Organization page"
 msgstr "Organisationsseite"
 
-#: lib/vutuv_web/views/report_html.ex:53
+#: lib/vutuv_web/views/report_html.ex:120
 #, elixir-autogen, elixir-format
 msgctxt "content type"
 msgid "Picture"
 msgstr "Bild"
 
-#: lib/vutuv_web/views/report_html.ex:48
+#: lib/vutuv_web/views/report_html.ex:115
 #, elixir-autogen, elixir-format
 msgctxt "content type"
 msgid "Post"
 msgstr "Beitrag"
 
-#: lib/vutuv_web/views/report_html.ex:49
+#: lib/vutuv_web/views/report_html.ex:116
 #, elixir-autogen, elixir-format
 msgctxt "content type"
 msgid "Private message"
 msgstr "Private Nachricht"
 
-#: lib/vutuv_web/views/report_html.ex:50
+#: lib/vutuv_web/views/report_html.ex:117
 #, elixir-autogen, elixir-format
 msgctxt "content type"
 msgid "Profile"
@@ -24276,8 +24249,8 @@ msgstr "Meldung verworfen: die Adresse wurde nie bestätigt"
 msgid "Send the report again"
 msgstr "Meldung erneut senden"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:95
-#: lib/vutuv_web/controllers/public_report_controller.ex:117
+#: lib/vutuv_web/controllers/public_report_controller.ex:99
+#: lib/vutuv_web/controllers/public_report_controller.ex:121
 #: lib/vutuv_web/templates/public_report/expired.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "This link has expired"
@@ -24353,67 +24326,67 @@ msgstr "Einfacher LinkedIn-Profil-Import."
 msgid "No person made this decision: a report from somebody with a good record hides the reported content automatically, the moment it arrives."
 msgstr "Diese Entscheidung hat kein Mensch getroffen: Die Meldung einer Person mit guter Bilanz verbirgt den gemeldeten Inhalt automatisch, sobald sie eintrifft."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:413
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content becomes visible again - the consequence here is the strike (warn, suspend, deactivate)."
 msgstr "Die Meldung ist berechtigt. Der Inhalt wird wieder sichtbar; die Folge ist hier der Verwarnungspunkt (verwarnen, sperren, deaktivieren)."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:417
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:433
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content is not hidden and upholding does not hide it; the owner gets a strike (warn, suspend, deactivate)."
 msgstr "Die Meldung ist berechtigt. Der Inhalt ist nicht verborgen und wird es dadurch auch nicht; der Besitzer erhält einen Verwarnungspunkt (verwarnen, sperren, deaktivieren)."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:405
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The reported picture is deleted, the private original included, and the owner gets a strike (warn, suspend, deactivate)."
 msgstr "Die Meldung ist berechtigt. Das gemeldete Bild wird gelöscht, auch das private Original, und der Besitzer erhält einen Verwarnungspunkt (verwarnen, sperren, deaktivieren)."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:252
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "This picture is still on the profile: the address behind the copyright notice is not confirmed yet, so nothing has been hidden. Upholding the case deletes it, the private original included."
 msgstr "Dieses Bild ist weiterhin im Profil zu sehen: Die Adresse hinter der Urheberrechtsmeldung ist noch nicht bestätigt, deshalb ist nichts verborgen. Wird der Meldung stattgegeben, wird es gelöscht, auch das private Original."
 
-#: lib/vutuv_web/views/report_html.ex:82
+#: lib/vutuv_web/views/report_html.ex:149
 #, elixir-autogen, elixir-format
 msgid "somebody reported one of your job postings on vutuv."
 msgstr "eine Ihrer Stellenanzeigen auf vutuv wurde gemeldet."
 
-#: lib/vutuv_web/views/report_html.ex:85
+#: lib/vutuv_web/views/report_html.ex:152
 #, elixir-autogen, elixir-format
 msgid "somebody reported one of your pages on vutuv."
 msgstr "eine Ihrer Seiten auf vutuv wurde gemeldet."
 
-#: lib/vutuv_web/views/report_html.ex:76
+#: lib/vutuv_web/views/report_html.ex:143
 #, elixir-autogen, elixir-format
 msgid "somebody reported one of your pictures on vutuv."
 msgstr "eines Ihrer Bilder auf vutuv wurde gemeldet."
 
-#: lib/vutuv_web/views/report_html.ex:73
+#: lib/vutuv_web/views/report_html.ex:140
 #, elixir-autogen, elixir-format
 msgid "somebody reported one of your posts on vutuv."
 msgstr "einer Ihrer Beiträge auf vutuv wurde gemeldet."
 
-#: lib/vutuv_web/views/report_html.ex:79
+#: lib/vutuv_web/views/report_html.ex:146
 #, elixir-autogen, elixir-format
 msgid "somebody reported one of your private messages on vutuv."
 msgstr "eine Ihrer privaten Nachrichten auf vutuv wurde gemeldet."
 
-#: lib/vutuv_web/views/report_html.ex:91
+#: lib/vutuv_web/views/report_html.ex:158
 #, elixir-autogen, elixir-format
 msgid "somebody reported something of yours on vutuv."
 msgstr "etwas von Ihnen auf vutuv wurde gemeldet."
 
-#: lib/vutuv_web/views/report_html.ex:88
+#: lib/vutuv_web/views/report_html.ex:155
 #, elixir-autogen, elixir-format
 msgid "somebody reported your profile on vutuv."
 msgstr "Ihr Profil auf vutuv wurde gemeldet."
 
-#: lib/vutuv_web/views/report_html.ex:105
+#: lib/vutuv_web/views/report_html.ex:172
 #, elixir-autogen, elixir-format
 msgid "A report from a member in good standing hides the reported content automatically, the moment it arrives."
 msgstr "Die Meldung eines Mitglieds mit guter Bilanz verbirgt den gemeldeten Inhalt automatisch, sobald sie eintrifft."
 
-#: lib/vutuv_web/views/report_html.ex:111
+#: lib/vutuv_web/views/report_html.ex:178
 #, elixir-autogen, elixir-format
 msgid "A report from somebody with a good record hides the reported content automatically, the moment it arrives."
 msgstr "Die Meldung einer Person mit guter Bilanz verbirgt den gemeldeten Inhalt automatisch, sobald sie eintrifft."
@@ -24448,17 +24421,52 @@ msgstr "Der Inhalt bleibt verborgen."
 msgid "Owner replaced the content"
 msgstr "Besitzer hat den Inhalt ersetzt"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:184
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Owner deadline"
 msgstr "Frist des Besitzers"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:181
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Reported"
 msgstr "Gemeldet"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:330
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "declared in good faith"
 msgstr "in gutem Glauben erklärt"
+
+#: lib/vutuv_web/views/report_html.ex:61
+#, elixir-autogen, elixir-format
+msgid "Please report honestly. Reporting to harm someone breaks our {guidelines}."
+msgstr "Melden Sie ehrlich. Wer meldet, um jemandem zu schaden, verstößt gegen unsere {guidelines}."
+
+#: lib/vutuv_web/templates/page/community.html.heex:50
+#, elixir-autogen, elixir-format
+msgid "Texts, photos and videos belong to whoever made them. Post your own work, or work you have permission to use. A rights holder can report content here without an account, through {form}; such a complaint is decided by one of our admins, and an edit does not settle it."
+msgstr "Texte, Fotos und Videos gehören denen, die sie gemacht haben. Veröffentlichen Sie eigene Werke oder solche, für die Sie die Erlaubnis haben. Rechteinhaber können Inhalte auch ohne Konto melden, über {form}; über eine solche Meldung entscheidet einer unserer Admins, und eine Korrektur erledigt sie nicht."
+
+#: lib/vutuv_web/controllers/public_report_controller.ex:143
+#, elixir-autogen, elixir-format
+msgid "That address is one of our own pages, not content somebody published here, so there is nothing on it we could act on. Please paste the address of the post, picture, video, profile or job posting itself."
+msgstr "Diese Adresse gehört zu einer unserer eigenen Seiten und nicht zu einem Inhalt, den jemand hier veröffentlicht hat; dort gibt es also nichts, wogegen wir vorgehen könnten. Bitte fügen Sie die Adresse des Beitrags, des Bildes, des Videos, des Profils oder der Stellenanzeige selbst ein."
+
+#: lib/vutuv_web/templates/public_report/new.html.heex:12
+#, elixir-autogen, elixir-format
+msgid "We will send you an email with a confirmation link. Your report is in front of our admins right away; until you follow that link nothing about the reported content changes."
+msgstr "Wir schicken Ihnen eine E-Mail mit einem Bestätigungslink. Ihre Meldung liegt sofort bei unseren Admins; bis Sie dem Link folgen, ändert sich am gemeldeten Inhalt nichts."
+
+#: lib/vutuv_web/templates/public_report/sent.html.heex:13
+#, elixir-autogen, elixir-format
+msgid "Your report is already with our admins. Follow the link in that email to confirm your address; until you do, nothing about the reported content changes."
+msgstr "Ihre Meldung liegt bereits bei unseren Admins. Folgen Sie dem Link in der E-Mail, um Ihre Adresse zu bestätigen; bis dahin ändert sich am gemeldeten Inhalt nichts."
+
+#: lib/vutuv_web/templates/page/community.html.heex:56
+#, elixir-autogen, elixir-format
+msgid "the report form"
+msgstr "das Meldeformular"
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:356
+#, elixir-autogen, elixir-format
+msgid "“%{note}”"
+msgstr "„%{note}“"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -125,7 +125,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:113
-#: lib/vutuv_web/templates/report/new.html.heex:172
+#: lib/vutuv_web/templates/report/new.html.heex:155
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:255
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
@@ -1127,7 +1127,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
 #: lib/vutuv_web/live/admin/job_live.ex:199
 #: lib/vutuv_web/live/admin/member_badges.ex:22
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:131
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:144
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:127
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
@@ -2864,7 +2864,7 @@ msgstr ""
 msgid "liked your post."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:158
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:171
 #, elixir-autogen, elixir-format
 msgid "%{count} active strike"
 msgid_plural "%{count} active strikes"
@@ -2879,13 +2879,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:335
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:302
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:315
 #: lib/vutuv_web/templates/moderation_evidence/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "(deleted account)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:221
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:234
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "(no text)"
@@ -2911,7 +2911,7 @@ msgstr ""
 msgid "Anything our admins should know? (optional)"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:14
+#: lib/vutuv_web/views/report_html.ex:81
 #, elixir-autogen, elixir-format
 msgid "Bullying or harassment"
 msgstr ""
@@ -2926,12 +2926,12 @@ msgstr ""
 msgid "Community guidelines"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:78
+#: lib/vutuv_web/templates/page/community.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Confirmed violations follow three steps: a warning, then a one-week suspension, then permanent deactivation. Strikes expire after twelve months."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:288
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "Conversation context (the reported message last)"
 msgstr ""
@@ -2941,7 +2941,7 @@ msgstr ""
 msgid "Criticize ideas, never people. Demeaning, threatening or repeatedly unwanted messages get accounts suspended - in public posts and in private messages alike."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:280
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "Current version (edited since the report)"
 msgstr ""
@@ -2956,7 +2956,7 @@ msgstr ""
 msgid "Deleted. The report is settled, no further steps needed."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:188
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:201
 #: lib/vutuv_web/views/admin/moderation_html.ex:9
 #, elixir-autogen, elixir-format
 msgid "Escalated"
@@ -2992,7 +2992,7 @@ msgstr ""
 msgid "Keep it family-friendly"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:132
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:145
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
 #: lib/vutuv_web/notification_line.ex:322
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
@@ -3001,8 +3001,8 @@ msgstr ""
 msgid "Moderation"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:43
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:129
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:56
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "Moderation case"
 msgstr ""
@@ -3048,7 +3048,7 @@ msgstr ""
 msgid "No unwanted advertising, fake profiles, fraud or link bait."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:13
+#: lib/vutuv_web/views/report_html.ex:80
 #, elixir-autogen, elixir-format
 msgid "Not family-friendly"
 msgstr ""
@@ -3058,7 +3058,7 @@ msgstr ""
 msgid "Nothing here - none of your content is currently reported."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:25
+#: lib/vutuv_web/views/report_html.ex:92
 #, elixir-autogen, elixir-format
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
@@ -3103,12 +3103,6 @@ msgstr ""
 msgid "Owner"
 msgstr ""
 
-#: lib/vutuv_web/templates/public_report/new.html.heex:144
-#: lib/vutuv_web/templates/report/new.html.heex:160
-#, elixir-autogen, elixir-format
-msgid "Please report honestly. Reporting to harm someone breaks our"
-msgstr ""
-
 #: lib/vutuv_web/components/ui.ex:5174
 #: lib/vutuv_web/live/shell_live.ex:1373
 #: lib/vutuv_web/templates/import/new.html.heex:16
@@ -3117,7 +3111,7 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:458
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "Reject the report"
 msgstr ""
@@ -3142,7 +3136,7 @@ msgstr ""
 msgid "Report"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:239
+#: lib/vutuv_web/controllers/public_report_controller.ex:255
 #: lib/vutuv_web/controllers/report_controller.ex:54
 #: lib/vutuv_web/templates/layout/app.html.heex:131
 #: lib/vutuv_web/templates/page/legal.html.heex:42
@@ -3150,13 +3144,13 @@ msgstr ""
 msgid "Report content"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:53
+#: lib/vutuv_web/templates/page/community.html.heex:61
 #, elixir-autogen, elixir-format
 msgid "Report honestly"
 msgstr ""
 
 #: lib/vutuv_web/controllers/admin/moderation_controller.ex:55
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:59
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:72
 #, elixir-autogen, elixir-format
 msgid "Report rejected; the content is visible again."
 msgstr ""
@@ -3173,7 +3167,7 @@ msgid "Report this message"
 msgstr ""
 
 #: lib/vutuv_web/controllers/admin/moderation_controller.ex:39
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:51
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Report upheld; the owner got a strike."
 msgstr ""
@@ -3191,7 +3185,7 @@ msgstr ""
 msgid "Reported content"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:68
+#: lib/vutuv_web/templates/page/community.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Reported content is hidden right away while the report is handled. Nobody is publicly marked."
 msgstr ""
@@ -3209,7 +3203,7 @@ msgstr ""
 msgid "Reporter track records"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:312
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:325
 #: lib/vutuv_web/live/admin/moderation_live.ex:57
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3229,13 +3223,13 @@ msgstr ""
 msgid "Review"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:56
+#: lib/vutuv_web/templates/page/community.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "See something that breaks these rules? Report it - every post, message and profile has a report option, and reports are anonymous. But reporting is not a weapon: deliberately false reports count as bullying and earn the reporter the same strikes."
 msgstr ""
 
-#: lib/vutuv_web/templates/public_report/new.html.heex:154
-#: lib/vutuv_web/templates/report/new.html.heex:174
+#: lib/vutuv_web/templates/public_report/new.html.heex:134
+#: lib/vutuv_web/templates/report/new.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Send report"
 msgstr ""
@@ -3250,12 +3244,12 @@ msgstr ""
 msgid "Settled: you revised the content and it is visible again."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:21
+#: lib/vutuv_web/views/report_html.ex:88
 #, elixir-autogen, elixir-format
 msgid "Something else"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:15
+#: lib/vutuv_web/views/report_html.ex:82
 #, elixir-autogen, elixir-format
 msgid "Spam or scam"
 msgstr ""
@@ -3284,12 +3278,12 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:27
+#: lib/vutuv_web/views/report_html.ex:94
 #, elixir-autogen, elixir-format
 msgid "Targets, demeans or threatens a person."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:36
+#: lib/vutuv_web/views/report_html.ex:103
 #, elixir-autogen, elixir-format
 msgid "Tell us more in the note below."
 msgstr ""
@@ -3304,7 +3298,7 @@ msgstr ""
 msgid "The content in question"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:73
+#: lib/vutuv_web/templates/page/community.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "The owner is notified and can delete the content, fix it (it becomes visible again immediately) or stand by it - then our admins decide."
 msgstr ""
@@ -3314,12 +3308,12 @@ msgstr ""
 msgid "The queue is empty - the self-service flow settled everything."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:446
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "The report by @%{slug} was a deliberate weapon (strikes the reporter)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:409
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content stays hidden and the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
@@ -3361,12 +3355,12 @@ msgstr ""
 msgid "Understood. The content stays hidden until one of our admins has ruled."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:28
+#: lib/vutuv_web/views/report_html.ex:95
 #, elixir-autogen, elixir-format
 msgid "Unwanted advertising, fraud or fake activity."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:423
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "Uphold the report"
 msgstr ""
@@ -3376,7 +3370,7 @@ msgstr ""
 msgid "Visible. Our admins will take a look."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:64
+#: lib/vutuv_web/templates/page/community.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "What happens after a report"
 msgstr ""
@@ -3428,8 +3422,7 @@ msgid "Your report is anonymous. If it checks out, the content is hidden right a
 msgstr ""
 
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:145
-#: lib/vutuv_web/templates/public_report/new.html.heex:149
-#: lib/vutuv_web/templates/report/new.html.heex:162
+#: lib/vutuv_web/views/report_html.ex:69
 #, elixir-autogen, elixir-format
 msgid "community guidelines"
 msgstr ""
@@ -3540,19 +3533,19 @@ msgstr ""
 msgid "%{count} follows"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "%{count} report so far"
 msgid_plural "%{count} reports so far"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "%{rejected} rejected, %{abusive} abusive"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:133
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Case"
 msgstr ""
@@ -3567,7 +3560,7 @@ msgstr ""
 msgid "Content frozen"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:393
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "Decision"
 msgstr ""
@@ -3577,17 +3570,17 @@ msgstr ""
 msgid "Escalated - the 72h deadline passed"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:196
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Evidence"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:366
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:206
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:219
 #, elixir-autogen, elixir-format
 msgid "Open the profile"
 msgstr ""
@@ -3627,7 +3620,7 @@ msgstr ""
 msgid "Report upheld"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:355
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:371
 #, elixir-autogen, elixir-format
 msgid "Reporter and owner are separated since this report (connection, follows, messages)."
 msgstr ""
@@ -3657,17 +3650,17 @@ msgstr ""
 msgid "Strike issued"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:351
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "The protective separation from the owner was lifted on %{date}."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:434
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:450
 #, elixir-autogen, elixir-format
 msgid "The report is unfounded. The content becomes visible again, any protective separation is lifted, and the rejection counts against each reporter's trust."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:200
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "The whole profile was reported. Judge the profile itself - the snapshot below only preserves the name at report time."
 msgstr ""
@@ -3707,7 +3700,7 @@ msgstr ""
 msgid "messages"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:369
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "No history recorded - this case predates the audit log."
 msgstr ""
@@ -3742,7 +3735,7 @@ msgstr ""
 msgid "Evidence screenshot captured"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:269
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Evidence screenshot captured when the report was filed"
 msgstr ""
@@ -3752,7 +3745,7 @@ msgstr ""
 msgid "Moderation evidence - reported private message with context"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:264
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "Screenshot at report time"
 msgstr ""
@@ -3762,7 +3755,7 @@ msgstr ""
 msgid "reported message"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:275
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
@@ -5204,7 +5197,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5397
 #: lib/vutuv_web/controllers/settings_controller.ex:161
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:501
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:517
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
@@ -5228,7 +5221,7 @@ msgid "The ad could not be approved."
 msgstr ""
 
 #: lib/vutuv_web/controllers/admin/moderation_controller.ex:106
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:90
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "This case has already been resolved."
 msgstr ""
@@ -7539,7 +7532,7 @@ msgstr ""
 msgid "That address no longer exists."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:37
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:50
 #, elixir-autogen, elixir-format
 msgid "This case no longer exists."
 msgstr ""
@@ -9756,13 +9749,13 @@ msgstr ""
 msgid "Account deactivated and marked as spam."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:69
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:82
 #, elixir-autogen, elixir-format
 msgid "Account deactivated and marked as spam. Restore it from the member browser if this was wrong."
 msgstr ""
 
 #: lib/vutuv_web/controllers/admin/moderation_controller.ex:89
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:77
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Account deleted."
 msgstr ""
@@ -9782,7 +9775,7 @@ msgstr ""
 msgid "Accounts removed as spam"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:468
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Clear-cut spam or abuse?"
 msgstr ""
@@ -9792,22 +9785,22 @@ msgstr ""
 msgid "Could not restore this member."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:483
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "Deactivate @%{slug} and mark the account as spam?"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:486
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "Deactivate account"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:495
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "Permanently DELETE @%{slug} and everything they posted? This cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:471
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:487
 #, elixir-autogen, elixir-format
 msgid "Remove the account outright, skipping the warning ladder. Deactivating marks it as spam and is reversible from the member browser; deleting is permanent."
 msgstr ""
@@ -11844,7 +11837,7 @@ msgstr ""
 msgid "%{views} views · %{clicks} apply clicks"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:31
+#: lib/vutuv_web/views/report_html.ex:98
 #, elixir-autogen, elixir-format
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr ""
@@ -12058,7 +12051,7 @@ msgstr ""
 msgid "Mini-job"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:16
+#: lib/vutuv_web/views/report_html.ex:83
 #, elixir-autogen, elixir-format
 msgid "Misleading job posting"
 msgstr ""
@@ -12731,7 +12724,7 @@ msgstr ""
 msgid "Open reports"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:216
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Open the job posting"
 msgstr ""
@@ -22864,27 +22857,17 @@ msgstr ""
 msgid "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:153
-#, elixir-autogen, elixir-format
-msgid "I declare in good faith that this use is authorized neither by the rights holder nor by law."
-msgstr ""
-
 #: lib/vutuv_web/templates/page/community.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Publish only what you hold the rights to"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:34
+#: lib/vutuv_web/views/report_html.ex:101
 #, elixir-autogen, elixir-format
 msgid "Tell us which work it is and where the original can be seen."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:46
-#, elixir-autogen, elixir-format
-msgid "Texts, photos and videos belong to whoever made them. Post your own work, or work you have permission to use. A rights holder can report content here, and such a complaint is decided by one of our admins - an edit does not settle it."
-msgstr ""
-
-#: lib/vutuv_web/views/report_html.ex:19
+#: lib/vutuv_web/views/report_html.ex:86
 #, elixir-autogen, elixir-format
 msgid "Uses a text, photo or video without the rights holder's permission"
 msgstr ""
@@ -23140,12 +23123,12 @@ msgstr ""
 msgid "Report the profile picture"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:229
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "The reported picture"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:248
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Upholding the case deletes it, the private original included. Rejecting it puts every file back where it was."
 msgstr ""
@@ -23213,7 +23196,7 @@ msgstr ""
 msgid "Thank you for your report. Our moderators have been notified and will review this picture."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:256
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "This picture is still on the profile: only a copyright notice takes one offline before a ruling. Upholding the case deletes it, the private original included."
 msgstr ""
@@ -23238,16 +23221,11 @@ msgstr ""
 msgid "Confirm the report"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:87
-#: lib/vutuv_web/controllers/public_report_controller.ex:107
+#: lib/vutuv_web/controllers/public_report_controller.ex:91
+#: lib/vutuv_web/controllers/public_report_controller.ex:111
 #: lib/vutuv_web/templates/public_report/confirm.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Confirm your report"
-msgstr ""
-
-#: lib/vutuv_web/templates/public_report/sent.html.heex:10
-#, elixir-autogen, elixir-format
-msgid "Follow the link in it and your report goes to our admins. Until then nothing about the reported content changes."
 msgstr ""
 
 #: lib/vutuv_web/templates/public_report/new.html.heex:76
@@ -23255,7 +23233,7 @@ msgstr ""
 msgid "For a copyright claim: which work it is, and where the original can be seen."
 msgstr ""
 
-#: lib/vutuv_web/templates/public_report/new.html.heex:137
+#: lib/vutuv_web/views/report_html.ex:42
 #, elixir-autogen, elixir-format
 msgid "I declare in good faith that what I describe here is true and that this use is authorized neither by the rights holder nor by law."
 msgstr ""
@@ -23270,7 +23248,7 @@ msgstr ""
 msgid "Moderation: something was reported"
 msgstr ""
 
-#: lib/vutuv_web/templates/public_report/sent.html.heex:15
+#: lib/vutuv_web/templates/public_report/sent.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "No email? Please check your spam folder."
 msgstr ""
@@ -23296,8 +23274,8 @@ msgstr ""
 msgid "Please confirm your report"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:84
-#: lib/vutuv_web/controllers/public_report_controller.ex:112
+#: lib/vutuv_web/controllers/public_report_controller.ex:88
+#: lib/vutuv_web/controllers/public_report_controller.ex:116
 #, elixir-autogen, elixir-format
 msgid "Report confirmed"
 msgstr ""
@@ -23312,7 +23290,7 @@ msgstr ""
 msgid "Report filed from outside"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:155
+#: lib/vutuv_web/controllers/public_report_controller.ex:171
 #, elixir-autogen, elixir-format
 msgid "Report sent"
 msgstr ""
@@ -23327,7 +23305,7 @@ msgstr ""
 msgid "Thank you - your report is with our admins"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:129
+#: lib/vutuv_web/controllers/public_report_controller.ex:133
 #, elixir-autogen, elixir-format
 msgid "That address is not on this site. We can only act on content published here."
 msgstr ""
@@ -23337,12 +23315,12 @@ msgstr ""
 msgid "The post, picture, video, profile, page or job posting you are reporting. Copy it out of your browser's address bar."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:451
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "The report by %{email} was a deliberate weapon (that address loses our trust)"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:216
+#: lib/vutuv_web/controllers/public_report_controller.ex:232
 #, elixir-autogen, elixir-format
 msgid "We could not find that page. Please check the address."
 msgstr ""
@@ -23352,17 +23330,12 @@ msgstr ""
 msgid "We have sent an email to %{email}."
 msgstr ""
 
-#: lib/vutuv_web/templates/public_report/new.html.heex:12
-#, elixir-autogen, elixir-format
-msgid "We will send you an email with a confirmation link. Nothing happens until you follow it - your report reaches our admins, and the reported content stays exactly where it is."
-msgstr ""
-
 #: lib/vutuv_web/templates/public_report/new.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "What is wrong with it?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:160
+#: lib/vutuv_web/controllers/public_report_controller.ex:176
 #, elixir-autogen, elixir-format
 msgid "You already sent us this report. Please use the confirmation link in the email we sent you."
 msgstr ""
@@ -23377,7 +23350,7 @@ msgstr ""
 msgid "You do not need to do anything else."
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:68
+#: lib/vutuv_web/controllers/public_report_controller.ex:72
 #, elixir-autogen, elixir-format
 msgid "You have sent us a lot of reports just now. Please try again later."
 msgstr ""
@@ -23392,37 +23365,37 @@ msgstr ""
 msgid "address not confirmed"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:52
+#: lib/vutuv_web/views/report_html.ex:119
 #, elixir-autogen, elixir-format
 msgctxt "content type"
 msgid "Job posting"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:51
+#: lib/vutuv_web/views/report_html.ex:118
 #, elixir-autogen, elixir-format
 msgctxt "content type"
 msgid "Organization page"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:53
+#: lib/vutuv_web/views/report_html.ex:120
 #, elixir-autogen, elixir-format
 msgctxt "content type"
 msgid "Picture"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:48
+#: lib/vutuv_web/views/report_html.ex:115
 #, elixir-autogen, elixir-format
 msgctxt "content type"
 msgid "Post"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:49
+#: lib/vutuv_web/views/report_html.ex:116
 #, elixir-autogen, elixir-format
 msgctxt "content type"
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:50
+#: lib/vutuv_web/views/report_html.ex:117
 #, elixir-autogen, elixir-format
 msgctxt "content type"
 msgid "Profile"
@@ -23443,8 +23416,8 @@ msgstr ""
 msgid "Send the report again"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:95
-#: lib/vutuv_web/controllers/public_report_controller.ex:117
+#: lib/vutuv_web/controllers/public_report_controller.ex:99
+#: lib/vutuv_web/controllers/public_report_controller.ex:121
 #: lib/vutuv_web/templates/public_report/expired.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "This link has expired"
@@ -23520,67 +23493,67 @@ msgstr ""
 msgid "No person made this decision: a report from somebody with a good record hides the reported content automatically, the moment it arrives."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:413
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content becomes visible again - the consequence here is the strike (warn, suspend, deactivate)."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:417
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:433
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content is not hidden and upholding does not hide it; the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:405
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The reported picture is deleted, the private original included, and the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:252
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "This picture is still on the profile: the address behind the copyright notice is not confirmed yet, so nothing has been hidden. Upholding the case deletes it, the private original included."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:82
+#: lib/vutuv_web/views/report_html.ex:149
 #, elixir-autogen, elixir-format
 msgid "somebody reported one of your job postings on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:85
+#: lib/vutuv_web/views/report_html.ex:152
 #, elixir-autogen, elixir-format
 msgid "somebody reported one of your pages on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:76
+#: lib/vutuv_web/views/report_html.ex:143
 #, elixir-autogen, elixir-format
 msgid "somebody reported one of your pictures on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:73
+#: lib/vutuv_web/views/report_html.ex:140
 #, elixir-autogen, elixir-format
 msgid "somebody reported one of your posts on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:79
+#: lib/vutuv_web/views/report_html.ex:146
 #, elixir-autogen, elixir-format
 msgid "somebody reported one of your private messages on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:91
+#: lib/vutuv_web/views/report_html.ex:158
 #, elixir-autogen, elixir-format
 msgid "somebody reported something of yours on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:88
+#: lib/vutuv_web/views/report_html.ex:155
 #, elixir-autogen, elixir-format
 msgid "somebody reported your profile on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:105
+#: lib/vutuv_web/views/report_html.ex:172
 #, elixir-autogen, elixir-format
 msgid "A report from a member in good standing hides the reported content automatically, the moment it arrives."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:111
+#: lib/vutuv_web/views/report_html.ex:178
 #, elixir-autogen, elixir-format
 msgid "A report from somebody with a good record hides the reported content automatically, the moment it arrives."
 msgstr ""
@@ -23615,17 +23588,52 @@ msgstr ""
 msgid "Owner replaced the content"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:184
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Owner deadline"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:181
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Reported"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:330
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "declared in good faith"
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:61
+#, elixir-autogen, elixir-format
+msgid "Please report honestly. Reporting to harm someone breaks our {guidelines}."
+msgstr ""
+
+#: lib/vutuv_web/templates/page/community.html.heex:50
+#, elixir-autogen, elixir-format
+msgid "Texts, photos and videos belong to whoever made them. Post your own work, or work you have permission to use. A rights holder can report content here without an account, through {form}; such a complaint is decided by one of our admins, and an edit does not settle it."
+msgstr ""
+
+#: lib/vutuv_web/controllers/public_report_controller.ex:143
+#, elixir-autogen, elixir-format
+msgid "That address is one of our own pages, not content somebody published here, so there is nothing on it we could act on. Please paste the address of the post, picture, video, profile or job posting itself."
+msgstr ""
+
+#: lib/vutuv_web/templates/public_report/new.html.heex:12
+#, elixir-autogen, elixir-format
+msgid "We will send you an email with a confirmation link. Your report is in front of our admins right away; until you follow that link nothing about the reported content changes."
+msgstr ""
+
+#: lib/vutuv_web/templates/public_report/sent.html.heex:13
+#, elixir-autogen, elixir-format
+msgid "Your report is already with our admins. Follow the link in that email to confirm your address; until you do, nothing about the reported content changes."
+msgstr ""
+
+#: lib/vutuv_web/templates/page/community.html.heex:56
+#, elixir-autogen, elixir-format
+msgid "the report form"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:356
+#, elixir-autogen, elixir-format
+msgid "“%{note}”"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -123,7 +123,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:113
-#: lib/vutuv_web/templates/report/new.html.heex:172
+#: lib/vutuv_web/templates/report/new.html.heex:155
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:255
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
@@ -1125,7 +1125,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
 #: lib/vutuv_web/live/admin/job_live.ex:199
 #: lib/vutuv_web/live/admin/member_badges.ex:22
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:131
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:144
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:127
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
@@ -2862,7 +2862,7 @@ msgstr ""
 msgid "liked your post."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:158
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:171
 #, elixir-autogen, elixir-format
 msgid "%{count} active strike"
 msgid_plural "%{count} active strikes"
@@ -2877,13 +2877,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:335
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:302
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:315
 #: lib/vutuv_web/templates/moderation_evidence/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "(deleted account)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:221
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:234
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "(no text)"
@@ -2909,7 +2909,7 @@ msgstr ""
 msgid "Anything our admins should know? (optional)"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:14
+#: lib/vutuv_web/views/report_html.ex:81
 #, elixir-autogen, elixir-format
 msgid "Bullying or harassment"
 msgstr ""
@@ -2924,12 +2924,12 @@ msgstr ""
 msgid "Community guidelines"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:78
+#: lib/vutuv_web/templates/page/community.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Confirmed violations follow three steps: a warning, then a one-week suspension, then permanent deactivation. Strikes expire after twelve months."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:288
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "Conversation context (the reported message last)"
 msgstr ""
@@ -2939,7 +2939,7 @@ msgstr ""
 msgid "Criticize ideas, never people. Demeaning, threatening or repeatedly unwanted messages get accounts suspended - in public posts and in private messages alike."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:280
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "Current version (edited since the report)"
 msgstr ""
@@ -2954,7 +2954,7 @@ msgstr ""
 msgid "Deleted. The report is settled, no further steps needed."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:188
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:201
 #: lib/vutuv_web/views/admin/moderation_html.ex:9
 #, elixir-autogen, elixir-format
 msgid "Escalated"
@@ -2990,7 +2990,7 @@ msgstr ""
 msgid "Keep it family-friendly"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:132
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:145
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
 #: lib/vutuv_web/notification_line.ex:322
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
@@ -2999,8 +2999,8 @@ msgstr ""
 msgid "Moderation"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:43
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:129
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:56
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "Moderation case"
 msgstr ""
@@ -3046,7 +3046,7 @@ msgstr ""
 msgid "No unwanted advertising, fake profiles, fraud or link bait."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:13
+#: lib/vutuv_web/views/report_html.ex:80
 #, elixir-autogen, elixir-format
 msgid "Not family-friendly"
 msgstr ""
@@ -3056,7 +3056,7 @@ msgstr ""
 msgid "Nothing here - none of your content is currently reported."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:25
+#: lib/vutuv_web/views/report_html.ex:92
 #, elixir-autogen, elixir-format
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
@@ -3101,12 +3101,6 @@ msgstr ""
 msgid "Owner"
 msgstr ""
 
-#: lib/vutuv_web/templates/public_report/new.html.heex:144
-#: lib/vutuv_web/templates/report/new.html.heex:160
-#, elixir-autogen, elixir-format
-msgid "Please report honestly. Reporting to harm someone breaks our"
-msgstr ""
-
 #: lib/vutuv_web/components/ui.ex:5174
 #: lib/vutuv_web/live/shell_live.ex:1373
 #: lib/vutuv_web/templates/import/new.html.heex:16
@@ -3115,7 +3109,7 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:458
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "Reject the report"
 msgstr ""
@@ -3140,7 +3134,7 @@ msgstr ""
 msgid "Report"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:239
+#: lib/vutuv_web/controllers/public_report_controller.ex:255
 #: lib/vutuv_web/controllers/report_controller.ex:54
 #: lib/vutuv_web/templates/layout/app.html.heex:131
 #: lib/vutuv_web/templates/page/legal.html.heex:42
@@ -3148,13 +3142,13 @@ msgstr ""
 msgid "Report content"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:53
+#: lib/vutuv_web/templates/page/community.html.heex:61
 #, elixir-autogen, elixir-format
 msgid "Report honestly"
 msgstr ""
 
 #: lib/vutuv_web/controllers/admin/moderation_controller.ex:55
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:59
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:72
 #, elixir-autogen, elixir-format
 msgid "Report rejected; the content is visible again."
 msgstr ""
@@ -3171,7 +3165,7 @@ msgid "Report this message"
 msgstr ""
 
 #: lib/vutuv_web/controllers/admin/moderation_controller.ex:39
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:51
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Report upheld; the owner got a strike."
 msgstr ""
@@ -3189,7 +3183,7 @@ msgstr ""
 msgid "Reported content"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:68
+#: lib/vutuv_web/templates/page/community.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Reported content is hidden right away while the report is handled. Nobody is publicly marked."
 msgstr ""
@@ -3207,7 +3201,7 @@ msgstr ""
 msgid "Reporter track records"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:312
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:325
 #: lib/vutuv_web/live/admin/moderation_live.ex:57
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3227,13 +3221,13 @@ msgstr ""
 msgid "Review"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:56
+#: lib/vutuv_web/templates/page/community.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "See something that breaks these rules? Report it - every post, message and profile has a report option, and reports are anonymous. But reporting is not a weapon: deliberately false reports count as bullying and earn the reporter the same strikes."
 msgstr ""
 
-#: lib/vutuv_web/templates/public_report/new.html.heex:154
-#: lib/vutuv_web/templates/report/new.html.heex:174
+#: lib/vutuv_web/templates/public_report/new.html.heex:134
+#: lib/vutuv_web/templates/report/new.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Send report"
 msgstr ""
@@ -3248,12 +3242,12 @@ msgstr ""
 msgid "Settled: you revised the content and it is visible again."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:21
+#: lib/vutuv_web/views/report_html.ex:88
 #, elixir-autogen, elixir-format
 msgid "Something else"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:15
+#: lib/vutuv_web/views/report_html.ex:82
 #, elixir-autogen, elixir-format
 msgid "Spam or scam"
 msgstr ""
@@ -3282,12 +3276,12 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:27
+#: lib/vutuv_web/views/report_html.ex:94
 #, elixir-autogen, elixir-format
 msgid "Targets, demeans or threatens a person."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:36
+#: lib/vutuv_web/views/report_html.ex:103
 #, elixir-autogen, elixir-format
 msgid "Tell us more in the note below."
 msgstr ""
@@ -3302,7 +3296,7 @@ msgstr ""
 msgid "The content in question"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:73
+#: lib/vutuv_web/templates/page/community.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "The owner is notified and can delete the content, fix it (it becomes visible again immediately) or stand by it - then our admins decide."
 msgstr ""
@@ -3312,12 +3306,12 @@ msgstr ""
 msgid "The queue is empty - the self-service flow settled everything."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:446
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "The report by @%{slug} was a deliberate weapon (strikes the reporter)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:409
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content stays hidden and the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
@@ -3359,12 +3353,12 @@ msgstr ""
 msgid "Understood. The content stays hidden until one of our admins has ruled."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:28
+#: lib/vutuv_web/views/report_html.ex:95
 #, elixir-autogen, elixir-format
 msgid "Unwanted advertising, fraud or fake activity."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:423
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "Uphold the report"
 msgstr ""
@@ -3374,7 +3368,7 @@ msgstr ""
 msgid "Visible. Our admins will take a look."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:64
+#: lib/vutuv_web/templates/page/community.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "What happens after a report"
 msgstr ""
@@ -3426,8 +3420,7 @@ msgid "Your report is anonymous. If it checks out, the content is hidden right a
 msgstr ""
 
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:145
-#: lib/vutuv_web/templates/public_report/new.html.heex:149
-#: lib/vutuv_web/templates/report/new.html.heex:162
+#: lib/vutuv_web/views/report_html.ex:69
 #, elixir-autogen, elixir-format
 msgid "community guidelines"
 msgstr ""
@@ -3538,19 +3531,19 @@ msgstr ""
 msgid "%{count} follows"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "%{count} report so far"
 msgid_plural "%{count} reports so far"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "%{rejected} rejected, %{abusive} abusive"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:133
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Case"
 msgstr ""
@@ -3565,7 +3558,7 @@ msgstr ""
 msgid "Content frozen"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:393
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "Decision"
 msgstr ""
@@ -3575,17 +3568,17 @@ msgstr ""
 msgid "Escalated - the 72h deadline passed"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:196
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Evidence"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:366
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:206
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:219
 #, elixir-autogen, elixir-format
 msgid "Open the profile"
 msgstr ""
@@ -3625,7 +3618,7 @@ msgstr ""
 msgid "Report upheld"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:355
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:371
 #, elixir-autogen, elixir-format
 msgid "Reporter and owner are separated since this report (connection, follows, messages)."
 msgstr ""
@@ -3655,17 +3648,17 @@ msgstr ""
 msgid "Strike issued"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:351
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "The protective separation from the owner was lifted on %{date}."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:434
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:450
 #, elixir-autogen, elixir-format
 msgid "The report is unfounded. The content becomes visible again, any protective separation is lifted, and the rejection counts against each reporter's trust."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:200
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "The whole profile was reported. Judge the profile itself - the snapshot below only preserves the name at report time."
 msgstr ""
@@ -3705,7 +3698,7 @@ msgstr ""
 msgid "messages"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:369
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "No history recorded - this case predates the audit log."
 msgstr ""
@@ -3740,7 +3733,7 @@ msgstr ""
 msgid "Evidence screenshot captured"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:269
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Evidence screenshot captured when the report was filed"
 msgstr ""
@@ -3750,7 +3743,7 @@ msgstr ""
 msgid "Moderation evidence - reported private message with context"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:264
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "Screenshot at report time"
 msgstr ""
@@ -3760,7 +3753,7 @@ msgstr ""
 msgid "reported message"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:275
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
@@ -5202,7 +5195,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:5397
 #: lib/vutuv_web/controllers/settings_controller.ex:161
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:501
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:517
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
@@ -5226,7 +5219,7 @@ msgid "The ad could not be approved."
 msgstr ""
 
 #: lib/vutuv_web/controllers/admin/moderation_controller.ex:106
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:90
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "This case has already been resolved."
 msgstr ""
@@ -7537,7 +7530,7 @@ msgstr ""
 msgid "That address no longer exists."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:37
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:50
 #, elixir-autogen, elixir-format
 msgid "This case no longer exists."
 msgstr ""
@@ -9754,13 +9747,13 @@ msgstr ""
 msgid "Account deactivated and marked as spam."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:69
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:82
 #, elixir-autogen, elixir-format
 msgid "Account deactivated and marked as spam. Restore it from the member browser if this was wrong."
 msgstr ""
 
 #: lib/vutuv_web/controllers/admin/moderation_controller.ex:89
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:77
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Account deleted."
 msgstr ""
@@ -9780,7 +9773,7 @@ msgstr ""
 msgid "Accounts removed as spam"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:468
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Clear-cut spam or abuse?"
 msgstr ""
@@ -9790,22 +9783,22 @@ msgstr ""
 msgid "Could not restore this member."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:483
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "Deactivate @%{slug} and mark the account as spam?"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:486
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "Deactivate account"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:495
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "Permanently DELETE @%{slug} and everything they posted? This cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:471
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:487
 #, elixir-autogen, elixir-format
 msgid "Remove the account outright, skipping the warning ladder. Deactivating marks it as spam and is reversible from the member browser; deleting is permanent."
 msgstr ""
@@ -11842,7 +11835,7 @@ msgstr ""
 msgid "%{views} views · %{clicks} apply clicks"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:31
+#: lib/vutuv_web/views/report_html.ex:98
 #, elixir-autogen, elixir-format
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr ""
@@ -12056,7 +12049,7 @@ msgstr ""
 msgid "Mini-job"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:16
+#: lib/vutuv_web/views/report_html.ex:83
 #, elixir-autogen, elixir-format
 msgid "Misleading job posting"
 msgstr ""
@@ -12729,7 +12722,7 @@ msgstr ""
 msgid "Open reports"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:216
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Open the job posting"
 msgstr ""
@@ -22862,27 +22855,17 @@ msgstr ""
 msgid "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."
 msgstr ""
 
-#: lib/vutuv_web/templates/report/new.html.heex:153
-#, elixir-autogen, elixir-format
-msgid "I declare in good faith that this use is authorized neither by the rights holder nor by law."
-msgstr ""
-
 #: lib/vutuv_web/templates/page/community.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Publish only what you hold the rights to"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:34
+#: lib/vutuv_web/views/report_html.ex:101
 #, elixir-autogen, elixir-format
 msgid "Tell us which work it is and where the original can be seen."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/community.html.heex:46
-#, elixir-autogen, elixir-format
-msgid "Texts, photos and videos belong to whoever made them. Post your own work, or work you have permission to use. A rights holder can report content here, and such a complaint is decided by one of our admins - an edit does not settle it."
-msgstr ""
-
-#: lib/vutuv_web/views/report_html.ex:19
+#: lib/vutuv_web/views/report_html.ex:86
 #, elixir-autogen, elixir-format
 msgid "Uses a text, photo or video without the rights holder's permission"
 msgstr ""
@@ -23138,12 +23121,12 @@ msgstr ""
 msgid "Report the profile picture"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:229
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "The reported picture"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:248
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Upholding the case deletes it, the private original included. Rejecting it puts every file back where it was."
 msgstr ""
@@ -23211,7 +23194,7 @@ msgstr ""
 msgid "Thank you for your report. Our moderators have been notified and will review this picture."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:256
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "This picture is still on the profile: only a copyright notice takes one offline before a ruling. Upholding the case deletes it, the private original included."
 msgstr ""
@@ -23236,16 +23219,11 @@ msgstr ""
 msgid "Confirm the report"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:87
-#: lib/vutuv_web/controllers/public_report_controller.ex:107
+#: lib/vutuv_web/controllers/public_report_controller.ex:91
+#: lib/vutuv_web/controllers/public_report_controller.ex:111
 #: lib/vutuv_web/templates/public_report/confirm.html.heex:4
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Confirm your report"
-msgstr ""
-
-#: lib/vutuv_web/templates/public_report/sent.html.heex:10
-#, elixir-autogen, elixir-format
-msgid "Follow the link in it and your report goes to our admins. Until then nothing about the reported content changes."
 msgstr ""
 
 #: lib/vutuv_web/templates/public_report/new.html.heex:76
@@ -23253,7 +23231,7 @@ msgstr ""
 msgid "For a copyright claim: which work it is, and where the original can be seen."
 msgstr ""
 
-#: lib/vutuv_web/templates/public_report/new.html.heex:137
+#: lib/vutuv_web/views/report_html.ex:42
 #, elixir-autogen, elixir-format
 msgid "I declare in good faith that what I describe here is true and that this use is authorized neither by the rights holder nor by law."
 msgstr ""
@@ -23268,7 +23246,7 @@ msgstr ""
 msgid "Moderation: something was reported"
 msgstr ""
 
-#: lib/vutuv_web/templates/public_report/sent.html.heex:15
+#: lib/vutuv_web/templates/public_report/sent.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "No email? Please check your spam folder."
 msgstr ""
@@ -23294,8 +23272,8 @@ msgstr ""
 msgid "Please confirm your report"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:84
-#: lib/vutuv_web/controllers/public_report_controller.ex:112
+#: lib/vutuv_web/controllers/public_report_controller.ex:88
+#: lib/vutuv_web/controllers/public_report_controller.ex:116
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report confirmed"
 msgstr ""
@@ -23310,7 +23288,7 @@ msgstr ""
 msgid "Report filed from outside"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:155
+#: lib/vutuv_web/controllers/public_report_controller.ex:171
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report sent"
 msgstr ""
@@ -23325,7 +23303,7 @@ msgstr ""
 msgid "Thank you - your report is with our admins"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:129
+#: lib/vutuv_web/controllers/public_report_controller.ex:133
 #, elixir-autogen, elixir-format
 msgid "That address is not on this site. We can only act on content published here."
 msgstr ""
@@ -23335,12 +23313,12 @@ msgstr ""
 msgid "The post, picture, video, profile, page or job posting you are reporting. Copy it out of your browser's address bar."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:451
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "The report by %{email} was a deliberate weapon (that address loses our trust)"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:216
+#: lib/vutuv_web/controllers/public_report_controller.ex:232
 #, elixir-autogen, elixir-format
 msgid "We could not find that page. Please check the address."
 msgstr ""
@@ -23350,17 +23328,12 @@ msgstr ""
 msgid "We have sent an email to %{email}."
 msgstr ""
 
-#: lib/vutuv_web/templates/public_report/new.html.heex:12
-#, elixir-autogen, elixir-format
-msgid "We will send you an email with a confirmation link. Nothing happens until you follow it - your report reaches our admins, and the reported content stays exactly where it is."
-msgstr ""
-
 #: lib/vutuv_web/templates/public_report/new.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "What is wrong with it?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:160
+#: lib/vutuv_web/controllers/public_report_controller.ex:176
 #, elixir-autogen, elixir-format
 msgid "You already sent us this report. Please use the confirmation link in the email we sent you."
 msgstr ""
@@ -23375,7 +23348,7 @@ msgstr ""
 msgid "You do not need to do anything else."
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:68
+#: lib/vutuv_web/controllers/public_report_controller.ex:72
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You have sent us a lot of reports just now. Please try again later."
 msgstr ""
@@ -23390,37 +23363,37 @@ msgstr ""
 msgid "address not confirmed"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:52
+#: lib/vutuv_web/views/report_html.ex:119
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "content type"
 msgid "Job posting"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:51
+#: lib/vutuv_web/views/report_html.ex:118
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "content type"
 msgid "Organization page"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:53
+#: lib/vutuv_web/views/report_html.ex:120
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "content type"
 msgid "Picture"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:48
+#: lib/vutuv_web/views/report_html.ex:115
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "content type"
 msgid "Post"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:49
+#: lib/vutuv_web/views/report_html.ex:116
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "content type"
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:50
+#: lib/vutuv_web/views/report_html.ex:117
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "content type"
 msgid "Profile"
@@ -23441,8 +23414,8 @@ msgstr ""
 msgid "Send the report again"
 msgstr ""
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:95
-#: lib/vutuv_web/controllers/public_report_controller.ex:117
+#: lib/vutuv_web/controllers/public_report_controller.ex:99
+#: lib/vutuv_web/controllers/public_report_controller.ex:121
 #: lib/vutuv_web/templates/public_report/expired.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "This link has expired"
@@ -23518,67 +23491,67 @@ msgstr ""
 msgid "No person made this decision: a report from somebody with a good record hides the reported content automatically, the moment it arrives."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:413
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content becomes visible again - the consequence here is the strike (warn, suspend, deactivate)."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:417
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:433
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content is not hidden and upholding does not hide it; the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:405
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The reported picture is deleted, the private original included, and the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:252
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "This picture is still on the profile: the address behind the copyright notice is not confirmed yet, so nothing has been hidden. Upholding the case deletes it, the private original included."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:82
+#: lib/vutuv_web/views/report_html.ex:149
 #, elixir-autogen, elixir-format
 msgid "somebody reported one of your job postings on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:85
+#: lib/vutuv_web/views/report_html.ex:152
 #, elixir-autogen, elixir-format
 msgid "somebody reported one of your pages on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:76
+#: lib/vutuv_web/views/report_html.ex:143
 #, elixir-autogen, elixir-format
 msgid "somebody reported one of your pictures on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:73
+#: lib/vutuv_web/views/report_html.ex:140
 #, elixir-autogen, elixir-format
 msgid "somebody reported one of your posts on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:79
+#: lib/vutuv_web/views/report_html.ex:146
 #, elixir-autogen, elixir-format
 msgid "somebody reported one of your private messages on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:91
+#: lib/vutuv_web/views/report_html.ex:158
 #, elixir-autogen, elixir-format
 msgid "somebody reported something of yours on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:88
+#: lib/vutuv_web/views/report_html.ex:155
 #, elixir-autogen, elixir-format
 msgid "somebody reported your profile on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:105
+#: lib/vutuv_web/views/report_html.ex:172
 #, elixir-autogen, elixir-format
 msgid "A report from a member in good standing hides the reported content automatically, the moment it arrives."
 msgstr ""
 
-#: lib/vutuv_web/views/report_html.ex:111
+#: lib/vutuv_web/views/report_html.ex:178
 #, elixir-autogen, elixir-format
 msgid "A report from somebody with a good record hides the reported content automatically, the moment it arrives."
 msgstr ""
@@ -23613,17 +23586,52 @@ msgstr ""
 msgid "Owner replaced the content"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:184
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Owner deadline"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:181
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Reported"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:330
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "declared in good faith"
+msgstr ""
+
+#: lib/vutuv_web/views/report_html.ex:61
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Please report honestly. Reporting to harm someone breaks our {guidelines}."
+msgstr ""
+
+#: lib/vutuv_web/templates/page/community.html.heex:50
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Texts, photos and videos belong to whoever made them. Post your own work, or work you have permission to use. A rights holder can report content here without an account, through {form}; such a complaint is decided by one of our admins, and an edit does not settle it."
+msgstr ""
+
+#: lib/vutuv_web/controllers/public_report_controller.ex:143
+#, elixir-autogen, elixir-format
+msgid "That address is one of our own pages, not content somebody published here, so there is nothing on it we could act on. Please paste the address of the post, picture, video, profile or job posting itself."
+msgstr ""
+
+#: lib/vutuv_web/templates/public_report/new.html.heex:12
+#, elixir-autogen, elixir-format, fuzzy
+msgid "We will send you an email with a confirmation link. Your report is in front of our admins right away; until you follow that link nothing about the reported content changes."
+msgstr ""
+
+#: lib/vutuv_web/templates/public_report/sent.html.heex:13
+#, elixir-autogen, elixir-format
+msgid "Your report is already with our admins. Follow the link in that email to confirm your address; until you do, nothing about the reported content changes."
+msgstr ""
+
+#: lib/vutuv_web/templates/page/community.html.heex:56
+#, elixir-autogen, elixir-format, fuzzy
+msgid "the report form"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:356
+#, elixir-autogen, elixir-format, fuzzy
+msgid "“%{note}”"
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -125,7 +125,7 @@ msgstr "Compleanno"
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:113
-#: lib/vutuv_web/templates/report/new.html.heex:172
+#: lib/vutuv_web/templates/report/new.html.heex:155
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:255
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:23
@@ -1148,7 +1148,7 @@ msgstr "Aggiungi localizzazione"
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
 #: lib/vutuv_web/live/admin/job_live.ex:199
 #: lib/vutuv_web/live/admin/member_badges.ex:22
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:131
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:144
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:127
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
@@ -2915,7 +2915,7 @@ msgstr "Benvenuto su vutuv, %{name}."
 msgid "liked your post."
 msgstr "ha messo Mi piace al Suo post."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:158
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:171
 #, elixir-autogen, elixir-format
 msgid "%{count} active strike"
 msgid_plural "%{count} active strikes"
@@ -2930,13 +2930,13 @@ msgstr[0] "%{formatted} caso attende una decisione."
 msgstr[1] "%{formatted} casi attendono una decisione."
 
 #: lib/vutuv_web/live/admin/job_live.ex:335
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:302
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:315
 #: lib/vutuv_web/templates/moderation_evidence/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "(deleted account)"
 msgstr "(account eliminato)"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:221
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:234
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "(no text)"
@@ -2964,7 +2964,7 @@ msgstr "Offensivo"
 msgid "Anything our admins should know? (optional)"
 msgstr "Qualcosa che i nostri amministratori dovrebbero sapere? (facoltativo)"
 
-#: lib/vutuv_web/views/report_html.ex:14
+#: lib/vutuv_web/views/report_html.ex:81
 #, elixir-autogen, elixir-format
 msgid "Bullying or harassment"
 msgstr "Bullismo o molestie"
@@ -2979,7 +2979,7 @@ msgstr "Bullismo o molestie"
 msgid "Community guidelines"
 msgstr "Regole della community"
 
-#: lib/vutuv_web/templates/page/community.html.heex:78
+#: lib/vutuv_web/templates/page/community.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Confirmed violations follow three steps: a warning, then a one-week suspension, then permanent deactivation. Strikes expire after twelve months."
 msgstr ""
@@ -2987,7 +2987,7 @@ msgstr ""
 "sospensione di una settimana, poi la disattivazione definitiva. I richiami "
 "decadono dopo dodici mesi."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:288
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "Conversation context (the reported message last)"
 msgstr "Contesto della conversazione (il messaggio segnalato per ultimo)"
@@ -3000,7 +3000,7 @@ msgstr ""
 "ripetutamente indesiderati portano alla sospensione dell'account, tanto nei "
 "post pubblici quanto nei messaggi privati."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:280
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "Current version (edited since the report)"
 msgstr "Versione attuale (modificata dopo la segnalazione)"
@@ -3015,7 +3015,7 @@ msgstr "Eliminare definitivamente questo contenuto?"
 msgid "Deleted. The report is settled, no further steps needed."
 msgstr "Eliminato. La segnalazione è chiusa, non serve altro."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:188
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:201
 #: lib/vutuv_web/views/admin/moderation_html.ex:9
 #, elixir-autogen, elixir-format
 msgid "Escalated"
@@ -3053,7 +3053,7 @@ msgstr "Nascosto: segnalato, in esame"
 msgid "Keep it family-friendly"
 msgstr "Contenuti adatti a tutti"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:132
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:145
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
 #: lib/vutuv_web/notification_line.ex:322
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
@@ -3062,8 +3062,8 @@ msgstr "Contenuti adatti a tutti"
 msgid "Moderation"
 msgstr "Moderazione"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:43
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:129
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:56
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "Moderation case"
 msgstr "Caso di moderazione"
@@ -3114,7 +3114,7 @@ msgid "No unwanted advertising, fake profiles, fraud or link bait."
 msgstr ""
 "Niente pubblicità indesiderata, profili falsi, frodi o link acchiappaclic."
 
-#: lib/vutuv_web/views/report_html.ex:13
+#: lib/vutuv_web/views/report_html.ex:80
 #, elixir-autogen, elixir-format
 msgid "Not family-friendly"
 msgstr "Non adatto a tutti"
@@ -3124,7 +3124,7 @@ msgstr "Non adatto a tutti"
 msgid "Nothing here - none of your content is currently reported."
 msgstr "Qui non c'è nulla: al momento nessun Suo contenuto è segnalato."
 
-#: lib/vutuv_web/views/report_html.ex:25
+#: lib/vutuv_web/views/report_html.ex:92
 #, elixir-autogen, elixir-format
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nudità, violenza o altri contenuti che non hanno posto su vutuv."
@@ -3171,13 +3171,6 @@ msgstr "Aperto"
 msgid "Owner"
 msgstr "Proprietario"
 
-#: lib/vutuv_web/templates/public_report/new.html.heex:144
-#: lib/vutuv_web/templates/report/new.html.heex:160
-#, elixir-autogen, elixir-format
-msgid "Please report honestly. Reporting to harm someone breaks our"
-msgstr "Segnali in modo onesto. Chi segnala per danneggiare qualcuno viola le nostre"
-"Segnali in buona fede. Segnalare per danneggiare qualcuno viola le nostre"
-
 #: lib/vutuv_web/components/ui.ex:5174
 #: lib/vutuv_web/live/shell_live.ex:1373
 #: lib/vutuv_web/templates/import/new.html.heex:16
@@ -3186,7 +3179,7 @@ msgstr "Segnali in modo onesto. Chi segnala per danneggiare qualcuno viola le no
 msgid "Profile"
 msgstr "Profilo"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:458
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "Reject the report"
 msgstr "Respingi la segnalazione"
@@ -3211,7 +3204,7 @@ msgstr "Lo rimuova. La segnalazione si chiude, senza altre domande."
 msgid "Report"
 msgstr "Segnala"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:239
+#: lib/vutuv_web/controllers/public_report_controller.ex:255
 #: lib/vutuv_web/controllers/report_controller.ex:54
 #: lib/vutuv_web/templates/layout/app.html.heex:131
 #: lib/vutuv_web/templates/page/legal.html.heex:42
@@ -3219,13 +3212,13 @@ msgstr "Segnala"
 msgid "Report content"
 msgstr "Segnala il contenuto"
 
-#: lib/vutuv_web/templates/page/community.html.heex:53
+#: lib/vutuv_web/templates/page/community.html.heex:61
 #, elixir-autogen, elixir-format
 msgid "Report honestly"
 msgstr "Segnali in buona fede"
 
 #: lib/vutuv_web/controllers/admin/moderation_controller.ex:55
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:59
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:72
 #, elixir-autogen, elixir-format
 msgid "Report rejected; the content is visible again."
 msgstr "Segnalazione respinta; il contenuto è di nuovo visibile."
@@ -3242,7 +3235,7 @@ msgid "Report this message"
 msgstr "Segnala questo messaggio"
 
 #: lib/vutuv_web/controllers/admin/moderation_controller.ex:39
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:51
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Report upheld; the owner got a strike."
 msgstr "Segnalazione accolta; il proprietario ha ricevuto un richiamo."
@@ -3260,7 +3253,7 @@ msgstr "Segnalato come"
 msgid "Reported content"
 msgstr "Contenuto segnalato"
 
-#: lib/vutuv_web/templates/page/community.html.heex:68
+#: lib/vutuv_web/templates/page/community.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Reported content is hidden right away while the report is handled. Nobody is publicly marked."
 msgstr ""
@@ -3280,7 +3273,7 @@ msgstr "Segnalante"
 msgid "Reporter track records"
 msgstr "Storico dei segnalanti"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:312
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:325
 #: lib/vutuv_web/live/admin/moderation_live.ex:57
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3302,7 +3295,7 @@ msgstr ""
 msgid "Review"
 msgstr "Esamina"
 
-#: lib/vutuv_web/templates/page/community.html.heex:56
+#: lib/vutuv_web/templates/page/community.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "See something that breaks these rules? Report it - every post, message and profile has a report option, and reports are anonymous. But reporting is not a weapon: deliberately false reports count as bullying and earn the reporter the same strikes."
 msgstr ""
@@ -3311,8 +3304,8 @@ msgstr ""
 " segnalazione non è un'arma: le segnalazioni deliberatamente false valgono "
 "come bullismo e portano al segnalante gli stessi richiami."
 
-#: lib/vutuv_web/templates/public_report/new.html.heex:154
-#: lib/vutuv_web/templates/report/new.html.heex:174
+#: lib/vutuv_web/templates/public_report/new.html.heex:134
+#: lib/vutuv_web/templates/report/new.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Send report"
 msgstr "Invia la segnalazione"
@@ -3327,12 +3320,12 @@ msgstr "Chiuso: il contenuto è stato eliminato."
 msgid "Settled: you revised the content and it is visible again."
 msgstr "Chiuso: ha corretto il contenuto ed è di nuovo visibile."
 
-#: lib/vutuv_web/views/report_html.ex:21
+#: lib/vutuv_web/views/report_html.ex:88
 #, elixir-autogen, elixir-format
 msgid "Something else"
 msgstr "Altro"
 
-#: lib/vutuv_web/views/report_html.ex:15
+#: lib/vutuv_web/views/report_html.ex:82
 #, elixir-autogen, elixir-format
 msgid "Spam or scam"
 msgstr "Spam o truffa"
@@ -3363,12 +3356,12 @@ msgstr ""
 msgid "Status"
 msgstr "Stato"
 
-#: lib/vutuv_web/views/report_html.ex:27
+#: lib/vutuv_web/views/report_html.ex:94
 #, elixir-autogen, elixir-format
 msgid "Targets, demeans or threatens a person."
 msgstr "Prende di mira, umilia o minaccia una persona."
 
-#: lib/vutuv_web/views/report_html.ex:36
+#: lib/vutuv_web/views/report_html.ex:103
 #, elixir-autogen, elixir-format
 msgid "Tell us more in the note below."
 msgstr "Ci dica di più nella nota qui sotto."
@@ -3383,7 +3376,7 @@ msgstr "Grazie per la segnalazione. Ce ne occupiamo noi."
 msgid "The content in question"
 msgstr "Il contenuto in questione"
 
-#: lib/vutuv_web/templates/page/community.html.heex:73
+#: lib/vutuv_web/templates/page/community.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "The owner is notified and can delete the content, fix it (it becomes visible again immediately) or stand by it - then our admins decide."
 msgstr ""
@@ -3396,14 +3389,14 @@ msgstr ""
 msgid "The queue is empty - the self-service flow settled everything."
 msgstr "La coda è vuota: la procedura autonoma ha risolto tutto."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:446
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "The report by @%{slug} was a deliberate weapon (strikes the reporter)"
 msgstr ""
 "La segnalazione di @%{slug} è stata un'arma deliberata (richiamo al "
 "segnalante)"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:409
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content stays hidden and the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
@@ -3449,12 +3442,12 @@ msgstr ""
 "Inteso. Il contenuto resta nascosto finché uno dei nostri amministratori non"
 " avrà deciso."
 
-#: lib/vutuv_web/views/report_html.ex:28
+#: lib/vutuv_web/views/report_html.ex:95
 #, elixir-autogen, elixir-format
 msgid "Unwanted advertising, fraud or fake activity."
 msgstr "Pubblicità indesiderata, frode o attività falsa."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:423
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "Uphold the report"
 msgstr "Accogli la segnalazione"
@@ -3464,7 +3457,7 @@ msgstr "Accogli la segnalazione"
 msgid "Visible. Our admins will take a look."
 msgstr "Visibile. I nostri amministratori daranno un'occhiata."
 
-#: lib/vutuv_web/templates/page/community.html.heex:64
+#: lib/vutuv_web/templates/page/community.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "What happens after a report"
 msgstr "Cosa succede dopo una segnalazione"
@@ -3521,8 +3514,7 @@ msgstr ""
 "nascosto subito e al proprietario viene chiesto di correggerlo."
 
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:145
-#: lib/vutuv_web/templates/public_report/new.html.heex:149
-#: lib/vutuv_web/templates/report/new.html.heex:162
+#: lib/vutuv_web/views/report_html.ex:69
 #, elixir-autogen, elixir-format
 msgid "community guidelines"
 msgstr "regole della community"
@@ -3639,19 +3631,19 @@ msgstr ""
 msgid "%{count} follows"
 msgstr "%{count} follow"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "%{count} report so far"
 msgid_plural "%{count} reports so far"
 msgstr[0] "%{count} segnalazione finora"
 msgstr[1] "%{count} segnalazioni finora"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:338
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "%{rejected} rejected, %{abusive} abusive"
 msgstr "%{rejected} respinte, %{abusive} abusive"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:133
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Case"
 msgstr "Caso"
@@ -3666,7 +3658,7 @@ msgstr "Contenuto eliminato"
 msgid "Content frozen"
 msgstr "Contenuto bloccato"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:393
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "Decision"
 msgstr "Decisione"
@@ -3676,17 +3668,17 @@ msgstr "Decisione"
 msgid "Escalated - the 72h deadline passed"
 msgstr "Inoltrato: sono passate le 72 ore"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:196
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Evidence"
 msgstr "Prove"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:366
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "History"
 msgstr "Cronologia"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:206
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:219
 #, elixir-autogen, elixir-format
 msgid "Open the profile"
 msgstr "Apri il profilo"
@@ -3728,7 +3720,7 @@ msgstr "Segnalazione respinta"
 msgid "Report upheld"
 msgstr "Segnalazione accolta"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:355
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:371
 #, elixir-autogen, elixir-format
 msgid "Reporter and owner are separated since this report (connection, follows, messages)."
 msgstr ""
@@ -3760,13 +3752,13 @@ msgstr "Chiuso con l'eliminazione"
 msgid "Strike issued"
 msgstr "Richiamo assegnato"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:351
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "The protective separation from the owner was lifted on %{date}."
 msgstr ""
 "La separazione protettiva dal proprietario è stata revocata il %{date}."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:434
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:450
 #, elixir-autogen, elixir-format
 msgid "The report is unfounded. The content becomes visible again, any protective separation is lifted, and the rejection counts against each reporter's trust."
 msgstr ""
@@ -3774,7 +3766,7 @@ msgstr ""
 "protettiva viene revocata e il respingimento pesa sull'affidabilità di "
 "ciascun segnalante."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:200
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "The whole profile was reported. Judge the profile itself - the snapshot below only preserves the name at report time."
 msgstr ""
@@ -3819,7 +3811,7 @@ msgstr "livello %{level}, %{role}"
 msgid "messages"
 msgstr "messaggi"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:369
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "No history recorded - this case predates the audit log."
 msgstr ""
@@ -3865,7 +3857,7 @@ msgstr "Caso %{id}, acquisito il %{at} UTC"
 msgid "Evidence screenshot captured"
 msgstr "Screenshot di prova acquisito"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:269
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Evidence screenshot captured when the report was filed"
 msgstr "Screenshot di prova acquisito al momento della segnalazione"
@@ -3875,7 +3867,7 @@ msgstr "Screenshot di prova acquisito al momento della segnalazione"
 msgid "Moderation evidence - reported private message with context"
 msgstr "Prova di moderazione: messaggio privato segnalato con il contesto"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:264
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "Screenshot at report time"
 msgstr "Screenshot al momento della segnalazione"
@@ -3885,7 +3877,7 @@ msgstr "Screenshot al momento della segnalazione"
 msgid "reported message"
 msgstr "messaggio segnalato"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:275
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Scorra dentro il riquadro, o prema per aprire l'immagine intera."
@@ -5407,7 +5399,7 @@ msgstr "Documentazione dell'API"
 
 #: lib/vutuv_web/components/ui.ex:5397
 #: lib/vutuv_web/controllers/settings_controller.ex:161
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:501
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:517
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
@@ -5433,7 +5425,7 @@ msgid "The ad could not be approved."
 msgstr "Non è stato possibile approvare la pubblicità."
 
 #: lib/vutuv_web/controllers/admin/moderation_controller.ex:106
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:90
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "This case has already been resolved."
 msgstr "Questo caso è già stato risolto."
@@ -7840,7 +7832,7 @@ msgstr "Questo account non esiste più."
 msgid "That address no longer exists."
 msgstr "Questo indirizzo non esiste più."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:37
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:50
 #, elixir-autogen, elixir-format
 msgid "This case no longer exists."
 msgstr "Questo caso non esiste più."
@@ -10186,7 +10178,7 @@ msgstr "%{action} (%{reason})"
 msgid "Account deactivated and marked as spam."
 msgstr "Account disattivato e contrassegnato come spam."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:69
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:82
 #, elixir-autogen, elixir-format
 msgid "Account deactivated and marked as spam. Restore it from the member browser if this was wrong."
 msgstr ""
@@ -10194,7 +10186,7 @@ msgstr ""
 "ripristini dall'elenco dei membri."
 
 #: lib/vutuv_web/controllers/admin/moderation_controller.ex:89
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:77
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Account deleted."
 msgstr "Account eliminato."
@@ -10214,7 +10206,7 @@ msgstr "Account ripristinato. Il membro può accedere di nuovo."
 msgid "Accounts removed as spam"
 msgstr "Account rimossi come spam"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:468
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Clear-cut spam or abuse?"
 msgstr "Spam o abuso lampante?"
@@ -10224,24 +10216,24 @@ msgstr "Spam o abuso lampante?"
 msgid "Could not restore this member."
 msgstr "Non è stato possibile ripristinare questo membro."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:483
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "Deactivate @%{slug} and mark the account as spam?"
 msgstr "Disattivare @%{slug} e contrassegnare l'account come spam?"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:486
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "Deactivate account"
 msgstr "Disattiva l'account"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:495
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "Permanently DELETE @%{slug} and everything they posted? This cannot be undone."
 msgstr ""
 "ELIMINARE definitivamente @%{slug} e tutto ciò che ha pubblicato? "
 "L'operazione non si può annullare."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:471
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:487
 #, elixir-autogen, elixir-format
 msgid "Remove the account outright, skipping the warning ladder. Deactivating marks it as spam and is reversible from the member browser; deleting is permanent."
 msgstr ""
@@ -12459,7 +12451,7 @@ msgstr "Ente pubblico"
 msgid "%{views} views · %{clicks} apply clicks"
 msgstr "%{views} visualizzazioni · %{clicks} clic per candidarsi"
 
-#: lib/vutuv_web/views/report_html.ex:31
+#: lib/vutuv_web/views/report_html.ex:98
 #, elixir-autogen, elixir-format
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr "Un annuncio di lavoro falso, ingannevole o discriminatorio."
@@ -12675,7 +12667,7 @@ msgstr "Scriva a chi ha pubblicato"
 msgid "Mini-job"
 msgstr "Mini-job"
 
-#: lib/vutuv_web/views/report_html.ex:16
+#: lib/vutuv_web/views/report_html.ex:83
 #, elixir-autogen, elixir-format
 msgid "Misleading job posting"
 msgstr "Annuncio di lavoro ingannevole"
@@ -13396,7 +13388,7 @@ msgstr "Apri la supervisione degli annunci"
 msgid "Open reports"
 msgstr "Segnalazioni aperte"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:216
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Open the job posting"
 msgstr "Apri l'annuncio di lavoro"
@@ -23662,30 +23654,30 @@ msgid "Your post appears as soon as the video is ready"
 msgstr "Il Suo post apparirà appena il video sarà pronto"
 
 #: lib/vutuv_web/live/notification_live/index.ex:1424
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "%{formatted} connection"
 msgid_plural "%{formatted} connections"
-msgstr[0] "%{formatted} nuovo"
-msgstr[1] "%{formatted} nuovi"
+msgstr[0] "%{formatted} collegamento"
+msgstr[1] "%{formatted} collegamenti"
 
 #: lib/vutuv_web/live/notification_live/index.ex:1570
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "%{formatted} new connection"
 msgid_plural "%{formatted} new connections"
-msgstr[0] "%{formatted} nuovo"
-msgstr[1] "%{formatted} nuovi"
+msgstr[0] "%{formatted} nuovo collegamento"
+msgstr[1] "%{formatted} nuovi collegamenti"
 
 #: lib/vutuv_web/live/notification_live/index.ex:1574
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "%{formatted} new follower"
 msgid_plural "%{formatted} new followers"
-msgstr[0] "%{formatted} follower"
-msgstr[1] "%{formatted} follower"
+msgstr[0] "%{formatted} nuovo follower"
+msgstr[1] "%{formatted} nuovi follower"
 
 #: lib/vutuv_web/live/notification_live/index.ex:1430
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Last 30 days: %{parts}"
-msgstr "Ultimi 30 giorni"
+msgstr "Ultimi 30 giorni: %{parts}"
 
 #: lib/vutuv_web/components/post_components.ex:4902
 #: lib/vutuv_web/live/notification_live/index.ex:1003
@@ -23694,9 +23686,9 @@ msgid "Less"
 msgstr "Meno"
 
 #: lib/vutuv_web/live/notification_live/index.ex:1332
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Reactions"
-msgstr "Sezione"
+msgstr "Reazioni"
 
 #: lib/vutuv_web/live/notification_live/index.ex:505
 #, elixir-autogen, elixir-format
@@ -23704,24 +23696,24 @@ msgid "Seen before"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:617
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Show %{formatted} more"
-msgstr "Mostra %{formatted} altra risposta"
+msgstr "Mostra altri %{formatted}"
 
 #: lib/vutuv_web/live/notification_live/index.ex:828
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "The post is no longer available."
-msgstr "Questa posizione non è più disponibile."
+msgstr "Il post non è più disponibile."
 
 #: lib/vutuv_web/live/notification_live/index.ex:1538
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Thread by %{name}"
-msgstr "Piace a %{name}"
+msgstr "Conversazione di %{name}"
 
 #: lib/vutuv_web/live/notification_live/index.ex:1479
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "mentioned you."
-msgstr "L'ha menzionata in un post."
+msgstr "L'ha menzionata."
 
 #: lib/vutuv_web/live/notification_live/index.ex:1478
 #, elixir-autogen, elixir-format
@@ -24329,27 +24321,17 @@ msgstr "Attiva per il mio account"
 msgid "Fix it. One of our admins then looks at the revision; the post stays hidden until they have."
 msgstr "Correggilo. Uno dei nostri amministratori esaminerà poi la modifica; fino ad allora il contributo resta nascosto."
 
-#: lib/vutuv_web/templates/report/new.html.heex:153
-#, elixir-autogen, elixir-format
-msgid "I declare in good faith that this use is authorized neither by the rights holder nor by law."
-msgstr "Dichiaro in buona fede che questo utilizzo non è autorizzato né dal titolare dei diritti né dalla legge."
-
 #: lib/vutuv_web/templates/page/community.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Publish only what you hold the rights to"
 msgstr "Pubblica solo ciò di cui detieni i diritti"
 
-#: lib/vutuv_web/views/report_html.ex:34
+#: lib/vutuv_web/views/report_html.ex:101
 #, elixir-autogen, elixir-format
 msgid "Tell us which work it is and where the original can be seen."
 msgstr "Indica di quale opera si tratta e dove si può vedere l'originale."
 
-#: lib/vutuv_web/templates/page/community.html.heex:46
-#, elixir-autogen, elixir-format
-msgid "Texts, photos and videos belong to whoever made them. Post your own work, or work you have permission to use. A rights holder can report content here, and such a complaint is decided by one of our admins - an edit does not settle it."
-msgstr "Testi, foto e video appartengono a chi li ha creati. Pubblica opere tue o per le quali hai il permesso. Il titolare dei diritti può segnalare un contenuto qui, e su una segnalazione del genere decide uno dei nostri amministratori: una modifica non la risolve."
-
-#: lib/vutuv_web/views/report_html.ex:19
+#: lib/vutuv_web/views/report_html.ex:86
 #, elixir-autogen, elixir-format
 msgid "Uses a text, photo or video without the rights holder's permission"
 msgstr "Usa un testo, una foto o un video senza il permesso del titolare dei diritti"
@@ -24641,12 +24623,12 @@ msgstr "Segnala l'immagine di copertina"
 msgid "Report the profile picture"
 msgstr "Segnala l'immagine del profilo"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:229
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "The reported picture"
 msgstr "L'immagine segnalata"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:248
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Upholding the case deletes it, the private original included. Rejecting it puts every file back where it was."
 msgstr "Se il caso viene accolto, l'immagine viene eliminata, originale privato compreso. Se viene respinto, ogni file torna al suo posto."
@@ -24719,7 +24701,7 @@ msgstr ""
 "Grazie per la segnalazione. I nostri moderatori sono stati avvisati ed "
 "esamineranno questa immagine."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:256
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "This picture is still on the profile: only a copyright notice takes one offline before a ruling. Upholding the case deletes it, the private original included."
 msgstr ""
@@ -24750,24 +24732,19 @@ msgstr "Indirizzo della pagina"
 msgid "Confirm the report"
 msgstr "Confermare la segnalazione"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:87
-#: lib/vutuv_web/controllers/public_report_controller.ex:107
+#: lib/vutuv_web/controllers/public_report_controller.ex:91
+#: lib/vutuv_web/controllers/public_report_controller.ex:111
 #: lib/vutuv_web/templates/public_report/confirm.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Confirm your report"
 msgstr "Confermi la Sua segnalazione"
-
-#: lib/vutuv_web/templates/public_report/sent.html.heex:10
-#, elixir-autogen, elixir-format
-msgid "Follow the link in it and your report goes to our admins. Until then nothing about the reported content changes."
-msgstr "Segua il link contenuto nel messaggio e la Sua segnalazione arriverà ai nostri amministratori. Fino ad allora nulla cambia per il contenuto segnalato."
 
 #: lib/vutuv_web/templates/public_report/new.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "For a copyright claim: which work it is, and where the original can be seen."
 msgstr "Per una rivendicazione di copyright: di quale opera si tratta e dove si può vedere l'originale."
 
-#: lib/vutuv_web/templates/public_report/new.html.heex:137
+#: lib/vutuv_web/views/report_html.ex:42
 #, elixir-autogen, elixir-format
 msgid "I declare in good faith that what I describe here is true and that this use is authorized neither by the rights holder nor by law."
 msgstr "Dichiaro in buona fede che quanto descrivo qui è vero e che questo utilizzo non è autorizzato né dal titolare dei diritti né dalla legge."
@@ -24782,7 +24759,7 @@ msgstr "Un contenuto pubblicato qui è Suo, oppure viola la legge? Può segnalar
 msgid "Moderation: something was reported"
 msgstr "Moderazione: un contenuto è stato segnalato"
 
-#: lib/vutuv_web/templates/public_report/sent.html.heex:15
+#: lib/vutuv_web/templates/public_report/sent.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "No email? Please check your spam folder."
 msgstr "Nessuna e-mail? Controlli la cartella spam."
@@ -24808,8 +24785,8 @@ msgstr "Il segnalante esterno ha confermato il proprio indirizzo"
 msgid "Please confirm your report"
 msgstr "Confermi la Sua segnalazione"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:84
-#: lib/vutuv_web/controllers/public_report_controller.ex:112
+#: lib/vutuv_web/controllers/public_report_controller.ex:88
+#: lib/vutuv_web/controllers/public_report_controller.ex:116
 #, elixir-autogen, elixir-format
 msgid "Report confirmed"
 msgstr "Segnalazione confermata"
@@ -24824,7 +24801,7 @@ msgstr "Segnalare un contenuto di questo sito"
 msgid "Report filed from outside"
 msgstr "Segnalazione ricevuta dall'esterno"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:155
+#: lib/vutuv_web/controllers/public_report_controller.ex:171
 #, elixir-autogen, elixir-format
 msgid "Report sent"
 msgstr "Segnalazione inviata"
@@ -24839,7 +24816,7 @@ msgstr "Segnalare contenuti di questo sito"
 msgid "Thank you - your report is with our admins"
 msgstr "Grazie, la Sua segnalazione è presso i nostri amministratori"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:129
+#: lib/vutuv_web/controllers/public_report_controller.ex:133
 #, elixir-autogen, elixir-format
 msgid "That address is not on this site. We can only act on content published here."
 msgstr "Questo indirizzo non appartiene a questo sito. Possiamo intervenire solo su contenuti pubblicati qui."
@@ -24849,12 +24826,12 @@ msgstr "Questo indirizzo non appartiene a questo sito. Possiamo intervenire solo
 msgid "The post, picture, video, profile, page or job posting you are reporting. Copy it out of your browser's address bar."
 msgstr "Il post, l'immagine, il video, il profilo, la pagina o l'annuncio di lavoro che sta segnalando. Copi l'indirizzo dalla barra del Suo browser."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:451
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "The report by %{email} was a deliberate weapon (that address loses our trust)"
 msgstr "La segnalazione di %{email} era un'arma deliberata (quell'indirizzo perde la nostra fiducia)"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:216
+#: lib/vutuv_web/controllers/public_report_controller.ex:232
 #, elixir-autogen, elixir-format
 msgid "We could not find that page. Please check the address."
 msgstr "Non abbiamo trovato questa pagina. Controlli l'indirizzo."
@@ -24864,17 +24841,12 @@ msgstr "Non abbiamo trovato questa pagina. Controlli l'indirizzo."
 msgid "We have sent an email to %{email}."
 msgstr "Abbiamo inviato un'e-mail a %{email}."
 
-#: lib/vutuv_web/templates/public_report/new.html.heex:12
-#, elixir-autogen, elixir-format
-msgid "We will send you an email with a confirmation link. Nothing happens until you follow it - your report reaches our admins, and the reported content stays exactly where it is."
-msgstr "Le invieremo un'e-mail con un link di conferma. Finché non lo segue non accade nulla: la Sua segnalazione arriva ai nostri amministratori e il contenuto segnalato resta esattamente dov'è."
-
 #: lib/vutuv_web/templates/public_report/new.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "What is wrong with it?"
 msgstr "Che cosa non va?"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:160
+#: lib/vutuv_web/controllers/public_report_controller.ex:176
 #, elixir-autogen, elixir-format
 msgid "You already sent us this report. Please use the confirmation link in the email we sent you."
 msgstr "Ci ha già inviato questa segnalazione. Utilizzi il link di conferma contenuto nell'e-mail che Le abbiamo inviato."
@@ -24889,7 +24861,7 @@ msgstr "Non Le serve un account. Ci dica quale pagina è il problema e che cosa 
 msgid "You do not need to do anything else."
 msgstr "Non deve fare altro."
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:68
+#: lib/vutuv_web/controllers/public_report_controller.ex:72
 #, elixir-autogen, elixir-format
 msgid "You have sent us a lot of reports just now. Please try again later."
 msgstr "Ci ha inviato molte segnalazioni in poco tempo. Riprovi più tardi."
@@ -24904,37 +24876,37 @@ msgstr "Il Suo indirizzo e-mail"
 msgid "address not confirmed"
 msgstr "indirizzo non confermato"
 
-#: lib/vutuv_web/views/report_html.ex:52
+#: lib/vutuv_web/views/report_html.ex:119
 #, elixir-autogen, elixir-format
 msgctxt "content type"
 msgid "Job posting"
 msgstr "Annuncio di lavoro"
 
-#: lib/vutuv_web/views/report_html.ex:51
+#: lib/vutuv_web/views/report_html.ex:118
 #, elixir-autogen, elixir-format
 msgctxt "content type"
 msgid "Organization page"
 msgstr "Pagina dell'organizzazione"
 
-#: lib/vutuv_web/views/report_html.ex:53
+#: lib/vutuv_web/views/report_html.ex:120
 #, elixir-autogen, elixir-format
 msgctxt "content type"
 msgid "Picture"
 msgstr "Immagine"
 
-#: lib/vutuv_web/views/report_html.ex:48
+#: lib/vutuv_web/views/report_html.ex:115
 #, elixir-autogen, elixir-format
 msgctxt "content type"
 msgid "Post"
 msgstr "Post"
 
-#: lib/vutuv_web/views/report_html.ex:49
+#: lib/vutuv_web/views/report_html.ex:116
 #, elixir-autogen, elixir-format
 msgctxt "content type"
 msgid "Private message"
 msgstr "Messaggio privato"
 
-#: lib/vutuv_web/views/report_html.ex:50
+#: lib/vutuv_web/views/report_html.ex:117
 #, elixir-autogen, elixir-format
 msgctxt "content type"
 msgid "Profile"
@@ -24955,8 +24927,8 @@ msgstr "Segnalazione scartata: l'indirizzo non è mai stato confermato"
 msgid "Send the report again"
 msgstr "Invii di nuovo la segnalazione"
 
-#: lib/vutuv_web/controllers/public_report_controller.ex:95
-#: lib/vutuv_web/controllers/public_report_controller.ex:117
+#: lib/vutuv_web/controllers/public_report_controller.ex:99
+#: lib/vutuv_web/controllers/public_report_controller.ex:121
 #: lib/vutuv_web/templates/public_report/expired.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "This link has expired"
@@ -25032,67 +25004,67 @@ msgstr "Importazione del profilo LinkedIn semplice."
 msgid "No person made this decision: a report from somebody with a good record hides the reported content automatically, the moment it arrives."
 msgstr "Questa decisione non l'ha presa nessuna persona: la segnalazione di una persona affidabile nasconde il contenuto segnalato automaticamente, nel momento in cui arriva."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:413
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content becomes visible again - the consequence here is the strike (warn, suspend, deactivate)."
 msgstr "La segnalazione è fondata. Il contenuto torna visibile; qui la conseguenza è il richiamo (avvertimento, sospensione, disattivazione)."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:417
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:433
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The content is not hidden and upholding does not hide it; the owner gets a strike (warn, suspend, deactivate)."
 msgstr "La segnalazione è fondata. Il contenuto non è nascosto e accogliere il caso non lo nasconde; il proprietario riceve un richiamo (avvertimento, sospensione, disattivazione)."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:405
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #, elixir-autogen, elixir-format
 msgid "The report is justified. The reported picture is deleted, the private original included, and the owner gets a strike (warn, suspend, deactivate)."
 msgstr "La segnalazione è fondata. L'immagine segnalata viene eliminata, originale privato compreso, e il proprietario riceve un richiamo (avvertimento, sospensione, disattivazione)."
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:252
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "This picture is still on the profile: the address behind the copyright notice is not confirmed yet, so nothing has been hidden. Upholding the case deletes it, the private original included."
 msgstr "L'immagine è ancora sul profilo: l'indirizzo dietro la segnalazione per violazione del diritto d'autore non è ancora confermato, quindi non è stato nascosto nulla. Se il caso viene accolto, l'immagine viene eliminata, originale privato compreso."
 
-#: lib/vutuv_web/views/report_html.ex:82
+#: lib/vutuv_web/views/report_html.ex:149
 #, elixir-autogen, elixir-format
 msgid "somebody reported one of your job postings on vutuv."
 msgstr "qualcuno ha segnalato un Suo annuncio di lavoro su vutuv."
 
-#: lib/vutuv_web/views/report_html.ex:85
+#: lib/vutuv_web/views/report_html.ex:152
 #, elixir-autogen, elixir-format
 msgid "somebody reported one of your pages on vutuv."
 msgstr "qualcuno ha segnalato una Sua pagina su vutuv."
 
-#: lib/vutuv_web/views/report_html.ex:76
+#: lib/vutuv_web/views/report_html.ex:143
 #, elixir-autogen, elixir-format
 msgid "somebody reported one of your pictures on vutuv."
 msgstr "qualcuno ha segnalato una Sua immagine su vutuv."
 
-#: lib/vutuv_web/views/report_html.ex:73
+#: lib/vutuv_web/views/report_html.ex:140
 #, elixir-autogen, elixir-format
 msgid "somebody reported one of your posts on vutuv."
 msgstr "qualcuno ha segnalato un Suo contributo su vutuv."
 
-#: lib/vutuv_web/views/report_html.ex:79
+#: lib/vutuv_web/views/report_html.ex:146
 #, elixir-autogen, elixir-format
 msgid "somebody reported one of your private messages on vutuv."
 msgstr "qualcuno ha segnalato un Suo messaggio privato su vutuv."
 
-#: lib/vutuv_web/views/report_html.ex:91
+#: lib/vutuv_web/views/report_html.ex:158
 #, elixir-autogen, elixir-format
 msgid "somebody reported something of yours on vutuv."
 msgstr "qualcuno ha segnalato un Suo contenuto su vutuv."
 
-#: lib/vutuv_web/views/report_html.ex:88
+#: lib/vutuv_web/views/report_html.ex:155
 #, elixir-autogen, elixir-format
 msgid "somebody reported your profile on vutuv."
 msgstr "qualcuno ha segnalato il Suo profilo su vutuv."
 
-#: lib/vutuv_web/views/report_html.ex:105
+#: lib/vutuv_web/views/report_html.ex:172
 #, elixir-autogen, elixir-format
 msgid "A report from a member in good standing hides the reported content automatically, the moment it arrives."
 msgstr "La segnalazione di un membro affidabile nasconde il contenuto segnalato automaticamente, nel momento in cui arriva."
 
-#: lib/vutuv_web/views/report_html.ex:111
+#: lib/vutuv_web/views/report_html.ex:178
 #, elixir-autogen, elixir-format
 msgid "A report from somebody with a good record hides the reported content automatically, the moment it arrives."
 msgstr "La segnalazione di una persona affidabile nasconde il contenuto segnalato automaticamente, nel momento in cui arriva."
@@ -25127,17 +25099,52 @@ msgstr "Il contenuto resta nascosto."
 msgid "Owner replaced the content"
 msgstr "Il proprietario ha sostituito il contenuto"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:184
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Owner deadline"
 msgstr "Termine per il proprietario"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:181
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Reported"
 msgstr "Segnalato"
 
-#: lib/vutuv_web/live/admin/moderation_case_live.ex:330
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "declared in good faith"
 msgstr "dichiarato in buona fede"
+
+#: lib/vutuv_web/views/report_html.ex:61
+#, elixir-autogen, elixir-format
+msgid "Please report honestly. Reporting to harm someone breaks our {guidelines}."
+msgstr "Segnali in modo onesto. Chi segnala per danneggiare qualcuno viola le nostre {guidelines}."
+
+#: lib/vutuv_web/templates/page/community.html.heex:50
+#, elixir-autogen, elixir-format
+msgid "Texts, photos and videos belong to whoever made them. Post your own work, or work you have permission to use. A rights holder can report content here without an account, through {form}; such a complaint is decided by one of our admins, and an edit does not settle it."
+msgstr "Testi, foto e video appartengono a chi li ha creati. Pubblica opere tue o per le quali hai il permesso. Il titolare dei diritti può segnalare un contenuto anche senza un account, tramite {form}; su una segnalazione del genere decide uno dei nostri amministratori, e una modifica non la risolve."
+
+#: lib/vutuv_web/controllers/public_report_controller.ex:143
+#, elixir-autogen, elixir-format
+msgid "That address is one of our own pages, not content somebody published here, so there is nothing on it we could act on. Please paste the address of the post, picture, video, profile or job posting itself."
+msgstr "Questo indirizzo è una nostra pagina, non un contenuto pubblicato qui da qualcuno: non c'è nulla su cui possiamo intervenire. Incolli l'indirizzo del post, dell'immagine, del video, del profilo o dell'annuncio di lavoro."
+
+#: lib/vutuv_web/templates/public_report/new.html.heex:12
+#, elixir-autogen, elixir-format
+msgid "We will send you an email with a confirmation link. Your report is in front of our admins right away; until you follow that link nothing about the reported content changes."
+msgstr "Le invieremo un'e-mail con un link di conferma. La Sua segnalazione è subito davanti ai nostri amministratori; finché non segue quel link, nulla cambia per il contenuto segnalato."
+
+#: lib/vutuv_web/templates/public_report/sent.html.heex:13
+#, elixir-autogen, elixir-format
+msgid "Your report is already with our admins. Follow the link in that email to confirm your address; until you do, nothing about the reported content changes."
+msgstr "La Sua segnalazione è già presso i nostri amministratori. Segua il link nell'e-mail per confermare il Suo indirizzo; fino ad allora nulla cambia per il contenuto segnalato."
+
+#: lib/vutuv_web/templates/page/community.html.heex:56
+#, elixir-autogen, elixir-format
+msgid "the report form"
+msgstr "il modulo di segnalazione"
+
+#: lib/vutuv_web/live/admin/moderation_case_live.ex:356
+#, elixir-autogen, elixir-format
+msgid "“%{note}”"
+msgstr "“%{note}”"

--- a/test/vutuv_web/controllers/public_report_controller_test.exs
+++ b/test/vutuv_web/controllers/public_report_controller_test.exs
@@ -72,6 +72,39 @@ defmodule VutuvWeb.PublicReportControllerTest do
       assert conn |> get(~p"/impressum") |> html_response(200) =~ ~s(href="/system/report")
     end
 
+    # Issue #2068: the house rules invited rights holders to report "here" and
+    # left the word as plain text, with the only link to the form down in the
+    # footer's Legal group — which is why asserting on the whole page above
+    # passed while the sentence itself led nowhere.
+    test "is linked from the sentence in the house rules that invites it", %{conn: conn} do
+      html =
+        conn
+        |> put_req_header("accept-language", "de-DE,de")
+        |> get(~p"/community")
+        |> html_response(200)
+
+      assert html =~
+               ~r{ohne Konto melden, über <a[^>]+href="/system/report"[^>]*>das Meldeformular</a>}
+    end
+
+    # What a rights holder reads before typing anything, in the language they
+    # read it in. The form used to promise that following the link is what
+    # leaves the content in place, and the house-rules link sat beside the
+    # sentence rather than inside it, so the full stop rendered a space away
+    # ("Community-Richtlinien .").
+    test "says what the confirmation link does, and closes its own sentences", %{conn: conn} do
+      html =
+        conn
+        |> put_req_header("accept-language", "de-DE,de")
+        |> get(~p"/system/report")
+        |> html_response(200)
+
+      assert html =~ "Ihre Meldung liegt sofort bei unseren Admins"
+      assert html =~ "bis Sie dem Link folgen, ändert sich am gemeldeten Inhalt nichts"
+      assert html =~ ~r{>Community-Richtlinien</a>\.}
+      refute html =~ ~r{Community-Richtlinien\s+</a>}
+    end
+
     # The form's own rendered action, not a path the test knows: a Save button
     # posting to a retired URL is exactly what shipped once here.
     test "submits to the URL it renders", %{conn: conn, post: post} do
@@ -123,6 +156,54 @@ defmodule VutuvWeb.PublicReportControllerTest do
       conn = submit(conn, VutuvWeb.Endpoint.url() <> "/no-such-handle")
 
       assert html_response(conn, 422) =~ "could not find that page"
+    end
+
+    # Issue #2068: `/impressum` is a perfectly correct address, and being told
+    # we could not find it sends a rights holder back to re-check a link that
+    # was right all along. A page of the site itself is its own answer — and
+    # the two-and-three-segment ones count, which is why the discriminator is
+    # the matched route's first segment rather than "no `:param` anywhere".
+    test "one of our own pages is neither reportable nor missing", %{conn: conn} do
+      for path <- [
+            "/impressum",
+            "/community",
+            "/system/members",
+            "/system/members/w",
+            "/system/posts/2026/09"
+          ] do
+        conn = submit(conn, VutuvWeb.Endpoint.url() <> path)
+        html = html_response(conn, 422)
+
+        assert html =~ "one of our own pages", "#{path} should be named as a page of ours"
+        refute html =~ "could not find that page"
+      end
+    end
+
+    # The same answer in the language a German rights holder reads it in, and
+    # the short middle clause too: a fuzzy merge is likeliest exactly there.
+    test "and says so in German", %{conn: conn} do
+      html =
+        conn
+        |> put_req_header("accept-language", "de-DE,de")
+        |> submit(VutuvWeb.Endpoint.url() <> "/impressum")
+        |> html_response(422)
+
+      assert html =~ "gehört zu einer unserer eigenen Seiten"
+      assert html =~ "wogegen wir vorgehen könnten"
+      refute html =~ "konnten diese Seite nicht finden"
+    end
+
+    # The distinction must not cost the anti-oracle rule anything. `/stefan` is
+    # the interesting one: a reserved word, so it never reaches a handle
+    # lookup, but nothing routes it either — it is a name still to be claimed,
+    # not a page of ours.
+    test "an address where a handle would stand still gets the answer a typo gets", %{conn: conn} do
+      for path <- ["/no-such-handle/tags", "/stefan"] do
+        conn = submit(conn, VutuvWeb.Endpoint.url() <> path)
+
+        assert html_response(conn, 422) =~ "could not find that page",
+               "#{path} must not be named a page of ours"
+      end
     end
 
     # The anti-oracle rule: a frozen post is not public, so the form must not
@@ -245,6 +326,30 @@ defmodule VutuvWeb.PublicReportControllerTest do
       [email | _] = flush_emails()
       assert email.subject == "Bitte bestätigen Sie Ihre Meldung"
       assert email.text_body =~ "wir haben Ihre Meldung erhalten"
+    end
+
+    # The page and the receipt used to disagree about the one fact a notifier
+    # acts on: the page said the admins see the case only after the
+    # confirmation, the mail said it is already with them. The mail was right
+    # — `file_public_notice/3` opens the case `flagged`, which is a queue
+    # status — so the page had to move.
+    test "the sent page and the receipt mail agree about when the admins see it", %{
+      conn: conn,
+      post: post
+    } do
+      conn = put_req_header(conn, "accept-language", "de-DE,de")
+      html = conn |> submit(post_url(post)) |> html_response(200)
+
+      assert html =~ "Ihre Meldung liegt bereits bei unseren Admins"
+      assert html =~ "bis dahin ändert sich am gemeldeten Inhalt nichts"
+
+      [email | _] = flush_emails()
+      assert email.text_body =~ "liegt der Fall unbearbeitet bei unseren Admins"
+
+      # And it is true: the case is in the admin queue before anybody has
+      # followed the link.
+      assert Moderation.open_case_for(post).status == "flagged"
+      assert Enum.any?(Moderation.list_queue(), &(&1.id == Moderation.open_case_for(post).id))
     end
   end
 end

--- a/test/vutuv_web/controllers/report_controller_test.exs
+++ b/test/vutuv_web/controllers/report_controller_test.exs
@@ -167,6 +167,34 @@ defmodule VutuvWeb.ReportControllerTest do
       assert response =~ "Um welches Werk geht es"
     end
 
+    # Issue #2068: the two forms promised the same thing in two wordings — the
+    # public one added "that my statements are correct", the member one did
+    # not — while a single column (`good_faith_declared_at`, issue #2069)
+    # records what was declared. One column, one meaning, one sentence.
+    test "declares good faith in the same words the public form uses", %{conn: conn, post: post} do
+      {conn, _me} = create_and_login_user(conn)
+
+      member =
+        conn
+        |> recycle()
+        |> put_req_header("accept-language", "de-DE,de")
+        |> get(~p"/reports/new?type=post&id=#{post.id}")
+        |> html_response(200)
+
+      outsider =
+        build_conn()
+        |> put_req_header("accept-language", "de-DE,de")
+        |> get(~p"/system/report")
+        |> html_response(200)
+
+      declaration =
+        "Ich versichere nach bestem Wissen, dass meine Angaben zutreffen und dass diese " <>
+          "Nutzung weder vom Rechteinhaber noch vom Gesetz gedeckt ist."
+
+      assert member =~ declaration
+      assert outsider =~ declaration
+    end
+
     test "a reporter tied to the open case still reaches the form", %{conn: conn} do
       {conn, reporter} = create_and_login_user(conn)
       author = insert_activated_user()

--- a/test/vutuv_web/live/admin/moderation_outside_reporter_test.exs
+++ b/test/vutuv_web/live/admin/moderation_outside_reporter_test.exs
@@ -59,6 +59,22 @@ defmodule VutuvWeb.Admin.ModerationOutsideReporterTest do
       refute html =~ "was a deliberate weapon (strikes the reporter)"
     end
 
+    # The notice was quoted with a German opening mark and an ASCII closing
+    # one, hardcoded, on a page that renders in three languages (issue #2068).
+    # The quotes are the translation's now, like everywhere else in the app.
+    test "quotes the notice with the marks the reader's language uses", %{conn: conn, post: post} do
+      {case_record, _token} = file!(post)
+
+      assert conn |> get(~p"/admin/moderation/#{case_record.id}") |> html_response(200) =~
+               "“That photograph is mine.”"
+
+      assert conn
+             |> recycle()
+             |> put_req_header("accept-language", "de-DE,de")
+             |> get(~p"/admin/moderation/#{case_record.id}")
+             |> html_response(200) =~ "„That photograph is mine.“"
+    end
+
     test "renders a confirmed notice beside a member's own report", %{
       conn: conn,
       post: post


### PR DESCRIPTION
Pasting `/impressum` into `/system/report` answered "we could not find that page", sending a rights holder back to a link that was right all along. `Vutuv.Moderation.ContentUrl.resolve/1` now tells three misses apart: another server, a page of this installation, an actual miss. A page of ours is a reserved first path segment plus a router match whose own first segment is literal, which also covers `/system/members/w` and the post calendar. It reads no row, so a typo, a frozen post and `/stefan` all still answer "not found".

Beside it: the English source sentence claimed that following the confirmation link leaves the content in place, and the success page said the admins only see the case afterwards, while it is `flagged` in the queue from the submit. `/community` links the form from the sentence inviting it, and both forms share one good-faith declaration and one house-rules line (`VutuvWeb.ReportHTML`).

German and Italian written by hand; the merge fuzzy-filled five entries in each.

Closes #2068

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01UGPe7bHVS11M1W7fNehSku

<!-- closing-note #2068 -->
A rights holder pasting a real but unreportable address of ours is now told so, instead of being sent back to check a correct link, and the form and its receipt mail agree that the case reaches the admins on the submit while nothing about the content moves until the confirmation. I decided a page of the site by asking the router rather than by listing paths, gated on the reserved-slug list so a missing handle keeps the answer a typo gets; the two forms' good-faith declaration became one component, since a single column records that it was made.

*An AI agent wrote this text in my name. I know that is problematic.*
