### PR TITLE
Professional experience no longer pushed off the profile by volunteering

### DIFF
--- a/lib/vutuv_web/live/user_profile_live.ex
+++ b/lib/vutuv_web/live/user_profile_live.ex
@@ -57,6 +57,7 @@ defmodule VutuvWeb.UserProfileLive do
   alias VutuvWeb.Live.MountHandoff
   alias VutuvWeb.Live.PostTranslations
   alias VutuvWeb.Live.VideoProgress
+  alias VutuvWeb.WorkExperienceHTML
 
   # The controller embeds this LiveView with `live_render/3` (not a `live/3`
   # router route), so `VutuvWeb.Live.InitAssigns` cannot be the on_mount: it
@@ -969,11 +970,15 @@ defmodule VutuvWeb.UserProfileLive do
     |> assign(:post_filter, "all")
     |> assign(:post_filter_total, posts_total)
     |> assign(:user_tags, user.user_tags)
-    # The whole history: the Experience card clusters it and previews up to
-    # WorkExperienceHTML.profile_preview_limit/0 roles. Clustering must see every
-    # role so a truncated employer still shows its true total tenure (a preview
-    # cut inside an organization must not report only the shown roles' years).
+    # The whole history: the Experience card clusters it and previews each CV
+    # category on its own cap. Clustering must see every role so a truncated
+    # employer still shows its true total tenure (a preview cut inside an
+    # organization must not report only the shown roles' years), and the "N more
+    # entries" note counts what the cut left out. The card's groups are built
+    # here rather than in the template so the profile's frequent patches (a
+    # follow, a like, a PubSub count) do not re-cluster the whole CV each time.
     |> assign(:work_experience, user.work_experiences)
+    |> assign(:experience_groups, WorkExperienceHTML.profile_groups(user.work_experiences))
     |> assign(:education, user.educations)
     |> assign(:languages, user.languages)
     # Expired-credential hiding (issue #859) is already applied in the preload
@@ -1316,12 +1321,11 @@ defmodule VutuvWeb.UserProfileLive do
   # THE single source of the per-section preview caps: preload_user_for_show/2
   # limits its preloads with it and user/show.html.heex reads the same numbers
   # for its `preview={...}` / "more than the preview" checks, so the queries
-  # and the template can never disagree. :experience rides along too — its
-  # preload is deliberately unlimited (see below) and the cap is applied
-  # in memory by WorkExperienceHTML.grouped_clusters/3, reached through the
-  # delegating WorkExperienceHTML.profile_preview_limit/0.
+  # and the template can never disagree. Experience is deliberately absent: one
+  # number cannot say how much of a CV to show, since the jobs and the Ehrenämter
+  # are capped apart (WorkExperienceHTML.profile_groups/1), so its preload stays
+  # unlimited and the cut happens in memory.
   @preview_limits %{
-    experience: 10,
     educations: 3,
     languages: 6,
     qualifications: 8,
@@ -1347,8 +1351,8 @@ defmodule VutuvWeb.UserProfileLive do
       user_tags: user_tags_query(),
       # Deliberately unlimited: the header-job pick must see every role (a
       # pinned one can sit outside the newest three; see load_profile). The
-      # Experience card takes its preview_limit(:experience) top roles in
-      # memory; rows per member are few.
+      # Experience card applies its per-category caps in memory; rows per member
+      # are few.
       # display_preloads: the verified organization page (issue #931) and the
       # cited credential (issue #858) ride along for the Experience card.
       work_experiences:

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -660,35 +660,44 @@ the resulting ~200px rail width. --%>
       length, so the gaps stay legible) ranks the blocks by how long they ran.
       Work experiences arrive newest-first (WorkExperience.order_by_date) and,
       like the section page, split into the CV categories (issue #840) under
-      their own headings once a non-employment entry exists. The block markup is
-      shared with the section page via `experience_block/1`; the preview keeps it
-      tight (no descriptions, no owner controls). --%>
-      <div
-        :for={
-          {kind, blocks} <-
-            VutuvWeb.WorkExperienceHTML.grouped_clusters(
-              @work_experience,
-              :compact,
-              VutuvWeb.WorkExperienceHTML.profile_preview_limit()
-            )
-        }
-        class="mt-6 first:mt-0"
-      >
-        <h3
-          :if={VutuvWeb.WorkExperienceHTML.show_kind_headings?(@work_experience)}
-          class="mb-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
-        >
-          {VutuvWeb.WorkExperienceHTML.kind_label(kind)}
+      their own headings once a non-employment entry exists. Each category is
+      capped on its own (`profile_groups/1`), so a long list of Ehrenämter can
+      never push the jobs — what a business network is read for — off the card.
+      The block markup is shared with the section page via `experience_block/1`;
+      the preview keeps it tight (no descriptions, no owner controls). --%>
+      <div :for={group <- @experience_groups} class="mt-6 first:mt-0">
+        <%!-- The heading is a link because it names the part of the CV a reader
+              wants more of: on a member with many roles it is the shortest way
+              from "Berufserfahrung" to the whole list. It stays a quiet caption
+              like every other section title, so it names its own colour — the
+              legacy `a { color: brand-600 }` beats a colour merely inherited
+              from the h3 and would paint these two headings brand blue. --%>
+        <h3 :if={VutuvWeb.WorkExperienceHTML.show_kind_headings?(@work_experience)} class="mb-3">
+          <.link
+            href={~p"/#{@user}/work_experiences"}
+            class="text-xs font-semibold uppercase tracking-wide text-slate-500 hover:text-brand-700 dark:text-slate-400 dark:hover:text-brand-300"
+          >
+            {VutuvWeb.WorkExperienceHTML.kind_label(group.kind)}
+          </.link>
         </h3>
         <%!-- The published Zeugnisse, keyed by the CV entry each documents, so
               a role can name its reference the way it already names the
               qualification it was earned with. Built from the references this
               page loaded, which are the published ones only. --%>
         <VutuvWeb.WorkExperienceHTML.experience_block
-          :for={block <- blocks}
+          :for={block <- group.blocks}
           block={block}
           user={@user}
           references={VutuvWeb.JobReferenceHTML.references_by_subject(@job_references)}
+        />
+
+        <%!-- What the cap left out, in this category's own words: how many roles
+              and which years they cover, so a reader can tell a cut-off decade
+              of jobs from a couple of recent ones. --%>
+        <VutuvWeb.WorkExperienceHTML.experience_more
+          :if={group.hidden}
+          user={@user}
+          hidden={group.hidden}
         />
       </div>
 
@@ -696,7 +705,7 @@ the resulting ~200px rail width. --%>
         href={~p"/#{@user}/work_experiences"}
         manage_href={~p"/settings/work_experiences"}
         total={@totals.jobs}
-        preview={VutuvWeb.WorkExperienceHTML.profile_preview_limit()}
+        preview={Enum.sum_by(@experience_groups, & &1.shown)}
         owner={@as_owner?}
       />
     </.card>

--- a/lib/vutuv_web/views/work_experience_html.ex
+++ b/lib/vutuv_web/views/work_experience_html.ex
@@ -5,7 +5,6 @@ defmodule VutuvWeb.WorkExperienceHTML do
 
   alias Vutuv.Organizations
   alias Vutuv.Profiles.WorkExperience
-  alias VutuvWeb.UserProfileLive
 
   @doc """
   The `{label, value}` options for the start/end month selects on the
@@ -90,14 +89,17 @@ defmodule VutuvWeb.WorkExperienceHTML do
   largest circle; and short internships still can't inflate past a decade-long
   job because the whole list is measured before any grouping.
 
-  `limit` caps the number of **displayed** roles (nil = no cap, the full CV page;
-  the profile preview passes `profile_preview_limit/0`). Always pass the member's
-  **whole** work history and let `limit` do the trimming — the block aggregates
+  `caps` is a `%{kind => cap}` map of how many **displayed** roles each category
+  keeps (a kind it does not name is uncapped, so `%{}` is the full CV page).
+  Per category and never one shared budget: a shared budget is spent
+  newest-first, so a member whose newest rows are all Ehrenämter saw two jobs
+  and eight of them. Always pass the member's **whole** work history and let the
+  cap do the trimming — the block aggregates
   (tenure, span, circle) are built from every role at an employer *before* the
   cut, so a truncated organization still reports its true total (a member with 3 roles
   over 9 years at one employer keeps "9 years" even when the cut shows only 2).
   """
-  def grouped_clusters(work_experiences, label_style \\ :years, limit \\ nil) do
+  def grouped_clusters(work_experiences, label_style \\ :years, caps \\ %{}) do
     indexed_circles =
       work_experiences
       |> circle_durations(label_style)
@@ -119,22 +121,105 @@ defmodule VutuvWeb.WorkExperienceHTML do
       end)
       |> Enum.sort_by(&elem(&1, 0))
       |> Enum.map(&elem(&1, 1))
-      |> take_roles(limit)
 
     groups = Enum.group_by(built, & &1.kind)
-    for kind <- WorkExperience.kinds(), kind_blocks = groups[kind], do: {kind, kind_blocks}
+
+    for kind <- WorkExperience.kinds(),
+        kind_blocks = groups[kind],
+        do: {kind, take_roles(kind_blocks, caps[kind])}
+  end
+
+  # What a business network is read for is the paid work, so employment and
+  # self-employment preview generously while an internship, an Ehrenamt or a
+  # hobby keeps a short taste with a link to the rest. Per category, never one
+  # shared budget: with 7 jobs and 13 Ehrenämter sharing a budget of 10 spent
+  # newest-first, tim_lueck's profile showed two jobs (2026-09).
+  @preview_caps Map.new(WorkExperience.kinds(), fn
+                  kind when kind in ~w(employment self_employed) -> {kind, 8}
+                  kind -> {kind, 3}
+                end)
+
+  @doc """
+  The profile Experience card's groups, in display order: one entry per non-empty
+  CV category with its capped timeline `:blocks`, the number of roles those hold
+  (`:shown`, what the card's footer measures itself against) and, where the cap
+  cut something, a `:hidden` note saying how many roles it left out and which
+  years they cover (`nil` when the category fits).
+
+  That note is what turns a truncated category into a usable pointer — "9 more
+  entries (1994 - 2015)" beside a link to the full CV beats a list that simply
+  stops. Its `:years` is `nil` when not one hidden role carries a year; nothing
+  is invented to fill the phrase.
+  """
+  def profile_groups(work_experiences) do
+    by_kind = Map.new(WorkExperience.group_by_kind(work_experiences))
+
+    for {kind, blocks} <- grouped_clusters(work_experiences, :compact, @preview_caps) do
+      shown = Enum.sum_by(blocks, &length(&1.roles))
+      # `take_roles/2` cuts a category's roles from the back and keeps their
+      # order, so the hidden ones are exactly what a drop of that many leaves.
+      hidden = by_kind |> Map.fetch!(kind) |> Enum.drop(shown)
+
+      %{kind: kind, blocks: blocks, shown: shown, hidden: hidden_note(hidden)}
+    end
+  end
+
+  defp hidden_note([]), do: nil
+  defp hidden_note(entries), do: %{count: length(entries), years: hidden_years(entries)}
+
+  # The span the hidden roles cover, through the same labeller the rail's own
+  # date column uses: "1994 - 2015", a lone "2003" when they all sit in one
+  # year, and running to "Present" while one of them is still going.
+  defp hidden_years(entries) do
+    years =
+      entries |> Enum.flat_map(&[&1.start_year, &1.end_year]) |> Enum.reject(&is_nil/1)
+
+    ongoing? = Enum.any?(entries, &(&1.start_year && is_nil(&1.end_year)))
+
+    if years != [] do
+      last = unless ongoing?, do: Enum.max(years)
+
+      duration_with_detail(nil, Enum.min(years), nil, last).label
+      |> IO.iodata_to_binary()
+    end
   end
 
   @doc """
-  How many roles the profile Experience card previews before truncating with an
-  "Alle anzeigen" link; the section page (`/:slug/work_experiences`) shows all.
-  Shared by the preview call and the `manage_footer` "View All" threshold so the
-  two can never disagree. The number itself lives in the profile's per-section
-  cap map (`VutuvWeb.UserProfileLive.preview_limit/1`) with every other
-  section's — this stays the view-side accessor the template and the
-  `grouped_clusters/3` docs point at.
+  The line under a category the profile preview truncated: how many roles the
+  cap left out, the years they cover, and the way to the whole CV. It rides the
+  timeline's own grid, so it lines up under the role titles above it rather than
+  opening a second margin.
   """
-  def profile_preview_limit, do: UserProfileLive.preview_limit(:experience)
+  attr(:user, :any, required: true)
+  attr(:hidden, :map, required: true)
+
+  def experience_more(assigns) do
+    ~H"""
+    <div class="grid grid-cols-[6.5rem_1fr] gap-3">
+      <.link
+        href={~p"/#{@user}/work_experiences"}
+        class="col-start-2 border-l border-transparent pl-5 text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+      >
+        <%= if @hidden.years do %>
+          {ngettext(
+            "One more entry (%{years})",
+            "%{formatted} more entries (%{years})",
+            @hidden.count,
+            formatted: compact_count(@hidden.count),
+            years: @hidden.years
+          )}
+        <% else %>
+          {ngettext(
+            "One more entry",
+            "%{formatted} more entries",
+            @hidden.count,
+            formatted: compact_count(@hidden.count)
+          )}
+        <% end %>
+      </.link>
+    </div>
+    """
+  end
 
   # Cap the number of *displayed* roles at `limit` (nil = no cap), truncating the
   # block that straddles the cap and dropping the blocks past it. A truncated

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -38,7 +38,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1494
+#: lib/vutuv_web/templates/user/show.html.heex:1503
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -104,7 +104,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/agent_docs/markdown.ex:677
 #: lib/vutuv_web/agent_docs/text.ex:636
 #: lib/vutuv_web/agent_docs/text.ex:637
-#: lib/vutuv_web/templates/user/show.html.heex:1125
+#: lib/vutuv_web/templates/user/show.html.heex:1134
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Geburtstag"
@@ -154,7 +154,7 @@ msgstr "Wählen Sie einen Typ aus"
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1163
+#: lib/vutuv_web/templates/user/show.html.heex:1172
 #, elixir-autogen
 msgid "Contact"
 msgstr "Kontakt"
@@ -225,7 +225,7 @@ msgstr "Download"
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:113
-#: lib/vutuv_web/templates/user/show.html.heex:1148
+#: lib/vutuv_web/templates/user/show.html.heex:1157
 #, elixir-autogen
 msgid "Edit"
 msgstr "Ändern"
@@ -333,13 +333,13 @@ msgstr "Follower"
 #: lib/vutuv_web/live/organization_live/show.ex:618
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:993
+#: lib/vutuv_web/templates/user/show.html.heex:1002
 #: lib/vutuv_web/views/user_html.ex:640
 #, elixir-autogen
 msgid "Following"
 msgstr "Folge ich"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:212
+#: lib/vutuv_web/live/admin/dashboard_live.ex:310
 #: lib/vutuv_web/templates/page/index.html.heex:121
 #: lib/vutuv_web/templates/user/edit.html.heex:207
 #: lib/vutuv_web/views/account_event_text.ex:219
@@ -693,13 +693,13 @@ msgstr "Slug"
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1277
+#: lib/vutuv_web/templates/user/show.html.heex:1286
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1279
+#: lib/vutuv_web/templates/user/show.html.heex:1288
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr "Profil hinzufügen"
@@ -738,7 +738,7 @@ msgstr "Code & Repositorys"
 #: lib/vutuv_web/controllers/follow_controller.ex:24
 #: lib/vutuv_web/controllers/remote_follow_controller.ex:174
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
-#: lib/vutuv_web/live/user_profile_live.ex:178
+#: lib/vutuv_web/live/user_profile_live.ex:179
 #, elixir-autogen
 msgid "Something went wrong"
 msgstr "Etwas ist schiefgelaufen"
@@ -853,8 +853,8 @@ msgid "vCard"
 msgstr "vCard"
 
 #: lib/vutuv_web/components/ui.ex:4860
-#: lib/vutuv_web/templates/user/show.html.heex:987
-#: lib/vutuv_web/templates/user/show.html.heex:1010
+#: lib/vutuv_web/templates/user/show.html.heex:996
+#: lib/vutuv_web/templates/user/show.html.heex:1019
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
@@ -1057,7 +1057,7 @@ msgstr "Diese Seite ist für Sie gesperrt."
 msgid "An error occurred"
 msgstr "Es gab einen Fehler."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1114
+#: lib/vutuv_web/templates/user/show.html.heex:1123
 #, elixir-autogen
 msgid "General Info"
 msgstr "Allgemeines"
@@ -1096,8 +1096,8 @@ msgstr "100 Usern mit den meisten Followern"
 msgid "Curious? Have a look at the "
 msgstr "Neugierig? Hier ist die Liste "
 
-#: lib/vutuv_web/views/work_experience_html.ex:308
-#: lib/vutuv_web/views/work_experience_html.ex:361
+#: lib/vutuv_web/views/work_experience_html.ex:393
+#: lib/vutuv_web/views/work_experience_html.ex:446
 #, elixir-autogen
 msgid "Present"
 msgstr "Heute"
@@ -1703,7 +1703,7 @@ msgstr "Empfehlen"
 #: lib/vutuv_web/live/organization_live/show.ex:616
 #: lib/vutuv_web/live/post_live/feed.ex:902
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
-#: lib/vutuv_web/templates/user/show.html.heex:1318
+#: lib/vutuv_web/templates/user/show.html.heex:1327
 #: lib/vutuv_web/views/user_html.ex:651
 #, elixir-autogen, elixir-format
 msgid "Follow"
@@ -1956,26 +1956,26 @@ msgstr "Eintrag löschen"
 msgid "Options"
 msgstr "Optionen"
 
-#: lib/vutuv_web/views/work_experience_html.ex:420
+#: lib/vutuv_web/views/work_experience_html.ex:505
 #, elixir-autogen, elixir-format
 msgid "%{count} month"
 msgid_plural "%{count} months"
 msgstr[0] "%{count} Monat"
 msgstr[1] "%{count} Monate"
 
-#: lib/vutuv_web/views/work_experience_html.ex:423
+#: lib/vutuv_web/views/work_experience_html.ex:508
 #, elixir-autogen, elixir-format
 msgid "%{count} year"
 msgid_plural "%{count} years"
 msgstr[0] "%{count} Jahr"
 msgstr[1] "%{count} Jahre"
 
-#: lib/vutuv_web/views/work_experience_html.ex:505
+#: lib/vutuv_web/views/work_experience_html.ex:590
 #, elixir-autogen, elixir-format
 msgid "Time in this role"
 msgstr "Dauer in dieser Position"
 
-#: lib/vutuv_web/views/work_experience_html.ex:504
+#: lib/vutuv_web/views/work_experience_html.ex:589
 #, elixir-autogen, elixir-format
 msgid "Total time at this employer"
 msgstr "Gesamtdauer bei diesem Arbeitgeber"
@@ -2215,7 +2215,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/controllers/post_controller.ex:90
 #: lib/vutuv_web/controllers/user_controller.ex:77
 #: lib/vutuv_web/gettext_extraction_anchors.ex:113
-#: lib/vutuv_web/live/admin/dashboard_live.ex:172
+#: lib/vutuv_web/live/admin/dashboard_live.ex:270
 #: lib/vutuv_web/live/fediverse_account_live.ex:446
 #: lib/vutuv_web/live/organization_live/show.ex:710
 #: lib/vutuv_web/live/post_live/saved.ex:536
@@ -2730,33 +2730,33 @@ msgstr "Andere E-Mail-Adresse verwenden"
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:923
+#: lib/vutuv_web/templates/user/show.html.heex:932
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr "Link hinzufügen"
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1237
+#: lib/vutuv_web/templates/user/show.html.heex:1246
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Telefonnummer hinzufügen"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1496
+#: lib/vutuv_web/templates/user/show.html.heex:1505
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Adresse hinzufügen"
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1165
+#: lib/vutuv_web/templates/user/show.html.heex:1174
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "E-Mail-Adresse hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1116
+#: lib/vutuv_web/templates/user/show.html.heex:1125
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Persönliche Angaben hinzufügen"
@@ -2891,7 +2891,7 @@ msgid "Endorsement"
 msgstr "Empfehlung"
 
 #: lib/vutuv_web/notification_line.ex:312
-#: lib/vutuv_web/templates/user/show.html.heex:971
+#: lib/vutuv_web/templates/user/show.html.heex:980
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3123,8 +3123,8 @@ msgstr "Nichts zu sehen, keiner Ihrer Inhalte ist derzeit gemeldet."
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1205
-#: lib/vutuv_web/templates/user/show.html.heex:1206
+#: lib/vutuv_web/templates/user/show.html.heex:1214
+#: lib/vutuv_web/templates/user/show.html.heex:1215
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
@@ -4623,7 +4623,7 @@ msgid "You have not blocked anyone."
 msgstr "Sie haben niemanden blockiert."
 
 #: lib/vutuv_web/controllers/block_controller.ex:89
-#: lib/vutuv_web/live/user_profile_live.ex:338
+#: lib/vutuv_web/live/user_profile_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
@@ -4642,7 +4642,7 @@ msgstr "Mitglieder finden"
 #: lib/vutuv_web/live/organization_live/following.ex:313
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:993
+#: lib/vutuv_web/templates/user/show.html.heex:1002
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folgt"
@@ -5533,7 +5533,7 @@ msgstr "Profil vervollständigen"
 msgid "A few quick steps so people can find and recognize you."
 msgstr "Ein paar schnelle Schritte, damit andere Sie finden und erkennen."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1464
+#: lib/vutuv_web/live/user_profile_live.ex:1468
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr "Profilfoto hinzufügen"
@@ -6210,7 +6210,7 @@ msgstr "z. B. MacBook"
 msgid "or"
 msgstr "oder"
 
-#: lib/vutuv_web/live/user_profile_live.ex:1469
+#: lib/vutuv_web/live/user_profile_live.ex:1473
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr "Kurzbeschreibung hinzufügen"
@@ -6225,7 +6225,7 @@ msgstr "Kurzbeschreibung"
 #: lib/vutuv_web/components/ui.ex:487
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:921
+#: lib/vutuv_web/templates/user/show.html.heex:930
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
@@ -6246,7 +6246,7 @@ msgstr[1] "Beiträge"
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1546
+#: lib/vutuv_web/templates/user/show.html.heex:1555
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Auch auf"
@@ -6292,8 +6292,8 @@ msgstr "Foto verwenden"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1131
-#: lib/vutuv_web/templates/user/show.html.heex:1141
+#: lib/vutuv_web/templates/user/show.html.heex:1140
+#: lib/vutuv_web/templates/user/show.html.heex:1150
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6335,12 +6335,12 @@ msgstr "Tagesbericht für %{day}"
 msgid "Jump to a day"
 msgstr "Zu einem Tag springen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1253
+#: lib/vutuv_web/templates/user/show.html.heex:1262
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr "E-Mails verwalten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1264
+#: lib/vutuv_web/templates/user/show.html.heex:1273
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr "Telefon verwalten"
@@ -6383,7 +6383,7 @@ msgstr "Vorheriger Tag"
 msgid "Reposts"
 msgstr "Reposts"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1262
+#: lib/vutuv_web/templates/user/show.html.heex:1271
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr "Alle Telefonnummern anzeigen"
@@ -6444,9 +6444,9 @@ msgstr "Anzuzeigende Kartendienste"
 msgid "Maps"
 msgstr "Karten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1536
-#: lib/vutuv_web/templates/user/show.html.heex:1540
-#: lib/vutuv_web/templates/user/show.html.heex:1552
+#: lib/vutuv_web/templates/user/show.html.heex:1545
+#: lib/vutuv_web/templates/user/show.html.heex:1549
+#: lib/vutuv_web/templates/user/show.html.heex:1561
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
@@ -6817,7 +6817,7 @@ msgid "Mute"
 msgstr "Stummschalten"
 
 #: lib/vutuv_web/controllers/follow_controller.ex:49
-#: lib/vutuv_web/live/user_profile_live.ex:279
+#: lib/vutuv_web/live/user_profile_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr "Stummgeschaltet. Die Beiträge erscheinen nicht mehr in Ihrem Feed."
@@ -6846,7 +6846,7 @@ msgid "Unmute"
 msgstr "Stummschaltung aufheben"
 
 #: lib/vutuv_web/controllers/follow_controller.ex:51
-#: lib/vutuv_web/live/user_profile_live.ex:281
+#: lib/vutuv_web/live/user_profile_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr ""
@@ -7935,51 +7935,51 @@ msgstr "Noch keine Klicks erfasst."
 msgid "(deleted member)"
 msgstr "(gelöschtes Mitglied)"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:128
+#: lib/vutuv_web/live/admin/dashboard_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Currently online"
 msgstr "Gerade online"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:179
+#: lib/vutuv_web/live/admin/dashboard_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "Direct messages"
 msgstr "Direktnachrichten"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:317
+#: lib/vutuv_web/live/admin/dashboard_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "Latest"
 msgstr "Zuletzt"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:117
+#: lib/vutuv_web/live/admin/dashboard_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Live activity"
 msgstr "Live-Aktivität"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:143
+#: lib/vutuv_web/live/admin/dashboard_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "Members online right now"
 msgstr "Mitglieder, die gerade online sind"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:154
+#: lib/vutuv_web/live/admin/dashboard_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "New members"
 msgstr "Neue Mitglieder"
 
 #: lib/vutuv_web/components/job_components.ex:219
-#: lib/vutuv_web/live/admin/dashboard_live.ex:304
+#: lib/vutuv_web/live/admin/dashboard_live.ex:425
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:468
 #: lib/vutuv_web/live/notification_live/index.ex:1368
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Heute"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:308
+#: lib/vutuv_web/live/admin/dashboard_live.ex:429
 #: lib/vutuv_web/live/notification_live/index.ex:1371
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr "Gestern"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:120
+#: lib/vutuv_web/live/admin/dashboard_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "updates automatically"
 msgstr "aktualisiert sich automatisch"
@@ -8339,12 +8339,12 @@ msgstr "Verifiziert"
 msgid "name, @handle or email"
 msgstr "Name, @Handle oder E-Mail"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:163
+#: lib/vutuv_web/live/admin/dashboard_live.ex:258
 #, elixir-autogen, elixir-format
 msgid "No members yet."
 msgstr "Noch keine Mitglieder."
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:148
+#: lib/vutuv_web/live/admin/dashboard_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Nobody is online right now."
 msgstr "Zurzeit ist niemand online."
@@ -8400,7 +8400,7 @@ msgstr[1] "%{count} Berufserfahrungen"
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:709
+#: lib/vutuv_web/templates/user/show.html.heex:718
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr "Ausbildung hinzufügen"
@@ -8424,7 +8424,7 @@ msgstr "Abschluss"
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
-#: lib/vutuv_web/templates/user/show.html.heex:706
+#: lib/vutuv_web/templates/user/show.html.heex:715
 #: lib/vutuv_web/views/import_html.ex:70
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
@@ -8479,7 +8479,7 @@ msgstr "Import"
 
 #: lib/vutuv_web/controllers/import_controller.ex:37
 #: lib/vutuv_web/controllers/import_controller.ex:128
-#: lib/vutuv_web/live/user_profile_live.ex:1480
+#: lib/vutuv_web/live/user_profile_live.ex:1484
 #: lib/vutuv_web/templates/import/new.html.heex:1
 #: lib/vutuv_web/templates/import/preview.html.heex:1
 #, elixir-autogen, elixir-format
@@ -8612,7 +8612,7 @@ msgid "Loading posts"
 msgstr "Beiträge werden geladen"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1400
+#: lib/vutuv_web/templates/user/show.html.heex:1409
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Social-Media-Beiträge"
@@ -8964,7 +8964,7 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1305
+#: lib/vutuv_web/templates/user/show.html.heex:1314
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr "Fediverse"
@@ -9025,18 +9025,18 @@ msgstr ""
 msgid "Category"
 msgstr "Kategorie"
 
-#: lib/vutuv_web/views/work_experience_html.ex:23
+#: lib/vutuv_web/views/work_experience_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Employment"
 msgstr "Anstellung"
 
 #: lib/vutuv/jobs/job_posting.ex:155
-#: lib/vutuv_web/views/work_experience_html.ex:25
+#: lib/vutuv_web/views/work_experience_html.ex:24
 #, elixir-autogen, elixir-format
 msgid "Internship"
 msgstr "Praktikum"
 
-#: lib/vutuv_web/views/work_experience_html.ex:35
+#: lib/vutuv_web/views/work_experience_html.ex:34
 #, elixir-autogen, elixir-format
 msgid "Internships"
 msgstr "Praktika"
@@ -9048,13 +9048,13 @@ msgstr ""
 "Wählen Sie auf dieser Seite „Größeres Datenarchiv herunterladen“ (Profil, "
 "Positionen, Ehrenämter, Ausbildung, Kenntnisse)."
 
-#: lib/vutuv_web/views/work_experience_html.ex:33
+#: lib/vutuv_web/views/work_experience_html.ex:32
 #, elixir-autogen, elixir-format
 msgid "Professional Experience"
 msgstr "Berufserfahrung"
 
-#: lib/vutuv_web/views/work_experience_html.ex:29
-#: lib/vutuv_web/views/work_experience_html.ex:36
+#: lib/vutuv_web/views/work_experience_html.ex:28
+#: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Volunteering & hobbies"
 msgstr "Ehrenamt, Hobby & Freiwilligenarbeit"
@@ -9218,14 +9218,14 @@ msgstr ""
 "Der Lebenslauf von %{name} auf vutuv: Berufserfahrung, Ausbildung und "
 "Kenntnisse zum Ansehen und Herunterladen."
 
-#: lib/vutuv_web/views/work_experience_html.ex:24
-#: lib/vutuv_web/views/work_experience_html.ex:34
+#: lib/vutuv_web/views/work_experience_html.ex:23
+#: lib/vutuv_web/views/work_experience_html.ex:33
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr "Freiberuflich / Selbstständig"
 
-#: lib/vutuv_web/views/work_experience_html.ex:30
-#: lib/vutuv_web/views/work_experience_html.ex:37
+#: lib/vutuv_web/views/work_experience_html.ex:29
+#: lib/vutuv_web/views/work_experience_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Other activities"
 msgstr "Sonstige Tätigkeiten"
@@ -9396,7 +9396,7 @@ msgstr "A2 (Grundkenntnisse)"
 #: lib/vutuv_web/live/feed_languages_live.ex:317
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:771
+#: lib/vutuv_web/templates/user/show.html.heex:780
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr "Sprache hinzufügen"
@@ -9621,7 +9621,7 @@ msgstr "Sprache erfolgreich aktualisiert."
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:768
+#: lib/vutuv_web/templates/user/show.html.heex:777
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Sprachen"
@@ -9912,7 +9912,7 @@ msgstr[0] "%{count} Zertifikat oder Lizenz"
 msgstr[1] "%{count} Zertifikate oder Lizenzen"
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:875
+#: lib/vutuv_web/templates/user/show.html.heex:884
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
@@ -9960,7 +9960,7 @@ msgstr "Zertifikate"
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:872
+#: lib/vutuv_web/templates/user/show.html.heex:881
 #: lib/vutuv_web/views/import_html.ex:71
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
@@ -10084,8 +10084,8 @@ msgstr "Bevorzugt"
 msgid "Preferred contact language"
 msgstr "Bevorzugte Kontaktsprache"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1227
-#: lib/vutuv_web/templates/user/show.html.heex:1228
+#: lib/vutuv_web/templates/user/show.html.heex:1236
+#: lib/vutuv_web/templates/user/show.html.heex:1237
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr "+%{code} ist die Ländervorwahl von %{region}"
@@ -10615,7 +10615,7 @@ msgstr[1] "%{formatted} Sterne"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:71
 #: lib/vutuv_web/agent_docs/text.ex:66
-#: lib/vutuv_web/templates/user/show.html.heex:1374
+#: lib/vutuv_web/templates/user/show.html.heex:1383
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Code"
@@ -10867,12 +10867,12 @@ msgstr "PHP, JavaScript, Ruby on Rails"
 msgid "Separate tags with a comma. A tag may be several words long, like Ruby on Rails."
 msgstr "Tags mit Komma trennen. Ein Tag darf aus mehreren Wörtern bestehen, zum Beispiel Ruby on Rails."
 
-#: lib/vutuv_web/views/work_experience_html.ex:436
+#: lib/vutuv_web/views/work_experience_html.ex:521
 #, elixir-autogen, elixir-format
 msgid "%{n}m"
 msgstr "%{n} M."
 
-#: lib/vutuv_web/views/work_experience_html.ex:437
+#: lib/vutuv_web/views/work_experience_html.ex:522
 #, elixir-autogen, elixir-format
 msgid "%{n}y"
 msgstr "%{n} J."
@@ -14039,7 +14039,7 @@ msgstr "Signal und WhatsApp akzeptieren eine Telefonnummer oder einen Benutzerna
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1340
+#: lib/vutuv_web/templates/user/show.html.heex:1349
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr "Messenger hinzufügen"
@@ -14076,7 +14076,7 @@ msgstr "Messenger wurde geändert."
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1338
+#: lib/vutuv_web/templates/user/show.html.heex:1347
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr "Messenger"
@@ -14264,7 +14264,7 @@ msgstr "Optional: das Zertifikat oder die Lizenz, mit der Sie diese Stelle erlan
 msgid "Qualification"
 msgstr "Qualifikation"
 
-#: lib/vutuv_web/views/work_experience_html.ex:624
+#: lib/vutuv_web/views/work_experience_html.ex:709
 #, elixir-autogen, elixir-format
 msgid "With qualification:"
 msgstr "Mit Qualifikation:"
@@ -15452,7 +15452,7 @@ msgstr "Anwendung bearbeiten"
 msgid "Book an ad"
 msgstr "Anzeige buchen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1047
+#: lib/vutuv_web/templates/user/show.html.heex:1056
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr "%{name} hat dieses Fediverse-Konto umgezogen. Folgen Sie stattdessen der neuen Adresse:"
@@ -18360,7 +18360,7 @@ msgstr "Für dieses Zeugnis läuft bereits eine Prüfung."
 #: lib/vutuv_web/controllers/job_reference_controller.ex:144
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:18
 #: lib/vutuv_web/templates/job_reference/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:809
+#: lib/vutuv_web/templates/user/show.html.heex:818
 #, elixir-autogen, elixir-format
 msgid "Add an employment reference"
 msgstr "Arbeitszeugnis hinzufügen"
@@ -18437,7 +18437,7 @@ msgstr "Arbeitszeugnis aktualisiert."
 #: lib/vutuv_web/templates/job_reference/new.html.heex:4
 #: lib/vutuv_web/templates/job_reference/show.html.heex:12
 #: lib/vutuv_web/templates/job_reference/view.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:806
+#: lib/vutuv_web/templates/user/show.html.heex:815
 #, elixir-autogen, elixir-format
 msgid "Employment references"
 msgstr "Arbeitszeugnisse"
@@ -19068,12 +19068,12 @@ msgstr "Ihr vutuv-Benutzername steht fest."
 msgid "by the lawyer Tom Braegelmann"
 msgstr "von Rechtsanwalt Tom Braegelmann"
 
-#: lib/vutuv_web/templates/user/show.html.heex:850
+#: lib/vutuv_web/templates/user/show.html.heex:859
 #, elixir-autogen, elixir-format
 msgid "Documents:"
 msgstr "Belegt:"
 
-#: lib/vutuv_web/views/work_experience_html.ex:663
+#: lib/vutuv_web/views/work_experience_html.ex:748
 #, elixir-autogen, elixir-format
 msgid "Employment reference:"
 msgstr "Arbeitszeugnis:"
@@ -19211,7 +19211,7 @@ msgstr "Weiblich"
 msgid "Male"
 msgstr "Männlich"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:226
+#: lib/vutuv_web/live/admin/dashboard_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
@@ -24475,3 +24475,17 @@ msgstr "Fotos vergrößern"
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr "Foto vergrößern"
+
+#: lib/vutuv_web/views/work_experience_html.ex:212
+#, elixir-autogen, elixir-format
+msgid "One more entry"
+msgid_plural "%{formatted} more entries"
+msgstr[0] "Ein weiterer Eintrag"
+msgstr[1] "%{formatted} weitere Einträge"
+
+#: lib/vutuv_web/views/work_experience_html.ex:204
+#, elixir-autogen, elixir-format
+msgid "One more entry (%{years})"
+msgid_plural "%{formatted} more entries (%{years})"
+msgstr[0] "Ein weiterer Eintrag (%{years})"
+msgstr[1] "%{formatted} weitere Einträge (%{years})"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -40,7 +40,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1494
+#: lib/vutuv_web/templates/user/show.html.heex:1503
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -106,7 +106,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:677
 #: lib/vutuv_web/agent_docs/text.ex:636
 #: lib/vutuv_web/agent_docs/text.ex:637
-#: lib/vutuv_web/templates/user/show.html.heex:1125
+#: lib/vutuv_web/templates/user/show.html.heex:1134
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -154,7 +154,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1163
+#: lib/vutuv_web/templates/user/show.html.heex:1172
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -225,7 +225,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:113
-#: lib/vutuv_web/templates/user/show.html.heex:1148
+#: lib/vutuv_web/templates/user/show.html.heex:1157
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -333,13 +333,13 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/show.ex:618
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:993
+#: lib/vutuv_web/templates/user/show.html.heex:1002
 #: lib/vutuv_web/views/user_html.ex:640
 #, elixir-autogen
 msgid "Following"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:212
+#: lib/vutuv_web/live/admin/dashboard_live.ex:310
 #: lib/vutuv_web/templates/page/index.html.heex:121
 #: lib/vutuv_web/templates/user/edit.html.heex:207
 #: lib/vutuv_web/views/account_event_text.ex:219
@@ -693,13 +693,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1277
+#: lib/vutuv_web/templates/user/show.html.heex:1286
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1279
+#: lib/vutuv_web/templates/user/show.html.heex:1288
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -738,7 +738,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/follow_controller.ex:24
 #: lib/vutuv_web/controllers/remote_follow_controller.ex:174
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
-#: lib/vutuv_web/live/user_profile_live.ex:178
+#: lib/vutuv_web/live/user_profile_live.ex:179
 #, elixir-autogen
 msgid "Something went wrong"
 msgstr ""
@@ -851,8 +851,8 @@ msgid "vCard"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4860
-#: lib/vutuv_web/templates/user/show.html.heex:987
-#: lib/vutuv_web/templates/user/show.html.heex:1010
+#: lib/vutuv_web/templates/user/show.html.heex:996
+#: lib/vutuv_web/templates/user/show.html.heex:1019
 #, elixir-autogen
 msgid "View All"
 msgstr ""
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1114
+#: lib/vutuv_web/templates/user/show.html.heex:1123
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1077,8 +1077,8 @@ msgstr ""
 msgid "Curious? Have a look at the "
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:308
-#: lib/vutuv_web/views/work_experience_html.ex:361
+#: lib/vutuv_web/views/work_experience_html.ex:393
+#: lib/vutuv_web/views/work_experience_html.ex:446
 #, elixir-autogen
 msgid "Present"
 msgstr ""
@@ -1676,7 +1676,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/show.ex:616
 #: lib/vutuv_web/live/post_live/feed.ex:902
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
-#: lib/vutuv_web/templates/user/show.html.heex:1318
+#: lib/vutuv_web/templates/user/show.html.heex:1327
 #: lib/vutuv_web/views/user_html.ex:651
 #, elixir-autogen, elixir-format
 msgid "Follow"
@@ -1918,26 +1918,26 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:420
+#: lib/vutuv_web/views/work_experience_html.ex:505
 #, elixir-autogen, elixir-format
 msgid "%{count} month"
 msgid_plural "%{count} months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:423
+#: lib/vutuv_web/views/work_experience_html.ex:508
 #, elixir-autogen, elixir-format
 msgid "%{count} year"
 msgid_plural "%{count} years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:505
+#: lib/vutuv_web/views/work_experience_html.ex:590
 #, elixir-autogen, elixir-format
 msgid "Time in this role"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:504
+#: lib/vutuv_web/views/work_experience_html.ex:589
 #, elixir-autogen, elixir-format
 msgid "Total time at this employer"
 msgstr ""
@@ -2175,7 +2175,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/post_controller.ex:90
 #: lib/vutuv_web/controllers/user_controller.ex:77
 #: lib/vutuv_web/gettext_extraction_anchors.ex:113
-#: lib/vutuv_web/live/admin/dashboard_live.ex:172
+#: lib/vutuv_web/live/admin/dashboard_live.ex:270
 #: lib/vutuv_web/live/fediverse_account_live.ex:446
 #: lib/vutuv_web/live/organization_live/show.ex:710
 #: lib/vutuv_web/live/post_live/saved.ex:536
@@ -2686,33 +2686,33 @@ msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:923
+#: lib/vutuv_web/templates/user/show.html.heex:932
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1237
+#: lib/vutuv_web/templates/user/show.html.heex:1246
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1496
+#: lib/vutuv_web/templates/user/show.html.heex:1505
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1165
+#: lib/vutuv_web/templates/user/show.html.heex:1174
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1116
+#: lib/vutuv_web/templates/user/show.html.heex:1125
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
@@ -2847,7 +2847,7 @@ msgid "Endorsement"
 msgstr ""
 
 #: lib/vutuv_web/notification_line.ex:312
-#: lib/vutuv_web/templates/user/show.html.heex:971
+#: lib/vutuv_web/templates/user/show.html.heex:980
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3063,8 +3063,8 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1205
-#: lib/vutuv_web/templates/user/show.html.heex:1206
+#: lib/vutuv_web/templates/user/show.html.heex:1214
+#: lib/vutuv_web/templates/user/show.html.heex:1215
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
@@ -4465,7 +4465,7 @@ msgid "You have not blocked anyone."
 msgstr ""
 
 #: lib/vutuv_web/controllers/block_controller.ex:89
-#: lib/vutuv_web/live/user_profile_live.ex:338
+#: lib/vutuv_web/live/user_profile_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "You unblocked @%{slug}."
 msgstr ""
@@ -4484,7 +4484,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:313
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:993
+#: lib/vutuv_web/templates/user/show.html.heex:1002
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -5321,7 +5321,7 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1464
+#: lib/vutuv_web/live/user_profile_live.ex:1468
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5979,7 +5979,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1469
+#: lib/vutuv_web/live/user_profile_live.ex:1473
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -5994,7 +5994,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:487
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:921
+#: lib/vutuv_web/templates/user/show.html.heex:930
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
@@ -6015,7 +6015,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1546
+#: lib/vutuv_web/templates/user/show.html.heex:1555
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6059,8 +6059,8 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1131
-#: lib/vutuv_web/templates/user/show.html.heex:1141
+#: lib/vutuv_web/templates/user/show.html.heex:1140
+#: lib/vutuv_web/templates/user/show.html.heex:1150
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6100,12 +6100,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1253
+#: lib/vutuv_web/templates/user/show.html.heex:1262
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1264
+#: lib/vutuv_web/templates/user/show.html.heex:1273
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6148,7 +6148,7 @@ msgstr ""
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1262
+#: lib/vutuv_web/templates/user/show.html.heex:1271
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6207,9 +6207,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1536
-#: lib/vutuv_web/templates/user/show.html.heex:1540
-#: lib/vutuv_web/templates/user/show.html.heex:1552
+#: lib/vutuv_web/templates/user/show.html.heex:1545
+#: lib/vutuv_web/templates/user/show.html.heex:1549
+#: lib/vutuv_web/templates/user/show.html.heex:1561
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6551,7 +6551,7 @@ msgid "Mute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:49
-#: lib/vutuv_web/live/user_profile_live.ex:279
+#: lib/vutuv_web/live/user_profile_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr ""
@@ -6580,7 +6580,7 @@ msgid "Unmute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:51
-#: lib/vutuv_web/live/user_profile_live.ex:281
+#: lib/vutuv_web/live/user_profile_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr ""
@@ -7614,51 +7614,51 @@ msgstr ""
 msgid "(deleted member)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:128
+#: lib/vutuv_web/live/admin/dashboard_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Currently online"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:179
+#: lib/vutuv_web/live/admin/dashboard_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "Direct messages"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:317
+#: lib/vutuv_web/live/admin/dashboard_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "Latest"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:117
+#: lib/vutuv_web/live/admin/dashboard_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Live activity"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:143
+#: lib/vutuv_web/live/admin/dashboard_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "Members online right now"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:154
+#: lib/vutuv_web/live/admin/dashboard_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "New members"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:219
-#: lib/vutuv_web/live/admin/dashboard_live.ex:304
+#: lib/vutuv_web/live/admin/dashboard_live.ex:425
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:468
 #: lib/vutuv_web/live/notification_live/index.ex:1368
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:308
+#: lib/vutuv_web/live/admin/dashboard_live.ex:429
 #: lib/vutuv_web/live/notification_live/index.ex:1371
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:120
+#: lib/vutuv_web/live/admin/dashboard_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "updates automatically"
 msgstr ""
@@ -7986,12 +7986,12 @@ msgstr ""
 msgid "name, @handle or email"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:163
+#: lib/vutuv_web/live/admin/dashboard_live.ex:258
 #, elixir-autogen, elixir-format
 msgid "No members yet."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:148
+#: lib/vutuv_web/live/admin/dashboard_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Nobody is online right now."
 msgstr ""
@@ -8047,7 +8047,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:709
+#: lib/vutuv_web/templates/user/show.html.heex:718
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8071,7 +8071,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
-#: lib/vutuv_web/templates/user/show.html.heex:706
+#: lib/vutuv_web/templates/user/show.html.heex:715
 #: lib/vutuv_web/views/import_html.ex:70
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
@@ -8121,7 +8121,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/import_controller.ex:37
 #: lib/vutuv_web/controllers/import_controller.ex:128
-#: lib/vutuv_web/live/user_profile_live.ex:1480
+#: lib/vutuv_web/live/user_profile_live.ex:1484
 #: lib/vutuv_web/templates/import/new.html.heex:1
 #: lib/vutuv_web/templates/import/preview.html.heex:1
 #, elixir-autogen, elixir-format
@@ -8251,7 +8251,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1400
+#: lib/vutuv_web/templates/user/show.html.heex:1409
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8559,7 +8559,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1305
+#: lib/vutuv_web/templates/user/show.html.heex:1314
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8613,18 +8613,18 @@ msgstr ""
 msgid "Category"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:23
+#: lib/vutuv_web/views/work_experience_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:155
-#: lib/vutuv_web/views/work_experience_html.ex:25
+#: lib/vutuv_web/views/work_experience_html.ex:24
 #, elixir-autogen, elixir-format
 msgid "Internship"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:35
+#: lib/vutuv_web/views/work_experience_html.ex:34
 #, elixir-autogen, elixir-format
 msgid "Internships"
 msgstr ""
@@ -8634,13 +8634,13 @@ msgstr ""
 msgid "On that page, select \"Download larger data archive\" (profile, positions, volunteering, education, skills)."
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:33
+#: lib/vutuv_web/views/work_experience_html.ex:32
 #, elixir-autogen, elixir-format
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:29
-#: lib/vutuv_web/views/work_experience_html.ex:36
+#: lib/vutuv_web/views/work_experience_html.ex:28
+#: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Volunteering & hobbies"
 msgstr ""
@@ -8786,14 +8786,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:24
-#: lib/vutuv_web/views/work_experience_html.ex:34
+#: lib/vutuv_web/views/work_experience_html.ex:23
+#: lib/vutuv_web/views/work_experience_html.ex:33
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:30
-#: lib/vutuv_web/views/work_experience_html.ex:37
+#: lib/vutuv_web/views/work_experience_html.ex:29
+#: lib/vutuv_web/views/work_experience_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Other activities"
 msgstr ""
@@ -8952,7 +8952,7 @@ msgstr ""
 #: lib/vutuv_web/live/feed_languages_live.ex:317
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:771
+#: lib/vutuv_web/templates/user/show.html.heex:780
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9177,7 +9177,7 @@ msgstr ""
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:768
+#: lib/vutuv_web/templates/user/show.html.heex:777
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -9457,7 +9457,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:875
+#: lib/vutuv_web/templates/user/show.html.heex:884
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
@@ -9505,7 +9505,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:872
+#: lib/vutuv_web/templates/user/show.html.heex:881
 #: lib/vutuv_web/views/import_html.ex:71
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
@@ -9624,8 +9624,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1227
-#: lib/vutuv_web/templates/user/show.html.heex:1228
+#: lib/vutuv_web/templates/user/show.html.heex:1236
+#: lib/vutuv_web/templates/user/show.html.heex:1237
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -10112,7 +10112,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:71
 #: lib/vutuv_web/agent_docs/text.ex:66
-#: lib/vutuv_web/templates/user/show.html.heex:1374
+#: lib/vutuv_web/templates/user/show.html.heex:1383
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10343,12 +10343,12 @@ msgstr ""
 msgid "Separate tags with a comma. A tag may be several words long, like Ruby on Rails."
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:436
+#: lib/vutuv_web/views/work_experience_html.ex:521
 #, elixir-autogen, elixir-format
 msgid "%{n}m"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:437
+#: lib/vutuv_web/views/work_experience_html.ex:522
 #, elixir-autogen, elixir-format
 msgid "%{n}y"
 msgstr ""
@@ -13386,7 +13386,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1340
+#: lib/vutuv_web/templates/user/show.html.heex:1349
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13423,7 +13423,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1338
+#: lib/vutuv_web/templates/user/show.html.heex:1347
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13611,7 +13611,7 @@ msgstr ""
 msgid "Qualification"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:624
+#: lib/vutuv_web/views/work_experience_html.ex:709
 #, elixir-autogen, elixir-format
 msgid "With qualification:"
 msgstr ""
@@ -14781,7 +14781,7 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1047
+#: lib/vutuv_web/templates/user/show.html.heex:1056
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
@@ -17638,7 +17638,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/job_reference_controller.ex:144
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:18
 #: lib/vutuv_web/templates/job_reference/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:809
+#: lib/vutuv_web/templates/user/show.html.heex:818
 #, elixir-autogen, elixir-format
 msgid "Add an employment reference"
 msgstr ""
@@ -17715,7 +17715,7 @@ msgstr ""
 #: lib/vutuv_web/templates/job_reference/new.html.heex:4
 #: lib/vutuv_web/templates/job_reference/show.html.heex:12
 #: lib/vutuv_web/templates/job_reference/view.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:806
+#: lib/vutuv_web/templates/user/show.html.heex:815
 #, elixir-autogen, elixir-format
 msgid "Employment references"
 msgstr ""
@@ -18346,12 +18346,12 @@ msgstr ""
 msgid "by the lawyer Tom Braegelmann"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:850
+#: lib/vutuv_web/templates/user/show.html.heex:859
 #, elixir-autogen, elixir-format
 msgid "Documents:"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:663
+#: lib/vutuv_web/views/work_experience_html.ex:748
 #, elixir-autogen, elixir-format
 msgid "Employment reference:"
 msgstr ""
@@ -18477,7 +18477,7 @@ msgstr ""
 msgid "Male"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:226
+#: lib/vutuv_web/live/admin/dashboard_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
@@ -23642,3 +23642,17 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr ""
+
+#: lib/vutuv_web/views/work_experience_html.ex:212
+#, elixir-autogen, elixir-format
+msgid "One more entry"
+msgid_plural "%{formatted} more entries"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/views/work_experience_html.ex:204
+#, elixir-autogen, elixir-format
+msgid "One more entry (%{years})"
+msgid_plural "%{formatted} more entries (%{years})"
+msgstr[0] ""
+msgstr[1] ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -38,7 +38,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1494
+#: lib/vutuv_web/templates/user/show.html.heex:1503
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -104,7 +104,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:677
 #: lib/vutuv_web/agent_docs/text.ex:636
 #: lib/vutuv_web/agent_docs/text.ex:637
-#: lib/vutuv_web/templates/user/show.html.heex:1125
+#: lib/vutuv_web/templates/user/show.html.heex:1134
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -152,7 +152,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1163
+#: lib/vutuv_web/templates/user/show.html.heex:1172
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -223,7 +223,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:113
-#: lib/vutuv_web/templates/user/show.html.heex:1148
+#: lib/vutuv_web/templates/user/show.html.heex:1157
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -331,13 +331,13 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/show.ex:618
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:993
+#: lib/vutuv_web/templates/user/show.html.heex:1002
 #: lib/vutuv_web/views/user_html.ex:640
 #, elixir-autogen
 msgid "Following"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:212
+#: lib/vutuv_web/live/admin/dashboard_live.ex:310
 #: lib/vutuv_web/templates/page/index.html.heex:121
 #: lib/vutuv_web/templates/user/edit.html.heex:207
 #: lib/vutuv_web/views/account_event_text.ex:219
@@ -691,13 +691,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1277
+#: lib/vutuv_web/templates/user/show.html.heex:1286
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1279
+#: lib/vutuv_web/templates/user/show.html.heex:1288
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -736,7 +736,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/follow_controller.ex:24
 #: lib/vutuv_web/controllers/remote_follow_controller.ex:174
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
-#: lib/vutuv_web/live/user_profile_live.ex:178
+#: lib/vutuv_web/live/user_profile_live.ex:179
 #, elixir-autogen
 msgid "Something went wrong"
 msgstr ""
@@ -849,8 +849,8 @@ msgid "vCard"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4860
-#: lib/vutuv_web/templates/user/show.html.heex:987
-#: lib/vutuv_web/templates/user/show.html.heex:1010
+#: lib/vutuv_web/templates/user/show.html.heex:996
+#: lib/vutuv_web/templates/user/show.html.heex:1019
 #, elixir-autogen
 msgid "View All"
 msgstr ""
@@ -1036,7 +1036,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1114
+#: lib/vutuv_web/templates/user/show.html.heex:1123
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1075,8 +1075,8 @@ msgstr ""
 msgid "Curious? Have a look at the "
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:308
-#: lib/vutuv_web/views/work_experience_html.ex:361
+#: lib/vutuv_web/views/work_experience_html.ex:393
+#: lib/vutuv_web/views/work_experience_html.ex:446
 #, elixir-autogen
 msgid "Present"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/show.ex:616
 #: lib/vutuv_web/live/post_live/feed.ex:902
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
-#: lib/vutuv_web/templates/user/show.html.heex:1318
+#: lib/vutuv_web/templates/user/show.html.heex:1327
 #: lib/vutuv_web/views/user_html.ex:651
 #, elixir-autogen, elixir-format
 msgid "Follow"
@@ -1916,26 +1916,26 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:420
+#: lib/vutuv_web/views/work_experience_html.ex:505
 #, elixir-autogen, elixir-format
 msgid "%{count} month"
 msgid_plural "%{count} months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:423
+#: lib/vutuv_web/views/work_experience_html.ex:508
 #, elixir-autogen, elixir-format
 msgid "%{count} year"
 msgid_plural "%{count} years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:505
+#: lib/vutuv_web/views/work_experience_html.ex:590
 #, elixir-autogen, elixir-format
 msgid "Time in this role"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:504
+#: lib/vutuv_web/views/work_experience_html.ex:589
 #, elixir-autogen, elixir-format
 msgid "Total time at this employer"
 msgstr ""
@@ -2173,7 +2173,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/post_controller.ex:90
 #: lib/vutuv_web/controllers/user_controller.ex:77
 #: lib/vutuv_web/gettext_extraction_anchors.ex:113
-#: lib/vutuv_web/live/admin/dashboard_live.ex:172
+#: lib/vutuv_web/live/admin/dashboard_live.ex:270
 #: lib/vutuv_web/live/fediverse_account_live.ex:446
 #: lib/vutuv_web/live/organization_live/show.ex:710
 #: lib/vutuv_web/live/post_live/saved.ex:536
@@ -2684,33 +2684,33 @@ msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:923
+#: lib/vutuv_web/templates/user/show.html.heex:932
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1237
+#: lib/vutuv_web/templates/user/show.html.heex:1246
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1496
+#: lib/vutuv_web/templates/user/show.html.heex:1505
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1165
+#: lib/vutuv_web/templates/user/show.html.heex:1174
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1116
+#: lib/vutuv_web/templates/user/show.html.heex:1125
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
@@ -2845,7 +2845,7 @@ msgid "Endorsement"
 msgstr ""
 
 #: lib/vutuv_web/notification_line.ex:312
-#: lib/vutuv_web/templates/user/show.html.heex:971
+#: lib/vutuv_web/templates/user/show.html.heex:980
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3061,8 +3061,8 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1205
-#: lib/vutuv_web/templates/user/show.html.heex:1206
+#: lib/vutuv_web/templates/user/show.html.heex:1214
+#: lib/vutuv_web/templates/user/show.html.heex:1215
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
@@ -4463,7 +4463,7 @@ msgid "You have not blocked anyone."
 msgstr ""
 
 #: lib/vutuv_web/controllers/block_controller.ex:89
-#: lib/vutuv_web/live/user_profile_live.ex:338
+#: lib/vutuv_web/live/user_profile_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "You unblocked @%{slug}."
 msgstr ""
@@ -4482,7 +4482,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:313
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:993
+#: lib/vutuv_web/templates/user/show.html.heex:1002
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -5319,7 +5319,7 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1464
+#: lib/vutuv_web/live/user_profile_live.ex:1468
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5977,7 +5977,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1469
+#: lib/vutuv_web/live/user_profile_live.ex:1473
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -5992,7 +5992,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:487
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:921
+#: lib/vutuv_web/templates/user/show.html.heex:930
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
@@ -6013,7 +6013,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1546
+#: lib/vutuv_web/templates/user/show.html.heex:1555
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6057,8 +6057,8 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1131
-#: lib/vutuv_web/templates/user/show.html.heex:1141
+#: lib/vutuv_web/templates/user/show.html.heex:1140
+#: lib/vutuv_web/templates/user/show.html.heex:1150
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6098,12 +6098,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1253
+#: lib/vutuv_web/templates/user/show.html.heex:1262
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1264
+#: lib/vutuv_web/templates/user/show.html.heex:1273
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6146,7 +6146,7 @@ msgstr ""
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1262
+#: lib/vutuv_web/templates/user/show.html.heex:1271
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6205,9 +6205,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1536
-#: lib/vutuv_web/templates/user/show.html.heex:1540
-#: lib/vutuv_web/templates/user/show.html.heex:1552
+#: lib/vutuv_web/templates/user/show.html.heex:1545
+#: lib/vutuv_web/templates/user/show.html.heex:1549
+#: lib/vutuv_web/templates/user/show.html.heex:1561
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6549,7 +6549,7 @@ msgid "Mute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:49
-#: lib/vutuv_web/live/user_profile_live.ex:279
+#: lib/vutuv_web/live/user_profile_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr ""
@@ -6578,7 +6578,7 @@ msgid "Unmute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:51
-#: lib/vutuv_web/live/user_profile_live.ex:281
+#: lib/vutuv_web/live/user_profile_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr ""
@@ -7612,51 +7612,51 @@ msgstr ""
 msgid "(deleted member)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:128
+#: lib/vutuv_web/live/admin/dashboard_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Currently online"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:179
+#: lib/vutuv_web/live/admin/dashboard_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "Direct messages"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:317
+#: lib/vutuv_web/live/admin/dashboard_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "Latest"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:117
+#: lib/vutuv_web/live/admin/dashboard_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Live activity"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:143
+#: lib/vutuv_web/live/admin/dashboard_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "Members online right now"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:154
+#: lib/vutuv_web/live/admin/dashboard_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "New members"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:219
-#: lib/vutuv_web/live/admin/dashboard_live.ex:304
+#: lib/vutuv_web/live/admin/dashboard_live.ex:425
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:468
 #: lib/vutuv_web/live/notification_live/index.ex:1368
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:308
+#: lib/vutuv_web/live/admin/dashboard_live.ex:429
 #: lib/vutuv_web/live/notification_live/index.ex:1371
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:120
+#: lib/vutuv_web/live/admin/dashboard_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "updates automatically"
 msgstr ""
@@ -7984,12 +7984,12 @@ msgstr ""
 msgid "name, @handle or email"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:163
+#: lib/vutuv_web/live/admin/dashboard_live.ex:258
 #, elixir-autogen, elixir-format
 msgid "No members yet."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:148
+#: lib/vutuv_web/live/admin/dashboard_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Nobody is online right now."
 msgstr ""
@@ -8045,7 +8045,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:709
+#: lib/vutuv_web/templates/user/show.html.heex:718
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8069,7 +8069,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
-#: lib/vutuv_web/templates/user/show.html.heex:706
+#: lib/vutuv_web/templates/user/show.html.heex:715
 #: lib/vutuv_web/views/import_html.ex:70
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
@@ -8119,7 +8119,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/import_controller.ex:37
 #: lib/vutuv_web/controllers/import_controller.ex:128
-#: lib/vutuv_web/live/user_profile_live.ex:1480
+#: lib/vutuv_web/live/user_profile_live.ex:1484
 #: lib/vutuv_web/templates/import/new.html.heex:1
 #: lib/vutuv_web/templates/import/preview.html.heex:1
 #, elixir-autogen, elixir-format
@@ -8249,7 +8249,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1400
+#: lib/vutuv_web/templates/user/show.html.heex:1409
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8557,7 +8557,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1305
+#: lib/vutuv_web/templates/user/show.html.heex:1314
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8611,18 +8611,18 @@ msgstr ""
 msgid "Category"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:23
+#: lib/vutuv_web/views/work_experience_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:155
-#: lib/vutuv_web/views/work_experience_html.ex:25
+#: lib/vutuv_web/views/work_experience_html.ex:24
 #, elixir-autogen, elixir-format
 msgid "Internship"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:35
+#: lib/vutuv_web/views/work_experience_html.ex:34
 #, elixir-autogen, elixir-format
 msgid "Internships"
 msgstr ""
@@ -8632,13 +8632,13 @@ msgstr ""
 msgid "On that page, select \"Download larger data archive\" (profile, positions, volunteering, education, skills)."
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:33
+#: lib/vutuv_web/views/work_experience_html.ex:32
 #, elixir-autogen, elixir-format
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:29
-#: lib/vutuv_web/views/work_experience_html.ex:36
+#: lib/vutuv_web/views/work_experience_html.ex:28
+#: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Volunteering & hobbies"
 msgstr ""
@@ -8784,14 +8784,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:24
-#: lib/vutuv_web/views/work_experience_html.ex:34
+#: lib/vutuv_web/views/work_experience_html.ex:23
+#: lib/vutuv_web/views/work_experience_html.ex:33
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:30
-#: lib/vutuv_web/views/work_experience_html.ex:37
+#: lib/vutuv_web/views/work_experience_html.ex:29
+#: lib/vutuv_web/views/work_experience_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Other activities"
 msgstr ""
@@ -8950,7 +8950,7 @@ msgstr ""
 #: lib/vutuv_web/live/feed_languages_live.ex:317
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:771
+#: lib/vutuv_web/templates/user/show.html.heex:780
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9175,7 +9175,7 @@ msgstr ""
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:768
+#: lib/vutuv_web/templates/user/show.html.heex:777
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -9455,7 +9455,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:875
+#: lib/vutuv_web/templates/user/show.html.heex:884
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
@@ -9503,7 +9503,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:872
+#: lib/vutuv_web/templates/user/show.html.heex:881
 #: lib/vutuv_web/views/import_html.ex:71
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
@@ -9622,8 +9622,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1227
-#: lib/vutuv_web/templates/user/show.html.heex:1228
+#: lib/vutuv_web/templates/user/show.html.heex:1236
+#: lib/vutuv_web/templates/user/show.html.heex:1237
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -10110,7 +10110,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:71
 #: lib/vutuv_web/agent_docs/text.ex:66
-#: lib/vutuv_web/templates/user/show.html.heex:1374
+#: lib/vutuv_web/templates/user/show.html.heex:1383
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10341,12 +10341,12 @@ msgstr ""
 msgid "Separate tags with a comma. A tag may be several words long, like Ruby on Rails."
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:436
+#: lib/vutuv_web/views/work_experience_html.ex:521
 #, elixir-autogen, elixir-format
 msgid "%{n}m"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:437
+#: lib/vutuv_web/views/work_experience_html.ex:522
 #, elixir-autogen, elixir-format
 msgid "%{n}y"
 msgstr ""
@@ -13384,7 +13384,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1340
+#: lib/vutuv_web/templates/user/show.html.heex:1349
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13421,7 +13421,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1338
+#: lib/vutuv_web/templates/user/show.html.heex:1347
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13609,7 +13609,7 @@ msgstr ""
 msgid "Qualification"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:624
+#: lib/vutuv_web/views/work_experience_html.ex:709
 #, elixir-autogen, elixir-format
 msgid "With qualification:"
 msgstr ""
@@ -14779,7 +14779,7 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1047
+#: lib/vutuv_web/templates/user/show.html.heex:1056
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
@@ -17636,7 +17636,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/job_reference_controller.ex:144
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:18
 #: lib/vutuv_web/templates/job_reference/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:809
+#: lib/vutuv_web/templates/user/show.html.heex:818
 #, elixir-autogen, elixir-format
 msgid "Add an employment reference"
 msgstr ""
@@ -17713,7 +17713,7 @@ msgstr ""
 #: lib/vutuv_web/templates/job_reference/new.html.heex:4
 #: lib/vutuv_web/templates/job_reference/show.html.heex:12
 #: lib/vutuv_web/templates/job_reference/view.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:806
+#: lib/vutuv_web/templates/user/show.html.heex:815
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employment references"
 msgstr ""
@@ -18344,12 +18344,12 @@ msgstr ""
 msgid "by the lawyer Tom Braegelmann"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:850
+#: lib/vutuv_web/templates/user/show.html.heex:859
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Documents:"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:663
+#: lib/vutuv_web/views/work_experience_html.ex:748
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employment reference:"
 msgstr ""
@@ -18475,7 +18475,7 @@ msgstr ""
 msgid "Male"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:226
+#: lib/vutuv_web/live/admin/dashboard_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
@@ -23640,3 +23640,17 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr ""
+
+#: lib/vutuv_web/views/work_experience_html.ex:212
+#, elixir-autogen, elixir-format
+msgid "One more entry"
+msgid_plural "%{formatted} more entries"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/views/work_experience_html.ex:204
+#, elixir-autogen, elixir-format
+msgid "One more entry (%{years})"
+msgid_plural "%{formatted} more entries (%{years})"
+msgstr[0] ""
+msgstr[1] ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -40,7 +40,7 @@ msgstr "Aggiungi"
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1494
+#: lib/vutuv_web/templates/user/show.html.heex:1503
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -106,7 +106,7 @@ msgstr "Data di nascita"
 #: lib/vutuv_web/agent_docs/markdown.ex:677
 #: lib/vutuv_web/agent_docs/text.ex:636
 #: lib/vutuv_web/agent_docs/text.ex:637
-#: lib/vutuv_web/templates/user/show.html.heex:1125
+#: lib/vutuv_web/templates/user/show.html.heex:1134
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Compleanno"
@@ -154,7 +154,7 @@ msgstr "Selezioni una voce"
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1163
+#: lib/vutuv_web/templates/user/show.html.heex:1172
 #, elixir-autogen
 msgid "Contact"
 msgstr "Contatto"
@@ -225,7 +225,7 @@ msgstr "Scarica"
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:113
-#: lib/vutuv_web/templates/user/show.html.heex:1148
+#: lib/vutuv_web/templates/user/show.html.heex:1157
 #, elixir-autogen
 msgid "Edit"
 msgstr "Modifica"
@@ -333,13 +333,13 @@ msgstr "Follower"
 #: lib/vutuv_web/live/organization_live/show.ex:618
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:993
+#: lib/vutuv_web/templates/user/show.html.heex:1002
 #: lib/vutuv_web/views/user_html.ex:640
 #, elixir-autogen
 msgid "Following"
 msgstr "Seguiti"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:212
+#: lib/vutuv_web/live/admin/dashboard_live.ex:310
 #: lib/vutuv_web/templates/page/index.html.heex:121
 #: lib/vutuv_web/templates/user/edit.html.heex:207
 #: lib/vutuv_web/views/account_event_text.ex:219
@@ -695,13 +695,13 @@ msgstr "Slug"
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1277
+#: lib/vutuv_web/templates/user/show.html.heex:1286
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profili"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1279
+#: lib/vutuv_web/templates/user/show.html.heex:1288
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr "Aggiungi un profilo"
@@ -740,7 +740,7 @@ msgstr "Codice e repository"
 #: lib/vutuv_web/controllers/follow_controller.ex:24
 #: lib/vutuv_web/controllers/remote_follow_controller.ex:174
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
-#: lib/vutuv_web/live/user_profile_live.ex:178
+#: lib/vutuv_web/live/user_profile_live.ex:179
 #, elixir-autogen
 msgid "Something went wrong"
 msgstr "Qualcosa è andato storto"
@@ -853,8 +853,8 @@ msgid "vCard"
 msgstr "vCard"
 
 #: lib/vutuv_web/components/ui.ex:4860
-#: lib/vutuv_web/templates/user/show.html.heex:987
-#: lib/vutuv_web/templates/user/show.html.heex:1010
+#: lib/vutuv_web/templates/user/show.html.heex:996
+#: lib/vutuv_web/templates/user/show.html.heex:1019
 #, elixir-autogen
 msgid "View All"
 msgstr "Mostra tutti"
@@ -1058,7 +1058,7 @@ msgstr "Non ha i permessi per vedere questa pagina."
 msgid "An error occurred"
 msgstr "Si è verificato un errore"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1114
+#: lib/vutuv_web/templates/user/show.html.heex:1123
 #, elixir-autogen
 msgid "General Info"
 msgstr "Informazioni generali"
@@ -1097,8 +1097,8 @@ msgstr "I 100 utenti con più follower"
 msgid "Curious? Have a look at the "
 msgstr "Curioso? Dia un'occhiata a "
 
-#: lib/vutuv_web/views/work_experience_html.ex:308
-#: lib/vutuv_web/views/work_experience_html.ex:361
+#: lib/vutuv_web/views/work_experience_html.ex:393
+#: lib/vutuv_web/views/work_experience_html.ex:446
 #, elixir-autogen
 msgid "Present"
 msgstr "Oggi"
@@ -1704,7 +1704,7 @@ msgstr "Conferma"
 #: lib/vutuv_web/live/organization_live/show.ex:616
 #: lib/vutuv_web/live/post_live/feed.ex:902
 #: lib/vutuv_web/templates/remote_actor_card/card.html.heex:285
-#: lib/vutuv_web/templates/user/show.html.heex:1318
+#: lib/vutuv_web/templates/user/show.html.heex:1327
 #: lib/vutuv_web/views/user_html.ex:651
 #, elixir-autogen, elixir-format
 msgid "Follow"
@@ -1956,26 +1956,26 @@ msgstr "Elimina voce"
 msgid "Options"
 msgstr "Opzioni"
 
-#: lib/vutuv_web/views/work_experience_html.ex:420
+#: lib/vutuv_web/views/work_experience_html.ex:505
 #, elixir-autogen, elixir-format
 msgid "%{count} month"
 msgid_plural "%{count} months"
 msgstr[0] "%{count} mese"
 msgstr[1] "%{count} mesi"
 
-#: lib/vutuv_web/views/work_experience_html.ex:423
+#: lib/vutuv_web/views/work_experience_html.ex:508
 #, elixir-autogen, elixir-format
 msgid "%{count} year"
 msgid_plural "%{count} years"
 msgstr[0] "%{count} anno"
 msgstr[1] "%{count} anni"
 
-#: lib/vutuv_web/views/work_experience_html.ex:505
+#: lib/vutuv_web/views/work_experience_html.ex:590
 #, elixir-autogen, elixir-format
 msgid "Time in this role"
 msgstr "Tempo in questo ruolo"
 
-#: lib/vutuv_web/views/work_experience_html.ex:504
+#: lib/vutuv_web/views/work_experience_html.ex:589
 #, elixir-autogen, elixir-format
 msgid "Total time at this employer"
 msgstr "Tempo totale presso questo datore di lavoro"
@@ -2217,7 +2217,7 @@ msgstr "Post eliminato."
 #: lib/vutuv_web/controllers/post_controller.ex:90
 #: lib/vutuv_web/controllers/user_controller.ex:77
 #: lib/vutuv_web/gettext_extraction_anchors.ex:113
-#: lib/vutuv_web/live/admin/dashboard_live.ex:172
+#: lib/vutuv_web/live/admin/dashboard_live.ex:270
 #: lib/vutuv_web/live/fediverse_account_live.ex:446
 #: lib/vutuv_web/live/organization_live/show.ex:710
 #: lib/vutuv_web/live/post_live/saved.ex:536
@@ -2737,33 +2737,33 @@ msgstr "Usa un altro indirizzo e-mail"
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:923
+#: lib/vutuv_web/templates/user/show.html.heex:932
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr "Aggiungi un link"
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1237
+#: lib/vutuv_web/templates/user/show.html.heex:1246
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Aggiungi un numero di telefono"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1496
+#: lib/vutuv_web/templates/user/show.html.heex:1505
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Aggiungi un indirizzo"
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1165
+#: lib/vutuv_web/templates/user/show.html.heex:1174
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "Aggiungi un indirizzo e-mail"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1116
+#: lib/vutuv_web/templates/user/show.html.heex:1125
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Aggiungi i dati personali"
@@ -2898,7 +2898,7 @@ msgid "Endorsement"
 msgstr "Conferma"
 
 #: lib/vutuv_web/notification_line.ex:312
-#: lib/vutuv_web/templates/user/show.html.heex:971
+#: lib/vutuv_web/templates/user/show.html.heex:980
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3129,8 +3129,8 @@ msgstr "Qui non c'è nulla: al momento nessun Suo contenuto è segnalato."
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nudità, violenza o altri contenuti che non hanno posto su vutuv."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1205
-#: lib/vutuv_web/templates/user/show.html.heex:1206
+#: lib/vutuv_web/templates/user/show.html.heex:1214
+#: lib/vutuv_web/templates/user/show.html.heex:1215
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr "Visibile solo a Lei"
@@ -4631,7 +4631,7 @@ msgid "You have not blocked anyone."
 msgstr "Non ha bloccato nessuno."
 
 #: lib/vutuv_web/controllers/block_controller.ex:89
-#: lib/vutuv_web/live/user_profile_live.ex:338
+#: lib/vutuv_web/live/user_profile_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "You unblocked @%{slug}."
 msgstr "Ha sbloccato @%{slug}."
@@ -4650,7 +4650,7 @@ msgstr "Trova membri"
 #: lib/vutuv_web/live/organization_live/following.ex:313
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:993
+#: lib/vutuv_web/templates/user/show.html.heex:1002
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Segue"
@@ -5527,7 +5527,7 @@ msgstr "Completi il Suo profilo"
 msgid "A few quick steps so people can find and recognize you."
 msgstr "Pochi passaggi veloci perché le persone La trovino e La riconoscano."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1464
+#: lib/vutuv_web/live/user_profile_live.ex:1468
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr "Aggiungi una foto del profilo"
@@ -6197,7 +6197,7 @@ msgstr "ad esempio MacBook"
 msgid "or"
 msgstr "oppure"
 
-#: lib/vutuv_web/live/user_profile_live.ex:1469
+#: lib/vutuv_web/live/user_profile_live.ex:1473
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr "Aggiungi una descrizione breve"
@@ -6212,7 +6212,7 @@ msgstr "Descrizione breve"
 #: lib/vutuv_web/components/ui.ex:487
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:921
+#: lib/vutuv_web/templates/user/show.html.heex:930
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
@@ -6233,7 +6233,7 @@ msgstr[1] "post"
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Dopo aver scelto un file può spostarlo e ingrandirlo."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1546
+#: lib/vutuv_web/templates/user/show.html.heex:1555
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Anche su"
@@ -6279,8 +6279,8 @@ msgstr "Usa questa foto"
 msgid "Zoom"
 msgstr "Ingrandimento"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1131
-#: lib/vutuv_web/templates/user/show.html.heex:1141
+#: lib/vutuv_web/templates/user/show.html.heex:1140
+#: lib/vutuv_web/templates/user/show.html.heex:1150
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6322,12 +6322,12 @@ msgstr "Rapporto giornaliero del %{day}"
 msgid "Jump to a day"
 msgstr "Vai a un giorno"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1253
+#: lib/vutuv_web/templates/user/show.html.heex:1262
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr "Gestisci gli indirizzi e-mail"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1264
+#: lib/vutuv_web/templates/user/show.html.heex:1273
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr "Gestisci i numeri di telefono"
@@ -6370,7 +6370,7 @@ msgstr "Giorno precedente"
 msgid "Reposts"
 msgstr "Ripubblicazioni"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1262
+#: lib/vutuv_web/templates/user/show.html.heex:1271
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr "Vedi tutti i numeri di telefono"
@@ -6431,9 +6431,9 @@ msgstr "Servizi di mappe da mostrare"
 msgid "Maps"
 msgstr "Mappe"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1536
-#: lib/vutuv_web/templates/user/show.html.heex:1540
-#: lib/vutuv_web/templates/user/show.html.heex:1552
+#: lib/vutuv_web/templates/user/show.html.heex:1545
+#: lib/vutuv_web/templates/user/show.html.heex:1549
+#: lib/vutuv_web/templates/user/show.html.heex:1561
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "Apri in %{name}"
@@ -6806,7 +6806,7 @@ msgid "Mute"
 msgstr "Silenzia"
 
 #: lib/vutuv_web/controllers/follow_controller.ex:49
-#: lib/vutuv_web/live/user_profile_live.ex:279
+#: lib/vutuv_web/live/user_profile_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr "Silenziato. I suoi post non compaiono più nel Suo feed."
@@ -6835,7 +6835,7 @@ msgid "Unmute"
 msgstr "Riattiva"
 
 #: lib/vutuv_web/controllers/follow_controller.ex:51
-#: lib/vutuv_web/live/user_profile_live.ex:281
+#: lib/vutuv_web/live/user_profile_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr "Riattivato. I suoi post tornano a comparire nel Suo feed."
@@ -7920,51 +7920,51 @@ msgstr "Ancora nessun clic registrato."
 msgid "(deleted member)"
 msgstr "(membro eliminato)"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:128
+#: lib/vutuv_web/live/admin/dashboard_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Currently online"
 msgstr "Online in questo momento"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:179
+#: lib/vutuv_web/live/admin/dashboard_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "Direct messages"
 msgstr "Messaggi diretti"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:317
+#: lib/vutuv_web/live/admin/dashboard_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "Latest"
 msgstr "Ultimi"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:117
+#: lib/vutuv_web/live/admin/dashboard_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Live activity"
 msgstr "Attività in tempo reale"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:143
+#: lib/vutuv_web/live/admin/dashboard_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "Members online right now"
 msgstr "Membri online in questo momento"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:154
+#: lib/vutuv_web/live/admin/dashboard_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "New members"
 msgstr "Nuovi membri"
 
 #: lib/vutuv_web/components/job_components.ex:219
-#: lib/vutuv_web/live/admin/dashboard_live.ex:304
+#: lib/vutuv_web/live/admin/dashboard_live.ex:425
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:468
 #: lib/vutuv_web/live/notification_live/index.ex:1368
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Oggi"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:308
+#: lib/vutuv_web/live/admin/dashboard_live.ex:429
 #: lib/vutuv_web/live/notification_live/index.ex:1371
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr "Ieri"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:120
+#: lib/vutuv_web/live/admin/dashboard_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "updates automatically"
 msgstr "si aggiorna da solo"
@@ -8325,12 +8325,12 @@ msgstr "Verificato"
 msgid "name, @handle or email"
 msgstr "nome, @handle o e-mail"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:163
+#: lib/vutuv_web/live/admin/dashboard_live.ex:258
 #, elixir-autogen, elixir-format
 msgid "No members yet."
 msgstr "Ancora nessun membro."
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:148
+#: lib/vutuv_web/live/admin/dashboard_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Nobody is online right now."
 msgstr "In questo momento non c'è nessuno online."
@@ -8386,7 +8386,7 @@ msgstr[1] "%{count} esperienze lavorative"
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:709
+#: lib/vutuv_web/templates/user/show.html.heex:718
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr "Aggiungi una formazione"
@@ -8410,7 +8410,7 @@ msgstr "Titolo di studio"
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
-#: lib/vutuv_web/templates/user/show.html.heex:706
+#: lib/vutuv_web/templates/user/show.html.heex:715
 #: lib/vutuv_web/views/import_html.ex:70
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
@@ -8464,7 +8464,7 @@ msgstr "Importa"
 
 #: lib/vutuv_web/controllers/import_controller.ex:37
 #: lib/vutuv_web/controllers/import_controller.ex:128
-#: lib/vutuv_web/live/user_profile_live.ex:1480
+#: lib/vutuv_web/live/user_profile_live.ex:1484
 #: lib/vutuv_web/templates/import/new.html.heex:1
 #: lib/vutuv_web/templates/import/preview.html.heex:1
 #, elixir-autogen, elixir-format
@@ -8596,7 +8596,7 @@ msgid "Loading posts"
 msgstr "Caricamento dei post"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1400
+#: lib/vutuv_web/templates/user/show.html.heex:1409
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Post dai social media"
@@ -8938,7 +8938,7 @@ msgstr "La scriva in Amministrazione › Pagine legali"
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1305
+#: lib/vutuv_web/templates/user/show.html.heex:1314
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr "Fediverso"
@@ -8997,18 +8997,18 @@ msgstr ""
 msgid "Category"
 msgstr "Categoria"
 
-#: lib/vutuv_web/views/work_experience_html.ex:23
+#: lib/vutuv_web/views/work_experience_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Employment"
 msgstr "Lavoro dipendente"
 
 #: lib/vutuv/jobs/job_posting.ex:155
-#: lib/vutuv_web/views/work_experience_html.ex:25
+#: lib/vutuv_web/views/work_experience_html.ex:24
 #, elixir-autogen, elixir-format
 msgid "Internship"
 msgstr "Tirocinio"
 
-#: lib/vutuv_web/views/work_experience_html.ex:35
+#: lib/vutuv_web/views/work_experience_html.ex:34
 #, elixir-autogen, elixir-format
 msgid "Internships"
 msgstr "Tirocini"
@@ -9020,13 +9020,13 @@ msgstr ""
 "In quella pagina selezioni \"Download larger data archive\" (profilo, "
 "posizioni, volontariato, formazione, competenze)."
 
-#: lib/vutuv_web/views/work_experience_html.ex:33
+#: lib/vutuv_web/views/work_experience_html.ex:32
 #, elixir-autogen, elixir-format
 msgid "Professional Experience"
 msgstr "Esperienza professionale"
 
-#: lib/vutuv_web/views/work_experience_html.ex:29
-#: lib/vutuv_web/views/work_experience_html.ex:36
+#: lib/vutuv_web/views/work_experience_html.ex:28
+#: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Volunteering & hobbies"
 msgstr "Volontariato e hobby"
@@ -9186,14 +9186,14 @@ msgstr ""
 "Il CV di %{name} su vutuv: esperienza lavorativa, formazione e competenze da"
 " consultare e scaricare."
 
-#: lib/vutuv_web/views/work_experience_html.ex:24
-#: lib/vutuv_web/views/work_experience_html.ex:34
+#: lib/vutuv_web/views/work_experience_html.ex:23
+#: lib/vutuv_web/views/work_experience_html.ex:33
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr "Libero professionista / Lavoratore autonomo"
 
-#: lib/vutuv_web/views/work_experience_html.ex:30
-#: lib/vutuv_web/views/work_experience_html.ex:37
+#: lib/vutuv_web/views/work_experience_html.ex:29
+#: lib/vutuv_web/views/work_experience_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Other activities"
 msgstr "Altre attività"
@@ -9364,7 +9364,7 @@ msgstr "A2 (Elementare)"
 #: lib/vutuv_web/live/feed_languages_live.ex:317
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:771
+#: lib/vutuv_web/templates/user/show.html.heex:780
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr "Aggiungi una lingua"
@@ -9589,7 +9589,7 @@ msgstr "Lingua aggiornata."
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:768
+#: lib/vutuv_web/templates/user/show.html.heex:777
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Lingue"
@@ -9879,7 +9879,7 @@ msgstr[0] "%{count} certificato o abilitazione"
 msgstr[1] "%{count} certificati o abilitazioni"
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:875
+#: lib/vutuv_web/templates/user/show.html.heex:884
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr "Aggiungi un certificato o un'abilitazione"
@@ -9927,7 +9927,7 @@ msgstr "Certificati"
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:872
+#: lib/vutuv_web/templates/user/show.html.heex:881
 #: lib/vutuv_web/views/import_html.ex:71
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
@@ -10051,8 +10051,8 @@ msgstr "Preferita"
 msgid "Preferred contact language"
 msgstr "Lingua di contatto preferita"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1227
-#: lib/vutuv_web/templates/user/show.html.heex:1228
+#: lib/vutuv_web/templates/user/show.html.heex:1236
+#: lib/vutuv_web/templates/user/show.html.heex:1237
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr "+%{code} è il prefisso telefonico di %{region}"
@@ -10580,7 +10580,7 @@ msgstr[1] "%{formatted} stelle"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:71
 #: lib/vutuv_web/agent_docs/text.ex:66
-#: lib/vutuv_web/templates/user/show.html.heex:1374
+#: lib/vutuv_web/templates/user/show.html.heex:1383
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Codice"
@@ -10832,12 +10832,12 @@ msgstr ""
 "Separi i tag con una virgola. Un tag può essere lungo più parole, come Ruby "
 "on Rails."
 
-#: lib/vutuv_web/views/work_experience_html.ex:436
+#: lib/vutuv_web/views/work_experience_html.ex:521
 #, elixir-autogen, elixir-format
 msgid "%{n}m"
 msgstr "%{n}m"
 
-#: lib/vutuv_web/views/work_experience_html.ex:437
+#: lib/vutuv_web/views/work_experience_html.ex:522
 #, elixir-autogen, elixir-format
 msgid "%{n}y"
 msgstr "%{n}a"
@@ -14116,7 +14116,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1340
+#: lib/vutuv_web/templates/user/show.html.heex:1349
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr "Aggiungi un messenger"
@@ -14153,7 +14153,7 @@ msgstr "Messenger aggiornato."
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1338
+#: lib/vutuv_web/templates/user/show.html.heex:1347
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr "Messenger"
@@ -14348,7 +14348,7 @@ msgstr ""
 msgid "Qualification"
 msgstr "Certificazione"
 
-#: lib/vutuv_web/views/work_experience_html.ex:624
+#: lib/vutuv_web/views/work_experience_html.ex:709
 #, elixir-autogen, elixir-format
 msgid "With qualification:"
 msgstr "Con certificazione:"
@@ -15631,7 +15631,7 @@ msgstr "Modifica l'applicazione"
 msgid "Book an ad"
 msgstr "Prenoti una pubblicità"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1047
+#: lib/vutuv_web/templates/user/show.html.heex:1056
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
@@ -18751,7 +18751,7 @@ msgstr "Per questo attestato è già in corso un'analisi."
 #: lib/vutuv_web/controllers/job_reference_controller.ex:144
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:18
 #: lib/vutuv_web/templates/job_reference/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:809
+#: lib/vutuv_web/templates/user/show.html.heex:818
 #, elixir-autogen, elixir-format
 msgid "Add an employment reference"
 msgstr "Aggiungi un attestato di lavoro"
@@ -18831,7 +18831,7 @@ msgstr "Attestato di lavoro aggiornato."
 #: lib/vutuv_web/templates/job_reference/new.html.heex:4
 #: lib/vutuv_web/templates/job_reference/show.html.heex:12
 #: lib/vutuv_web/templates/job_reference/view.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:806
+#: lib/vutuv_web/templates/user/show.html.heex:815
 #, elixir-autogen, elixir-format
 msgid "Employment references"
 msgstr "Attestati di lavoro"
@@ -19512,12 +19512,12 @@ msgstr "Il Suo nome utente vutuv è pronto."
 msgid "by the lawyer Tom Braegelmann"
 msgstr "dall'avvocato Tom Braegelmann"
 
-#: lib/vutuv_web/templates/user/show.html.heex:850
+#: lib/vutuv_web/templates/user/show.html.heex:859
 #, elixir-autogen, elixir-format
 msgid "Documents:"
 msgstr "Documenti:"
 
-#: lib/vutuv_web/views/work_experience_html.ex:663
+#: lib/vutuv_web/views/work_experience_html.ex:748
 #, elixir-autogen, elixir-format
 msgid "Employment reference:"
 msgstr "Attestato di lavoro:"
@@ -19659,7 +19659,7 @@ msgstr "Femminile"
 msgid "Male"
 msgstr "Maschile"
 
-#: lib/vutuv_web/live/admin/dashboard_live.ex:226
+#: lib/vutuv_web/live/admin/dashboard_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
@@ -25153,3 +25153,17 @@ msgstr "Ingrandisci le foto"
 #, elixir-autogen, elixir-format
 msgid "Show this photo larger"
 msgstr "Ingrandisci la foto"
+
+#: lib/vutuv_web/views/work_experience_html.ex:212
+#, elixir-autogen, elixir-format
+msgid "One more entry"
+msgid_plural "%{formatted} more entries"
+msgstr[0] "Un'altra voce"
+msgstr[1] "Altre %{formatted} voci"
+
+#: lib/vutuv_web/views/work_experience_html.ex:204
+#, elixir-autogen, elixir-format
+msgid "One more entry (%{years})"
+msgid_plural "%{formatted} more entries (%{years})"
+msgstr[0] "Un'altra voce (%{years})"
+msgstr[1] "Altre %{formatted} voci (%{years})"

--- a/test/vutuv_web/views/work_experience_html_test.exs
+++ b/test/vutuv_web/views/work_experience_html_test.exs
@@ -12,6 +12,22 @@ defmodule VutuvWeb.WorkExperienceHTMLTest do
     struct(WorkExperience, Map.merge(%{title: "Role", organization: "Org"}, Map.new(attrs)))
   end
 
+  # The shape of tim_lueck's CV (2026-09): a handful of jobs, twice as many
+  # Ehrenämter, and the newest rows of all are Ehrenämter. Under one shared
+  # budget spent newest-first the card showed 2 jobs and 8 Ehrenämter — a
+  # business network reading as a club directory. Each category has its own cap.
+  defp mixed_cv do
+    volunteers =
+      for year <- [2026, 2026, 2026, 2022, 2022, 2021, 2021, 2014, 2010, 2010, 1994, 1994],
+          do: job(kind: "volunteer", organization: "Verein #{year}", start_year: year)
+
+    jobs =
+      for year <- [2023, 2002, 2021, 2016, 2009, 2004, 1998],
+          do: job(kind: "employment", organization: "Firma #{year}", start_year: year)
+
+    Enum.sort_by(volunteers ++ jobs, & &1.start_year, :desc)
+  end
+
   describe "circle_durations/1" do
     test "labels roles by whole years, sub-year as <1, undated as blank" do
       [long, short, undated] =
@@ -319,7 +335,7 @@ defmodule VutuvWeb.WorkExperienceHTMLTest do
     end
   end
 
-  describe "grouped_clusters/3 display limit" do
+  describe "grouped_clusters/3 per-category caps" do
     test "caps the shown roles but keeps each employer's full tenure" do
       # x-ion (1 role) + 2 of Open-Xchange's 3 roles fit under a 3-role cap; the
       # third OX role is cut, but the block must still report the whole 9-year,
@@ -355,7 +371,7 @@ defmodule VutuvWeb.WorkExperienceHTMLTest do
             )
           ],
           :compact,
-          3
+          %{"employment" => 3}
         )
 
       refute x_ion.multi?
@@ -365,7 +381,7 @@ defmodule VutuvWeb.WorkExperienceHTMLTest do
       assert IO.iodata_to_binary(ox.span.label) == "2016 - 2025"
     end
 
-    test "a limit at or above the role count shows every role" do
+    test "a cap at or above the category's role count shows every role" do
       [{"employment", blocks}] =
         WorkExperienceHTML.grouped_clusters(
           [
@@ -373,10 +389,76 @@ defmodule VutuvWeb.WorkExperienceHTMLTest do
             job(title: "B", organization: "Beta", start_year: 2020, end_year: 2022)
           ],
           :compact,
-          10
+          %{"employment" => 10}
         )
 
       assert Enum.flat_map(blocks, & &1.roles) |> length() == 2
+    end
+  end
+
+  describe "profile_groups/1" do
+    test "the jobs keep their own cap however many Ehrenämter sit above them" do
+      [employment, volunteer] = WorkExperienceHTML.profile_groups(mixed_cv())
+
+      assert employment.kind == "employment"
+      assert employment.blocks |> Enum.flat_map(& &1.roles) |> length() == 7
+      assert employment.hidden == nil
+
+      assert volunteer.kind == "volunteer"
+      assert volunteer.blocks |> Enum.flat_map(& &1.roles) |> length() == 3
+      assert volunteer.hidden.count == 9
+    end
+
+    test "the hidden count names the years it covers, ongoing rows running to Present" do
+      %{hidden: hidden} =
+        [
+          job(kind: "volunteer", organization: "A", start_year: 2020, end_year: 2021),
+          job(kind: "volunteer", organization: "B", start_year: 2018, end_year: 2019),
+          job(kind: "volunteer", organization: "C", start_year: 2016, end_year: 2017),
+          job(kind: "volunteer", organization: "D", start_year: 2014, end_year: 2015),
+          job(kind: "volunteer", organization: "E", start_year: 1994, end_year: 1996)
+        ]
+        |> WorkExperienceHTML.profile_groups()
+        |> hd()
+
+      assert hidden.count == 2
+      assert hidden.years == "1994 - 2015"
+
+      %{hidden: ongoing} =
+        [
+          job(kind: "internship", organization: "A", start_year: 2020, end_year: 2021),
+          job(kind: "internship", organization: "B", start_year: 2018, end_year: 2019),
+          job(kind: "internship", organization: "C", start_year: 2016, end_year: 2017),
+          job(kind: "internship", organization: "D", start_year: 2001)
+        ]
+        |> WorkExperienceHTML.profile_groups()
+        |> hd()
+
+      assert ongoing.count == 1
+      assert ongoing.years == "2001 - Present"
+    end
+
+    test "undated hidden entries are counted without inventing a year span" do
+      %{hidden: hidden} =
+        [
+          job(kind: "volunteer", organization: "A", start_year: 2020),
+          job(kind: "volunteer", organization: "B", start_year: 2018),
+          job(kind: "volunteer", organization: "C", start_year: 2016),
+          job(kind: "volunteer", organization: "D")
+        ]
+        |> WorkExperienceHTML.profile_groups()
+        |> hd()
+
+      assert hidden.count == 1
+      assert hidden.years == nil
+    end
+
+    test "a category inside its cap has nothing hidden" do
+      [%{hidden: nil}] =
+        WorkExperienceHTML.profile_groups([
+          job(organization: "Acme", start_year: 2022, end_year: 2024),
+          job(organization: "Beta", start_year: 2020, end_year: 2022)
+        ])
     end
   end
 


### PR DESCRIPTION
On `/:slug` the Lebenslauf card capped the shown roles at ten across all CV categories, spent newest-first. A member whose newest entries are Ehrenämter saw eight of those and two jobs — tim_lueck has 7 jobs and 13 Ehrenämter and his profile showed two.

Each category now has its own cap: 8 for employment and self-employment, 3 for internships, volunteering and "other". Both category headings link to `/:slug/work_experiences`, and a truncated category ends in a line saying what is missing and from which years ("10 weitere Einträge (1994 - Heute)"). The card footer measures itself against what was actually shown instead of a fixed number.

Entry point: `VutuvWeb.WorkExperienceHTML.profile_groups/1`, rendered by `templates/user/show.html.heex`. The groups are built in `UserProfileLive` so the profile's frequent patches do not re-cluster the CV. The `.md`/`.txt`/`.json`/`.xml` siblings never previewed, so they are untouched.

Verified in a browser against the dev copy, German and jobs-only profiles; the regression test was calibrated by restoring the shared budget and watching it go red.

https://claude.ai/code/session_01QUk4DWRnu7WDZuC24iakYx