### PR TITLE
Show who I already follow in the admin live-activity cards, and let me follow from there

### DIFF
--- a/lib/vutuv/social.ex
+++ b/lib/vutuv/social.ex
@@ -1066,6 +1066,27 @@ defmodule Vutuv.Social do
   end
 
   @doc """
+  The mirror of `follow_edges/2`: which of `follower_ids` follow `user_id`, as a
+  `MapSet` of their ids. One query for a whole list, so a row that wants to say
+  "follows you" never asks on its own.
+
+  Ids only, no edge: the inbound edge belongs to the other member, so nothing
+  here may act on it — the viewer can mute or drop their *own* follow, never
+  somebody else's. Empty set for no viewer or no candidates.
+  """
+  def inbound_follower_ids(nil, _follower_ids), do: MapSet.new()
+  def inbound_follower_ids(_user_id, []), do: MapSet.new()
+
+  def inbound_follower_ids(user_id, follower_ids) do
+    from(c in Follow,
+      where: c.followee_id == ^user_id and c.follower_id in ^follower_ids,
+      select: c.follower_id
+    )
+    |> Repo.all()
+    |> MapSet.new()
+  end
+
+  @doc """
   The newest members who really show a face, newest first — the pool the
   feed's "New here" welcome card draws its handful out of.
 

--- a/lib/vutuv_web/live/admin/dashboard_live.ex
+++ b/lib/vutuv_web/live/admin/dashboard_live.ex
@@ -11,7 +11,14 @@ defmodule VutuvWeb.Admin.DashboardLive do
   landed today versus yesterday, with the timestamp of the last post and
   message. The "currently online" and "new members" cards also list the newest
   ten members behind each figure, each a link straight to that profile, so an
-  admin can eyeball who is online or who just joined without searching. The
+  admin can eyeball who is online or who just joined without searching.
+
+  Every one of those rows also carries the admin's **own** relationship to that
+  member: the follow / unfollow pill every listing row on the site wears, plus
+  the emerald chip that says when the member follows the admin back. Both are
+  read for the whole list in two queries and toggled over the socket, so
+  greeting the twenty-two people who signed up today is twenty-two clicks on
+  the page an admin already has open rather than twenty-two profile visits. The
   "online now" figure and its list update the instant a member connects or
   disconnects (they ride the `VutuvWeb.Presence` diffs, in-memory, no database);
   the database figures refresh on a gentle timer.
@@ -31,11 +38,15 @@ defmodule VutuvWeb.Admin.DashboardLive do
 
   use Gettext, backend: VutuvWeb.Gettext
 
-  import VutuvWeb.UI, only: [avatar: 1, card: 1, local_time: 1, delimited_count: 1]
-  import VutuvWeb.UserHelpers, only: [full_name: 1]
+  import VutuvWeb.UI,
+    only: [avatar: 1, card: 1, local_time: 1, delimited_count: 1, follow_button: 1]
+
+  import VutuvWeb.UserHelpers, only: [full_name: 1, following_map: 2]
+  import VutuvWeb.UserHTML, only: [profile_relationship_chip: 1]
 
   alias Vutuv.Accounts.User
   alias Vutuv.Dashboard
+  alias Vutuv.Social
   alias VutuvWeb.Live.InitAssigns
   alias VutuvWeb.Presence
 
@@ -48,7 +59,10 @@ defmodule VutuvWeb.Admin.DashboardLive do
   def mount(_params, session, socket) do
     # The shared preamble for an off-router child: resolves the viewer from the
     # cookie's session token and applies their locale and clock.
-    socket = InitAssigns.assign_embedded(socket, session)
+    socket =
+      socket
+      |> InitAssigns.assign_embedded(session)
+      |> assign(following_by_id: %{}, follows_me: MapSet.new(), relationship_ids: [])
 
     cond do
       # The throwaway dead render: the HTTP request that produced it already
@@ -75,19 +89,26 @@ defmodule VutuvWeb.Admin.DashboardLive do
     |> assign_snapshot()
     |> assign_newest_members()
     |> assign(:gender_breakdown, Dashboard.gender_breakdown())
+    |> assign_relationships()
   end
 
   @impl true
   def handle_info(:refresh, socket) do
     schedule_refresh()
-    {:noreply, socket |> assign_online() |> assign_snapshot() |> assign_newest_members()}
+
+    {:noreply,
+     socket
+     |> assign_online()
+     |> assign_snapshot()
+     |> assign_newest_members()
+     |> assign_relationships()}
   end
 
   # A member connected or disconnected somewhere: re-read the in-memory online
   # set so the "online now" count and its member list are always current. The
   # newest-members list can't change on presence, so it waits for the timer.
   def handle_info(%Phoenix.Socket.Broadcast{event: "presence_diff"}, socket),
-    do: {:noreply, assign_online(socket)}
+    do: {:noreply, socket |> assign_online() |> assign_relationships()}
 
   def handle_info(_other, socket), do: {:noreply, socket}
 
@@ -108,6 +129,74 @@ defmodule VutuvWeb.Admin.DashboardLive do
   defp assign_newest_members(socket),
     do: assign(socket, :newest_members, Dashboard.newest_members())
 
+  # ── The admin's own relationship to the people in the two lists ────────────
+
+  # The follow pill on a row, the site's ordinary follow reached from here: the
+  # same two events `VutuvWeb.PostLive.Feed` and the profile fire, refusals and
+  # all (see `Social.follow/2`).
+  @impl true
+  def handle_event(_event, _params, %{assigns: %{current_user: nil}} = socket),
+    do: {:noreply, socket}
+
+  def handle_event("follow", %{"followee" => followee_id}, socket) do
+    Social.follow(socket.assigns.current_user, followee_id)
+    {:noreply, assign_following(socket)}
+  end
+
+  # Scoped to the viewer by `unfollow!/2`, so a tampered id can only ever drop
+  # an edge the admin owns.
+  def handle_event("unfollow", %{"id" => follow_id}, socket) do
+    Social.unfollow!(socket.assigns.current_user.id, follow_id)
+    {:noreply, assign_following(socket)}
+  end
+
+  # Both directions for the whole page: the admin's outbound edges (the pill,
+  # and the id an unfollow needs) and the ids of the members who follow the
+  # admin (the chip).
+  #
+  # Guarded on the id list rather than run on every pass, because a presence
+  # diff is site-wide socket churn — `ShellLive` tracks on every page — while
+  # who is in these two lists changes far more rarely. The dead render pays for
+  # it too: it is thrown away, but without it every row paints a "Follow" pill
+  # that flips the moment the socket connects.
+  defp assign_relationships(socket) do
+    members = listed_members(socket)
+
+    if Enum.map(members, & &1.id) == socket.assigns.relationship_ids,
+      do: socket,
+      else: load_relationships(socket, members)
+  end
+
+  # After the admin's own follow or unfollow. Only the outbound half is re-read:
+  # the admin writing their own edge cannot change who follows *them*, so asking
+  # again would be a query per click that can only ever answer the same thing.
+  defp assign_following(socket) do
+    members = listed_members(socket)
+    assign(socket, :following_by_id, following_map(socket.assigns.current_user, members))
+  end
+
+  # Both lists, in id order so the result doubles as the guard's cache key, and
+  # without the admin's own row: they are in the "currently online" list because
+  # they are reading this page, and nobody follows themselves.
+  defp listed_members(socket) do
+    (socket.assigns.online_members ++ socket.assigns.newest_members)
+    |> Enum.uniq_by(& &1.id)
+    |> Enum.reject(&(&1.id == socket.assigns.current_user_id))
+    |> Enum.sort_by(& &1.id)
+  end
+
+  # `following_map/2` is the app's one batched "which of these do I follow", and
+  # its `%{followee_id => follow_id}` is the shape every other people listing
+  # binds to `following_by_id`. Both helpers answer empty for a nil viewer.
+  defp load_relationships(socket, members) do
+    ids = Enum.map(members, & &1.id)
+
+    socket
+    |> assign(:following_by_id, following_map(socket.assigns.current_user, members))
+    |> assign(:follows_me, Social.inbound_follower_ids(socket.assigns.current_user_id, ids))
+    |> assign(:relationship_ids, ids)
+  end
+
   @impl true
   def render(assigns) do
     ~H"""
@@ -121,7 +210,10 @@ defmodule VutuvWeb.Admin.DashboardLive do
         </span>
       </div>
 
-      <div class="grid gap-4 sm:grid-cols-2">
+      <%!-- `grid-cols-1` is load-bearing below `sm`, not a spelling of the
+      default: an implicit track is min-content sized, so the widest member row
+      pushed the card past a 375px phone. See `mobile_overflow_test.exs`. --%>
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <.card>
           <div class="flex items-center justify-between">
             <p class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">
@@ -146,6 +238,9 @@ defmodule VutuvWeb.Admin.DashboardLive do
             id="online-members"
             members={@online_members}
             empty={gettext("Nobody is online right now.")}
+            current_user_id={@current_user_id}
+            following_by_id={@following_by_id}
+            follows_me={@follows_me}
           />
         </.card>
 
@@ -161,12 +256,15 @@ defmodule VutuvWeb.Admin.DashboardLive do
               id="newest-members"
               members={@newest_members}
               empty={gettext("No members yet.")}
+              current_user_id={@current_user_id}
+              following_by_id={@following_by_id}
+              follows_me={@follows_me}
             />
           </:extra>
         </.stat_tile>
       </div>
 
-      <div class="mt-4 grid gap-4 sm:grid-cols-2">
+      <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
         <.stat_tile
           id="stat-posts"
           title={gettext("Posts")}
@@ -241,9 +339,18 @@ defmodule VutuvWeb.Admin.DashboardLive do
   # that navigates straight to that profile, so an admin can eyeball who is
   # online or who just signed up without searching. Falls back to a muted empty
   # line. Newest first (the caller orders the list).
+  #
+  # Each row also carries the admin's own side of the relationship, split the
+  # way `.claude/rules/design.md` asks: **an act is a button, a status is not**.
+  # The follow pill takes the action column on the right; the "follows you" /
+  # "connected" chip takes a line of its own under the handle, because sharing
+  # the handle's line cut it to "@nah…" on a 375px phone.
   attr(:id, :string, required: true)
   attr(:members, :list, required: true)
   attr(:empty, :string, required: true)
+  attr(:current_user_id, :any, required: true)
+  attr(:following_by_id, :map, required: true)
+  attr(:follows_me, MapSet, required: true)
 
   def member_list(assigns) do
     ~H"""
@@ -253,10 +360,10 @@ defmodule VutuvWeb.Admin.DashboardLive do
       role="list"
       class="mt-4 space-y-1 border-t border-slate-100 pt-3 dark:border-slate-800"
     >
-      <li :for={member <- @members}>
+      <li :for={member <- @members} class="flex items-center gap-2">
         <.link
           navigate={~p"/#{member}"}
-          class="group flex items-center gap-3 rounded-lg p-1.5 hover:bg-slate-50 dark:hover:bg-slate-800/60"
+          class="group flex min-w-0 flex-1 items-start gap-3 rounded-lg p-1.5 hover:bg-slate-50 dark:hover:bg-slate-800/60"
         >
           <.avatar user={member} size="sm" />
           <span class="min-w-0 flex-1">
@@ -266,8 +373,22 @@ defmodule VutuvWeb.Admin.DashboardLive do
             <span class="block truncate text-xs text-slate-600 dark:text-slate-400">
               @{member.username}
             </span>
+            <span :if={MapSet.member?(@follows_me, member.id)} class="mt-1 flex">
+              <.profile_relationship_chip
+                follow_id={Map.get(@following_by_id, member.id)}
+                follows_viewer?={true}
+              />
+            </span>
           </span>
         </.link>
+        <.follow_button
+          :if={@current_user_id && member.id != @current_user_id}
+          variant="text"
+          live?
+          follower_id={@current_user_id}
+          followee_id={member.id}
+          follow_id={Map.get(@following_by_id, member.id)}
+        />
       </li>
     </ul>
     <p

--- a/test/vutuv_web/live/admin/dashboard_live_test.exs
+++ b/test/vutuv_web/live/admin/dashboard_live_test.exs
@@ -28,6 +28,20 @@ defmodule VutuvWeb.Admin.DashboardLiveTest do
   defp mount_dashboard(session),
     do: live_isolated(build_conn(), VutuvWeb.Admin.DashboardLive, session: session)
 
+  # Tracks `user` on the global presence topic and returns once `view` has
+  # really processed the resulting diff. We subscribe here too so the wait is
+  # deterministic: seeing the broadcast ourselves means the dashboard has it
+  # queued, and `:sys.get_state/1` then flushes its mailbox.
+  defp bring_online(view, user) do
+    Presence.subscribe_online()
+    agent = start_supervised!({Agent, fn -> :ok end}, id: {:presence, user.id})
+    {:ok, _ref} = Presence.track_user(agent, user.id)
+
+    assert_receive %Broadcast{event: "presence_diff"}
+    _ = :sys.get_state(view.pid)
+    :ok
+  end
+
   describe "embedded on the admin home page" do
     test "the admin home renders the live dashboard at the top", %{conn: conn} do
       {conn, _admin} = create_and_login_admin(conn)
@@ -91,18 +105,8 @@ defmodule VutuvWeb.Admin.DashboardLiveTest do
 
       assert has_element?(view, "#stat-online", "0")
 
-      # Subscribe here too so we can wait for the join diff deterministically.
-      Presence.subscribe_online()
-
       # A member comes online: a live process tracks them on the presence topic.
-      online = insert(:user)
-      agent = start_supervised!({Agent, fn -> :ok end})
-      {:ok, _ref} = Presence.track_user(agent, online.id)
-
-      # Once we have seen the diff, the dashboard has it queued too; flush its
-      # mailbox so it has processed the same broadcast before we assert.
-      assert_receive %Broadcast{event: "presence_diff"}
-      _ = :sys.get_state(view.pid)
+      bring_online(view, insert(:user))
 
       assert has_element?(view, "#stat-online", "1")
     end
@@ -112,14 +116,8 @@ defmodule VutuvWeb.Admin.DashboardLiveTest do
 
       assert has_element?(view, "#online-members", "Nobody is online right now")
 
-      Presence.subscribe_online()
-
       online = insert(:user)
-      agent = start_supervised!({Agent, fn -> :ok end})
-      {:ok, _ref} = Presence.track_user(agent, online.id)
-
-      assert_receive %Broadcast{event: "presence_diff"}
-      _ = :sys.get_state(view.pid)
+      bring_online(view, online)
 
       assert has_element?(view, "#online-members a[href='/#{online.username}']")
     end
@@ -179,6 +177,91 @@ defmodule VutuvWeb.Admin.DashboardLiveTest do
 
       assert has_element?(view, "#stat-gender [data-gender=female]", "—")
       refute render(view) =~ "0%"
+    end
+
+    # ── The admin's own relationship to the listed members ──────────────────
+    #
+    # The two cards are where an admin meets the people who just signed up, so
+    # each row carries the follow pill and, when it applies, the chip that says
+    # the member follows them back. Both are keyed on `phx-value-*` and
+    # `data-profile-relationship` rather than on a translated word, which is the
+    # steadier probe.
+
+    test "a member the admin does not follow gets a Follow pill", %{session: session} do
+      member = insert(:user, email_confirmed?: true)
+
+      {:ok, view, _html} = mount_dashboard(session)
+
+      assert has_element?(view, "#newest-members button[phx-value-followee='#{member.id}']")
+      refute has_element?(view, "#newest-members [data-profile-relationship]")
+    end
+
+    test "the pill follows the member over the socket, with no reload", %{
+      admin: admin,
+      session: session
+    } do
+      member = insert(:user, email_confirmed?: true)
+
+      {:ok, view, _html} = mount_dashboard(session)
+
+      view
+      |> element("#newest-members button[phx-value-followee='#{member.id}']")
+      |> render_click()
+
+      assert Vutuv.Social.user_follows_user?(admin.id, member.id)
+
+      # The pill has flipped to its "Following" state, which is the unfollow
+      # half: it now carries the edge id rather than the followee id.
+      follow_id = Vutuv.Social.follow_id(admin.id, member.id)
+      assert has_element?(view, "#newest-members button[phx-value-id='#{follow_id}']")
+      refute has_element?(view, "#newest-members button[phx-value-followee='#{member.id}']")
+    end
+
+    test "the same pill takes the follow back", %{admin: admin, session: session} do
+      member = insert(:user, email_confirmed?: true)
+      follow = follow!(admin, member)
+
+      {:ok, view, _html} = mount_dashboard(session)
+
+      view
+      |> element("#newest-members button[phx-value-id='#{follow.id}']")
+      |> render_click()
+
+      refute Vutuv.Social.user_follows_user?(admin.id, member.id)
+      assert has_element?(view, "#newest-members button[phx-value-followee='#{member.id}']")
+    end
+
+    # The whole point of the chip: an admin greeting today's sign-ups can see at
+    # a glance which of them already came to them.
+    test "a member who follows the admin is marked, and a mutual follow reads as connected", %{
+      admin: admin,
+      session: session
+    } do
+      inbound = insert(:user, email_confirmed?: true)
+      mutual = insert(:user, email_confirmed?: true)
+      follow!(inbound, admin)
+      connect!(admin, mutual)
+
+      {:ok, view, _html} = mount_dashboard(session)
+
+      assert has_element?(view, "#newest-members [data-profile-relationship=inbound]")
+      assert has_element?(view, "#newest-members [data-profile-relationship=mutual]")
+
+      # The one-way inbound follow is still an offer to take up, the mutual one
+      # is not.
+      assert has_element?(view, "#newest-members button[phx-value-followee='#{inbound.id}']")
+      refute has_element?(view, "#newest-members button[phx-value-followee='#{mutual.id}']")
+    end
+
+    # The admin is in the "currently online" list themselves — they are reading
+    # the page. A pill there would be a control that cannot do anything.
+    test "the admin's own row carries no follow pill", %{admin: admin, session: session} do
+      {:ok, view, _html} = mount_dashboard(session)
+
+      bring_online(view, admin)
+
+      assert has_element?(view, "#online-members a[href='/#{admin.username}']")
+      refute has_element?(view, "#online-members button[phx-value-followee='#{admin.id}']")
     end
 
     # The admin's own stored locale is what decides, not the request's — the

--- a/test/vutuv_web/mobile_overflow_test.exs
+++ b/test/vutuv_web/mobile_overflow_test.exs
@@ -50,6 +50,34 @@ defmodule VutuvWeb.MobileOverflowTest do
     end
   end
 
+  # The same bug, fixed from the other side. `min-w-0` above is the *item* fix
+  # and needs a class attribute to land on; where the grid item is a component
+  # that passes no class through to its own root (`<.stat_tile>` wrapping
+  # `<.card>` on the admin dashboard), the fix goes on the *track* instead:
+  # spelling the single column out as `grid-cols-1` makes Tailwind emit
+  # `minmax(0, 1fr)`, which is exactly the shape `md:grid-cols-*` gets for free
+  # above the breakpoint. It reads like a no-op — the column is single either
+  # way — which is why deleting it is the plausible mistake this test exists to
+  # catch. Measured on the admin dashboard at 375px: 41px of overflow without
+  # it, 0 with.
+  @explicit_single_tracks [
+    {"live/admin/dashboard_live.ex", "sm:grid-cols-2"}
+  ]
+
+  test "a grid whose items carry no min-w-0 spells its single column out" do
+    for {file, breakpoint} <- @explicit_single_tracks do
+      content = File.read!(Path.join(@web, file))
+
+      for class <- Regex.scan(~r/class="([^"]*#{Regex.escape(breakpoint)}[^"]*)"/, content),
+          [_, class] = class do
+        assert String.contains?(class, "grid-cols-1"),
+               "#{file}: the grid \"#{class}\" leaves its single column implicit, so " <>
+                 "below the breakpoint it is min-content sized and the widest row " <>
+                 "pushes the card past a 375px phone. Spell it `grid-cols-1`."
+      end
+    end
+  end
+
   test "components.css lets rendered Markdown break long unbreakable tokens" do
     # A long unbreakable token (a pasted URL, a long word) in a post body has
     # `overflow-wrap: normal` by default and overflows its column on a phone


### PR DESCRIPTION
The "Live activity" cards at the top of `/admin` list who is online and who just signed up, with names and handles but nothing about the reader's own relationship to them — so greeting today's twenty-two new members meant twenty-two profile visits.

Each row now carries the site's ordinary follow pill on the right and, when there is something to say, an emerald "Follows you" / "Connected" chip under the handle. Clicks go over the socket, so the dashboard never reloads. Both states are read for the whole list in two queries (`UserHelpers.following_map/2` plus a new `Social.inbound_follower_ids/2`), guarded on the id list so the site-wide presence churn does not re-query, and a click re-reads only the outbound half.

The wider rows overflowed the card by 41px on a 375px phone: the single grid column was implicit and therefore min-content sized. `grid-cols-1` makes it `minmax(0, 1fr)`; `mobile_overflow_test.exs` now guards that, since the class reads like a no-op.

Where: `VutuvWeb.Admin.DashboardLive.member_list/1`, `/admin`.

Driven in a browser at 1470px and 375px: follow and unfollow both toggled with a single `GET /admin` in the log.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01LmsBwb1FoQt5uC9KyJ5zkf
