### PR TITLE
Education card no longer loses a whole category to the newest entries

### DIFF
--- a/lib/vutuv_web/live/user_profile_live.ex
+++ b/lib/vutuv_web/live/user_profile_live.ex
@@ -51,6 +51,7 @@ defmodule VutuvWeb.UserProfileLive do
   alias Vutuv.Tags
   alias Vutuv.Tags.UserTag
   alias Vutuv.Tags.UserTagEndorsement
+  alias VutuvWeb.EducationHTML
   alias VutuvWeb.Fediverse.Docs
   alias VutuvWeb.Live.ComposerPanel
   alias VutuvWeb.Live.InitAssigns
@@ -980,6 +981,7 @@ defmodule VutuvWeb.UserProfileLive do
     |> assign(:work_experience, user.work_experiences)
     |> assign(:experience_groups, WorkExperienceHTML.profile_groups(user.work_experiences))
     |> assign(:education, user.educations)
+    |> assign(:education_groups, EducationHTML.profile_groups(user.educations))
     |> assign(:languages, user.languages)
     # Expired-credential hiding (issue #859) is already applied in the preload
     # via Qualification.visible_to(owner?): a visitor gets only valid entries,
@@ -1321,12 +1323,12 @@ defmodule VutuvWeb.UserProfileLive do
   # THE single source of the per-section preview caps: preload_user_for_show/2
   # limits its preloads with it and user/show.html.heex reads the same numbers
   # for its `preview={...}` / "more than the preview" checks, so the queries
-  # and the template can never disagree. Experience is deliberately absent: one
-  # number cannot say how much of a CV to show, since the jobs and the Ehrenämter
-  # are capped apart (WorkExperienceHTML.profile_groups/1), so its preload stays
-  # unlimited and the cut happens in memory.
+  # and the template can never disagree. The two CV sections are deliberately
+  # absent: one number cannot say how much of a CV to show, since each category
+  # is capped on its own (`WorkExperienceHTML.profile_groups/1` and
+  # `EducationHTML.profile_groups/1`), so both preloads stay unlimited and the
+  # cut happens in memory — a cut before the grouping drops whole categories.
   @preview_limits %{
-    educations: 3,
     languages: 6,
     qualifications: 8,
     phone_numbers: 3,
@@ -1357,9 +1359,11 @@ defmodule VutuvWeb.UserProfileLive do
       # cited credential (issue #858) ride along for the Experience card.
       work_experiences:
         {WorkExperience.order_by_date(WorkExperience), WorkExperience.display_preloads()},
-      educations:
-        from(e in Education, limit: ^preview_limit(:educations))
-        |> Education.order_by_date(),
+      # Unlimited for the same two reasons the work history is: the header line
+      # resolves a pinned education from this list (profile_headline/3, issue
+      # #882), which a SQL cut could hide, and the card caps each CV category on
+      # its own in memory — a cut before the grouping drops whole categories.
+      educations: Education.order_by_date(Education),
       languages: Language.ordered() |> limit(^preview_limit(:languages)),
       # visible_to(owner?) hides expired credentials from visitors in SQL (the
       # same scope the section page, CV and agent docs use), so the card renders

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -694,9 +694,9 @@ the resulting ~200px rail width. --%>
         <%!-- What the cap left out, in this category's own words: how many roles
               and which years they cover, so a reader can tell a cut-off decade
               of jobs from a couple of recent ones. --%>
-        <VutuvWeb.WorkExperienceHTML.experience_more
+        <VutuvWeb.WorkExperienceHTML.cv_more
           :if={group.hidden}
-          user={@user}
+          href={~p"/#{@user}/work_experiences"}
           hidden={group.hidden}
         />
       </div>
@@ -721,19 +721,22 @@ the resulting ~200px rail width. --%>
       <%!-- A year-led date range on the left, the degree/school on a rail.
       Entries arrive newest-first (Education.order_by_date) and, like the
       section page, split into the CV categories (issue #849) under their own
-      headings once a non-university entry exists. --%>
-      <div
-        :for={{kind, entries} <- VutuvWeb.EducationHTML.group_by_kind(@education)}
-        class="mt-6 first:mt-0"
-      >
-        <h3
-          :if={VutuvWeb.EducationHTML.show_kind_headings?(@education)}
-          class="mb-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
-        >
-          {VutuvWeb.EducationHTML.kind_label(kind)}
+      headings once a non-university entry exists. Each category is capped on
+      its own (`profile_groups/1`), so a member whose newest rows are all
+      Hochschulbildung keeps their Ausbildung on the card. --%>
+      <div :for={group <- @education_groups} class="mt-6 first:mt-0">
+        <%!-- Linked for the same reason the Experience headings are: the
+              category name is what a reader wanting more of it reaches for. --%>
+        <h3 :if={VutuvWeb.EducationHTML.show_kind_headings?(@education)} class="mb-3">
+          <.link
+            href={~p"/#{@user}/educations"}
+            class="text-xs font-semibold uppercase tracking-wide text-slate-500 hover:text-brand-700 dark:text-slate-400 dark:hover:text-brand-300"
+          >
+            {VutuvWeb.EducationHTML.kind_label(group.kind)}
+          </.link>
         </h3>
         <div
-          :for={edu <- entries}
+          :for={edu <- group.entries}
           class="grid grid-cols-[6.5rem_1fr] items-start gap-3"
         >
           <div class="pt-0.5 text-right text-xs font-semibold leading-tight text-slate-600 dark:text-slate-400 tabular-nums">
@@ -756,13 +759,19 @@ the resulting ~200px rail width. --%>
             </p>
           </div>
         </div>
+
+        <VutuvWeb.WorkExperienceHTML.cv_more
+          :if={group.hidden}
+          href={~p"/#{@user}/educations"}
+          hidden={group.hidden}
+        />
       </div>
 
       <.manage_footer
         href={~p"/#{@user}/educations"}
         manage_href={~p"/settings/educations"}
         total={@totals.educations}
-        preview={VutuvWeb.UserProfileLive.preview_limit(:educations)}
+        preview={Enum.sum_by(@education_groups, & &1.shown)}
         owner={@as_owner?}
       />
     </.card>
@@ -1624,14 +1633,16 @@ the resulting ~200px rail width. --%>
 
 <JsonLd.script data={JsonLd.breadcrumbs(@user)} />
 <%!-- Markup mirrors the page (schema.org accuracy rule): a noindexed
-member's profile carries no Person entity. --%>
+member's profile carries no Person entity, and `alumniOf` is fed the entries the
+Ausbildung card really shows rather than the whole preload — the preview caps
+each CV category now, so @education holds every row. --%>
 <JsonLd.script
   :if={not @user.noindex?}
   data={
     JsonLd.person(@user, @header_job, @user_tags, @user.social_media_accounts, %{
       followers: @follower_count,
       posts: @posts_total,
-      educations: @education,
+      educations: Enum.flat_map(@education_groups, & &1.entries),
       languages: @languages,
       qualifications: @qualifications,
       addresses: @user.addresses,

--- a/lib/vutuv_web/views/education_html.ex
+++ b/lib/vutuv_web/views/education_html.ex
@@ -2,16 +2,47 @@ defmodule VutuvWeb.EducationHTML do
   @moduledoc false
   use VutuvWeb, :html
   import VutuvWeb.UserHelpers
-  # The month select options and the date-range formatter are identical to a
-  # work experience's; reuse them rather than duplicate the logic. The pin
-  # helpers (pinned_entry/2, pin_star/1, headline_pin_controls/1) come from
-  # VutuvWeb.UserHelpers, shared with the work-experience list.
+  # The month select options, the date-range formatter and the profile card's
+  # "N more entries" line are identical to a work experience's; reuse them
+  # rather than duplicate the logic. The pin helpers (pinned_entry/2,
+  # pin_star/1, headline_pin_controls/1) come from VutuvWeb.UserHelpers, shared
+  # with the work-experience list.
   import VutuvWeb.WorkExperienceHTML,
-    only: [month_options: 0, format_duration: 4, format_duration: 5]
+    only: [month_options: 0, format_duration: 4, format_duration: 5, hidden_note: 1]
 
   alias Vutuv.Profiles.Education
 
   defdelegate group_by_kind(educations), to: Education
+
+  # Every category previews the same three entries. Three because that is what
+  # the whole card used to show, so no profile shows less than before; per
+  # category because one shared budget starves whatever sorts last — a member
+  # whose three newest rows are all Hochschulbildung lost their Ausbildung from
+  # the card outright, heading and all (3 of the 73 members with a CV in the
+  # dev copy, 2026-09). Unlike a work history there is no ranking to make
+  # between these three: a Lehre is not worth less page than a Studium.
+  @preview_cap 3
+
+  @doc """
+  The profile Education card's groups, in display order: one entry per non-empty
+  CV category with its capped `:entries`, how many that is (`:shown`, what the
+  card's footer measures itself against) and, where the cap cut something, the
+  `hidden_note/1` naming what it left out. The twin of
+  `VutuvWeb.WorkExperienceHTML.profile_groups/1`, which cuts blocks of clustered
+  roles where this one cuts plain rows.
+  """
+  def profile_groups(educations) do
+    for {kind, entries} <- group_by_kind(educations) do
+      shown = Enum.take(entries, @preview_cap)
+
+      %{
+        kind: kind,
+        entries: shown,
+        shown: length(shown),
+        hidden: hidden_note(Enum.drop(entries, @preview_cap))
+      }
+    end
+  end
 
   @doc """
   A category's label (issue #849) — one wording for the form's picker, the

--- a/lib/vutuv_web/views/work_experience_html.ex
+++ b/lib/vutuv_web/views/work_experience_html.ex
@@ -164,10 +164,16 @@ defmodule VutuvWeb.WorkExperienceHTML do
     end
   end
 
-  defp hidden_note([]), do: nil
-  defp hidden_note(entries), do: %{count: length(entries), years: hidden_years(entries)}
+  @doc """
+  What a profile card's per-category cap left out: `%{count:, years:}`, or `nil`
+  when the category fits. Shared with the Education card (`VutuvWeb.EducationHTML`)
+  — both CV sections ask the same question of the same two year columns, and the
+  answer is rendered by the same `cv_more/1` below.
+  """
+  def hidden_note([]), do: nil
+  def hidden_note(entries), do: %{count: length(entries), years: hidden_years(entries)}
 
-  # The span the hidden roles cover, through the same labeller the rail's own
+  # The span the hidden entries cover, through the same labeller the rail's own
   # date column uses: "1994 - 2015", a lone "2003" when they all sit in one
   # year, and running to "Present" while one of them is still going.
   defp hidden_years(entries) do
@@ -185,19 +191,21 @@ defmodule VutuvWeb.WorkExperienceHTML do
   end
 
   @doc """
-  The line under a category the profile preview truncated: how many roles the
-  cap left out, the years they cover, and the way to the whole CV. It rides the
-  timeline's own grid, so it lines up under the role titles above it rather than
-  opening a second margin.
+  The line under a CV category the profile preview truncated: how many entries
+  the cap left out, the years they cover, and the way to the full section. It
+  rides the timeline's own grid, so it lines up under the entry titles above it
+  rather than opening a second margin — which is also why it lives here beside
+  `experience_block/1` and is shared with the Education card rather than being
+  hand-copied into the profile template.
   """
-  attr(:user, :any, required: true)
+  attr(:href, :any, required: true)
   attr(:hidden, :map, required: true)
 
-  def experience_more(assigns) do
+  def cv_more(assigns) do
     ~H"""
     <div class="grid grid-cols-[6.5rem_1fr] gap-3">
       <.link
-        href={~p"/#{@user}/work_experiences"}
+        href={@href}
         class="col-start-2 border-l border-transparent pl-5 text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
       >
         <%= if @hidden.years do %>

--- a/test/vutuv_web/controllers/profile_cv_preview_test.exs
+++ b/test/vutuv_web/controllers/profile_cv_preview_test.exs
@@ -1,0 +1,139 @@
+defmodule VutuvWeb.ProfileCvPreviewTest do
+  @moduledoc """
+  How much of a CV the profile's Lebenslauf and Ausbildung cards preview.
+
+  Both used to spend ONE budget over every category, newest entry first, so
+  whichever category sorted last was starved: a member with a dozen Ehrenämter
+  saw two jobs, and a member whose three newest rows were all Hochschulbildung
+  lost their Ausbildung from the card outright, heading and all. Education's cut
+  happened in SQL (`limit:` on the preload), before the grouping could see the
+  list, which is why that half has to be tested through a rendered page rather
+  than through the view module.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  defp profile(conn, user, opts \\ []) do
+    conn
+    |> put_req_header("accept-language", Keyword.get(opts, :locale, "en"))
+    |> get(~p"/#{user}")
+    |> html_response(200)
+  end
+
+  describe "a category the newest entries crowd out" do
+    test "keeps its place on the Ausbildung card", %{conn: conn} do
+      user = insert_activated_user()
+
+      # The newest three rows are all Hochschulbildung, so a cut of three taken
+      # before the grouping leaves nothing for the Ausbildung heading to hold.
+      for year <- [2024, 2020, 2016] do
+        insert(:education, user: user, kind: "university", school: "Uni #{year}", end_year: year)
+      end
+
+      insert(:education,
+        user: user,
+        kind: "apprenticeship",
+        school: "IHK Koblenz",
+        end_year: 2012
+      )
+
+      html = profile(conn, user)
+
+      assert html =~ "IHK Koblenz"
+      assert html =~ "Vocational Training"
+    end
+
+    test "keeps its place on the Lebenslauf card", %{conn: conn} do
+      user = insert_activated_user()
+
+      for year <- [2026, 2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017] do
+        insert(:work_experience,
+          user: user,
+          kind: "volunteer",
+          organization: "Verein #{year}",
+          start_year: year
+        )
+      end
+
+      insert(:work_experience,
+        user: user,
+        kind: "employment",
+        organization: "Acme GmbH",
+        start_year: 2001,
+        end_year: 2010
+      )
+
+      html = profile(conn, user)
+
+      assert html =~ "Acme GmbH"
+      assert html =~ "Professional Experience"
+    end
+  end
+
+  describe "the note under a truncated category" do
+    test "counts the hidden entries and names the years they cover", %{conn: conn} do
+      user = insert_activated_user()
+
+      for year <- [2024, 2020, 2016, 2008, 2004] do
+        insert(:education,
+          user: user,
+          kind: "university",
+          school: "Uni #{year}",
+          start_year: year - 3,
+          end_year: year
+        )
+      end
+
+      html = profile(conn, user)
+
+      # Three shown, two hidden, spanning the earliest start to the latest end
+      # among the hidden pair.
+      assert html =~ "2 more entries (2001 - 2008)"
+      assert html =~ ~s(href="/#{user.username}/educations")
+    end
+
+    test "reads in German for a German visitor", %{conn: conn} do
+      user = insert_activated_user()
+
+      for year <- [2024, 2020, 2016, 2008] do
+        insert(:education,
+          user: user,
+          kind: "university",
+          school: "Uni #{year}",
+          start_year: year - 3,
+          end_year: year
+        )
+      end
+
+      html = profile(conn, user, locale: "de-DE,de;q=0.9")
+
+      assert html =~ "Ein weiterer Eintrag (2005 - 2008)"
+    end
+
+    test "stays away while the category fits", %{conn: conn} do
+      user = insert_activated_user()
+      insert(:education, user: user, kind: "university", school: "Uni Trier", end_year: 2010)
+
+      html = profile(conn, user)
+
+      refute html =~ "more entries"
+      refute html =~ "One more entry"
+    end
+  end
+
+  describe "the category headings" do
+    test "link to the section that holds the rest", %{conn: conn} do
+      user = insert_activated_user()
+      insert(:work_experience, user: user, kind: "employment", organization: "Acme GmbH")
+      insert(:work_experience, user: user, kind: "volunteer", organization: "Chor Trier")
+      insert(:education, user: user, kind: "university", school: "Uni Trier")
+      insert(:education, user: user, kind: "school", school: "Gymnasium Trier")
+
+      html = profile(conn, user)
+
+      assert html =~
+               ~r{<a href="/#{user.username}/work_experiences"[^>]*>\s*Professional Experience}
+
+      assert html =~ ~r{<a href="/#{user.username}/educations"[^>]*>\s*Higher Education}
+    end
+  end
+end


### PR DESCRIPTION
The Ausbildung card on `/:slug` cut to three rows in SQL, before the grouping could see the list, so a member whose newest three entries are all Hochschulbildung lost their Berufsausbildung from the card outright — heading and all, with nothing saying anything was missing. In the dev copy that hits 3 of the 73 members who have a CV. It is the same starvation #2090 fixed for work experience, one card lower and worse, because there the cut happened before the template.

Each category now previews its own three entries. Three because that was the number for the whole card, so no profile shows less than before; per category because a shared budget starves whatever sorts last. Unlike a work history there is no ranking to make here — a Lehre is not worth less page than a Studium — so the cap is flat.

Two things ride along. The preload loses its `limit:`, which also fixes a pinned education (#882) outside the newest three falling out of the header line, since `profile_headline/3` reads the same list. And the JSON-LD `alumniOf` is now fed the entries the card really shows, so "markup mirrors the page" stays true instead of silently widening to the whole list.

Entry point: `VutuvWeb.EducationHTML.profile_groups/1`. The truncation note and the year label are shared with the Experience card as `WorkExperienceHTML.cv_more/1` and `hidden_note/1` rather than copied.

Verified in a browser against the dev copy in German on the three affected members; the regression test was calibrated by restoring the SQL limit and watching three of its six cases go red.

https://claude.ai/code/session_01QUk4DWRnu7WDZuC24iakYx